### PR TITLE
feat: multi-channel parallel connection support

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -50,8 +50,10 @@ export class WhatsAppChannel implements Channel {
   }
 
   async connect(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this.connectInternal(resolve).catch(reject);
+    // Don't block on connection - start connecting and return immediately
+    // The channel will emit events when connection state changes
+    this.connectInternal().catch((err) => {
+      logger.error({ err }, 'WhatsApp initial connection failed, will retry');
     });
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,12 @@ import { readEnvFile } from './env.js';
 // Read config values from .env (falls back to process.env).
 // Secrets are NOT read here — they stay on disk and are loaded only
 // where needed (container-runner.ts) to avoid leaking to child processes.
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'FEISHU_APP_ID',
+  'FEISHU_APP_SECRET',
+]);
 
 export const ASSISTANT_NAME =
   process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
@@ -62,3 +67,8 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export const FEISHU_APP_ID =
+  process.env.FEISHU_APP_ID || envConfig.FEISHU_APP_ID || '';
+export const FEISHU_APP_SECRET =
+  process.env.FEISHU_APP_SECRET || envConfig.FEISHU_APP_SECRET || '';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -204,7 +204,15 @@ function buildVolumeMounts(
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    // Generic LLM provider (DeepSeek/GLM/OpenAI-compatible)
+    'LLM_API_KEY',
+    'LLM_API_BASE',
+    'LLM_MODEL',
+    'LLM_PROVIDER',
+  ]);
 }
 
 function buildContainerArgs(


### PR DESCRIPTION
Refactor channel initialization to support parallel connections and improve resilience when one channel fails to connect.

Changes:
- Parallel channel connections with Promise.allSettled
- WhatsApp: Non-blocking connect() with background retry
- Feishu: Conditional registration when credentials configured
- Container: Pass LLM_* secrets for generic provider support

Channels now connect independently - one failing doesn't block others. Core changes to support skills/add-feishu and skills/add-generic-llm.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
