### PR TITLE
fix: resolve launch stalls and startup reliability issues

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -51,9 +51,21 @@ export class WhatsAppChannel implements Channel {
   }
 
   async connect(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+    const connectionPromise = new Promise<void>((resolve, reject) => {
       this.connectInternal(resolve).catch(reject);
     });
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              'WhatsApp connection timed out after 30s — check auth or delete store/auth/ and re-authenticate',
+            ),
+          ),
+        30000,
+      ),
+    );
+    return Promise.race([connectionPromise, timeoutPromise]);
   }
 
   private async connectInternal(onFirstOpen?: () => void): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,11 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
   10,
 ); // 10MB default
 export const IPC_POLL_INTERVAL = 1000;
-export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+// IDLE_TIMEOUT must be significantly less than CONTAINER_TIMEOUT so the
+// graceful _close sentinel fires first. container-runner.ts sets the hard
+// kill deadline to Math.max(CONTAINER_TIMEOUT, IDLE_TIMEOUT + 30_000), so
+// IDLE_TIMEOUT < CONTAINER_TIMEOUT is required for graceful shutdown to work.
+export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '300000', 10); // 5min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -65,14 +65,14 @@ export function cleanupOrphans(): void {
   try {
     const output = execSync(
       `${CONTAINER_RUNTIME_BIN} ps --filter name=nanoclaw- --format '{{.Names}}'`,
-      { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
+      { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', timeout: 5000 },
     );
     const orphans = output.trim().split('\n').filter(Boolean);
     for (const name of orphans) {
       try {
-        execSync(stopContainer(name), { stdio: 'pipe' });
+        execSync(stopContainer(name), { stdio: 'pipe', timeout: 15000 });
       } catch {
-        /* already stopped */
+        /* already stopped or timed out */
       }
     }
     if (orphans.length > 0) {


### PR DESCRIPTION
## Type of Change

  - [ ] **Skill** - adds a new skill in `.claude/skills/`
  - [x] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code

  ## Description

  Five bugs found during a fresh Linux install that caused the service to hang
  on startup or shut down uncleanly. All five are independently reproducible.

  ---

  **1. `src/config.ts` — IDLE_TIMEOUT reduced from 30min to 5min**

  `container-runner.ts` sets the hard kill deadline to
  `Math.max(CONTAINER_TIMEOUT, IDLE_TIMEOUT + 30_000)`. When both timeouts were
  30min (1800000ms), this resolved to the same value — the graceful `_close`
  sentinel never had time to fire before the hard SIGKILL. Containers always
  exited with code 137. Reducing `IDLE_TIMEOUT` to 300000ms (5min) gives the
  graceful path 25 minutes of headroom before the hard kill fires.

  **2. `src/channels/whatsapp.ts` — 30s timeout on `connect()`**

  If Baileys never emitted a `connection.update` event (bad auth state, stale
  QR code, network issue), `connect()` blocked forever with no error and no
  timeout. The service appeared to start but never processed any messages.
  Wrapped `connectInternal()` in a `Promise.race` with a 30-second deadline.
  The timeout error message directs the user to check auth or delete
  `store/auth/` and re-authenticate.

  **3. `src/container-runner.ts` — `buildVolumeMounts` made async**

  All `fs.*Sync` calls in `buildVolumeMounts()` ran on the main thread. Every
  container spawn blocked the event loop while host directories were checked and
  created — visible as message-processing latency when multiple groups are active.
  Converted to `async` using `fs.promises.*` throughout. Also adds
  `chmod(groupSessionsDir, 0o777)` after `mkdir` so the container's `node` user
  (uid 1000) can create subdirectories like `.claude/debug/` when running as root.

  **4. `src/container-runtime.ts` — timeouts on `cleanupOrphans()` docker calls**

  `docker ps` and `docker stop` in `cleanupOrphans()` ran via `execSync` with no
  timeout. A hung Docker daemon or a slow-stopping container could block service
  startup indefinitely with no log output. Added `timeout: 5000` to the
  `docker ps` call and `timeout: 15000` to each `docker stop` call.

  **5. `src/index.ts` — `validateEnvironment()` pre-flight check**

  Startup had no pre-flight validation. A missing API credential caused silent
  failures deep inside container runs (unhelpful "container exited with code 1"
  errors). A missing container image caused confusing spawn errors. Added
  `validateEnvironment()` called before `ensureContainerSystemRunning()`:
  - Checks for `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`, exits with a
    clear message if neither is set.
  - Runs `docker images -q` to verify the container image exists, exits with
    instructions to run `./container/build.sh` if missing.
  - If Docker isn't running yet when we check, logs a warning and continues
    (the existing `ensureContainerSystemRunning` handles that case).

  ---

  Tested on: Linux (Ubuntu, systemd), fresh install, `npm run build` passes
  cleanly, service starts and processes messages without hanging. 03/01/2026