### PR TITLE
feat: add skill for claude-mem cross-session memory integration

### DIFF
--- a/.claude/skills/add-claude-mem/CLAUDE_MEM_SETUP.md
+++ b/.claude/skills/add-claude-mem/CLAUDE_MEM_SETUP.md
@@ -1,0 +1,208 @@
+# claude-mem Setup Reference
+
+Detailed installation and configuration reference for the claude-mem integration with NanoClaw.
+
+## Plugin Installation
+
+### Via Claude Code CLI
+
+```bash
+claude plugins add thedotmack/claude-mem
+```
+
+This installs to `~/.claude/plugins/cache/thedotmack/claude-mem/<version>/`.
+
+### Verify Installation
+
+```bash
+# Check plugin exists
+ls ~/.claude/plugins/cache/thedotmack/claude-mem/
+
+# Check MCP server script
+ls ~/.claude/plugins/cache/thedotmack/claude-mem/*/scripts/mcp-server.cjs
+
+# Check worker script
+ls ~/.claude/plugins/cache/thedotmack/claude-mem/*/scripts/worker.cjs
+```
+
+## Worker Configuration
+
+### Settings File
+
+Location: `~/.claude-mem/settings.json`
+
+```json
+{
+  "workerHost": "0.0.0.0",
+  "workerPort": 37777
+}
+```
+
+| Setting | Default | NanoClaw Requirement |
+|---------|---------|---------------------|
+| `workerHost` | `127.0.0.1` | Must be `0.0.0.0` — Docker containers connect via bridge network |
+| `workerPort` | `37777` | Default is fine unless port conflicts exist |
+
+### Why 0.0.0.0?
+
+Docker containers use `host.docker.internal` (resolved via `--add-host=host.docker.internal:host-gateway`) to reach the host. This resolves to the Docker bridge IP (typically `172.17.0.1`), not `127.0.0.1`. If the worker only listens on localhost, containers can't connect.
+
+## Service Templates
+
+### Linux (systemd)
+
+File: `~/.config/systemd/user/claude-mem-worker.service`
+
+```ini
+[Unit]
+Description=claude-mem worker
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node %h/.claude/plugins/cache/thedotmack/claude-mem/latest/scripts/worker.cjs
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target
+```
+
+Commands:
+```bash
+systemctl --user daemon-reload
+systemctl --user enable claude-mem-worker
+systemctl --user start claude-mem-worker
+systemctl --user status claude-mem-worker
+
+# View logs
+journalctl --user -u claude-mem-worker -f
+
+# Restart
+systemctl --user restart claude-mem-worker
+```
+
+> **Note**: `%h` expands to `$HOME` in systemd unit files. The `latest` directory should be a symlink or the actual version directory.
+
+### macOS (launchd)
+
+File: `~/Library/LaunchAgents/com.claude-mem.worker.plist`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-mem.worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/Users/YOUR_USER/.claude/plugins/cache/thedotmack/claude-mem/latest/scripts/worker.cjs</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/claude-mem-worker.err</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/claude-mem-worker.out</string>
+</dict>
+</plist>
+```
+
+Commands:
+```bash
+# Load (start + enable on login)
+launchctl load ~/Library/LaunchAgents/com.claude-mem.worker.plist
+
+# Unload
+launchctl unload ~/Library/LaunchAgents/com.claude-mem.worker.plist
+
+# View logs
+tail -f /tmp/claude-mem-worker.err
+```
+
+## Connectivity Architecture
+
+```
+Docker Container (agent)
+  └─ mcp-server.cjs (MCP stdio)
+       └─ HTTP → host.docker.internal:37777
+                   │
+                   ▼
+Host Machine
+  └─ worker.cjs (HTTP server)
+       └─ SQLite → ~/.claude-mem/memory.db
+```
+
+### Network Flow
+
+1. `container-runner.ts` adds `--add-host=host.docker.internal:host-gateway` to Docker run args
+2. `container-runner.ts` mounts `~/.claude/plugins/cache/.../scripts/` to `/opt/claude-mem/scripts/` (read-only)
+3. `agent-runner/index.ts` checks if `/opt/claude-mem/scripts/mcp-server.cjs` exists
+4. If yes, registers `mcp-search` MCP server with `CLAUDE_MEM_WORKER_HOST=host.docker.internal`
+5. Agent tools (`mcp__mcp-search__*`) make HTTP calls to `host.docker.internal:37777`
+6. Worker processes requests against the SQLite database
+
+### Per-Group Isolation
+
+Each NanoClaw group gets an isolated memory namespace via `CLAUDE_MEM_PROJECT=<groupFolder>`. Group `main`'s observations are separate from group `my-project`'s observations.
+
+## Troubleshooting
+
+### Worker won't start
+
+```bash
+# Check Node.js version (18+ required)
+node --version
+
+# Try running manually
+node ~/.claude/plugins/cache/thedotmack/claude-mem/*/scripts/worker.cjs
+```
+
+### Port already in use
+
+```bash
+# Find what's using port 37777
+lsof -i :37777
+
+# Kill it or change the port in settings.json
+```
+
+### Container can't reach worker
+
+```bash
+# Test from a Docker container
+docker run --rm --add-host=host.docker.internal:host-gateway alpine wget -qO- http://host.docker.internal:37777/health
+
+# If this fails, check:
+# 1. Worker is running and bound to 0.0.0.0
+# 2. No firewall blocking port 37777 from Docker bridge
+# 3. Docker daemon supports --add-host (most versions do)
+```
+
+### Database issues
+
+```bash
+# Check database exists
+ls -la ~/.claude-mem/
+
+# Check database size
+du -h ~/.claude-mem/memory.db
+
+# Test a search (from host, not container)
+curl -s http://localhost:37777/api/search?query=test
+```
+
+### Plugin version mismatch
+
+```bash
+# List installed versions
+ls ~/.claude/plugins/cache/thedotmack/claude-mem/
+
+# findClaudeMemScripts() picks the last version alphabetically
+# If you have multiple versions and need a specific one, remove the others
+```

--- a/.claude/skills/add-claude-mem/SKILL.md
+++ b/.claude/skills/add-claude-mem/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: add-claude-mem
+description: Add cross-session memory to NanoClaw agents via claude-mem MCP server. Agents can search, store, and recall observations across conversations. Runs on the host — no npm dependencies.
+---
+
+# Add Cross-Session Memory (claude-mem)
+
+This skill adds persistent cross-session memory to NanoClaw agents using the [claude-mem](https://github.com/thedotmack/claude-mem) MCP server. After setup, agents can search past conversations, recall decisions, and build on prior work across sessions.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `claude-mem` is in `applied_skills`, skip to Phase 3 (Install claude-mem). The code changes are already in place.
+
+### Check prerequisites
+
+1. Claude Code CLI must be installed and working
+2. Docker must be running (containers need `--add-host` support)
+3. The host machine must be Linux or macOS (claude-mem worker uses systemd or launchd)
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-claude-mem
+```
+
+This deterministically:
+- Exports `HOME_DIR` from `src/config.ts` (was a local const)
+- Adds `findClaudeMemScripts()` to `src/container-runner.ts` (discovers plugin cache)
+- Adds claude-mem volume mount and `--add-host=host.docker.internal:host-gateway`
+- Adds `mcp__mcp-search__*` to allowed tools in `container/agent-runner/src/index.ts`
+- Adds conditional mcp-search MCP server configuration
+- Adds `HOME_DIR` mock to `src/container-runner.test.ts`
+
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/config.ts.intent.md`
+- `modify/src/container-runner.ts.intent.md`
+- `modify/src/container-runner.test.ts.intent.md`
+- `modify/container/agent-runner/src/index.ts.intent.md`
+
+### Validate code changes
+
+```bash
+npx vitest run src/container-runner.test.ts
+npm run build
+```
+
+All tests must pass and build must be clean before proceeding.
+
+## Phase 3: Install claude-mem
+
+### Install the plugin
+
+Install claude-mem as a Claude Code plugin:
+
+```bash
+claude plugins add thedotmack/claude-mem
+```
+
+This installs the plugin to `~/.claude/plugins/cache/thedotmack/claude-mem/<version>/`.
+
+### Verify installation
+
+```bash
+ls ~/.claude/plugins/cache/thedotmack/claude-mem/*/scripts/mcp-server.cjs
+```
+
+Should show the mcp-server.cjs file. If not, the plugin install may have failed.
+
+## Phase 4: Configure Worker
+
+The claude-mem worker needs to:
+1. Bind to `0.0.0.0` (not just localhost) so Docker containers can reach it
+2. Run as a background service
+
+### Configure settings
+
+Create or update `~/.claude-mem/settings.json`:
+
+```json
+{
+  "workerHost": "0.0.0.0",
+  "workerPort": 37777
+}
+```
+
+See [CLAUDE_MEM_SETUP.md](CLAUDE_MEM_SETUP.md) for the full settings reference.
+
+### Create systemd service (Linux)
+
+Create `~/.config/systemd/user/claude-mem-worker.service`:
+
+```ini
+[Unit]
+Description=claude-mem worker
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node %h/.claude/plugins/cache/thedotmack/claude-mem/latest/scripts/worker.cjs
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target
+```
+
+> **Note**: Replace `latest` with the actual version directory name if there's no `latest` symlink. Check with `ls ~/.claude/plugins/cache/thedotmack/claude-mem/`.
+
+Enable and start:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable claude-mem-worker
+systemctl --user start claude-mem-worker
+systemctl --user status claude-mem-worker
+```
+
+### Create launchd plist (macOS)
+
+Create `~/Library/LaunchAgents/com.claude-mem.worker.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-mem.worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/Users/YOUR_USER/.claude/plugins/cache/thedotmack/claude-mem/latest/scripts/worker.cjs</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/claude-mem-worker.err</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/claude-mem-worker.out</string>
+</dict>
+</plist>
+```
+
+Load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.claude-mem.worker.plist
+```
+
+## Phase 5: Rebuild Container
+
+The container image doesn't need rebuilding — the MCP server scripts are bind-mounted from the host. But you do need to rebuild if the agent-runner source changed:
+
+```bash
+./container/build.sh
+```
+
+Then restart NanoClaw:
+
+```bash
+# Linux
+systemctl --user restart nanoclaw
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 6: Verify
+
+### Health check
+
+Check the worker is running:
+
+```bash
+curl -s http://localhost:37777/health
+```
+
+Should return a JSON response.
+
+### Docker bridge connectivity
+
+From a test container, verify the host is reachable:
+
+```bash
+docker run --rm --add-host=host.docker.internal:host-gateway alpine wget -qO- http://host.docker.internal:37777/health
+```
+
+### Test message
+
+Send a message to any registered channel mentioning the assistant. The agent should have access to memory tools (`mcp__mcp-search__*`). Check the container logs:
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+Look for MCP server registration messages indicating `mcp-search` was loaded.
+
+## Troubleshooting
+
+### Agent doesn't have memory tools
+
+1. Check claude-mem is installed: `ls ~/.claude/plugins/cache/thedotmack/claude-mem/*/scripts/mcp-server.cjs`
+2. Check worker is running: `curl http://localhost:37777/health`
+3. Check container logs for MCP registration errors
+4. Rebuild container: `./container/build.sh`
+
+### Worker not reachable from containers
+
+1. Verify worker binds to `0.0.0.0`: check `~/.claude-mem/settings.json`
+2. Test Docker bridge: `docker run --rm --add-host=host.docker.internal:host-gateway alpine wget -qO- http://host.docker.internal:37777/health`
+3. Check firewall rules (port 37777 must be accessible from Docker bridge network)
+
+### Memory not persisting
+
+1. Check worker logs: `journalctl --user -u claude-mem-worker` (Linux) or `/tmp/claude-mem-worker.err` (macOS)
+2. Verify the database exists: `ls ~/.claude-mem/`
+3. Check per-group isolation: each group folder maps to a separate `CLAUDE_MEM_PROJECT`
+
+## Architecture
+
+```
+Host Machine                          Docker Container
+┌─────────────────────┐               ┌─────────────────────┐
+│ claude-mem worker    │               │ agent-runner         │
+│ (port 37777)         │◄──────────────│                     │
+│                      │  HTTP via     │ mcp-server.cjs      │
+│ ~/.claude-mem/db     │  host.docker  │ (MCP stdio server)  │
+│                      │  .internal    │                     │
+│ ~/.claude/plugins/   │               │ /opt/claude-mem/    │
+│   cache/thedotmack/  │──mount(ro)──→│   scripts/          │
+│   claude-mem/v/      │               │                     │
+│   scripts/           │               │                     │
+└─────────────────────┘               └─────────────────────┘
+```
+
+## Known Limitations
+
+- **Host-only worker** — The claude-mem worker runs on the host machine, not in containers. It cannot be containerized because it needs persistent database access.
+- **Single-node only** — The worker binds to one host. Multi-node NanoClaw setups would need a shared worker or database.
+- **Plugin version tracking** — `findClaudeMemScripts()` picks the lexicographically last version directory. If the plugin cache has multiple versions, it always uses the latest alphabetically (which should be the newest semver).
+- **No automatic cleanup** — Observations accumulate indefinitely. Manual database pruning may be needed for long-running installations.

--- a/.claude/skills/add-claude-mem/manifest.yaml
+++ b/.claude/skills/add-claude-mem/manifest.yaml
@@ -1,0 +1,14 @@
+skill: claude-mem
+version: 1.0.0
+description: "Cross-session memory for NanoClaw agents via claude-mem MCP server"
+core_version: 0.1.0
+adds: []
+modifies:
+  - src/config.ts
+  - src/container-runner.ts
+  - src/container-runner.test.ts
+  - container/agent-runner/src/index.ts
+structured: {}
+conflicts: []
+depends: []
+test: "npx vitest run src/container-runner.test.ts"

--- a/.claude/skills/add-claude-mem/modify/container/agent-runner/src/index.ts
+++ b/.claude/skills/add-claude-mem/modify/container/agent-runner/src/index.ts
@@ -1,0 +1,600 @@
+/**
+ * NanoClaw Agent Runner
+ * Runs inside a container, receives config via stdin, outputs result to stdout
+ *
+ * Input protocol:
+ *   Stdin: Full ContainerInput JSON (read until EOF, like before)
+ *   IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
+ *          Files: {type:"message", text:"..."}.json — polled and consumed
+ *          Sentinel: /workspace/ipc/input/_close — signals session end
+ *
+ * Stdout protocol:
+ *   Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
+ *   Multiple results may be emitted (one per agent teams result).
+ *   Final marker after loop ends signals completion.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { fileURLToPath } from 'url';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+/**
+ * Push-based async iterable for streaming user messages to the SDK.
+ * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
+ */
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    log(`Sessions index not found at ${indexPath}`);
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch (err) {
+    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return null;
+}
+
+/**
+ * Archive the full transcript to conversations/ before compaction.
+ */
+function createPreCompactHook(assistantName?: string): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+
+      if (messages.length === 0) {
+        log('No messages to archive');
+        return {};
+      }
+
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `${date}-${name}.md`;
+      const filePath = path.join(conversationsDir, filename);
+
+      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      fs.writeFileSync(filePath, markdown);
+
+      log(`Archived conversation to ${filePath}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {};
+  };
+}
+
+// Secrets to strip from Bash tool subprocess environments.
+// These are needed by claude-code for API auth but should never
+// be visible to commands Kit runs.
+const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+function createSanitizeBashHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preInput = input as PreToolUseHookInput;
+    const command = (preInput.tool_input as { command?: string })?.command;
+    if (!command) return {};
+
+    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: {
+          ...(preInput.tool_input as Record<string, unknown>),
+          command: unsetPrefix + command,
+        },
+      },
+    };
+  };
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+    }
+  }
+
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Check for _close sentinel.
+ */
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drain all pending IPC input messages.
+ * Returns messages found, or empty array.
+ */
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Wait for a new IPC message or _close sentinel.
+ * Returns the messages as a single string, or null if _close.
+ */
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Run a single query and stream results via writeOutput.
+ * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
+ * allowing agent teams subagents to run to completion.
+ * Also pipes IPC messages into the stream during the query.
+ */
+async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+  const stream = new MessageStream();
+  stream.push(prompt);
+
+  // Poll IPC for follow-up messages and _close sentinel during the query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+  let messageCount = 0;
+  let resultCount = 0;
+
+  // Load global CLAUDE.md as additional system context (shared across all groups)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Discover additional directories mounted at /workspace/extra/*
+  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
+  const extraDirs: string[] = [];
+  const extraBase = '/workspace/extra';
+  if (fs.existsSync(extraBase)) {
+    for (const entry of fs.readdirSync(extraBase)) {
+      const fullPath = path.join(extraBase, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+  if (extraDirs.length > 0) {
+    log(`Additional directories: ${extraDirs.join(', ')}`);
+  }
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      cwd: '/workspace/group',
+      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+      resume: sessionId,
+      resumeSessionAt: resumeAt,
+      systemPrompt: globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        : undefined,
+      allowedTools: [
+        'Bash',
+        'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'WebSearch', 'WebFetch',
+        'Task', 'TaskOutput', 'TaskStop',
+        'TeamCreate', 'TeamDelete', 'SendMessage',
+        'TodoWrite', 'ToolSearch', 'Skill',
+        'NotebookEdit',
+        'mcp__nanoclaw__*',
+        'mcp__mcp-search__*',
+      ],
+      env: sdkEnv,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers: {
+        nanoclaw: {
+          command: 'node',
+          args: [mcpServerPath],
+          env: {
+            NANOCLAW_CHAT_JID: containerInput.chatJid,
+            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        ...(fs.existsSync('/opt/claude-mem/scripts/mcp-server.cjs') ? {
+          'mcp-search': {
+            command: 'node',
+            args: ['/opt/claude-mem/scripts/mcp-server.cjs'],
+            env: {
+              CLAUDE_MEM_WORKER_HOST: 'host.docker.internal',
+              CLAUDE_MEM_WORKER_PORT: '37777',
+              CLAUDE_MEM_PROJECT: containerInput.groupFolder,
+            },
+          },
+        } : {}),
+      },
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
+      },
+    }
+  })) {
+    messageCount++;
+    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    log(`[msg #${messageCount}] type=${msgType}`);
+
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      log(`Session initialized: ${newSessionId}`);
+    }
+
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+      const tn = message as { task_id: string; status: string; summary: string };
+      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    }
+
+    if (message.type === 'result') {
+      resultCount++;
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      writeOutput({
+        status: 'success',
+        result: textResult || null,
+        newSessionId
+      });
+    }
+  }
+
+  ipcPolling = false;
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+}
+
+async function main(): Promise<void> {
+  let containerInput: ContainerInput;
+
+  try {
+    const stdinData = await readStdin();
+    containerInput = JSON.parse(stdinData);
+    // Delete the temp file the entrypoint wrote — it contains secrets
+    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    log(`Received input for group: ${containerInput.groupFolder}`);
+  } catch (err) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+    });
+    process.exit(1);
+  }
+
+  // Build SDK env: merge secrets into process.env for the SDK only.
+  // Secrets never touch process.env itself, so Bash subprocesses can't see them.
+  const sdkEnv: Record<string, string | undefined> = { ...process.env };
+  for (const [key, value] of Object.entries(containerInput.secrets || {})) {
+    sdkEnv[key] = value;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+
+  let sessionId = containerInput.sessionId;
+  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+
+  // Clean up stale _close sentinel from previous container runs
+  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+
+  // Build initial prompt (drain any pending IPC messages too)
+  let prompt = containerInput.prompt;
+  if (containerInput.isScheduledTask) {
+    prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+  }
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
+    prompt += '\n' + pending.join('\n');
+  }
+
+  // Query loop: run query → wait for IPC message → run new query → repeat
+  let resumeAt: string | undefined;
+  try {
+    while (true) {
+      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+
+      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      if (queryResult.newSessionId) {
+        sessionId = queryResult.newSessionId;
+      }
+      if (queryResult.lastAssistantUuid) {
+        resumeAt = queryResult.lastAssistantUuid;
+      }
+
+      // If _close was consumed during the query, exit immediately.
+      // Don't emit a session-update marker (it would reset the host's
+      // idle timer and cause a 30-min delay before the next _close).
+      if (queryResult.closedDuringQuery) {
+        log('Close sentinel consumed during query, exiting');
+        break;
+      }
+
+      // Emit session update so host can track it
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+      log('Query ended, waiting for next IPC message...');
+
+      // Wait for the next message or _close sentinel
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      log(`Got new message (${nextMessage.length} chars), starting new query`);
+      prompt = nextMessage;
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log(`Agent error: ${errorMessage}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: sessionId,
+      error: errorMessage
+    });
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/add-claude-mem/modify/container/agent-runner/src/index.ts.intent.md
+++ b/.claude/skills/add-claude-mem/modify/container/agent-runner/src/index.ts.intent.md
@@ -1,0 +1,43 @@
+# Intent: container/agent-runner/src/index.ts modifications
+
+## What changed
+Added claude-mem MCP server registration and tool allowlisting inside the container agent.
+
+## Key sections
+
+### allowedTools array
+- Added: `'mcp__mcp-search__*'` — allows the agent to use all tools from the mcp-search MCP server (search, timeline, get_observations, smart_search, smart_unfold, smart_outline)
+- The wildcard pattern matches the Claude Code MCP tool naming convention: `mcp__<server-name>__<tool-name>`
+
+### mcpServers configuration
+- Added conditional mcp-search MCP server alongside the existing nanoclaw server
+- Uses spread operator with conditional: `...(fs.existsSync('/opt/claude-mem/scripts/mcp-server.cjs') ? { ... } : {})`
+- Only registers the server if the script exists at `/opt/claude-mem/scripts/mcp-server.cjs` (mounted from host by container-runner)
+- Environment variables:
+  - `CLAUDE_MEM_WORKER_HOST: 'host.docker.internal'` — resolves to the Docker host
+  - `CLAUDE_MEM_WORKER_PORT: '37777'` — default claude-mem worker port
+  - `CLAUDE_MEM_PROJECT: containerInput.groupFolder` — isolates memory per group
+
+## Invariants
+- The nanoclaw MCP server is always registered (unchanged)
+- The mcp-search server is only registered when the mount exists
+- All existing allowedTools entries are preserved
+- The hooks configuration is unchanged
+- All other query options are unchanged
+
+## Design decisions
+
+### Conditional registration
+The `fs.existsSync` check means the skill degrades gracefully — if claude-mem is not installed or the mount fails, agents work normally without memory tools. No errors, no warnings.
+
+### Per-group project isolation
+`CLAUDE_MEM_PROJECT: containerInput.groupFolder` ensures each NanoClaw group has isolated memory. Group A's observations are not visible to Group B's agents.
+
+### host.docker.internal
+The claude-mem worker runs on the host, not inside containers. Containers reach it via Docker's built-in `host.docker.internal` DNS entry (enabled by `--add-host` in container-runner.ts).
+
+## Must-keep
+- All existing MCP server configurations
+- The conditional pattern for mcp-search registration
+- The `mcp__mcp-search__*` entry in allowedTools
+- All existing hooks and query options

--- a/.claude/skills/add-claude-mem/modify/src/config.ts
+++ b/.claude/skills/add-claude-mem/modify/src/config.ts
@@ -1,0 +1,64 @@
+import os from 'os';
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+
+// Read config values from .env (falls back to process.env).
+// Secrets are NOT read here — they stay on disk and are loaded only
+// where needed (container-runner.ts) to avoid leaking to child processes.
+const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+
+export const ASSISTANT_NAME =
+  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
+export const ASSISTANT_HAS_OWN_NUMBER =
+  (process.env.ASSISTANT_HAS_OWN_NUMBER ||
+    envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
+export const POLL_INTERVAL = 2000;
+export const SCHEDULER_POLL_INTERVAL = 60000;
+
+// Absolute paths needed for container mounts
+const PROJECT_ROOT = process.cwd();
+export const HOME_DIR = process.env.HOME || os.homedir();
+
+// Mount security: allowlist stored OUTSIDE project root, never mounted into containers
+export const MOUNT_ALLOWLIST_PATH = path.join(
+  HOME_DIR,
+  '.config',
+  'nanoclaw',
+  'mount-allowlist.json',
+);
+export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
+export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
+export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+export const MAIN_GROUP_FOLDER = 'main';
+
+export const CONTAINER_IMAGE =
+  process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
+export const CONTAINER_TIMEOUT = parseInt(
+  process.env.CONTAINER_TIMEOUT || '1800000',
+  10,
+);
+export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
+  process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
+  10,
+); // 10MB default
+export const IPC_POLL_INTERVAL = 1000;
+export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const MAX_CONCURRENT_CONTAINERS = Math.max(
+  1,
+  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
+);
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const TRIGGER_PATTERN = new RegExp(
+  `^@${escapeRegex(ASSISTANT_NAME)}\\b`,
+  'i',
+);
+
+// Timezone for scheduled tasks (cron expressions, etc.)
+// Uses system timezone by default
+export const TIMEZONE =
+  process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/.claude/skills/add-claude-mem/modify/src/config.ts.intent.md
+++ b/.claude/skills/add-claude-mem/modify/src/config.ts.intent.md
@@ -1,0 +1,19 @@
+# Intent: src/config.ts modifications
+
+## What changed
+Exported `HOME_DIR` so container-runner.ts can import it for locating the claude-mem plugin cache.
+
+## Key sections
+- **HOME_DIR**: Changed from `const` to `export const`. Used by container-runner to find `~/.claude/plugins/cache/thedotmack/claude-mem/`.
+- No new env vars or readEnvFile changes — claude-mem runs on the host, not from config.
+
+## Invariants
+- All existing config exports remain unchanged
+- HOME_DIR value calculation is unchanged (`process.env.HOME || os.homedir()`)
+- The `import os` was already present before this skill
+- No new dependencies or env vars
+
+## Must-keep
+- All existing exports
+- The `readEnvFile` pattern for all config values
+- `escapeRegex` helper and `TRIGGER_PATTERN` construction

--- a/.claude/skills/add-claude-mem/modify/src/container-runner.test.ts
+++ b/.claude/skills/add-claude-mem/modify/src/container-runner.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+
+// Sentinel markers must match container-runner.ts
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+// Mock config
+vi.mock('./config.js', () => ({
+  CONTAINER_IMAGE: 'nanoclaw-agent:latest',
+  CONTAINER_MAX_OUTPUT_SIZE: 10485760,
+  CONTAINER_TIMEOUT: 1800000, // 30min
+  DATA_DIR: '/tmp/nanoclaw-test-data',
+  GROUPS_DIR: '/tmp/nanoclaw-test-groups',
+  HOME_DIR: '/tmp/nanoclaw-test-home',
+  IDLE_TIMEOUT: 1800000, // 30min
+  TIMEZONE: 'America/Los_Angeles',
+}));
+
+// Mock logger
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock fs
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      readFileSync: vi.fn(() => ''),
+      readdirSync: vi.fn(() => []),
+      statSync: vi.fn(() => ({ isDirectory: () => false })),
+      copyFileSync: vi.fn(),
+    },
+  };
+});
+
+// Mock mount-security
+vi.mock('./mount-security.js', () => ({
+  validateAdditionalMounts: vi.fn(() => []),
+}));
+
+// Create a controllable fake ChildProcess
+function createFakeProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new PassThrough();
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+let fakeProc: ReturnType<typeof createFakeProcess>;
+
+// Mock child_process.spawn
+vi.mock('child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(() => fakeProc),
+    exec: vi.fn(
+      (_cmd: string, _opts: unknown, cb?: (err: Error | null) => void) => {
+        if (cb) cb(null);
+        return new EventEmitter();
+      },
+    ),
+  };
+});
+
+import { runContainerAgent, ContainerOutput } from './container-runner.js';
+import type { RegisteredGroup } from './types.js';
+
+const testGroup: RegisteredGroup = {
+  name: 'Test Group',
+  folder: 'test-group',
+  trigger: '@Andy',
+  added_at: new Date().toISOString(),
+};
+
+const testInput = {
+  prompt: 'Hello',
+  groupFolder: 'test-group',
+  chatJid: 'test@g.us',
+  isMain: false,
+};
+
+function emitOutputMarker(
+  proc: ReturnType<typeof createFakeProcess>,
+  output: ContainerOutput,
+) {
+  const json = JSON.stringify(output);
+  proc.stdout.push(`${OUTPUT_START_MARKER}\n${json}\n${OUTPUT_END_MARKER}\n`);
+}
+
+describe('container-runner timeout behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('timeout after output resolves as success', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // Emit output with a result
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Here is my response',
+      newSessionId: 'session-123',
+    });
+
+    // Let output processing settle
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Fire the hard timeout (IDLE_TIMEOUT + 30s = 1830000ms)
+    await vi.advanceTimersByTimeAsync(1830000);
+
+    // Emit close event (as if container was stopped by the timeout)
+    fakeProc.emit('close', 137);
+
+    // Let the promise resolve
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+    expect(result.newSessionId).toBe('session-123');
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'Here is my response' }),
+    );
+  });
+
+  it('timeout with no output resolves as error', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // No output emitted — fire the hard timeout
+    await vi.advanceTimersByTimeAsync(1830000);
+
+    // Emit close event
+    fakeProc.emit('close', 137);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('timed out');
+    expect(onOutput).not.toHaveBeenCalled();
+  });
+
+  it('normal exit after output resolves as success', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    // Emit output
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Done',
+      newSessionId: 'session-456',
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Normal exit (no timeout)
+    fakeProc.emit('close', 0);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result.status).toBe('success');
+    expect(result.newSessionId).toBe('session-456');
+  });
+});

--- a/.claude/skills/add-claude-mem/modify/src/container-runner.test.ts.intent.md
+++ b/.claude/skills/add-claude-mem/modify/src/container-runner.test.ts.intent.md
@@ -1,0 +1,17 @@
+# Intent: src/container-runner.test.ts modifications
+
+## What changed
+Added `HOME_DIR` to the config mock so the test module satisfies the new import from container-runner.ts.
+
+## Key sections
+- **vi.mock('./config.js')**: Added `HOME_DIR: '/tmp/nanoclaw-test-home'` to the mock return object. Without this, `findClaudeMemScripts()` would fail trying to read `undefined/.claude/plugins/...`.
+
+## Invariants
+- All existing mock values are unchanged
+- All existing test cases are unchanged
+- The mock HOME_DIR points to a non-existent temp path, so `findClaudeMemScripts()` returns null (fs.existsSync is already mocked to return false)
+
+## Must-keep
+- All existing test cases and assertions
+- The fake process factory and output marker helpers
+- All other config mock values (CONTAINER_IMAGE, CONTAINER_MAX_OUTPUT_SIZE, etc.)

--- a/.claude/skills/add-claude-mem/modify/src/container-runner.ts
+++ b/.claude/skills/add-claude-mem/modify/src/container-runner.ts
@@ -1,0 +1,710 @@
+/**
+ * Container Runner for NanoClaw
+ * Spawns agent execution in containers and handles IPC
+ */
+import { ChildProcess, exec, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  CONTAINER_IMAGE,
+  CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_TIMEOUT,
+  DATA_DIR,
+  GROUPS_DIR,
+  HOME_DIR,
+  IDLE_TIMEOUT,
+  TIMEZONE,
+} from './config.js';
+import { readEnvFile } from './env.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+
+// Sentinel markers for robust output parsing (must match agent-runner)
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+function findClaudeMemScripts(): string | null {
+  const base = path.join(HOME_DIR, '.claude', 'plugins', 'cache', 'thedotmack', 'claude-mem');
+  if (!fs.existsSync(base)) return null;
+  const versions = fs.readdirSync(base).sort();
+  const latest = versions[versions.length - 1];
+  if (!latest) return null;
+  const scripts = path.join(base, latest, 'scripts');
+  return fs.existsSync(path.join(scripts, 'mcp-server.cjs')) ? scripts : null;
+}
+
+function buildVolumeMounts(
+  group: RegisteredGroup,
+  isMain: boolean,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+  const projectRoot = process.cwd();
+  const groupDir = resolveGroupFolderPath(group.folder);
+
+  if (isMain) {
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart.
+    mounts.push({
+      hostPath: projectRoot,
+      containerPath: '/workspace/project',
+      readonly: true,
+    });
+
+    // Main also gets its group folder as the working directory
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+  } else {
+    // Other groups only get their own folder
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+  }
+
+  // Per-group Claude sessions directory (isolated from other groups)
+  // Each group gets their own .claude/ to prevent cross-group session access
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(
+        {
+          env: {
+            // Enable agent swarms (subagent orchestration)
+            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            // Load CLAUDE.md from additional mounted directories
+            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+            // Enable Claude's memory feature (persists user preferences between sessions)
+            // https://code.claude.com/docs/en/memory#manage-auto-memory
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+
+  // Sync skills from container/skills/ into each group's .claude/skills/
+  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsDst = path.join(groupSessionsDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    for (const skillDir of fs.readdirSync(skillsSrc)) {
+      const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.statSync(srcDir).isDirectory()) continue;
+      const dstDir = path.join(skillsDst, skillDir);
+      fs.cpSync(srcDir, dstDir, { recursive: true });
+    }
+  }
+  mounts.push({
+    hostPath: groupSessionsDir,
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Per-group IPC namespace: each group gets its own IPC directory
+  // This prevents cross-group privilege escalation via IPC
+  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  mounts.push({
+    hostPath: groupIpcDir,
+    containerPath: '/workspace/ipc',
+    readonly: false,
+  });
+
+  // Copy agent-runner source into a per-group writable location so agents
+  // can customize it (add tools, change behavior) without affecting other
+  // groups. Recompiled on container startup via entrypoint.sh.
+  const agentRunnerSrc = path.join(
+    projectRoot,
+    'container',
+    'agent-runner',
+    'src',
+  );
+  const groupAgentRunnerDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    'agent-runner-src',
+  );
+  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
+  mounts.push({
+    hostPath: groupAgentRunnerDir,
+    containerPath: '/app/src',
+    readonly: false,
+  });
+
+  // Additional mounts validated against external allowlist (tamper-proof from containers)
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isMain,
+    );
+    mounts.push(...validatedMounts);
+  }
+
+  // claude-mem MCP server (read-only, optional)
+  const claudeMemScripts = findClaudeMemScripts();
+  if (claudeMemScripts) {
+    mounts.push({
+      hostPath: claudeMemScripts,
+      containerPath: '/opt/claude-mem/scripts',
+      readonly: true,
+    });
+  }
+
+  return mounts;
+}
+
+/**
+ * Read allowed secrets from .env for passing to the container via stdin.
+ * Secrets are never written to disk or mounted as files.
+ */
+function readSecrets(): Record<string, string> {
+  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+}
+
+function buildContainerArgs(
+  mounts: VolumeMount[],
+  containerName: string,
+): string[] {
+  const args: string[] = ['run', '-i', '--rm', '--name', containerName];
+
+  // Allow container to reach host services (e.g. claude-mem worker)
+  args.push('--add-host=host.docker.internal:host-gateway');
+
+  // Pass host timezone so container's local time matches the user's
+  args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Run as host user so bind-mounted files are accessible.
+  // Skip when running as root (uid 0), as the container's node user (uid 1000),
+  // or when getuid is unavailable (native Windows without WSL).
+  const hostUid = process.getuid?.();
+  const hostGid = process.getgid?.();
+  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+    args.push('--user', `${hostUid}:${hostGid}`);
+    args.push('-e', 'HOME=/home/node');
+  }
+
+  for (const mount of mounts) {
+    if (mount.readonly) {
+      args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
+    } else {
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  args.push(CONTAINER_IMAGE);
+
+  return args;
+}
+
+export async function runContainerAgent(
+  group: RegisteredGroup,
+  input: ContainerInput,
+  onProcess: (proc: ChildProcess, containerName: string) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+
+  const groupDir = resolveGroupFolderPath(group.folder);
+  fs.mkdirSync(groupDir, { recursive: true });
+
+  const mounts = buildVolumeMounts(group, input.isMain);
+  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const containerArgs = buildContainerArgs(mounts, containerName);
+
+  logger.debug(
+    {
+      group: group.name,
+      containerName,
+      mounts: mounts.map(
+        (m) =>
+          `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+      ),
+      containerArgs: containerArgs.join(' '),
+    },
+    'Container mount configuration',
+  );
+
+  logger.info(
+    {
+      group: group.name,
+      containerName,
+      mountCount: mounts.length,
+      isMain: input.isMain,
+    },
+    'Spawning container agent',
+  );
+
+  const logsDir = path.join(groupDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  return new Promise((resolve) => {
+    const container = spawn(CONTAINER_RUNTIME_BIN, containerArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    onProcess(container, containerName);
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    // Pass secrets via stdin (never written to disk or mounted as files)
+    input.secrets = readSecrets();
+    container.stdin.write(JSON.stringify(input));
+    container.stdin.end();
+    // Remove secrets from input so they don't appear in logs
+    delete input.secrets;
+
+    // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
+    let parseBuffer = '';
+    let newSessionId: string | undefined;
+    let outputChain = Promise.resolve();
+
+    container.stdout.on('data', (data) => {
+      const chunk = data.toString();
+
+      // Always accumulate for logging
+      if (!stdoutTruncated) {
+        const remaining = CONTAINER_MAX_OUTPUT_SIZE - stdout.length;
+        if (chunk.length > remaining) {
+          stdout += chunk.slice(0, remaining);
+          stdoutTruncated = true;
+          logger.warn(
+            { group: group.name, size: stdout.length },
+            'Container stdout truncated due to size limit',
+          );
+        } else {
+          stdout += chunk;
+        }
+      }
+
+      // Stream-parse for output markers
+      if (onOutput) {
+        parseBuffer += chunk;
+        let startIdx: number;
+        while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
+          const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);
+          if (endIdx === -1) break; // Incomplete pair, wait for more data
+
+          const jsonStr = parseBuffer
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+          parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
+
+          try {
+            const parsed: ContainerOutput = JSON.parse(jsonStr);
+            if (parsed.newSessionId) {
+              newSessionId = parsed.newSessionId;
+            }
+            hadStreamingOutput = true;
+            // Activity detected — reset the hard timeout
+            resetTimeout();
+            // Call onOutput for all markers (including null results)
+            // so idle timers start even for "silent" query completions.
+            outputChain = outputChain.then(() => onOutput(parsed));
+          } catch (err) {
+            logger.warn(
+              { group: group.name, error: err },
+              'Failed to parse streamed output chunk',
+            );
+          }
+        }
+      }
+    });
+
+    container.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      const lines = chunk.trim().split('\n');
+      for (const line of lines) {
+        if (line) logger.debug({ container: group.folder }, line);
+      }
+      // Don't reset timeout on stderr — SDK writes debug logs continuously.
+      // Timeout only resets on actual output (OUTPUT_MARKER in stdout).
+      if (stderrTruncated) return;
+      const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
+      if (chunk.length > remaining) {
+        stderr += chunk.slice(0, remaining);
+        stderrTruncated = true;
+        logger.warn(
+          { group: group.name, size: stderr.length },
+          'Container stderr truncated due to size limit',
+        );
+      } else {
+        stderr += chunk;
+      }
+    });
+
+    let timedOut = false;
+    let hadStreamingOutput = false;
+    const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+    // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
+    // graceful _close sentinel has time to trigger before the hard kill fires.
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const killOnTimeout = () => {
+      timedOut = true;
+      logger.error(
+        { group: group.name, containerName },
+        'Container timeout, stopping gracefully',
+      );
+      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+        if (err) {
+          logger.warn(
+            { group: group.name, containerName, err },
+            'Graceful stop failed, force killing',
+          );
+          container.kill('SIGKILL');
+        }
+      });
+    };
+
+    let timeout = setTimeout(killOnTimeout, timeoutMs);
+
+    // Reset the timeout whenever there's activity (streaming output)
+    const resetTimeout = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(killOnTimeout, timeoutMs);
+    };
+
+    container.on('close', (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      if (timedOut) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const timeoutLog = path.join(logsDir, `container-${ts}.log`);
+        fs.writeFileSync(
+          timeoutLog,
+          [
+            `=== Container Run Log (TIMEOUT) ===`,
+            `Timestamp: ${new Date().toISOString()}`,
+            `Group: ${group.name}`,
+            `Container: ${containerName}`,
+            `Duration: ${duration}ms`,
+            `Exit Code: ${code}`,
+            `Had Streaming Output: ${hadStreamingOutput}`,
+          ].join('\n'),
+        );
+
+        // Timeout after output = idle cleanup, not failure.
+        // The agent already sent its response; this is just the
+        // container being reaped after the idle period expired.
+        if (hadStreamingOutput) {
+          logger.info(
+            { group: group.name, containerName, duration, code },
+            'Container timed out after output (idle cleanup)',
+          );
+          outputChain.then(() => {
+            resolve({
+              status: 'success',
+              result: null,
+              newSessionId,
+            });
+          });
+          return;
+        }
+
+        logger.error(
+          { group: group.name, containerName, duration, code },
+          'Container timed out with no output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const logFile = path.join(logsDir, `container-${timestamp}.log`);
+      const isVerbose =
+        process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+
+      const logLines = [
+        `=== Container Run Log ===`,
+        `Timestamp: ${new Date().toISOString()}`,
+        `Group: ${group.name}`,
+        `IsMain: ${input.isMain}`,
+        `Duration: ${duration}ms`,
+        `Exit Code: ${code}`,
+        `Stdout Truncated: ${stdoutTruncated}`,
+        `Stderr Truncated: ${stderrTruncated}`,
+        ``,
+      ];
+
+      const isError = code !== 0;
+
+      if (isVerbose || isError) {
+        logLines.push(
+          `=== Input ===`,
+          JSON.stringify(input, null, 2),
+          ``,
+          `=== Container Args ===`,
+          containerArgs.join(' '),
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map(
+              (m) =>
+                `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+            )
+            .join('\n'),
+          ``,
+          `=== Stderr${stderrTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stderr,
+          ``,
+          `=== Stdout${stdoutTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stdout,
+        );
+      } else {
+        logLines.push(
+          `=== Input Summary ===`,
+          `Prompt length: ${input.prompt.length} chars`,
+          `Session ID: ${input.sessionId || 'new'}`,
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
+            .join('\n'),
+          ``,
+        );
+      }
+
+      fs.writeFileSync(logFile, logLines.join('\n'));
+      logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
+
+      if (code !== 0) {
+        logger.error(
+          {
+            group: group.name,
+            code,
+            duration,
+            stderr,
+            stdout,
+            logFile,
+          },
+          'Container exited with error',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container exited with code ${code}: ${stderr.slice(-200)}`,
+        });
+        return;
+      }
+
+      // Streaming mode: wait for output chain to settle, return completion marker
+      if (onOutput) {
+        outputChain.then(() => {
+          logger.info(
+            { group: group.name, duration, newSessionId },
+            'Container completed (streaming mode)',
+          );
+          resolve({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        });
+        return;
+      }
+
+      // Legacy mode: parse the last output marker pair from accumulated stdout
+      try {
+        // Extract JSON between sentinel markers for robust parsing
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          // Fallback: last non-empty line (backwards compatibility)
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+
+        const output: ContainerOutput = JSON.parse(jsonLine);
+
+        logger.info(
+          {
+            group: group.name,
+            duration,
+            status: output.status,
+            hasResult: !!output.result,
+          },
+          'Container completed',
+        );
+
+        resolve(output);
+      } catch (err) {
+        logger.error(
+          {
+            group: group.name,
+            stdout,
+            stderr,
+            error: err,
+          },
+          'Failed to parse container output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Failed to parse container output: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+
+    container.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error(
+        { group: group.name, containerName, error: err },
+        'Container spawn error',
+      );
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Container spawn error: ${err.message}`,
+      });
+    });
+  });
+}
+
+export function writeTasksSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  tasks: Array<{
+    id: string;
+    groupFolder: string;
+    prompt: string;
+    schedule_type: string;
+    schedule_value: string;
+    status: string;
+    next_run: string | null;
+  }>,
+): void {
+  // Write filtered tasks to the group's IPC directory
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all tasks, others only see their own
+  const filteredTasks = isMain
+    ? tasks
+    : tasks.filter((t) => t.groupFolder === groupFolder);
+
+  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
+  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
+}
+
+export interface AvailableGroup {
+  jid: string;
+  name: string;
+  lastActivity: string;
+  isRegistered: boolean;
+}
+
+/**
+ * Write available groups snapshot for the container to read.
+ * Only main group can see all available groups (for activation).
+ * Non-main groups only see their own registration status.
+ */
+export function writeGroupsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  groups: AvailableGroup[],
+  registeredJids: Set<string>,
+): void {
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all groups; others see nothing (they can't activate groups)
+  const visibleGroups = isMain ? groups : [];
+
+  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
+  fs.writeFileSync(
+    groupsFile,
+    JSON.stringify(
+      {
+        groups: visibleGroups,
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/.claude/skills/add-claude-mem/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/add-claude-mem/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,53 @@
+# Intent: src/container-runner.ts modifications
+
+## What changed
+Added claude-mem MCP server discovery, volume mounting, and Docker host-gateway networking.
+
+## Key sections
+
+### Imports (top of file)
+- Added: `HOME_DIR` from `./config.js` — needed by `findClaudeMemScripts()` to locate the plugin cache
+
+### findClaudeMemScripts() (new function)
+- Discovers the claude-mem plugin in `~/.claude/plugins/cache/thedotmack/claude-mem/`
+- Finds the latest version by sorting version directories
+- Returns the `scripts/` path if `mcp-server.cjs` exists, null otherwise
+- This is a host-side discovery — the plugin is installed via Claude Code's plugin system
+
+### buildVolumeMounts()
+- Added optional claude-mem mount at the end of the function (after additionalMounts)
+- Mounts `scripts/` directory read-only to `/opt/claude-mem/scripts` inside the container
+- The agent-runner checks for `/opt/claude-mem/scripts/mcp-server.cjs` to conditionally start the MCP server
+- Mount is skipped silently if claude-mem is not installed
+
+### buildContainerArgs()
+- Added `--add-host=host.docker.internal:host-gateway` flag
+- This allows containers to reach the host's claude-mem worker via `host.docker.internal:37777`
+- Placed before the timezone argument for clarity
+
+## Invariants
+- All existing volume mounts are preserved (project root, group, sessions, IPC, agent-runner, additional)
+- claude-mem mount is always last — after all required mounts and validated additional mounts
+- claude-mem mount is always read-only — containers cannot modify the plugin scripts
+- `findClaudeMemScripts()` returns null gracefully when not installed (no errors, no warnings)
+- The `--add-host` flag is harmless when claude-mem is not installed
+
+## Design decisions
+
+### Plugin cache discovery
+The function traverses the Claude Code plugin cache directory structure (`~/.claude/plugins/cache/<org>/<plugin>/<version>/`). Version directories are sorted lexicographically to find the latest. This avoids hardcoding a version and automatically picks up updates when the plugin is upgraded.
+
+### Read-only mount
+The MCP server scripts are mounted read-only because:
+1. Containers should never modify host plugin files
+2. The scripts only need to be executed, not written to
+3. Matches the security pattern of the project root mount
+
+### Host-gateway networking
+`--add-host=host.docker.internal:host-gateway` resolves to the host IP from inside Docker. The claude-mem worker listens on `0.0.0.0:37777` on the host. Inside the container, the MCP server connects to `host.docker.internal:37777`.
+
+## Must-keep
+- All existing imports and mount logic
+- The claude-mem mount MUST be after additionalMounts (after validation)
+- `findClaudeMemScripts()` must gracefully handle: missing directory, empty version list, missing mcp-server.cjs
+- The `--add-host` flag in buildContainerArgs

--- a/.claude/skills/add-claude-mem/tests/claude-mem.test.ts
+++ b/.claude/skills/add-claude-mem/tests/claude-mem.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// These tests validate the claude-mem integration points.
+// They run against the actual source files (not mocked) to verify
+// the skill was applied correctly.
+
+const ROOT = process.cwd();
+
+describe('claude-mem integration', () => {
+  describe('HOME_DIR export', () => {
+    it('config.ts exports HOME_DIR', async () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/config.ts'), 'utf-8');
+      expect(content).toContain('export const HOME_DIR');
+    });
+  });
+
+  describe('findClaudeMemScripts', () => {
+    it('returns null when plugin is not installed', async () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/container-runner.ts'), 'utf-8');
+      expect(content).toContain('function findClaudeMemScripts()');
+      expect(content).toContain("return fs.existsSync(path.join(scripts, 'mcp-server.cjs')) ? scripts : null;");
+    });
+
+    it('container-runner imports HOME_DIR', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/container-runner.ts'), 'utf-8');
+      expect(content).toContain("HOME_DIR,");
+      expect(content).toContain("from './config.js'");
+    });
+
+    it('container-runner adds host-gateway flag', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/container-runner.ts'), 'utf-8');
+      expect(content).toContain('--add-host=host.docker.internal:host-gateway');
+    });
+
+    it('container-runner mounts claude-mem scripts read-only', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/container-runner.ts'), 'utf-8');
+      expect(content).toContain("containerPath: '/opt/claude-mem/scripts'");
+      expect(content).toContain('readonly: true');
+    });
+  });
+
+  describe('agent-runner MCP configuration', () => {
+    it('allowedTools includes mcp-search wildcard', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'container/agent-runner/src/index.ts'), 'utf-8');
+      expect(content).toContain("'mcp__mcp-search__*'");
+    });
+
+    it('registers mcp-search MCP server conditionally', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'container/agent-runner/src/index.ts'), 'utf-8');
+      expect(content).toContain("fs.existsSync('/opt/claude-mem/scripts/mcp-server.cjs')");
+      expect(content).toContain("'mcp-search'");
+      expect(content).toContain("CLAUDE_MEM_WORKER_HOST: 'host.docker.internal'");
+      expect(content).toContain("CLAUDE_MEM_WORKER_PORT: '37777'");
+      expect(content).toContain('CLAUDE_MEM_PROJECT: containerInput.groupFolder');
+    });
+  });
+
+  describe('test mock', () => {
+    it('container-runner.test.ts mocks HOME_DIR', () => {
+      const content = fs.readFileSync(path.join(ROOT, 'src/container-runner.test.ts'), 'utf-8');
+      expect(content).toContain("HOME_DIR: '/tmp/nanoclaw-test-home'");
+    });
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Adds the `add-claude-mem` skill that gives NanoClaw agents persistent cross-session memory via the [claude-mem](https://github.com/thedotmack/claude-mem) MCP server.

**What it does:**
- Discovers the claude-mem plugin from `~/.claude/plugins/cache/` and mounts its MCP server scripts into containers (read-only)
- Adds `--add-host=host.docker.internal:host-gateway` so containers can reach the host-side claude-mem worker
- Registers the `mcp-search` MCP server conditionally inside the agent-runner (only when scripts are present)
- Per-group memory isolation via `CLAUDE_MEM_PROJECT`

**Skill structure:**
- `manifest.yaml` — modifies 4 files, no adds, no npm dependencies
- `SKILL.md` — 6-phase interactive setup guide (pre-flight, code apply, install plugin, configure worker, rebuild, verify)
- `CLAUDE_MEM_SETUP.md` — detailed install/config reference with systemd and launchd service templates
- `modify/` — 4 source files + 4 intent files
- `tests/` — 8 verification tests

**Files modified by the skill (via skills engine three-way merge):**
| File | Change |
|------|--------|
| `src/config.ts` | Export `HOME_DIR` (was local const) |
| `src/container-runner.ts` | Add `findClaudeMemScripts()`, claude-mem mount, host-gateway flag |
| `src/container-runner.test.ts` | Add `HOME_DIR` to config mock |
| `container/agent-runner/src/index.ts` | Add `mcp__mcp-search__*` to allowedTools, conditional MCP server |

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone