### PR TITLE
feat(setup): add Generic LLM provider option in setup skill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,13 @@
 
+
+# Added by skill
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+
+# Generic LLM Provider (DeepSeek / GLM / OpenAI-compatible)
+# When configured, agent-runner will use this provider for text-only responses
+# instead of Claude (no tool calling, code execution, or MCP support)
+# LLM_PROVIDER=generic
+# LLM_API_BASE=https://api.deepseek.com/v1
+# LLM_MODEL=deepseek-chat
+# LLM_API_KEY=sk-xxxxxx

--- a/scripts/init-skills.ts
+++ b/scripts/init-skills.ts
@@ -1,0 +1,4 @@
+import { initSkillsSystem } from '../skills-engine/migrate.js';
+
+initSkillsSystem();
+console.log('Skills system initialized.');


### PR DESCRIPTION
Add Generic LLM (DeepSeek/GLM/OpenAI-compatible) as a third model provider option alongside Claude subscription and Anthropic API key.

Changes:
- setup/SKILL.md: Add LLM provider selection flow with Chinese UI
- .env.example: Add LLM_* configuration examples
- scripts/init-skills.ts: Skills system initialization script

When user selects "通用 LLM", setup guides them to:
1. Apply add-generic-llm skill
2. Configure LLM_API_BASE, LLM_MODEL, LLM_API_KEY
3. Restart service (no /login required)

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
