### PR TITLE
feat(slack): reply in threads instead of flattening to channel

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -219,7 +219,7 @@ The Slack channel supports:
 
 ## Known Limitations
 
-- **Threads are flattened** — Threaded replies are delivered to the agent as regular channel messages. The agent sees them but has no awareness they originated in a thread. Responses always go to the channel, not back into the thread. Users in a thread will need to check the main channel for the bot's reply. Full thread-aware routing (respond in-thread) requires pipeline-wide changes: database schema, `NewMessage` type, `Channel.sendMessage` interface, and routing logic.
+- **Thread support is best-effort** — The bot replies in the same thread as the most recent inbound message. However, if multiple threads in the same channel are active concurrently, the last message's thread wins. Full per-message thread routing requires passing thread context through the `Channel.sendMessage` interface.
 - **No typing indicator** — Slack's Bot API does not expose a typing indicator endpoint. The `setTyping()` method is a no-op. Users won't see "bot is typing..." while the agent works.
 - **Message splitting is naive** — Long messages are split at a fixed 4000-character boundary, which may break mid-word or mid-sentence. A smarter split (on paragraph or sentence boundaries) would improve readability.
 - **No file/image handling** — The bot only processes text content. File uploads, images, and rich message blocks are not forwarded to the agent.


### PR DESCRIPTION
## Summary
- Track `thread_ts` from incoming Slack messages and reply in the same thread
- Preserve thread context in the outgoing queue so queued/retried messages land in the correct thread
- Extract `postMessage()` helper to DRY the send + queue flush + message splitting logic
- Fix `msg.user` TypeScript narrowing (`string | undefined` passed to `resolveUserName`)

## Known limitation
If multiple threads in the same channel are active concurrently, the last inbound message's thread wins. Full per-message thread routing requires passing thread context through the `Channel.sendMessage` interface — left as a follow-up.

## Test plan
- [x] 460 tests pass (`npm test`)
- [x] Clean TypeScript build (`npm run build`)
- [x] Tested in live Slack workspace — bot replies in-thread when messaged in a thread
- [x] Messages to channel root still go to channel root

🤖 Generated with [Claude Code](https://claude.com/claude-code)