### PR TITLE
feat: add Generic LLM provider for text-only mode

### DIFF
--- a/.claude/skills/add-generic-llm/SKILL.md
+++ b/.claude/skills/add-generic-llm/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: add-generic-llm
+description: Add a generic OpenAI-compatible LLM provider (DeepSeek/GLM) for text-only responses
+---
+
+# Add Generic LLM Provider (DeepSeek / GLM)
+
+本技能为 NanoClaw 添加一个**通用 LLM 提供方**，使用 OpenAI 兼容的 Chat Completions API（如 DeepSeek、智谱 GLM）。启用后，容器内的 agent-runner 将切换到**文本生成模式**，不再依赖 Claude 的工具套件（Bash/Read/Write/MCP 等）。适合通知、简单问答和基础总结场景。
+
+## 能力与限制
+- 支持 DeepSeek 与智谱 GLM（或其他 OpenAI 兼容接口）
+- 保留 NanoClaw 的消息路由、容器隔离、组上下文
+- 不支持 Claude Code 的工具调用、Agent Teams、MCP 集成（若需要这些，请继续使用 Claude）
+
+## 环境配置
+在项目 `.env` 添加以下变量：
+```bash
+LLM_PROVIDER=generic
+LLM_API_BASE=https://api.deepseek.com/v1      # DeepSeek
+# 或 GLM: https://open.bigmodel.cn/api/paas/v4
+LLM_MODEL=deepseek-chat                       # 对应的模型名
+LLM_API_KEY=sk-xxxxxx                         # 你的 API Key
+```
+
+## 应用技能
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-generic-llm
+```
+
+这会：
+- 添加 `container/agent-runner/src/provider-generic-llm.ts`（通用 LLM 调用逻辑）
+- 修改 `container/agent-runner/src/index.ts` 增加提供方切换（如检测到 `LLM_PROVIDER=generic`）
+- 扩展宿主侧 `src/container-runner.ts`，把上述 LLM 环境变量作为密钥传入容器（仅进程内可见）
+
+## 运行与验证
+- 设置好 `.env`，重启 NanoClaw
+- 发送消息，容器会调用通用 LLM，并将结果以 `---NANOCLAW_OUTPUT_START---/END` 标记返回
+- 如果需要恢复 Claude 能力：移除 `LLM_PROVIDER` 或清空 `LLM_API_KEY/BASE/MODEL` 即可
+
+## 选择建议
+- 需要工具调用、代码执行、Web 抓取、MCP 集成：继续使用 Claude 模式
+- 仅需纯文本对话/摘要：可以使用通用 LLM，成本可能更低
+

--- a/.claude/skills/add-generic-llm/add/container/agent-runner/src/provider-generic-llm.ts
+++ b/.claude/skills/add-generic-llm/add/container/agent-runner/src/provider-generic-llm.ts
@@ -1,0 +1,142 @@
+import fs from 'fs';
+import path from 'path';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner/generic-llm] ${message}`);
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
+ * Call a generic OpenAI-compatible chat-completions endpoint.
+ * Works for:
+ * - DeepSeek: https://api.deepseek.com/v1/chat/completions
+ * - Zhipu(GLM): https://open.bigmodel.cn/api/paas/v4/chat/completions
+ * Configure via env:
+ * - LLM_API_BASE
+ * - LLM_MODEL
+ * - LLM_API_KEY
+ */
+async function callGenericLlm(
+  apiBase: string,
+  model: string,
+  apiKey: string,
+  prompt: string,
+): Promise<string> {
+  const url = `${apiBase.replace(/\/+$/, '')}/chat/completions`;
+  const body = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    stream: false,
+  };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`LLM HTTP ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  // OpenAI-compatible response shape: { choices: [{ message: { content } }]}
+  const content = json?.choices?.[0]?.message?.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('LLM returned empty content');
+  }
+  return content;
+}
+
+async function main(): Promise<void> {
+  let input: ContainerInput;
+  try {
+    const raw = await readStdin();
+    input = JSON.parse(raw);
+    try {
+      fs.unlinkSync('/tmp/input.json');
+    } catch {}
+  } catch (err) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    process.exit(1);
+    return;
+  }
+
+  const env = { ...process.env, ...(input.secrets || {}) };
+  const apiBase = env.LLM_API_BASE || '';
+  const apiKey = env.LLM_API_KEY || '';
+  const model = env.LLM_MODEL || '';
+  if (!apiBase || !apiKey || !model) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: 'Missing LLM_API_BASE/LLM_API_KEY/LLM_MODEL',
+    });
+    process.exit(1);
+    return;
+  }
+
+  try {
+    const text = await callGenericLlm(apiBase, model, apiKey, input.prompt);
+    writeOutput({
+      status: 'success',
+      result: text,
+      newSessionId: input.sessionId, // keep same session semantics (no resume)
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`LLM error: ${msg}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: input.sessionId,
+      error: msg,
+    });
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/add-generic-llm/manifest.yaml
+++ b/.claude/skills/add-generic-llm/manifest.yaml
@@ -1,0 +1,19 @@
+skill: generic-llm
+version: 1.0.0
+description: "Add a generic OpenAI-compatible LLM provider (DeepSeek/GLM) for text-only responses"
+core_version: 0.1.0
+adds:
+  - container/agent-runner/src/provider-generic-llm.ts
+modifies:
+  - container/agent-runner/src/index.ts
+  - src/container-runner.ts
+structured:
+  npm_dependencies: {}
+  env_additions:
+    - LLM_API_KEY
+    - LLM_API_BASE
+    - LLM_MODEL
+    - LLM_PROVIDER
+conflicts: []
+depends: []
+test: "echo 'No tests for generic LLM provider yet'"

--- a/.claude/skills/add-generic-llm/modify/container/agent-runner/src/index.ts
+++ b/.claude/skills/add-generic-llm/modify/container/agent-runner/src/index.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Claude provider imports (original)
+import {
+  query,
+  HookCallback,
+  PreCompactHookInput,
+  PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+
+// Conditional generic LLM provider
+const USE_GENERIC_LLM =
+  process.env.LLM_PROVIDER === 'generic' ||
+  (!!process.env.LLM_API_KEY &&
+    !!process.env.LLM_API_BASE &&
+    !!process.env.LLM_MODEL);
+
+if (USE_GENERIC_LLM) {
+  // In generic mode, delegate to provider-generic-llm (compiled JS path)
+  // Note: skills engine will replace this file, so we implement a tiny delegator here.
+  const provider = await import('./provider-generic-llm.js');
+  // provider-generic-llm has its own main() that reads stdin and writes output markers
+  // To keep container entrypoint unchanged, we simply re-export its main.
+  (provider as any).default?.() ?? (provider as any).main?.();
+} else {
+  // Fallback to original Claude implementation
+  // This block mirrors the original index.ts content by importing its JS output.
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const original = await import(path.join(__dirname, 'index.claude.js')).catch(
+    () => null,
+  );
+  if (original?.main) {
+    (original as any).main();
+  } else {
+    // If original module isn't available, inline minimal bootstrap to avoid crash.
+    console.error(
+      '[agent-runner] Missing Claude runner. Please rebuild container or disable generic LLM mode.',
+    );
+    process.exit(1);
+  }
+}

--- a/.claude/skills/add-generic-llm/modify/container/agent-runner/src/index.ts.intent.md
+++ b/.claude/skills/add-generic-llm/modify/container/agent-runner/src/index.ts.intent.md
@@ -1,0 +1,13 @@
+# Intent for container/agent-runner/src/index.ts
+
+Add a provider switch to run a generic OpenAI-compatible LLM (DeepSeek/GLM) for text-only responses.
+
+## Changes
+- Detect `process.env.LLM_PROVIDER === 'generic'` (or presence of `LLM_API_KEY`) to switch execution path.
+- In generic mode, instead of using `@anthropic-ai/claude-agent-sdk`, require and delegate to `./provider-generic-llm.js` (compiled from TS) to produce one text result.
+- Keep existing behavior as default when not configured.
+
+## Invariants
+- Preserve input/output protocol (OUTPUT_START/END markers).
+- Do not remove Claude-specific flows; only add a conditional alternative.
+- Secrets must remain process-local; do not leak to subprocesses.

--- a/.claude/skills/add-generic-llm/modify/src/container-runner.ts
+++ b/.claude/skills/add-generic-llm/modify/src/container-runner.ts
@@ -1,0 +1,19 @@
+/**
+ * Intent: Extend readSecrets() to pass generic LLM credentials to container
+ * Changes:
+ * - Include LLM_API_KEY, LLM_API_BASE, LLM_MODEL, LLM_PROVIDER in the allowlist
+ * Invariants:
+ * - Keep existing CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY
+ */
+import { readEnvFile } from './env.js';
+
+function readSecrets(): Record<string, string> {
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'LLM_API_KEY',
+    'LLM_API_BASE',
+    'LLM_MODEL',
+    'LLM_PROVIDER',
+  ]);
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,8 +16,14 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  HookCallback,
+  PreCompactHookInput,
+  PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import { runGenericLlm } from './provider-generic-llm.js';
 
 interface ContainerInput {
   prompt: string;
@@ -89,7 +95,9 @@ class MessageStream {
         yield this.queue.shift()!;
       }
       if (this.done) return;
-      await new Promise<void>(r => { this.waiting = r; });
+      await new Promise<void>((r) => {
+        this.waiting = r;
+      });
       this.waiting = null;
     }
   }
@@ -99,7 +107,9 @@ async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
     process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
@@ -118,7 +128,10 @@ function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
 }
 
-function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+function getSessionSummary(
+  sessionId: string,
+  transcriptPath: string,
+): string | null {
   const projectDir = path.dirname(transcriptPath);
   const indexPath = path.join(projectDir, 'sessions-index.json');
 
@@ -128,13 +141,17 @@ function getSessionSummary(sessionId: string, transcriptPath: string): string | 
   }
 
   try {
-    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-    const entry = index.entries.find(e => e.sessionId === sessionId);
+    const index: SessionsIndex = JSON.parse(
+      fs.readFileSync(indexPath, 'utf-8'),
+    );
+    const entry = index.entries.find((e) => e.sessionId === sessionId);
     if (entry?.summary) {
       return entry.summary;
     }
   } catch (err) {
-    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+    log(
+      `Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   return null;
@@ -173,12 +190,18 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       const filename = `${date}-${name}.md`;
       const filePath = path.join(conversationsDir, filename);
 
-      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      const markdown = formatTranscriptMarkdown(
+        messages,
+        summary,
+        assistantName,
+      );
       fs.writeFileSync(filePath, markdown);
 
       log(`Archived conversation to ${filePath}`);
     } catch (err) {
-      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     return {};
@@ -235,9 +258,12 @@ function parseTranscript(content: string): ParsedMessage[] {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content
+                .map((c: { text?: string }) => c.text || '')
+                .join('');
         if (text) messages.push({ role: 'user', content: text });
       } else if (entry.type === 'assistant' && entry.message?.content) {
         const textParts = entry.message.content
@@ -246,22 +272,26 @@ function parseTranscript(content: string): ParsedMessage[] {
         const text = textParts.join('');
         if (text) messages.push({ role: 'assistant', content: text });
       }
-    } catch {
-    }
+    } catch {}
   }
 
   return messages;
 }
 
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+function formatTranscriptMarkdown(
+  messages: ParsedMessage[],
+  title?: string | null,
+  assistantName?: string,
+): string {
   const now = new Date();
-  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  });
+  const formatDateTime = (d: Date) =>
+    d.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
 
   const lines: string[] = [];
   lines.push(`# ${title || 'Conversation'}`);
@@ -272,10 +302,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
   lines.push('');
 
   for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
-    const content = msg.content.length > 2000
-      ? msg.content.slice(0, 2000) + '...'
-      : msg.content;
+    const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
+    const content =
+      msg.content.length > 2000
+        ? msg.content.slice(0, 2000) + '...'
+        : msg.content;
     lines.push(`**${sender}**: ${content}`);
     lines.push('');
   }
@@ -288,7 +319,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
  */
 function shouldClose(): boolean {
   if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    try {
+      fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+    } catch {
+      /* ignore */
+    }
     return true;
   }
   return false;
@@ -301,8 +336,9 @@ function shouldClose(): boolean {
 function drainIpcInput(): string[] {
   try {
     fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
-    const files = fs.readdirSync(IPC_INPUT_DIR)
-      .filter(f => f.endsWith('.json'))
+    const files = fs
+      .readdirSync(IPC_INPUT_DIR)
+      .filter((f) => f.endsWith('.json'))
       .sort();
 
     const messages: string[] = [];
@@ -315,8 +351,14 @@ function drainIpcInput(): string[] {
           messages.push(data.text);
         }
       } catch (err) {
-        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
-        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+        log(
+          `Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        try {
+          fs.unlinkSync(filePath);
+        } catch {
+          /* ignore */
+        }
       }
     }
     return messages;
@@ -361,7 +403,11 @@ async function runQuery(
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+): Promise<{
+  newSessionId?: string;
+  lastAssistantUuid?: string;
+  closedDuringQuery: boolean;
+}> {
   const stream = new MessageStream();
   stream.push(prompt);
 
@@ -422,17 +468,32 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        ? {
+            type: 'preset' as const,
+            preset: 'claude_code' as const,
+            append: globalClaudeMd,
+          }
         : undefined,
       allowedTools: [
         'Bash',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'WebSearch', 'WebFetch',
-        'Task', 'TaskOutput', 'TaskStop',
-        'TeamCreate', 'TeamDelete', 'SendMessage',
-        'TodoWrite', 'ToolSearch', 'Skill',
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+        'WebSearch',
+        'WebFetch',
+        'Task',
+        'TaskOutput',
+        'TaskStop',
+        'TeamCreate',
+        'TeamDelete',
+        'SendMessage',
+        'TodoWrite',
+        'ToolSearch',
+        'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -450,13 +511,18 @@ async function runQuery(
         },
       },
       hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreCompact: [
+          { hooks: [createPreCompactHook(containerInput.assistantName)] },
+        ],
         PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
       },
-    }
+    },
   })) {
     messageCount++;
-    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    const msgType =
+      message.type === 'system'
+        ? `system/${(message as { subtype?: string }).subtype}`
+        : message.type;
     log(`[msg #${messageCount}] type=${msgType}`);
 
     if (message.type === 'assistant' && 'uuid' in message) {
@@ -468,25 +534,39 @@ async function runQuery(
       log(`Session initialized: ${newSessionId}`);
     }
 
-    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
-      const tn = message as { task_id: string; status: string; summary: string };
-      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    if (
+      message.type === 'system' &&
+      (message as { subtype?: string }).subtype === 'task_notification'
+    ) {
+      const tn = message as {
+        task_id: string;
+        status: string;
+        summary: string;
+      };
+      log(
+        `Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
+      );
     }
 
     if (message.type === 'result') {
       resultCount++;
-      const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      const textResult =
+        'result' in message ? (message as { result?: string }).result : null;
+      log(
+        `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
+      );
       writeOutput({
         status: 'success',
         result: textResult || null,
-        newSessionId
+        newSessionId,
       });
     }
   }
 
   ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  log(
+    `Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`,
+  );
   return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
@@ -497,15 +577,36 @@ async function main(): Promise<void> {
     const stdinData = await readStdin();
     containerInput = JSON.parse(stdinData);
     // Delete the temp file the entrypoint wrote — it contains secrets
-    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    try {
+      fs.unlinkSync('/tmp/input.json');
+    } catch {
+      /* may not exist */
+    }
     log(`Received input for group: ${containerInput.groupFolder}`);
   } catch (err) {
     writeOutput({
       status: 'error',
       result: null,
-      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`,
     });
     process.exit(1);
+  }
+
+  // Check for generic LLM mode (check secrets from input + process.env)
+  const secrets = containerInput.secrets || {};
+  const env = { ...process.env, ...secrets };
+  const isGenericMode =
+    env.LLM_PROVIDER === 'generic' ||
+    !!(env.LLM_API_KEY && env.LLM_API_BASE && env.LLM_MODEL);
+
+  if (isGenericMode) {
+    log('Using generic LLM provider (text-only mode)');
+    // Pass secrets to generic provider via process.env
+    for (const [key, value] of Object.entries(secrets)) {
+      process.env[key] = value;
+    }
+    await runGenericLlm(containerInput);
+    return;
   }
 
   // Build SDK env: merge secrets into process.env for the SDK only.
@@ -522,7 +623,11 @@ async function main(): Promise<void> {
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
   // Clean up stale _close sentinel from previous container runs
-  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+  try {
+    fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+  } catch {
+    /* ignore */
+  }
 
   // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
@@ -539,9 +644,18 @@ async function main(): Promise<void> {
   let resumeAt: string | undefined;
   try {
     while (true) {
-      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+      log(
+        `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
+      );
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      const queryResult = await runQuery(
+        prompt,
+        sessionId,
+        mcpServerPath,
+        containerInput,
+        sdkEnv,
+        resumeAt,
+      );
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
@@ -579,7 +693,7 @@ async function main(): Promise<void> {
       status: 'error',
       result: null,
       newSessionId: sessionId,
-      error: errorMessage
+      error: errorMessage,
     });
     process.exit(1);
   }

--- a/container/agent-runner/src/provider-generic-llm.ts
+++ b/container/agent-runner/src/provider-generic-llm.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner/generic-llm] ${message}`);
+}
+
+/**
+ * Call a generic OpenAI-compatible chat-completions endpoint.
+ * Works for:
+ * - DeepSeek: https://api.deepseek.com/v1/chat/completions
+ * - Zhipu(GLM): https://open.bigmodel.cn/api/paas/v4/chat/completions
+ * Configure via env:
+ * - LLM_API_BASE
+ * - LLM_MODEL
+ * - LLM_API_KEY
+ */
+async function callGenericLlm(
+  apiBase: string,
+  model: string,
+  apiKey: string,
+  prompt: string,
+): Promise<string> {
+  const url = `${apiBase.replace(/\/+$/, '')}/chat/completions`;
+  const body = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    stream: false,
+  };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`LLM HTTP ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  // OpenAI-compatible response shape: { choices: [{ message: { content } }]}
+  const content = json?.choices?.[0]?.message?.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('LLM returned empty content');
+  }
+  return content;
+}
+
+export async function runGenericLlm(input: ContainerInput): Promise<void> {
+  // Delete the temp file the entrypoint wrote — it contains secrets
+  try {
+    fs.unlinkSync('/tmp/input.json');
+  } catch {}
+
+  const env = { ...process.env, ...(input.secrets || {}) };
+  const apiBase = env.LLM_API_BASE || '';
+  const apiKey = env.LLM_API_KEY || '';
+  const model = env.LLM_MODEL || '';
+
+  log(
+    `Config: model=${model}, apiBase=${apiBase.replace(/\/[^\/]*$/, '/***')}`,
+  );
+
+  if (!apiBase || !apiKey || !model) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: 'Missing LLM_API_BASE/LLM_API_KEY/LLM_MODEL',
+    });
+    process.exit(1);
+    return;
+  }
+
+  try {
+    log(`Calling ${model}...`);
+    const text = await callGenericLlm(apiBase, model, apiKey, input.prompt);
+    log(`Got response (${text.length} chars)`);
+    writeOutput({
+      status: 'success',
+      result: text,
+      newSessionId: input.sessionId,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`LLM error: ${msg}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: input.sessionId,
+      error: msg,
+    });
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Add support for OpenAI-compatible LLM providers (DeepSeek, GLM, etc.) as an alternative to Claude. This enables text-only responses without tool calling, code execution, or MCP support.

Features:
- Detect LLM_PROVIDER=generic or (LLM_API_KEY + LLM_API_BASE + LLM_MODEL)
- Call /chat/completions endpoint via native fetch
- Pass secrets via stdin (never written to disk)

Skill includes:
- add/container/agent-runner/src/provider-generic-llm.ts - Provider impl
- modify/container/agent-runner/src/index.ts - Detection logic
- modify/src/container-runner.ts - Pass LLM_* secrets

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
