### PR TITLE
feat: add prompt trace logging for internal and external flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
 
+# Prompt trace logging (disabled by default).
+# Stores JSONL events with inbound prompts, runner inputs, and outputs.
+# PROMPT_TRACE_ENABLED=false
+# PROMPT_TRACE_REDACT=true
+# PROMPT_TRACE_INCLUDE_INTERNAL=true
+# PROMPT_TRACE_MAX_CHARS=20000
+# PROMPT_TRACE_DIR=logs/prompt-trace

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -19,6 +19,7 @@ import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 import { CONTAINER_RUNTIME_BIN, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { validateAdditionalMounts } from './mount-security.js';
+import { inferChannelFromJid, tracePromptEvent } from './prompt-trace.js';
 import { RegisteredGroup } from './types.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
@@ -254,6 +255,19 @@ export async function runContainerAgent(
     },
     'Spawning container agent',
   );
+  tracePromptEvent({
+    event: 'runner_input_prompt',
+    direction: 'internal',
+    groupFolder: group.folder,
+    chatJid: input.chatJid,
+    channel: inferChannelFromJid(input.chatJid),
+    sessionId: input.sessionId,
+    payload: input.prompt,
+    meta: {
+      isMain: input.isMain,
+      isScheduledTask: !!input.isScheduledTask,
+    },
+  });
 
   const logsDir = path.join(GROUPS_DIR, group.folder, 'logs');
   fs.mkdirSync(logsDir, { recursive: true });
@@ -318,6 +332,20 @@ export async function runContainerAgent(
             if (parsed.newSessionId) {
               newSessionId = parsed.newSessionId;
             }
+            tracePromptEvent({
+              event: 'runner_stream_output',
+              direction: 'internal',
+              groupFolder: group.folder,
+              chatJid: input.chatJid,
+              channel: inferChannelFromJid(input.chatJid),
+              sessionId: parsed.newSessionId || newSessionId || input.sessionId,
+              payload: parsed.result,
+              meta: {
+                status: parsed.status,
+                hasResult: parsed.result != null,
+                error: parsed.error,
+              },
+            });
             hadStreamingOutput = true;
             // Activity detected — reset the hard timeout
             resetTimeout();
@@ -325,6 +353,18 @@ export async function runContainerAgent(
             // so idle timers start even for "silent" query completions.
             outputChain = outputChain.then(() => onOutput(parsed));
           } catch (err) {
+            tracePromptEvent({
+              event: 'runner_stream_parse_error',
+              direction: 'internal',
+              groupFolder: group.folder,
+              chatJid: input.chatJid,
+              channel: inferChannelFromJid(input.chatJid),
+              sessionId: newSessionId || input.sessionId,
+              payload: jsonStr,
+              meta: {
+                error: err instanceof Error ? err.message : String(err),
+              },
+            });
             logger.warn(
               { group: group.name, error: err },
               'Failed to parse streamed output chunk',
@@ -387,6 +427,20 @@ export async function runContainerAgent(
       const duration = Date.now() - startTime;
 
       if (timedOut) {
+        tracePromptEvent({
+          event: 'runner_timeout',
+          direction: 'internal',
+          groupFolder: group.folder,
+          chatJid: input.chatJid,
+          channel: inferChannelFromJid(input.chatJid),
+          sessionId: newSessionId || input.sessionId,
+          meta: {
+            durationMs: duration,
+            configTimeoutMs: configTimeout,
+            exitCode: code,
+            hadStreamingOutput,
+          },
+        });
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         const timeoutLog = path.join(logsDir, `container-${ts}.log`);
         fs.writeFileSync(timeoutLog, [
@@ -488,6 +542,19 @@ export async function runContainerAgent(
       logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
 
       if (code !== 0) {
+        tracePromptEvent({
+          event: 'runner_exit_error',
+          direction: 'internal',
+          groupFolder: group.folder,
+          chatJid: input.chatJid,
+          channel: inferChannelFromJid(input.chatJid),
+          sessionId: newSessionId || input.sessionId,
+          payload: stderr.slice(-2000),
+          meta: {
+            exitCode: code,
+            durationMs: duration,
+          },
+        });
         logger.error(
           {
             group: group.name,
@@ -542,6 +609,19 @@ export async function runContainerAgent(
         }
 
         const output: ContainerOutput = JSON.parse(jsonLine);
+        tracePromptEvent({
+          event: 'runner_output_legacy',
+          direction: 'internal',
+          groupFolder: group.folder,
+          chatJid: input.chatJid,
+          channel: inferChannelFromJid(input.chatJid),
+          sessionId: output.newSessionId || input.sessionId,
+          payload: output.result,
+          meta: {
+            status: output.status,
+            error: output.error,
+          },
+        });
 
         logger.info(
           {
@@ -555,6 +635,18 @@ export async function runContainerAgent(
 
         resolve(output);
       } catch (err) {
+        tracePromptEvent({
+          event: 'runner_output_parse_error',
+          direction: 'internal',
+          groupFolder: group.folder,
+          chatJid: input.chatJid,
+          channel: inferChannelFromJid(input.chatJid),
+          sessionId: newSessionId || input.sessionId,
+          payload: stdout.slice(-2000),
+          meta: {
+            error: err instanceof Error ? err.message : String(err),
+          },
+        });
         logger.error(
           {
             group: group.name,
@@ -575,6 +667,17 @@ export async function runContainerAgent(
 
     container.on('error', (err) => {
       clearTimeout(timeout);
+      tracePromptEvent({
+        event: 'runner_spawn_error',
+        direction: 'internal',
+        groupFolder: group.folder,
+        chatJid: input.chatJid,
+        channel: inferChannelFromJid(input.chatJid),
+        sessionId: input.sessionId,
+        meta: {
+          error: err.message,
+        },
+      });
       logger.error({ group: group.name, containerName, error: err }, 'Container spawn error');
       resolve({
         status: 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
+import { inferChannelFromJid, tracePromptEvent } from './prompt-trace.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -144,6 +145,19 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
 
   const prompt = formatMessages(missedMessages);
+  tracePromptEvent({
+    event: 'agent_prompt_ready',
+    direction: 'external',
+    groupFolder: group.folder,
+    chatJid,
+    channel: inferChannelFromJid(chatJid),
+    sessionId: sessions[group.folder],
+    payload: prompt,
+    meta: {
+      messageCount: missedMessages.length,
+      isMainGroup,
+    },
+  });
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -179,6 +193,18 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      tracePromptEvent({
+        event: 'agent_output_filtered',
+        direction: 'external',
+        groupFolder: group.folder,
+        chatJid,
+        channel: inferChannelFromJid(chatJid),
+        sessionId: sessions[group.folder],
+        payload: text,
+        meta: {
+          rawLength: raw.length,
+        },
+      });
       if (text) {
         await channel.sendMessage(chatJid, text);
         outputSentToUser = true;
@@ -188,6 +214,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     }
 
     if (result.status === 'error') {
+      tracePromptEvent({
+        event: 'agent_output_error',
+        direction: 'internal',
+        groupFolder: group.folder,
+        chatJid,
+        channel: inferChannelFromJid(chatJid),
+        sessionId: sessions[group.folder],
+        meta: {
+          error: result.error || 'unknown',
+        },
+      });
       hadError = true;
     }
   });
@@ -356,6 +393,18 @@ async function startMessageLoop(): Promise<void> {
           const messagesToSend =
             allPending.length > 0 ? allPending : groupMessages;
           const formatted = formatMessages(messagesToSend);
+          tracePromptEvent({
+            event: 'active_container_followup_prompt',
+            direction: 'internal',
+            groupFolder: group.folder,
+            chatJid,
+            channel: inferChannelFromJid(chatJid),
+            sessionId: sessions[group.folder],
+            payload: formatted,
+            meta: {
+              messageCount: messagesToSend.length,
+            },
+          });
 
           if (queue.sendMessage(chatJid, formatted)) {
             logger.debug(
@@ -421,7 +470,23 @@ async function main(): Promise<void> {
 
   // Channel callbacks (shared by all channels)
   const channelOpts = {
-    onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onMessage: (chatJid: string, msg: NewMessage) => {
+      tracePromptEvent({
+        event: 'channel_inbound_message',
+        direction: 'external',
+        groupFolder: registeredGroups[chatJid]?.folder,
+        chatJid,
+        channel: inferChannelFromJid(chatJid),
+        payload: msg.content,
+        meta: {
+          sender: msg.sender,
+          senderName: msg.sender_name,
+          timestamp: msg.timestamp,
+          isFromMe: !!msg.is_from_me,
+        },
+      });
+      storeMessage(msg);
+    },
     onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
       storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
     registeredGroups: () => registeredGroups,
@@ -444,14 +509,40 @@ async function main(): Promise<void> {
         console.log(`Warning: no channel owns JID ${jid}, cannot send message`);
         return;
       }
+      tracePromptEvent({
+        event: 'scheduler_output_raw',
+        direction: 'internal',
+        groupFolder: registeredGroups[jid]?.folder,
+        chatJid: jid,
+        channel: inferChannelFromJid(jid),
+        payload: rawText,
+      });
       const text = formatOutbound(rawText);
-      if (text) await channel.sendMessage(jid, text);
+      if (text) {
+        tracePromptEvent({
+          event: 'scheduler_output_outbound',
+          direction: 'external',
+          groupFolder: registeredGroups[jid]?.folder,
+          chatJid: jid,
+          channel: inferChannelFromJid(jid),
+          payload: text,
+        });
+        await channel.sendMessage(jid, text);
+      }
     },
   });
   startIpcWatcher({
     sendMessage: (jid, text) => {
       const channel = findChannel(channels, jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      tracePromptEvent({
+        event: 'ipc_outbound_message',
+        direction: 'external',
+        groupFolder: registeredGroups[jid]?.folder,
+        chatJid: jid,
+        channel: inferChannelFromJid(jid),
+        payload: text,
+      });
       return channel.sendMessage(jid, text);
     },
     registeredGroups: () => registeredGroups,

--- a/src/prompt-trace.test.ts
+++ b/src/prompt-trace.test.ts
@@ -1,0 +1,123 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  _resetPromptTraceCacheForTests,
+  tracePromptEvent,
+} from './prompt-trace.js';
+
+const TRACKED_ENV_KEYS = [
+  'PROMPT_TRACE_ENABLED',
+  'PROMPT_TRACE_REDACT',
+  'PROMPT_TRACE_INCLUDE_INTERNAL',
+  'PROMPT_TRACE_MAX_CHARS',
+  'PROMPT_TRACE_DIR',
+  'ANTHROPIC_API_KEY',
+] as const;
+
+function restoreEnv(snapshot: Partial<Record<(typeof TRACKED_ENV_KEYS)[number], string | undefined>>): void {
+  for (const key of TRACKED_ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe('prompt trace logger', () => {
+  const envSnapshot: Partial<Record<(typeof TRACKED_ENV_KEYS)[number], string | undefined>> = {};
+  let tempDir = '';
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+    _resetPromptTraceCacheForTests();
+  });
+
+  it('does not write files when disabled', () => {
+    for (const key of TRACKED_ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+    }
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-trace-'));
+    process.env.PROMPT_TRACE_ENABLED = 'false';
+    process.env.PROMPT_TRACE_DIR = tempDir;
+
+    _resetPromptTraceCacheForTests();
+    tracePromptEvent({
+      event: 'disabled-check',
+      direction: 'external',
+      payload: 'hello world',
+    });
+
+    expect(fs.readdirSync(tempDir)).toEqual([]);
+  });
+
+  it('writes redacted and truncated payload when enabled', () => {
+    for (const key of TRACKED_ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+    }
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-trace-'));
+    process.env.PROMPT_TRACE_ENABLED = 'true';
+    process.env.PROMPT_TRACE_REDACT = 'true';
+    process.env.PROMPT_TRACE_MAX_CHARS = '24';
+    process.env.PROMPT_TRACE_DIR = tempDir;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-super-secret-value';
+
+    _resetPromptTraceCacheForTests();
+    tracePromptEvent({
+      event: 'redaction-check',
+      direction: 'external',
+      groupFolder: 'main',
+      chatJid: 'tg:123',
+      payload: 'Token sk-ant-super-secret-value and extra content for truncation',
+    });
+
+    const filePath = path.join(tempDir, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    const content = fs.readFileSync(filePath, 'utf8').trim();
+    const record = JSON.parse(content) as { payload: string; truncated: boolean; payloadLength: number };
+
+    expect(record.payload).toContain('[REDACTED]');
+    expect(record.truncated).toBe(true);
+    expect(record.payloadLength).toBeGreaterThan(24);
+    expect(record.payload).toContain('[TRUNCATED');
+  });
+
+  it('skips internal events when internal tracing is disabled', () => {
+    for (const key of TRACKED_ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+    }
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-trace-'));
+    process.env.PROMPT_TRACE_ENABLED = 'true';
+    process.env.PROMPT_TRACE_INCLUDE_INTERNAL = 'false';
+    process.env.PROMPT_TRACE_DIR = tempDir;
+
+    _resetPromptTraceCacheForTests();
+    tracePromptEvent({
+      event: 'internal-should-skip',
+      direction: 'internal',
+      payload: 'internal text',
+    });
+    tracePromptEvent({
+      event: 'external-should-write',
+      direction: 'external',
+      payload: 'external text',
+    });
+
+    const filePath = path.join(tempDir, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    const lines = fs.readFileSync(filePath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0]) as { event: string };
+    expect(record.event).toBe('external-should-write');
+  });
+});

--- a/src/prompt-trace.ts
+++ b/src/prompt-trace.ts
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+import { logger } from './logger.js';
+
+const TRACE_CONFIG_KEYS = [
+  'PROMPT_TRACE_ENABLED',
+  'PROMPT_TRACE_REDACT',
+  'PROMPT_TRACE_MAX_CHARS',
+  'PROMPT_TRACE_DIR',
+  'PROMPT_TRACE_INCLUDE_INTERNAL',
+];
+
+const SECRET_ENV_KEYS = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'TELEGRAM_BOT_TOKEN',
+  'OPENAI_API_KEY',
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+  'CURSOR_API_KEY',
+];
+
+const CACHE_TTL_MS = 5_000;
+const DEFAULT_MAX_CHARS = 20_000;
+const DEFAULT_TRACE_DIR = path.resolve(process.cwd(), 'logs', 'prompt-trace');
+
+export type PromptTraceDirection = 'external' | 'internal';
+
+export interface PromptTraceEventInput {
+  event: string;
+  direction: PromptTraceDirection;
+  groupFolder?: string;
+  chatJid?: string;
+  channel?: string;
+  sessionId?: string;
+  payload?: string | null;
+  meta?: Record<string, unknown>;
+}
+
+interface PromptTraceSettings {
+  enabled: boolean;
+  redact: boolean;
+  includeInternal: boolean;
+  maxChars: number;
+  traceDir: string;
+  secrets: string[];
+}
+
+let cachedSettings: PromptTraceSettings | null = null;
+let cachedAt = 0;
+
+function parseBoolean(
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value == null || value === '') return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return defaultValue;
+}
+
+function parsePositiveInt(value: string | undefined, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return defaultValue;
+  return parsed;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function readSettings(): PromptTraceSettings {
+  const now = Date.now();
+  if (cachedSettings && now - cachedAt < CACHE_TTL_MS) {
+    return cachedSettings;
+  }
+
+  const fileEnv = readEnvFile([...TRACE_CONFIG_KEYS, ...SECRET_ENV_KEYS]);
+  const envValue = (key: string): string | undefined =>
+    process.env[key] ?? fileEnv[key];
+
+  const secrets = unique(
+    SECRET_ENV_KEYS
+      .map((key) => envValue(key))
+      .filter((value): value is string => !!value && value.length >= 4),
+  ).sort((a, b) => b.length - a.length);
+
+  cachedSettings = {
+    enabled: parseBoolean(envValue('PROMPT_TRACE_ENABLED'), false),
+    redact: parseBoolean(envValue('PROMPT_TRACE_REDACT'), true),
+    includeInternal: parseBoolean(envValue('PROMPT_TRACE_INCLUDE_INTERNAL'), true),
+    maxChars: parsePositiveInt(envValue('PROMPT_TRACE_MAX_CHARS'), DEFAULT_MAX_CHARS),
+    traceDir: path.resolve(envValue('PROMPT_TRACE_DIR') || DEFAULT_TRACE_DIR),
+    secrets,
+  };
+  cachedAt = now;
+  return cachedSettings;
+}
+
+function redactPayload(payload: string, secrets: string[]): string {
+  let out = payload;
+  for (const secret of secrets) {
+    out = out.split(secret).join('[REDACTED]');
+  }
+  out = out.replace(/sk-ant-[A-Za-z0-9_-]+/g, '[REDACTED_ANTHROPIC_KEY]');
+  out = out.replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, '[REDACTED_GITHUB_TOKEN]');
+  out = out.replace(/\b(?:xoxb|xoxp)-[A-Za-z0-9-]+\b/g, '[REDACTED_SLACK_TOKEN]');
+  return out;
+}
+
+function normalizePayload(
+  payload: string | null | undefined,
+  settings: PromptTraceSettings,
+): { payload?: string; payloadLength: number; truncated: boolean } {
+  if (payload == null) {
+    return { payloadLength: 0, truncated: false };
+  }
+
+  let processed = settings.redact
+    ? redactPayload(payload, settings.secrets)
+    : payload;
+  const payloadLength = processed.length;
+
+  let truncated = false;
+  if (processed.length > settings.maxChars) {
+    truncated = true;
+    const omitted = processed.length - settings.maxChars;
+    processed = `${processed.slice(0, settings.maxChars)}...[TRUNCATED ${omitted} chars]`;
+  }
+
+  return {
+    payload: processed,
+    payloadLength,
+    truncated,
+  };
+}
+
+export function inferChannelFromJid(jid: string | undefined): string | undefined {
+  if (!jid) return undefined;
+  if (jid.startsWith('tg:')) return 'telegram';
+  if (jid.startsWith('dc:')) return 'discord';
+  if (jid.endsWith('@g.us') || jid.endsWith('@s.whatsapp.net')) return 'whatsapp';
+  return undefined;
+}
+
+export function tracePromptEvent(input: PromptTraceEventInput): void {
+  const settings = readSettings();
+  if (!settings.enabled) return;
+  if (input.direction === 'internal' && !settings.includeInternal) return;
+
+  const ts = new Date().toISOString();
+  const normalized = normalizePayload(input.payload, settings);
+  const datePart = ts.slice(0, 10);
+  const filePath = path.join(settings.traceDir, `${datePart}.jsonl`);
+
+  const record: Record<string, unknown> = {
+    ts,
+    event: input.event,
+    direction: input.direction,
+    groupFolder: input.groupFolder,
+    chatJid: input.chatJid,
+    channel: input.channel,
+    sessionId: input.sessionId,
+    payloadLength: normalized.payloadLength,
+    truncated: normalized.truncated,
+    payload: normalized.payload,
+    meta: input.meta,
+  };
+
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) {
+      delete record[key];
+    }
+  }
+
+  try {
+    fs.mkdirSync(settings.traceDir, { recursive: true });
+    fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`, 'utf8');
+  } catch (err) {
+    logger.warn(
+      { err, filePath },
+      'Failed to write prompt trace event',
+    );
+  }
+}
+
+/** @internal - for tests only */
+export function _resetPromptTraceCacheForTests(): void {
+  cachedSettings = null;
+  cachedAt = 0;
+}


### PR DESCRIPTION
## Summary
- add prompt-trace logging for NanoClaw prompt/response flow
- capture internal and external events to JSONL files
- support configurable redaction, truncation, and internal-event filtering

## What is logged
- inbound user/channel message content
- prompts sent to agent runner
- streamed runner outputs and parse/spawn/timeout errors
- outbound/scheduler/IPC message payloads

## Configuration
- `PROMPT_TRACE_ENABLED`
- `PROMPT_TRACE_REDACT`
- `PROMPT_TRACE_INCLUDE_INTERNAL`
- `PROMPT_TRACE_MAX_CHARS`
- `PROMPT_TRACE_DIR`

## Tests
- adds `src/prompt-trace.test.ts`
- `npm test`
- `npm run build`
