### PR TITLE
Escape special regex characters in assistant name trigger pattern

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,11 @@ export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || 'nanoclaw-agent:la
 export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '300000', 10);
 export const IPC_POLL_INTERVAL = 1000;
 
-export const TRIGGER_PATTERN = new RegExp(`^@${ASSISTANT_NAME}\\b`, 'i');
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const TRIGGER_PATTERN = new RegExp(`^@${escapeRegex(ASSISTANT_NAME)}\\b`, 'i');
 
 // Timezone for scheduled tasks (cron expressions, etc.)
 // Uses system timezone by default


### PR DESCRIPTION
## Summary
Fixed a potential bug where special regex characters in the `ASSISTANT_NAME` environment variable could break the trigger pattern matching or cause unintended regex behavior.

## Changes
- Added `escapeRegex()` utility function to properly escape special regex metacharacters
- Updated `TRIGGER_PATTERN` to use the escaped assistant name, preventing regex injection vulnerabilities
- This ensures the trigger pattern matches the literal assistant name regardless of what characters it contains

## Details
Previously, if `ASSISTANT_NAME` contained regex special characters (e.g., `my-bot`, `bot.ai`, `bot[1]`), these would be interpreted as regex operators rather than literal characters. This could cause:
- Pattern matching failures when the name contains characters like `.`, `*`, `+`, etc.
- Unintended regex behavior or security issues

The fix escapes all regex metacharacters in the assistant name before constructing the trigger pattern, ensuring reliable and safe pattern matching.

https://claude.ai/code/session_01Lvuxq73qa9S4rtmGpX1WsP