### PR TITLE
feat(security): add network isolation for non-main containers

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,6 +21,11 @@ Agents execute in containers (lightweight Linux VMs), providing:
 
 This is the primary security boundary. Rather than relying on application-level permission checks, the attack surface is limited by what's mounted.
 
+**Network Isolation:**
+- Non-main containers run with `--network none` by default, preventing data exfiltration
+- Main containers have full network access (needed for WebFetch/WebSearch tools)
+- Override per-group via `containerConfig.networkMode: 'full' | 'none'`
+
 ### 2. Mount Security
 
 **External Allowlist** - Mount permissions stored at `~/.config/nanoclaw/mount-allowlist.json`, which is:
@@ -90,7 +95,7 @@ const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
 | Group folder | `/workspace/group` (rw) | `/workspace/group` (rw) |
 | Global memory | Implicit via project | `/workspace/global` (ro) |
 | Additional mounts | Configurable | Read-only unless allowed |
-| Network access | Unrestricted | Unrestricted |
+| Network access | Full (default) | None (default, configurable) |
 | MCP tools | All | All |
 
 ## Security Architecture Diagram
@@ -117,7 +122,7 @@ const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
 │  • Agent execution                                                │
 │  • Bash commands (sandboxed)                                      │
 │  • File operations (limited to mounts)                            │
-│  • Network access (unrestricted)                                  │
+│  • Network access (none for non-main, full for main)              │
 │  • Cannot modify security config                                  │
 └──────────────────────────────────────────────────────────────────┘
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface AllowedRoot {
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  networkMode?: 'full' | 'none'; // Default: 'full' for main, 'none' for non-main
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION
## Summary

- Non-main containers now run with `--network none` by default, preventing data exfiltration via network
- Main containers retain full network access (needed for `WebFetch`/`WebSearch` tools)
- Per-group override via `containerConfig.networkMode: 'full' | 'none'`

## Motivation

Containers currently have unrestricted network access (`docs/SECURITY.md` line 93). Combined with `bypassPermissions` mode, a prompt-injected agent can exfiltrate mounted filesystem data and API credentials to attacker-controlled servers. Issue #411 demonstrates this attack in practice.

Docker's `--network none` completely disables container networking at the kernel level. This is the simplest and most robust mitigation — no iptables rules, no proxy containers, no allowlists to maintain.

## Behavior

| Group type | Default `networkMode` | Network access |
|------------|----------------------|----------------|
| Main | `'full'` | Unrestricted (WebFetch/WebSearch work) |
| Non-main | `'none'` | Disabled (no outbound/inbound) |

Override per-group by setting `containerConfig.networkMode` in the group registration:

```json
{
  "containerConfig": {
    "networkMode": "full"
  }
}
```

## Breaking change

Non-main groups that rely on `WebFetch`, `WebSearch`, or outbound HTTP from Bash will need to explicitly set `networkMode: 'full'` in their `containerConfig`. This is an intentional security-by-default change.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `networkMode?: 'full' \| 'none'` to `ContainerConfig` |
| `src/container-runner.ts` | `buildContainerArgs()` applies `--network none` for non-main containers by default |
| `src/container-runner.test.ts` | 4 new tests: default non-main (none), default main (full), non-main override to full, main override to none |
| `docs/SECURITY.md` | Updated privilege table, architecture diagram, and container isolation section |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 384/384 tests pass (380 existing + 4 new)

## Related issues

- Closes #458
- Related: #411 (indirect prompt injection + exfiltration)
- Related: #398 (WebFetch/WebSearch attenuation — complementary)
- Related: #232 / PR #216 (credential exposure — network restriction limits exfiltration even if credentials are accessed)