### PR TITLE
feat(skills): add icloud-tools skill (CalDAV/CardDAV/IMAP/SMTP)

### DIFF
--- a/.claude/skills/icloud-tools/SKILL.md
+++ b/.claude/skills/icloud-tools/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: icloud-tools
+description: Use when a NanoClaw group needs access to iCloud Calendar, Contacts, Mail, or Notes. Gives agents CalDAV/CardDAV/IMAP/SMTP tools via an app-specific password. Works on any platform — no macOS required.
+---
+
+# iCloud Tools
+
+Gives NanoClaw agents access to Apple's productivity apps via iCloud's standard protocols using an app-specific password. Works on any platform (no macOS requirement).
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `icloud-tools` is in `applied_skills`, skip to Phase 3 (Verify).
+
+### Prepare app-specific password
+
+Generate one at [appleid.apple.com](https://appleid.apple.com) → Sign-In & Security → App-Specific Passwords. The password is 16 characters in `xxxx-xxxx-xxxx-xxxx` format.
+
+Add credentials to `.env`:
+```
+ICLOUD_EMAIL=user@icloud.com
+ICLOUD_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+ICLOUD_SENDER_EMAIL=alias@icloud.com  # Optional: use iCloud alias as sender
+```
+
+No OS-specific dependencies — the MCP server runs inside the existing container.
+
+## Phase 2: Apply
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/icloud-tools
+```
+
+This adds the icloud-tools MCP server to the container and wires up the credentials.
+
+### Validate
+
+```bash
+npm test && npm run build
+```
+
+## Phase 3: Verify
+
+### Choose modules
+
+Available modules (set via `ICLOUD_MODULES` in `.mcp.json`):
+
+| Module | Protocol | Tools | Description |
+|--------|----------|-------|-------------|
+| `calendar` | CalDAV | 6 | Calendars, events, upcoming, CRUD |
+| `contacts` | CardDAV | 4 | Search, groups, create, update |
+| `mail` | IMAP/SMTP | 12 | Folders, read, send, reply, forward, drafts, flag, move |
+| `notes` | IMAP | 2 | List and read notes (read-only) |
+
+Examples:
+- Family group: `calendar,notes`
+- Work group: `mail,contacts,calendar`
+- All modules: `calendar,contacts,mail,notes`
+
+### Configure per-group `.mcp.json`
+
+Add to the target group's `.mcp.json` (merge with existing entries):
+
+```json
+{
+  "mcpServers": {
+    "icloud-tools": {
+      "command": "node",
+      "args": ["/opt/icloud-tools/dist/server.js"],
+      "env": {
+        "ICLOUD_EMAIL": "${ICLOUD_EMAIL}",
+        "ICLOUD_APP_PASSWORD": "${ICLOUD_APP_PASSWORD}",
+        "ICLOUD_SENDER_EMAIL": "${ICLOUD_SENDER_EMAIL}",
+        "ICLOUD_MODULES": "calendar,contacts,mail,notes"
+      }
+    }
+  }
+}
+```
+
+Customize `ICLOUD_MODULES` per group as needed.
+
+### Rebuild container
+
+```bash
+cd container && ./build.sh
+```
+
+### Restart service
+
+**macOS (launchd):**
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+**Linux (systemd):**
+```bash
+systemctl --user restart nanoclaw
+```
+
+### Check logs
+
+```bash
+tail -f logs/nanoclaw.log | grep -i -E "icloud|caldav|imap|smtp"
+```
+
+Look for:
+- `icloud-tools server` started — MCP server loaded successfully
+- Module registration messages — calendar/contacts/mail/notes registered
+- Connection errors on first use — check credentials
+
+### Send a test message
+
+Ask the group: "What's on my calendar this week?" or "Send an email to..."
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ICLOUD_EMAIL` | Yes | iCloud account email |
+| `ICLOUD_APP_PASSWORD` | Yes | App-specific password (16-char, `xxxx-xxxx-xxxx-xxxx`) |
+| `ICLOUD_SENDER_EMAIL` | No | SMTP sender alias (defaults to ICLOUD_EMAIL) |
+| `ICLOUD_MODULES` | Yes (in `.mcp.json`) | Comma-separated modules: `calendar,contacts,mail,notes` |
+
+## Troubleshooting
+
+**"Connection refused" or auth error**: Check that `ICLOUD_EMAIL` and `ICLOUD_APP_PASSWORD` are set in `.env`. App-specific passwords expire if revoked — regenerate at appleid.apple.com.
+
+**"Module not loading"**: `ICLOUD_MODULES` must be set in the group's `.mcp.json` env block — it is not read from `.env`. An empty or missing value means no tools are registered.
+
+**"Auth failed" on IMAP/SMTP**: Verify the app-specific password is correct and hasn't been revoked. Regular iCloud passwords are not accepted — only app-specific passwords work.
+
+**"Notes read-only"**: Expected. iCloud Notes access via IMAP is read-only. There are no write tools for notes — this is by design.
+
+**Container not finding `/opt/icloud-tools`**: Rebuild the container after applying the skill: `cd container && ./build.sh`. The build step compiles the MCP server into `/opt/icloud-tools/dist/`.
+
+**Tools not appearing in agent**: Confirm `mcp__icloud-tools__*` is in the `allowedTools` list in `container/agent-runner/src/index.ts` and that the container was rebuilt.

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/package.json
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "icloud-tools",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "iCloud MCP server for NanoClaw agents",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "tsdav": "^2.1.8",
+    "imapflow": "^1.0.171",
+    "nodemailer": "^6.10.1",
+    "ical.js": "^2.1.0",
+    "marked": "^15.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/nodemailer": "^6.4.17",
+    "@types/node": "^22.10.7",
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/auth.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/auth.ts
@@ -1,0 +1,95 @@
+import { DAVClient } from 'tsdav';
+import { ImapFlow } from 'imapflow';
+import { createTransport, type Transporter } from 'nodemailer';
+
+let caldavClient: DAVClient | null = null;
+let carddavClient: DAVClient | null = null;
+let imapClient: ImapFlow | null = null;
+let smtpTransport: Transporter | null = null;
+
+function requireEnv(name: string): string {
+  const val = process.env[name];
+  if (!val) throw new Error(`Required environment variable ${name} is not set`);
+  return val;
+}
+
+function getCredentials() {
+  return {
+    username: requireEnv('ICLOUD_EMAIL'),
+    password: requireEnv('ICLOUD_APP_PASSWORD'),
+  };
+}
+
+export async function getCaldavClient(): Promise<DAVClient> {
+  if (!caldavClient) {
+    const creds = getCredentials();
+    caldavClient = new DAVClient({
+      serverUrl: 'https://caldav.icloud.com',
+      credentials: creds,
+      authMethod: 'Basic',
+      defaultAccountType: 'caldav',
+    });
+    await caldavClient.login();
+  }
+  return caldavClient;
+}
+
+export async function getCarddavClient(): Promise<DAVClient> {
+  if (!carddavClient) {
+    const creds = getCredentials();
+    carddavClient = new DAVClient({
+      serverUrl: 'https://contacts.icloud.com',
+      credentials: creds,
+      authMethod: 'Basic',
+      defaultAccountType: 'carddav',
+    });
+    await carddavClient.login();
+  }
+  return carddavClient;
+}
+
+export async function getImapClient(): Promise<ImapFlow> {
+  if (!imapClient) {
+    const creds = getCredentials();
+    imapClient = new ImapFlow({
+      host: 'imap.mail.me.com',
+      port: 993,
+      secure: true,
+      auth: { user: creds.username, pass: creds.password },
+      logger: false,
+    });
+    await imapClient.connect();
+  }
+  return imapClient;
+}
+
+export function getSmtpTransport(): Transporter {
+  if (!smtpTransport) {
+    const creds = getCredentials();
+    const senderEmail = process.env.ICLOUD_SENDER_EMAIL || creds.username;
+    smtpTransport = createTransport(
+      {
+        host: 'smtp.mail.me.com',
+        port: 587,
+        secure: false,
+        auth: { user: creds.username, pass: creds.password },
+      },
+      { from: senderEmail },
+    );
+  }
+  return smtpTransport;
+}
+
+/** Gracefully close all open connections */
+export async function closeAll(): Promise<void> {
+  if (imapClient) {
+    await imapClient.logout().catch(() => {});
+    imapClient = null;
+  }
+  if (smtpTransport) {
+    smtpTransport.close();
+    smtpTransport = null;
+  }
+  caldavClient = null;
+  carddavClient = null;
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/calendar.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/calendar.ts
@@ -1,0 +1,441 @@
+import { randomUUID } from 'crypto';
+import ICAL from 'ical.js';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { DAVCalendar, DAVObject } from 'tsdav';
+import { getCaldavClient } from '../auth.js';
+import { ok, err } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ParsedEvent {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  location: string | null;
+  description: string | null;
+  allDay: boolean;
+  url?: string;
+  etag?: string;
+  calendarName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fetch all calendars that have VEVENT component support (i.e. event calendars). */
+async function getEventCalendars(): Promise<DAVCalendar[]> {
+  const client = await getCaldavClient();
+  const calendars = await client.fetchCalendars();
+  return calendars.filter(
+    (cal) => cal.components && cal.components.includes('VEVENT'),
+  );
+}
+
+/** Find a single event calendar by display name. */
+async function findCalendar(name: string): Promise<DAVCalendar | undefined> {
+  const calendars = await getEventCalendars();
+  return calendars.find((c) => c.displayName === name);
+}
+
+/** Parse iCal data into a structured event object. */
+function parseEvent(obj: DAVObject): ParsedEvent | null {
+  try {
+    if (!obj.data) return null;
+
+    const jcal = ICAL.parse(obj.data as string);
+    const comp = new ICAL.Component(jcal);
+    const vevent = comp.getFirstSubcomponent('vevent');
+    if (!vevent) return null;
+
+    const uid = String(vevent.getFirstPropertyValue('uid') ?? '');
+    const summary = String(vevent.getFirstPropertyValue('summary') ?? '');
+
+    const dtstart = vevent.getFirstPropertyValue('dtstart');
+    const dtend = vevent.getFirstPropertyValue('dtend');
+
+    const locVal = vevent.getFirstPropertyValue('location');
+    const location: string | null = locVal ? String(locVal) : null;
+
+    const descVal = vevent.getFirstPropertyValue('description');
+    const description: string | null = descVal ? String(descVal) : null;
+
+    // All-day detection: ical.js Time objects have isDate property
+    const allDay = dtstart ? (dtstart as { isDate?: boolean }).isDate === true : false;
+
+    return {
+      id: uid,
+      title: summary,
+      start: dtstart ? dtstart.toString() : '',
+      end: dtend ? dtend.toString() : '',
+      location,
+      description,
+      allDay,
+      url: obj.url,
+      etag: obj.etag,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Build an iCal VEVENT string from fields. */
+function buildVeventIcal(fields: {
+  uid: string;
+  title: string;
+  start: string;
+  end: string;
+  location?: string;
+  description?: string;
+}): string {
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//icloud-tools//EN',
+    'BEGIN:VEVENT',
+    `UID:${fields.uid}`,
+    `DTSTAMP:${formatIcalDate(new Date())}`,
+    `SUMMARY:${fields.title}`,
+    `DTSTART:${formatIcalDate(new Date(fields.start))}`,
+    `DTEND:${formatIcalDate(new Date(fields.end))}`,
+  ];
+
+  if (fields.location) {
+    lines.push(`LOCATION:${fields.location}`);
+  }
+
+  if (fields.description) {
+    lines.push(`DESCRIPTION:${fields.description}`);
+  }
+
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+  return lines.join('\r\n');
+}
+
+/** Format a Date to iCal UTC timestamp (YYYYMMDDTHHmmssZ). */
+function formatIcalDate(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+}
+
+/**
+ * Search all event calendars for a VEVENT with the given UID.
+ * Returns the raw DAVObject and its parent calendar, or null.
+ */
+async function findEventById(
+  id: string,
+): Promise<{ obj: DAVObject; calendar: DAVCalendar } | null> {
+  const client = await getCaldavClient();
+  const calendars = await getEventCalendars();
+  for (const cal of calendars) {
+    const objects = await client.fetchCalendarObjects({ calendar: cal });
+    for (const obj of objects) {
+      const parsed = parseEvent(obj);
+      if (parsed && parsed.id === id) {
+        return { obj, calendar: cal };
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions
+// ---------------------------------------------------------------------------
+
+export async function handleListCalendars() {
+  try {
+    const calendars = await getEventCalendars();
+
+    const results = calendars.map((cal) => ({
+      name: cal.displayName,
+      color: (cal as Record<string, unknown>).calendarColor as string | undefined,
+      editable: true,
+    }));
+
+    return ok(results);
+  } catch (e) {
+    return err(`Failed to list calendars: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleListEvents(params: {
+  calendar?: string;
+  start_date: string;
+  end_date: string;
+}) {
+  try {
+    const client = await getCaldavClient();
+    let calendarsToQuery: DAVCalendar[];
+
+    if (params.calendar) {
+      const cal = await findCalendar(params.calendar);
+      if (!cal) {
+        return err(`Calendar "${params.calendar}" not found`);
+      }
+      calendarsToQuery = [cal];
+    } else {
+      calendarsToQuery = await getEventCalendars();
+    }
+
+    const timeRange = {
+      start: new Date(params.start_date).toISOString(),
+      end: new Date(params.end_date).toISOString(),
+    };
+
+    const events: ParsedEvent[] = [];
+    for (const cal of calendarsToQuery) {
+      const objects = await client.fetchCalendarObjects({
+        calendar: cal,
+        timeRange,
+      });
+      for (const obj of objects) {
+        const parsed = parseEvent(obj);
+        if (parsed) {
+          parsed.calendarName = String(cal.displayName ?? '');
+          events.push(parsed);
+        }
+      }
+    }
+
+    // Sort by start time
+    events.sort((a, b) => a.start.localeCompare(b.start));
+
+    // Return public-facing shape
+    const result = events.map((ev) => ({
+      id: ev.id,
+      title: ev.title,
+      start: ev.start,
+      end: ev.end,
+      location: ev.location,
+      allDay: ev.allDay,
+    }));
+
+    return ok(result);
+  } catch (e) {
+    return err(`Failed to list events: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleListUpcoming(params: {
+  count?: number;
+}) {
+  try {
+    const count = params.count ?? 10;
+    const client = await getCaldavClient();
+    const calendars = await getEventCalendars();
+
+    const now = new Date();
+    const endDate = new Date(now);
+    endDate.setDate(endDate.getDate() + 90);
+
+    const timeRange = {
+      start: now.toISOString(),
+      end: endDate.toISOString(),
+    };
+
+    const events: ParsedEvent[] = [];
+    for (const cal of calendars) {
+      const objects = await client.fetchCalendarObjects({
+        calendar: cal,
+        timeRange,
+      });
+      for (const obj of objects) {
+        const parsed = parseEvent(obj);
+        if (parsed) {
+          parsed.calendarName = String(cal.displayName ?? '');
+          events.push(parsed);
+        }
+      }
+    }
+
+    // Sort by start time
+    events.sort((a, b) => a.start.localeCompare(b.start));
+
+    // Slice to requested count
+    const sliced = events.slice(0, count);
+
+    const result = sliced.map((ev) => ({
+      id: ev.id,
+      title: ev.title,
+      start: ev.start,
+      end: ev.end,
+      location: ev.location,
+      calendar: ev.calendarName,
+    }));
+
+    return ok(result);
+  } catch (e) {
+    return err(`Failed to list upcoming events: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleCreateEvent(params: {
+  calendar: string;
+  title: string;
+  start: string;
+  end: string;
+  location?: string;
+  description?: string;
+}) {
+  try {
+    const cal = await findCalendar(params.calendar);
+    if (!cal) {
+      return err(`Calendar "${params.calendar}" not found`);
+    }
+
+    const uid = randomUUID();
+    const icalString = buildVeventIcal({
+      uid,
+      title: params.title,
+      start: params.start,
+      end: params.end,
+      location: params.location,
+      description: params.description,
+    });
+
+    const client = await getCaldavClient();
+    await client.createCalendarObject({
+      calendar: cal,
+      filename: `${uid}.ics`,
+      iCalString: icalString,
+    });
+
+    return ok({ id: uid });
+  } catch (e) {
+    return err(`Failed to create event: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleUpdateEvent(params: {
+  id: string;
+  title?: string;
+  start?: string;
+  end?: string;
+  location?: string;
+  description?: string;
+}) {
+  try {
+    const found = await findEventById(params.id);
+    if (!found) {
+      return err(`Event "${params.id}" not found`);
+    }
+
+    const { obj } = found;
+    const parsed = parseEvent(obj)!;
+
+    const updatedIcal = buildVeventIcal({
+      uid: parsed.id,
+      title: params.title ?? parsed.title,
+      start: params.start ?? parsed.start,
+      end: params.end ?? parsed.end,
+      location: params.location ?? parsed.location ?? undefined,
+      description: params.description ?? parsed.description ?? undefined,
+    });
+
+    const client = await getCaldavClient();
+    await client.updateCalendarObject({
+      calendarObject: {
+        url: obj.url,
+        etag: obj.etag,
+        data: updatedIcal,
+      },
+    });
+
+    return ok({ success: true });
+  } catch (e) {
+    return err(`Failed to update event: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleDeleteEvent(params: { id: string }) {
+  try {
+    const found = await findEventById(params.id);
+    if (!found) {
+      return err(`Event "${params.id}" not found`);
+    }
+
+    const { obj } = found;
+    const client = await getCaldavClient();
+    await client.deleteCalendarObject({
+      calendarObject: { url: obj.url, etag: obj.etag },
+    });
+
+    return ok({ success: true });
+  } catch (e) {
+    return err(`Failed to delete event: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Registration
+// ---------------------------------------------------------------------------
+
+export function registerCalendar(server: McpServer): void {
+  server.tool(
+    'icloud_calendar_list_calendars',
+    'List all iCloud event calendars',
+    {},
+    async () => handleListCalendars(),
+  );
+
+  server.tool(
+    'icloud_calendar_list_events',
+    'List events in a date range, optionally filtered by calendar',
+    {
+      calendar: z.string().optional().describe('Calendar name to filter by'),
+      start_date: z.string().describe('Start date in ISO 8601 format (e.g. 2026-03-01)'),
+      end_date: z.string().describe('End date in ISO 8601 format (e.g. 2026-03-31)'),
+    },
+    async (params) => handleListEvents(params),
+  );
+
+  server.tool(
+    'icloud_calendar_list_upcoming',
+    'List upcoming events (next 90 days), limited by count',
+    {
+      count: z.number().optional().describe('Maximum number of events to return (default: 10)'),
+    },
+    async (params) => handleListUpcoming(params),
+  );
+
+  server.tool(
+    'icloud_calendar_create_event',
+    'Create a new event on an iCloud calendar',
+    {
+      calendar: z.string().describe('Name of the calendar'),
+      title: z.string().describe('Event title'),
+      start: z.string().describe('Start date/time in ISO 8601 format'),
+      end: z.string().describe('End date/time in ISO 8601 format'),
+      location: z.string().optional().describe('Event location'),
+      description: z.string().optional().describe('Event description'),
+    },
+    async (params) => handleCreateEvent(params),
+  );
+
+  server.tool(
+    'icloud_calendar_update_event',
+    'Update an existing calendar event',
+    {
+      id: z.string().describe('UID of the event to update'),
+      title: z.string().optional().describe('New title'),
+      start: z.string().optional().describe('New start date/time in ISO 8601 format'),
+      end: z.string().optional().describe('New end date/time in ISO 8601 format'),
+      location: z.string().optional().describe('New location'),
+      description: z.string().optional().describe('New description'),
+    },
+    async (params) => handleUpdateEvent(params),
+  );
+
+  server.tool(
+    'icloud_calendar_delete_event',
+    'Delete a calendar event',
+    {
+      id: z.string().describe('UID of the event to delete'),
+    },
+    async (params) => handleDeleteEvent(params),
+  );
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/contacts.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/contacts.ts
@@ -1,0 +1,404 @@
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { DAVObject } from 'tsdav';
+import { getCarddavClient } from '../auth.js';
+import { ok, err } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ParsedContact {
+  id: string;
+  name: string;
+  structuredName: string | null;
+  phones: string[];
+  emails: string[];
+  organization: string | null;
+  notes: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// vCard Parsing (regex-based, no extra dependency)
+// ---------------------------------------------------------------------------
+
+/** Extract a single-value field from a vCard string. */
+function extractField(data: string, field: string): string | null {
+  const regex = new RegExp(`^${field}:(.+)$`, 'm');
+  const match = data.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+/** Extract all values for a multi-value field (TEL, EMAIL) from a vCard string. */
+function extractMultiField(data: string, field: string): string[] {
+  const regex = new RegExp(`^${field}(?:;[^:]*)?:(.+)$`, 'gm');
+  const values: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(data)) !== null) {
+    values.push(match[1].trim());
+  }
+  return values;
+}
+
+/** Parse a vCard string into a structured contact object. */
+function parseVCard(obj: DAVObject): ParsedContact | null {
+  try {
+    if (!obj.data) return null;
+    const data = obj.data as string;
+
+    const uid = extractField(data, 'UID');
+    const fn = extractField(data, 'FN');
+    if (!uid || !fn) return null;
+
+    const structuredName = extractField(data, 'N');
+    const phones = extractMultiField(data, 'TEL');
+    const emails = extractMultiField(data, 'EMAIL');
+    const organization = extractField(data, 'ORG');
+    const notes = extractField(data, 'NOTE');
+
+    return {
+      id: uid,
+      name: fn,
+      structuredName,
+      phones,
+      emails,
+      organization,
+      notes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Build a vCard 3.0 string from fields. */
+function buildVCard(fields: {
+  uid: string;
+  firstName: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
+  organization?: string;
+  notes?: string;
+}): string {
+  const fn = fields.lastName
+    ? `${fields.firstName} ${fields.lastName}`
+    : fields.firstName;
+  const n = `${fields.lastName ?? ''};${fields.firstName};;;`;
+
+  const lines: string[] = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `UID:${fields.uid}`,
+    `FN:${fn}`,
+    `N:${n}`,
+  ];
+
+  if (fields.phone) {
+    lines.push(`TEL;type=CELL:${fields.phone}`);
+  }
+
+  if (fields.email) {
+    lines.push(`EMAIL:${fields.email}`);
+  }
+
+  if (fields.organization) {
+    lines.push(`ORG:${fields.organization}`);
+  }
+
+  if (fields.notes) {
+    lines.push(`NOTE:${fields.notes}`);
+  }
+
+  lines.push('END:VCARD');
+  return lines.join('\r\n');
+}
+
+/**
+ * Rebuild a vCard string preserving existing fields and applying updates.
+ * This keeps the original FN, N, UID and replaces/adds only the specified fields.
+ */
+function rebuildVCard(
+  original: ParsedContact,
+  updates: {
+    phone?: string;
+    email?: string;
+    organization?: string;
+    notes?: string;
+  },
+): string {
+  const lines: string[] = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `UID:${original.id}`,
+    `FN:${original.name}`,
+  ];
+
+  // N: field is required by iCloud CardDAV
+  if (original.structuredName) {
+    lines.push(`N:${original.structuredName}`);
+  } else {
+    // Derive from FN: "First Last" -> "Last;First;;;"
+    const parts = original.name.split(' ');
+    const last = parts.length > 1 ? parts.slice(-1)[0] : '';
+    const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : parts[0];
+    lines.push(`N:${last};${first};;;`);
+  }
+
+  // Add phone: use updated if provided, else keep existing
+  if (updates.phone) {
+    lines.push(`TEL;type=CELL:${updates.phone}`);
+  } else {
+    for (const phone of original.phones) {
+      lines.push(`TEL;type=CELL:${phone}`);
+    }
+  }
+
+  // Add email: use updated if provided, else keep existing
+  if (updates.email) {
+    lines.push(`EMAIL:${updates.email}`);
+  } else {
+    for (const email of original.emails) {
+      lines.push(`EMAIL:${email}`);
+    }
+  }
+
+  // Organization
+  const org = updates.organization ?? original.organization;
+  if (org) {
+    lines.push(`ORG:${org}`);
+  }
+
+  // Notes
+  const note = updates.notes ?? original.notes;
+  if (note) {
+    lines.push(`NOTE:${note}`);
+  }
+
+  lines.push('END:VCARD');
+  return lines.join('\r\n');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fetch all address books. */
+async function getAddressBooks() {
+  const client = await getCarddavClient();
+  return client.fetchAddressBooks();
+}
+
+/**
+ * Search all address books for a contact with the given UID.
+ * Returns the raw DAVObject or null.
+ */
+async function findContactById(
+  id: string,
+): Promise<DAVObject | null> {
+  const client = await getCarddavClient();
+  const books = await getAddressBooks();
+  for (const book of books) {
+    const vcards = await client.fetchVCards({ addressBook: book });
+    for (const vc of vcards) {
+      const parsed = parseVCard(vc);
+      if (parsed && parsed.id === id) {
+        return vc;
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions
+// ---------------------------------------------------------------------------
+
+export async function handleSearch(params: { query: string }) {
+  try {
+    const client = await getCarddavClient();
+    const books = await getAddressBooks();
+    const query = params.query.toLowerCase();
+
+    const results: Array<{
+      id: string;
+      name: string;
+      phones: string[];
+      emails: string[];
+      organization: string | null;
+    }> = [];
+
+    for (const book of books) {
+      const vcards = await client.fetchVCards({ addressBook: book });
+      for (const vc of vcards) {
+        const parsed = parseVCard(vc);
+        if (!parsed) continue;
+
+        const searchable = [
+          parsed.name,
+          ...parsed.phones,
+          ...parsed.emails,
+          parsed.organization ?? '',
+        ]
+          .join(' ')
+          .toLowerCase();
+
+        if (searchable.includes(query)) {
+          results.push({
+            id: parsed.id,
+            name: parsed.name,
+            phones: parsed.phones,
+            emails: parsed.emails,
+            organization: parsed.organization,
+          });
+        }
+      }
+    }
+
+    return ok(results);
+  } catch (e) {
+    return err(`Failed to search contacts: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleListGroups() {
+  try {
+    const client = await getCarddavClient();
+    const books = await getAddressBooks();
+
+    const results = await Promise.all(
+      books.map(async (book) => {
+        const vcards = await client.fetchVCards({ addressBook: book });
+        return {
+          name: book.displayName as string,
+          memberCount: vcards.filter((vc) => parseVCard(vc) !== null).length,
+        };
+      }),
+    );
+
+    return ok(results);
+  } catch (e) {
+    return err(`Failed to list contact groups: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleCreate(params: {
+  first_name: string;
+  last_name?: string;
+  phone?: string;
+  email?: string;
+  organization?: string;
+}) {
+  try {
+    const client = await getCarddavClient();
+    const books = await getAddressBooks();
+
+    if (books.length === 0) {
+      return err('No address books found');
+    }
+
+    const uid = randomUUID();
+    const vCardString = buildVCard({
+      uid,
+      firstName: params.first_name,
+      lastName: params.last_name,
+      phone: params.phone,
+      email: params.email,
+      organization: params.organization,
+    });
+
+    await client.createVCard({
+      addressBook: books[0],
+      vCardString,
+      filename: `${uid}.vcf`,
+    });
+
+    return ok({ success: true, id: uid });
+  } catch (e) {
+    return err(`Failed to create contact: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleUpdate(params: {
+  id: string;
+  phone?: string;
+  email?: string;
+  organization?: string;
+  notes?: string;
+}) {
+  try {
+    const contact = await findContactById(params.id);
+    if (!contact) {
+      return err(`Contact "${params.id}" not found`);
+    }
+
+    const parsed = parseVCard(contact)!;
+    const updatedData = rebuildVCard(parsed, {
+      phone: params.phone,
+      email: params.email,
+      organization: params.organization,
+      notes: params.notes,
+    });
+
+    const client = await getCarddavClient();
+    await client.updateVCard({
+      vCard: {
+        url: contact.url,
+        etag: contact.etag,
+        data: updatedData,
+      },
+    });
+
+    return ok({ success: true });
+  } catch (e) {
+    return err(`Failed to update contact: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Registration
+// ---------------------------------------------------------------------------
+
+export function registerContacts(server: McpServer): void {
+  server.tool(
+    'icloud_contacts_search',
+    'Search iCloud contacts by name, phone, email, or organization',
+    {
+      query: z.string().describe('Search query (matches name, phone, email, or organization)'),
+    },
+    async (params) => handleSearch(params),
+  );
+
+  server.tool(
+    'icloud_contacts_list_groups',
+    'List all iCloud contact groups (address books) with member counts',
+    {},
+    async () => handleListGroups(),
+  );
+
+  server.tool(
+    'icloud_contacts_create',
+    'Create a new iCloud contact',
+    {
+      first_name: z.string().describe('First name of the contact'),
+      last_name: z.string().optional().describe('Last name of the contact'),
+      phone: z.string().optional().describe('Phone number'),
+      email: z.string().optional().describe('Email address'),
+      organization: z.string().optional().describe('Organization/company name'),
+    },
+    async (params) => handleCreate(params),
+  );
+
+  server.tool(
+    'icloud_contacts_update',
+    'Update an existing iCloud contact',
+    {
+      id: z.string().describe('UID of the contact to update'),
+      phone: z.string().optional().describe('New phone number (replaces existing)'),
+      email: z.string().optional().describe('New email address (replaces existing)'),
+      organization: z.string().optional().describe('New organization/company name'),
+      notes: z.string().optional().describe('Notes about the contact'),
+    },
+    async (params) => handleUpdate(params),
+  );
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/mail.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/mail.ts
@@ -1,0 +1,675 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getImapClient, getSmtpTransport } from '../auth.js';
+import { ok, err } from '../types.js';
+import { marked } from 'marked';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract plain-text body from a raw MIME source string. */
+function extractBody(source: string): string {
+  // Body starts after the first double CRLF (end of headers)
+  const idx = source.indexOf('\r\n\r\n');
+  if (idx === -1) return source;
+  return source.slice(idx + 4).trim();
+}
+
+/** Render markdown text to HTML. */
+function renderHtml(markdown: string): string {
+  return marked.parse(markdown, { async: false }) as string;
+}
+
+/** Build a raw MIME message string for draft/sent append. */
+function buildRawMime(fields: {
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  bcc?: string;
+}): string {
+  const senderEmail = process.env.ICLOUD_SENDER_EMAIL;
+  const boundary = `----nanoclaw-${Date.now()}`;
+  const headers: string[] = [];
+
+  if (senderEmail) headers.push(`From: ${senderEmail}`);
+  headers.push(
+    `To: ${fields.to}`,
+    `Subject: ${fields.subject}`,
+    `MIME-Version: 1.0`,
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    `Date: ${new Date().toUTCString()}`,
+  );
+  if (fields.cc) headers.push(`Cc: ${fields.cc}`);
+
+  const htmlBody = renderHtml(fields.body);
+
+  const parts = [
+    `--${boundary}`,
+    `Content-Type: text/plain; charset=utf-8`,
+    `Content-Transfer-Encoding: 8bit`,
+    ``,
+    fields.body,
+    `--${boundary}`,
+    `Content-Type: text/html; charset=utf-8`,
+    `Content-Transfer-Encoding: 8bit`,
+    ``,
+    htmlBody,
+    `--${boundary}--`,
+  ];
+
+  return [...headers, '', ...parts].join('\r\n');
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions
+// ---------------------------------------------------------------------------
+
+export async function handleListFolders() {
+  try {
+    const client = await getImapClient();
+    const folders = await client.list();
+
+    const results = folders.map((f: { name: string; path: string; status?: { messages?: number; unseen?: number } }) => ({
+      name: f.name,
+      path: f.path,
+      messageCount: f.status?.messages ?? 0,
+      unread: f.status?.unseen ?? 0,
+    }));
+
+    return ok(results);
+  } catch (e) {
+    return err(`Failed to list folders: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleListMessages(params: {
+  folder?: string;
+  limit?: number;
+}) {
+  const folder = params.folder ?? 'INBOX';
+  const limit = params.limit ?? 50;
+
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock(folder);
+    try {
+      const mailbox = client.mailbox;
+      if (!mailbox) return ok([]);
+      const total = mailbox.exists;
+      if (total === 0) {
+        return ok([]);
+      }
+
+      const start = Math.max(1, total - limit + 1);
+      const range = `${start}:*`;
+
+      const messages: Array<{
+        id: number;
+        subject: string;
+        sender: string;
+        date: string;
+        read: boolean;
+        flagged: boolean;
+      }> = [];
+
+      for await (const msg of client.fetch(range, { envelope: true, flags: true, uid: true })) {
+        const from = msg.envelope!.from?.[0];
+        messages.push({
+          id: msg.uid,
+          subject: msg.envelope!.subject ?? '',
+          sender: from?.address ?? '',
+          date: msg.envelope!.date?.toISOString?.() ?? String(msg.envelope!.date ?? ''),
+          read: msg.flags!.has('\\Seen'),
+          flagged: msg.flags!.has('\\Flagged'),
+        });
+      }
+
+      return ok(messages);
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to list messages: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleReadMessage(params: { id: number }) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    try {
+      let found = null;
+
+      for await (const msg of client.fetch(params.id, { envelope: true, source: true, uid: true }, { uid: true })) {
+        found = msg;
+      }
+
+      if (!found) {
+        return err(`Message ${params.id} not found`);
+      }
+
+      // Mark as read
+      await client.messageFlagsAdd(params.id, ['\\Seen'], { uid: true });
+
+      const source = found.source ? found.source.toString() : '';
+      const body = extractBody(source);
+
+      const from = found.envelope!.from?.[0];
+      const toAddrs = (found.envelope!.to ?? []).map((a: { address?: string }) => a.address).filter(Boolean);
+      const ccAddrs = (found.envelope!.cc ?? []).map((a: { address?: string }) => a.address).filter(Boolean);
+
+      return ok({
+        subject: found.envelope!.subject ?? '',
+        sender: from?.address ?? '',
+        to: toAddrs,
+        cc: ccAddrs,
+        date: found.envelope!.date?.toISOString?.() ?? String(found.envelope!.date ?? ''),
+        body,
+      });
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to read message: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleSend(params: {
+  to: string;
+  subject: string;
+  body: string;
+  from?: string;
+  cc?: string;
+  bcc?: string;
+}) {
+  try {
+    const transport = getSmtpTransport();
+
+    const mailOptions: Record<string, unknown> = {
+      to: params.to,
+      subject: params.subject,
+      text: params.body,
+      html: renderHtml(params.body),
+    };
+
+    if (params.from) mailOptions.from = params.from;
+    if (params.cc) mailOptions.cc = params.cc;
+    if (params.bcc) mailOptions.bcc = params.bcc;
+
+    const info = await transport.sendMail(mailOptions);
+
+    // Save copy to Sent Messages
+    try {
+      const client = await getImapClient();
+      const rawMime = buildRawMime({
+        to: params.to,
+        subject: params.subject,
+        body: params.body,
+        cc: params.cc,
+        bcc: params.bcc,
+      });
+      await client.append('Sent Messages', rawMime, ['\\Seen']);
+    } catch (appendErr) {
+      console.error('Failed to save to Sent Messages:', appendErr);
+    }
+
+    return ok({ success: true, messageId: info.messageId });
+  } catch (e) {
+    return err(`Failed to send email: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleReply(params: {
+  id: number;
+  body: string;
+  reply_all?: boolean;
+}) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    let original = null;
+    try {
+      for await (const msg of client.fetch(params.id, { envelope: true, uid: true }, { uid: true })) {
+        original = msg;
+      }
+    } finally {
+      lock.release();
+    }
+
+    if (!original) {
+      return err(`Message ${params.id} not found`);
+    }
+
+    const origSubject = original.envelope!.subject ?? '';
+    const subject = origSubject.startsWith('Re:') ? origSubject : `Re: ${origSubject}`;
+    const from = original.envelope!.from?.[0];
+    const messageId = original.envelope!.messageId;
+
+    const replyFrom = process.env.ICLOUD_SENDER_EMAIL;
+    const mailOptions: Record<string, unknown> = {
+      to: from?.address ?? '',
+      subject,
+      text: params.body,
+      html: renderHtml(params.body),
+      inReplyTo: messageId,
+    };
+    if (replyFrom) mailOptions.from = replyFrom;
+
+    if (params.reply_all) {
+      const ccAddrs = (original.envelope!.cc ?? [])
+        .map((a: { address?: string }) => a.address)
+        .filter(Boolean);
+      if (ccAddrs.length > 0) {
+        mailOptions.cc = ccAddrs.join(', ');
+      }
+    }
+
+    const transport = getSmtpTransport();
+    const info = await transport.sendMail(mailOptions);
+
+    // Save copy to Sent Messages
+    try {
+      const sentMime = buildRawMime({
+        to: from?.address ?? '',
+        subject,
+        body: params.body,
+        cc: typeof mailOptions.cc === 'string' ? mailOptions.cc : undefined,
+      });
+      await client.append('Sent Messages', sentMime, ['\\Seen']);
+    } catch (appendErr) {
+      console.error('Failed to save reply to Sent Messages:', appendErr);
+    }
+
+    return ok({ success: true, messageId: info.messageId });
+  } catch (e) {
+    return err(`Failed to reply: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleForward(params: {
+  id: number;
+  to: string;
+  body?: string;
+}) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    let original = null;
+    try {
+      for await (const msg of client.fetch(params.id, { envelope: true, source: true, uid: true }, { uid: true })) {
+        original = msg;
+      }
+    } finally {
+      lock.release();
+    }
+
+    if (!original) {
+      return err(`Message ${params.id} not found`);
+    }
+
+    const origSubject = original.envelope!.subject ?? '';
+    const subject = origSubject.startsWith('Fwd:') ? origSubject : `Fwd: ${origSubject}`;
+
+    const source = original.source ? original.source.toString() : '';
+    const originalBody = extractBody(source);
+
+    const from = original.envelope!.from?.[0];
+    const forwardedBlock = [
+      '---------- Forwarded message ----------',
+      `From: ${from?.address ?? ''}`,
+      `Subject: ${origSubject}`,
+      `Date: ${original.envelope!.date ?? ''}`,
+      '',
+      originalBody,
+    ].join('\n');
+
+    const textParts: string[] = [];
+    if (params.body) {
+      textParts.push(params.body);
+      textParts.push('');
+    }
+    textParts.push(forwardedBlock);
+
+    const fullText = textParts.join('\n');
+    const fwdFrom = process.env.ICLOUD_SENDER_EMAIL;
+    const fwdOptions: Record<string, unknown> = {
+      to: params.to,
+      subject,
+      text: fullText,
+      html: renderHtml(fullText),
+    };
+    if (fwdFrom) fwdOptions.from = fwdFrom;
+
+    const transport = getSmtpTransport();
+    const info = await transport.sendMail(fwdOptions);
+
+    // Save copy to Sent Messages
+    try {
+      const sentMime = buildRawMime({
+        to: params.to,
+        subject,
+        body: fullText,
+      });
+      await client.append('Sent Messages', sentMime, ['\\Seen']);
+    } catch (appendErr) {
+      console.error('Failed to save forward to Sent Messages:', appendErr);
+    }
+
+    return ok({ success: true, messageId: info.messageId });
+  } catch (e) {
+    return err(`Failed to forward: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleSearch(params: {
+  query: string;
+  folder?: string;
+}) {
+  const folder = params.folder ?? 'INBOX';
+
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock(folder);
+    try {
+      const searchResult = await client.search(
+        { or: [{ subject: params.query }, { from: params.query }, { body: params.query }] },
+        { uid: true },
+      );
+      const uids: number[] = searchResult || [];
+
+      if (uids.length === 0) {
+        return ok([]);
+      }
+
+      const results: Array<{
+        id: number;
+        subject: string;
+        sender: string;
+        date: string;
+      }> = [];
+
+      for await (const msg of client.fetch(uids, { envelope: true, uid: true }, { uid: true })) {
+        const from = msg.envelope!.from?.[0];
+        results.push({
+          id: msg.uid,
+          subject: msg.envelope!.subject ?? '',
+          sender: from?.address ?? '',
+          date: msg.envelope!.date?.toISOString?.() ?? String(msg.envelope!.date ?? ''),
+        });
+      }
+
+      return ok(results);
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to search: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleCreateDraft(params: {
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  bcc?: string;
+}) {
+  try {
+    const client = await getImapClient();
+
+    const rawMime = buildRawMime({
+      to: params.to,
+      subject: params.subject,
+      body: params.body,
+      cc: params.cc,
+      bcc: params.bcc,
+    });
+
+    const result = await client.append('Drafts', rawMime, ['\\Draft']);
+
+    return ok({ success: true, id: result && typeof result !== 'boolean' ? result.uid : null });
+  } catch (e) {
+    return err(`Failed to create draft: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleUpdateDraft(params: {
+  id: number;
+  to?: string;
+  subject?: string;
+  body?: string;
+}) {
+  try {
+    const client = await getImapClient();
+
+    let origTo = '';
+    let origSubject = '';
+    let origBody = '';
+
+    const lock = await client.getMailboxLock('Drafts');
+    try {
+      let original = null;
+      for await (const msg of client.fetch(params.id, { envelope: true, source: true, uid: true }, { uid: true })) {
+        original = msg;
+      }
+
+      if (!original) {
+        return err(`Draft ${params.id} not found`);
+      }
+
+      origTo = original.envelope!.to?.[0]?.address ?? '';
+      origSubject = original.envelope!.subject ?? '';
+      const origSource = original.source ? original.source.toString() : '';
+      origBody = extractBody(origSource);
+
+      // Delete old draft while holding the lock
+      await client.messageDelete(params.id, { uid: true });
+    } finally {
+      lock.release();
+    }
+
+    const newTo = params.to ?? origTo;
+    const newSubject = params.subject ?? origSubject;
+    const newBody = params.body ?? origBody;
+
+    const rawMime = buildRawMime({
+      to: newTo,
+      subject: newSubject,
+      body: newBody,
+    });
+
+    const result = await client.append('Drafts', rawMime, ['\\Draft']);
+
+    return ok({ success: true, id: result && typeof result !== 'boolean' ? result.uid : null });
+  } catch (e) {
+    return err(`Failed to update draft: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleFlag(params: { id: number; flagged: boolean }) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    try {
+      if (params.flagged) {
+        await client.messageFlagsAdd(params.id, ['\\Flagged'], { uid: true });
+      } else {
+        await client.messageFlagsRemove(params.id, ['\\Flagged'], { uid: true });
+      }
+      return ok({ success: true });
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to update flag: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleMarkRead(params: { id: number; read: boolean }) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    try {
+      if (params.read) {
+        await client.messageFlagsAdd(params.id, ['\\Seen'], { uid: true });
+      } else {
+        await client.messageFlagsRemove(params.id, ['\\Seen'], { uid: true });
+      }
+      return ok({ success: true });
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to update read status: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleMove(params: { id: number; target_folder: string }) {
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('INBOX');
+    try {
+      await client.messageMove(params.id, params.target_folder, { uid: true });
+      return ok({ success: true });
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to move message: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Registration
+// ---------------------------------------------------------------------------
+
+export function registerMail(server: McpServer): void {
+  server.tool(
+    'icloud_mail_list_folders',
+    'List all iCloud Mail folders with message counts',
+    {},
+    async () => handleListFolders(),
+  );
+
+  server.tool(
+    'icloud_mail_list_messages',
+    'List messages in a mail folder (most recent first)',
+    {
+      folder: z.string().optional().describe('Folder to list messages from (default: INBOX)'),
+      limit: z.number().optional().describe('Maximum number of messages to return (default: 50)'),
+    },
+    async (params) => handleListMessages(params),
+  );
+
+  server.tool(
+    'icloud_mail_read_message',
+    'Read the full content of an email message',
+    {
+      id: z.number().describe('UID of the message to read'),
+    },
+    async (params) => handleReadMessage(params),
+  );
+
+  server.tool(
+    'icloud_mail_send',
+    'Send a new email via iCloud Mail',
+    {
+      to: z.string().describe('Recipient email address(es)'),
+      subject: z.string().describe('Email subject line'),
+      body: z.string().describe('Email body text'),
+      from: z.string().optional().describe('Sender email address (defaults to ICLOUD_SENDER_EMAIL or account email)'),
+      cc: z.string().optional().describe('CC recipient(s)'),
+      bcc: z.string().optional().describe('BCC recipient(s)'),
+    },
+    async (params) => handleSend(params),
+  );
+
+  server.tool(
+    'icloud_mail_reply',
+    'Reply to an existing email message',
+    {
+      id: z.number().describe('UID of the message to reply to'),
+      body: z.string().describe('Reply body text'),
+      reply_all: z.boolean().optional().describe('Reply to all recipients (default: false)'),
+    },
+    async (params) => handleReply(params),
+  );
+
+  server.tool(
+    'icloud_mail_forward',
+    'Forward an email message to another recipient',
+    {
+      id: z.number().describe('UID of the message to forward'),
+      to: z.string().describe('Recipient to forward to'),
+      body: z.string().optional().describe('Additional text to prepend to forwarded message'),
+    },
+    async (params) => handleForward(params),
+  );
+
+  server.tool(
+    'icloud_mail_search',
+    'Search for emails by subject, sender, or body text',
+    {
+      query: z.string().describe('Search query (matches subject, from, or body)'),
+      folder: z.string().optional().describe('Folder to search in (default: INBOX)'),
+    },
+    async (params) => handleSearch(params),
+  );
+
+  server.tool(
+    'icloud_mail_create_draft',
+    'Create a new email draft',
+    {
+      to: z.string().describe('Recipient email address(es)'),
+      subject: z.string().describe('Email subject line'),
+      body: z.string().describe('Email body text'),
+      cc: z.string().optional().describe('CC recipient(s)'),
+      bcc: z.string().optional().describe('BCC recipient(s)'),
+    },
+    async (params) => handleCreateDraft(params),
+  );
+
+  server.tool(
+    'icloud_mail_update_draft',
+    'Update an existing email draft (deletes old and creates new)',
+    {
+      id: z.number().describe('UID of the draft to update'),
+      to: z.string().optional().describe('New recipient(s)'),
+      subject: z.string().optional().describe('New subject'),
+      body: z.string().optional().describe('New body text'),
+    },
+    async (params) => handleUpdateDraft(params),
+  );
+
+  server.tool(
+    'icloud_mail_flag',
+    'Flag or unflag an email message',
+    {
+      id: z.number().describe('UID of the message'),
+      flagged: z.boolean().describe('Whether to flag (true) or unflag (false)'),
+    },
+    async (params) => handleFlag(params),
+  );
+
+  server.tool(
+    'icloud_mail_mark_read',
+    'Mark an email message as read or unread',
+    {
+      id: z.number().describe('UID of the message'),
+      read: z.boolean().describe('Whether to mark as read (true) or unread (false)'),
+    },
+    async (params) => handleMarkRead(params),
+  );
+
+  server.tool(
+    'icloud_mail_move',
+    'Move an email message to a different folder',
+    {
+      id: z.number().describe('UID of the message to move'),
+      target_folder: z.string().describe('Target folder path'),
+    },
+    async (params) => handleMove(params),
+  );
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/notes.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/modules/notes.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getImapClient } from '../auth.js';
+import { ok, err } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract plain-text body from a raw MIME source string. */
+function extractBody(source: string): string {
+  const idx = source.indexOf('\r\n\r\n');
+  if (idx === -1) return source;
+  return source.slice(idx + 4).trim();
+}
+
+/** Build a snippet: first 100 chars, newlines replaced with spaces. */
+function buildSnippet(body: string): string {
+  return body.replace(/\r?\n/g, ' ').slice(0, 100);
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions
+// ---------------------------------------------------------------------------
+
+export async function handleList(params: { folder?: string }) {
+  const folder = params.folder ?? 'Notes';
+
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock(folder);
+    try {
+      const mailbox = client.mailbox;
+      if (!mailbox) return ok([]);
+      const total = mailbox.exists;
+      if (total === 0) {
+        return ok([]);
+      }
+
+      const range = '1:*';
+
+      const notes: Array<{
+        id: string;
+        title: string;
+        date: string;
+        snippet: string;
+      }> = [];
+
+      for await (const msg of client.fetch(range, { envelope: true, source: true, uid: true })) {
+        const source = msg.source ? msg.source.toString() : '';
+        const body = extractBody(source);
+
+        notes.push({
+          id: String(msg.uid),
+          title: msg.envelope!.subject ?? '',
+          date: msg.envelope!.date?.toISOString?.() ?? String(msg.envelope!.date ?? ''),
+          snippet: buildSnippet(body),
+        });
+      }
+
+      return ok(notes);
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to list notes: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export async function handleRead(params: { id: string }) {
+  const uid = parseInt(params.id, 10);
+
+  try {
+    const client = await getImapClient();
+    const lock = await client.getMailboxLock('Notes');
+    try {
+      let found = null;
+
+      for await (const msg of client.fetch(uid, { envelope: true, source: true, uid: true }, { uid: true })) {
+        found = msg;
+      }
+
+      if (!found) {
+        return err(`Note ${params.id} not found`);
+      }
+
+      const source = found.source ? found.source.toString() : '';
+      const body = extractBody(source);
+
+      return ok({
+        title: found.envelope!.subject ?? '',
+        date: found.envelope!.date?.toISOString?.() ?? String(found.envelope!.date ?? ''),
+        body,
+      });
+    } finally {
+      lock.release();
+    }
+  } catch (e) {
+    return err(`Failed to read note: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Registration
+// ---------------------------------------------------------------------------
+
+export function registerNotes(server: McpServer): void {
+  server.tool(
+    'icloud_notes_list',
+    'List all notes in an iCloud Notes folder',
+    {
+      folder: z.string().optional().describe('Notes folder to list (default: Notes). Use for subfolders like Notes/Work'),
+    },
+    async (params) => handleList(params),
+  );
+
+  server.tool(
+    'icloud_notes_read',
+    'Read the full content of an iCloud note',
+    {
+      id: z.string().describe('UID of the note to read'),
+    },
+    async (params) => handleRead(params),
+  );
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/server.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/server.ts
@@ -1,0 +1,73 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { closeAll } from './auth.js';
+
+const VALID_MODULES = ['calendar', 'contacts', 'mail', 'notes'] as const;
+type ModuleName = (typeof VALID_MODULES)[number];
+
+export function parseModules(): ModuleName[] {
+  const raw = process.env.ICLOUD_MODULES ?? '';
+  const names = raw.split(',').map(s => s.trim()).filter(Boolean);
+  for (const name of names) {
+    if (!VALID_MODULES.includes(name as ModuleName)) {
+      throw new Error(`Unknown module: ${name}. Valid modules: ${VALID_MODULES.join(', ')}`);
+    }
+  }
+  return names as ModuleName[];
+}
+
+const MODULE_LOADERS: Record<ModuleName, (server: McpServer) => Promise<void>> = {
+  calendar: async (server) => {
+    const { registerCalendar } = await import('./modules/calendar.js');
+    registerCalendar(server);
+  },
+  contacts: async (server) => {
+    const { registerContacts } = await import('./modules/contacts.js');
+    registerContacts(server);
+  },
+  mail: async (server) => {
+    const { registerMail } = await import('./modules/mail.js');
+    registerMail(server);
+  },
+  notes: async (server) => {
+    const { registerNotes } = await import('./modules/notes.js');
+    registerNotes(server);
+  },
+};
+
+async function main() {
+  const modules = parseModules();
+  if (modules.length === 0) {
+    console.error('Warning: ICLOUD_MODULES is empty — no tools will be registered');
+  }
+
+  const server = new McpServer({
+    name: 'icloud-tools',
+    version: '1.0.0',
+  });
+
+  for (const mod of modules) {
+    await MODULE_LOADERS[mod](server);
+  }
+
+  // Graceful shutdown
+  process.on('SIGINT', async () => {
+    await closeAll();
+    process.exit(0);
+  });
+  process.on('SIGTERM', async () => {
+    await closeAll();
+    process.exit(0);
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// Only run main() when executed directly, not when imported in tests
+if (!process.env.VITEST) {
+  main().catch((err) => {
+    console.error('icloud-tools server failed to start:', err);
+    process.exit(1);
+  });
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/src/types.ts
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/src/types.ts
@@ -1,0 +1,13 @@
+/** Helper to build MCP text content response */
+export function ok<T>(data: T) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data }) }],
+  };
+}
+
+export function err(message: string) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}

--- a/.claude/skills/icloud-tools/add/container/icloud-tools/tsconfig.json
+++ b/.claude/skills/icloud-tools/add/container/icloud-tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/.claude/skills/icloud-tools/manifest.yaml
+++ b/.claude/skills/icloud-tools/manifest.yaml
@@ -1,0 +1,27 @@
+skill: icloud-tools
+version: 1.1.0
+description: "iCloud productivity tools via CalDAV/CardDAV/IMAP/SMTP"
+core_version: 1.2.4
+adds:
+  - container/icloud-tools/package.json
+  - container/icloud-tools/tsconfig.json
+  - container/icloud-tools/src/server.ts
+  - container/icloud-tools/src/auth.ts
+  - container/icloud-tools/src/types.ts
+  - container/icloud-tools/src/modules/calendar.ts
+  - container/icloud-tools/src/modules/contacts.ts
+  - container/icloud-tools/src/modules/mail.ts
+  - container/icloud-tools/src/modules/notes.ts
+modifies:
+  - container/Dockerfile
+  - src/container-runner.ts
+  - container/agent-runner/src/index.ts
+structured:
+  npm_dependencies: {}
+  env_additions:
+    - ICLOUD_EMAIL
+    - ICLOUD_APP_PASSWORD
+    - ICLOUD_SENDER_EMAIL
+conflicts: []
+depends: []
+test: "npx vitest run --config .claude/skills/icloud-tools/vitest.config.ts .claude/skills/icloud-tools/tests/icloud-tools.test.ts"

--- a/.claude/skills/icloud-tools/modify/container/Dockerfile
+++ b/.claude/skills/icloud-tools/modify/container/Dockerfile
@@ -1,0 +1,75 @@
+# NanoClaw Agent Container
+# Runs Claude Agent SDK in isolated Linux VM with browser automation
+
+FROM node:22-slim
+
+# Install system dependencies for Chromium
+RUN apt-get update && apt-get install -y \
+    chromium \
+    fonts-liberation \
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    libgbm1 \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxshmfence1 \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Chromium path for agent-browser
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Install agent-browser and claude-code globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files first for better caching
+COPY agent-runner/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY agent-runner/ ./
+
+# Build TypeScript
+RUN npm run build
+
+# Build icloud-tools MCP server
+COPY icloud-tools/package*.json /opt/icloud-tools/
+RUN cd /opt/icloud-tools && npm install
+COPY icloud-tools/ /opt/icloud-tools/
+RUN cd /opt/icloud-tools && npx tsc && npm prune --omit=dev
+
+# Create workspace directories
+RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
+
+# Create entrypoint script
+# Secrets are passed via stdin JSON — temp file is deleted immediately after Node reads it
+# Follow-up messages arrive via IPC files in /workspace/ipc/input/
+RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+
+# Set ownership to node user (non-root) for writable directories
+RUN chown -R node:node /workspace && chmod 777 /home/node
+
+# Switch to non-root user (required for --dangerously-skip-permissions)
+USER node
+
+# Set working directory to group workspace
+WORKDIR /workspace/group
+
+# Entry point reads JSON from stdin, outputs JSON to stdout
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/.claude/skills/icloud-tools/modify/container/Dockerfile.intent.md
+++ b/.claude/skills/icloud-tools/modify/container/Dockerfile.intent.md
@@ -1,0 +1,16 @@
+# Intent: container/Dockerfile modifications
+
+## What changed
+Added build steps for the icloud-tools MCP server.
+
+## Key sections
+### icloud-tools build (after agent-runner)
+- Copies package.json first for Docker layer caching
+- Full npm install (devDeps needed for tsc), then compile, then prune
+- Output: /opt/icloud-tools/dist/server.js
+
+## Invariants (must-keep)
+- All existing apt-get packages unchanged
+- Chromium and agent-browser setup unchanged
+- agent-runner build steps unchanged
+- Workspace directories, entrypoint, user switching unchanged

--- a/.claude/skills/icloud-tools/modify/container/agent-runner/src/index.ts
+++ b/.claude/skills/icloud-tools/modify/container/agent-runner/src/index.ts
@@ -1,0 +1,589 @@
+/**
+ * NanoClaw Agent Runner
+ * Runs inside a container, receives config via stdin, outputs result to stdout
+ *
+ * Input protocol:
+ *   Stdin: Full ContainerInput JSON (read until EOF, like before)
+ *   IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
+ *          Files: {type:"message", text:"..."}.json — polled and consumed
+ *          Sentinel: /workspace/ipc/input/_close — signals session end
+ *
+ * Stdout protocol:
+ *   Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
+ *   Multiple results may be emitted (one per agent teams result).
+ *   Final marker after loop ends signals completion.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { fileURLToPath } from 'url';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+/**
+ * Push-based async iterable for streaming user messages to the SDK.
+ * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
+ */
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    log(`Sessions index not found at ${indexPath}`);
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch (err) {
+    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return null;
+}
+
+/**
+ * Archive the full transcript to conversations/ before compaction.
+ */
+function createPreCompactHook(assistantName?: string): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+
+      if (messages.length === 0) {
+        log('No messages to archive');
+        return {};
+      }
+
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `${date}-${name}.md`;
+      const filePath = path.join(conversationsDir, filename);
+
+      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      fs.writeFileSync(filePath, markdown);
+
+      log(`Archived conversation to ${filePath}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {};
+  };
+}
+
+// Secrets to strip from Bash tool subprocess environments.
+// These are needed by claude-code for API auth but should never
+// be visible to commands Kit runs.
+const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'ICLOUD_APP_PASSWORD'];
+
+function createSanitizeBashHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preInput = input as PreToolUseHookInput;
+    const command = (preInput.tool_input as { command?: string })?.command;
+    if (!command) return {};
+
+    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: {
+          ...(preInput.tool_input as Record<string, unknown>),
+          command: unsetPrefix + command,
+        },
+      },
+    };
+  };
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+    }
+  }
+
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Check for _close sentinel.
+ */
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drain all pending IPC input messages.
+ * Returns messages found, or empty array.
+ */
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Wait for a new IPC message or _close sentinel.
+ * Returns the messages as a single string, or null if _close.
+ */
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Run a single query and stream results via writeOutput.
+ * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
+ * allowing agent teams subagents to run to completion.
+ * Also pipes IPC messages into the stream during the query.
+ */
+async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+  const stream = new MessageStream();
+  stream.push(prompt);
+
+  // Poll IPC for follow-up messages and _close sentinel during the query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+  let messageCount = 0;
+  let resultCount = 0;
+
+  // Load global CLAUDE.md as additional system context (shared across all groups)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Discover additional directories mounted at /workspace/extra/*
+  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
+  const extraDirs: string[] = [];
+  const extraBase = '/workspace/extra';
+  if (fs.existsSync(extraBase)) {
+    for (const entry of fs.readdirSync(extraBase)) {
+      const fullPath = path.join(extraBase, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+  if (extraDirs.length > 0) {
+    log(`Additional directories: ${extraDirs.join(', ')}`);
+  }
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      cwd: '/workspace/group',
+      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+      resume: sessionId,
+      resumeSessionAt: resumeAt,
+      systemPrompt: globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        : undefined,
+      allowedTools: [
+        'Bash',
+        'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'WebSearch', 'WebFetch',
+        'Task', 'TaskOutput', 'TaskStop',
+        'TeamCreate', 'TeamDelete', 'SendMessage',
+        'TodoWrite', 'ToolSearch', 'Skill',
+        'NotebookEdit',
+        'mcp__nanoclaw__*',
+        'mcp__icloud-tools__*'
+      ],
+      env: sdkEnv,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers: {
+        nanoclaw: {
+          command: 'node',
+          args: [mcpServerPath],
+          env: {
+            NANOCLAW_CHAT_JID: containerInput.chatJid,
+            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+      },
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
+      },
+    }
+  })) {
+    messageCount++;
+    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    log(`[msg #${messageCount}] type=${msgType}`);
+
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      log(`Session initialized: ${newSessionId}`);
+    }
+
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+      const tn = message as { task_id: string; status: string; summary: string };
+      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    }
+
+    if (message.type === 'result') {
+      resultCount++;
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      writeOutput({
+        status: 'success',
+        result: textResult || null,
+        newSessionId
+      });
+    }
+  }
+
+  ipcPolling = false;
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+}
+
+async function main(): Promise<void> {
+  let containerInput: ContainerInput;
+
+  try {
+    const stdinData = await readStdin();
+    containerInput = JSON.parse(stdinData);
+    // Delete the temp file the entrypoint wrote — it contains secrets
+    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    log(`Received input for group: ${containerInput.groupFolder}`);
+  } catch (err) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+    });
+    process.exit(1);
+  }
+
+  // Build SDK env: merge secrets into process.env for the SDK only.
+  // Secrets never touch process.env itself, so Bash subprocesses can't see them.
+  const sdkEnv: Record<string, string | undefined> = { ...process.env };
+  for (const [key, value] of Object.entries(containerInput.secrets || {})) {
+    sdkEnv[key] = value;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+
+  let sessionId = containerInput.sessionId;
+  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+
+  // Clean up stale _close sentinel from previous container runs
+  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+
+  // Build initial prompt (drain any pending IPC messages too)
+  let prompt = containerInput.prompt;
+  if (containerInput.isScheduledTask) {
+    prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+  }
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
+    prompt += '\n' + pending.join('\n');
+  }
+
+  // Query loop: run query → wait for IPC message → run new query → repeat
+  let resumeAt: string | undefined;
+  try {
+    while (true) {
+      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+
+      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      if (queryResult.newSessionId) {
+        sessionId = queryResult.newSessionId;
+      }
+      if (queryResult.lastAssistantUuid) {
+        resumeAt = queryResult.lastAssistantUuid;
+      }
+
+      // If _close was consumed during the query, exit immediately.
+      // Don't emit a session-update marker (it would reset the host's
+      // idle timer and cause a 30-min delay before the next _close).
+      if (queryResult.closedDuringQuery) {
+        log('Close sentinel consumed during query, exiting');
+        break;
+      }
+
+      // Emit session update so host can track it
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+      log('Query ended, waiting for next IPC message...');
+
+      // Wait for the next message or _close sentinel
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      log(`Got new message (${nextMessage.length} chars), starting new query`);
+      prompt = nextMessage;
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log(`Agent error: ${errorMessage}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: sessionId,
+      error: errorMessage
+    });
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/icloud-tools/modify/container/agent-runner/src/index.ts.intent.md
+++ b/.claude/skills/icloud-tools/modify/container/agent-runner/src/index.ts.intent.md
@@ -1,0 +1,16 @@
+# Intent: container/agent-runner/src/index.ts modifications
+
+## What changed
+Registered icloud-tools MCP server tools and protected credentials from Bash leakage.
+
+## Key sections
+### SECRET_ENV_VARS array
+- Added `'ICLOUD_APP_PASSWORD'` — stripped from Bash subprocess env
+
+### allowedTools array (in query() options)
+- Added `'mcp__icloud-tools__*'` — wildcard allows all icloud-tools MCP tools
+
+## Invariants (must-keep)
+- All existing SECRET_ENV_VARS and allowedTools unchanged
+- MessageStream, query loop, IPC polling unchanged
+- Pre-compact hook and Bash sanitize hook unchanged

--- a/.claude/skills/icloud-tools/modify/src/container-runner.ts
+++ b/.claude/skills/icloud-tools/modify/src/container-runner.ts
@@ -1,0 +1,705 @@
+/**
+ * Container Runner for NanoClaw
+ * Spawns agent execution in containers and handles IPC
+ */
+import { ChildProcess, exec, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  CONTAINER_IMAGE,
+  CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_TIMEOUT,
+  DATA_DIR,
+  GROUPS_DIR,
+  IDLE_TIMEOUT,
+  TIMEZONE,
+} from './config.js';
+import { readEnvFile } from './env.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+
+// Sentinel markers for robust output parsing (must match agent-runner)
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+function buildVolumeMounts(
+  group: RegisteredGroup,
+  isMain: boolean,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+  const projectRoot = process.cwd();
+  const groupDir = resolveGroupFolderPath(group.folder);
+
+  if (isMain) {
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart.
+    mounts.push({
+      hostPath: projectRoot,
+      containerPath: '/workspace/project',
+      readonly: true,
+    });
+
+    // Shadow .env so the agent cannot read secrets from the mounted project root.
+    // Secrets are passed via stdin instead (see readSecrets()).
+    const envFile = path.join(projectRoot, '.env');
+    if (fs.existsSync(envFile)) {
+      mounts.push({
+        hostPath: '/dev/null',
+        containerPath: '/workspace/project/.env',
+        readonly: true,
+      });
+    }
+
+    // Main also gets its group folder as the working directory
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+  } else {
+    // Other groups only get their own folder
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+  }
+
+  // Per-group Claude sessions directory (isolated from other groups)
+  // Each group gets their own .claude/ to prevent cross-group session access
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(
+        {
+          env: {
+            // Enable agent swarms (subagent orchestration)
+            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            // Load CLAUDE.md from additional mounted directories
+            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+            // Enable Claude's memory feature (persists user preferences between sessions)
+            // https://code.claude.com/docs/en/memory#manage-auto-memory
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+
+  // Sync skills from container/skills/ into each group's .claude/skills/
+  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsDst = path.join(groupSessionsDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    for (const skillDir of fs.readdirSync(skillsSrc)) {
+      const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.statSync(srcDir).isDirectory()) continue;
+      const dstDir = path.join(skillsDst, skillDir);
+      fs.cpSync(srcDir, dstDir, { recursive: true });
+    }
+  }
+  mounts.push({
+    hostPath: groupSessionsDir,
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Per-group IPC namespace: each group gets its own IPC directory
+  // This prevents cross-group privilege escalation via IPC
+  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  mounts.push({
+    hostPath: groupIpcDir,
+    containerPath: '/workspace/ipc',
+    readonly: false,
+  });
+
+  // Copy agent-runner source into a per-group writable location so agents
+  // can customize it (add tools, change behavior) without affecting other
+  // groups. Recompiled on container startup via entrypoint.sh.
+  const agentRunnerSrc = path.join(
+    projectRoot,
+    'container',
+    'agent-runner',
+    'src',
+  );
+  const groupAgentRunnerDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    'agent-runner-src',
+  );
+  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
+  mounts.push({
+    hostPath: groupAgentRunnerDir,
+    containerPath: '/app/src',
+    readonly: false,
+  });
+
+  // Additional mounts validated against external allowlist (tamper-proof from containers)
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isMain,
+    );
+    mounts.push(...validatedMounts);
+  }
+
+  return mounts;
+}
+
+/**
+ * Read allowed secrets from .env for passing to the container via stdin.
+ * Secrets are never written to disk or mounted as files.
+ */
+function readSecrets(): Record<string, string> {
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ICLOUD_EMAIL',
+    'ICLOUD_APP_PASSWORD',
+    'ICLOUD_SENDER_EMAIL',
+  ]);
+}
+
+function buildContainerArgs(
+  mounts: VolumeMount[],
+  containerName: string,
+): string[] {
+  const args: string[] = ['run', '-i', '--rm', '--name', containerName];
+
+  // Pass host timezone so container's local time matches the user's
+  args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Run as host user so bind-mounted files are accessible.
+  // Skip when running as root (uid 0), as the container's node user (uid 1000),
+  // or when getuid is unavailable (native Windows without WSL).
+  const hostUid = process.getuid?.();
+  const hostGid = process.getgid?.();
+  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+    args.push('--user', `${hostUid}:${hostGid}`);
+    args.push('-e', 'HOME=/home/node');
+  }
+
+  for (const mount of mounts) {
+    if (mount.readonly) {
+      args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
+    } else {
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  args.push(CONTAINER_IMAGE);
+
+  return args;
+}
+
+export async function runContainerAgent(
+  group: RegisteredGroup,
+  input: ContainerInput,
+  onProcess: (proc: ChildProcess, containerName: string) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+
+  const groupDir = resolveGroupFolderPath(group.folder);
+  fs.mkdirSync(groupDir, { recursive: true });
+
+  const mounts = buildVolumeMounts(group, input.isMain);
+  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const containerArgs = buildContainerArgs(mounts, containerName);
+
+  logger.debug(
+    {
+      group: group.name,
+      containerName,
+      mounts: mounts.map(
+        (m) =>
+          `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+      ),
+      containerArgs: containerArgs.join(' '),
+    },
+    'Container mount configuration',
+  );
+
+  logger.info(
+    {
+      group: group.name,
+      containerName,
+      mountCount: mounts.length,
+      isMain: input.isMain,
+    },
+    'Spawning container agent',
+  );
+
+  const logsDir = path.join(groupDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  return new Promise((resolve) => {
+    const container = spawn(CONTAINER_RUNTIME_BIN, containerArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    onProcess(container, containerName);
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    // Pass secrets via stdin (never written to disk or mounted as files)
+    input.secrets = readSecrets();
+    container.stdin.write(JSON.stringify(input));
+    container.stdin.end();
+    // Remove secrets from input so they don't appear in logs
+    delete input.secrets;
+
+    // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
+    let parseBuffer = '';
+    let newSessionId: string | undefined;
+    let outputChain = Promise.resolve();
+
+    container.stdout.on('data', (data) => {
+      const chunk = data.toString();
+
+      // Always accumulate for logging
+      if (!stdoutTruncated) {
+        const remaining = CONTAINER_MAX_OUTPUT_SIZE - stdout.length;
+        if (chunk.length > remaining) {
+          stdout += chunk.slice(0, remaining);
+          stdoutTruncated = true;
+          logger.warn(
+            { group: group.name, size: stdout.length },
+            'Container stdout truncated due to size limit',
+          );
+        } else {
+          stdout += chunk;
+        }
+      }
+
+      // Stream-parse for output markers
+      if (onOutput) {
+        parseBuffer += chunk;
+        let startIdx: number;
+        while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
+          const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);
+          if (endIdx === -1) break; // Incomplete pair, wait for more data
+
+          const jsonStr = parseBuffer
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+          parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
+
+          try {
+            const parsed: ContainerOutput = JSON.parse(jsonStr);
+            if (parsed.newSessionId) {
+              newSessionId = parsed.newSessionId;
+            }
+            hadStreamingOutput = true;
+            // Activity detected — reset the hard timeout
+            resetTimeout();
+            // Call onOutput for all markers (including null results)
+            // so idle timers start even for "silent" query completions.
+            outputChain = outputChain.then(() => onOutput(parsed));
+          } catch (err) {
+            logger.warn(
+              { group: group.name, error: err },
+              'Failed to parse streamed output chunk',
+            );
+          }
+        }
+      }
+    });
+
+    container.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      const lines = chunk.trim().split('\n');
+      for (const line of lines) {
+        if (line) logger.debug({ container: group.folder }, line);
+      }
+      // Don't reset timeout on stderr — SDK writes debug logs continuously.
+      // Timeout only resets on actual output (OUTPUT_MARKER in stdout).
+      if (stderrTruncated) return;
+      const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
+      if (chunk.length > remaining) {
+        stderr += chunk.slice(0, remaining);
+        stderrTruncated = true;
+        logger.warn(
+          { group: group.name, size: stderr.length },
+          'Container stderr truncated due to size limit',
+        );
+      } else {
+        stderr += chunk;
+      }
+    });
+
+    let timedOut = false;
+    let hadStreamingOutput = false;
+    const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+    // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
+    // graceful _close sentinel has time to trigger before the hard kill fires.
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const killOnTimeout = () => {
+      timedOut = true;
+      logger.error(
+        { group: group.name, containerName },
+        'Container timeout, stopping gracefully',
+      );
+      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+        if (err) {
+          logger.warn(
+            { group: group.name, containerName, err },
+            'Graceful stop failed, force killing',
+          );
+          container.kill('SIGKILL');
+        }
+      });
+    };
+
+    let timeout = setTimeout(killOnTimeout, timeoutMs);
+
+    // Reset the timeout whenever there's activity (streaming output)
+    const resetTimeout = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(killOnTimeout, timeoutMs);
+    };
+
+    container.on('close', (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      if (timedOut) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const timeoutLog = path.join(logsDir, `container-${ts}.log`);
+        fs.writeFileSync(
+          timeoutLog,
+          [
+            `=== Container Run Log (TIMEOUT) ===`,
+            `Timestamp: ${new Date().toISOString()}`,
+            `Group: ${group.name}`,
+            `Container: ${containerName}`,
+            `Duration: ${duration}ms`,
+            `Exit Code: ${code}`,
+            `Had Streaming Output: ${hadStreamingOutput}`,
+          ].join('\n'),
+        );
+
+        // Timeout after output = idle cleanup, not failure.
+        // The agent already sent its response; this is just the
+        // container being reaped after the idle period expired.
+        if (hadStreamingOutput) {
+          logger.info(
+            { group: group.name, containerName, duration, code },
+            'Container timed out after output (idle cleanup)',
+          );
+          outputChain.then(() => {
+            resolve({
+              status: 'success',
+              result: null,
+              newSessionId,
+            });
+          });
+          return;
+        }
+
+        logger.error(
+          { group: group.name, containerName, duration, code },
+          'Container timed out with no output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const logFile = path.join(logsDir, `container-${timestamp}.log`);
+      const isVerbose =
+        process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+
+      const logLines = [
+        `=== Container Run Log ===`,
+        `Timestamp: ${new Date().toISOString()}`,
+        `Group: ${group.name}`,
+        `IsMain: ${input.isMain}`,
+        `Duration: ${duration}ms`,
+        `Exit Code: ${code}`,
+        `Stdout Truncated: ${stdoutTruncated}`,
+        `Stderr Truncated: ${stderrTruncated}`,
+        ``,
+      ];
+
+      const isError = code !== 0;
+
+      if (isVerbose || isError) {
+        logLines.push(
+          `=== Input ===`,
+          JSON.stringify(input, null, 2),
+          ``,
+          `=== Container Args ===`,
+          containerArgs.join(' '),
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map(
+              (m) =>
+                `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+            )
+            .join('\n'),
+          ``,
+          `=== Stderr${stderrTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stderr,
+          ``,
+          `=== Stdout${stdoutTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stdout,
+        );
+      } else {
+        logLines.push(
+          `=== Input Summary ===`,
+          `Prompt length: ${input.prompt.length} chars`,
+          `Session ID: ${input.sessionId || 'new'}`,
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
+            .join('\n'),
+          ``,
+        );
+      }
+
+      fs.writeFileSync(logFile, logLines.join('\n'));
+      logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
+
+      if (code !== 0) {
+        logger.error(
+          {
+            group: group.name,
+            code,
+            duration,
+            stderr,
+            stdout,
+            logFile,
+          },
+          'Container exited with error',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container exited with code ${code}: ${stderr.slice(-200)}`,
+        });
+        return;
+      }
+
+      // Streaming mode: wait for output chain to settle, return completion marker
+      if (onOutput) {
+        outputChain.then(() => {
+          logger.info(
+            { group: group.name, duration, newSessionId },
+            'Container completed (streaming mode)',
+          );
+          resolve({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        });
+        return;
+      }
+
+      // Legacy mode: parse the last output marker pair from accumulated stdout
+      try {
+        // Extract JSON between sentinel markers for robust parsing
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          // Fallback: last non-empty line (backwards compatibility)
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+
+        const output: ContainerOutput = JSON.parse(jsonLine);
+
+        logger.info(
+          {
+            group: group.name,
+            duration,
+            status: output.status,
+            hasResult: !!output.result,
+          },
+          'Container completed',
+        );
+
+        resolve(output);
+      } catch (err) {
+        logger.error(
+          {
+            group: group.name,
+            stdout,
+            stderr,
+            error: err,
+          },
+          'Failed to parse container output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Failed to parse container output: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+
+    container.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error(
+        { group: group.name, containerName, error: err },
+        'Container spawn error',
+      );
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Container spawn error: ${err.message}`,
+      });
+    });
+  });
+}
+
+export function writeTasksSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  tasks: Array<{
+    id: string;
+    groupFolder: string;
+    prompt: string;
+    schedule_type: string;
+    schedule_value: string;
+    status: string;
+    next_run: string | null;
+  }>,
+): void {
+  // Write filtered tasks to the group's IPC directory
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all tasks, others only see their own
+  const filteredTasks = isMain
+    ? tasks
+    : tasks.filter((t) => t.groupFolder === groupFolder);
+
+  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
+  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
+}
+
+export interface AvailableGroup {
+  jid: string;
+  name: string;
+  lastActivity: string;
+  isRegistered: boolean;
+}
+
+/**
+ * Write available groups snapshot for the container to read.
+ * Only main group can see all available groups (for activation).
+ * Non-main groups only see their own registration status.
+ */
+export function writeGroupsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  groups: AvailableGroup[],
+  registeredJids: Set<string>,
+): void {
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all groups; others see nothing (they can't activate groups)
+  const visibleGroups = isMain ? groups : [];
+
+  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
+  fs.writeFileSync(
+    groupsFile,
+    JSON.stringify(
+      {
+        groups: visibleGroups,
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/.claude/skills/icloud-tools/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/icloud-tools/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,15 @@
+# Intent: src/container-runner.ts modifications
+
+## What changed
+Added iCloud credentials to the secrets allowlist passed to containers via stdin.
+
+## Key sections
+### readSecrets() function
+- Added `'ICLOUD_EMAIL'` — account email for CalDAV/CardDAV/IMAP auth
+- Added `'ICLOUD_APP_PASSWORD'` — app-specific password (16-char)
+- Added `'ICLOUD_SENDER_EMAIL'` — optional SMTP alias (from field)
+
+## Invariants (must-keep)
+- All existing secrets (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_*) unchanged
+- buildVolumeMounts(), container spawn, timeout, streaming unchanged
+- .env shadow mount for main group unchanged

--- a/.claude/skills/icloud-tools/tests/icloud-tools.test.ts
+++ b/.claude/skills/icloud-tools/tests/icloud-tools.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('icloud-tools skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  describe('SKILL.md', () => {
+    const skillMdPath = path.join(skillDir, 'SKILL.md');
+
+    it('exists', () => {
+      expect(fs.existsSync(skillMdPath)).toBe(true);
+    });
+
+    it('has correct frontmatter', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('name: icloud-tools');
+      expect(content).toContain('description:');
+    });
+
+    it('documents all 4 modules', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('calendar');
+      expect(content).toContain('contacts');
+      expect(content).toContain('mail');
+      expect(content).toContain('notes');
+    });
+
+    it('documents required env vars', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('ICLOUD_EMAIL');
+      expect(content).toContain('ICLOUD_APP_PASSWORD');
+      expect(content).toContain('ICLOUD_SENDER_EMAIL');
+      expect(content).toContain('ICLOUD_MODULES');
+    });
+
+    it('documents server path', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('/opt/icloud-tools/dist/server.js');
+    });
+
+    it('has pre-flight check for already-applied state', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('state.yaml');
+      expect(content).toContain('applied_skills');
+    });
+
+    it('has apply command', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('apply-skill.ts .claude/skills/icloud-tools');
+    });
+
+    it('has validate step', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('npm test');
+      expect(content).toContain('npm run build');
+    });
+
+    it('has container rebuild instruction', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('./build.sh');
+    });
+
+    it('has restart instructions for both macOS and Linux', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('launchctl');
+      expect(content).toContain('systemctl');
+    });
+
+    it('has log check command', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('nanoclaw.log');
+      expect(content).toContain('icloud');
+    });
+
+    it('has configuration table', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('| Variable |');
+      expect(content).toContain('| `ICLOUD_EMAIL`');
+      expect(content).toContain('| `ICLOUD_APP_PASSWORD`');
+      expect(content).toContain('| `ICLOUD_MODULES`');
+    });
+
+    it('has troubleshooting section', () => {
+      const content = fs.readFileSync(skillMdPath, 'utf-8');
+      expect(content).toContain('Troubleshooting');
+      expect(content).toContain('Auth failed');
+      expect(content).toContain('read-only');
+    });
+  });
+
+  describe('manifest.yaml', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+
+    it('exists', () => {
+      expect(fs.existsSync(manifestPath)).toBe(true);
+    });
+
+    it('has correct skill name, version, description', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('skill: icloud-tools');
+      expect(content).toContain('version: 1.1.0');
+      expect(content).toContain('description:');
+    });
+
+    it('declares all 3 env_additions', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('ICLOUD_EMAIL');
+      expect(content).toContain('ICLOUD_APP_PASSWORD');
+      expect(content).toContain('ICLOUD_SENDER_EMAIL');
+    });
+
+    it('has conflicts: []', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('conflicts: []');
+    });
+
+    it('has depends: []', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('depends: []');
+    });
+
+    it('has a test command with a skill-local config (no root-level config file)', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('test:');
+      expect(content).toContain('icloud-tools');
+      // If --config is used, it must point inside .claude/skills/ (not a root-level file)
+      if (content.includes('--config')) {
+        expect(content).toContain('--config .claude/skills/icloud-tools');
+      }
+    });
+
+    it('lists all 9 added files', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('container/icloud-tools/package.json');
+      expect(content).toContain('container/icloud-tools/tsconfig.json');
+      expect(content).toContain('container/icloud-tools/src/server.ts');
+      expect(content).toContain('container/icloud-tools/src/auth.ts');
+      expect(content).toContain('container/icloud-tools/src/types.ts');
+      expect(content).toContain('container/icloud-tools/src/modules/calendar.ts');
+      expect(content).toContain('container/icloud-tools/src/modules/contacts.ts');
+      expect(content).toContain('container/icloud-tools/src/modules/mail.ts');
+      expect(content).toContain('container/icloud-tools/src/modules/notes.ts');
+    });
+
+    it('lists exactly 3 modified files (not ipc.ts or ipc-mcp-stdio.ts)', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).toContain('container/Dockerfile');
+      expect(content).toContain('src/container-runner.ts');
+      expect(content).toContain('container/agent-runner/src/index.ts');
+      expect(content).not.toContain('ipc.ts');
+      expect(content).not.toContain('ipc-mcp-stdio.ts');
+      // Count modifies entries
+      const modifiesSection = content.split('modifies:')[1]?.split('structured:')[0] || '';
+      const modifyLines = modifiesSection.split('\n').filter(l => l.trim().startsWith('-'));
+      expect(modifyLines).toHaveLength(3);
+    });
+
+    it('has no removes section', () => {
+      const content = fs.readFileSync(manifestPath, 'utf-8');
+      expect(content).not.toContain('removes:');
+    });
+  });
+
+  describe('add/ files', () => {
+    const addDir = path.join(skillDir, 'add');
+
+    it('all 9 add/ files exist', () => {
+      const expectedFiles = [
+        'container/icloud-tools/package.json',
+        'container/icloud-tools/tsconfig.json',
+        'container/icloud-tools/src/server.ts',
+        'container/icloud-tools/src/auth.ts',
+        'container/icloud-tools/src/types.ts',
+        'container/icloud-tools/src/modules/calendar.ts',
+        'container/icloud-tools/src/modules/contacts.ts',
+        'container/icloud-tools/src/modules/mail.ts',
+        'container/icloud-tools/src/modules/notes.ts',
+      ];
+      for (const file of expectedFiles) {
+        expect(fs.existsSync(path.join(addDir, file)), `Missing: ${file}`).toBe(true);
+      }
+    });
+
+    it('auth.ts uses tsdav and nodemailer', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/auth.ts'), 'utf-8');
+      expect(content).toContain('tsdav');
+      expect(content).toContain('nodemailer');
+    });
+
+    it('auth.ts contains ICLOUD_SENDER_EMAIL and exports getSmtpTransport', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/auth.ts'), 'utf-8');
+      expect(content).toContain('ICLOUD_SENDER_EMAIL');
+      expect(content).toContain('export function getSmtpTransport');
+    });
+
+    it('server.ts contains ICLOUD_MODULES and MODULE_LOADERS', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/server.ts'), 'utf-8');
+      expect(content).toContain('ICLOUD_MODULES');
+      expect(content).toContain('MODULE_LOADERS');
+    });
+
+    it('server.ts has graceful shutdown handlers', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/server.ts'), 'utf-8');
+      expect(content).toContain('SIGINT');
+      expect(content).toContain('SIGTERM');
+    });
+
+    it('calendar.ts uses CalDAV CRUD operations', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/modules/calendar.ts'), 'utf-8');
+      expect(content).toContain('createCalendarObject');
+      expect(content).toContain('updateCalendarObject');
+      expect(content).toContain('deleteCalendarObject');
+    });
+
+    it('contacts.ts uses CardDAV operations', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/modules/contacts.ts'), 'utf-8');
+      expect(content).toContain('createVCard');
+      expect(content).toContain('updateVCard');
+    });
+
+    it('mail.ts uses IMAP client and SMTP transport', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/modules/mail.ts'), 'utf-8');
+      expect(content).toContain('getImapClient');
+      expect(content).toContain('getSmtpTransport');
+    });
+
+    it('mail.ts exports a send handler', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/modules/mail.ts'), 'utf-8');
+      expect(content).toContain('export async function handleSend');
+    });
+
+    it('notes.ts is read-only (no write operations)', () => {
+      const content = fs.readFileSync(path.join(addDir, 'container/icloud-tools/src/modules/notes.ts'), 'utf-8');
+      expect(content).toContain('getImapClient');
+      // Notes module must not contain write operations
+      expect(content).not.toContain('append(');
+      expect(content).not.toContain('messageDelete');
+      expect(content).not.toContain('messageFlagsAdd');
+    });
+  });
+
+  describe('modify/ files', () => {
+    const modifyDir = path.join(skillDir, 'modify');
+
+    it('all 3 modify/ files exist', () => {
+      expect(fs.existsSync(path.join(modifyDir, 'container/Dockerfile'))).toBe(true);
+      expect(fs.existsSync(path.join(modifyDir, 'src/container-runner.ts'))).toBe(true);
+      expect(fs.existsSync(path.join(modifyDir, 'container/agent-runner/src/index.ts'))).toBe(true);
+    });
+
+    it('all 3 intent files exist and mention Invariants', () => {
+      const intentFiles = [
+        'container/Dockerfile.intent.md',
+        'src/container-runner.ts.intent.md',
+        'container/agent-runner/src/index.ts.intent.md',
+      ];
+      for (const file of intentFiles) {
+        const filePath = path.join(modifyDir, file);
+        expect(fs.existsSync(filePath), `Missing: ${file}`).toBe(true);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        expect(content, `${file} must mention Invariants`).toContain('Invariants');
+      }
+    });
+
+    it('Dockerfile contains icloud-tools build steps at /opt/icloud-tools', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'container/Dockerfile'), 'utf-8');
+      expect(content).toContain('icloud-tools');
+      expect(content).toContain('/opt/icloud-tools');
+      expect(content).toContain('npm prune');
+    });
+
+    it('Dockerfile does not contain unrelated tools', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'container/Dockerfile'), 'utf-8');
+      expect(content).not.toContain('vanta');
+      expect(content).not.toContain('pdf-reader');
+      expect(content).not.toContain('apple-reminders');
+      expect(content).not.toContain('python3');
+    });
+
+    it('agent-runner index.ts allows icloud-tools MCP tools', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'container/agent-runner/src/index.ts'), 'utf-8');
+      expect(content).toContain("'mcp__icloud-tools__*'");
+    });
+
+    it('agent-runner index.ts protects ICLOUD_APP_PASSWORD in SECRET_ENV_VARS', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'container/agent-runner/src/index.ts'), 'utf-8');
+      expect(content).toContain("'ICLOUD_APP_PASSWORD'");
+    });
+
+    it('agent-runner index.ts does not contain unrelated credentials', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'container/agent-runner/src/index.ts'), 'utf-8');
+      expect(content).not.toContain('GOOGLE_OAUTH');
+      expect(content).not.toContain('pushMultimodal');
+      expect(content).not.toContain('ContentBlock');
+    });
+
+    it('container-runner.ts contains all 3 iCloud secrets in readSecrets()', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'src/container-runner.ts'), 'utf-8');
+      expect(content).toContain("'ICLOUD_EMAIL'");
+      expect(content).toContain("'ICLOUD_APP_PASSWORD'");
+      expect(content).toContain("'ICLOUD_SENDER_EMAIL'");
+    });
+
+    it('container-runner.ts does not contain unrelated secrets', () => {
+      const content = fs.readFileSync(path.join(modifyDir, 'src/container-runner.ts'), 'utf-8');
+      expect(content).not.toContain('GOOGLE_OAUTH');
+      expect(content).not.toContain('imageAttachments');
+    });
+  });
+
+  it('mail.ts uses marked for HTML rendering', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'add', 'container', 'icloud-tools', 'src', 'modules', 'mail.ts'),
+      'utf-8',
+    );
+    expect(content).toContain("import { marked } from 'marked'");
+    expect(content).toContain('renderHtml');
+    expect(content).toContain('html:');
+  });
+
+  it('mail.ts marks messages as read on fetch', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'add', 'container', 'icloud-tools', 'src', 'modules', 'mail.ts'),
+      'utf-8',
+    );
+    expect(content).toContain("messageFlagsAdd(params.id, ['\\\\Seen']");
+  });
+
+  it('mail.ts saves sent emails to Sent Messages', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'add', 'container', 'icloud-tools', 'src', 'modules', 'mail.ts'),
+      'utf-8',
+    );
+    expect(content).toContain("'Sent Messages'");
+    const matches = content.match(/Sent Messages/g);
+    expect(matches!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('package.json includes marked dependency', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'add', 'container', 'icloud-tools', 'package.json'),
+      'utf-8',
+    );
+    expect(content).toContain('"marked"');
+  });
+});

--- a/.claude/skills/icloud-tools/vitest.config.ts
+++ b/.claude/skills/icloud-tools/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['.claude/skills/icloud-tools/tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Adds `icloud-tools` skill package that gives NanoClaw agents access to iCloud productivity apps via standard protocols (CalDAV, CardDAV, IMAP, SMTP) using an app-specific password.

**Tools provided:**
- Calendar (6 tools): list calendars, list/create/update/delete events, upcoming
- Contacts (4 tools): search, list groups, create, update
- Mail (12 tools): folders, read, send, reply, forward, drafts, flag, move, search
- Notes (2 tools): list, read (read-only via IMAP)

**Key features:**
- Works on any platform (no macOS requirement) — uses app-specific passwords
- Module selector (`ICLOUD_MODULES` env var) for per-group customization
- Optional sender alias support (`ICLOUD_SENDER_EMAIL`)

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)