### PR TITLE
fix: always register first channel to hardcoded "main" folder

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -120,7 +120,10 @@ AskUserQuestion: Shared number or dedicated? → AskUserQuestion: Trigger word? 
 
 ## 8. Register Channel
 
-Run `npx tsx setup/index.ts --step register -- --jid "JID" --name "main" --trigger "@TriggerWord" --folder "main"` plus `--no-trigger-required` if personal/DM/solo, `--assistant-name "Name"` if not Andy.
+Run `npx tsx setup/index.ts --step register -- --jid "JID" --name "DISPLAY_NAME" --trigger "@TriggerWord" --folder "main"` plus `--no-trigger-required` if personal/DM/solo, `--assistant-name "Name"` if not Andy.
+
+- `--name` → the WhatsApp group or chat display name (e.g. `"My Bot Group"`). Use the actual name from step 7.
+- `--folder` → **always the literal string `"main"`**. Do NOT replace this with the group name or any other value. The primary channel workspace folder is always `main`.
 
 ## 9. Mount Allowlist
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Fixes #375

During setup the AI agent was substituting the WhatsApp group display name as the `--folder` argument to the register step, creating e.g. `groups/my-bot-group` instead of `groups/main`. Because `MAIN_GROUP_FOLDER` is hardcoded to `'main'` in `config.ts`, the agent then operated with reduced permissions with no visible indication that anything was wrong.

### Two-layer fix

**1. `setup/register.ts` — code-level safety net**

If no groups have been registered yet and the caller supplies a folder name other than `MAIN_GROUP_FOLDER`, the value is silently overridden to `'main'` and a warning is logged. This guards against any caller (not just the setup skill) making the same mistake.

**2. `.claude/skills/setup/SKILL.md` — prompt hardening**

Step 8 previously showed `--name "main" --folder "main"` — both tokens looked like placeholders, so an LLM would replace *both* with the group display name. The fix:
- Renames the `--name` placeholder to `DISPLAY_NAME` so it is obviously a variable.
- Adds an explicit note that `--folder` must always be the literal string `"main"` and must never be substituted.

### Tests

Two new unit tests added to `setup/register.test.ts`:
- Override applied when no groups exist and wrong folder is supplied.
- Override NOT applied when groups already exist (intentional secondary registrations are allowed).