### PR TITLE
fix: service PATH broken on Nix-managed systems

### DIFF
--- a/setup/platform.test.ts
+++ b/setup/platform.test.ts
@@ -6,6 +6,7 @@ import {
   isRoot,
   isHeadless,
   hasSystemd,
+  isNixManaged,
   getServiceManager,
   commandExists,
   getNodeVersion,
@@ -64,6 +65,19 @@ describe('hasSystemd', () => {
     // On systemd systems, should return true
     // Just verify it doesn't throw
     const result = hasSystemd();
+    expect(typeof result).toBe('boolean');
+  });
+});
+
+// --- isNixManaged ---
+
+describe('isNixManaged', () => {
+  it('returns a boolean', () => {
+    expect(typeof isNixManaged()).toBe('boolean');
+  });
+
+  it('checks for /run/current-system/sw/bin', () => {
+    const result = isNixManaged();
     expect(typeof result).toBe('boolean');
   });
 });

--- a/setup/platform.ts
+++ b/setup/platform.ts
@@ -98,6 +98,15 @@ export function getServiceManager(): ServiceManager {
   return 'none';
 }
 
+/** Detect Nix-managed systems (NixOS, nix-darwin) by checking for the system profile. */
+export function isNixManaged(): boolean {
+  try {
+    return fs.existsSync('/run/current-system/sw/bin');
+  } catch {
+    return false;
+  }
+}
+
 export function getNodePath(): string {
   try {
     return execSync('command -v node', { encoding: 'utf-8' }).trim();

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -15,10 +15,22 @@ import {
   getNodePath,
   getServiceManager,
   hasSystemd,
+  isNixManaged,
   isRoot,
   isWSL,
 } from './platform.js';
 import { emitStatus } from './status.js';
+
+/** Build PATH for service units, auto-detecting Nix-managed system paths. */
+function servicePath(homeDir: string): string {
+  const parts = ['/usr/local/bin', '/usr/bin', '/bin', `${homeDir}/.local/bin`];
+  if (isNixManaged()) {
+    const user = os.userInfo().username;
+    parts.unshift('/run/current-system/sw/bin', '/run/wrappers/bin');
+    parts.push(`/etc/profiles/per-user/${user}/bin`, `${homeDir}/.nix-profile/bin`);
+  }
+  return parts.join(':');
+}
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -101,7 +113,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>${servicePath(homeDir)}</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>
@@ -244,7 +256,7 @@ WorkingDirectory=${projectRoot}
 Restart=always
 RestartSec=5
 Environment=HOME=${homeDir}
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
+Environment=PATH=${servicePath(homeDir)}
 StandardOutput=append:${projectRoot}/logs/nanoclaw.log
 StandardError=append:${projectRoot}/logs/nanoclaw.error.log
 


### PR DESCRIPTION
## Summary

- On NixOS and nix-darwin, system binaries live in `/run/current-system/sw/bin` instead of `/usr/bin`. The generated systemd unit and launchd plist hardcode a PATH that doesn't include these directories, causing NanoClaw to crash at startup with "Container runtime failed to start" because `docker` isn't found.
- Adds `isNixManaged()` detection to `setup/platform.ts` and a `servicePath()` helper to `setup/service.ts` that conditionally prepends the Nix system paths (`/run/current-system/sw/bin`, `/run/wrappers/bin`, `/etc/profiles/per-user/<user>/bin`)
- On non-Nix systems, the generated output is byte-identical to before

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `vitest run setup/platform.test.ts` passes (new `isNixManaged` test included)
- [x] Verified generated systemd unit contains correct NixOS paths on NixOS
- [x] Verified service starts and runs successfully on NixOS
- [ ] Verify no behavior change on non-Nix Linux (servicePath returns the same hardcoded string as before)
- [ ] Verify no behavior change on macOS without nix-darwin