### PR TITLE
fix: setup group sync race condition and mount schema docs

### DIFF
--- a/setup/groups.test.ts
+++ b/setup/groups.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for setup/groups.ts fixes from issue #537.
+ *
+ * The sync script is an inline string executed via `node .sync-groups.mjs`.
+ * We can't run it without a live WhatsApp connection, but we CAN validate
+ * the script structure and the race-condition fix patterns.
+ */
+
+// Extract the sync script string the same way groups.ts builds it,
+// so we can inspect it for the required patterns.
+function getSyncScript(): string {
+  // This mirrors the inline script from setup/groups.ts (the `syncScript` const).
+  // We re-read it from the source file to stay in sync.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs');
+  const path = require('path');
+  const source = fs.readFileSync(
+    path.join(__dirname, 'groups.ts'),
+    'utf-8',
+  ) as string;
+
+  // Extract the template literal between the first ` and matching `
+  const startMarker = 'const syncScript = `';
+  const startIdx = source.indexOf(startMarker);
+  if (startIdx === -1) throw new Error('Could not find syncScript in groups.ts');
+  const contentStart = startIdx + startMarker.length;
+  const endIdx = source.indexOf('`;', contentStart);
+  if (endIdx === -1) throw new Error('Could not find end of syncScript');
+  return source.slice(contentStart, endIdx);
+}
+
+describe('sync script — race condition fix (#537)', () => {
+  let script: string;
+
+  it('can extract the sync script from groups.ts', () => {
+    script = getSyncScript();
+    expect(script).toBeTruthy();
+    expect(script.length).toBeGreaterThan(100);
+  });
+
+  it('declares a `done` flag before the connection handler', () => {
+    script = getSyncScript();
+    // The done flag must exist to prevent the close handler from racing
+    expect(script).toContain('let done = false');
+  });
+
+  it('sets `done = true` in the finally block (before sock.end)', () => {
+    script = getSyncScript();
+    const finallyIdx = script.indexOf('} finally {');
+    const doneSetIdx = script.indexOf('done = true', finallyIdx);
+    const sockEndIdx = script.indexOf('sock.end(', finallyIdx);
+    expect(finallyIdx).toBeGreaterThan(-1);
+    expect(doneSetIdx).toBeGreaterThan(finallyIdx);
+    // done = true must come before sock.end to prevent the race
+    expect(doneSetIdx).toBeLessThan(sockEndIdx);
+  });
+
+  it('guards the close handler with `!done`', () => {
+    script = getSyncScript();
+    // The close handler must check !done to skip exit(1) after successful sync
+    expect(script).toContain("update.connection === 'close' && !done");
+  });
+
+  it('exits with 0 on success, not 1', () => {
+    script = getSyncScript();
+    // The finally block should exit(0)
+    const finallyIdx = script.indexOf('} finally {');
+    const exitZeroIdx = script.indexOf('process.exit(0)', finallyIdx);
+    expect(exitZeroIdx).toBeGreaterThan(finallyIdx);
+  });
+});
+
+describe('sync script — fetchLatestWaWebVersion (#537)', () => {
+  it('imports fetchLatestWaWebVersion from baileys', () => {
+    const script = getSyncScript();
+    expect(script).toContain('fetchLatestWaWebVersion');
+  });
+
+  it('imports DisconnectReason from baileys', () => {
+    const script = getSyncScript();
+    expect(script).toContain('DisconnectReason');
+  });
+
+  it('fetches version before creating socket', () => {
+    const script = getSyncScript();
+    const versionFetchIdx = script.indexOf('fetchLatestWaWebVersion');
+    const makeSocketIdx = script.indexOf('makeWASocket(');
+    expect(versionFetchIdx).toBeGreaterThan(-1);
+    expect(makeSocketIdx).toBeGreaterThan(-1);
+    // Version fetch must happen before socket creation
+    expect(versionFetchIdx).toBeLessThan(makeSocketIdx);
+  });
+
+  it('passes version to makeWASocket', () => {
+    const script = getSyncScript();
+    // After makeWASocket({, version should appear before the closing })
+    const socketStart = script.indexOf('makeWASocket({');
+    const socketEnd = script.indexOf('});', socketStart);
+    const socketBlock = script.slice(socketStart, socketEnd);
+    expect(socketBlock).toContain('version');
+  });
+
+  it('has a graceful fallback if version fetch fails', () => {
+    const script = getSyncScript();
+    // Should catch errors and fallback to undefined version
+    expect(script).toMatch(/fetchLatestWaWebVersion.*\.catch/);
+  });
+});
+
+describe('sync script — temp file execution (#537)', () => {
+  it('writes to a .mjs temp file instead of using node -e', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, 'groups.ts'),
+      'utf-8',
+    ) as string;
+
+    // Should write to a temp .mjs file
+    expect(source).toContain('.sync-groups.mjs');
+    // Should use `node ${tmpScript}` not `node --input-type=module -e`
+    expect(source).toContain('node ${tmpScript}');
+    // Should NOT use the old node -e approach
+    expect(source).not.toContain('--input-type=module -e');
+  });
+
+  it('cleans up the temp file in a finally block', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, 'groups.ts'),
+      'utf-8',
+    ) as string;
+
+    // Should have fs.unlinkSync in a finally block
+    expect(source).toContain('fs.unlinkSync(tmpScript)');
+  });
+
+  it('logs disconnect reason code on CONNECTION_CLOSED', () => {
+    const script = getSyncScript();
+    // Should include status code in the error message
+    expect(script).toContain("'CONNECTION_CLOSED:'");
+    expect(script).toContain('statusCode');
+  });
+});

--- a/setup/mounts.test.ts
+++ b/setup/mounts.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import Database from 'better-sqlite3';
+
+import { AllowedRoot, MountAllowlist } from '../src/types.js';
+
+/**
+ * Tests for mount allowlist schema and per-group mount config (#537).
+ *
+ * Issue: setup/mounts.ts doesn't validate the allowlist schema, so users
+ * (or the setup agent) can pass `mode: "rw"` instead of `allowReadWrite: true`.
+ * The mount-security module then silently treats mounts as read-only because
+ * `allowReadWrite` is undefined (falsy).
+ *
+ * Also tests that container_config.additionalMounts uses the correct schema
+ * expected by container-runner.ts.
+ */
+
+// --- Allowlist schema tests ---
+
+describe('mount allowlist schema — allowReadWrite field (#537)', () => {
+  it('requires allowReadWrite as boolean, not mode as string', () => {
+    const correctRoot: AllowedRoot = {
+      path: '~/projects',
+      allowReadWrite: true,
+    };
+    expect(correctRoot.allowReadWrite).toBe(true);
+    expect(typeof correctRoot.allowReadWrite).toBe('boolean');
+  });
+
+  it('correctly typed allowlist has allowReadWrite on each root', () => {
+    const allowlist: MountAllowlist = {
+      allowedRoots: [
+        { path: '~/projects', allowReadWrite: true, description: 'Dev' },
+        { path: '~/docs', allowReadWrite: false, description: 'Docs' },
+      ],
+      blockedPatterns: [],
+      nonMainReadOnly: true,
+    };
+
+    for (const root of allowlist.allowedRoots) {
+      expect(root).toHaveProperty('allowReadWrite');
+      expect(typeof root.allowReadWrite).toBe('boolean');
+      // Should NOT have a `mode` field
+      expect(root).not.toHaveProperty('mode');
+    }
+  });
+
+  it('detects the common mistake of using mode instead of allowReadWrite', () => {
+    // This is what the setup agent incorrectly generated before the fix
+    const badRoot = {
+      path: '~/projects',
+      mode: 'rw', // WRONG — should be allowReadWrite: true
+    };
+
+    // The AllowedRoot type requires allowReadWrite, so this object is missing it
+    expect(badRoot).not.toHaveProperty('allowReadWrite');
+    // When cast to AllowedRoot, allowReadWrite would be undefined (falsy)
+    expect((badRoot as unknown as AllowedRoot).allowReadWrite).toBeUndefined();
+  });
+
+  it('config-examples/mount-allowlist.json uses correct schema', () => {
+    const examplePath = path.join(
+      __dirname,
+      '..',
+      'config-examples',
+      'mount-allowlist.json',
+    );
+    const content = fs.readFileSync(examplePath, 'utf-8');
+    const parsed = JSON.parse(content) as MountAllowlist;
+
+    // Validate structure
+    expect(Array.isArray(parsed.allowedRoots)).toBe(true);
+    expect(Array.isArray(parsed.blockedPatterns)).toBe(true);
+    expect(typeof parsed.nonMainReadOnly).toBe('boolean');
+
+    // Every root must use allowReadWrite, not mode
+    for (const root of parsed.allowedRoots) {
+      expect(root).toHaveProperty('allowReadWrite');
+      expect(typeof root.allowReadWrite).toBe('boolean');
+      expect(root).not.toHaveProperty('mode');
+    }
+  });
+});
+
+// --- SKILL.md documentation tests ---
+
+describe('SKILL.md mount instructions (#537)', () => {
+  let skillContent: string;
+
+  beforeEach(() => {
+    skillContent = fs.readFileSync(
+      path.join(__dirname, '..', '.claude', 'skills', 'setup', 'SKILL.md'),
+      'utf-8',
+    );
+  });
+
+  it('documents allowReadWrite (not mode) in step 9', () => {
+    expect(skillContent).toContain('allowReadWrite');
+    // Should explicitly warn against using `mode`
+    expect(skillContent).toMatch(/NOT.*mode/i);
+  });
+
+  it('includes step 9b for additionalMounts in container_config', () => {
+    expect(skillContent).toContain('9b');
+    expect(skillContent).toContain('additionalMounts');
+    expect(skillContent).toContain('container_config');
+  });
+
+  it('shows the correct additionalMounts schema in step 9b', () => {
+    expect(skillContent).toContain('hostPath');
+    expect(skillContent).toContain('containerPath');
+    expect(skillContent).toContain('readonly');
+  });
+
+  it('warns that allowlist alone is not enough', () => {
+    // The skill doc should explain that step 9b is required
+    expect(skillContent).toMatch(/without step 9b/i);
+  });
+});
+
+// --- Per-group container_config tests ---
+
+describe('container_config additionalMounts schema (#537)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`CREATE TABLE IF NOT EXISTS registered_groups (
+      jid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      folder TEXT NOT NULL UNIQUE,
+      trigger_pattern TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      container_config TEXT,
+      requires_trigger INTEGER DEFAULT 1
+    )`);
+
+    db.prepare(
+      `INSERT INTO registered_groups
+       (jid, name, folder, trigger_pattern, added_at, requires_trigger)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('123@g.us', 'Main', 'main', '@Bot', '2024-01-01T00:00:00Z', 0);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('stores additionalMounts with correct field names', () => {
+    const config = JSON.stringify({
+      additionalMounts: [
+        { hostPath: '/home/user/projects', containerPath: 'projects', readonly: false },
+      ],
+    });
+
+    db.prepare(
+      "UPDATE registered_groups SET container_config = ? WHERE folder = 'main'",
+    ).run(config);
+
+    const row = db
+      .prepare("SELECT container_config FROM registered_groups WHERE folder = 'main'")
+      .get() as { container_config: string };
+
+    const parsed = JSON.parse(row.container_config);
+    expect(parsed.additionalMounts).toHaveLength(1);
+    expect(parsed.additionalMounts[0]).toHaveProperty('hostPath');
+    expect(parsed.additionalMounts[0]).toHaveProperty('containerPath');
+    expect(parsed.additionalMounts[0]).toHaveProperty('readonly');
+    // Should NOT use `mode`
+    expect(parsed.additionalMounts[0]).not.toHaveProperty('mode');
+  });
+
+  it('round-trips container_config correctly', () => {
+    const config = {
+      additionalMounts: [
+        { hostPath: '/home/user/projects', containerPath: 'projects', readonly: false },
+        { hostPath: '/home/user/docs', readonly: true },
+      ],
+    };
+
+    db.prepare(
+      "UPDATE registered_groups SET container_config = ? WHERE folder = 'main'",
+    ).run(JSON.stringify(config));
+
+    const row = db
+      .prepare("SELECT container_config FROM registered_groups WHERE folder = 'main'")
+      .get() as { container_config: string };
+
+    const parsed = JSON.parse(row.container_config);
+    expect(parsed).toEqual(config);
+  });
+
+  it('container_config can be null when no mounts needed', () => {
+    const row = db
+      .prepare("SELECT container_config FROM registered_groups WHERE folder = 'main'")
+      .get() as { container_config: string | null };
+
+    expect(row.container_config).toBeNull();
+  });
+
+  it('mount without additionalMounts in DB means no extra mounts', () => {
+    // Even if allowlist exists, no additionalMounts in container_config = no mounts
+    const row = db
+      .prepare("SELECT container_config FROM registered_groups WHERE folder = 'main'")
+      .get() as { container_config: string | null };
+
+    const config = row.container_config ? JSON.parse(row.container_config) : {};
+    const mounts = config.additionalMounts || [];
+    expect(mounts).toHaveLength(0);
+  });
+});
+
+// --- Allowlist file write/read integration ---
+
+describe('mount allowlist file format (#537)', () => {
+  let tmpDir: string;
+  let configFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-test-'));
+    configFile = path.join(tmpDir, 'mount-allowlist.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes valid allowlist with allowReadWrite booleans', () => {
+    const allowlist: MountAllowlist = {
+      allowedRoots: [
+        { path: '~/projects', allowReadWrite: true, description: 'Dev' },
+      ],
+      blockedPatterns: [],
+      nonMainReadOnly: true,
+    };
+
+    fs.writeFileSync(configFile, JSON.stringify(allowlist, null, 2) + '\n');
+    const read = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+
+    expect(read.allowedRoots[0].allowReadWrite).toBe(true);
+    expect(read.allowedRoots[0]).not.toHaveProperty('mode');
+  });
+
+  it('rejects allowlist missing required fields', () => {
+    // Missing blockedPatterns and nonMainReadOnly
+    const bad = { allowedRoots: [{ path: '~/x' }] };
+    fs.writeFileSync(configFile, JSON.stringify(bad));
+    const read = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+
+    // The mount-security loader validates these
+    expect(read.blockedPatterns).toBeUndefined();
+    expect(read.nonMainReadOnly).toBeUndefined();
+    // allowReadWrite is missing — this would cause mounts to be read-only
+    expect(read.allowedRoots[0].allowReadWrite).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs encountered during `/setup`:

- **Group sync script**: Failed to execute due to escaped newlines in `node -e` invocation, then had a race condition where `sock.end()` triggered a `CONNECTION_CLOSED` handler that raced with the successful `process.exit(0)`. Fixed by writing to a temp `.mjs` file and adding a `done` flag to skip the close handler after sync completes. Also added `fetchLatestWaWebVersion` for compatibility with the main app's connection pattern.
- **Mount setup docs (SKILL.md step 9)**: The setup skill instructions were missing the correct allowlist schema (`allowReadWrite: boolean` field) and entirely missing the step to write `additionalMounts` to the group's `container_config` in SQLite — meaning mounts were *permitted* but never actually *configured*.

## Test plan

- [x] Run `/setup` fresh — verify group sync completes on first attempt
- [x] Configure mounts during setup — verify agent can access directories at `/workspace/extra/`
- [x] Verify allowlist file uses `allowReadWrite: boolean` (not `mode: "rw"`)

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)