### PR TITLE
Allow Discord channel implementation to download files and use Read tool

### DIFF
--- a/.claude/skills/add-discord/SKILL.md
+++ b/.claude/skills/add-discord/SKILL.md
@@ -40,11 +40,13 @@ This deterministically:
 - Adds `src/channels/discord.ts` (DiscordChannel class with self-registration via `registerChannel`)
 - Adds `src/channels/discord.test.ts` (unit tests with discord.js mock)
 - Appends `import './discord.js'` to the channel barrel file `src/channels/index.ts`
+- Adds `files/` IPC subdirectory creation in `src/container-runner.ts` (for attachment downloads)
 - Installs the `discord.js` npm dependency
 - Records the application in `.nanoclaw/state.yaml`
 
-If the apply reports merge conflicts, read the intent file:
-- `modify/src/channels/index.ts.intent.md` — what changed and invariants
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/channels/index.ts.intent.md` — channel barrel import
+- `modify/src/container-runner.ts.intent.md` — files IPC directory
 
 ### Validate code changes
 
@@ -199,7 +201,7 @@ If you can't copy the channel ID:
 
 The Discord bot supports:
 - Text messages in registered channels
-- Attachment descriptions (images, videos, files shown as placeholders)
+- **File downloads**: Downloads all attachments (images, documents, spreadsheets, PDFs, audio, video, text files) to `/workspace/ipc/files/` so the agent can read/view them with the Read tool
 - Reply context (shows who the user is replying to)
 - @mention translation (Discord `<@botId>` → NanoClaw trigger format)
 - Message splitting for responses over 2000 characters

--- a/.claude/skills/add-discord/add/src/channels/discord.test.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.test.ts
@@ -24,6 +24,23 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
+// Mock fs (for image download)
+vi.mock('fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  },
+}));
+
+// Mock group-folder (for IPC path resolution)
+vi.mock('../group-folder.js', () => ({
+  resolveGroupIpcPath: vi.fn(() => '/tmp/test-ipc'),
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
 // --- discord.js mock ---
 
 type Handler = (...args: any[]) => any;
@@ -195,6 +212,11 @@ async function triggerMessage(message: any) {
 describe('DiscordChannel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: fetch succeeds (for image download tests)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
   });
 
   afterEach(() => {
@@ -490,13 +512,85 @@ describe('DiscordChannel', () => {
   // --- Attachments ---
 
   describe('attachments', () => {
-    it('stores image attachment with placeholder', async () => {
+    it('downloads image and includes container path', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
 
       const attachments = new Map([
-        ['att1', { name: 'photo.png', contentType: 'image/png' }],
+        ['att1', { id: 'att1', name: 'photo.png', contentType: 'image/png', url: 'https://cdn.discord.com/photo.png' }],
+      ]);
+      const msg = createMessage({
+        content: '',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(mockFetch).toHaveBeenCalledWith('https://cdn.discord.com/photo.png');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[Image: photo.png — view with Read tool at /workspace/ipc/files/msg_001-att1.png]',
+        }),
+      );
+    });
+
+    it('downloads document and includes container path', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        ['att1', { id: 'att1', name: 'report.pdf', contentType: 'application/pdf', url: 'https://cdn.discord.com/report.pdf' }],
+      ]);
+      const msg = createMessage({
+        content: '',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(mockFetch).toHaveBeenCalledWith('https://cdn.discord.com/report.pdf');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[File: report.pdf — view with Read tool at /workspace/ipc/files/msg_001-att1.pdf]',
+        }),
+      );
+    });
+
+    it('downloads audio and includes container path', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        ['att1', { id: 'att1', name: 'voice.ogg', contentType: 'audio/ogg', url: 'https://cdn.discord.com/voice.ogg' }],
+      ]);
+      const msg = createMessage({
+        content: '',
+        attachments,
+        guildName: 'Server',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[Audio: voice.ogg — view with Read tool at /workspace/ipc/files/msg_001-att1.ogg]',
+        }),
+      );
+    });
+
+    it('falls back to placeholder when download fails', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        ['att1', { id: 'att1', name: 'photo.png', contentType: 'image/png', url: 'https://cdn.discord.com/photo.png' }],
       ]);
       const msg = createMessage({
         content: '',
@@ -559,13 +653,13 @@ describe('DiscordChannel', () => {
       );
     });
 
-    it('includes text content with attachments', async () => {
+    it('includes text content with downloaded file path', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
 
       const attachments = new Map([
-        ['att1', { name: 'photo.jpg', contentType: 'image/jpeg' }],
+        ['att1', { id: 'att1', name: 'photo.jpg', contentType: 'image/jpeg', url: 'https://cdn.discord.com/photo.jpg' }],
       ]);
       const msg = createMessage({
         content: 'Check this out',
@@ -577,19 +671,19 @@ describe('DiscordChannel', () => {
       expect(opts.onMessage).toHaveBeenCalledWith(
         'dc:1234567890123456',
         expect.objectContaining({
-          content: 'Check this out\n[Image: photo.jpg]',
+          content: 'Check this out\n[Image: photo.jpg — view with Read tool at /workspace/ipc/files/msg_001-att1.jpg]',
         }),
       );
     });
 
-    it('handles multiple attachments', async () => {
+    it('downloads all attachment types', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
 
       const attachments = new Map([
-        ['att1', { name: 'a.png', contentType: 'image/png' }],
-        ['att2', { name: 'b.txt', contentType: 'text/plain' }],
+        ['att1', { id: 'att1', name: 'a.png', contentType: 'image/png', url: 'https://cdn.discord.com/a.png' }],
+        ['att2', { id: 'att2', name: 'b.txt', contentType: 'text/plain', url: 'https://cdn.discord.com/b.txt' }],
       ]);
       const msg = createMessage({
         content: '',
@@ -598,12 +692,33 @@ describe('DiscordChannel', () => {
       });
       await triggerMessage(msg);
 
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(opts.onMessage).toHaveBeenCalledWith(
         'dc:1234567890123456',
         expect.objectContaining({
-          content: '[Image: a.png]\n[File: b.txt]',
+          content: '[Image: a.png — view with Read tool at /workspace/ipc/files/msg_001-att1.png]\n[File: b.txt — view with Read tool at /workspace/ipc/files/msg_001-att2.txt]',
         }),
       );
+    });
+
+    it('skips image download for unregistered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        ['att1', { id: 'att1', name: 'photo.png', contentType: 'image/png', url: 'https://cdn.discord.com/photo.png' }],
+      ]);
+      const msg = createMessage({
+        channelId: '9999999999999999',
+        content: '',
+        attachments,
+        guildName: 'Other Server',
+      });
+      await triggerMessage(msg);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/.claude/skills/add-discord/add/src/channels/discord.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.ts
@@ -1,7 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
 import { Client, Events, GatewayIntentBits, Message, TextChannel } from 'discord.js';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
+import { resolveGroupIpcPath } from '../group-folder.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
@@ -135,6 +139,46 @@ export class DiscordChannel implements Channel {
           'Message from unregistered Discord channel',
         );
         return;
+      }
+
+      // Download attachments so the agent can read/view them with the Read tool
+      if (message.attachments.size > 0) {
+        const downloadable = [...message.attachments.values()].filter(
+          (att) => att.url,
+        );
+        if (downloadable.length > 0) {
+          try {
+            const ipcDir = resolveGroupIpcPath(group.folder);
+            const filesDir = path.join(ipcDir, 'files');
+            fs.mkdirSync(filesDir, { recursive: true });
+            for (const att of downloadable) {
+              const name = att.name || 'file';
+              const ext = path.extname(name) || '';
+              const filename = `${msgId}-${att.id}${ext}`;
+              // Build the placeholder tag to find in the content string
+              const contentType = att.contentType || '';
+              let tag: string;
+              if (contentType.startsWith('image/')) tag = `[Image: ${name}]`;
+              else if (contentType.startsWith('video/')) tag = `[Video: ${name}]`;
+              else if (contentType.startsWith('audio/')) tag = `[Audio: ${name}]`;
+              else tag = `[File: ${name}]`;
+              try {
+                const response = await fetch(att.url);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const buffer = Buffer.from(await response.arrayBuffer());
+                fs.writeFileSync(path.join(filesDir, filename), buffer);
+                content = content.replace(
+                  tag,
+                  `${tag.slice(0, -1)} — view with Read tool at /workspace/ipc/files/${filename}]`,
+                );
+              } catch (err) {
+                logger.warn({ att: name, err }, 'Failed to download Discord attachment');
+              }
+            }
+          } catch (err) {
+            logger.warn({ err }, 'Failed to set up file download directory');
+          }
+        }
       }
 
       // Deliver message — startMessageLoop() will pick it up

--- a/.claude/skills/add-discord/manifest.yaml
+++ b/.claude/skills/add-discord/manifest.yaml
@@ -7,6 +7,7 @@ adds:
   - src/channels/discord.test.ts
 modifies:
   - src/channels/index.ts
+  - src/container-runner.ts
 structured:
   npm_dependencies:
     discord.js: "^14.18.0"

--- a/.claude/skills/add-discord/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/add-discord/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,13 @@
+# Intent: Add files IPC subdirectory
+
+Add `fs.mkdirSync(path.join(groupIpcDir, 'files'), { recursive: true });`
+alongside the existing `messages`, `tasks`, and `input` directory creation
+in the `buildVolumeMounts` function.
+
+This creates a per-group `files/` directory under the IPC path so
+channels can download attachments (images, documents, spreadsheets,
+audio, etc.) for the agent to read/view with the Read tool.
+The directory is created at container startup alongside other IPC
+subdirectories.
+
+This is an append-only change — existing mkdir lines must be preserved.


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

This enhances `/add-discord` skill to allow agent to download and use `Read` tool, enabling your agent to see images you send and other documents.

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone
