### PR TITLE
fix: filter protocol messages before processing in WhatsApp handler

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -172,6 +172,15 @@ export class WhatsAppChannel implements Channel {
     this.sock.ev.on('messages.upsert', async ({ messages }) => {
       for (const msg of messages) {
         if (!msg.message) continue;
+        // Skip protocol/system messages that aren't user-generated content.
+        // These are delivered as messages.upsert but carry no user text —
+        // e.g. encryption key distribution, ephemeral timer changes,
+        // reactions, message edits/deletions.
+        // Note: senderKeyDistributionMessage is NOT filtered here because
+        // group messages often include it alongside actual text content
+        // (key rotation happens transparently within normal messages).
+        const m = msg.message;
+        if (m.protocolMessage || m.reactionMessage || m.editedMessage) continue;
         const rawJid = msg.key.remoteJid;
         if (!rawJid || rawJid === 'status@broadcast') continue;
 


### PR DESCRIPTION
## Summary

- Skip `protocolMessage`, `reactionMessage`, and `editedMessage` early in the `messages.upsert` handler
- These system messages carry no user text but still trigger JID translation, metadata updates, and content extraction — wasting cycles and polluting chat metadata timestamps
- `senderKeyDistributionMessage` is intentionally **not** filtered because WhatsApp bundles it alongside actual text content during group key rotation

## Test plan

- [ ] Send a text message in a registered group → delivered normally
- [ ] React to a message with an emoji → no container invocation, no metadata timestamp pollution
- [ ] Edit a previously sent message → filtered (WhatsApp delivers edits as a separate `editedMessage`)
- [ ] Send a message in a group with key rotation → `senderKeyDistributionMessage` is preserved alongside the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)