### PR TITLE
fix: avoid message loss and fragile timestamp comparison

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -363,9 +363,11 @@ export class WhatsAppChannel implements Channel {
         'Flushing outgoing message queue',
       );
       while (this.outgoingQueue.length > 0) {
-        const item = this.outgoingQueue.shift()!;
+        const item = this.outgoingQueue[0];
         // Send directly — queued items are already prefixed by sendMessage
         await this.sock.sendMessage(item.jid, { text: item.text });
+        // Only dequeue after a successful send to avoid losing messages on error
+        this.outgoingQueue.shift();
         logger.info(
           { jid: item.jid, length: item.text.length },
           'Queued message sent',

--- a/src/db.ts
+++ b/src/db.ts
@@ -314,7 +314,8 @@ export function getNewMessages(
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
-    if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+    if (!newTimestamp || new Date(row.timestamp) > new Date(newTimestamp))
+      newTimestamp = row.timestamp;
   }
 
   return { messages: rows, newTimestamp };


### PR DESCRIPTION
whatsapp: dequeue message only after successful send so a network error during flush does not silently drop the message.

db: use Date object comparison instead of string > for ISO 8601 timestamps to handle differing precision (e.g. Z vs .000Z).

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
