### PR TITLE
fix: destroy old Baileys socket on reconnect to prevent OOM crash

### DIFF
--- a/launchd/com.nanoclaw.plist
+++ b/launchd/com.nanoclaw.plist
@@ -7,6 +7,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>{{NODE_PATH}}</string>
+        <string>--max-old-space-size=512</string>
         <string>{{PROJECT_ROOT}}/dist/index.js</string>
     </array>
     <key>WorkingDirectory</key>


### PR DESCRIPTION
Fixes #595

## Problem

After running for ~40 hours, NanoClaw crashes with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

The heap grows to 4GB before the process dies. `launchd` restarts it automatically (KeepAlive: true), so the crash is silent — the bot stops responding for a minute then recovers. Without checking `logs/nanoclaw.error.log` you'd never know it happened.

## Root cause

`connectInternal()` creates a new `makeWASocket` instance on every reconnection but never destroys the previous socket. The old socket's event listeners (`connection.update`, `creds.update`, `messages.upsert`), `makeCacheableSignalKeyStore` LRU cache, and internal Baileys buffers all remain alive via closure references.

WhatsApp reconnections are frequent (network blips, phone sleep, WA server drops), so ghost sockets accumulate over time until the heap is exhausted.

Secondary risk: the old socket can still fire `connection.update` after `this.sock` is reassigned, causing the old listener to call `connectInternal()` again — potentially triggering a cascade of reconnects.

## Fix

Add explicit cleanup at the top of `connectInternal()`, before the new socket is created:

1. Remove the three registered event listeners so the old socket has no live references and can be GC'd
2. Call `end(undefined)` to drain the WebSocket cleanly

The `try/catch` handles the case where the socket is already fully closed.

## Defence-in-depth

Add `--max-old-space-size=512` to the launchd plist template. If any future memory issue slips through, the process fails fast at 512MB and recovers in seconds, rather than degrading silently for hours before crashing at 4GB.