### PR TITLE
feat: add shimmer typing indicator to Slack channel skill

### DIFF
--- a/.claude/skills/add-slack/add/src/channels/slack.test.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.test.ts
@@ -792,6 +792,8 @@ describe('SlackChannel', () => {
         ts: '1704067200.000000',
       }));
 
+      // Must first pin via setTyping(true) so setTyping(false) has a thread to clear
+      await channel.setTyping('slack:C0123456789', true);
       await channel.setTyping('slack:C0123456789', false);
 
       expect(currentApp().client.assistant.threads.setStatus).toHaveBeenCalledWith({
@@ -848,6 +850,61 @@ describe('SlackChannel', () => {
       await channel.setTyping('slack:C0123456789', true);
 
       expect(currentApp().client.assistant.threads.setStatus).not.toHaveBeenCalled();
+    });
+
+    it('pins thread_ts at setTyping(true) so new messages do not shift the clear target', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Hello',
+        ts: '1704067200.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', true);
+
+      // New message arrives while processing
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Follow up',
+        ts: '1704067201.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', false);
+
+      expect(currentApp().client.assistant.threads.setStatus).toHaveBeenNthCalledWith(1, {
+        channel_id: 'C0123456789',
+        thread_ts: '1704067200.000000',
+        status: 'is thinking...',
+      });
+      expect(currentApp().client.assistant.threads.setStatus).toHaveBeenNthCalledWith(2, {
+        channel_id: 'C0123456789',
+        thread_ts: '1704067200.000000',
+        status: '',
+      });
+    });
+
+    it('uses thread_ts for threaded replies instead of msg.ts', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Thread reply',
+        ts: '1704067201.000000',
+        threadTs: '1704067200.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', true);
+
+      expect(currentApp().client.assistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C0123456789',
+        thread_ts: '1704067200.000000',
+        status: 'is thinking...',
+      });
     });
   });
 

--- a/.claude/skills/add-slack/add/src/channels/slack.test.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.test.ts
@@ -53,6 +53,11 @@ vi.mock('@slack/bolt', () => ({
           user: { real_name: 'Alice Smith', name: 'alice' },
         }),
       },
+      assistant: {
+        threads: {
+          setStatus: vi.fn().mockResolvedValue({ ok: true }),
+        },
+      },
     };
 
     constructor(opts: any) {
@@ -752,26 +757,97 @@ describe('SlackChannel', () => {
     });
   });
 
-  // --- setTyping ---
+  // --- setTyping (assistant.threads.setStatus) ---
 
   describe('setTyping', () => {
-    it('resolves without error (no-op)', async () => {
+    it('calls assistant.threads.setStatus with status when user message exists', async () => {
       const opts = createTestOpts();
       const channel = new SlackChannel(opts);
+      await channel.connect();
 
-      // Should not throw — Slack has no bot typing indicator API
+      // Deliver a user message to populate lastUserMessageTs
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Hello',
+        ts: '1704067200.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', true);
+
+      expect(currentApp().client.assistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C0123456789',
+        thread_ts: '1704067200.000000',
+        status: 'is thinking...',
+      });
+    });
+
+    it('clears status when isTyping is false', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Hello',
+        ts: '1704067200.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', false);
+
+      expect(currentApp().client.assistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C0123456789',
+        thread_ts: '1704067200.000000',
+        status: '',
+      });
+    });
+
+    it('no-ops when no user message has been received', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await channel.setTyping('slack:C0123456789', true);
+
+      expect(currentApp().client.assistant.threads.setStatus).not.toHaveBeenCalled();
+    });
+
+    it('silently ignores API errors', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerMessageEvent(createMessageEvent({
+        user: 'U_USER_456',
+        text: 'Hello',
+        ts: '1704067200.000000',
+      }));
+
+      currentApp().client.assistant.threads.setStatus.mockRejectedValueOnce(
+        new Error('missing_scope'),
+      );
+
+      // Should not throw
       await expect(
         channel.setTyping('slack:C0123456789', true),
       ).resolves.toBeUndefined();
     });
 
-    it('accepts false without error', async () => {
+    it('does not track bot messages for typing indicator', async () => {
       const opts = createTestOpts();
       const channel = new SlackChannel(opts);
+      await channel.connect();
 
-      await expect(
-        channel.setTyping('slack:C0123456789', false),
-      ).resolves.toBeUndefined();
+      // Only a bot message — should NOT populate lastUserMessageTs
+      await triggerMessageEvent(createMessageEvent({
+        subtype: 'bot_message',
+        botId: 'B_MY_BOT',
+        text: 'Bot response',
+        ts: '1704067200.000000',
+      }));
+
+      await channel.setTyping('slack:C0123456789', true);
+
+      expect(currentApp().client.assistant.threads.setStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -36,6 +36,8 @@ export class SlackChannel implements Channel {
   private outgoingQueue: Array<{ jid: string; text: string }> = [];
   private flushing = false;
   private userNameCache = new Map<string, string>();
+  // Track latest user message ts per channel for assistant.threads.setStatus
+  private lastUserMessageTs = new Map<string, string>();
 
   private opts: SlackChannelOpts;
 
@@ -115,6 +117,11 @@ export class SlackChannel implements Channel {
         if (content.includes(mentionPattern) && !TRIGGER_PATTERN.test(content)) {
           content = `@${ASSISTANT_NAME} ${content}`;
         }
+      }
+
+      // Track last user message ts for typing indicator (assistant.threads.setStatus)
+      if (!isBotMessage) {
+        this.lastUserMessageTs.set(jid, msg.ts);
       }
 
       this.opts.onMessage(jid, {
@@ -203,11 +210,23 @@ export class SlackChannel implements Channel {
     await this.app.stop();
   }
 
-  // Slack does not expose a typing indicator API for bots.
-  // This no-op satisfies the Channel interface so the orchestrator
-  // doesn't need channel-specific branching.
-  async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
-    // no-op: Slack Bot API has no typing indicator endpoint
+  // Use Slack's Agents & Assistants API to show a shimmer/typing indicator.
+  // Requires the assistant:write scope (enable "Agents & AI Apps" in app settings).
+  // Only works in DM threads; silently ignored elsewhere.
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    const channelId = jid.replace(/^slack:/, '');
+    const threadTs = this.lastUserMessageTs.get(jid);
+    if (!threadTs) return;
+
+    try {
+      await this.app.client.assistant.threads.setStatus({
+        channel_id: channelId,
+        thread_ts: threadTs,
+        status: isTyping ? 'is thinking...' : '',
+      });
+    } catch {
+      // Silently ignore — requires assistant:write scope and only works in DM threads
+    }
   }
 
   /**

--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -38,6 +38,8 @@ export class SlackChannel implements Channel {
   private userNameCache = new Map<string, string>();
   // Track latest user message ts per channel for assistant.threads.setStatus
   private lastUserMessageTs = new Map<string, string>();
+  // Track the thread_ts used for the active typing indicator per channel
+  private activeTypingTs = new Map<string, string>();
 
   private opts: SlackChannelOpts;
 
@@ -119,9 +121,11 @@ export class SlackChannel implements Channel {
         }
       }
 
-      // Track last user message ts for typing indicator (assistant.threads.setStatus)
+      // Track last user message ts for typing indicator (assistant.threads.setStatus).
+      // For threaded replies, use thread_ts (the thread root) since the API targets threads.
       if (!isBotMessage) {
-        this.lastUserMessageTs.set(jid, msg.ts);
+        const threadRoot = (msg as { thread_ts?: string }).thread_ts ?? msg.ts;
+        this.lastUserMessageTs.set(jid, threadRoot);
       }
 
       this.opts.onMessage(jid, {
@@ -215,7 +219,17 @@ export class SlackChannel implements Channel {
   // Only works in DM threads; silently ignored elsewhere.
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     const channelId = jid.replace(/^slack:/, '');
-    const threadTs = this.lastUserMessageTs.get(jid);
+
+    let threadTs: string | undefined;
+    if (isTyping) {
+      // Pin the thread_ts at start so a new message arriving mid-processing
+      // won't cause setTyping(false) to clear a different thread.
+      threadTs = this.lastUserMessageTs.get(jid);
+      if (threadTs) this.activeTypingTs.set(jid, threadTs);
+    } else {
+      threadTs = this.activeTypingTs.get(jid);
+      this.activeTypingTs.delete(jid);
+    }
     if (!threadTs) return;
 
     try {


### PR DESCRIPTION
## Summary

- Implement Slack's Agents & Assistants API (`assistant.threads.setStatus`) in the add-slack skill to show a shimmer/typing indicator while the bot processes messages
- Track the latest user message timestamp per channel so the typing status can be set on the correct thread
- Silently degrade when the `assistant:write` scope is missing or when used outside of DM threads

## How it works

When the orchestrator calls `setTyping(jid, true)`, the Slack channel now calls `assistant.threads.setStatus` with `status: 'is thinking...'` on the thread of the last user message. When called with `false`, it clears the status by sending an empty string. Bot messages are excluded from timestamp tracking so the indicator only activates in response to real user messages.

## Slack-side configuration

To enable the shimmer typing indicator:

1. Go to your Slack app settings at [api.slack.com/apps](https://api.slack.com/apps)
2. Navigate to **Features** > **Agents & AI Apps** and enable it
3. This grants the `assistant:write` scope needed for `assistant.threads.setStatus`
4. Reinstall the app to your workspace if prompted

If the scope is not configured, the feature silently no-ops -- no errors will be thrown.

## Files changed

- `.claude/skills/add-slack/add/src/channels/slack.ts` -- Implementation
- `.claude/skills/add-slack/add/src/channels/slack.test.ts` -- Tests (5 new test cases)

## Test plan

- [x] Verify `setTyping(jid, true)` calls `assistant.threads.setStatus` with `'is thinking...'` status
- [x] Verify `setTyping(jid, false)` clears the status with empty string
- [x] Verify no-op when no user message has been received for the channel
- [x] Verify API errors are silently caught
- [x] Verify bot messages do not populate the tracked timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)