### PR TITLE
refactor: extract snapshot-writer from container-runner

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -621,66 +621,9 @@ export async function runContainerAgent(
   });
 }
 
-export function writeTasksSnapshot(
-  groupFolder: string,
-  isMain: boolean,
-  tasks: Array<{
-    id: string;
-    groupFolder: string;
-    prompt: string;
-    schedule_type: string;
-    schedule_value: string;
-    status: string;
-    next_run: string | null;
-  }>,
-): void {
-  // Write filtered tasks to the group's IPC directory
-  const groupIpcDir = resolveGroupIpcPath(groupFolder);
-  fs.mkdirSync(groupIpcDir, { recursive: true });
-
-  // Main sees all tasks, others only see their own
-  const filteredTasks = isMain
-    ? tasks
-    : tasks.filter((t) => t.groupFolder === groupFolder);
-
-  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
-  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
-}
-
-export interface AvailableGroup {
-  jid: string;
-  name: string;
-  lastActivity: string;
-  isRegistered: boolean;
-}
-
-/**
- * Write available groups snapshot for the container to read.
- * Only main group can see all available groups (for activation).
- * Non-main groups only see their own registration status.
- */
-export function writeGroupsSnapshot(
-  groupFolder: string,
-  isMain: boolean,
-  groups: AvailableGroup[],
-  registeredJids: Set<string>,
-): void {
-  const groupIpcDir = resolveGroupIpcPath(groupFolder);
-  fs.mkdirSync(groupIpcDir, { recursive: true });
-
-  // Main sees all groups; others see nothing (they can't activate groups)
-  const visibleGroups = isMain ? groups : [];
-
-  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
-  fs.writeFileSync(
-    groupsFile,
-    JSON.stringify(
-      {
-        groups: visibleGroups,
-        lastSync: new Date().toISOString(),
-      },
-      null,
-      2,
-    ),
-  );
-}
+// Re-export snapshot functions for backwards compatibility
+export {
+  AvailableGroup,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './snapshot-writer.js';

--- a/src/snapshot-writer.ts
+++ b/src/snapshot-writer.ts
@@ -1,0 +1,75 @@
+/**
+ * Snapshot writer for container IPC.
+ *
+ * Writes task and group snapshots to each group's IPC directory so the
+ * container agent can read current state without direct database access.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { resolveGroupIpcPath } from './group-folder.js';
+
+export interface AvailableGroup {
+  jid: string;
+  name: string;
+  lastActivity: string;
+  isRegistered: boolean;
+}
+
+export function writeTasksSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  tasks: Array<{
+    id: string;
+    groupFolder: string;
+    prompt: string;
+    schedule_type: string;
+    schedule_value: string;
+    status: string;
+    next_run: string | null;
+  }>,
+): void {
+  // Write filtered tasks to the group's IPC directory
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all tasks, others only see their own
+  const filteredTasks = isMain
+    ? tasks
+    : tasks.filter((t) => t.groupFolder === groupFolder);
+
+  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
+  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
+}
+
+/**
+ * Write available groups snapshot for the container to read.
+ * Only main group can see all available groups (for activation).
+ * Non-main groups only see their own registration status.
+ */
+export function writeGroupsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  groups: AvailableGroup[],
+  registeredJids: Set<string>,
+): void {
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all groups; others see nothing (they can't activate groups)
+  const visibleGroups = isMain ? groups : [];
+
+  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
+  fs.writeFileSync(
+    groupsFile,
+    JSON.stringify(
+      {
+        groups: visibleGroups,
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts snapshot writing functions (`writeTasksSnapshot`, `writeGroupsSnapshot`, `AvailableGroup`) from `container-runner.ts` into a dedicated `snapshot-writer.ts` module
- Reduces `container-runner.ts` to pure container orchestration — no more IPC file writing
- Re-exports maintained in `container-runner.ts` for backwards compatibility — zero changes needed in existing importers

## Changes

**New file: `src/snapshot-writer.ts`**
- `AvailableGroup` interface
- `writeTasksSnapshot(groupFolder, isMain, tasks)` — writes filtered tasks to IPC dir
- `writeGroupsSnapshot(groupFolder, isMain, groups, registeredJids)` — writes group list to IPC dir

**Modified: `src/container-runner.ts`**
- Replaces inline functions with re-exports from `./snapshot-writer.js`
- ~65 lines removed, replaced by 4-line re-export

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — 32 test files, 352 tests pass (same as before)
- [x] No changes to any importers — re-exports ensure full backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)