### PR TITLE
feat: add Telegram voice transcription to use-local-whisper skill

### DIFF
--- a/.claude/skills/use-local-whisper/SKILL.md
+++ b/.claude/skills/use-local-whisper/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: use-local-whisper
-description: Use when the user wants local voice transcription instead of OpenAI Whisper API. Switches to whisper.cpp running on Apple Silicon. WhatsApp only for now. Requires voice-transcription skill to be applied first.
+description: Use when the user wants local voice transcription instead of OpenAI Whisper API. Switches to whisper.cpp running on-device. Supports WhatsApp and Telegram channels. Requires voice-transcription and telegram skills to be applied first.
 ---
 
 # Use Local Whisper
 
 Switches voice transcription from OpenAI's Whisper API to local whisper.cpp. Runs entirely on-device — no API key, no network, no cost.
 
-**Channel support:** Currently WhatsApp only. The transcription module (`src/transcription.ts`) uses Baileys types for audio download. Other channels (Telegram, Discord, etc.) would need their own audio-download logic before this skill can serve them.
+**Channel support:** WhatsApp and Telegram. The transcription module exports a channel-agnostic `transcribeAudio(Buffer)` function that any channel can call. WhatsApp uses the existing `transcribeAudioMessage(WAMessage, WASocket)` wrapper. Telegram downloads voice files via the Bot API and passes the buffer directly.
 
 **Note:** The Homebrew package is `whisper-cpp`, but the CLI binary it installs is `whisper-cli`.
 
 ## Prerequisites
 
 - `voice-transcription` skill must be applied first (WhatsApp channel)
-- macOS with Apple Silicon (M1+) recommended
-- `whisper-cpp` installed: `brew install whisper-cpp` (provides the `whisper-cli` binary)
-- `ffmpeg` installed: `brew install ffmpeg`
+- `telegram` skill must be applied first (Telegram channel)
+- `whisper-cpp` CLI installed (see platform-specific instructions below)
+- `ffmpeg` installed
 - A GGML model file downloaded to `data/models/`
 
 ## Phase 1: Pre-flight
@@ -32,10 +32,31 @@ whisper-cli --help >/dev/null 2>&1 && echo "WHISPER_OK" || echo "WHISPER_MISSING
 ffmpeg -version >/dev/null 2>&1 && echo "FFMPEG_OK" || echo "FFMPEG_MISSING"
 ```
 
-If missing, install via Homebrew:
+If missing, install per platform:
+
+**macOS:**
 ```bash
 brew install whisper-cpp ffmpeg
 ```
+
+**Linux (Debian/Ubuntu):**
+```bash
+sudo apt-get install -y ffmpeg
+```
+
+Then build whisper.cpp from source with static linking:
+
+```bash
+cd /tmp
+git clone --depth 1 https://github.com/ggerganov/whisper.cpp.git
+cd whisper.cpp
+cmake -B build -DBUILD_SHARED_LIBS=OFF
+cmake --build build --config Release -j$(nproc)
+sudo cp build/bin/whisper-cli /usr/local/bin/
+rm -rf /tmp/whisper.cpp
+```
+
+**Important on Linux**: Build with `-DBUILD_SHARED_LIBS=OFF` to produce a statically-linked binary. Without this, `whisper-cli` will fail at runtime with `libwhisper.so.1: cannot open shared object file`.
 
 ### Check for model file
 
@@ -57,7 +78,10 @@ For better accuracy at the cost of speed, use `ggml-small.bin` (466MB) or `ggml-
 npx tsx scripts/apply-skill.ts .claude/skills/use-local-whisper
 ```
 
-This modifies `src/transcription.ts` to use the `whisper-cli` binary instead of the OpenAI API.
+This modifies:
+- `src/transcription.ts` — replaces OpenAI API with whisper.cpp, adds channel-agnostic `transcribeAudio(Buffer)` export
+- `src/channels/telegram.ts` — replaces voice placeholder with download + transcription handler
+- `src/channels/telegram.test.ts` — adds transcription mock and 5 voice transcription tests
 
 ### Validate
 
@@ -68,31 +92,35 @@ npm run build
 
 ## Phase 3: Verify
 
-### Ensure launchd PATH includes Homebrew
+### Ensure service PATH includes whisper-cli and ffmpeg
 
-The NanoClaw launchd service runs with a restricted PATH. `whisper-cli` and `ffmpeg` are in `/opt/homebrew/bin/` (Apple Silicon) or `/usr/local/bin/` (Intel), which may not be in the plist's PATH.
+The NanoClaw service runs with a restricted PATH. Ensure `whisper-cli` and `ffmpeg` are accessible.
 
-Check the current PATH:
+**macOS (launchd):**
 ```bash
 grep -A1 'PATH' ~/Library/LaunchAgents/com.nanoclaw.plist
 ```
+If `/opt/homebrew/bin` is missing, add it to the PATH in the plist, then reload.
 
-If `/opt/homebrew/bin` is missing, add it to the `<string>` value inside the `PATH` key in the plist. Then reload:
+**Linux (systemd):**
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
-launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+systemctl --user show nanoclaw | grep -i environment
 ```
+If `~/.local/bin` or `/usr/local/bin` is not in PATH, add `Environment="PATH=..."` to the service unit.
 
 ### Build and restart
 
 ```bash
 npm run build
+# macOS:
 launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux:
+systemctl --user restart nanoclaw
 ```
 
 ### Test
 
-Send a voice note in any registered group. The agent should receive it as `[Voice: <transcript>]`.
+Send a voice note in any registered WhatsApp or Telegram chat. The agent should receive it as `[Voice: <transcript>]`.
 
 ### Check logs
 
@@ -103,6 +131,7 @@ tail -f logs/nanoclaw.log | grep -i -E "voice|transcri|whisper"
 Look for:
 - `Transcribed voice message` — successful transcription
 - `whisper.cpp transcription failed` — check model path, ffmpeg, or PATH
+- `Voice download/transcription failed` — Telegram file download issue
 
 ## Configuration
 
@@ -115,14 +144,16 @@ Environment variables (optional, set in `.env`):
 
 ## Troubleshooting
 
-**"whisper.cpp transcription failed"**: Ensure both `whisper-cli` and `ffmpeg` are in PATH. The launchd service uses a restricted PATH — see Phase 3 above. Test manually:
+**"whisper.cpp transcription failed"**: Ensure both `whisper-cli` and `ffmpeg` are in PATH. The service uses a restricted PATH — see Phase 3 above. Test manually:
 ```bash
 ffmpeg -f lavfi -i anullsrc=r=16000:cl=mono -t 1 -f wav /tmp/test.wav -y
 whisper-cli -m data/models/ggml-base.bin -f /tmp/test.wav --no-timestamps -nt
 ```
 
-**Transcription works in dev but not as service**: The launchd plist PATH likely doesn't include `/opt/homebrew/bin`. See "Ensure launchd PATH includes Homebrew" in Phase 3.
+**"libwhisper.so.1: cannot open shared object file"**: The whisper-cli binary was built with shared libraries. Rebuild with `-DBUILD_SHARED_LIBS=OFF` (see Phase 1).
 
-**Slow transcription**: The base model processes ~30s of audio in <1s on M1+. If slower, check CPU usage — another process may be competing.
+**Transcription works in dev but not as service**: The service PATH likely doesn't include the directory containing `whisper-cli`. See Phase 3 above.
 
-**Wrong language**: whisper.cpp auto-detects language. To force a language, you can set `WHISPER_LANG` and modify `src/transcription.ts` to pass `-l $WHISPER_LANG`.
+**Slow transcription**: The base model processes ~30s of audio in <1s on modern hardware. If slower, check CPU usage.
+
+**Wrong language**: whisper.cpp auto-detects language. To force a language, set `WHISPER_LANG` and modify `src/transcription.ts` to pass `-l $WHISPER_LANG`.

--- a/.claude/skills/use-local-whisper/manifest.yaml
+++ b/.claude/skills/use-local-whisper/manifest.yaml
@@ -1,12 +1,15 @@
 skill: use-local-whisper
-version: 1.0.0
-description: "Switch voice transcription from OpenAI Whisper API to local whisper.cpp (WhatsApp only)"
+version: 2.0.0
+description: "Switch voice transcription from OpenAI Whisper API to local whisper.cpp. Supports WhatsApp and Telegram."
 core_version: 0.1.0
 adds: []
 modifies:
   - src/transcription.ts
+  - src/channels/telegram.ts
+  - src/channels/telegram.test.ts
 structured: {}
 conflicts: []
 depends:
   - voice-transcription
-test: "npx vitest run src/channels/whatsapp.test.ts"
+  - telegram
+test: "npx vitest run src/channels/whatsapp.test.ts src/channels/telegram.test.ts"

--- a/.claude/skills/use-local-whisper/modify/src/channels/telegram.test.ts
+++ b/.claude/skills/use-local-whisper/modify/src/channels/telegram.test.ts
@@ -1,0 +1,1029 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+// Mock registry (registerChannel runs at import time)
+vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
+
+// Mock env reader (used by the factory, not needed in unit tests)
+vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
+
+// Mock config
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock transcription
+const mockTranscribeAudio = vi.fn().mockResolvedValue(null);
+vi.mock('../transcription.js', () => ({
+  transcribeAudio: (...args: unknown[]) =>
+    (mockTranscribeAudio as Function)(...args),
+}));
+
+// --- Grammy mock ---
+
+type Handler = (...args: any[]) => any;
+
+const botRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('grammy', () => ({
+  Bot: class MockBot {
+    token: string;
+    commandHandlers = new Map<string, Handler>();
+    filterHandlers = new Map<string, Handler[]>();
+    errorHandler: Handler | null = null;
+
+    api = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+      getFile: vi.fn().mockResolvedValue({ file_path: 'voice/file_0.oga' }),
+    };
+
+    constructor(token: string) {
+      this.token = token;
+      botRef.current = this;
+    }
+
+    command(name: string, handler: Handler) {
+      this.commandHandlers.set(name, handler);
+    }
+
+    on(filter: string, handler: Handler) {
+      const existing = this.filterHandlers.get(filter) || [];
+      existing.push(handler);
+      this.filterHandlers.set(filter, existing);
+    }
+
+    catch(handler: Handler) {
+      this.errorHandler = handler;
+    }
+
+    start(opts: { onStart: (botInfo: any) => void }) {
+      opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+    }
+
+    stop() {}
+  },
+}));
+
+import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<TelegramChannelOpts>,
+): TelegramChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'tg:100200300': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function createTextCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  chatTitle?: string;
+  text: string;
+  fromId?: number;
+  firstName?: string;
+  username?: string;
+  messageId?: number;
+  date?: number;
+  entities?: any[];
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  const chatType = overrides.chatType ?? 'group';
+  return {
+    chat: {
+      id: chatId,
+      type: chatType,
+      title: overrides.chatTitle ?? 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: overrides.username ?? 'alice_user',
+    },
+    message: {
+      text: overrides.text,
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      entities: overrides.entities ?? [],
+    },
+    me: { username: 'andy_ai_bot' },
+    reply: vi.fn(),
+  };
+}
+
+function createMediaCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  fromId?: number;
+  firstName?: string;
+  date?: number;
+  messageId?: number;
+  caption?: string;
+  extra?: Record<string, any>;
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  return {
+    chat: {
+      id: chatId,
+      type: overrides.chatType ?? 'group',
+      title: 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: 'alice_user',
+    },
+    message: {
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      caption: overrides.caption,
+      ...(overrides.extra || {}),
+    },
+    api: {
+      getFile: vi.fn().mockResolvedValue({ file_path: 'voice/file_0.oga' }),
+    },
+    me: { username: 'andy_ai_bot' },
+  };
+}
+
+function currentBot() {
+  return botRef.current;
+}
+
+async function triggerTextMessage(ctx: ReturnType<typeof createTextCtx>) {
+  const handlers = currentBot().filterHandlers.get('message:text') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerMediaMessage(
+  filter: string,
+  ctx: ReturnType<typeof createMediaCtx>,
+) {
+  const handlers = currentBot().filterHandlers.get(filter) || [];
+  for (const h of handlers) await h(ctx);
+}
+
+// --- Tests ---
+
+describe('TelegramChannel', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(100)),
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when bot starts', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('registers command and message handlers on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().commandHandlers.has('chatid')).toBe(true);
+      expect(currentBot().commandHandlers.has('ping')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:text')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:photo')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:video')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:voice')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:audio')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:document')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:sticker')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:location')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:contact')).toBe(true);
+    });
+
+    it('registers error handler on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().errorHandler).not.toBeNull();
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Text message handling ---
+
+  describe('text message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello everyone' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          id: '1',
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          content: 'Hello everyone',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ chatId: 999999, text: 'Unknown chat' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:999999',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips command messages (starting with /)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: '/start' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('extracts sender name from first_name', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', firstName: 'Bob' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'Bob' }),
+      );
+    });
+
+    it('falls back to username when first_name missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi' });
+      ctx.from.first_name = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'alice_user' }),
+      );
+    });
+
+    it('falls back to user ID when name and username missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', fromId: 42 });
+      ctx.from.first_name = undefined as any;
+      ctx.from.username = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: '42' }),
+      );
+    });
+
+    it('uses sender name as chat name for private chats', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300': {
+            name: 'Private',
+            folder: 'private',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'private',
+        firstName: 'Alice',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Alice', // Private chats use sender name
+        'telegram',
+        false,
+      );
+    });
+
+    it('uses chat title as name for group chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'supergroup',
+        chatTitle: 'Project Team',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Project Team',
+        'telegram',
+        true,
+      );
+    });
+
+    it('converts message.date to ISO timestamp', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const unixTime = 1704067200; // 2024-01-01T00:00:00.000Z
+      const ctx = createTextCtx({ text: 'Hello', date: unixTime });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates @bot_username mention to trigger format', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@andy_ai_bot what time is it?',
+        entities: [{ type: 'mention', offset: 0, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot what time is it?',
+        }),
+      );
+    });
+
+    it('does not translate if message already matches trigger', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@Andy @andy_ai_bot hello',
+        entities: [{ type: 'mention', offset: 6, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Should NOT double-prepend — already starts with @Andy
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot hello',
+        }),
+      );
+    });
+
+    it('does not translate mentions of other bots', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@some_other_bot hi',
+        entities: [{ type: 'mention', offset: 0, length: 15 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@some_other_bot hi', // No translation
+        }),
+      );
+    });
+
+    it('handles mention in middle of message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'hey @andy_ai_bot check this',
+        entities: [{ type: 'mention', offset: 4, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Bot is mentioned, message doesn't match trigger → prepend trigger
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy hey @andy_ai_bot check this',
+        }),
+      );
+    });
+
+    it('handles message with no entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'plain message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'plain message',
+        }),
+      );
+    });
+
+    it('ignores non-mention entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'check https://example.com',
+        entities: [{ type: 'url', offset: 6, length: 19 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'check https://example.com',
+        }),
+      );
+    });
+  });
+
+  // --- Non-text messages ---
+
+  describe('non-text messages', () => {
+    it('stores photo with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo]' }),
+      );
+    });
+
+    it('stores photo with caption', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ caption: 'Look at this' });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo] Look at this' }),
+      );
+    });
+
+    it('stores video with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:video', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Video]' }),
+      );
+    });
+
+    it('transcribes voice message successfully', async () => {
+      mockTranscribeAudio.mockResolvedValue('Hello this is a test');
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'voice_file_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(mockTranscribeAudio).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Voice: Hello this is a test]' }),
+      );
+    });
+
+    it('falls back when transcription returns null', async () => {
+      mockTranscribeAudio.mockResolvedValue(null);
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'voice_file_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+    });
+
+    it('falls back when voice download fails', async () => {
+      (globalThis.fetch as any).mockResolvedValueOnce({ ok: false });
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'voice_file_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+    });
+
+    it('includes caption with transcribed voice message', async () => {
+      mockTranscribeAudio.mockResolvedValue('Some speech');
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        caption: 'Check this out',
+        extra: { voice: { file_id: 'voice_file_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice: Some speech] Check this out',
+        }),
+      );
+    });
+
+    it('ignores voice messages from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        chatId: 999999,
+        extra: { voice: { file_id: 'voice_file_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('stores audio with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:audio', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Audio]' }),
+      );
+    });
+
+    it('stores document with filename', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { document: { file_name: 'report.pdf' } },
+      });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: report.pdf]' }),
+      );
+    });
+
+    it('stores document with fallback name when filename missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ extra: { document: {} } });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: file]' }),
+      );
+    });
+
+    it('stores sticker with emoji', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { sticker: { emoji: '😂' } },
+      });
+      await triggerMediaMessage('message:sticker', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Sticker 😂]' }),
+      );
+    });
+
+    it('stores location with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:location', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Location]' }),
+      );
+    });
+
+    it('stores contact with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:contact', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Contact]' }),
+      );
+    });
+
+    it('ignores non-text messages from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ chatId: 999999 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via bot API', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Hello');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Hello',
+      );
+    });
+
+    it('strips tg: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:-1001234567890', 'Group message');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '-1001234567890',
+        'Group message',
+      );
+    });
+
+    it('splits messages exceeding 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300', longText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+      );
+    });
+
+    it('sends exactly one message at 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const exactText = 'y'.repeat(4096);
+      await channel.sendMessage('tg:100200300', exactText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles send failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendMessage.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      // Should not throw
+      await expect(
+        channel.sendMessage('tg:100200300', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect — bot is null
+      await channel.sendMessage('tg:100200300', 'No bot');
+
+      // No error, no API call
+    });
+  });
+
+  // --- ownsJid ---
+
+  describe('ownsJid', () => {
+    it('owns tg: JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:123456')).toBe(true);
+    });
+
+    it('owns tg: JIDs with negative IDs (groups)', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:-1001234567890')).toBe(true);
+    });
+
+    it('does not own WhatsApp group JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+    });
+
+    it('does not own WhatsApp DM JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('sends typing action when isTyping is true', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+      );
+    });
+
+    it('does nothing when isTyping is false', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', false);
+
+      expect(currentBot().api.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect
+      await channel.setTyping('tg:100200300', true);
+
+      // No error, no API call
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendChatAction.mockRejectedValueOnce(
+        new Error('Rate limited'),
+      );
+
+      await expect(
+        channel.setTyping('tg:100200300', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Bot commands ---
+
+  describe('bot commands', () => {
+    it('/chatid replies with chat ID and metadata', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'group' as const },
+        from: { first_name: 'Alice' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('tg:100200300'),
+        expect.objectContaining({ parse_mode: 'Markdown' }),
+      );
+    });
+
+    it('/chatid shows chat type', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 555, type: 'private' as const },
+        from: { first_name: 'Bob' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('private'),
+        expect.any(Object),
+      );
+    });
+
+    it('/ping replies with bot status', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "telegram"', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.name).toBe('telegram');
+    });
+  });
+});

--- a/.claude/skills/use-local-whisper/modify/src/channels/telegram.test.ts.intent.md
+++ b/.claude/skills/use-local-whisper/modify/src/channels/telegram.test.ts.intent.md
@@ -1,0 +1,29 @@
+# Intent: src/channels/telegram.test.ts modifications
+
+## What changed
+Added voice transcription test infrastructure and replaced the single voice placeholder test with 5 comprehensive voice transcription tests.
+
+## Key sections
+
+### Mock additions
+- Added `mockTranscribeAudio = vi.fn().mockResolvedValue(null)`
+- Added `vi.mock('../transcription.js', ...)` with the mock function
+- Added `getFile` mock to Grammy MockBot's `api` object
+- Added `api: { getFile: vi.fn()... }` to `createMediaCtx` return
+- Added global `fetch` stub in `beforeEach` / unstub in `afterEach`
+
+### Replaced test
+- Removed: `stores voice message with placeholder` (tested `[Voice message]`)
+- Added 5 tests:
+  1. `transcribes voice message successfully` — verifies `[Voice: Hello this is a test]`
+  2. `falls back when transcription returns null` — verifies fallback message
+  3. `falls back when voice download fails` — verifies fetch error handling
+  4. `includes caption with transcribed voice message` — verifies caption appended
+  5. `ignores voice messages from unregistered chats` — verifies early return
+
+## Invariants (must-keep)
+- All existing non-voice tests unchanged (photo, video, audio, document, sticker, location, contact)
+- Text message and @mention translation tests unchanged
+- sendMessage, ownsJid, setTyping, bot commands tests unchanged
+- Test helper functions (`createTestOpts`, `createTextCtx`, `triggerTextMessage`, `triggerMediaMessage`) signatures preserved
+- `createMediaCtx` extended (not replaced) with `api` field

--- a/.claude/skills/use-local-whisper/modify/src/channels/telegram.ts
+++ b/.claude/skills/use-local-whisper/modify/src/channels/telegram.ts
@@ -1,0 +1,322 @@
+import { Bot } from 'grammy';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { transcribeAudio } from '../transcription.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface TelegramChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class TelegramChannel implements Channel {
+  name = 'telegram';
+
+  private bot: Bot | null = null;
+  private opts: TelegramChannelOpts;
+  private botToken: string;
+
+  constructor(botToken: string, opts: TelegramChannelOpts) {
+    this.botToken = botToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.bot = new Bot(this.botToken);
+
+    // Command to get chat ID (useful for registration)
+    this.bot.command('chatid', (ctx) => {
+      const chatId = ctx.chat.id;
+      const chatType = ctx.chat.type;
+      const chatName =
+        chatType === 'private'
+          ? ctx.from?.first_name || 'Private'
+          : (ctx.chat as any).title || 'Unknown';
+
+      ctx.reply(
+        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    // Command to check bot status
+    this.bot.command('ping', (ctx) => {
+      ctx.reply(`${ASSISTANT_NAME} is online.`);
+    });
+
+    this.bot.on('message:text', async (ctx) => {
+      // Skip commands
+      if (ctx.message.text.startsWith('/')) return;
+
+      const chatJid = `tg:${ctx.chat.id}`;
+      let content = ctx.message.text;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() || '';
+      const msgId = ctx.message.message_id.toString();
+
+      // Determine chat name
+      const chatName =
+        ctx.chat.type === 'private'
+          ? senderName
+          : (ctx.chat as any).title || chatJid;
+
+      // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
+      // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      const botUsername = ctx.me?.username?.toLowerCase();
+      if (botUsername) {
+        const entities = ctx.message.entities || [];
+        const isBotMentioned = entities.some((entity) => {
+          if (entity.type === 'mention') {
+            const mentionText = content
+              .substring(entity.offset, entity.offset + entity.length)
+              .toLowerCase();
+            return mentionText === `@${botUsername}`;
+          }
+          return false;
+        });
+        if (isBotMentioned && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'telegram',
+        isGroup,
+      );
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug(
+          { chatJid, chatName },
+          'Message from unregistered Telegram chat',
+        );
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Telegram message stored',
+      );
+    });
+
+    // Handle non-text messages with placeholders so the agent knows something was sent
+    const storeNonText = (ctx: any, placeholder: string) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${placeholder}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+    };
+
+    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
+    this.bot.on('message:voice', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      let placeholder = '[Voice message - transcription unavailable]';
+      try {
+        const fileId = ctx.message.voice?.file_id;
+        if (fileId) {
+          const file = await ctx.api.getFile(fileId);
+          const fileUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+          const resp = await fetch(fileUrl);
+          if (resp.ok) {
+            const buffer = Buffer.from(await resp.arrayBuffer());
+            const transcript = await transcribeAudio(buffer);
+            if (transcript) {
+              placeholder = `[Voice: ${transcript}]`;
+            }
+          }
+        }
+      } catch (err) {
+        logger.error({ err, chatJid }, 'Voice download/transcription failed');
+      }
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${placeholder}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info({ chatJid, sender: senderName }, 'Voice message transcribed');
+    });
+    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
+    this.bot.on('message:document', (ctx) => {
+      const name = ctx.message.document?.file_name || 'file';
+      storeNonText(ctx, `[Document: ${name}]`);
+    });
+    this.bot.on('message:sticker', (ctx) => {
+      const emoji = ctx.message.sticker?.emoji || '';
+      storeNonText(ctx, `[Sticker ${emoji}]`);
+    });
+    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+
+    // Handle errors gracefully
+    this.bot.catch((err) => {
+      logger.error({ err: err.message }, 'Telegram bot error');
+    });
+
+    // Start polling — returns a Promise that resolves when started
+    return new Promise<void>((resolve) => {
+      this.bot!.start({
+        onStart: (botInfo) => {
+          logger.info(
+            { username: botInfo.username, id: botInfo.id },
+            'Telegram bot connected',
+          );
+          console.log(`\n  Telegram bot: @${botInfo.username}`);
+          console.log(
+            `  Send /chatid to the bot to get a chat's registration ID\n`,
+          );
+          resolve();
+        },
+      });
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+
+      // Telegram has a 4096 character limit per message — split if needed
+      const MAX_LENGTH = 4096;
+      if (text.length <= MAX_LENGTH) {
+        await this.bot.api.sendMessage(numericId, text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await this.bot.api.sendMessage(
+            numericId,
+            text.slice(i, i + MAX_LENGTH),
+          );
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.bot !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('tg:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.bot) {
+      this.bot.stop();
+      this.bot = null;
+      logger.info('Telegram bot stopped');
+    }
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.bot || !isTyping) return;
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendChatAction(numericId, 'typing');
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+    }
+  }
+}
+
+registerChannel('telegram', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
+  if (!token) {
+    logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
+    return null;
+  }
+  return new TelegramChannel(token, opts);
+});

--- a/.claude/skills/use-local-whisper/modify/src/channels/telegram.ts.intent.md
+++ b/.claude/skills/use-local-whisper/modify/src/channels/telegram.ts.intent.md
@@ -1,0 +1,27 @@
+# Intent: src/channels/telegram.ts modifications
+
+## What changed
+Added voice message transcription to the Telegram channel. The `message:voice` handler now downloads the audio file from the Telegram Bot API, passes it to the channel-agnostic `transcribeAudio(Buffer)` function, and delivers the transcript as `[Voice: <text>]` instead of a static placeholder.
+
+## Key sections
+
+### Imports
+- Added: `import { transcribeAudio } from '../transcription.js'`
+
+### Voice handler (replaces `storeNonText(ctx, '[Voice message]')`)
+- Checks registered group (early return if unregistered)
+- Gets file via `ctx.api.getFile(file_id)` → fetches from `https://api.telegram.org/file/bot{token}/{file_path}`
+- Converts response to Buffer
+- Calls `transcribeAudio(buffer)`
+- On success: `[Voice: <transcript>]`
+- On failure/null: `[Voice message - transcription unavailable]`
+- Appends caption if present
+- Delivers via `onMessage` with full metadata (same pattern as other handlers)
+
+## Invariants (must-keep)
+- All other message handlers (photo, video, audio, document, sticker, location, contact) unchanged
+- `storeNonText` helper unchanged
+- Text message handling and @mention translation unchanged
+- `sendMessage`, `ownsJid`, `setTyping`, `connect`, `disconnect` unchanged
+- Channel registration factory unchanged
+- Error logging uses `logger.error` with structured context

--- a/.claude/skills/use-local-whisper/modify/src/transcription.ts
+++ b/.claude/skills/use-local-whisper/modify/src/transcription.ts
@@ -15,7 +15,12 @@ const WHISPER_MODEL =
 
 const FALLBACK_MESSAGE = '[Voice Message - transcription unavailable]';
 
-async function transcribeWithWhisperCpp(
+/**
+ * Channel-agnostic transcription: accepts a raw audio buffer (ogg/opus),
+ * converts to 16kHz mono WAV via ffmpeg, and transcribes with whisper.cpp.
+ * Returns the transcript text or null on failure.
+ */
+export async function transcribeAudio(
   audioBuffer: Buffer,
 ): Promise<string | null> {
   const tmpDir = os.tmpdir();
@@ -76,7 +81,7 @@ export async function transcribeAudioMessage(
 
     console.log(`Downloaded audio message: ${buffer.length} bytes`);
 
-    const transcript = await transcribeWithWhisperCpp(buffer);
+    const transcript = await transcribeAudio(buffer);
 
     if (!transcript) {
       return FALLBACK_MESSAGE;

--- a/.claude/skills/use-local-whisper/modify/src/transcription.ts.intent.md
+++ b/.claude/skills/use-local-whisper/modify/src/transcription.ts.intent.md
@@ -3,6 +3,8 @@
 ## What changed
 Replaced the OpenAI Whisper API backend with local whisper.cpp CLI execution. Audio is converted from ogg/opus to 16kHz mono WAV via ffmpeg, then transcribed locally using whisper-cpp. No API key or network required.
 
+Added a channel-agnostic `transcribeAudio(Buffer)` export that any channel can call directly. The existing `transcribeAudioMessage(WAMessage, WASocket)` now uses `transcribeAudio` internally as a thin wrapper for WhatsApp.
+
 ## Key sections
 
 ### Imports
@@ -15,23 +17,25 @@ Replaced the OpenAI Whisper API backend with local whisper.cpp CLI execution. Au
 - Added: `WHISPER_MODEL` constant (env `WHISPER_MODEL` or `data/models/ggml-base.bin`)
 - Added: `FALLBACK_MESSAGE` constant
 
-### transcribeWithWhisperCpp (replaces transcribeWithOpenAI)
+### transcribeAudio (new channel-agnostic export)
+- Takes `audioBuffer: Buffer`, returns `Promise<string | null>`
 - Writes audio buffer to temp .ogg file
 - Converts to 16kHz mono WAV via ffmpeg
 - Runs whisper-cpp CLI with `--no-timestamps -nt` flags
 - Cleans up temp files in finally block
 - Returns trimmed stdout or null on error
 
-### transcribeAudioMessage
+### transcribeAudioMessage (WhatsApp wrapper)
 - Same signature: `(msg: WAMessage, sock: WASocket) => Promise<string | null>`
 - Same download logic via `downloadMediaMessage`
-- Calls `transcribeWithWhisperCpp` instead of `transcribeWithOpenAI`
+- Calls `transcribeAudio` internally instead of duplicating logic
 - Same fallback behavior on error/null
 
 ### isVoiceMessage
 - Unchanged: `msg.message?.audioMessage?.ptt === true`
 
 ## Invariants (must-keep)
+- `transcribeAudio` export signature: `(audioBuffer: Buffer) => Promise<string | null>`
 - `transcribeAudioMessage` export signature unchanged
 - `isVoiceMessage` export unchanged
 - Fallback message strings unchanged: `[Voice Message - transcription unavailable]`

--- a/.claude/skills/use-local-whisper/tests/use-local-whisper.test.ts
+++ b/.claude/skills/use-local-whisper/tests/use-local-whisper.test.ts
@@ -11,18 +11,20 @@ describe('use-local-whisper skill package', () => {
 
     const content = fs.readFileSync(manifestPath, 'utf-8');
     expect(content).toContain('skill: use-local-whisper');
-    expect(content).toContain('version: 1.0.0');
+    expect(content).toContain('version: 2.0.0');
     expect(content).toContain('src/transcription.ts');
-    expect(content).toContain('voice-transcription');
+    expect(content).toContain('src/channels/telegram.ts');
+    expect(content).toContain('src/channels/telegram.test.ts');
   });
 
-  it('declares voice-transcription as a dependency', () => {
+  it('declares voice-transcription and telegram as dependencies', () => {
     const content = fs.readFileSync(
       path.join(skillDir, 'manifest.yaml'),
       'utf-8',
     );
     expect(content).toContain('depends:');
     expect(content).toContain('voice-transcription');
+    expect(content).toContain('telegram');
   });
 
   it('has no structured operations (no new npm deps needed)', () => {
@@ -38,15 +40,67 @@ describe('use-local-whisper skill package', () => {
     expect(fs.existsSync(filePath)).toBe(true);
   });
 
-  it('has an intent file for the modified file', () => {
-    const intentPath = path.join(skillDir, 'modify', 'src', 'transcription.ts.intent.md');
-    expect(fs.existsSync(intentPath)).toBe(true);
+  it('has the modified telegram channel file', () => {
+    const filePath = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'channels',
+      'telegram.ts',
+    );
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
 
-    const content = fs.readFileSync(intentPath, 'utf-8');
-    expect(content).toContain('whisper.cpp');
-    expect(content).toContain('transcribeAudioMessage');
-    expect(content).toContain('isVoiceMessage');
-    expect(content).toContain('Invariants');
+  it('has the modified telegram test file', () => {
+    const filePath = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'channels',
+      'telegram.test.ts',
+    );
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('has intent files for all modified files', () => {
+    const transcriptionIntent = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'transcription.ts.intent.md',
+    );
+    const telegramIntent = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'channels',
+      'telegram.ts.intent.md',
+    );
+    const testIntent = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'channels',
+      'telegram.test.ts.intent.md',
+    );
+    expect(fs.existsSync(transcriptionIntent)).toBe(true);
+    expect(fs.existsSync(telegramIntent)).toBe(true);
+    expect(fs.existsSync(testIntent)).toBe(true);
+
+    const transcriptionContent = fs.readFileSync(transcriptionIntent, 'utf-8');
+    expect(transcriptionContent).toContain('whisper.cpp');
+    expect(transcriptionContent).toContain('transcribeAudioMessage');
+    expect(transcriptionContent).toContain('transcribeAudio');
+    expect(transcriptionContent).toContain('isVoiceMessage');
+    expect(transcriptionContent).toContain('Invariants');
+
+    const telegramContent = fs.readFileSync(telegramIntent, 'utf-8');
+    expect(telegramContent).toContain('transcribeAudio');
+    expect(telegramContent).toContain('Invariants');
+
+    const testContent = fs.readFileSync(testIntent, 'utf-8');
+    expect(testContent).toContain('mockTranscribeAudio');
+    expect(testContent).toContain('Invariants');
   });
 
   it('uses whisper-cli (not OpenAI) for transcription', () => {
@@ -69,7 +123,7 @@ describe('use-local-whisper skill package', () => {
     expect(content).not.toContain('readEnvFile');
   });
 
-  it('preserves the public API (transcribeAudioMessage and isVoiceMessage)', () => {
+  it('preserves the WhatsApp API (transcribeAudioMessage and isVoiceMessage)', () => {
     const content = fs.readFileSync(
       path.join(skillDir, 'modify', 'src', 'transcription.ts'),
       'utf-8',
@@ -81,6 +135,26 @@ describe('use-local-whisper skill package', () => {
     expect(content).toContain('Promise<string | null>');
     expect(content).toContain('export function isVoiceMessage(');
     expect(content).toContain('downloadMediaMessage');
+  });
+
+  it('exports channel-agnostic transcribeAudio(Buffer)', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'transcription.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain('export async function transcribeAudio(');
+    expect(content).toContain('audioBuffer: Buffer');
+  });
+
+  it('transcribeAudioMessage uses transcribeAudio internally', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'transcription.ts'),
+      'utf-8',
+    );
+
+    // transcribeAudioMessage should call transcribeAudio(buffer)
+    expect(content).toContain('await transcribeAudio(buffer)');
   });
 
   it('preserves fallback message strings', () => {
@@ -111,5 +185,45 @@ describe('use-local-whisper skill package', () => {
 
     expect(content).toContain('finally');
     expect(content).toContain('unlinkSync');
+  });
+
+  it('modified telegram.ts imports transcribeAudio', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'telegram.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain("import { transcribeAudio }");
+    expect(content).toContain("'../transcription.js'");
+  });
+
+  it('modified telegram.ts has async voice handler with transcription', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'telegram.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain("'message:voice'");
+    expect(content).toContain('transcribeAudio(buffer)');
+    expect(content).toContain('[Voice:');
+    expect(content).toContain(
+      '[Voice message - transcription unavailable]',
+    );
+    expect(content).toContain('ctx.api.getFile');
+  });
+
+  it('modified telegram.test.ts mocks transcription module', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'telegram.test.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain('mockTranscribeAudio');
+    expect(content).toContain("vi.mock('../transcription.js'");
+    expect(content).toContain('transcribes voice message successfully');
+    expect(content).toContain('falls back when transcription returns null');
+    expect(content).toContain('falls back when voice download fails');
+    expect(content).toContain('includes caption with transcribed voice');
+    expect(content).toContain('ignores voice messages from unregistered');
   });
 });


### PR DESCRIPTION
## Summary

- Adds Telegram voice transcription to the existing `use-local-whisper` skill (as suggested in #718)
- Exports a channel-agnostic `transcribeAudio(Buffer)` from `transcription.ts` — any channel can call it directly
- Keeps the WhatsApp-specific `transcribeAudioMessage(WAMessage, WASocket)` as a thin wrapper that calls `transcribeAudio` internally
- Adds Telegram voice handler: downloads via Bot API, transcribes with whisper.cpp, delivers `[Voice: <transcript>]`
- Adds 5 Telegram voice tests and 3 new skill package tests (17 total)
- Updates SKILL.md with Linux setup instructions (including `-DBUILD_SHARED_LIBS=OFF` for static linking)

## Test plan

- [ ] Skill package tests pass (17/17)
- [ ] Full test suite passes (374/374)
- [ ] Build compiles clean
- [ ] Send voice note in Telegram → agent receives `[Voice: <transcript>]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)