### PR TITLE
skill: add /add-memory — semantic memory with RAG

### DIFF
--- a/.claude/skills/add-memory/SKILL.md
+++ b/.claude/skills/add-memory/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: add-memory
+description: Add three-layer semantic memory system with RAG. Gives agents automatic recall of past conversations and stored facts using sqlite-vec and local embeddings. Triggers on "add memory", "memory system", "semantic memory", "RAG memory", "agent memory".
+---
+
+# Add Semantic Memory System
+
+Adds a three-layer memory architecture that gives container agents automatic recall of past conversations and stored facts. Uses sqlite-vec for vector search within the existing SQLite database and local embeddings via @huggingface/transformers (all-MiniLM-L6-v2) — no external API costs.
+
+## Memory Layers
+
+1. **Core Memories** — discrete facts/preferences stored by the agent via IPC, auto-injected into prompts when semantically relevant
+2. **Conversation Memory** — every message is embedded after each conversation; relevant past messages retrieved via RAG before each agent invocation
+3. **Archival Memory** — session summaries searchable via memory_search
+
+## Agent MCP Tools (via IPC)
+
+Four new IPC operations: `memory_add`, `memory_update`, `memory_remove`, `memory_search` — all operating through the existing IPC filesystem with a request-response pattern for search.
+
+## Phase 1: Pre-flight Checks
+
+Before applying, verify:
+
+1. Node.js >= 18 is installed
+2. `npm run build` succeeds on the current codebase
+3. No uncommitted changes in `src/db.ts`, `src/index.ts`, `src/ipc.ts`, or `src/task-scheduler.ts`
+
+```bash
+node -v  # Must be >= 18
+npm run build
+git diff --name-only src/db.ts src/index.ts src/ipc.ts src/task-scheduler.ts
+```
+
+## Phase 2: Apply Skill
+
+### Install dependencies
+
+```bash
+npm install sqlite-vec@^0.1.7-alpha.2 @huggingface/transformers@^3.8.1
+```
+
+### Apply code changes
+
+The skill engine will:
+1. Add `src/memory.ts` (new file — the complete memory system)
+2. Modify `src/db.ts` — load sqlite-vec extension into better-sqlite3
+3. Modify `src/index.ts` — initialize memory schema, inject RAG context, embed conversations, write memory snapshots
+4. Modify `src/ipc.ts` — handle memory IPC operations (add/update/remove/search)
+5. Modify `src/task-scheduler.ts` — inject memory context into scheduled task prompts
+
+### Build and verify
+
+```bash
+npm run build
+npx vitest run .claude/skills/add-memory/tests/add-memory.test.ts
+```
+
+## Phase 3: First Run
+
+On first startup after applying:
+
+1. The embedding model (~23MB) downloads automatically to `data/models/`
+2. Memory tables and vector indexes are created in the existing SQLite database
+3. No configuration needed — memory is per-group isolated automatically
+
+## Phase 4: Verify
+
+```bash
+# Check that memory tables exist
+sqlite3 data/store/messages.db ".tables" | grep -q "core_memories"
+
+# Check that vector tables exist
+sqlite3 data/store/messages.db ".tables" | grep -q "core_memories_vec"
+
+# Run the skill tests
+npx vitest run .claude/skills/add-memory/tests/add-memory.test.ts
+```
+
+## How It Works
+
+### Prompt Injection (RAG)
+
+Before each agent invocation, `retrieveMemoryContext()` is called with the incoming messages. It:
+1. Searches core memories (pinned + semantically relevant) and formats them as `<memory type="core">` XML
+2. Searches past conversation chunks and formats them as `<memory type="past_conversations">` XML
+3. Prepends both to the agent prompt
+
+### Conversation Embedding
+
+After the agent produces its first successful output, all incoming messages from that turn are embedded asynchronously. Each message gets a 384-dimensional vector (all-MiniLM-L6-v2) with 2 preceding messages as context.
+
+### Memory Snapshot
+
+Before each agent invocation, a `memory_snapshot.json` is written to the group's IPC directory. This lets the container agent see existing memory IDs for update/remove operations.
+
+### IPC Memory Operations
+
+The container agent writes JSON files to `data/ipc/{group}/memory/`:
+- `memory_add` — stores a new core memory with embedding
+- `memory_update` — updates content and re-embeds
+- `memory_remove` — deletes memory and vector
+- `memory_search` — request-response pattern: agent writes request, host writes `res-{id}.json` with results
+
+## Troubleshooting
+
+### Model download fails
+
+The embedding model is cached in `data/models/`. If download fails:
+```bash
+rm -rf data/models/
+# Restart — it will re-download
+```
+
+### "sqlite-vec not loaded" errors
+
+Ensure `sqlite-vec` is installed and the native binary matches your platform:
+```bash
+npm ls sqlite-vec
+# If issues, reinstall:
+npm install sqlite-vec@^0.1.7-alpha.2
+```
+
+### Memory not injected into prompts
+
+Check logs for "Memory retrieval failed" warnings. The system gracefully degrades — if memory retrieval fails, the agent still runs without context.
+
+### onnxruntime mutex warning on exit
+
+Harmless. Known onnxruntime cleanup race that only happens when Node.js exits. Does not affect data integrity.

--- a/.claude/skills/add-memory/add/src/memory.ts
+++ b/.claude/skills/add-memory/add/src/memory.ts
@@ -1,0 +1,650 @@
+/**
+ * Memory System for NanoClaw
+ *
+ * Three-layer memory architecture:
+ * 1. Core Memories — discrete facts, preferences, instructions (always injected)
+ * 2. Conversation Memory — embedded message chunks for RAG retrieval
+ * 3. Archival Memory — session summaries for deep recall
+ *
+ * Uses sqlite-vec for vector search and @huggingface/transformers for local embeddings.
+ * All operations are per-group isolated.
+ */
+
+import crypto from 'crypto';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { getDb } from './db.js';
+import { logger } from './logger.js';
+import { NewMessage } from './types.js';
+
+// --- Types ---
+
+export interface CoreMemory {
+  id: string;
+  group_folder: string;
+  category: string;
+  content: string;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+  is_pinned: number;
+}
+
+export interface ConversationChunk {
+  id: string;
+  group_folder: string;
+  chat_jid: string;
+  message_id: string | null;
+  content: string;
+  context: string | null;
+  sender_name: string | null;
+  timestamp: string;
+  created_at: string;
+}
+
+export interface ArchivalMemory {
+  id: string;
+  group_folder: string;
+  session_id: string | null;
+  title: string | null;
+  content: string;
+  timestamp: string;
+  message_count: number | null;
+  created_at: string;
+}
+
+// --- Schema ---
+
+export function initMemorySchema(): void {
+  const db = getDb();
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS core_memories (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      category TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      is_pinned INTEGER DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_core_memories_group ON core_memories(group_folder);
+    CREATE INDEX IF NOT EXISTS idx_core_memories_category ON core_memories(group_folder, category);
+
+    CREATE TABLE IF NOT EXISTS conversation_chunks (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      chat_jid TEXT NOT NULL,
+      message_id TEXT,
+      content TEXT NOT NULL,
+      context TEXT,
+      sender_name TEXT,
+      timestamp TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_conv_chunks_group ON conversation_chunks(group_folder);
+    CREATE INDEX IF NOT EXISTS idx_conv_chunks_ts ON conversation_chunks(group_folder, timestamp);
+
+    CREATE TABLE IF NOT EXISTS archival_memories (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      session_id TEXT,
+      title TEXT,
+      content TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      message_count INTEGER,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_archival_group ON archival_memories(group_folder);
+  `);
+
+  // Create vec0 virtual tables (idempotent — errors if already exists)
+  const vecTables = [
+    `CREATE VIRTUAL TABLE IF NOT EXISTS core_memories_vec USING vec0(memory_id TEXT PRIMARY KEY, embedding float[384])`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS conversation_chunks_vec USING vec0(chunk_id TEXT PRIMARY KEY, embedding float[384])`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS archival_memories_vec USING vec0(memory_id TEXT PRIMARY KEY, embedding float[384])`,
+  ];
+
+  for (const sql of vecTables) {
+    try {
+      db.exec(sql);
+    } catch (err) {
+      // vec0 tables don't support IF NOT EXISTS in all versions — ignore if exists
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('already exists')) throw err;
+    }
+  }
+
+  logger.info('Memory schema initialized');
+}
+
+// --- Embedding Pipeline ---
+
+let embedder: unknown = null;
+
+async function getEmbedder(): Promise<
+  (
+    text: string,
+    opts: { pooling: string; normalize: boolean },
+  ) => Promise<{ data: Float32Array }>
+> {
+  if (!embedder) {
+    const { pipeline } = await import('@huggingface/transformers');
+    const cacheDir = path.join(DATA_DIR, 'models');
+    embedder = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {
+      cache_dir: cacheDir,
+    });
+    logger.info({ cacheDir }, 'Embedding model loaded');
+  }
+  return embedder as (
+    text: string,
+    opts: { pooling: string; normalize: boolean },
+  ) => Promise<{ data: Float32Array }>;
+}
+
+export async function embed(text: string): Promise<Float32Array> {
+  const extractor = await getEmbedder();
+  const output = await extractor(text, { pooling: 'mean', normalize: true });
+  return new Float32Array(output.data);
+}
+
+function uid(): string {
+  return crypto.randomUUID();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// --- Layer 1: Core Memory CRUD ---
+
+export function addCoreMemory(
+  groupFolder: string,
+  category: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): string {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+  db.prepare(
+    `INSERT INTO core_memories (id, group_folder, category, content, metadata, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    groupFolder,
+    category,
+    content,
+    metadata ? JSON.stringify(metadata) : null,
+    ts,
+    ts,
+  );
+  return id;
+}
+
+export async function addCoreMemoryWithEmbedding(
+  groupFolder: string,
+  category: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): Promise<string> {
+  const id = addCoreMemory(groupFolder, category, content, metadata);
+  try {
+    const vec = await embed(content);
+    getDb()
+      .prepare(
+        `INSERT INTO core_memories_vec (memory_id, embedding) VALUES (?, ?)`,
+      )
+      .run(id, Buffer.from(vec.buffer));
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to embed core memory');
+  }
+  return id;
+}
+
+export function updateCoreMemory(id: string, content: string): void {
+  const db = getDb();
+  db.prepare(
+    `UPDATE core_memories SET content = ?, updated_at = ? WHERE id = ?`,
+  ).run(content, now(), id);
+}
+
+export async function updateCoreMemoryWithEmbedding(
+  id: string,
+  content: string,
+): Promise<void> {
+  updateCoreMemory(id, content);
+  try {
+    const vec = await embed(content);
+    const db = getDb();
+    // Delete old embedding and insert new one
+    db.prepare(`DELETE FROM core_memories_vec WHERE memory_id = ?`).run(id);
+    db.prepare(
+      `INSERT INTO core_memories_vec (memory_id, embedding) VALUES (?, ?)`,
+    ).run(id, Buffer.from(vec.buffer));
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to re-embed core memory');
+  }
+}
+
+export function removeCoreMemory(id: string): void {
+  const db = getDb();
+  db.prepare(`DELETE FROM core_memories WHERE id = ?`).run(id);
+  try {
+    db.prepare(`DELETE FROM core_memories_vec WHERE memory_id = ?`).run(id);
+  } catch {
+    /* vec entry may not exist */
+  }
+}
+
+export function getCoreMemories(
+  groupFolder: string,
+  category?: string,
+): CoreMemory[] {
+  const db = getDb();
+  if (category) {
+    return db
+      .prepare(
+        `SELECT * FROM core_memories WHERE group_folder = ? AND category = ? ORDER BY updated_at DESC`,
+      )
+      .all(groupFolder, category) as CoreMemory[];
+  }
+  return db
+    .prepare(
+      `SELECT * FROM core_memories WHERE group_folder = ? ORDER BY updated_at DESC`,
+    )
+    .all(groupFolder) as CoreMemory[];
+}
+
+export function getPinnedMemories(groupFolder: string): CoreMemory[] {
+  return getDb()
+    .prepare(
+      `SELECT * FROM core_memories WHERE group_folder = ? AND is_pinned = 1 ORDER BY updated_at DESC`,
+    )
+    .all(groupFolder) as CoreMemory[];
+}
+
+export async function searchCoreMemories(
+  groupFolder: string,
+  query: string,
+  limit = 10,
+): Promise<CoreMemory[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  // Vector search returns memory_ids ranked by similarity
+  const vecResults = db
+    .prepare(
+      `SELECT memory_id, distance
+       FROM core_memories_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{
+    memory_id: string;
+    distance: number;
+  }>;
+
+  if (vecResults.length === 0) return [];
+
+  // Filter to this group's memories and fetch full records
+  const ids = vecResults.map((r) => r.memory_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const memories = db
+    .prepare(
+      `SELECT * FROM core_memories WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as CoreMemory[];
+
+  // Preserve similarity order
+  const memoryMap = new Map(memories.map((m) => [m.id, m]));
+  return vecResults
+    .map((r) => memoryMap.get(r.memory_id))
+    .filter((m): m is CoreMemory => m !== undefined)
+    .slice(0, limit);
+}
+
+// --- Layer 2: Conversation Memory ---
+
+export async function embedMessage(
+  groupFolder: string,
+  chatJid: string,
+  message: NewMessage,
+  contextMessages: NewMessage[],
+): Promise<void> {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+
+  // Build context string (preceding messages for embedding context)
+  const contextParts = contextMessages.map(
+    (m) => `${m.sender_name}: ${m.content}`,
+  );
+  const embeddingText =
+    contextParts.length > 0
+      ? `${contextParts.join('\n')}\n${message.sender_name}: ${message.content}`
+      : `${message.sender_name}: ${message.content}`;
+
+  const contextStr = contextParts.length > 0 ? contextParts.join('\n') : null;
+
+  db.prepare(
+    `INSERT INTO conversation_chunks (id, group_folder, chat_jid, message_id, content, context, sender_name, timestamp, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    groupFolder,
+    chatJid,
+    message.id,
+    message.content,
+    contextStr,
+    message.sender_name,
+    message.timestamp,
+    ts,
+  );
+
+  const vec = await embed(embeddingText);
+  db.prepare(
+    `INSERT INTO conversation_chunks_vec (chunk_id, embedding) VALUES (?, ?)`,
+  ).run(id, Buffer.from(vec.buffer));
+}
+
+export async function embedConversationMessages(
+  groupFolder: string,
+  chatJid: string,
+  messages: NewMessage[],
+): Promise<void> {
+  for (let i = 0; i < messages.length; i++) {
+    // Use up to 2 preceding messages as context
+    const contextStart = Math.max(0, i - 2);
+    const contextMessages = messages.slice(contextStart, i);
+    try {
+      await embedMessage(groupFolder, chatJid, messages[i], contextMessages);
+    } catch (err) {
+      logger.warn(
+        { err, messageId: messages[i].id },
+        'Failed to embed message',
+      );
+    }
+  }
+}
+
+export async function retrieveRelevantChunks(
+  groupFolder: string,
+  query: string,
+  limit = 10,
+): Promise<ConversationChunk[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  const vecResults = db
+    .prepare(
+      `SELECT chunk_id, distance
+       FROM conversation_chunks_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{
+    chunk_id: string;
+    distance: number;
+  }>;
+
+  if (vecResults.length === 0) return [];
+
+  const ids = vecResults.map((r) => r.chunk_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const chunks = db
+    .prepare(
+      `SELECT * FROM conversation_chunks WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as ConversationChunk[];
+
+  const chunkMap = new Map(chunks.map((c) => [c.id, c]));
+  return vecResults
+    .map((r) => chunkMap.get(r.chunk_id))
+    .filter((c): c is ConversationChunk => c !== undefined)
+    .slice(0, limit);
+}
+
+// --- Layer 3: Archival Memory ---
+
+export async function archiveSession(
+  groupFolder: string,
+  sessionId: string | null,
+  title: string | null,
+  content: string,
+  messageCount?: number,
+): Promise<string> {
+  const db = getDb();
+  const id = uid();
+  const ts = now();
+
+  db.prepare(
+    `INSERT INTO archival_memories (id, group_folder, session_id, title, content, timestamp, message_count, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    groupFolder,
+    sessionId,
+    title,
+    content,
+    ts,
+    messageCount ?? null,
+    ts,
+  );
+
+  try {
+    const vec = await embed(content.slice(0, 1000)); // Embed first 1000 chars of summary
+    db.prepare(
+      `INSERT INTO archival_memories_vec (memory_id, embedding) VALUES (?, ?)`,
+    ).run(id, Buffer.from(vec.buffer));
+  } catch (err) {
+    logger.warn({ err, id }, 'Failed to embed archival memory');
+  }
+
+  return id;
+}
+
+export async function searchArchive(
+  groupFolder: string,
+  query: string,
+  limit = 5,
+): Promise<ArchivalMemory[]> {
+  const vec = await embed(query);
+  const db = getDb();
+
+  const vecResults = db
+    .prepare(
+      `SELECT memory_id, distance
+       FROM archival_memories_vec
+       WHERE embedding MATCH ? AND k = ?
+       ORDER BY distance`,
+    )
+    .all(Buffer.from(vec.buffer), limit * 2) as Array<{
+    memory_id: string;
+    distance: number;
+  }>;
+
+  if (vecResults.length === 0) return [];
+
+  const ids = vecResults.map((r) => r.memory_id);
+  const placeholders = ids.map(() => '?').join(',');
+  const memories = db
+    .prepare(
+      `SELECT * FROM archival_memories WHERE id IN (${placeholders}) AND group_folder = ?`,
+    )
+    .all(...ids, groupFolder) as ArchivalMemory[];
+
+  const memoryMap = new Map(memories.map((m) => [m.id, m]));
+  return vecResults
+    .map((r) => memoryMap.get(r.memory_id))
+    .filter((m): m is ArchivalMemory => m !== undefined)
+    .slice(0, limit);
+}
+
+// --- Memory Context Retrieval ---
+
+/**
+ * Retrieve relevant memory context for injection into the agent prompt.
+ * Called before each agent invocation.
+ */
+export async function retrieveMemoryContext(
+  groupFolder: string,
+  messages: NewMessage[],
+): Promise<string> {
+  // Build query from incoming messages
+  const queryText = messages
+    .map((m) => m.content)
+    .join(' ')
+    .slice(0, 500);
+
+  if (!queryText.trim()) return '';
+
+  const parts: string[] = [];
+
+  try {
+    // Layer 1: Core memories (pinned + relevant)
+    const pinned = getPinnedMemories(groupFolder);
+    const allCore = getCoreMemories(groupFolder);
+
+    // If we have vectors, do semantic search; otherwise use all memories
+    let relevantCore: CoreMemory[] = [];
+    try {
+      relevantCore = await searchCoreMemories(groupFolder, queryText, 10);
+    } catch {
+      // Vector table might be empty
+      relevantCore = allCore.slice(0, 10);
+    }
+
+    // Merge pinned + relevant (deduplicated)
+    const seenIds = new Set<string>();
+    const coreMemories: CoreMemory[] = [];
+    for (const m of [...pinned, ...relevantCore]) {
+      if (!seenIds.has(m.id)) {
+        seenIds.add(m.id);
+        coreMemories.push(m);
+      }
+    }
+
+    if (coreMemories.length > 0) {
+      parts.push('<memory type="core">');
+      for (const mem of coreMemories) {
+        parts.push(
+          `<fact category="${mem.category}" id="${mem.id}"${mem.is_pinned ? ' pinned="true"' : ''}>${mem.content}</fact>`,
+        );
+      }
+      parts.push('</memory>');
+    }
+
+    // Layer 2: Relevant conversation chunks
+    let relevantChunks: ConversationChunk[] = [];
+    try {
+      relevantChunks = await retrieveRelevantChunks(groupFolder, queryText, 8);
+    } catch {
+      // Vector table might be empty
+    }
+
+    if (relevantChunks.length > 0) {
+      parts.push('<memory type="past_conversations">');
+      for (const chunk of relevantChunks) {
+        parts.push(
+          `<past_message sender="${chunk.sender_name || 'Unknown'}" time="${chunk.timestamp}">${chunk.content}</past_message>`,
+        );
+      }
+      parts.push('</memory>');
+    }
+  } catch (err) {
+    logger.warn({ err, groupFolder }, 'Failed to retrieve memory context');
+  }
+
+  return parts.length > 0 ? parts.join('\n') + '\n\n' : '';
+}
+
+/**
+ * Build memory snapshot for the agent (written to IPC dir).
+ * Agent uses this to see existing memory IDs for update/remove operations.
+ */
+export function buildMemorySnapshot(groupFolder: string): {
+  coreMemories: Array<{
+    id: string;
+    category: string;
+    content: string;
+    is_pinned: boolean;
+    updated_at: string;
+  }>;
+} {
+  const memories = getCoreMemories(groupFolder);
+  return {
+    coreMemories: memories.map((m) => ({
+      id: m.id,
+      category: m.category,
+      content: m.content,
+      is_pinned: m.is_pinned === 1,
+      updated_at: m.updated_at,
+    })),
+  };
+}
+
+/**
+ * Combined search across all memory layers.
+ * Used by the agent's memory_search IPC tool.
+ */
+export async function searchAllMemory(
+  groupFolder: string,
+  query: string,
+  scope: 'all' | 'conversations' | 'facts' = 'all',
+  limit = 10,
+): Promise<string> {
+  const results: string[] = [];
+
+  if (scope === 'all' || scope === 'facts') {
+    try {
+      const coreResults = await searchCoreMemories(groupFolder, query, limit);
+      if (coreResults.length > 0) {
+        results.push('## Stored Facts');
+        for (const m of coreResults) {
+          results.push(`- [${m.category}] ${m.content} (id: ${m.id})`);
+        }
+      }
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (scope === 'all' || scope === 'conversations') {
+    try {
+      const convResults = await retrieveRelevantChunks(
+        groupFolder,
+        query,
+        limit,
+      );
+      if (convResults.length > 0) {
+        results.push('## Past Conversations');
+        for (const c of convResults) {
+          results.push(`- [${c.timestamp}] ${c.sender_name}: ${c.content}`);
+        }
+      }
+    } catch {
+      /* empty */
+    }
+
+    try {
+      const archiveResults = await searchArchive(groupFolder, query, 3);
+      if (archiveResults.length > 0) {
+        results.push('## Session Archives');
+        for (const a of archiveResults) {
+          results.push(
+            `- [${a.timestamp}] ${a.title || 'Untitled session'}: ${a.content.slice(0, 200)}...`,
+          );
+        }
+      }
+    } catch {
+      /* empty */
+    }
+  }
+
+  return results.length > 0
+    ? results.join('\n')
+    : 'No relevant memories found.';
+}

--- a/.claude/skills/add-memory/manifest.yaml
+++ b/.claude/skills/add-memory/manifest.yaml
@@ -1,0 +1,19 @@
+skill: add-memory
+version: 1.0.0
+description: "Three-layer semantic memory system with RAG using sqlite-vec and local embeddings"
+core_version: 0.1.0
+adds:
+  - src/memory.ts
+modifies:
+  - src/db.ts
+  - src/index.ts
+  - src/ipc.ts
+  - src/task-scheduler.ts
+structured:
+  npm_dependencies:
+    sqlite-vec: "^0.1.7-alpha.2"
+    "@huggingface/transformers": "^3.8.1"
+  env_additions: []
+conflicts: []
+depends: []
+test: "npx vitest run .claude/skills/add-memory/tests/add-memory.test.ts"

--- a/.claude/skills/add-memory/modify/src/db.ts
+++ b/.claude/skills/add-memory/modify/src/db.ts
@@ -1,0 +1,699 @@
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import * as sqliteVec from 'sqlite-vec';
+
+import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
+import { isValidGroupFolder } from './group-folder.js';
+import { logger } from './logger.js';
+import {
+  NewMessage,
+  RegisteredGroup,
+  ScheduledTask,
+  TaskRunLog,
+} from './types.js';
+
+let db: Database.Database;
+
+/** Get the database instance. Must call initDatabase() first. */
+export function getDb(): Database.Database {
+  if (!db)
+    throw new Error('Database not initialized — call initDatabase() first');
+  return db;
+}
+
+function createSchema(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS chats (
+      jid TEXT PRIMARY KEY,
+      name TEXT,
+      last_message_time TEXT,
+      channel TEXT,
+      is_group INTEGER DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT,
+      chat_jid TEXT,
+      sender TEXT,
+      sender_name TEXT,
+      content TEXT,
+      timestamp TEXT,
+      is_from_me INTEGER,
+      is_bot_message INTEGER DEFAULT 0,
+      PRIMARY KEY (id, chat_jid),
+      FOREIGN KEY (chat_jid) REFERENCES chats(jid)
+    );
+    CREATE INDEX IF NOT EXISTS idx_timestamp ON messages(timestamp);
+
+    CREATE TABLE IF NOT EXISTS scheduled_tasks (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      chat_jid TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      schedule_type TEXT NOT NULL,
+      schedule_value TEXT NOT NULL,
+      next_run TEXT,
+      last_run TEXT,
+      last_result TEXT,
+      status TEXT DEFAULT 'active',
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_next_run ON scheduled_tasks(next_run);
+    CREATE INDEX IF NOT EXISTS idx_status ON scheduled_tasks(status);
+
+    CREATE TABLE IF NOT EXISTS task_run_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      run_at TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      result TEXT,
+      error TEXT,
+      FOREIGN KEY (task_id) REFERENCES scheduled_tasks(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_task_run_logs ON task_run_logs(task_id, run_at);
+
+    CREATE TABLE IF NOT EXISTS router_state (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS sessions (
+      group_folder TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS registered_groups (
+      jid TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      folder TEXT NOT NULL UNIQUE,
+      trigger_pattern TEXT NOT NULL,
+      added_at TEXT NOT NULL,
+      container_config TEXT,
+      requires_trigger INTEGER DEFAULT 1
+    );
+  `);
+
+  // Add context_mode column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE scheduled_tasks ADD COLUMN context_mode TEXT DEFAULT 'isolated'`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add is_bot_message column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN is_bot_message INTEGER DEFAULT 0`,
+    );
+    // Backfill: mark existing bot messages that used the content prefix pattern
+    database
+      .prepare(`UPDATE messages SET is_bot_message = 1 WHERE content LIKE ?`)
+      .run(`${ASSISTANT_NAME}:%`);
+  } catch {
+    /* column already exists */
+  }
+
+  // Add is_main column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN is_main INTEGER DEFAULT 0`,
+    );
+    // Backfill: existing rows with folder = 'main' are the main group
+    database.exec(
+      `UPDATE registered_groups SET is_main = 1 WHERE folder = 'main'`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add channel and is_group columns if they don't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE chats ADD COLUMN channel TEXT`);
+    database.exec(`ALTER TABLE chats ADD COLUMN is_group INTEGER DEFAULT 0`);
+    // Backfill from JID patterns
+    database.exec(
+      `UPDATE chats SET channel = 'whatsapp', is_group = 1 WHERE jid LIKE '%@g.us'`,
+    );
+    database.exec(
+      `UPDATE chats SET channel = 'whatsapp', is_group = 0 WHERE jid LIKE '%@s.whatsapp.net'`,
+    );
+    database.exec(
+      `UPDATE chats SET channel = 'discord', is_group = 1 WHERE jid LIKE 'dc:%'`,
+    );
+    database.exec(
+      `UPDATE chats SET channel = 'telegram', is_group = 1 WHERE jid LIKE 'tg:%'`,
+    );
+  } catch {
+    /* columns already exist */
+  }
+}
+
+export function initDatabase(): void {
+  const dbPath = path.join(STORE_DIR, 'messages.db');
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  db = new Database(dbPath);
+
+  // Load sqlite-vec extension for vector search
+  sqliteVec.load(db);
+
+  createSchema(db);
+
+  // Migrate from JSON files if they exist
+  migrateJsonState();
+}
+
+/** @internal - for tests only. Creates a fresh in-memory database. */
+export function _initTestDatabase(): void {
+  db = new Database(':memory:');
+  createSchema(db);
+}
+
+/**
+ * Store chat metadata only (no message content).
+ * Used for all chats to enable group discovery without storing sensitive content.
+ */
+export function storeChatMetadata(
+  chatJid: string,
+  timestamp: string,
+  name?: string,
+  channel?: string,
+  isGroup?: boolean,
+): void {
+  const ch = channel ?? null;
+  const group = isGroup === undefined ? null : isGroup ? 1 : 0;
+
+  if (name) {
+    // Update with name, preserving existing timestamp if newer
+    db.prepare(
+      `
+      INSERT INTO chats (jid, name, last_message_time, channel, is_group) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(jid) DO UPDATE SET
+        name = excluded.name,
+        last_message_time = MAX(last_message_time, excluded.last_message_time),
+        channel = COALESCE(excluded.channel, channel),
+        is_group = COALESCE(excluded.is_group, is_group)
+    `,
+    ).run(chatJid, name, timestamp, ch, group);
+  } else {
+    // Update timestamp only, preserve existing name if any
+    db.prepare(
+      `
+      INSERT INTO chats (jid, name, last_message_time, channel, is_group) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(jid) DO UPDATE SET
+        last_message_time = MAX(last_message_time, excluded.last_message_time),
+        channel = COALESCE(excluded.channel, channel),
+        is_group = COALESCE(excluded.is_group, is_group)
+    `,
+    ).run(chatJid, chatJid, timestamp, ch, group);
+  }
+}
+
+/**
+ * Update chat name without changing timestamp for existing chats.
+ * New chats get the current time as their initial timestamp.
+ * Used during group metadata sync.
+ */
+export function updateChatName(chatJid: string, name: string): void {
+  db.prepare(
+    `
+    INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
+    ON CONFLICT(jid) DO UPDATE SET name = excluded.name
+  `,
+  ).run(chatJid, name, new Date().toISOString());
+}
+
+export interface ChatInfo {
+  jid: string;
+  name: string;
+  last_message_time: string;
+  channel: string;
+  is_group: number;
+}
+
+/**
+ * Get all known chats, ordered by most recent activity.
+ */
+export function getAllChats(): ChatInfo[] {
+  return db
+    .prepare(
+      `
+    SELECT jid, name, last_message_time, channel, is_group
+    FROM chats
+    ORDER BY last_message_time DESC
+  `,
+    )
+    .all() as ChatInfo[];
+}
+
+/**
+ * Get timestamp of last group metadata sync.
+ */
+export function getLastGroupSync(): string | null {
+  // Store sync time in a special chat entry
+  const row = db
+    .prepare(`SELECT last_message_time FROM chats WHERE jid = '__group_sync__'`)
+    .get() as { last_message_time: string } | undefined;
+  return row?.last_message_time || null;
+}
+
+/**
+ * Record that group metadata was synced.
+ */
+export function setLastGroupSync(): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR REPLACE INTO chats (jid, name, last_message_time) VALUES ('__group_sync__', '__group_sync__', ?)`,
+  ).run(now);
+}
+
+/**
+ * Store a message with full content.
+ * Only call this for registered groups where message history is needed.
+ */
+export function storeMessage(msg: NewMessage): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    msg.id,
+    msg.chat_jid,
+    msg.sender,
+    msg.sender_name,
+    msg.content,
+    msg.timestamp,
+    msg.is_from_me ? 1 : 0,
+    msg.is_bot_message ? 1 : 0,
+  );
+}
+
+/**
+ * Store a message directly.
+ */
+export function storeMessageDirect(msg: {
+  id: string;
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  content: string;
+  timestamp: string;
+  is_from_me: boolean;
+  is_bot_message?: boolean;
+}): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    msg.id,
+    msg.chat_jid,
+    msg.sender,
+    msg.sender_name,
+    msg.content,
+    msg.timestamp,
+    msg.is_from_me ? 1 : 0,
+    msg.is_bot_message ? 1 : 0,
+  );
+}
+
+export function getNewMessages(
+  jids: string[],
+  lastTimestamp: string,
+  botPrefix: string,
+): { messages: NewMessage[]; newTimestamp: string } {
+  if (jids.length === 0) return { messages: [], newTimestamp: lastTimestamp };
+
+  const placeholders = jids.map(() => '?').join(',');
+  // Filter bot messages using both the is_bot_message flag AND the content
+  // prefix as a backstop for messages written before the migration ran.
+  const sql = `
+    SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+    FROM messages
+    WHERE timestamp > ? AND chat_jid IN (${placeholders})
+      AND is_bot_message = 0 AND content NOT LIKE ?
+      AND content != '' AND content IS NOT NULL
+    ORDER BY timestamp
+  `;
+
+  const rows = db
+    .prepare(sql)
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`) as NewMessage[];
+
+  let newTimestamp = lastTimestamp;
+  for (const row of rows) {
+    if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+  }
+
+  return { messages: rows, newTimestamp };
+}
+
+export function getMessagesSince(
+  chatJid: string,
+  sinceTimestamp: string,
+  botPrefix: string,
+): NewMessage[] {
+  // Filter bot messages using both the is_bot_message flag AND the content
+  // prefix as a backstop for messages written before the migration ran.
+  const sql = `
+    SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+    FROM messages
+    WHERE chat_jid = ? AND timestamp > ?
+      AND is_bot_message = 0 AND content NOT LIKE ?
+      AND content != '' AND content IS NOT NULL
+    ORDER BY timestamp
+  `;
+  return db
+    .prepare(sql)
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`) as NewMessage[];
+}
+
+export function createTask(
+  task: Omit<ScheduledTask, 'last_run' | 'last_result'>,
+): void {
+  db.prepare(
+    `
+    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `,
+  ).run(
+    task.id,
+    task.group_folder,
+    task.chat_jid,
+    task.prompt,
+    task.schedule_type,
+    task.schedule_value,
+    task.context_mode || 'isolated',
+    task.next_run,
+    task.status,
+    task.created_at,
+  );
+}
+
+export function getTaskById(id: string): ScheduledTask | undefined {
+  return db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as
+    | ScheduledTask
+    | undefined;
+}
+
+export function getTasksForGroup(groupFolder: string): ScheduledTask[] {
+  return db
+    .prepare(
+      'SELECT * FROM scheduled_tasks WHERE group_folder = ? ORDER BY created_at DESC',
+    )
+    .all(groupFolder) as ScheduledTask[];
+}
+
+export function getAllTasks(): ScheduledTask[] {
+  return db
+    .prepare('SELECT * FROM scheduled_tasks ORDER BY created_at DESC')
+    .all() as ScheduledTask[];
+}
+
+export function updateTask(
+  id: string,
+  updates: Partial<
+    Pick<
+      ScheduledTask,
+      'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+    >
+  >,
+): void {
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (updates.prompt !== undefined) {
+    fields.push('prompt = ?');
+    values.push(updates.prompt);
+  }
+  if (updates.schedule_type !== undefined) {
+    fields.push('schedule_type = ?');
+    values.push(updates.schedule_type);
+  }
+  if (updates.schedule_value !== undefined) {
+    fields.push('schedule_value = ?');
+    values.push(updates.schedule_value);
+  }
+  if (updates.next_run !== undefined) {
+    fields.push('next_run = ?');
+    values.push(updates.next_run);
+  }
+  if (updates.status !== undefined) {
+    fields.push('status = ?');
+    values.push(updates.status);
+  }
+
+  if (fields.length === 0) return;
+
+  values.push(id);
+  db.prepare(
+    `UPDATE scheduled_tasks SET ${fields.join(', ')} WHERE id = ?`,
+  ).run(...values);
+}
+
+export function deleteTask(id: string): void {
+  // Delete child records first (FK constraint)
+  db.prepare('DELETE FROM task_run_logs WHERE task_id = ?').run(id);
+  db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+}
+
+export function getDueTasks(): ScheduledTask[] {
+  const now = new Date().toISOString();
+  return db
+    .prepare(
+      `
+    SELECT * FROM scheduled_tasks
+    WHERE status = 'active' AND next_run IS NOT NULL AND next_run <= ?
+    ORDER BY next_run
+  `,
+    )
+    .all(now) as ScheduledTask[];
+}
+
+export function updateTaskAfterRun(
+  id: string,
+  nextRun: string | null,
+  lastResult: string,
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `
+    UPDATE scheduled_tasks
+    SET next_run = ?, last_run = ?, last_result = ?, status = CASE WHEN ? IS NULL THEN 'completed' ELSE status END
+    WHERE id = ?
+  `,
+  ).run(nextRun, now, lastResult, nextRun, id);
+}
+
+export function logTaskRun(log: TaskRunLog): void {
+  db.prepare(
+    `
+    INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `,
+  ).run(
+    log.task_id,
+    log.run_at,
+    log.duration_ms,
+    log.status,
+    log.result,
+    log.error,
+  );
+}
+
+// --- Router state accessors ---
+
+export function getRouterState(key: string): string | undefined {
+  const row = db
+    .prepare('SELECT value FROM router_state WHERE key = ?')
+    .get(key) as { value: string } | undefined;
+  return row?.value;
+}
+
+export function setRouterState(key: string, value: string): void {
+  db.prepare(
+    'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
+  ).run(key, value);
+}
+
+// --- Session accessors ---
+
+export function getSession(groupFolder: string): string | undefined {
+  const row = db
+    .prepare('SELECT session_id FROM sessions WHERE group_folder = ?')
+    .get(groupFolder) as { session_id: string } | undefined;
+  return row?.session_id;
+}
+
+export function setSession(groupFolder: string, sessionId: string): void {
+  db.prepare(
+    'INSERT OR REPLACE INTO sessions (group_folder, session_id) VALUES (?, ?)',
+  ).run(groupFolder, sessionId);
+}
+
+export function getAllSessions(): Record<string, string> {
+  const rows = db
+    .prepare('SELECT group_folder, session_id FROM sessions')
+    .all() as Array<{ group_folder: string; session_id: string }>;
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    result[row.group_folder] = row.session_id;
+  }
+  return result;
+}
+
+// --- Registered group accessors ---
+
+export function getRegisteredGroup(
+  jid: string,
+): (RegisteredGroup & { jid: string }) | undefined {
+  const row = db
+    .prepare('SELECT * FROM registered_groups WHERE jid = ?')
+    .get(jid) as
+    | {
+        jid: string;
+        name: string;
+        folder: string;
+        trigger_pattern: string;
+        added_at: string;
+        container_config: string | null;
+        requires_trigger: number | null;
+        is_main: number | null;
+      }
+    | undefined;
+  if (!row) return undefined;
+  if (!isValidGroupFolder(row.folder)) {
+    logger.warn(
+      { jid: row.jid, folder: row.folder },
+      'Skipping registered group with invalid folder',
+    );
+    return undefined;
+  }
+  return {
+    jid: row.jid,
+    name: row.name,
+    folder: row.folder,
+    trigger: row.trigger_pattern,
+    added_at: row.added_at,
+    containerConfig: row.container_config
+      ? JSON.parse(row.container_config)
+      : undefined,
+    requiresTrigger:
+      row.requires_trigger === null ? undefined : row.requires_trigger === 1,
+    isMain: row.is_main === 1 ? true : undefined,
+  };
+}
+
+export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
+  if (!isValidGroupFolder(group.folder)) {
+    throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
+  }
+  db.prepare(
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    jid,
+    group.name,
+    group.folder,
+    group.trigger,
+    group.added_at,
+    group.containerConfig ? JSON.stringify(group.containerConfig) : null,
+    group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
+    group.isMain ? 1 : 0,
+  );
+}
+
+export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
+  const rows = db.prepare('SELECT * FROM registered_groups').all() as Array<{
+    jid: string;
+    name: string;
+    folder: string;
+    trigger_pattern: string;
+    added_at: string;
+    container_config: string | null;
+    requires_trigger: number | null;
+    is_main: number | null;
+  }>;
+  const result: Record<string, RegisteredGroup> = {};
+  for (const row of rows) {
+    if (!isValidGroupFolder(row.folder)) {
+      logger.warn(
+        { jid: row.jid, folder: row.folder },
+        'Skipping registered group with invalid folder',
+      );
+      continue;
+    }
+    result[row.jid] = {
+      name: row.name,
+      folder: row.folder,
+      trigger: row.trigger_pattern,
+      added_at: row.added_at,
+      containerConfig: row.container_config
+        ? JSON.parse(row.container_config)
+        : undefined,
+      requiresTrigger:
+        row.requires_trigger === null ? undefined : row.requires_trigger === 1,
+      isMain: row.is_main === 1 ? true : undefined,
+    };
+  }
+  return result;
+}
+
+// --- JSON migration ---
+
+function migrateJsonState(): void {
+  const migrateFile = (filename: string) => {
+    const filePath = path.join(DATA_DIR, filename);
+    if (!fs.existsSync(filePath)) return null;
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      fs.renameSync(filePath, `${filePath}.migrated`);
+      return data;
+    } catch {
+      return null;
+    }
+  };
+
+  // Migrate router_state.json
+  const routerState = migrateFile('router_state.json') as {
+    last_timestamp?: string;
+    last_agent_timestamp?: Record<string, string>;
+  } | null;
+  if (routerState) {
+    if (routerState.last_timestamp) {
+      setRouterState('last_timestamp', routerState.last_timestamp);
+    }
+    if (routerState.last_agent_timestamp) {
+      setRouterState(
+        'last_agent_timestamp',
+        JSON.stringify(routerState.last_agent_timestamp),
+      );
+    }
+  }
+
+  // Migrate sessions.json
+  const sessions = migrateFile('sessions.json') as Record<
+    string,
+    string
+  > | null;
+  if (sessions) {
+    for (const [folder, sessionId] of Object.entries(sessions)) {
+      setSession(folder, sessionId);
+    }
+  }
+
+  // Migrate registered_groups.json
+  const groups = migrateFile('registered_groups.json') as Record<
+    string,
+    RegisteredGroup
+  > | null;
+  if (groups) {
+    for (const [jid, group] of Object.entries(groups)) {
+      try {
+        setRegisteredGroup(jid, group);
+      } catch (err) {
+        logger.warn(
+          { jid, folder: group.folder, err },
+          'Skipping migrated registered group with invalid folder',
+        );
+      }
+    }
+  }
+}

--- a/.claude/skills/add-memory/modify/src/db.ts.intent.md
+++ b/.claude/skills/add-memory/modify/src/db.ts.intent.md
@@ -1,0 +1,23 @@
+# Intent: src/db.ts modifications
+
+## What changed
+Added sqlite-vec extension loading and exposed `getDb()` for use by the memory module.
+
+## Key sections
+- **Import**: Added `import * as sqliteVec from 'sqlite-vec'` at top
+- **getDb() export**: New public function that returns the database instance (needed by `src/memory.ts` to run memory queries)
+- **initDatabase()**: Added `sqliteVec.load(db)` call after creating the Database instance, before `createSchema()`
+
+## Invariants
+- All existing schema creation, migrations, and accessors remain unchanged
+- The `_initTestDatabase()` function does NOT load sqlite-vec (in-memory test DBs don't need it)
+- All existing exports are preserved with identical signatures
+- The `createSchema()` function is unchanged
+
+## Must-keep
+- All existing table schemas (chats, messages, scheduled_tasks, task_run_logs, router_state, sessions, registered_groups)
+- All migration ALTER TABLE blocks
+- All existing accessor functions (storeMessage, getNewMessages, createTask, etc.)
+- The `_initTestDatabase()` function for test compatibility
+- The `migrateJsonState()` function
+- The `is_main` column migration

--- a/.claude/skills/add-memory/modify/src/index.ts
+++ b/.claude/skills/add-memory/modify/src/index.ts
@@ -1,0 +1,631 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ASSISTANT_NAME,
+  DATA_DIR,
+  IDLE_TIMEOUT,
+  POLL_INTERVAL,
+  TRIGGER_PATTERN,
+} from './config.js';
+import './channels/index.js';
+import {
+  getChannelFactory,
+  getRegisteredChannelNames,
+} from './channels/registry.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import {
+  cleanupOrphans,
+  ensureContainerRuntimeRunning,
+} from './container-runtime.js';
+import {
+  buildMemorySnapshot,
+  embedConversationMessages,
+  initMemorySchema,
+  retrieveMemoryContext,
+} from './memory.js';
+import {
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getAllTasks,
+  getMessagesSince,
+  getNewMessages,
+  getRouterState,
+  initDatabase,
+  setRegisteredGroup,
+  setRouterState,
+  setSession,
+  storeChatMetadata,
+  storeMessage,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { startIpcWatcher } from './ipc.js';
+import { findChannel, formatMessages, formatOutbound } from './router.js';
+import {
+  isSenderAllowed,
+  isTriggerAllowed,
+  loadSenderAllowlist,
+  shouldDropMessage,
+} from './sender-allowlist.js';
+import { startSchedulerLoop } from './task-scheduler.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { logger } from './logger.js';
+
+// Re-export for backwards compatibility during refactor
+export { escapeXml, formatMessages } from './router.js';
+
+let lastTimestamp = '';
+let sessions: Record<string, string> = {};
+let registeredGroups: Record<string, RegisteredGroup> = {};
+let lastAgentTimestamp: Record<string, string> = {};
+let messageLoopRunning = false;
+
+const channels: Channel[] = [];
+const queue = new GroupQueue();
+
+function loadState(): void {
+  lastTimestamp = getRouterState('last_timestamp') || '';
+  const agentTs = getRouterState('last_agent_timestamp');
+  try {
+    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+  } catch {
+    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+    lastAgentTimestamp = {};
+  }
+  sessions = getAllSessions();
+  registeredGroups = getAllRegisteredGroups();
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    'State loaded',
+  );
+}
+
+function saveState(): void {
+  setRouterState('last_timestamp', lastTimestamp);
+  setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
+}
+
+function registerGroup(jid: string, group: RegisteredGroup): void {
+  let groupDir: string;
+  try {
+    groupDir = resolveGroupFolderPath(group.folder);
+  } catch (err) {
+    logger.warn(
+      { jid, folder: group.folder, err },
+      'Rejecting group registration with invalid folder',
+    );
+    return;
+  }
+
+  registeredGroups[jid] = group;
+  setRegisteredGroup(jid, group);
+
+  // Create group folder
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    'Group registered',
+  );
+}
+
+/**
+ * Get available groups list for the agent.
+ * Returns groups ordered by most recent activity.
+ */
+export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}
+
+/** @internal - exported for testing */
+export function _setRegisteredGroups(
+  groups: Record<string, RegisteredGroup>,
+): void {
+  registeredGroups = groups;
+}
+
+/**
+ * Process all pending messages for a group.
+ * Called by the GroupQueue when it's this group's turn.
+ */
+async function processGroupMessages(chatJid: string): Promise<boolean> {
+  const group = registeredGroups[chatJid];
+  if (!group) return true;
+
+  const channel = findChannel(channels, chatJid);
+  if (!channel) {
+    logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+    return true;
+  }
+
+  const isMainGroup = group.isMain === true;
+
+  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+  const missedMessages = getMessagesSince(
+    chatJid,
+    sinceTimestamp,
+    ASSISTANT_NAME,
+  );
+
+  if (missedMessages.length === 0) return true;
+
+  // For non-main groups, check if trigger is required and present
+  if (!isMainGroup && group.requiresTrigger !== false) {
+    const allowlistCfg = loadSenderAllowlist();
+    const hasTrigger = missedMessages.some(
+      (m) =>
+        TRIGGER_PATTERN.test(m.content.trim()) &&
+        (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+    );
+    if (!hasTrigger) return true;
+  }
+
+  // Retrieve relevant memory context (RAG) to prepend to the prompt
+  let memoryContext = '';
+  try {
+    memoryContext = await retrieveMemoryContext(group.folder, missedMessages);
+  } catch (err) {
+    logger.warn(
+      { group: group.name, err },
+      'Memory retrieval failed, continuing without',
+    );
+  }
+
+  const prompt = memoryContext + formatMessages(missedMessages);
+
+  // Advance cursor so the piping path in startMessageLoop won't re-fetch
+  // these messages. Save the old cursor so we can roll back on error.
+  const previousCursor = lastAgentTimestamp[chatJid] || '';
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    'Processing messages',
+  );
+
+  // Track idle timer for closing stdin when agent is idle
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.debug(
+        { group: group.name },
+        'Idle timeout, closing container stdin',
+      );
+      queue.closeStdin(chatJid);
+    }, IDLE_TIMEOUT);
+  };
+
+  await channel.setTyping?.(chatJid, true);
+  let hadError = false;
+  let outputSentToUser = false;
+  let messagesEmbedded = false;
+
+  const output = await runAgent(group, prompt, chatJid, async (result) => {
+    // Streaming output callback — called for each agent result
+    if (result.result) {
+      const raw =
+        typeof result.result === 'string'
+          ? result.result
+          : JSON.stringify(result.result);
+      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      if (text) {
+        await channel.sendMessage(chatJid, text);
+        outputSentToUser = true;
+      }
+      // Only reset idle timer on actual results, not session-update markers (result: null)
+      resetIdleTimer();
+
+      // Embed conversation messages on first successful output (don't wait for container exit)
+      if (!messagesEmbedded) {
+        messagesEmbedded = true;
+        embedConversationMessages(group.folder, chatJid, missedMessages).catch(
+          (err) =>
+            logger.warn(
+              { group: group.name, err },
+              'Failed to embed conversation messages',
+            ),
+        );
+      }
+    }
+
+    if (result.status === 'success') {
+      queue.notifyIdle(chatJid);
+    }
+
+    if (result.status === 'error') {
+      hadError = true;
+    }
+  });
+
+  await channel.setTyping?.(chatJid, false);
+  if (idleTimer) clearTimeout(idleTimer);
+
+  if (output === 'error' || hadError) {
+    // If we already sent output to the user, don't roll back the cursor —
+    // the user got their response and re-processing would send duplicates.
+    if (outputSentToUser) {
+      logger.warn(
+        { group: group.name },
+        'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+      );
+      return true;
+    }
+    // Roll back cursor so retries can re-process these messages
+    lastAgentTimestamp[chatJid] = previousCursor;
+    saveState();
+    logger.warn(
+      { group: group.name },
+      'Agent error, rolled back message cursor for retry',
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<'success' | 'error'> {
+  const isMain = group.isMain === true;
+  const sessionId = sessions[group.folder];
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Write memory snapshot for the agent (so it can see existing memory IDs)
+  try {
+    const snapshot = buildMemorySnapshot(group.folder);
+    const groupIpcDir = path.join(DATA_DIR, 'ipc', group.folder);
+    fs.mkdirSync(groupIpcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(groupIpcDir, 'memory_snapshot.json'),
+      JSON.stringify(snapshot, null, 2),
+    );
+  } catch (err) {
+    logger.warn({ group: group.name, err }, 'Failed to write memory snapshot');
+  }
+
+  // Update available groups snapshot (main group only can see all groups)
+  const availableGroups = getAvailableGroups();
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
+
+  // Wrap onOutput to track session ID from streamed results
+  const wrappedOnOutput = onOutput
+    ? async (output: ContainerOutput) => {
+        if (output.newSessionId) {
+          sessions[group.folder] = output.newSessionId;
+          setSession(group.folder, output.newSessionId);
+        }
+        await onOutput(output);
+      }
+    : undefined;
+
+  try {
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        assistantName: ASSISTANT_NAME,
+      },
+      (proc, containerName) =>
+        queue.registerProcess(chatJid, proc, containerName, group.folder),
+      wrappedOnOutput,
+    );
+
+    if (output.newSessionId) {
+      sessions[group.folder] = output.newSessionId;
+      setSession(group.folder, output.newSessionId);
+    }
+
+    if (output.status === 'error') {
+      logger.error(
+        { group: group.name, error: output.error },
+        'Container agent error',
+      );
+      return 'error';
+    }
+
+    return 'success';
+  } catch (err) {
+    logger.error({ group: group.name, err }, 'Agent error');
+    return 'error';
+  }
+}
+
+async function startMessageLoop(): Promise<void> {
+  if (messageLoopRunning) {
+    logger.debug('Message loop already running, skipping duplicate start');
+    return;
+  }
+  messageLoopRunning = true;
+
+  logger.info(`NanoClaw running (trigger: @${ASSISTANT_NAME})`);
+
+  while (true) {
+    try {
+      const jids = Object.keys(registeredGroups);
+      const { messages, newTimestamp } = getNewMessages(
+        jids,
+        lastTimestamp,
+        ASSISTANT_NAME,
+      );
+
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
+
+        // Advance the "seen" cursor for all messages immediately
+        lastTimestamp = newTimestamp;
+        saveState();
+
+        // Deduplicate by group
+        const messagesByGroup = new Map<string, NewMessage[]>();
+        for (const msg of messages) {
+          const existing = messagesByGroup.get(msg.chat_jid);
+          if (existing) {
+            existing.push(msg);
+          } else {
+            messagesByGroup.set(msg.chat_jid, [msg]);
+          }
+        }
+
+        for (const [chatJid, groupMessages] of messagesByGroup) {
+          const group = registeredGroups[chatJid];
+          if (!group) continue;
+
+          const channel = findChannel(channels, chatJid);
+          if (!channel) {
+            logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+            continue;
+          }
+
+          const isMainGroup = group.isMain === true;
+          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
+          // For non-main groups, only act on trigger messages.
+          // Non-trigger messages accumulate in DB and get pulled as
+          // context when a trigger eventually arrives.
+          if (needsTrigger) {
+            const allowlistCfg = loadSenderAllowlist();
+            const hasTrigger = groupMessages.some(
+              (m) =>
+                TRIGGER_PATTERN.test(m.content.trim()) &&
+                (m.is_from_me ||
+                  isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+            );
+            if (!hasTrigger) continue;
+          }
+
+          // Pull all messages since lastAgentTimestamp so non-trigger
+          // context that accumulated between triggers is included.
+          const allPending = getMessagesSince(
+            chatJid,
+            lastAgentTimestamp[chatJid] || '',
+            ASSISTANT_NAME,
+          );
+          const messagesToSend =
+            allPending.length > 0 ? allPending : groupMessages;
+          const formatted = formatMessages(messagesToSend);
+
+          if (queue.sendMessage(chatJid, formatted)) {
+            logger.debug(
+              { chatJid, count: messagesToSend.length },
+              'Piped messages to active container',
+            );
+            lastAgentTimestamp[chatJid] =
+              messagesToSend[messagesToSend.length - 1].timestamp;
+            saveState();
+            // Show typing indicator while the container processes the piped message
+            channel
+              .setTyping?.(chatJid, true)
+              ?.catch((err) =>
+                logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
+              );
+          } else {
+            // No active container — enqueue for a new one
+            queue.enqueueMessageCheck(chatJid);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in message loop');
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+/**
+ * Startup recovery: check for unprocessed messages in registered groups.
+ * Handles crash between advancing lastTimestamp and processing messages.
+ */
+function recoverPendingMessages(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+    if (pending.length > 0) {
+      logger.info(
+        { group: group.name, pendingCount: pending.length },
+        'Recovery: found unprocessed messages',
+      );
+      queue.enqueueMessageCheck(chatJid);
+    }
+  }
+}
+
+function ensureContainerSystemRunning(): void {
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
+}
+
+async function main(): Promise<void> {
+  ensureContainerSystemRunning();
+  initDatabase();
+  initMemorySchema();
+  logger.info('Database initialized');
+  loadState();
+
+  // Graceful shutdown handlers
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Channel callbacks (shared by all channels)
+  const channelOpts = {
+    onMessage: (chatJid: string, msg: NewMessage) => {
+      // Sender allowlist drop mode: discard messages from denied senders before storing
+      if (!msg.is_from_me && !msg.is_bot_message && registeredGroups[chatJid]) {
+        const cfg = loadSenderAllowlist();
+        if (
+          shouldDropMessage(chatJid, cfg) &&
+          !isSenderAllowed(chatJid, msg.sender, cfg)
+        ) {
+          if (cfg.logDenied) {
+            logger.debug(
+              { chatJid, sender: msg.sender },
+              'sender-allowlist: dropping message (drop mode)',
+            );
+          }
+          return;
+        }
+      }
+      storeMessage(msg);
+    },
+    onChatMetadata: (
+      chatJid: string,
+      timestamp: string,
+      name?: string,
+      channel?: string,
+      isGroup?: boolean,
+    ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create and connect all registered channels.
+  // Each channel self-registers via the barrel import above.
+  // Factories return null when credentials are missing, so unconfigured channels are skipped.
+  for (const channelName of getRegisteredChannelNames()) {
+    const factory = getChannelFactory(channelName)!;
+    const channel = factory(channelOpts);
+    if (!channel) {
+      logger.warn(
+        { channel: channelName },
+        'Channel installed but credentials missing — skipping. Check .env or re-run the channel skill.',
+      );
+      continue;
+    }
+    channels.push(channel);
+    await channel.connect();
+  }
+  if (channels.length === 0) {
+    logger.fatal('No channels connected');
+    process.exit(1);
+  }
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) =>
+      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn({ jid }, 'No channel owns JID, cannot send message');
+        return;
+      }
+      const text = formatOutbound(rawText);
+      if (text) await channel.sendMessage(jid, text);
+    },
+  });
+  startIpcWatcher({
+    sendMessage: (jid, text) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      return channel.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroups: async (force: boolean) => {
+      await Promise.all(
+        channels
+          .filter((ch) => ch.syncGroups)
+          .map((ch) => ch.syncGroups!(force)),
+      );
+    },
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) =>
+      writeGroupsSnapshot(gf, im, ag, rj),
+  });
+  queue.setProcessMessagesFn(processGroupMessages);
+  recoverPendingMessages();
+  startMessageLoop().catch((err) => {
+    logger.fatal({ err }, 'Message loop crashed unexpectedly');
+    process.exit(1);
+  });
+}
+
+// Guard: only run when executed directly, not when imported by tests
+const isDirectRun =
+  process.argv[1] &&
+  new URL(import.meta.url).pathname ===
+    new URL(`file://${process.argv[1]}`).pathname;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    logger.error({ err }, 'Failed to start NanoClaw');
+    process.exit(1);
+  });
+}

--- a/.claude/skills/add-memory/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-memory/modify/src/index.ts.intent.md
@@ -1,0 +1,26 @@
+# Intent: src/index.ts modifications
+
+## What changed
+Integrated the memory system into the message processing pipeline and agent invocation.
+
+## Key sections
+- **Imports**: Added `import { buildMemorySnapshot, embedConversationMessages, initMemorySchema, retrieveMemoryContext } from './memory.js'` and `import { DATA_DIR } from './config.js'`
+- **main()**: Added `initMemorySchema()` call after `initDatabase()` to create memory tables on startup
+- **processGroupMessages()**: Added RAG memory retrieval before formatting the prompt — `retrieveMemoryContext()` is called with missed messages, and the result is prepended to the formatted prompt
+- **processGroupMessages()**: Added conversation embedding — after first successful agent output, `embedConversationMessages()` is called asynchronously (fire-and-forget with error logging)
+- **runAgent()**: Added memory snapshot writing — `buildMemorySnapshot()` is called and written to `{ipcDir}/memory_snapshot.json` before running the container agent
+
+## Invariants
+- All existing message processing, cursor management, and error recovery logic is unchanged
+- The sender allowlist system is preserved exactly as-is
+- Channel registration and connection logic is unchanged
+- The message loop, queue management, and typing indicators remain identical
+- Memory failures are gracefully handled — if retrieval fails, the agent runs without memory context
+
+## Must-keep
+- All sender-allowlist imports and usage (`isSenderAllowed`, `isTriggerAllowed`, `loadSenderAllowlist`, `shouldDropMessage`)
+- The `isMain === true` pattern for main group detection (not `MAIN_GROUP_FOLDER`)
+- The channel registry system (`getChannelFactory`, `getRegisteredChannelNames`, barrel import)
+- All existing exports (`escapeXml`, `formatMessages`, `getAvailableGroups`, `_setRegisteredGroups`)
+- The `syncGroups` IPC dependency (not `syncGroupMetadata`)
+- Error recovery with cursor rollback in `processGroupMessages`

--- a/.claude/skills/add-memory/modify/src/ipc.ts
+++ b/.claude/skills/add-memory/modify/src/ipc.ts
@@ -1,0 +1,528 @@
+import fs from 'fs';
+import path from 'path';
+
+import { CronExpressionParser } from 'cron-parser';
+
+import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
+import { AvailableGroup } from './container-runner.js';
+import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
+import { isValidGroupFolder } from './group-folder.js';
+import { logger } from './logger.js';
+import {
+  addCoreMemoryWithEmbedding,
+  removeCoreMemory,
+  searchAllMemory,
+  updateCoreMemoryWithEmbedding,
+} from './memory.js';
+import { RegisteredGroup } from './types.js';
+
+export interface IpcDeps {
+  sendMessage: (jid: string, text: string) => Promise<void>;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  registerGroup: (jid: string, group: RegisteredGroup) => void;
+  syncGroups: (force: boolean) => Promise<void>;
+  getAvailableGroups: () => AvailableGroup[];
+  writeGroupsSnapshot: (
+    groupFolder: string,
+    isMain: boolean,
+    availableGroups: AvailableGroup[],
+    registeredJids: Set<string>,
+  ) => void;
+}
+
+let ipcWatcherRunning = false;
+
+export function startIpcWatcher(deps: IpcDeps): void {
+  if (ipcWatcherRunning) {
+    logger.debug('IPC watcher already running, skipping duplicate start');
+    return;
+  }
+  ipcWatcherRunning = true;
+
+  const ipcBaseDir = path.join(DATA_DIR, 'ipc');
+  fs.mkdirSync(ipcBaseDir, { recursive: true });
+
+  const processIpcFiles = async () => {
+    // Scan all group IPC directories (identity determined by directory)
+    let groupFolders: string[];
+    try {
+      groupFolders = fs.readdirSync(ipcBaseDir).filter((f) => {
+        const stat = fs.statSync(path.join(ipcBaseDir, f));
+        return stat.isDirectory() && f !== 'errors';
+      });
+    } catch (err) {
+      logger.error({ err }, 'Error reading IPC base directory');
+      setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
+      return;
+    }
+
+    const registeredGroups = deps.registeredGroups();
+
+    // Build folder→isMain lookup from registered groups
+    const folderIsMain = new Map<string, boolean>();
+    for (const group of Object.values(registeredGroups)) {
+      if (group.isMain) folderIsMain.set(group.folder, true);
+    }
+
+    for (const sourceGroup of groupFolders) {
+      const isMain = folderIsMain.get(sourceGroup) === true;
+      const messagesDir = path.join(ipcBaseDir, sourceGroup, 'messages');
+      const tasksDir = path.join(ipcBaseDir, sourceGroup, 'tasks');
+
+      // Process messages from this group's IPC directory
+      try {
+        if (fs.existsSync(messagesDir)) {
+          const messageFiles = fs
+            .readdirSync(messagesDir)
+            .filter((f) => f.endsWith('.json'));
+          for (const file of messageFiles) {
+            const filePath = path.join(messagesDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              if (data.type === 'message' && data.chatJid && data.text) {
+                // Authorization: verify this group can send to this chatJid
+                const targetGroup = registeredGroups[data.chatJid];
+                if (
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup)
+                ) {
+                  await deps.sendMessage(data.chatJid, data.text);
+                  logger.info(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'IPC message sent',
+                  );
+                } else {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC message attempt blocked',
+                  );
+                }
+              }
+              fs.unlinkSync(filePath);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC message',
+              );
+              const errorDir = path.join(ipcBaseDir, 'errors');
+              fs.mkdirSync(errorDir, { recursive: true });
+              fs.renameSync(
+                filePath,
+                path.join(errorDir, `${sourceGroup}-${file}`),
+              );
+            }
+          }
+        }
+      } catch (err) {
+        logger.error(
+          { err, sourceGroup },
+          'Error reading IPC messages directory',
+        );
+      }
+
+      // Process tasks from this group's IPC directory
+      try {
+        if (fs.existsSync(tasksDir)) {
+          const taskFiles = fs
+            .readdirSync(tasksDir)
+            .filter((f) => f.endsWith('.json'));
+          for (const file of taskFiles) {
+            const filePath = path.join(tasksDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              // Pass source group identity to processTaskIpc for authorization
+              await processTaskIpc(data, sourceGroup, isMain, deps);
+              fs.unlinkSync(filePath);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC task',
+              );
+              const errorDir = path.join(ipcBaseDir, 'errors');
+              fs.mkdirSync(errorDir, { recursive: true });
+              fs.renameSync(
+                filePath,
+                path.join(errorDir, `${sourceGroup}-${file}`),
+              );
+            }
+          }
+        }
+      } catch (err) {
+        logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
+      }
+
+      // Process memory operations from this group's IPC directory
+      const memoryDir = path.join(ipcBaseDir, sourceGroup, 'memory');
+      try {
+        if (fs.existsSync(memoryDir)) {
+          const memoryFiles = fs
+            .readdirSync(memoryDir)
+            .filter((f) => f.endsWith('.json') && !f.startsWith('res-'));
+          for (const file of memoryFiles) {
+            const filePath = path.join(memoryDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              fs.unlinkSync(filePath);
+              await processMemoryIpc(data, sourceGroup, memoryDir);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC memory request',
+              );
+              try {
+                fs.unlinkSync(path.join(memoryDir, file));
+              } catch {
+                /* ignore */
+              }
+            }
+          }
+        }
+      } catch (err) {
+        logger.error(
+          { err, sourceGroup },
+          'Error reading IPC memory directory',
+        );
+      }
+    }
+
+    setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
+  };
+
+  processIpcFiles();
+  logger.info('IPC watcher started (per-group namespaces)');
+}
+
+export async function processTaskIpc(
+  data: {
+    type: string;
+    taskId?: string;
+    prompt?: string;
+    schedule_type?: string;
+    schedule_value?: string;
+    context_mode?: string;
+    groupFolder?: string;
+    chatJid?: string;
+    targetJid?: string;
+    // For register_group
+    jid?: string;
+    name?: string;
+    folder?: string;
+    trigger?: string;
+    requiresTrigger?: boolean;
+    containerConfig?: RegisteredGroup['containerConfig'];
+  },
+  sourceGroup: string, // Verified identity from IPC directory
+  isMain: boolean, // Verified from directory path
+  deps: IpcDeps,
+): Promise<void> {
+  const registeredGroups = deps.registeredGroups();
+
+  switch (data.type) {
+    case 'schedule_task':
+      if (
+        data.prompt &&
+        data.schedule_type &&
+        data.schedule_value &&
+        data.targetJid
+      ) {
+        // Resolve the target group from JID
+        const targetJid = data.targetJid as string;
+        const targetGroupEntry = registeredGroups[targetJid];
+
+        if (!targetGroupEntry) {
+          logger.warn(
+            { targetJid },
+            'Cannot schedule task: target group not registered',
+          );
+          break;
+        }
+
+        const targetFolder = targetGroupEntry.folder;
+
+        // Authorization: non-main groups can only schedule for themselves
+        if (!isMain && targetFolder !== sourceGroup) {
+          logger.warn(
+            { sourceGroup, targetFolder },
+            'Unauthorized schedule_task attempt blocked',
+          );
+          break;
+        }
+
+        const scheduleType = data.schedule_type as 'cron' | 'interval' | 'once';
+
+        let nextRun: string | null = null;
+        if (scheduleType === 'cron') {
+          try {
+            const interval = CronExpressionParser.parse(data.schedule_value, {
+              tz: TIMEZONE,
+            });
+            nextRun = interval.next().toISOString();
+          } catch {
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              'Invalid cron expression',
+            );
+            break;
+          }
+        } else if (scheduleType === 'interval') {
+          const ms = parseInt(data.schedule_value, 10);
+          if (isNaN(ms) || ms <= 0) {
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              'Invalid interval',
+            );
+            break;
+          }
+          nextRun = new Date(Date.now() + ms).toISOString();
+        } else if (scheduleType === 'once') {
+          const scheduled = new Date(data.schedule_value);
+          if (isNaN(scheduled.getTime())) {
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              'Invalid timestamp',
+            );
+            break;
+          }
+          nextRun = scheduled.toISOString();
+        }
+
+        const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const contextMode =
+          data.context_mode === 'group' || data.context_mode === 'isolated'
+            ? data.context_mode
+            : 'isolated';
+        createTask({
+          id: taskId,
+          group_folder: targetFolder,
+          chat_jid: targetJid,
+          prompt: data.prompt,
+          schedule_type: scheduleType,
+          schedule_value: data.schedule_value,
+          context_mode: contextMode,
+          next_run: nextRun,
+          status: 'active',
+          created_at: new Date().toISOString(),
+        });
+        logger.info(
+          { taskId, sourceGroup, targetFolder, contextMode },
+          'Task created via IPC',
+        );
+      }
+      break;
+
+    case 'pause_task':
+      if (data.taskId) {
+        const task = getTaskById(data.taskId);
+        if (task && (isMain || task.group_folder === sourceGroup)) {
+          updateTask(data.taskId, { status: 'paused' });
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            'Task paused via IPC',
+          );
+        } else {
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            'Unauthorized task pause attempt',
+          );
+        }
+      }
+      break;
+
+    case 'resume_task':
+      if (data.taskId) {
+        const task = getTaskById(data.taskId);
+        if (task && (isMain || task.group_folder === sourceGroup)) {
+          updateTask(data.taskId, { status: 'active' });
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            'Task resumed via IPC',
+          );
+        } else {
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            'Unauthorized task resume attempt',
+          );
+        }
+      }
+      break;
+
+    case 'cancel_task':
+      if (data.taskId) {
+        const task = getTaskById(data.taskId);
+        if (task && (isMain || task.group_folder === sourceGroup)) {
+          deleteTask(data.taskId);
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            'Task cancelled via IPC',
+          );
+        } else {
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            'Unauthorized task cancel attempt',
+          );
+        }
+      }
+      break;
+
+    case 'refresh_groups':
+      // Only main group can request a refresh
+      if (isMain) {
+        logger.info(
+          { sourceGroup },
+          'Group metadata refresh requested via IPC',
+        );
+        await deps.syncGroups(true);
+        // Write updated snapshot immediately
+        const availableGroups = deps.getAvailableGroups();
+        deps.writeGroupsSnapshot(
+          sourceGroup,
+          true,
+          availableGroups,
+          new Set(Object.keys(registeredGroups)),
+        );
+      } else {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized refresh_groups attempt blocked',
+        );
+      }
+      break;
+
+    case 'register_group':
+      // Only main group can register new groups
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized register_group attempt blocked',
+        );
+        break;
+      }
+      if (data.jid && data.name && data.folder && data.trigger) {
+        if (!isValidGroupFolder(data.folder)) {
+          logger.warn(
+            { sourceGroup, folder: data.folder },
+            'Invalid register_group request - unsafe folder name',
+          );
+          break;
+        }
+        // Defense in depth: agent cannot set isMain via IPC
+        deps.registerGroup(data.jid, {
+          name: data.name,
+          folder: data.folder,
+          trigger: data.trigger,
+          added_at: new Date().toISOString(),
+          containerConfig: data.containerConfig,
+          requiresTrigger: data.requiresTrigger,
+        });
+      } else {
+        logger.warn(
+          { data },
+          'Invalid register_group request - missing required fields',
+        );
+      }
+      break;
+
+    default:
+      logger.warn({ type: data.type }, 'Unknown IPC task type');
+  }
+}
+
+async function processMemoryIpc(
+  data: {
+    type: string;
+    requestId?: string;
+    content?: string;
+    category?: string;
+    memoryId?: string;
+    query?: string;
+    scope?: string;
+    limit?: number;
+    groupFolder?: string;
+  },
+  sourceGroup: string,
+  memoryDir: string,
+): Promise<void> {
+  const groupFolder = sourceGroup;
+
+  switch (data.type) {
+    case 'memory_add':
+      if (data.content && data.category) {
+        const id = await addCoreMemoryWithEmbedding(
+          groupFolder,
+          data.category,
+          data.content,
+        );
+        logger.info(
+          { sourceGroup, id, category: data.category },
+          'Core memory added via IPC',
+        );
+        // Write response if requestId provided
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok', id }));
+        }
+      }
+      break;
+
+    case 'memory_update':
+      if (data.memoryId && data.content) {
+        await updateCoreMemoryWithEmbedding(data.memoryId, data.content);
+        logger.info(
+          { sourceGroup, memoryId: data.memoryId },
+          'Core memory updated via IPC',
+        );
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok' }));
+        }
+      }
+      break;
+
+    case 'memory_remove':
+      if (data.memoryId) {
+        removeCoreMemory(data.memoryId);
+        logger.info(
+          { sourceGroup, memoryId: data.memoryId },
+          'Core memory removed via IPC',
+        );
+        if (data.requestId) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok' }));
+        }
+      }
+      break;
+
+    case 'memory_search':
+      if (data.query && data.requestId) {
+        try {
+          const scope =
+            (data.scope as 'all' | 'conversations' | 'facts') || 'all';
+          const results = await searchAllMemory(
+            groupFolder,
+            data.query,
+            scope,
+            data.limit || 10,
+          );
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(resFile, JSON.stringify({ status: 'ok', results }));
+          logger.debug(
+            { sourceGroup, query: data.query },
+            'Memory search completed via IPC',
+          );
+        } catch (err) {
+          const resFile = path.join(memoryDir, `res-${data.requestId}.json`);
+          fs.writeFileSync(
+            resFile,
+            JSON.stringify({
+              status: 'error',
+              results: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+            }),
+          );
+        }
+      }
+      break;
+
+    default:
+      logger.warn({ type: data.type }, 'Unknown IPC memory type');
+  }
+}

--- a/.claude/skills/add-memory/modify/src/ipc.ts.intent.md
+++ b/.claude/skills/add-memory/modify/src/ipc.ts.intent.md
@@ -1,0 +1,24 @@
+# Intent: src/ipc.ts modifications
+
+## What changed
+Added memory IPC processing to the IPC watcher loop and a new `processMemoryIpc()` function.
+
+## Key sections
+- **Imports**: Added memory function imports from `./memory.js` (`addCoreMemoryWithEmbedding`, `removeCoreMemory`, `searchAllMemory`, `updateCoreMemoryWithEmbedding`)
+- **processIpcFiles loop**: Added a new block after task processing that scans `{ipcDir}/{group}/memory/` for JSON files (excluding `res-*` response files) and processes them via `processMemoryIpc()`
+- **processMemoryIpc()**: New function handling four IPC types: `memory_add`, `memory_update`, `memory_remove`, `memory_search`. Uses request-response pattern for search (writes `res-{requestId}.json`).
+- **isMain detection**: Uses `folderIsMain` Map built from `group.isMain` property (same as upstream pattern)
+
+## Invariants
+- All existing IPC message and task processing is unchanged
+- The `IpcDeps` interface keeps the `syncGroups` method name (upstream pattern)
+- Authorization logic for messages, tasks, and register_group is preserved exactly
+- The error-file-move pattern for failed IPC processing is preserved
+- The `processTaskIpc` function signature and logic are identical to upstream
+
+## Must-keep
+- The `folderIsMain` Map pattern for determining isMain from registered groups
+- The `syncGroups` method on IpcDeps (not `syncGroupMetadata`)
+- All existing task IPC types (schedule_task, pause_task, resume_task, cancel_task, refresh_groups, register_group)
+- Error handling with move-to-errors-dir pattern
+- The "defense in depth" comment on register_group

--- a/.claude/skills/add-memory/modify/src/task-scheduler.ts
+++ b/.claude/skills/add-memory/modify/src/task-scheduler.ts
@@ -1,0 +1,313 @@
+import { ChildProcess } from 'child_process';
+import { CronExpressionParser } from 'cron-parser';
+import fs from 'fs';
+import path from 'path';
+
+import { ASSISTANT_NAME, SCHEDULER_POLL_INTERVAL, TIMEZONE } from './config.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import {
+  getAllTasks,
+  getDueTasks,
+  getTaskById,
+  logTaskRun,
+  updateTask,
+  updateTaskAfterRun,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { buildMemorySnapshot, retrieveMemoryContext } from './memory.js';
+import { NewMessage, RegisteredGroup, ScheduledTask } from './types.js';
+
+/**
+ * Compute the next run time for a recurring task, anchored to the
+ * task's scheduled time rather than Date.now() to prevent cumulative
+ * drift on interval-based tasks.
+ *
+ * Co-authored-by: @community-pr-601
+ */
+export function computeNextRun(task: ScheduledTask): string | null {
+  if (task.schedule_type === 'once') return null;
+
+  const now = Date.now();
+
+  if (task.schedule_type === 'cron') {
+    const interval = CronExpressionParser.parse(task.schedule_value, {
+      tz: TIMEZONE,
+    });
+    return interval.next().toISOString();
+  }
+
+  if (task.schedule_type === 'interval') {
+    const ms = parseInt(task.schedule_value, 10);
+    if (!ms || ms <= 0) {
+      // Guard against malformed interval that would cause an infinite loop
+      logger.warn(
+        { taskId: task.id, value: task.schedule_value },
+        'Invalid interval value',
+      );
+      return new Date(now + 60_000).toISOString();
+    }
+    // Anchor to the scheduled time, not now, to prevent drift.
+    // Skip past any missed intervals so we always land in the future.
+    let next = new Date(task.next_run!).getTime() + ms;
+    while (next <= now) {
+      next += ms;
+    }
+    return new Date(next).toISOString();
+  }
+
+  return null;
+}
+
+export interface SchedulerDependencies {
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  getSessions: () => Record<string, string>;
+  queue: GroupQueue;
+  onProcess: (
+    groupJid: string,
+    proc: ChildProcess,
+    containerName: string,
+    groupFolder: string,
+  ) => void;
+  sendMessage: (jid: string, text: string) => Promise<void>;
+}
+
+async function runTask(
+  task: ScheduledTask,
+  deps: SchedulerDependencies,
+): Promise<void> {
+  const startTime = Date.now();
+  let groupDir: string;
+  try {
+    groupDir = resolveGroupFolderPath(task.group_folder);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    // Stop retry churn for malformed legacy rows.
+    updateTask(task.id, { status: 'paused' });
+    logger.error(
+      { taskId: task.id, groupFolder: task.group_folder, error },
+      'Task has invalid group folder',
+    );
+    logTaskRun({
+      task_id: task.id,
+      run_at: new Date().toISOString(),
+      duration_ms: Date.now() - startTime,
+      status: 'error',
+      result: null,
+      error,
+    });
+    return;
+  }
+  fs.mkdirSync(groupDir, { recursive: true });
+
+  logger.info(
+    { taskId: task.id, group: task.group_folder },
+    'Running scheduled task',
+  );
+
+  const groups = deps.registeredGroups();
+  const group = Object.values(groups).find(
+    (g) => g.folder === task.group_folder,
+  );
+
+  if (!group) {
+    logger.error(
+      { taskId: task.id, groupFolder: task.group_folder },
+      'Group not found for task',
+    );
+    logTaskRun({
+      task_id: task.id,
+      run_at: new Date().toISOString(),
+      duration_ms: Date.now() - startTime,
+      status: 'error',
+      result: null,
+      error: `Group not found: ${task.group_folder}`,
+    });
+    return;
+  }
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const isMain = group.isMain === true;
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    task.group_folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Retrieve memory context (RAG) to prepend to the task prompt
+  let memoryContext = '';
+  try {
+    memoryContext = await retrieveMemoryContext(task.group_folder, [
+      { content: task.prompt } as NewMessage,
+    ]);
+  } catch (err) {
+    logger.warn(
+      { taskId: task.id, err },
+      'Memory retrieval failed for scheduled task',
+    );
+  }
+
+  // Write memory snapshot so the agent can see existing memory IDs
+  const groupIpcDir = resolveGroupIpcPath(task.group_folder);
+  try {
+    const snapshot = buildMemorySnapshot(task.group_folder);
+    fs.writeFileSync(
+      path.join(groupIpcDir, 'memory_snapshot.json'),
+      JSON.stringify(snapshot, null, 2),
+    );
+  } catch (err) {
+    logger.warn(
+      { taskId: task.id, err },
+      'Failed to write memory snapshot for scheduled task',
+    );
+  }
+
+  const prompt = memoryContext + task.prompt;
+
+  let result: string | null = null;
+  let error: string | null = null;
+
+  // For group context mode, use the group's current session
+  const sessions = deps.getSessions();
+  const sessionId =
+    task.context_mode === 'group' ? sessions[task.group_folder] : undefined;
+
+  // After the task produces a result, close the container promptly.
+  // Tasks are single-turn — no need to wait IDLE_TIMEOUT (30 min) for the
+  // query loop to time out. A short delay handles any final MCP calls.
+  const TASK_CLOSE_DELAY_MS = 10000;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const scheduleClose = () => {
+    if (closeTimer) return; // already scheduled
+    closeTimer = setTimeout(() => {
+      logger.debug({ taskId: task.id }, 'Closing task container after result');
+      deps.queue.closeStdin(task.chat_jid);
+    }, TASK_CLOSE_DELAY_MS);
+  };
+
+  try {
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: task.group_folder,
+        chatJid: task.chat_jid,
+        isMain,
+        isScheduledTask: true,
+        assistantName: ASSISTANT_NAME,
+      },
+      (proc, containerName) =>
+        deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),
+      async (streamedOutput: ContainerOutput) => {
+        if (streamedOutput.result) {
+          result = streamedOutput.result;
+          // Forward result to user (sendMessage handles formatting)
+          await deps.sendMessage(task.chat_jid, streamedOutput.result);
+          scheduleClose();
+        }
+        if (streamedOutput.status === 'success') {
+          deps.queue.notifyIdle(task.chat_jid);
+        }
+        if (streamedOutput.status === 'error') {
+          error = streamedOutput.error || 'Unknown error';
+        }
+      },
+    );
+
+    if (closeTimer) clearTimeout(closeTimer);
+
+    if (output.status === 'error') {
+      error = output.error || 'Unknown error';
+    } else if (output.result) {
+      // Messages are sent via MCP tool (IPC), result text is just logged
+      result = output.result;
+    }
+
+    logger.info(
+      { taskId: task.id, durationMs: Date.now() - startTime },
+      'Task completed',
+    );
+  } catch (err) {
+    if (closeTimer) clearTimeout(closeTimer);
+    error = err instanceof Error ? err.message : String(err);
+    logger.error({ taskId: task.id, error }, 'Task failed');
+  }
+
+  const durationMs = Date.now() - startTime;
+
+  logTaskRun({
+    task_id: task.id,
+    run_at: new Date().toISOString(),
+    duration_ms: durationMs,
+    status: error ? 'error' : 'success',
+    result,
+    error,
+  });
+
+  const nextRun = computeNextRun(task);
+  const resultSummary = error
+    ? `Error: ${error}`
+    : result
+      ? result.slice(0, 200)
+      : 'Completed';
+  updateTaskAfterRun(task.id, nextRun, resultSummary);
+}
+
+let schedulerRunning = false;
+
+export function startSchedulerLoop(deps: SchedulerDependencies): void {
+  if (schedulerRunning) {
+    logger.debug('Scheduler loop already running, skipping duplicate start');
+    return;
+  }
+  schedulerRunning = true;
+  logger.info('Scheduler loop started');
+
+  const loop = async () => {
+    try {
+      const dueTasks = getDueTasks();
+      if (dueTasks.length > 0) {
+        logger.info({ count: dueTasks.length }, 'Found due tasks');
+      }
+
+      for (const task of dueTasks) {
+        // Re-check task status in case it was paused/cancelled
+        const currentTask = getTaskById(task.id);
+        if (!currentTask || currentTask.status !== 'active') {
+          continue;
+        }
+
+        deps.queue.enqueueTask(currentTask.chat_jid, currentTask.id, () =>
+          runTask(currentTask, deps),
+        );
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in scheduler loop');
+    }
+
+    setTimeout(loop, SCHEDULER_POLL_INTERVAL);
+  };
+
+  loop();
+}
+
+/** @internal - for tests only. */
+export function _resetSchedulerLoopForTests(): void {
+  schedulerRunning = false;
+}

--- a/.claude/skills/add-memory/modify/src/task-scheduler.ts.intent.md
+++ b/.claude/skills/add-memory/modify/src/task-scheduler.ts.intent.md
@@ -1,0 +1,27 @@
+# Intent: src/task-scheduler.ts modifications
+
+## What changed
+Scheduled tasks now receive memory context (RAG) just like regular messages, and a memory snapshot is written so the container agent can manage memories.
+
+## Key sections
+- **Imports**: Added `import path from 'path'`, `import { buildMemorySnapshot, retrieveMemoryContext } from './memory.js'`, `import { resolveGroupIpcPath } from './group-folder.js'`, and `import { NewMessage } from './types.js'`
+- **runTask() — memory retrieval**: After writing the tasks snapshot, calls `retrieveMemoryContext()` with the task prompt wrapped as a `NewMessage`, prepends the result to the prompt
+- **runTask() — memory snapshot**: Writes `memory_snapshot.json` to the group's IPC directory via `resolveGroupIpcPath()` so the container agent can see existing memory IDs
+- **runTask() — prompt composition**: Changed from `prompt: task.prompt` to `prompt: memoryContext + task.prompt` (the `prompt` variable now includes memory context)
+
+## Invariants
+- The `computeNextRun()` function is unchanged (upstream addition from community PR)
+- The `SchedulerDependencies` interface is unchanged
+- Invalid group folder handling (pausing task) is unchanged
+- Group lookup logic is unchanged
+- Task close delay pattern is unchanged
+- The scheduler loop, `startSchedulerLoop`, and `_resetSchedulerLoopForTests` are unchanged
+- `isMain` detection uses `group.isMain === true` (upstream pattern)
+
+## Must-keep
+- The `computeNextRun()` function and its export
+- The `isMain = group.isMain === true` pattern (not `MAIN_GROUP_FOLDER`)
+- All `logTaskRun()` calls with correct fields
+- The `TASK_CLOSE_DELAY_MS` pattern for closing task containers
+- The `scheduleClose()` callback pattern
+- `_resetSchedulerLoopForTests` export

--- a/.claude/skills/add-memory/tests/add-memory.test.ts
+++ b/.claude/skills/add-memory/tests/add-memory.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'yaml';
+
+describe('add-memory skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  it('has a valid SKILL.md with frontmatter', () => {
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    expect(fs.existsSync(skillPath)).toBe(true);
+    const content = fs.readFileSync(skillPath, 'utf-8');
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain('name: add-memory');
+    expect(content).toContain('description:');
+  });
+
+  it('has a valid manifest.yaml', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    const manifest = yaml.parse(content);
+    expect(manifest.skill).toBe('add-memory');
+    expect(manifest.version).toBe('1.0.0');
+    expect(manifest.adds).toContain('src/memory.ts');
+    expect(manifest.modifies).toEqual(
+      expect.arrayContaining([
+        'src/db.ts',
+        'src/index.ts',
+        'src/ipc.ts',
+        'src/task-scheduler.ts',
+      ]),
+    );
+    expect(manifest.structured.npm_dependencies).toHaveProperty('sqlite-vec');
+    expect(manifest.structured.npm_dependencies).toHaveProperty(
+      '@huggingface/transformers',
+    );
+  });
+
+  it('has all files listed in adds/', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    const manifest = yaml.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    for (const addedFile of manifest.adds) {
+      const filePath = path.join(skillDir, 'add', addedFile);
+      expect(
+        fs.existsSync(filePath),
+        `add/${addedFile} should exist`,
+      ).toBe(true);
+    }
+  });
+
+  it('has all files listed in modifies/', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    const manifest = yaml.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    for (const modifiedFile of manifest.modifies) {
+      const filePath = path.join(skillDir, 'modify', modifiedFile);
+      expect(
+        fs.existsSync(filePath),
+        `modify/${modifiedFile} should exist`,
+      ).toBe(true);
+    }
+  });
+
+  it('has intent files for all modified files', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    const manifest = yaml.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    for (const modifiedFile of manifest.modifies) {
+      const intentPath = path.join(
+        skillDir,
+        'modify',
+        `${modifiedFile}.intent.md`,
+      );
+      expect(
+        fs.existsSync(intentPath),
+        `modify/${modifiedFile}.intent.md should exist`,
+      ).toBe(true);
+      const content = fs.readFileSync(intentPath, 'utf-8');
+      expect(content).toContain('## What changed');
+      expect(content).toContain('## Invariants');
+      expect(content).toContain('## Must-keep');
+    }
+  });
+
+  it('memory.ts exports key functions', () => {
+    const memoryPath = path.join(skillDir, 'add', 'src', 'memory.ts');
+    const content = fs.readFileSync(memoryPath, 'utf-8');
+
+    // Core exports needed by other modified files
+    expect(content).toContain('export function initMemorySchema');
+    expect(content).toContain('export async function retrieveMemoryContext');
+    expect(content).toContain('export async function embedConversationMessages');
+    expect(content).toContain('export function buildMemorySnapshot');
+    expect(content).toContain('export async function addCoreMemoryWithEmbedding');
+    expect(content).toContain('export async function updateCoreMemoryWithEmbedding');
+    expect(content).toContain('export function removeCoreMemory');
+    expect(content).toContain('export async function searchAllMemory');
+  });
+
+  it('modified db.ts loads sqlite-vec extension', () => {
+    const dbPath = path.join(skillDir, 'modify', 'src', 'db.ts');
+    const content = fs.readFileSync(dbPath, 'utf-8');
+    expect(content).toContain("import * as sqliteVec from 'sqlite-vec'");
+    expect(content).toContain('sqliteVec.load(db)');
+    expect(content).toContain('export function getDb()');
+  });
+
+  it('modified index.ts integrates memory system', () => {
+    const indexPath = path.join(skillDir, 'modify', 'src', 'index.ts');
+    const content = fs.readFileSync(indexPath, 'utf-8');
+
+    // Memory imports
+    expect(content).toContain("from './memory.js'");
+    expect(content).toContain('initMemorySchema');
+    expect(content).toContain('retrieveMemoryContext');
+    expect(content).toContain('embedConversationMessages');
+    expect(content).toContain('buildMemorySnapshot');
+
+    // Memory schema initialization in main()
+    expect(content).toContain('initMemorySchema()');
+
+    // RAG context retrieval in processGroupMessages
+    expect(content).toContain(
+      'await retrieveMemoryContext(group.folder, missedMessages)',
+    );
+
+    // Conversation embedding
+    expect(content).toContain(
+      'embedConversationMessages(group.folder, chatJid, missedMessages)',
+    );
+
+    // Memory snapshot writing
+    expect(content).toContain('memory_snapshot.json');
+
+    // Preserves upstream patterns
+    expect(content).toContain('group.isMain === true');
+    expect(content).toContain("from './sender-allowlist.js'");
+    expect(content).toContain("from './channels/registry.js'");
+  });
+
+  it('modified ipc.ts adds memory IPC handlers', () => {
+    const ipcPath = path.join(skillDir, 'modify', 'src', 'ipc.ts');
+    const content = fs.readFileSync(ipcPath, 'utf-8');
+
+    // Memory imports
+    expect(content).toContain("from './memory.js'");
+    expect(content).toContain('addCoreMemoryWithEmbedding');
+    expect(content).toContain('searchAllMemory');
+
+    // Memory IPC processing
+    expect(content).toContain('processMemoryIpc');
+    expect(content).toContain("case 'memory_add'");
+    expect(content).toContain("case 'memory_update'");
+    expect(content).toContain("case 'memory_remove'");
+    expect(content).toContain("case 'memory_search'");
+
+    // Preserves upstream patterns
+    expect(content).toContain('syncGroups');
+    expect(content).toContain('folderIsMain');
+    expect(content).toContain('group.isMain');
+  });
+
+  it('modified task-scheduler.ts injects memory context', () => {
+    const schedulerPath = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'task-scheduler.ts',
+    );
+    const content = fs.readFileSync(schedulerPath, 'utf-8');
+
+    // Memory imports
+    expect(content).toContain("from './memory.js'");
+    expect(content).toContain('retrieveMemoryContext');
+    expect(content).toContain('buildMemorySnapshot');
+
+    // Memory context retrieval
+    expect(content).toContain('memoryContext');
+    expect(content).toContain('memoryContext + task.prompt');
+
+    // Memory snapshot
+    expect(content).toContain('memory_snapshot.json');
+
+    // Preserves upstream patterns
+    expect(content).toContain('computeNextRun');
+    expect(content).toContain('group.isMain === true');
+    expect(content).toContain('resolveGroupIpcPath');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `/add-memory` skill — a three-layer semantic memory system with RAG that gives container agents automatic recall of past conversations and stored facts.

This is a repackaging of PRs #560 and #561 as a standalone skill, following the feedback that the memory system is too complex for core but would work well as a skill.

## What this skill does

- **Core Memories** — discrete facts/preferences stored by the agent via IPC, auto-injected into prompts when semantically relevant
- **Conversation Memory** — every message is embedded after each conversation; relevant past messages retrieved via RAG
- **Archival Memory** — session summaries searchable via memory_search
- **Four IPC tools** — `memory_add`, `memory_update`, `memory_remove`, `memory_search`

Uses sqlite-vec for vector search within the existing SQLite database and local embeddings via @huggingface/transformers (all-MiniLM-L6-v2) — no external API costs.

## Skill type

Code modification — adds `src/memory.ts` and modifies `src/db.ts`, `src/index.ts`, `src/ipc.ts`, `src/task-scheduler.ts`.

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Installation guide with 4 phases |
| `manifest.yaml` | Skill metadata, deps, file lists |
| `add/src/memory.ts` | Complete memory system (3 layers, embeddings, RAG) |
| `modify/src/db.ts` | Load sqlite-vec extension, export `getDb()` |
| `modify/src/index.ts` | Init schema, RAG retrieval, conversation embedding, memory snapshots |
| `modify/src/ipc.ts` | Memory IPC handlers (add/update/remove/search) |
| `modify/src/task-scheduler.ts` | Inject memory context into scheduled tasks |
| `tests/add-memory.test.ts` | 10 tests validating skill package structure |

## Testing

- [x] Skill package tests pass (10/10)
- [x] All modified files preserve upstream patterns (`isMain`, `syncGroups`, sender-allowlist, channel registry)
- [x] Intent files document all changes and invariants
- [x] Built against upstream/main (v1.2.6)

## Dependencies

| Package | Version |
|---------|---------|
| `sqlite-vec` | `^0.1.7-alpha.2` |
| `@huggingface/transformers` | `^3.8.1` |

## New environment variables

None

## Supersedes

- #560 (feat: add three-layer semantic memory system with RAG)
- #561 (feat: inject memory context into scheduled tasks)

---
Generated with `/create-skill`