### PR TITLE
feat: support configurable non-Claude runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then run `/setup`. Claude Code handles everything: dependencies, authentication,
 - **Scheduled tasks** - Recurring jobs that run Claude and can message you back
 - **Web access** - Search and fetch content from the Web
 - **Container isolation** - Agents are sandboxed in Apple Container (macOS) or Docker (macOS/Linux)
+- **Runtime selection (experimental)** - Choose `containerConfig.runtime` per group (`claude` default, plus `codex`, `gemini`, `opencode`) with backward-compatible fallback
 - **Agent Swarms** - Spin up teams of specialized agents that collaborate on complex tasks. NanoClaw is the first personal AI assistant to support agent swarms.
 - **Optional integrations** - Add Gmail (`/add-gmail`) and more via skills
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -31,7 +31,7 @@ ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install agent-browser and claude-code globally
-RUN npm install -g agent-browser @anthropic-ai/claude-code
+RUN npm install -g agent-browser @anthropic-ai/claude-code @openai/codex @google/gemini-cli opencode-ai
 
 # Create app directory
 WORKDIR /app

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { spawn } from 'child_process';
 import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
@@ -27,6 +28,7 @@ interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  runtime?: string;
   secrets?: Record<string, string>;
 }
 
@@ -58,6 +60,29 @@ interface SDKUserMessage {
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
+
+
+type AgentRuntime = 'claude' | 'codex' | 'gemini' | 'opencode';
+
+function normalizeRuntime(runtime?: string): AgentRuntime {
+  const value = (runtime || 'claude').toLowerCase();
+  if (value === 'codex' || value === 'gemini' || value === 'opencode') return value;
+  return 'claude';
+}
+
+function runtimeCommand(runtime: AgentRuntime): { cmd: string; args: string[] } {
+  switch (runtime) {
+    case 'codex':
+      return { cmd: 'codex', args: ['exec', '--json'] };
+    case 'gemini':
+      return { cmd: 'gemini', args: ['-p'] };
+    case 'opencode':
+      return { cmd: 'opencode', args: ['run', '--json'] };
+    case 'claude':
+    default:
+      return { cmd: 'claude', args: ['-p'] };
+  }
+}
 
 /**
  * Push-based async iterable for streaming user messages to the SDK.
@@ -490,6 +515,43 @@ async function runQuery(
   return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
+
+async function runGenericRuntimeQuery(
+  runtime: AgentRuntime,
+  prompt: string,
+  cwd: string,
+  sdkEnv: Record<string, string | undefined>,
+): Promise<string> {
+  const { cmd, args } = runtimeCommand(runtime);
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, [...args, prompt], {
+      cwd,
+      env: sdkEnv as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('error', (err) => reject(err));
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${cmd} exited with code ${code}: ${stderr.slice(-500)}`));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
 async function main(): Promise<void> {
   let containerInput: ContainerInput;
 
@@ -535,34 +597,37 @@ async function main(): Promise<void> {
     prompt += '\n' + pending.join('\n');
   }
 
+  const runtime = normalizeRuntime(containerInput.runtime);
+
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
   try {
     while (true) {
-      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+      if (runtime === 'claude') {
+        log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
-      if (queryResult.newSessionId) {
-        sessionId = queryResult.newSessionId;
-      }
-      if (queryResult.lastAssistantUuid) {
-        resumeAt = queryResult.lastAssistantUuid;
-      }
+        const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+        if (queryResult.newSessionId) {
+          sessionId = queryResult.newSessionId;
+        }
+        if (queryResult.lastAssistantUuid) {
+          resumeAt = queryResult.lastAssistantUuid;
+        }
 
-      // If _close was consumed during the query, exit immediately.
-      // Don't emit a session-update marker (it would reset the host's
-      // idle timer and cause a 30-min delay before the next _close).
-      if (queryResult.closedDuringQuery) {
-        log('Close sentinel consumed during query, exiting');
-        break;
-      }
+        if (queryResult.closedDuringQuery) {
+          log('Close sentinel consumed during query, exiting');
+          break;
+        }
 
-      // Emit session update so host can track it
-      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+        writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+      } else {
+        log(`Starting ${runtime} query...`);
+        const result = await runGenericRuntimeQuery(runtime, prompt, '/workspace/group', sdkEnv);
+        writeOutput({ status: 'success', result: result || null, newSessionId: sessionId });
+        writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+      }
 
       log('Query ended, waiting for next IPC message...');
-
-      // Wait for the next message or _close sentinel
       const nextMessage = await waitForIpcMessage();
       if (nextMessage === null) {
         log('Close sentinel received, exiting');

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -783,3 +783,15 @@ npm run dev
 # or
 node dist/index.js
 ```
+
+
+### Agent Runtime Selection
+
+`registered_groups.container_config.runtime` supports:
+
+- `claude` (default, backward-compatible)
+- `codex`
+- `gemini`
+- `opencode`
+
+If runtime is missing or invalid, NanoClaw falls back to `claude` to preserve existing behavior.

--- a/src/agent-runtime.test.ts
+++ b/src/agent-runtime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getAgentRuntimeSecrets,
+  resolveAgentRuntime,
+} from './agent-runtime.js';
+
+describe('resolveAgentRuntime', () => {
+  it('defaults to claude when runtime is missing', () => {
+    expect(resolveAgentRuntime(undefined)).toBe('claude');
+    expect(resolveAgentRuntime({})).toBe('claude');
+  });
+
+  it('normalizes supported runtime names', () => {
+    expect(resolveAgentRuntime({ runtime: 'codex' })).toBe('codex');
+    expect(resolveAgentRuntime({ runtime: 'gemini' })).toBe('gemini');
+    expect(resolveAgentRuntime({ runtime: 'opencode' })).toBe('opencode');
+  });
+
+  it('falls back to claude for unknown runtime values', () => {
+    expect(resolveAgentRuntime({ runtime: 'foo' as never })).toBe('claude');
+  });
+});
+
+describe('getAgentRuntimeSecrets', () => {
+  it('keeps claude secrets backward-compatible', () => {
+    const secrets = getAgentRuntimeSecrets('claude');
+    expect(secrets).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(secrets).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('returns provider-specific env vars for codex/gemini/opencode', () => {
+    expect(getAgentRuntimeSecrets('codex')).toContain('OPENAI_API_KEY');
+    expect(getAgentRuntimeSecrets('gemini')).toContain('GEMINI_API_KEY');
+    const opencode = getAgentRuntimeSecrets('opencode');
+    expect(opencode).toContain('OPENAI_API_KEY');
+    expect(opencode).toContain('ANTHROPIC_API_KEY');
+    expect(opencode).toContain('GEMINI_API_KEY');
+  });
+});

--- a/src/agent-runtime.ts
+++ b/src/agent-runtime.ts
@@ -1,0 +1,68 @@
+import { AgentRuntime, ContainerConfig } from './types.js';
+
+const SUPPORTED_AGENT_RUNTIMES: AgentRuntime[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+];
+
+export function isAgentRuntime(value: string): value is AgentRuntime {
+  return SUPPORTED_AGENT_RUNTIMES.includes(value as AgentRuntime);
+}
+
+export function resolveAgentRuntime(config?: ContainerConfig): AgentRuntime {
+  const raw = config?.runtime?.toLowerCase();
+  if (!raw) return 'claude';
+  if (isAgentRuntime(raw)) return raw;
+  return 'claude';
+}
+
+export function getAgentRuntimeSecrets(runtime: AgentRuntime): string[] {
+  switch (runtime) {
+    case 'claude':
+      return [
+        'CLAUDE_CODE_OAUTH_TOKEN',
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_BASE_URL',
+        'ANTHROPIC_AUTH_TOKEN',
+      ];
+    case 'codex':
+      return [
+        'OPENAI_API_KEY',
+        'OPENAI_BASE_URL',
+        'OPENAI_ORG_ID',
+        'OPENAI_PROJECT',
+      ];
+    case 'gemini':
+      return [
+        'GEMINI_API_KEY',
+        'GOOGLE_API_KEY',
+        'GOOGLE_GENAI_API_KEY',
+        'GOOGLE_CLOUD_PROJECT',
+        'GOOGLE_CLOUD_LOCATION',
+        'VERTEX_PROJECT',
+        'VERTEX_LOCATION',
+      ];
+    case 'opencode':
+      return [
+        // OpenCode can proxy to multiple providers; pass common auth envs.
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_BASE_URL',
+        'ANTHROPIC_AUTH_TOKEN',
+        'OPENAI_API_KEY',
+        'OPENAI_BASE_URL',
+        'OPENAI_ORG_ID',
+        'OPENAI_PROJECT',
+        'GEMINI_API_KEY',
+        'GOOGLE_API_KEY',
+        'GOOGLE_GENAI_API_KEY',
+        'GOOGLE_CLOUD_PROJECT',
+        'GOOGLE_CLOUD_LOCATION',
+        'VERTEX_PROJECT',
+        'VERTEX_LOCATION',
+      ];
+    default:
+      return [];
+  }
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,10 @@ import {
   IDLE_TIMEOUT,
   TIMEZONE,
 } from './config.js';
+import {
+  resolveAgentRuntime,
+  getAgentRuntimeSecrets,
+} from './agent-runtime.js';
 import { readEnvFile } from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
@@ -38,6 +42,7 @@ export interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  runtime?: string;
   secrets?: Record<string, string>;
 }
 
@@ -214,13 +219,9 @@ function buildVolumeMounts(
  * Read allowed secrets from .env for passing to the container via stdin.
  * Secrets are never written to disk or mounted as files.
  */
-function readSecrets(): Record<string, string> {
-  return readEnvFile([
-    'CLAUDE_CODE_OAUTH_TOKEN',
-    'ANTHROPIC_API_KEY',
-    'ANTHROPIC_BASE_URL',
-    'ANTHROPIC_AUTH_TOKEN',
-  ]);
+function readSecrets(group: RegisteredGroup): Record<string, string> {
+  const runtime = resolveAgentRuntime(group.containerConfig);
+  return readEnvFile(getAgentRuntimeSecrets(runtime));
 }
 
 function buildContainerArgs(
@@ -310,7 +311,7 @@ export async function runContainerAgent(
     let stderrTruncated = false;
 
     // Pass secrets via stdin (never written to disk or mounted as files)
-    input.secrets = readSecrets();
+    input.secrets = readSecrets(group);
     container.stdin.write(JSON.stringify(input));
     container.stdin.end();
     // Remove secrets from input so they don't appear in logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { startIpcWatcher } from './ipc.js';
 import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { resolveAgentRuntime } from './agent-runtime.js';
 import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
@@ -254,6 +255,7 @@ async function runAgent(
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
+  const runtime = resolveAgentRuntime(group.containerConfig);
 
   // Update tasks snapshot for container to read (filtered by group)
   const tasks = getAllTasks();
@@ -301,6 +303,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        runtime,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type AgentRuntime = 'claude' | 'codex' | 'gemini' | 'opencode';
+
 export interface AdditionalMount {
   hostPath: string; // Absolute path on host (supports ~ for home)
   containerPath?: string; // Optional — defaults to basename of hostPath. Mounted at /workspace/extra/{value}
@@ -30,6 +32,7 @@ export interface AllowedRoot {
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  runtime?: AgentRuntime; // Default: 'claude' for backward compatibility
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION
Closes #80

## Summary

This PR adds **configurable multi-runtime support** so NanoClaw is no longer hard-wired to Claude only.

### What changed

1. Added runtime config in group container config:
   - `containerConfig.runtime?: 'claude' | 'codex' | 'gemini' | 'opencode'`
2. Added runtime resolver/utilities (`src/agent-runtime.ts`):
   - normalize + validate runtime
   - preserve backward compatibility (`claude` fallback)
   - runtime-specific secret allowlist
3. Host runner updates:
   - pass selected runtime into container input (`src/index.ts`)
   - load runtime-specific credentials from `.env` (`src/container-runner.ts`)
4. Container runner updates:
   - keep existing Claude Agent SDK path for `claude`
   - add CLI execution path for `codex` / `gemini` / `opencode`
5. Container image updates:
   - installs `@openai/codex`, `@google/gemini-cli`, `opencode-ai`
6. Docs/tests:
   - added tests for runtime resolution and secret mapping
   - documented runtime selection in README + SPEC

## Backward compatibility

- If `containerConfig.runtime` is missing or invalid, NanoClaw defaults to `claude`.
- Existing deployments continue to behave exactly as before.

## Validation

- `npm run build` ✅
- `npm test` ✅ (302 tests passing)

