### PR TITLE
feat(slack): thread-aware reply routing and App Home DM fix

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -67,7 +67,8 @@ Quick summary of what's needed:
 2. Enable Socket Mode and generate an App-Level Token (`xapp-...`)
 3. Subscribe to bot events: `message.channels`, `message.groups`, `message.im`
 4. Add OAuth scopes: `chat:write`, `channels:history`, `groups:history`, `im:history`, `channels:read`, `groups:read`, `users:read`
-5. Install to workspace and copy the Bot Token (`xoxb-...`)
+5. In **App Home**, enable **"Allow users to send Slash commands and messages from the messages tab"** (required for DMs)
+6. Install to workspace and copy the Bot Token (`xoxb-...`)
 
 Wait for the user to provide both tokens.
 

--- a/.claude/skills/add-slack/SLACK_SETUP.md
+++ b/.claude/skills/add-slack/SLACK_SETUP.md
@@ -60,14 +60,24 @@ These scopes control what the bot is allowed to do.
 | `groups:read` | List private channels (for metadata sync) |
 | `users:read` | Look up user display names |
 
-## Step 5: Install to Workspace
+## Step 5: Enable Direct Messages (App Home)
+
+This step is required to allow users to DM the bot directly. Without it, Slack silently blocks DMs even if `message.im` is subscribed.
+
+1. In the sidebar, click **App Home**
+2. Scroll down to **Show Tabs**
+3. Check **Allow users to send Slash commands and messages from the messages tab**
+
+## Step 6: Install to Workspace
 
 1. In the sidebar, click **Install App**
 2. Click **Install to Workspace**
 3. Review the permissions and click **Allow**
 4. **Copy the Bot User OAuth Token** — it starts with `xoxb-`. Save this somewhere safe.
 
-## Step 6: Configure NanoClaw
+> **Note:** After changing scopes or event subscriptions, Slack sometimes shows a yellow banner prompting reinstallation. If you don't see the banner, go to **OAuth & Permissions** and click **Reinstall to Workspace** manually. The bot token (`xoxb-`) may change on reinstall — update `.env` if it does.
+
+## Step 7: Configure NanoClaw
 
 Add both tokens to your `.env` file:
 
@@ -88,7 +98,7 @@ Then sync the environment to the container:
 mkdir -p data/env && cp .env data/env/env
 ```
 
-## Step 7: Add the Bot to Channels
+## Step 8: Add the Bot to Channels
 
 The bot only receives messages from channels it has been explicitly added to.
 
@@ -99,7 +109,7 @@ The bot only receives messages from channels it has been explicitly added to.
 
 Repeat for each channel you want the bot in.
 
-## Step 8: Get Channel IDs for Registration
+## Step 9: Get Channel IDs for Registration
 
 You need the Slack channel ID to register it with NanoClaw.
 
@@ -133,7 +143,12 @@ The NanoClaw JID format is `slack:` followed by the channel ID, e.g., `slack:C01
 **Bot not receiving messages:**
 - Verify Socket Mode is enabled (Step 2)
 - Verify all three events are subscribed (Step 3)
-- Verify the bot has been added to the channel (Step 7)
+- Verify the bot has been added to the channel (Step 8)
+
+**Bot not responding to DMs:**
+- Go to **App Home** and ensure **"Allow users to send Slash commands and messages from the messages tab"** is checked (Step 5)
+- Verify `message.im` is in the bot event subscriptions (Step 3)
+- Reinstall the app after any changes — the yellow reinstall banner doesn't always appear; use **OAuth & Permissions → Reinstall to Workspace** manually if needed
 
 **"missing_scope" errors:**
 - Go back to **OAuth & Permissions** and add the missing scope

--- a/.claude/skills/add-slack/add/src/channels/slack.test.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.test.ts
@@ -420,7 +420,7 @@ describe('SlackChannel', () => {
       );
     });
 
-    it('flattens threaded replies into channel messages', async () => {
+    it('delivers threaded replies to onMessage (channel receives all messages)', async () => {
       const opts = createTestOpts();
       const channel = new SlackChannel(opts);
       await channel.connect();
@@ -432,7 +432,7 @@ describe('SlackChannel', () => {
       });
       await triggerMessageEvent(event);
 
-      // Threaded replies are delivered as regular channel messages
+      // Threaded replies are delivered to the agent like any other message
       expect(opts.onMessage).toHaveBeenCalledWith(
         'slack:C0123456789',
         expect.objectContaining({
@@ -846,6 +846,195 @@ describe('SlackChannel', () => {
     it('has name "slack"', () => {
       const channel = new SlackChannel(createTestOpts());
       expect(channel.name).toBe('slack');
+    });
+  });
+
+  // --- Thread routing ---
+
+  describe('thread routing', () => {
+    it('replies in thread when message is a threaded reply', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      // thread_ts != ts → this is a reply to an existing thread
+      const event = createMessageEvent({
+        ts: '1704067201.000000',
+        threadTs: '1704067200.000000',
+        text: 'Thread reply',
+      });
+      await triggerMessageEvent(event);
+
+      await channel.sendMessage('slack:C0123456789', 'My response');
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'C0123456789',
+        text: 'My response',
+        thread_ts: '1704067200.000000',
+      });
+    });
+
+    it('replies to channel for root messages (no thread_ts)', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        ts: '1704067200.000000',
+        text: 'Root channel message',
+      });
+      await triggerMessageEvent(event);
+
+      await channel.sendMessage('slack:C0123456789', 'My response');
+
+      // No thread_ts — reply goes to channel
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'C0123456789',
+        text: 'My response',
+      });
+    });
+
+    it('replies to channel when thread_ts equals ts (thread root/parent message)', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      // thread_ts === ts means this is the thread root, not a reply
+      const event = createMessageEvent({
+        ts: '1704067200.000000',
+        threadTs: '1704067200.000000',
+        text: 'Thread parent message',
+      });
+      await triggerMessageEvent(event);
+
+      await channel.sendMessage('slack:C0123456789', 'My response');
+
+      // Thread root is treated as a channel message — reply goes to channel
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'C0123456789',
+        text: 'My response',
+      });
+    });
+
+    it('clears thread context after sending (second reply goes to channel)', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        ts: '1704067201.000000',
+        threadTs: '1704067200.000000',
+        text: 'Thread reply',
+      });
+      await triggerMessageEvent(event);
+
+      // First send consumes the pending thread context
+      await channel.sendMessage('slack:C0123456789', 'First response');
+      // Second send (no new incoming message) has no pending context
+      await channel.sendMessage('slack:C0123456789', 'Second response');
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledTimes(2);
+      expect(currentApp().client.chat.postMessage).toHaveBeenNthCalledWith(1, {
+        channel: 'C0123456789',
+        text: 'First response',
+        thread_ts: '1704067200.000000',
+      });
+      expect(currentApp().client.chat.postMessage).toHaveBeenNthCalledWith(2, {
+        channel: 'C0123456789',
+        text: 'Second response',
+      });
+    });
+
+    it('queued messages preserve thread context through disconnect/reconnect', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      // Receive a threaded reply — sets pendingThreadTs
+      const event = createMessageEvent({
+        ts: '1704067201.000000',
+        threadTs: '1704067200.000000',
+        text: 'Thread reply',
+      });
+      await triggerMessageEvent(event);
+
+      // Disconnect before responding
+      await channel.disconnect();
+
+      // sendMessage queues with thread context captured at queue time
+      await channel.sendMessage('slack:C0123456789', 'Queued response');
+
+      // Reconnect triggers flush of queued messages
+      await channel.connect();
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C0123456789',
+          text: 'Queued response',
+          thread_ts: '1704067200.000000',
+        }),
+      );
+    });
+
+    describe('SLACK_ALWAYS_REPLY_IN_THREAD=true', () => {
+      beforeEach(() => {
+        vi.mocked(readEnvFile).mockReturnValue({
+          SLACK_BOT_TOKEN: 'xoxb-test-token',
+          SLACK_APP_TOKEN: 'xapp-test-token',
+          SLACK_ALWAYS_REPLY_IN_THREAD: 'true',
+        });
+      });
+
+      afterEach(() => {
+        vi.mocked(readEnvFile).mockReturnValue({
+          SLACK_BOT_TOKEN: 'xoxb-test-token',
+          SLACK_APP_TOKEN: 'xapp-test-token',
+        });
+      });
+
+      it('replies in new thread for root channel messages', async () => {
+        const opts = createTestOpts();
+        const channel = new SlackChannel(opts);
+        await channel.connect();
+
+        // Root channel message (no thread_ts)
+        const event = createMessageEvent({
+          ts: '1704067200.000000',
+          text: 'Root message',
+        });
+        await triggerMessageEvent(event);
+
+        await channel.sendMessage('slack:C0123456789', 'My response');
+
+        // Uses the message's own ts to start a new thread
+        expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+          channel: 'C0123456789',
+          text: 'My response',
+          thread_ts: '1704067200.000000',
+        });
+      });
+
+      it('replies in existing thread for threaded replies', async () => {
+        const opts = createTestOpts();
+        const channel = new SlackChannel(opts);
+        await channel.connect();
+
+        // Threaded reply — should use the thread's thread_ts, not msg.ts
+        const event = createMessageEvent({
+          ts: '1704067201.000000',
+          threadTs: '1704067200.000000',
+          text: 'Thread reply',
+        });
+        await triggerMessageEvent(event);
+
+        await channel.sendMessage('slack:C0123456789', 'My response');
+
+        expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+          channel: 'C0123456789',
+          text: 'My response',
+          thread_ts: '1704067200.000000',
+        });
+      });
     });
   });
 });

--- a/.claude/skills/add-slack/add/src/channels/slack.test.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.test.ts
@@ -1035,6 +1035,39 @@ describe('SlackChannel', () => {
           thread_ts: '1704067200.000000',
         });
       });
+
+      it('replies directly (no thread) for DM root messages', async () => {
+        const opts = createTestOpts();
+        const channel = new SlackChannel(opts);
+        await channel.connect();
+
+        // DM channel (channel_type: 'im') — threading would hide the reply
+        const event = createMessageEvent({
+          channel: 'D0123456789',
+          channelType: 'im',
+          ts: '1704067200.000000',
+          text: 'Hey Joe',
+        });
+
+        // Register the DM JID so the message is delivered
+        vi.mocked(opts.registeredGroups).mockReturnValue({
+          'slack:D0123456789': {
+            name: 'Reid DM',
+            folder: 'reid-dm',
+            trigger: '@Jonesy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        });
+
+        await triggerMessageEvent(event);
+        await channel.sendMessage('slack:D0123456789', 'My response');
+
+        // No thread_ts — reply goes directly to the DM conversation
+        expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+          channel: 'D0123456789',
+          text: 'My response',
+        });
+      });
     });
   });
 });

--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -34,9 +34,15 @@ export class SlackChannel implements Channel {
   private app: App;
   private botUserId: string | undefined;
   private connected = false;
-  private outgoingQueue: Array<{ jid: string; text: string }> = [];
+  private outgoingQueue: Array<{ jid: string; text: string; threadTs?: string }> = [];
   private flushing = false;
   private userNameCache = new Map<string, string>();
+  // Tracks the thread_ts to reply into for each JID.
+  // Set when an incoming message is part of a thread, or when
+  // SLACK_ALWAYS_REPLY_IN_THREAD is enabled (uses the message ts).
+  // Consumed and cleared when sendMessage is called for that JID.
+  private pendingThreadTs = new Map<string, string>();
+  private alwaysReplyInThread: boolean;
 
   private opts: SlackChannelOpts;
 
@@ -45,9 +51,11 @@ export class SlackChannel implements Channel {
 
     // Read tokens from .env (not process.env — keeps secrets off the environment
     // so they don't leak to child processes, matching NanoClaw's security pattern)
-    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN']);
+    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_ALWAYS_REPLY_IN_THREAD']);
     const botToken = env.SLACK_BOT_TOKEN;
     const appToken = env.SLACK_APP_TOKEN;
+    this.alwaysReplyInThread =
+      (process.env.SLACK_ALWAYS_REPLY_IN_THREAD ?? env.SLACK_ALWAYS_REPLY_IN_THREAD) === 'true';
 
     if (!botToken || !appToken) {
       throw new Error(
@@ -79,10 +87,6 @@ export class SlackChannel implements Channel {
 
       if (!msg.text) return;
 
-      // Threaded replies are flattened into the channel conversation.
-      // The agent sees them alongside channel-level messages; responses
-      // always go to the channel, not back into the thread.
-
       const jid = `slack:${msg.channel}`;
       const timestamp = new Date(parseFloat(msg.ts) * 1000).toISOString();
       const isGroup = msg.channel_type !== 'im';
@@ -102,7 +106,7 @@ export class SlackChannel implements Channel {
         senderName = ASSISTANT_NAME;
       } else {
         senderName =
-          (await this.resolveUserName(msg.user)) ||
+          (await this.resolveUserName(msg.user ?? '')) ||
           msg.user ||
           'unknown';
       }
@@ -115,6 +119,23 @@ export class SlackChannel implements Channel {
         const mentionPattern = `<@${this.botUserId}>`;
         if (content.includes(mentionPattern) && !TRIGGER_PATTERN.test(content)) {
           content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Track thread context so replies go back into the same thread.
+      // thread_ts is present on all messages in a thread (including the root).
+      // A message is a threaded reply when thread_ts differs from its own ts.
+      if (!isBotMessage) {
+        const threadTs = (msg as GenericMessageEvent).thread_ts;
+        if (threadTs && threadTs !== msg.ts) {
+          // Threaded reply — respond in the same thread
+          this.pendingThreadTs.set(jid, threadTs);
+        } else if (this.alwaysReplyInThread) {
+          // Root channel message, always-in-thread mode — start a new thread
+          this.pendingThreadTs.set(jid, msg.ts);
+        } else {
+          // Root channel message — respond in channel
+          this.pendingThreadTs.delete(jid);
         }
       }
 
@@ -159,9 +180,11 @@ export class SlackChannel implements Channel {
 
   async sendMessage(jid: string, text: string): Promise<void> {
     const channelId = jid.replace(/^slack:/, '');
+    const threadTs = this.pendingThreadTs.get(jid);
+    this.pendingThreadTs.delete(jid);
 
     if (!this.connected) {
-      this.outgoingQueue.push({ jid, text });
+      this.outgoingQueue.push({ jid, text, threadTs });
       logger.info(
         { jid, queueSize: this.outgoingQueue.length },
         'Slack disconnected, message queued',
@@ -169,21 +192,25 @@ export class SlackChannel implements Channel {
       return;
     }
 
+    const post = (chunk: string) =>
+      this.app.client.chat.postMessage({
+        channel: channelId,
+        text: chunk,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+
     try {
       // Slack limits messages to ~4000 characters; split if needed
       if (text.length <= MAX_MESSAGE_LENGTH) {
-        await this.app.client.chat.postMessage({ channel: channelId, text });
+        await post(text);
       } else {
         for (let i = 0; i < text.length; i += MAX_MESSAGE_LENGTH) {
-          await this.app.client.chat.postMessage({
-            channel: channelId,
-            text: text.slice(i, i + MAX_MESSAGE_LENGTH),
-          });
+          await post(text.slice(i, i + MAX_MESSAGE_LENGTH));
         }
       }
-      logger.info({ jid, length: text.length }, 'Slack message sent');
+      logger.info({ jid, length: text.length, threadTs }, 'Slack message sent');
     } catch (err) {
-      this.outgoingQueue.push({ jid, text });
+      this.outgoingQueue.push({ jid, text, threadTs });
       logger.warn(
         { jid, err, queueSize: this.outgoingQueue.length },
         'Failed to send Slack message, queued',
@@ -278,6 +305,7 @@ export class SlackChannel implements Channel {
         await this.app.client.chat.postMessage({
           channel: channelId,
           text: item.text,
+          ...(item.threadTs ? { thread_ts: item.threadTs } : {}),
         });
         logger.info(
           { jid: item.jid, length: item.text.length },

--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -130,8 +130,9 @@ export class SlackChannel implements Channel {
         if (threadTs && threadTs !== msg.ts) {
           // Threaded reply — respond in the same thread
           this.pendingThreadTs.set(jid, threadTs);
-        } else if (this.alwaysReplyInThread) {
-          // Root channel message, always-in-thread mode — start a new thread
+        } else if (this.alwaysReplyInThread && isGroup) {
+          // Root channel message, always-in-thread mode — start a new thread.
+          // Not applied to DMs: threading a DM reply hides it in Slack's thread panel.
           this.pendingThreadTs.set(jid, msg.ts);
         } else {
           // Root channel message — respond in channel


### PR DESCRIPTION
## Summary

Three improvements to the Slack channel skill, discovered during real-world setup on a Raspberry Pi 5 (ARM64, Docker runtime).

### 1. Missing App Home DM setup step (docs fix)

Slack silently blocks DMs to the bot unless **"Allow users to send Slash commands and messages from the messages tab"** is enabled in App Home settings. This setting is completely separate from event subscriptions and OAuth scopes — no API error is surfaced when it's missing, making it very difficult to diagnose.

- Added as Step 5 in `SLACK_SETUP.md` (renumbered subsequent steps)
- Added as item 5 in `SKILL.md` quick summary
- Added "Bot not responding to DMs" troubleshooting entry
- Added note that the reinstall yellow banner doesn't always appear after scope/event changes

### 2. Thread-aware reply routing

**Default behaviour (no config change needed):**
- Message in a thread → bot replies in that same thread
- Message in the channel root → bot replies in the channel

**`SLACK_ALWAYS_REPLY_IN_THREAD=true`:**
- Message in a channel thread → bot replies in that thread
- Message in a channel root → bot starts a new thread anchored to that message
- DM → bot always replies directly, regardless of this setting (see below)

**Implementation:** Self-contained in `SlackChannel` with a `pendingThreadTs: Map<string, string>` that carries thread context from the incoming message event to the outgoing `sendMessage` call. No changes to the `Channel` interface, DB schema, or other channels.

Also fixes a TypeScript error: `resolveUserName()` called with `msg.user ?? ''` to handle the undefined case on `BotMessageEvent`.

### 3. Fix: DM replies broken when `SLACK_ALWAYS_REPLY_IN_THREAD=true`

When `SLACK_ALWAYS_REPLY_IN_THREAD` was enabled, DM replies were silently sent with a `thread_ts`, causing Slack to route them into a thread panel rather than the main DM conversation — invisible to the user, with no error surfaced. This is the same class of silent failure as the App Home issue. The fix skips always-in-thread mode for DM channels (`channel_type === 'im'`).

## Design trade-off / future direction

This implementation deliberately keeps thread context **in-memory and local to `SlackChannel`** to avoid pipeline-wide changes. The consequence is that `thread_ts` is never persisted: the DB stores the message content, sender, timestamp, and JID, but not which Slack thread the message belonged to. Threaded replies and root channel messages are indistinguishable in stored history, and if the process restarts between receiving a message and sending the reply, the thread context is lost.

A "proper" pipeline-wide solution would store `thread_ts` (or a generic `thread_id`) as an optional field on every message and propagate it through the `NewMessage` type, `Channel.sendMessage`, and the router. This would give the agent awareness of thread structure and make history queryable by thread.

Slack is unlikely to be the only channel where this matters — Telegram supports threaded replies, Discord has forum channels, and future channels may too. **If the maintainer would prefer to land a consistent `thread_id` field across the pipeline first, this PR could be held or rebased on top of that work.** The in-memory approach is offered as a pragmatic first step that is fully correct within its constraints and easy to replace later.

## Tests

8 new unit tests added to `slack.test.ts` covering:
- Threaded reply → `postMessage` includes `thread_ts`
- Root channel message → no `thread_ts` in `postMessage`
- `thread_ts === ts` (thread parent/root) → treated as root, no `thread_ts`
- Thread context cleared after first `sendMessage`
- Queued messages preserve thread context through disconnect/reconnect
- `SLACK_ALWAYS_REPLY_IN_THREAD=true`: root channel messages reply in new thread
- `SLACK_ALWAYS_REPLY_IN_THREAD=true`: threaded replies use existing `thread_ts`
- `SLACK_ALWAYS_REPLY_IN_THREAD=true`: DM root messages reply directly (no `thread_ts`)

All 54 Slack unit tests pass.

## Manual testing

Tested on Pi5 (ARM64, Docker runtime) with a real Slack workspace:

- ✅ DMs to the bot work after enabling the App Home checkbox
- ✅ Message in channel root → bot replies in channel (default)
- ✅ Reply in a thread → bot replies in the same thread
- ✅ `SLACK_ALWAYS_REPLY_IN_THREAD=true` → root channel message starts a new thread
- ✅ `SLACK_ALWAYS_REPLY_IN_THREAD=true` → threaded reply continues in the same thread
- ✅ `SLACK_ALWAYS_REPLY_IN_THREAD=true` → DM replies directly (not threaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)