### PR TITLE
fix: use container-based claude login for setup

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -112,15 +112,29 @@ Run `npx tsx setup/index.ts --step container -- --runtime <chosen>` and parse th
 
 **If TEST_OK=false but BUILD_OK=true:** The image built but won't run. Check logs — common cause is runtime not fully started. Wait a moment and retry the test.
 
-## 4. Claude Authentication (No Script)
+## 4. Claude Authentication
 
-If HAS_ENV=true from step 2, read `.env` and check for `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. If present, confirm with user: keep or reconfigure?
+If `data/claude-auth/.credentials.json` exists or `.env` contains `ANTHROPIC_API_KEY`, confirm with user: keep or reconfigure?
 
 AskUserQuestion: Claude subscription (Pro/Max) vs Anthropic API key?
 
-**Subscription:** Tell user to run `claude setup-token` in another terminal, copy the token, add `CLAUDE_CODE_OAUTH_TOKEN=<token>` to `.env`. Do NOT collect the token in chat.
+**Subscription:** Tell user to run in another terminal:
 
-**API key:** Tell user to add `ANTHROPIC_API_KEY=<key>` to `.env`.
+```bash
+docker run -it --entrypoint bash \
+  -v $(pwd)/data/claude-auth:/home/node/.claude \
+  nanoclaw-agent:latest
+```
+
+Then run `claude login` inside the container and `exit` when done.
+
+Credentials are saved to `data/claude-auth/.credentials.json` and automatically copied into each group's session directory on container startup (handled by `container-runner.ts`).
+
+Then use AskUserQuestion to ask whether they have completed the steps (options: "Done" / "I need help"). Do NOT collect tokens in chat.
+
+**API key:** Tell user to get key from Anthropic Console (https://console.anthropic.com/) and add `ANTHROPIC_API_KEY=<key>` to `.env`.
+
+Then use AskUserQuestion to ask whether they have completed the steps (options: "Done" / "I need help"). Do NOT collect the key in chat.
 
 ## 5. Set Up Channels
 


### PR DESCRIPTION
## Summary

- Replace `claude setup-token` flow with container-based `claude login` for Claude subscription authentication
- Users run `claude login` inside a Docker container that mounts `data/claude-auth/`
- Credentials persist to `data/claude-auth/.credentials.json` and are automatically propagated to group sessions by `container-runner.ts`
- Update API key flow to link to Anthropic Console and use AskUserQuestion confirmation steps

## Why

The previous setup required users to run `claude setup-token`, manually copy a token, and paste it into `.env` as `CLAUDE_CODE_OAUTH_TOKEN`. The new approach runs `claude login` inside the actual agent container, which uses the standard browser-based OAuth flow and stores credentials in a persistent volume.

**Updated:** Rebased onto latest origin/main.

## Test plan

- [ ] Run `/setup` and reach step 4 (Claude Authentication)
- [ ] Verify container-based `claude login` instructions are shown for subscription path
- [ ] Verify Anthropic Console link is shown for API key path
- [ ] Verify both paths use AskUserQuestion with "Done" / "I need help" options

🤖 Generated with [Claude Code](https://claude.com/claude-code)