### PR TITLE
feat: inject memory context into scheduled tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,9 @@ Single Node.js process that connects to WhatsApp, routes messages to Claude Agen
 | `src/config.ts` | Trigger pattern, paths, intervals |
 | `src/container-runner.ts` | Spawns agent containers with mounts |
 | `src/task-scheduler.ts` | Runs scheduled tasks |
-| `src/db.ts` | SQLite operations |
-| `groups/{name}/CLAUDE.md` | Per-group memory (isolated) |
+| `src/memory.ts` | Three-layer memory: core facts, conversation RAG, archives |
+| `src/db.ts` | SQLite + sqlite-vec operations |
+| `groups/{name}/CLAUDE.md` | Per-group instructions (isolated) |
 | `container/skills/agent-browser.md` | Browser automation tool (available to all agents via Bash) |
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then run `/setup`. Claude Code handles everything: dependencies, authentication,
 - **Semantic memory (RAG)** - Three-layer memory with vector search: core facts, conversation RAG, and session archives. Agents recall relevant context automatically and store new knowledge via MCP tools. Powered by local embeddings (no API costs).
 - **Isolated group context** - Each group has its own memory, isolated filesystem, and runs in its own container sandbox with only that filesystem mounted to it.
 - **Main channel** - Your private channel (self-chat) for admin control; every group is completely isolated
-- **Scheduled tasks** - Recurring jobs that run Claude and can message you back
+- **Scheduled tasks** - Recurring jobs that run Claude with full memory context and can message you back
 - **Web access** - Search and fetch content from the Web
 - **Container isolation** - Agents are sandboxed in Apple Container (macOS) or Docker (macOS/Linux)
 - **Agent Swarms** - Spin up teams of specialized agents that collaborate on complex tasks. NanoClaw is the first personal AI assistant to support agent swarms.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Then run `/setup`. Claude Code handles everything: dependencies, authentication,
 ## What It Supports
 
 - **Messenger I/O** - Message NanoClaw from your phone. Supports WhatsApp, Telegram, Discord, Slack, Signal and headless operation.
-- **Isolated group context** - Each group has its own `CLAUDE.md` memory, isolated filesystem, and runs in its own container sandbox with only that filesystem mounted to it.
+- **Semantic memory (RAG)** - Three-layer memory with vector search: core facts, conversation RAG, and session archives. Agents recall relevant context automatically and store new knowledge via MCP tools. Powered by local embeddings (no API costs).
+- **Isolated group context** - Each group has its own memory, isolated filesystem, and runs in its own container sandbox with only that filesystem mounted to it.
 - **Main channel** - Your private channel (self-chat) for admin control; every group is completely isolated
 - **Scheduled tasks** - Recurring jobs that run Claude and can message you back
 - **Web access** - Search and fetch content from the Web
@@ -121,21 +122,24 @@ Skills we'd like to see:
 ## Architecture
 
 ```
-WhatsApp (baileys) --> SQLite --> Polling loop --> Container (Claude Agent SDK) --> Response
+WhatsApp (baileys) --> SQLite --> Memory retrieval (RAG) --> Container (Claude Agent SDK) --> Response
+                                                                      |
+                                                              Embed messages (async)
 ```
 
-Single Node.js process. Agents execute in isolated Linux containers with filesystem isolation. Only mounted directories are accessible. Per-group message queue with concurrency control. IPC via filesystem.
+Single Node.js process. Agents execute in isolated Linux containers with filesystem isolation. Only mounted directories are accessible. Per-group message queue with concurrency control. IPC via filesystem. Semantic memory via sqlite-vec (vector search) and local embeddings.
 
 Key files:
 - `src/index.ts` - Orchestrator: state, message loop, agent invocation
+- `src/memory.ts` - Three-layer memory: core facts, conversation RAG, session archives
 - `src/channels/whatsapp.ts` - WhatsApp connection, auth, send/receive
 - `src/ipc.ts` - IPC watcher and task processing
 - `src/router.ts` - Message formatting and outbound routing
 - `src/group-queue.ts` - Per-group queue with global concurrency limit
 - `src/container-runner.ts` - Spawns streaming agent containers
 - `src/task-scheduler.ts` - Runs scheduled tasks
-- `src/db.ts` - SQLite operations (messages, groups, sessions, state)
-- `groups/*/CLAUDE.md` - Per-group memory
+- `src/db.ts` - SQLite + sqlite-vec operations (messages, groups, sessions, memory)
+- `groups/*/CLAUDE.md` - Per-group instructions
 
 ## FAQ
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -1,6 +1,6 @@
-# Andy
+# Obekt
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+You are Obekt, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
 ## What You Can Do
 
@@ -40,12 +40,42 @@ Files you create are saved in `/workspace/group/`. Use this for notes, research,
 
 ## Memory
 
-The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
+You have a semantic memory system with three layers:
 
-When you learn something important:
-- Create files for structured data (e.g., `customers.md`, `preferences.md`)
-- Split files larger than 500 lines into folders
-- Keep an index in your memory for the files you create
+1. *Core Memories* — facts, preferences, instructions you've stored. These are automatically included in your context when relevant. You can manage them with `memory_add`, `memory_update`, and `memory_remove`.
+
+2. *Conversation Memory* — past messages are automatically embedded and retrieved when relevant. You'll see them in `<memory type="past_conversations">` in your prompt.
+
+3. *Archival Memory* — session summaries searchable via `memory_search`.
+
+### When to store memories
+
+Use `mcp__nanoclaw__memory_add` proactively when:
+- User states a preference ("I prefer short responses", "My timezone is EST")
+- User shares personal info (name, job, projects they're working on)
+- User gives standing instructions ("Always reply in Bulgarian")
+- You learn something important for future conversations
+
+Do NOT store trivial or temporary information.
+
+### When to search memories
+
+Use `mcp__nanoclaw__memory_search` when:
+- User references something from a past conversation
+- You need context about the user's preferences or history
+- You're unsure if you've discussed something before
+
+### Memory context in your prompt
+
+Relevant memories are automatically injected as `<memory>` blocks at the top of your prompt. You don't need to search for these — they're already there. Use `memory_search` only when you need deeper recall beyond what's automatically provided.
+
+### Existing memory IDs
+
+To update or remove a memory, check the `<memory type="core">` block in your prompt (each `<fact>` has an `id` attribute) or read `/workspace/ipc/memory_snapshot.json`.
+
+### File-based memory
+
+The `conversations/` folder contains archived past conversations as markdown. You can still create files in `/workspace/group/` for structured data, but prefer using `memory_add` for discrete facts.
 
 ## Message Formatting
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -1,6 +1,6 @@
-# Andy
+# Obekt
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+You are Obekt, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
 ## What You Can Do
 
@@ -36,12 +36,42 @@ When working as a sub-agent or teammate, only use `send_message` if instructed t
 
 ## Memory
 
-The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
+You have a semantic memory system with three layers:
 
-When you learn something important:
-- Create files for structured data (e.g., `customers.md`, `preferences.md`)
-- Split files larger than 500 lines into folders
-- Keep an index in your memory for the files you create
+1. *Core Memories* — facts, preferences, instructions you've stored. These are automatically included in your context when relevant. You can manage them with `memory_add`, `memory_update`, and `memory_remove`.
+
+2. *Conversation Memory* — past messages are automatically embedded and retrieved when relevant. You'll see them in `<memory type="past_conversations">` in your prompt.
+
+3. *Archival Memory* — session summaries searchable via `memory_search`.
+
+### When to store memories
+
+Use `mcp__nanoclaw__memory_add` proactively when:
+- User states a preference ("I prefer short responses", "My timezone is EST")
+- User shares personal info (name, job, projects they're working on)
+- User gives standing instructions ("Always reply in Bulgarian")
+- You learn something important for future conversations
+
+Do NOT store trivial or temporary information.
+
+### When to search memories
+
+Use `mcp__nanoclaw__memory_search` when:
+- User references something from a past conversation
+- You need context about the user's preferences or history
+- You're unsure if you've discussed something before
+
+### Memory context in your prompt
+
+Relevant memories are automatically injected as `<memory>` blocks at the top of your prompt. You don't need to search for these — they're already there. Use `memory_search` only when you need deeper recall beyond what's automatically provided.
+
+### Existing memory IDs
+
+To update or remove a memory, check the `<memory type="core">` block in your prompt (each `<fact>` has an `id` attribute) or read `/workspace/ipc/memory_snapshot.json`.
+
+### File-based memory
+
+The `conversations/` folder contains archived past conversations as markdown. You can still create files in `/workspace/group/` for structured data, but prefer using `memory_add` for discrete facts.
 
 ## WhatsApp Formatting (and other messaging apps)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nanoclaw",
       "version": "1.1.3",
       "dependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
@@ -15,6 +16,7 @@
         "pino-pretty": "^13.0.0",
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
+        "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
@@ -606,6 +608,27 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
+      "integrity": "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
@@ -1069,6 +1092,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1924,6 +1959,13 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2107,6 +2149,40 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2115,6 +2191,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -2137,11 +2219,35 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2184,6 +2290,18 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -2288,6 +2406,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2337,6 +2461,57 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2345,6 +2520,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hashery": {
@@ -2490,12 +2677,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2622,6 +2814,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -2650,6 +2854,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -2732,6 +2957,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2760,6 +2994,49 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -2854,7 +3131,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2930,6 +3206,12 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
     },
     "node_modules/pngjs": {
@@ -3177,6 +3459,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -3279,6 +3578,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -3291,7 +3611,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -3410,6 +3729,90 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
+        "sqlite-vec-darwin-x64": "0.1.7-alpha.2",
+        "sqlite-vec-linux-arm64": "0.1.7-alpha.2",
+        "sqlite-vec-linux-x64": "0.1.7-alpha.2",
+        "sqlite-vec-windows-x64": "0.1.7-alpha.2"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3500,6 +3903,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -3526,6 +3945,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thread-stream": {
@@ -3611,7 +4039,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3636,6 +4063,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3682,7 +4121,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3758,7 +4196,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3907,12 +4344,20 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
@@ -26,6 +27,7 @@
     "pino-pretty": "^13.0.0",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
+    "sqlite-vec": "^0.1.7-alpha.2",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -156,6 +156,7 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'memory'), { recursive: true });
   mounts.push({
     hostPath: groupIpcDir,
     containerPath: '/workspace/ipc',

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
+import * as sqliteVec from 'sqlite-vec';
 
 import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
 import { isValidGroupFolder } from './group-folder.js';
@@ -13,6 +14,12 @@ import {
 } from './types.js';
 
 let db: Database.Database;
+
+/** Get the database instance. Must call initDatabase() first. */
+export function getDb(): Database.Database {
+  if (!db) throw new Error('Database not initialized — call initDatabase() first');
+  return db;
+}
 
 function createSchema(database: Database.Database): void {
   database.exec(`
@@ -133,6 +140,10 @@ export function initDatabase(): void {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
   db = new Database(dbPath);
+
+  // Load sqlite-vec extension for vector search
+  sqliteVec.load(db);
+
   createSchema(db);
 
   // Migrate from JSON files if they exist

--- a/src/db.ts
+++ b/src/db.ts
@@ -17,7 +17,8 @@ let db: Database.Database;
 
 /** Get the database instance. Must call initDatabase() first. */
 export function getDb(): Database.Database {
-  if (!db) throw new Error('Database not initialized — call initDatabase() first');
+  if (!db)
+    throw new Error('Database not initialized — call initDatabase() first');
   return db;
 }
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -13,6 +13,12 @@ import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
+import {
+  addCoreMemoryWithEmbedding,
+  removeCoreMemory,
+  searchAllMemory,
+  updateCoreMemoryWithEmbedding,
+} from './memory.js';
 import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
@@ -142,6 +148,32 @@ export function startIpcWatcher(deps: IpcDeps): void {
         }
       } catch (err) {
         logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
+      }
+
+      // Process memory operations from this group's IPC directory
+      const memoryDir = path.join(ipcBaseDir, sourceGroup, 'memory');
+      try {
+        if (fs.existsSync(memoryDir)) {
+          const memoryFiles = fs
+            .readdirSync(memoryDir)
+            .filter((f) => f.startsWith('req-') && f.endsWith('.json'));
+          for (const file of memoryFiles) {
+            const filePath = path.join(memoryDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              fs.unlinkSync(filePath);
+              await processMemoryIpc(data, sourceGroup, memoryDir);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC memory request',
+              );
+              try { fs.unlinkSync(path.join(memoryDir, file)); } catch { /* ignore */ }
+            }
+          }
+        }
+      } catch (err) {
+        logger.error({ err, sourceGroup }, 'Error reading IPC memory directory');
       }
     }
 
@@ -383,5 +415,104 @@ export async function processTaskIpc(
 
     default:
       logger.warn({ type: data.type }, 'Unknown IPC task type');
+  }
+}
+
+async function processMemoryIpc(
+  data: {
+    type: string;
+    requestId?: string;
+    content?: string;
+    category?: string;
+    memoryId?: string;
+    query?: string;
+    scope?: string;
+    limit?: number;
+    groupFolder?: string;
+  },
+  sourceGroup: string,
+  memoryDir: string,
+): Promise<void> {
+  const groupFolder = sourceGroup;
+
+  switch (data.type) {
+    case 'memory_add':
+      if (data.content && data.category) {
+        const id = await addCoreMemoryWithEmbedding(
+          groupFolder,
+          data.category,
+          data.content,
+        );
+        logger.info(
+          { sourceGroup, id, category: data.category },
+          'Core memory added via IPC',
+        );
+        // Write response if requestId provided
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok', id }));
+        }
+      }
+      break;
+
+    case 'memory_update':
+      if (data.memoryId && data.content) {
+        await updateCoreMemoryWithEmbedding(data.memoryId, data.content);
+        logger.info(
+          { sourceGroup, memoryId: data.memoryId },
+          'Core memory updated via IPC',
+        );
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok' }));
+        }
+      }
+      break;
+
+    case 'memory_remove':
+      if (data.memoryId) {
+        removeCoreMemory(data.memoryId);
+        logger.info(
+          { sourceGroup, memoryId: data.memoryId },
+          'Core memory removed via IPC',
+        );
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok' }));
+        }
+      }
+      break;
+
+    case 'memory_search':
+      if (data.query && data.requestId) {
+        try {
+          const scope = (data.scope as 'all' | 'conversations' | 'facts') || 'all';
+          const results = await searchAllMemory(
+            groupFolder,
+            data.query,
+            scope,
+            data.limit || 10,
+          );
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok', results }));
+          logger.debug(
+            { sourceGroup, query: data.query },
+            'Memory search completed via IPC',
+          );
+        } catch (err) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(
+            resFile,
+            JSON.stringify({
+              status: 'error',
+              results: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+            }),
+          );
+        }
+      }
+      break;
+
+    default:
+      logger.warn({ type: data.type }, 'Unknown IPC memory type');
   }
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -156,7 +156,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
         if (fs.existsSync(memoryDir)) {
           const memoryFiles = fs
             .readdirSync(memoryDir)
-            .filter((f) => f.startsWith('req-') && f.endsWith('.json'));
+            .filter((f) => f.endsWith('.json') && !f.startsWith('res-'));
           for (const file of memoryFiles) {
             const filePath = path.join(memoryDir, file);
             try {
@@ -168,12 +168,19 @@ export function startIpcWatcher(deps: IpcDeps): void {
                 { file, sourceGroup, err },
                 'Error processing IPC memory request',
               );
-              try { fs.unlinkSync(path.join(memoryDir, file)); } catch { /* ignore */ }
+              try {
+                fs.unlinkSync(path.join(memoryDir, file));
+              } catch {
+                /* ignore */
+              }
             }
           }
         }
       } catch (err) {
-        logger.error({ err, sourceGroup }, 'Error reading IPC memory directory');
+        logger.error(
+          { err, sourceGroup },
+          'Error reading IPC memory directory',
+        );
       }
     }
 
@@ -486,7 +493,8 @@ async function processMemoryIpc(
     case 'memory_search':
       if (data.query && data.requestId) {
         try {
-          const scope = (data.scope as 'all' | 'conversations' | 'facts') || 'all';
+          const scope =
+            (data.scope as 'all' | 'conversations' | 'facts') || 'all';
           const results = await searchAllMemory(
             groupFolder,
             data.query,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,599 @@
+/**
+ * Memory System for NanoClaw
+ *
+ * Three-layer memory architecture:
+ * 1. Core Memories — discrete facts, preferences, instructions (always injected)
+ * 2. Conversation Memory — embedded message chunks for RAG retrieval
+ * 3. Archival Memory — session summaries for deep recall
+ *
+ * Uses sqlite-vec for vector search and @huggingface/transformers for local embeddings.
+ * All operations are per-group isolated.
+ */
+
+import crypto from 'crypto';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { getDb } from './db.js';
+import { logger } from './logger.js';
+import { NewMessage } from './types.js';
+
+// --- Types ---
+
+export interface CoreMemory {
+  id: string;
+  group_folder: string;
+  category: string;
+  content: string;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+  is_pinned: number;
+}
+
+export interface ConversationChunk {
+  id: string;
+  group_folder: string;
+  chat_jid: string;
+  message_id: string | null;
+  content: string;
+  context: string | null;
+  sender_name: string | null;
+  timestamp: string;
+  created_at: string;
+}
+
+export interface ArchivalMemory {
+  id: string;
+  group_folder: string;
+  session_id: string | null;
+  title: string | null;
+  content: string;
+  timestamp: string;
+  message_count: number | null;
+  created_at: string;
+}
+
+// --- Schema ---
+
+export function initMemorySchema(): void {
+  const db = getDb();
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS core_memories (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      category TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      is_pinned INTEGER DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_core_memories_group ON core_memories(group_folder);
+    CREATE INDEX IF NOT EXISTS idx_core_memories_category ON core_memories(group_folder, category);
+
+    CREATE TABLE IF NOT EXISTS conversation_chunks (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      chat_jid TEXT NOT NULL,
+      message_id TEXT,
+      content TEXT NOT NULL,
+      context TEXT,
+      sender_name TEXT,
+      timestamp TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_conv_chunks_group ON conversation_chunks(group_folder);
+    CREATE INDEX IF NOT EXISTS idx_conv_chunks_ts ON conversation_chunks(group_folder, timestamp);
+
+    CREATE TABLE IF NOT EXISTS archival_memories (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      session_id TEXT,
+      title TEXT,
+      content TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      message_count INTEGER,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_archival_group ON archival_memories(group_folder);
+  `);
+
+  // Create vec0 virtual tables (idempotent — errors if already exists)
+  const vecTables = [
+    `CREATE VIRTUAL TABLE IF NOT EXISTS core_memories_vec USING vec0(memory_id TEXT PRIMARY KEY, embedding float[384])`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS conversation_chunks_vec USING vec0(chunk_id TEXT PRIMARY KEY, embedding float[384])`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS archival_memories_vec USING vec0(memory_id TEXT PRIMARY KEY, embedding float[384])`,
+  ];
+
+  for (const sql of vecTables) {
+    try {
+      db.exec(sql);
+    } catch (err) {
+      // vec0 tables don't support IF NOT EXISTS in all versions — ignore if exists
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('already exists')) throw err;
+    }
+  }
+
+  logger.info('Memory schema initialized');
+}
+
+// --- Embedding Pipeline ---
+
+let embedder: unknown = null;
+
+async function getEmbedder(): Promise<
+  (text: string, opts: { pooling: string; normalize: boolean }) => Promise<{ data: Float32Array }>
+> {
+  if (!embedder) {
+    const { pipeline } = await import('@huggingface/transformers');
+    const cacheDir = path.join(DATA_DIR, 'models');
+    embedder = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {
+      cache_dir: cacheDir,
+    });
+    logger.info({ cacheDir }, 'Embedding model loaded');
+  }
+  return embedder as (
+    text: string,
+    opts: { pooling: string; normalize: boolean },
+  ) => Promise<{ data: Float32Array }>;
+}
+
+export async function embed(text: string): Promise<Float32Array> {
+  const extractor = await getEmbedder();
+  const output = await extractor(text, { pooling: 'mean', normalize: true });
+  return new Float32Array(output.data);
+}
+
+function uid(): string {
+  return crypto.randomUUID();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// --- Layer 1: Core Memory CRUD ---
+
+export function addCoreMemory(
+  groupFolder: string,
+  category: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): string {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+  db.prepare(
+    `INSERT INTO core_memories (id, group_folder, category, content, metadata, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, groupFolder, category, content, metadata ? JSON.stringify(metadata) : null, ts, ts);
+  return id;
+}
+
+export async function addCoreMemoryWithEmbedding(
+  groupFolder: string,
+  category: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): Promise<string> {
+  const id = addCoreMemory(groupFolder, category, content, metadata);
+  try {
+    const vec = await embed(content);
+    getDb()
+      .prepare(`INSERT INTO core_memories_vec (memory_id, embedding) VALUES (?, ?)`)
+      .run(id, Buffer.from(vec.buffer));
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to embed core memory');
+  }
+  return id;
+}
+
+export function updateCoreMemory(id: string, content: string): void {
+  const db = getDb();
+  db.prepare(`UPDATE core_memories SET content = ?, updated_at = ? WHERE id = ?`).run(
+    content,
+    now(),
+    id,
+  );
+}
+
+export async function updateCoreMemoryWithEmbedding(id: string, content: string): Promise<void> {
+  updateCoreMemory(id, content);
+  try {
+    const vec = await embed(content);
+    const db = getDb();
+    // Delete old embedding and insert new one
+    db.prepare(`DELETE FROM core_memories_vec WHERE memory_id = ?`).run(id);
+    db.prepare(`INSERT INTO core_memories_vec (memory_id, embedding) VALUES (?, ?)`).run(
+      id,
+      Buffer.from(vec.buffer),
+    );
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to re-embed core memory');
+  }
+}
+
+export function removeCoreMemory(id: string): void {
+  const db = getDb();
+  db.prepare(`DELETE FROM core_memories WHERE id = ?`).run(id);
+  try {
+    db.prepare(`DELETE FROM core_memories_vec WHERE memory_id = ?`).run(id);
+  } catch {
+    /* vec entry may not exist */
+  }
+}
+
+export function getCoreMemories(groupFolder: string, category?: string): CoreMemory[] {
+  const db = getDb();
+  if (category) {
+    return db
+      .prepare(`SELECT * FROM core_memories WHERE group_folder = ? AND category = ? ORDER BY updated_at DESC`)
+      .all(groupFolder, category) as CoreMemory[];
+  }
+  return db
+    .prepare(`SELECT * FROM core_memories WHERE group_folder = ? ORDER BY updated_at DESC`)
+    .all(groupFolder) as CoreMemory[];
+}
+
+export function getPinnedMemories(groupFolder: string): CoreMemory[] {
+  return getDb()
+    .prepare(`SELECT * FROM core_memories WHERE group_folder = ? AND is_pinned = 1 ORDER BY updated_at DESC`)
+    .all(groupFolder) as CoreMemory[];
+}
+
+export async function searchCoreMemories(
+  groupFolder: string,
+  query: string,
+  limit = 10,
+): Promise<CoreMemory[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  // Vector search returns memory_ids ranked by similarity
+  const vecResults = db
+    .prepare(
+      `SELECT memory_id, distance
+       FROM core_memories_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{ memory_id: string; distance: number }>;
+
+  if (vecResults.length === 0) return [];
+
+  // Filter to this group's memories and fetch full records
+  const ids = vecResults.map((r) => r.memory_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const memories = db
+    .prepare(
+      `SELECT * FROM core_memories WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as CoreMemory[];
+
+  // Preserve similarity order
+  const memoryMap = new Map(memories.map((m) => [m.id, m]));
+  return vecResults
+    .map((r) => memoryMap.get(r.memory_id))
+    .filter((m): m is CoreMemory => m !== undefined)
+    .slice(0, limit);
+}
+
+// --- Layer 2: Conversation Memory ---
+
+export async function embedMessage(
+  groupFolder: string,
+  chatJid: string,
+  message: NewMessage,
+  contextMessages: NewMessage[],
+): Promise<void> {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+
+  // Build context string (preceding messages for embedding context)
+  const contextParts = contextMessages.map(
+    (m) => `${m.sender_name}: ${m.content}`,
+  );
+  const embeddingText =
+    contextParts.length > 0
+      ? `${contextParts.join('\n')}\n${message.sender_name}: ${message.content}`
+      : `${message.sender_name}: ${message.content}`;
+
+  const contextStr =
+    contextParts.length > 0 ? contextParts.join('\n') : null;
+
+  db.prepare(
+    `INSERT INTO conversation_chunks (id, group_folder, chat_jid, message_id, content, context, sender_name, timestamp, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    groupFolder,
+    chatJid,
+    message.id,
+    message.content,
+    contextStr,
+    message.sender_name,
+    message.timestamp,
+    ts,
+  );
+
+  const vec = await embed(embeddingText);
+  db.prepare(`INSERT INTO conversation_chunks_vec (chunk_id, embedding) VALUES (?, ?)`).run(
+    id,
+    Buffer.from(vec.buffer),
+  );
+}
+
+export async function embedConversationMessages(
+  groupFolder: string,
+  chatJid: string,
+  messages: NewMessage[],
+): Promise<void> {
+  for (let i = 0; i < messages.length; i++) {
+    // Use up to 2 preceding messages as context
+    const contextStart = Math.max(0, i - 2);
+    const contextMessages = messages.slice(contextStart, i);
+    try {
+      await embedMessage(groupFolder, chatJid, messages[i], contextMessages);
+    } catch (err) {
+      logger.warn(
+        { err, messageId: messages[i].id },
+        'Failed to embed message',
+      );
+    }
+  }
+}
+
+export async function retrieveRelevantChunks(
+  groupFolder: string,
+  query: string,
+  limit = 10,
+): Promise<ConversationChunk[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  const vecResults = db
+    .prepare(
+      `SELECT chunk_id, distance
+       FROM conversation_chunks_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{ chunk_id: string; distance: number }>;
+
+  if (vecResults.length === 0) return [];
+
+  const ids = vecResults.map((r) => r.chunk_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const chunks = db
+    .prepare(
+      `SELECT * FROM conversation_chunks WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as ConversationChunk[];
+
+  const chunkMap = new Map(chunks.map((c) => [c.id, c]));
+  return vecResults
+    .map((r) => chunkMap.get(r.chunk_id))
+    .filter((c): c is ConversationChunk => c !== undefined)
+    .slice(0, limit);
+}
+
+// --- Layer 3: Archival Memory ---
+
+export async function archiveSession(
+  groupFolder: string,
+  sessionId: string | null,
+  title: string | null,
+  content: string,
+  messageCount?: number,
+): Promise<string> {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+
+  db.prepare(
+    `INSERT INTO archival_memories (id, group_folder, session_id, title, content, timestamp, message_count, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, groupFolder, sessionId, title, content, ts, messageCount ?? null, ts);
+
+  try {
+    const vec = await embed(content.slice(0, 1000)); // Embed first 1000 chars of summary
+    db.prepare(`INSERT INTO archival_memories_vec (memory_id, embedding) VALUES (?, ?)`).run(
+      id,
+      Buffer.from(vec.buffer),
+    );
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to embed archival memory');
+  }
+
+  return id;
+}
+
+export async function searchArchive(
+  groupFolder: string,
+  query: string,
+  limit = 5,
+): Promise<ArchivalMemory[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  const vecResults = db
+    .prepare(
+      `SELECT memory_id, distance
+       FROM archival_memories_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{ memory_id: string; distance: number }>;
+
+  if (vecResults.length === 0) return [];
+
+  const ids = vecResults.map((r) => r.memory_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const memories = db
+    .prepare(
+      `SELECT * FROM archival_memories WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as ArchivalMemory[];
+
+  const memoryMap = new Map(memories.map((m) => [m.id, m]));
+  return vecResults
+    .map((r) => memoryMap.get(r.memory_id))
+    .filter((m): m is ArchivalMemory => m !== undefined)
+    .slice(0, limit);
+}
+
+// --- Memory Context Retrieval ---
+
+/**
+ * Retrieve relevant memory context for injection into the agent prompt.
+ * Called before each agent invocation.
+ */
+export async function retrieveMemoryContext(
+  groupFolder: string,
+  messages: NewMessage[],
+): Promise<string> {
+  // Build query from incoming messages
+  const queryText = messages
+    .map((m) => m.content)
+    .join(' ')
+    .slice(0, 500);
+
+  if (!queryText.trim()) return '';
+
+  const parts: string[] = [];
+
+  try {
+    // Layer 1: Core memories (pinned + relevant)
+    const pinned = getPinnedMemories(groupFolder);
+    const allCore = getCoreMemories(groupFolder);
+
+    // If we have vectors, do semantic search; otherwise use all memories
+    let relevantCore: CoreMemory[] = [];
+    try {
+      relevantCore = await searchCoreMemories(groupFolder, queryText, 10);
+    } catch {
+      // Vector table might be empty
+      relevantCore = allCore.slice(0, 10);
+    }
+
+    // Merge pinned + relevant (deduplicated)
+    const seenIds = new Set<string>();
+    const coreMemories: CoreMemory[] = [];
+    for (const m of [...pinned, ...relevantCore]) {
+      if (!seenIds.has(m.id)) {
+        seenIds.add(m.id);
+        coreMemories.push(m);
+      }
+    }
+
+    if (coreMemories.length > 0) {
+      parts.push('<memory type="core">');
+      for (const mem of coreMemories) {
+        parts.push(
+          `<fact category="${mem.category}" id="${mem.id}"${mem.is_pinned ? ' pinned="true"' : ''}>${mem.content}</fact>`,
+        );
+      }
+      parts.push('</memory>');
+    }
+
+    // Layer 2: Relevant conversation chunks
+    let relevantChunks: ConversationChunk[] = [];
+    try {
+      relevantChunks = await retrieveRelevantChunks(groupFolder, queryText, 8);
+    } catch {
+      // Vector table might be empty
+    }
+
+    if (relevantChunks.length > 0) {
+      parts.push('<memory type="past_conversations">');
+      for (const chunk of relevantChunks) {
+        parts.push(
+          `<past_message sender="${chunk.sender_name || 'Unknown'}" time="${chunk.timestamp}">${chunk.content}</past_message>`,
+        );
+      }
+      parts.push('</memory>');
+    }
+  } catch (err) {
+    logger.warn({ err, groupFolder }, 'Failed to retrieve memory context');
+  }
+
+  return parts.length > 0 ? parts.join('\n') + '\n\n' : '';
+}
+
+/**
+ * Build memory snapshot for the agent (written to IPC dir).
+ * Agent uses this to see existing memory IDs for update/remove operations.
+ */
+export function buildMemorySnapshot(
+  groupFolder: string,
+): { coreMemories: Array<{ id: string; category: string; content: string; is_pinned: boolean; updated_at: string }> } {
+  const memories = getCoreMemories(groupFolder);
+  return {
+    coreMemories: memories.map((m) => ({
+      id: m.id,
+      category: m.category,
+      content: m.content,
+      is_pinned: m.is_pinned === 1,
+      updated_at: m.updated_at,
+    })),
+  };
+}
+
+/**
+ * Combined search across all memory layers.
+ * Used by the agent's memory_search MCP tool.
+ */
+export async function searchAllMemory(
+  groupFolder: string,
+  query: string,
+  scope: 'all' | 'conversations' | 'facts' = 'all',
+  limit = 10,
+): Promise<string> {
+  const results: string[] = [];
+
+  if (scope === 'all' || scope === 'facts') {
+    try {
+      const coreResults = await searchCoreMemories(groupFolder, query, limit);
+      if (coreResults.length > 0) {
+        results.push('## Stored Facts');
+        for (const m of coreResults) {
+          results.push(`- [${m.category}] ${m.content} (id: ${m.id})`);
+        }
+      }
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (scope === 'all' || scope === 'conversations') {
+    try {
+      const convResults = await retrieveRelevantChunks(groupFolder, query, limit);
+      if (convResults.length > 0) {
+        results.push('## Past Conversations');
+        for (const c of convResults) {
+          results.push(`- [${c.timestamp}] ${c.sender_name}: ${c.content}`);
+        }
+      }
+    } catch {
+      /* empty */
+    }
+
+    try {
+      const archiveResults = await searchArchive(groupFolder, query, 3);
+      if (archiveResults.length > 0) {
+        results.push('## Session Archives');
+        for (const a of archiveResults) {
+          results.push(`- [${a.timestamp}] ${a.title || 'Untitled session'}: ${a.content.slice(0, 200)}...`);
+        }
+      }
+    } catch {
+      /* empty */
+    }
+  }
+
+  return results.length > 0 ? results.join('\n') : 'No relevant memories found.';
+}

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -6,6 +6,45 @@ import {
   startSchedulerLoop,
 } from './task-scheduler.js';
 
+// Mock memory module
+vi.mock('./memory.js', () => ({
+  retrieveMemoryContext: vi.fn().mockResolvedValue('<memory>test context</memory>\n\n'),
+  buildMemorySnapshot: vi.fn().mockReturnValue({ coreMemories: [] }),
+}));
+
+// Mock container-runner to capture the prompt passed to runContainerAgent
+vi.mock('./container-runner.js', () => ({
+  runContainerAgent: vi.fn().mockResolvedValue({
+    status: 'success',
+    result: 'task done',
+    newSessionId: undefined,
+  }),
+  writeTasksSnapshot: vi.fn(),
+}));
+
+// Mock fs.mkdirSync and fs.writeFileSync to avoid filesystem side effects
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    },
+  };
+});
+
+// Mock logger
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 describe('task scheduler', () => {
   beforeEach(() => {
     _initTestDatabase();
@@ -15,6 +54,7 @@ describe('task scheduler', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.clearAllMocks();
   });
 
   it('pauses due tasks with invalid group folders to prevent retry churn', async () => {
@@ -49,5 +89,66 @@ describe('task scheduler', () => {
 
     const task = getTaskById('task-invalid-folder');
     expect(task?.status).toBe('paused');
+  });
+
+  it('injects memory context and snapshot into scheduled task prompt', async () => {
+    const { retrieveMemoryContext, buildMemorySnapshot } = await import(
+      './memory.js'
+    );
+    const { runContainerAgent } = await import('./container-runner.js');
+
+    createTask({
+      id: 'task-with-memory',
+      group_folder: 'test-group',
+      chat_jid: 'test@g.us',
+      prompt: 'summarize recent conversations',
+      schedule_type: 'once',
+      schedule_value: '2026-02-22T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      created_at: '2026-02-22T00:00:00.000Z',
+    });
+
+    const enqueueTask = vi.fn(
+      (_groupJid: string, _taskId: string, fn: () => Promise<void>) => {
+        void fn();
+      },
+    );
+
+    startSchedulerLoop({
+      registeredGroups: () => ({
+        'test@g.us': {
+          name: 'Test Group',
+          folder: 'test-group',
+          trigger: '@bot',
+          added_at: '2026-01-01T00:00:00.000Z',
+        },
+      }),
+      getSessions: () => ({}),
+      queue: { enqueueTask, closeStdin: vi.fn(), notifyIdle: vi.fn() } as any,
+      onProcess: () => {},
+      sendMessage: async () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Memory context was retrieved using the task prompt
+    expect(retrieveMemoryContext).toHaveBeenCalledWith('test-group', [
+      expect.objectContaining({ content: 'summarize recent conversations' }),
+    ]);
+
+    // Memory snapshot was built for the group
+    expect(buildMemorySnapshot).toHaveBeenCalledWith('test-group');
+
+    // Container agent received the memory-enriched prompt
+    expect(runContainerAgent).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        prompt: '<memory>test context</memory>\n\nsummarize recent conversations',
+      }),
+      expect.any(Function),
+      expect.any(Function),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Scheduled tasks now receive the same RAG memory context that regular messages get — previously they ran completely memory-blind
- `retrieveMemoryContext()` is called with the task prompt to prepend relevant core memories and past conversations
- `buildMemorySnapshot()` writes existing memory IDs to the IPC directory so the container agent can update/remove memories
- Added test that verifies memory retrieval, snapshot write, and enriched prompt are passed to the container agent

## Test plan

- [x] Existing scheduler test passes (invalid folder → paused)
- [x] New test verifies `retrieveMemoryContext` called with task prompt
- [x] New test verifies `buildMemorySnapshot` called for the group
- [x] New test verifies `runContainerAgent` receives memory-enriched prompt
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)