### PR TITLE
fix: Not all Anthropic secrets/vars are getting passed when Apple container skill is applied

### DIFF
--- a/.claude/skills/convert-to-apple-container/modify/src/container-runner.ts
+++ b/.claude/skills/convert-to-apple-container/modify/src/container-runner.ts
@@ -204,7 +204,12 @@ function buildVolumeMounts(
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_AUTH_TOKEN',
+  ]);
 }
 
 function buildContainerArgs(


### PR DESCRIPTION
This might fix #685 but I'm not sure. In my setup when I tried a third party API then the missing ANTHROPIC_BASE_URL because I applied the Apple container skill was definitely the issue.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
