### PR TITLE
Secure IPC with per-group namespaces to prevent privilege escalation

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -40,9 +40,10 @@ async function runTask(task: ScheduledTask, deps: SchedulerDependencies): Promis
     return;
   }
 
-  // Update tasks snapshot for container to read
+  // Update tasks snapshot for container to read (filtered by group)
+  const isMain = task.group_folder === MAIN_GROUP_FOLDER;
   const tasks = getAllTasks();
-  writeTasksSnapshot(tasks.map(t => ({
+  writeTasksSnapshot(task.group_folder, isMain, tasks.map(t => ({
     id: t.id,
     groupFolder: t.group_folder,
     prompt: t.prompt,
@@ -56,7 +57,6 @@ async function runTask(task: ScheduledTask, deps: SchedulerDependencies): Promis
   let error: string | null = null;
 
   try {
-    const isMain = task.group_folder === MAIN_GROUP_FOLDER;
     const output = await runContainerAgent(group, {
       prompt: task.prompt,
       groupFolder: task.group_folder,


### PR DESCRIPTION
Each container now gets its own IPC directory (/data/ipc/{groupFolder}/)
instead of a shared global directory. Identity is determined by which
directory a request came from, not by self-reported data in IPC files.

Authorization enforced:
- send_message: only to chatJids belonging to the source group
- schedule_task: only for the source group (main can target any)
- pause/resume/cancel_task: only for tasks owned by source group

https://claude.ai/code/session_018nmxNEbtgJH7cKDyBSQGAw