### PR TITLE
feat: allow agents to send cross-group messages via send_message

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -41,15 +41,17 @@ const server = new McpServer({
 
 server.tool(
   'send_message',
-  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times.",
+  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times. Note: when running as a scheduled task, your final output is NOT sent to the user — use this tool if you need to communicate with the user or group. To send to a different registered group, supply target_chat_jid (find JIDs in /workspace/ipc/available_groups.json).",
   {
     text: z.string().describe('The message text to send'),
     sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
+    target_chat_jid: z.string().optional().describe('Send to a different registered group instead of the current one. Find JIDs in /workspace/ipc/available_groups.json.'),
   },
   async (args) => {
+    const targetJid = args.target_chat_jid || chatJid;
     const data: Record<string, string | undefined> = {
       type: 'message',
-      chatJid,
+      chatJid: targetJid,
       text: args.text,
       sender: args.sender || undefined,
       groupFolder,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -699,8 +699,11 @@ export function writeGroupsSnapshot(
   const groupIpcDir = resolveGroupIpcPath(groupFolder);
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
-  // Main sees all groups; others see nothing (they can't activate groups)
-  const visibleGroups = isMain ? groups : [];
+  // Main sees all groups; registered groups see their registered peers so
+  // they can use send_message with target_chat_jid to notify other groups.
+  const visibleGroups = isMain
+    ? groups
+    : groups.filter((g) => registeredJids.has(g.jid));
 
   const groupsFile = path.join(groupIpcDir, 'available_groups.json');
   fs.writeFileSync(

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -77,10 +77,10 @@ export function startIpcWatcher(deps: IpcDeps): void {
               if (data.type === 'message' && data.chatJid && data.text) {
                 // Authorization: verify this group can send to this chatJid
                 const targetGroup = registeredGroups[data.chatJid];
-                if (
-                  isMain ||
-                  (targetGroup && targetGroup.folder === sourceGroup)
-                ) {
+                // Any registered group can send to any other registered target.
+                // The source identity comes from the IPC directory (host-controlled),
+                // so it cannot be spoofed by container-side code.
+                if (isMain || targetGroup) {
                   await deps.sendMessage(data.chatJid, data.text);
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup },
@@ -89,7 +89,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
                 } else {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },
-                    'Unauthorized IPC message attempt blocked',
+                    'Unauthorized IPC message attempt blocked (target not registered)',
                   );
                 }
               }


### PR DESCRIPTION
## Summary

Enables any registered group's agent to notify another registered group by passing an optional `target_chat_jid` to the MCP `send_message` tool — without routing the request through the main group.

### Use cases

- A family-chat agent completes a long task and pings a work-chat group: _"Your report is ready."_
- A monitoring agent in one group broadcasts alerts to multiple groups
- Scheduled tasks running in one group context deliver results to another group

### Changes (three coordinated files)

**`container/agent-runner/src/ipc-mcp-stdio.ts`**
- Add optional `target_chat_jid` parameter to `send_message`
- When omitted, behaviour is identical to today (sends to the current group)
- When set, the IPC file's `chatJid` field is replaced with the supplied JID

**`src/ipc.ts`**
- Relax send-message authorization: `isMain || (target.folder === source)` → `isMain || target registered`
- The source identity is derived from the IPC directory path on the host filesystem — it cannot be spoofed by container-side code
- The destination must be a registered group; unregistered JIDs are still blocked with a warning

**`src/container-runner.ts`** (`writeGroupsSnapshot`)
- Non-main groups now receive the list of registered peers (previously an empty array) in `/workspace/ipc/available_groups.json`
- Agents can look up target JIDs from this file before calling `send_message`
- All groups (registered and unregistered) are still visible to the main group as before

### Security notes

- Source identity is host-controlled (IPC directory path), not container-supplied → cannot be forged
- Destination must be a registered JID → no enumeration of arbitrary JIDs
- Non-main groups still cannot register new groups or schedule tasks for other groups

## Test plan

- [ ] Non-main agent calls `send_message` without `target_chat_jid` → message goes to its own group (unchanged behaviour)
- [ ] Non-main agent calls `send_message` with `target_chat_jid` of another registered group → message delivered to that group
- [ ] Non-main agent calls `send_message` with an unregistered JID → IPC blocked with warning log
- [ ] `/workspace/ipc/available_groups.json` in a non-main container shows registered peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)