### PR TITLE
fix: prevent duplicate messages from message loop piping fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -391,8 +391,11 @@ async function startMessageLoop(): Promise<void> {
             lastAgentTimestamp[chatJid] || '',
             ASSISTANT_NAME,
           );
-          const messagesToSend =
-            allPending.length > 0 ? allPending : groupMessages;
+          if (allPending.length === 0) {
+            logger.debug({ chatJid }, 'No pending messages after cursor, skipping pipe');
+            continue;
+          }
+          const messagesToSend = allPending;
           const formatted = formatMessages(messagesToSend);
 
           if (queue.sendMessage(chatJid, formatted)) {


### PR DESCRIPTION
## Type of Change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Description

Fixes #529

The message loop's piping fallback logic causes duplicate agent responses when messages arrive in fast succession.

### Root Cause

The fallback pattern in the message loop:

```ts
const messagesToPipe = allPending.length > 0 ? allPending : groupMessages;
```

When the cursor has already advanced past `groupMessages` (they've been processed), but `allPending` is empty, this fallback re-sends the already-processed `groupMessages` to the agent — producing duplicate responses.

### Changes

- **Remove the `groupMessages` fallback** — use only `allPending` (messages after the cursor)
- **Skip piping when no pending messages exist** — guard the pipe call so we don't invoke the agent with an empty payload

### Testing

- Reproduced the duplicate message issue by sending multiple messages in quick succession
- Verified that after the fix, only genuinely pending messages are piped to the agent
- Confirmed normal single-message flow is unaffected