### PR TITLE
fix: render Markdown in Telegram messages

### DIFF
--- a/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
@@ -14,6 +14,11 @@ vi.mock('../config.js', () => ({
   TRIGGER_PATTERN: /^@Andy\b/i,
 }));
 
+// Pass-through: conversion logic is the library's responsibility, not ours
+vi.mock('telegramify-markdown', () => ({
+  default: (text: string) => text,
+}));
+
 // Mock logger
 vi.mock('../logger.js', () => ({
   logger: {
@@ -710,6 +715,7 @@ describe('TelegramChannel', () => {
       expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
         '100200300',
         'Hello',
+        { parse_mode: 'MarkdownV2' },
       );
     });
 
@@ -723,6 +729,7 @@ describe('TelegramChannel', () => {
       expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
         '-1001234567890',
         'Group message',
+        { parse_mode: 'MarkdownV2' },
       );
     });
 
@@ -739,11 +746,13 @@ describe('TelegramChannel', () => {
         1,
         '100200300',
         'x'.repeat(4096),
+        { parse_mode: 'MarkdownV2' },
       );
       expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
         2,
         '100200300',
         'x'.repeat(904),
+        { parse_mode: 'MarkdownV2' },
       );
     });
 

--- a/.claude/skills/add-telegram/add/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.ts
@@ -1,4 +1,5 @@
 import { Bot } from 'grammy';
+import telegramifyMarkdown from 'telegramify-markdown';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -200,15 +201,20 @@ export class TelegramChannel implements Channel {
     try {
       const numericId = jid.replace(/^tg:/, '');
 
+      const formatted = telegramifyMarkdown(text, 'escape');
+
       // Telegram has a 4096 character limit per message — split if needed
       const MAX_LENGTH = 4096;
-      if (text.length <= MAX_LENGTH) {
-        await this.bot.api.sendMessage(numericId, text);
+      if (formatted.length <= MAX_LENGTH) {
+        await this.bot.api.sendMessage(numericId, formatted, {
+          parse_mode: 'MarkdownV2',
+        });
       } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+        for (let i = 0; i < formatted.length; i += MAX_LENGTH) {
           await this.bot.api.sendMessage(
             numericId,
-            text.slice(i, i + MAX_LENGTH),
+            formatted.slice(i, i + MAX_LENGTH),
+            { parse_mode: 'MarkdownV2' },
           );
         }
       }

--- a/.claude/skills/add-telegram/manifest.yaml
+++ b/.claude/skills/add-telegram/manifest.yaml
@@ -10,6 +10,7 @@ modifies:
 structured:
   npm_dependencies:
     grammy: "^1.39.3"
+    telegramify-markdown: "^1.3.2"
   env_additions:
     - TELEGRAM_BOT_TOKEN
 conflicts: []


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [X] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Telegram has [a weird flavor of Markdown](https://core.telegram.org/bots/api#formatting-options). It needs to be explicitly enabled as `parse_mode`, and even then, certain characters need to be escaped. Therefore, a new 3rd party dependency is introduced that does the conversion.


## For Skills

- [X] I have not made any changes to source code
- [X] My skill contains instructions for Claude to follow (not pre-built code)
- [X] I tested this skill on a fresh clone
