### PR TITLE
fix(add-discord): clarify bot invite flow and add Code Grant troubleshooting

### DIFF
--- a/.claude/skills/add-discord/SKILL.md
+++ b/.claude/skills/add-discord/SKILL.md
@@ -78,10 +78,12 @@ If the user doesn't have a bot token, tell them:
 > 5. Under **Privileged Gateway Intents**, enable:
 >    - **Message Content Intent** (required to read message text)
 >    - **Server Members Intent** (optional, for member display names)
-> 6. Go to **OAuth2** > **URL Generator**:
->    - Scopes: select `bot`
->    - Bot Permissions: select `Send Messages`, `Read Message History`, `View Channels`
->    - Copy the generated URL and open it in your browser to invite the bot to your server
+> 6. Scroll down to **"Requires OAuth2 Code Grant"** and make sure it is **OFF** — if enabled, the bot invite will fail
+> 7. Invite the bot to your server using this URL (replace `YOUR_CLIENT_ID` with the value from the **General Information** tab):
+>    ```
+>    https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=bot&permissions=68608
+>    ```
+>    (The OAuth2 URL Generator requires a redirect URI and is not suitable for bot invites)
 
 Wait for the user to provide the token.
 
@@ -177,6 +179,10 @@ tail -f logs/nanoclaw.log
 ```
 
 ## Troubleshooting
+
+### "This integration requires a code grant" when inviting
+
+Go to the [Discord Developer Portal](https://discord.com/developers/applications) → **Bot** tab → scroll down → toggle **"Requires OAuth2 Code Grant"** OFF → Save Changes. Then try the invite URL again.
 
 ### Bot not responding
 


### PR DESCRIPTION
## What

Two friction points when following the `add-discord` skill to invite the bot to a server. Tested while trying out the `refactor/pluggable-channels` branch — easy to cherry-pick into that PR.

### Problem 1: OAuth2 URL Generator is broken for bot invites

The instructions send users to **OAuth2 → URL Generator** to select the `bot` scope. In practice:
- The `bot` scope doesn't appear in the scope list
- Selecting any other scope triggers a "redirect URI required" error

### Problem 2: "Requires OAuth2 Code Grant" blocks the invite

New applications often have this setting enabled by default. With it on, any bot invite URL returns *"This integration requires a code grant"* — no obvious fix surfaced in the UI.

## Changes

- Replace the URL Generator instructions with a direct invite URL:
  ```
  https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=bot&permissions=68608
  ```
- Add a step during bot creation to disable "Requires OAuth2 Code Grant"
- Add two new troubleshooting entries covering both issues