### PR TITLE
Fix: only update lastAgentTimestamp on agent success

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,9 +86,8 @@ async function processMessage(msg: NewMessage): Promise<void> {
   const response = await runAgent(group, prompt, msg.chat_jid);
   await setTyping(msg.chat_jid, false);
 
-  lastAgentTimestamp[msg.chat_jid] = msg.timestamp;
-
   if (response) {
+    lastAgentTimestamp[msg.chat_jid] = msg.timestamp;
     await sendMessage(msg.chat_jid, `${ASSISTANT_NAME}: ${response}`);
   }
 }


### PR DESCRIPTION
Previously, lastAgentTimestamp was updated regardless of whether
runAgent succeeded or failed. This caused messages to be skipped
on retry after a failure since they were already marked as processed.

Now the timestamp is only advanced when the agent returns a valid
response, ensuring failed messages will be included in the next retry.

https://claude.ai/code/session_0118wNAJCKY2Asr17Lb91TE2