### PR TITLE
Replace IPC busy-loop polling with async fs.watch

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,5 @@ export const MAIN_GROUP_FOLDER = 'main';
 
 export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
 export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '300000', 10);
-export const IPC_POLL_INTERVAL = 1000;
 
 export const TRIGGER_PATTERN = new RegExp(`^@${ASSISTANT_NAME}\\b`, 'i');


### PR DESCRIPTION
- Use fs.watch for event-driven file watching instead of setTimeout polling
- Replace synchronous fs calls (readdirSync, readFileSync, unlinkSync, renameSync)
  with async fs.promises equivalents to avoid blocking the event loop
- Add simple coalescing via pending flags to prevent redundant processing
- Remove unused IPC_POLL_INTERVAL config constant

https://claude.ai/code/session_01Lccp65bZyEMMbDdF7d9E4j