### PR TITLE
fix(sessions): rotate oversized JSONL sessions to prevent container timeouts

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -526,6 +526,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function deleteSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import {
   ASSISTANT_NAME,
+  DATA_DIR,
   IDLE_TIMEOUT,
   POLL_INTERVAL,
   TIMEZONE,
@@ -24,6 +25,7 @@ import {
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
 import {
+  deleteSession,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -264,7 +266,36 @@ async function runAgent(
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
-  const sessionId = sessions[group.folder];
+  let sessionId: string | undefined = sessions[group.folder];
+
+  // Rotate session if JSONL file exceeds size threshold to prevent
+  // container timeouts from unbounded append-only compaction growth
+  const MAX_SESSION_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+  if (sessionId) {
+    const sessionFile = path.join(
+      DATA_DIR,
+      'sessions',
+      group.folder,
+      '.claude',
+      'projects',
+      '-workspace-group',
+      `${sessionId}.jsonl`,
+    );
+    try {
+      const size = fs.statSync(sessionFile).size;
+      if (size > MAX_SESSION_FILE_SIZE) {
+        logger.info(
+          { group: group.folder, sizeBytes: size, sessionId },
+          'Session file exceeds size threshold, rotating to new session',
+        );
+        delete sessions[group.folder];
+        deleteSession(group.folder);
+        sessionId = undefined;
+      }
+    } catch {
+      // File doesn't exist or stat failed — proceed with existing sessionId
+    }
+  }
 
   // Update tasks snapshot for container to read (filtered by group)
   const tasks = getAllTasks();


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Closes #697

Adds a size check in `runAgent()` before spawning the container. When the current session JSONL file exceeds 5 MB, it rotates to a new session ID. The old file is preserved for reference.

Without this, long-running groups accumulate session files that cause container timeouts on startup, making the bot silently stop responding.