### PR TITLE
fix: retry with fresh session when session resume fails

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -503,6 +503,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function deleteSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
 import {
+  deleteSession,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -311,6 +312,18 @@ async function runAgent(
     }
 
     if (output.status === 'error') {
+      // If we had a session and it failed, clear it and retry once with a fresh session.
+      // This handles corrupted/incompatible sessions after container rebuilds or SDK updates.
+      if (sessionId) {
+        logger.warn(
+          { group: group.name, sessionId, error: output.error },
+          'Session resume failed, retrying with fresh session',
+        );
+        delete sessions[group.folder];
+        deleteSession(group.folder);
+        return runAgent(group, prompt, chatJid, onOutput);
+      }
+
       logger.error(
         { group: group.name, error: output.error },
         'Container agent error',
@@ -320,6 +333,17 @@ async function runAgent(
 
     return 'success';
   } catch (err) {
+    // Same retry logic for thrown errors (e.g. container crash during resume)
+    if (sessionId) {
+      logger.warn(
+        { group: group.name, sessionId, err },
+        'Session resume threw, retrying with fresh session',
+      );
+      delete sessions[group.folder];
+      deleteSession(group.folder);
+      return runAgent(group, prompt, chatJid, onOutput);
+    }
+
     logger.error({ group: group.name, err }, 'Agent error');
     return 'error';
   }


### PR DESCRIPTION
## Summary

- When a container rebuild or SDK update makes an existing session incompatible, the agent crashes on resume (`__dirname is not defined` or similar). The message cursor rolls back, creating an **infinite retry loop** against the same broken session.
- Adds `deleteSession()` to `db.ts` and retry logic in `runAgent()`: if the container returns an error while a `sessionId` was set, clear the session and retry once with a fresh session.
- If the fresh session also fails, the error is returned normally (no infinite loop).

## Reproduction

1. Start NanoClaw, send a message so a session is created
2. Rebuild the container (`./container/build.sh`)
3. Send another message — the agent crashes repeatedly with the same error, retrying the broken session forever

## Changes

| File | Change |
|------|--------|
| `src/db.ts` | Add `deleteSession(groupFolder)` function |
| `src/index.ts` | Import `deleteSession`, add retry-with-clear logic in `runAgent()` for both error returns and caught exceptions |

## Test plan

- [ ] Verify normal session resume still works (send message, wait, send another)
- [ ] Verify recovery: rebuild container while session exists, send message — should warn "Session resume failed, retrying with fresh session" and succeed
- [ ] Verify no infinite loop: if fresh session also fails, error is returned once

🤖 Generated with [Claude Code](https://claude.com/claude-code)