### PR TITLE
fix: command injection in stopContainer + OOM from ghost sockets

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -2,7 +2,7 @@
  * Container Runner for NanoClaw
  * Spawns agent execution in containers and handles IPC
  */
-import { ChildProcess, exec, spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -413,15 +413,15 @@ export async function runContainerAgent(
         { group: group.name, containerName },
         'Container timeout, stopping gracefully',
       );
-      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
-        if (err) {
-          logger.warn(
-            { group: group.name, containerName, err },
-            'Graceful stop failed, force killing',
-          );
-          container.kill('SIGKILL');
-        }
-      });
+      try {
+        stopContainer(containerName);
+      } catch (err) {
+        logger.warn(
+          { group: group.name, containerName, err },
+          'Graceful stop failed, force killing',
+        );
+        container.kill('SIGKILL');
+      }
     };
 
     let timeout = setTimeout(killOnTimeout, timeoutMs);

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 
@@ -57,9 +57,12 @@ export function readonlyMountArgs(
   return ['-v', `${hostPath}:${containerPath}:ro`];
 }
 
-/** Returns the shell command to stop a container by name. */
-export function stopContainer(name: string): string {
-  return `${CONTAINER_RUNTIME_BIN} stop ${name}`;
+/** Stops a container by name using execFileSync (no shell interpolation). */
+export function stopContainer(name: string): void {
+  execFileSync(CONTAINER_RUNTIME_BIN, ['stop', name], {
+    stdio: 'pipe',
+    timeout: 15000,
+  });
 }
 
 /** Ensure the container runtime is running, starting it if needed. */
@@ -110,7 +113,7 @@ export function cleanupOrphans(): void {
     const orphans = output.trim().split('\n').filter(Boolean);
     for (const name of orphans) {
       try {
-        execSync(stopContainer(name), { stdio: 'pipe' });
+        stopContainer(name);
       } catch {
         /* already stopped */
       }


### PR DESCRIPTION
## Summary

- **#457**: `stopContainer()` used shell string interpolation with `exec()`, creating a command injection vector. Replaced with `execFileSync()` which bypasses the shell entirely. Updated all call sites and tests.

- ~~**#595**: Ghost socket OOM fix~~ — Dropped from this PR because `src/channels/whatsapp.ts` was moved to the [nanoclaw-whatsapp](https://github.com/qwibitai/nanoclaw-whatsapp) repo in #500. The ghost socket fix needs to be filed as a separate PR there.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] Manual verification: container timeout gracefully stops container via `execFileSync`

Closes #457