### PR TITLE
Add google chat

### DIFF
--- a/.claude/skills/add-google-chat/SKILL.md
+++ b/.claude/skills/add-google-chat/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: add-google-chat
+description: Add Google Chat as a channel to NanoClaw. Polls a DM space for messages and delivers them to the main group. Replies are sent back via the Chat API.
+---
+
+# Add Google Chat Channel
+
+This skill adds Google Chat as a messaging channel. The bot polls a configured DM space for human messages and delivers them to the main WhatsApp group. Agent replies are sent back to the Chat space.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `google-chat` is in `applied_skills`, skip to Phase 3 (Setup). The code changes are already in place.
+
+## Phase 2: Apply Code Changes
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-google-chat
+```
+
+This deterministically:
+
+- Adds `src/channels/googlechat.ts` (GoogleChatChannel class implementing Channel interface)
+- Adds `src/channels/googlechat.test.ts` (unit tests)
+- Three-way merges Google Chat channel wiring into `src/index.ts` (GoogleChatChannel creation)
+- Three-way merges Google Chat credentials mount into `src/container-runner.ts` (~/.google-chat-mcp -> /home/node/.google-chat-mcp)
+- Three-way merges Google Chat JID tests into `src/routing.test.ts`
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent files:
+
+- `modify/src/index.ts.intent.md` — what changed and invariants for index.ts
+- `modify/src/container-runner.ts.intent.md` — what changed for container-runner.ts
+
+### Add Chat message handling instructions
+
+Append the following to `groups/main/CLAUDE.md` (before the formatting section):
+
+```markdown
+## Google Chat Messages
+
+When you receive a Google Chat message (messages starting with `[Google Chat from ...`), respond to the user. The reply will be sent back to the Chat space automatically.
+```
+
+### Validate
+
+```bash
+npm test
+npm run build
+```
+
+All tests must pass (including the new googlechat tests) and build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Check existing Google Chat credentials
+
+```bash
+ls -la ~/.google-chat-mcp/ 2>/dev/null || echo "No Google Chat config found"
+```
+
+If `credentials.json` already exists, skip to "Set space ID" below.
+
+### GCP Project Setup
+
+Tell the user:
+
+> I need you to set up Google Cloud OAuth credentials for Google Chat:
+>
+> 1. Open https://console.cloud.google.com — create a new project or select existing
+> 2. Go to **APIs & Services > Library**, search "Google Chat API", click **Enable**
+> 3. Go to **APIs & Services > Credentials**, click **+ CREATE CREDENTIALS > OAuth client ID**
+>    - If prompted for consent screen: choose "Internal" (for Workspace), fill in app name and email, save
+>    - Application type: **Desktop app**, name: anything (e.g., "NanoClaw Chat")
+> 4. Click **DOWNLOAD JSON** and save as `gcp-oauth.keys.json`
+>
+> Where did you save the file? (Give me the full path, or paste the file contents here)
+
+If user provides a path, copy it:
+
+```bash
+mkdir -p ~/.google-chat-mcp
+cp "/path/user/provided/gcp-oauth.keys.json" ~/.google-chat-mcp/gcp-oauth.keys.json
+```
+
+If user pastes JSON content, write it to `~/.google-chat-mcp/gcp-oauth.keys.json`.
+
+### OAuth Authorization
+
+There is no third-party auth tool for Google Chat (unlike Gmail). Run a Node.js inline script to complete the OAuth flow:
+
+```bash
+node -e "
+const fs = require('fs');
+const path = require('path');
+const { google } = require('googleapis');
+const http = require('http');
+const url = require('url');
+
+const credDir = path.join(require('os').homedir(), '.google-chat-mcp');
+const keys = JSON.parse(fs.readFileSync(path.join(credDir, 'gcp-oauth.keys.json'), 'utf-8'));
+const config = keys.installed || keys.web || keys;
+
+const oauth2Client = new google.auth.OAuth2(
+  config.client_id,
+  config.client_secret,
+  'http://localhost:3000/oauth2callback'
+);
+
+const scopes = [
+  'https://www.googleapis.com/auth/chat.messages',
+  'https://www.googleapis.com/auth/chat.spaces.readonly',
+];
+
+const authUrl = oauth2Client.generateAuthUrl({ access_type: 'offline', scope: scopes, prompt: 'consent' });
+console.log('Open this URL in your browser:\n\n' + authUrl + '\n');
+
+const server = http.createServer(async (req, res) => {
+  const qs = new url.URL(req.url, 'http://localhost:3000').searchParams;
+  const code = qs.get('code');
+  if (code) {
+    const { tokens } = await oauth2Client.getToken(code);
+    fs.writeFileSync(path.join(credDir, 'credentials.json'), JSON.stringify(tokens, null, 2));
+    res.end('Authorization complete! You can close this tab.');
+    console.log('Credentials saved to ~/.google-chat-mcp/credentials.json');
+    server.close();
+  }
+}).listen(3000);
+"
+```
+
+Tell the user:
+
+> A URL will be printed. Open it in your browser, sign in with the bot account (e.g., `cseeker@sowbug.com`), and grant access. If you see an "app isn't verified" warning, click "Advanced" then "Go to [app name] (unsafe)".
+
+Verify credentials were saved:
+
+```bash
+ls ~/.google-chat-mcp/credentials.json
+```
+
+### Find DM Space ID
+
+Run the following to list spaces:
+
+```bash
+node -e "
+const fs = require('fs');
+const path = require('path');
+const { google } = require('googleapis');
+const os = require('os');
+
+const credDir = path.join(os.homedir(), '.google-chat-mcp');
+const keys = JSON.parse(fs.readFileSync(path.join(credDir, 'gcp-oauth.keys.json'), 'utf-8'));
+const tokens = JSON.parse(fs.readFileSync(path.join(credDir, 'credentials.json'), 'utf-8'));
+const config = keys.installed || keys.web || keys;
+
+const oauth2Client = new google.auth.OAuth2(config.client_id, config.client_secret, config.redirect_uris?.[0]);
+oauth2Client.setCredentials(tokens);
+
+const chat = google.chat({ version: 'v1', auth: oauth2Client });
+chat.spaces.list({ pageSize: 100 }).then(res => {
+  const spaces = res.data.spaces || [];
+  console.log('Available spaces:');
+  for (const s of spaces) {
+    const id = s.name?.split('/').pop() || s.name;
+    console.log('  ' + (s.displayName || '(DM)') + '  ->  ' + id + '  type: ' + s.type);
+  }
+  console.log('\nSet GOOGLE_CHAT_SPACE_ID=<space-id> in your .env file.');
+});
+"
+```
+
+### Set Space ID
+
+Tell the user to add the space ID to `.env`:
+
+```
+GOOGLE_CHAT_SPACE_ID=<the-space-id>
+```
+
+### Build and restart
+
+```bash
+npm run build
+systemctl --user restart nanoclaw  # Linux
+# macOS: launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 4: Verify
+
+Tell the user:
+
+> Google Chat is connected! Send a message in the configured DM space. It should appear in your main WhatsApp group within ~15 seconds.
+
+Monitor:
+
+```bash
+tail -f logs/nanoclaw.log | grep -iE "(google.chat|gchat)"
+```
+
+## Troubleshooting
+
+### Google Chat connection not responding
+
+- Verify credentials exist: `ls ~/.google-chat-mcp/`
+- Verify `GOOGLE_CHAT_SPACE_ID` is set in `.env`
+- Check logs: `grep -i "google chat" logs/nanoclaw.log | tail -20`
+
+### OAuth token expired
+
+Re-authorize by running the OAuth flow from Phase 3 again:
+
+```bash
+rm ~/.google-chat-mcp/credentials.json
+# Re-run the OAuth authorization script above
+```
+
+### Messages not being detected
+
+- Check the space ID is correct (re-run the space listing script)
+- Ensure the bot account can see messages in the DM space
+- The channel polls every 15 seconds by default
+
+## Removal
+
+1. Delete `src/channels/googlechat.ts` and `src/channels/googlechat.test.ts`
+2. Remove `GoogleChatChannel` import and creation from `src/index.ts`
+3. Remove `~/.google-chat-mcp` mount from `src/container-runner.ts`
+4. Remove Google Chat JID tests from `src/routing.test.ts`
+5. Remove `google-chat` from `.nanoclaw/state.yaml`
+6. Rebuild: `npm run build && systemctl --user restart nanoclaw` (Linux) or `launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS)

--- a/.claude/skills/add-google-chat/SKILL.md
+++ b/.claude/skills/add-google-chat/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: add-google-chat
-description: Add Google Chat as a channel to NanoClaw. Polls a DM space for messages and delivers them to the main group. Replies are sent back via the Chat API.
+description: Add Google Chat as a multi-space channel to NanoClaw. Automatically discovers all DMs and rooms the authenticated user belongs to. DMs route directly, rooms require @mention trigger.
 ---
 
 # Add Google Chat Channel
 
-This skill adds Google Chat as a messaging channel. The bot polls a configured DM space for human messages and delivers them to the main WhatsApp group. Agent replies are sent back to the Chat space.
+This skill adds Google Chat as a messaging channel with multi-space support. The bot automatically discovers all spaces (DMs and rooms) the authenticated user belongs to. DM messages are delivered directly; room messages require an @mention trigger. Replies are sent back to the originating space.
+
+> **Note:** The Google Chat API historically required a Google Workspace account. Personal @gmail.com accounts may now work — if space discovery returns zero results, a Workspace account may still be needed.
 
 ## Phase 1: Pre-flight
 
@@ -33,7 +35,7 @@ This deterministically:
 
 - Adds `src/channels/googlechat.ts` (GoogleChatChannel class implementing Channel interface)
 - Adds `src/channels/googlechat.test.ts` (unit tests)
-- Three-way merges Google Chat channel wiring into `src/index.ts` (GoogleChatChannel creation)
+- Three-way merges Google Chat channel wiring into `src/index.ts` (GoogleChatChannel creation with `onSpaceDiscovered` callback)
 - Three-way merges Google Chat credentials mount into `src/container-runner.ts` (~/.google-chat-mcp -> /home/node/.google-chat-mcp)
 - Three-way merges Google Chat JID tests into `src/routing.test.ts`
 - Records the application in `.nanoclaw/state.yaml`
@@ -70,7 +72,7 @@ All tests must pass (including the new googlechat tests) and build must be clean
 ls -la ~/.google-chat-mcp/ 2>/dev/null || echo "No Google Chat config found"
 ```
 
-If `credentials.json` already exists, skip to "Set space ID" below.
+If `credentials.json` already exists, skip to "Build and restart" below.
 
 ### GCP Project Setup
 
@@ -142,7 +144,7 @@ const server = http.createServer(async (req, res) => {
 
 Tell the user:
 
-> A URL will be printed. Open it in your browser, sign in with the bot account (e.g., `cseeker@sowbug.com`), and grant access. If you see an "app isn't verified" warning, click "Advanced" then "Go to [app name] (unsafe)".
+> A URL will be printed. Open it in your browser, sign in with your Google Workspace account, and grant access. If you see an "app isn't verified" warning, click "Advanced" then "Go to [app name] (unsafe)".
 
 Verify credentials were saved:
 
@@ -150,47 +152,9 @@ Verify credentials were saved:
 ls ~/.google-chat-mcp/credentials.json
 ```
 
-### Find DM Space ID
-
-Run the following to list spaces:
-
-```bash
-node -e "
-const fs = require('fs');
-const path = require('path');
-const { google } = require('googleapis');
-const os = require('os');
-
-const credDir = path.join(os.homedir(), '.google-chat-mcp');
-const keys = JSON.parse(fs.readFileSync(path.join(credDir, 'gcp-oauth.keys.json'), 'utf-8'));
-const tokens = JSON.parse(fs.readFileSync(path.join(credDir, 'credentials.json'), 'utf-8'));
-const config = keys.installed || keys.web || keys;
-
-const oauth2Client = new google.auth.OAuth2(config.client_id, config.client_secret, config.redirect_uris?.[0]);
-oauth2Client.setCredentials(tokens);
-
-const chat = google.chat({ version: 'v1', auth: oauth2Client });
-chat.spaces.list({ pageSize: 100 }).then(res => {
-  const spaces = res.data.spaces || [];
-  console.log('Available spaces:');
-  for (const s of spaces) {
-    const id = s.name?.split('/').pop() || s.name;
-    console.log('  ' + (s.displayName || '(DM)') + '  ->  ' + id + '  type: ' + s.type);
-  }
-  console.log('\nSet GOOGLE_CHAT_SPACE_ID=<space-id> in your .env file.');
-});
-"
-```
-
-### Set Space ID
-
-Tell the user to add the space ID to `.env`:
-
-```
-GOOGLE_CHAT_SPACE_ID=<the-space-id>
-```
-
 ### Build and restart
+
+Spaces are discovered automatically — all DMs and rooms the authenticated user belongs to will be found. If you want to limit the bot to a single space, set `GOOGLE_CHAT_SPACE_ID=<space-id>` in `.env` (optional).
 
 ```bash
 npm run build
@@ -202,12 +166,16 @@ systemctl --user restart nanoclaw  # Linux
 
 Tell the user:
 
-> Google Chat is connected! Send a message in the configured DM space. It should appear in your main WhatsApp group within ~15 seconds.
+> Google Chat is connected! The bot automatically discovers all your DMs and rooms:
+> - **DMs**: Send a message directly — no trigger needed
+> - **Rooms**: @mention the bot to trigger a response
+>
+> Messages should appear within ~15 seconds.
 
 Monitor:
 
 ```bash
-tail -f logs/nanoclaw.log | grep -iE "(google.chat|gchat)"
+tail -f logs/nanoclaw.log | grep -iE "(google.chat|gchat|discover)"
 ```
 
 ## Troubleshooting
@@ -215,8 +183,8 @@ tail -f logs/nanoclaw.log | grep -iE "(google.chat|gchat)"
 ### Google Chat connection not responding
 
 - Verify credentials exist: `ls ~/.google-chat-mcp/`
-- Verify `GOOGLE_CHAT_SPACE_ID` is set in `.env`
 - Check logs: `grep -i "google chat" logs/nanoclaw.log | tail -20`
+- If using a personal @gmail.com account and it doesn't work, try a Google Workspace account
 
 ### OAuth token expired
 
@@ -229,9 +197,15 @@ rm ~/.google-chat-mcp/credentials.json
 
 ### Messages not being detected
 
-- Check the space ID is correct (re-run the space listing script)
-- Ensure the bot account can see messages in the DM space
+- Ensure the authenticated user can see messages in the space
 - The channel polls every 15 seconds by default
+- Last poll timestamps are persisted across restarts — old messages won't replay
+
+### No spaces discovered
+
+- If using a personal Gmail account, try a Workspace account — some API features may still require it
+- Check that the Chat API is enabled in your GCP project
+- Verify the OAuth scopes include `chat.spaces.readonly`
 
 ## Removal
 

--- a/.claude/skills/add-google-chat/add/src/channels/googlechat.test.ts
+++ b/.claude/skills/add-google-chat/add/src/channels/googlechat.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GoogleChatChannel, GoogleChatChannelOpts } from './googlechat.js';
+
+function makeOpts(overrides?: Partial<GoogleChatChannelOpts>): GoogleChatChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: () => ({}),
+    ...overrides,
+  };
+}
+
+describe('GoogleChatChannel', () => {
+  let channel: GoogleChatChannel;
+
+  beforeEach(() => {
+    channel = new GoogleChatChannel(makeOpts());
+  });
+
+  describe('ownsJid', () => {
+    it('returns true for gchat: prefixed JIDs', () => {
+      expect(channel.ownsJid('gchat:abc123')).toBe(true);
+      expect(channel.ownsJid('gchat:space-id-456')).toBe(true);
+    });
+
+    it('returns false for non-gchat JIDs', () => {
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+      expect(channel.ownsJid('gmail:abc123')).toBe(false);
+      expect(channel.ownsJid('tg:123')).toBe(false);
+      expect(channel.ownsJid('user@s.whatsapp.net')).toBe(false);
+    });
+  });
+
+  describe('name', () => {
+    it('is googlechat', () => {
+      expect(channel.name).toBe('googlechat');
+    });
+  });
+
+  describe('isConnected', () => {
+    it('returns false before connect', () => {
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('sets connected to false', async () => {
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('constructor options', () => {
+    it('accepts custom poll interval', () => {
+      const ch = new GoogleChatChannel(makeOpts(), 5000);
+      expect(ch.name).toBe('googlechat');
+    });
+  });
+});

--- a/.claude/skills/add-google-chat/add/src/channels/googlechat.test.ts
+++ b/.claude/skills/add-google-chat/add/src/channels/googlechat.test.ts
@@ -7,6 +7,9 @@ function makeOpts(overrides?: Partial<GoogleChatChannelOpts>): GoogleChatChannel
     onMessage: vi.fn(),
     onChatMetadata: vi.fn(),
     registeredGroups: () => ({}),
+    onSpaceDiscovered: vi.fn(),
+    getState: vi.fn(),
+    setState: vi.fn(),
     ...overrides,
   };
 }

--- a/.claude/skills/add-google-chat/add/src/channels/googlechat.ts
+++ b/.claude/skills/add-google-chat/add/src/channels/googlechat.ts
@@ -1,0 +1,231 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { google, chat_v1 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+import { MAIN_GROUP_FOLDER } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface GoogleChatChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class GoogleChatChannel implements Channel {
+  name = 'googlechat';
+
+  private oauth2Client: OAuth2Client | null = null;
+  private chat: chat_v1.Chat | null = null;
+  private opts: GoogleChatChannelOpts;
+  private pollIntervalMs: number;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastPollTime: string | null = null;
+  private spaceId: string;
+  private consecutiveErrors = 0;
+
+  constructor(opts: GoogleChatChannelOpts, pollIntervalMs = 15000) {
+    this.opts = opts;
+    this.pollIntervalMs = pollIntervalMs;
+    const envConfig = readEnvFile(['GOOGLE_CHAT_SPACE_ID']);
+    this.spaceId = process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
+  }
+
+  async connect(): Promise<void> {
+    const credDir = path.join(os.homedir(), '.google-chat-mcp');
+    const keysPath = path.join(credDir, 'gcp-oauth.keys.json');
+    const tokensPath = path.join(credDir, 'credentials.json');
+
+    if (!fs.existsSync(keysPath) || !fs.existsSync(tokensPath)) {
+      logger.warn(
+        'Google Chat credentials not found in ~/.google-chat-mcp/. Skipping Google Chat channel. Run /add-google-chat to set up.',
+      );
+      return;
+    }
+
+    if (!this.spaceId) {
+      logger.warn(
+        'GOOGLE_CHAT_SPACE_ID not set. Skipping Google Chat channel. Set it in .env.',
+      );
+      return;
+    }
+
+    const keys = JSON.parse(fs.readFileSync(keysPath, 'utf-8'));
+    const tokens = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+
+    const clientConfig = keys.installed || keys.web || keys;
+    const { client_id, client_secret, redirect_uris } = clientConfig;
+    this.oauth2Client = new google.auth.OAuth2(
+      client_id,
+      client_secret,
+      redirect_uris?.[0],
+    );
+    this.oauth2Client.setCredentials(tokens);
+
+    // Persist refreshed tokens
+    this.oauth2Client.on('tokens', (newTokens) => {
+      try {
+        const current = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+        Object.assign(current, newTokens);
+        fs.writeFileSync(tokensPath, JSON.stringify(current, null, 2));
+        logger.debug('Google Chat OAuth tokens refreshed');
+      } catch (err) {
+        logger.warn({ err }, 'Failed to persist refreshed Google Chat tokens');
+      }
+    });
+
+    this.chat = google.chat({ version: 'v1', auth: this.oauth2Client });
+
+    logger.info({ spaceId: this.spaceId }, 'Google Chat channel connected');
+
+    // Start polling with error backoff
+    const schedulePoll = () => {
+      const backoffMs = this.consecutiveErrors > 0
+        ? Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000)
+        : this.pollIntervalMs;
+      this.pollTimer = setTimeout(() => {
+        this.pollForMessages()
+          .catch((err) => logger.error({ err }, 'Google Chat poll error'))
+          .finally(() => {
+            if (this.chat) schedulePoll();
+          });
+      }, backoffMs);
+    };
+
+    // Initial poll
+    await this.pollForMessages();
+    schedulePoll();
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.chat) {
+      logger.warn('Google Chat not initialized');
+      return;
+    }
+
+    const spaceId = jid.replace(/^gchat:/, '');
+
+    try {
+      await this.chat.spaces.messages.create({
+        parent: `spaces/${spaceId}`,
+        requestBody: { text },
+      });
+      logger.info({ spaceId }, 'Google Chat message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Google Chat message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.chat !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('gchat:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.chat = null;
+    this.oauth2Client = null;
+    logger.info('Google Chat channel stopped');
+  }
+
+  // --- Private ---
+
+  private async pollForMessages(): Promise<void> {
+    if (!this.chat) return;
+
+    try {
+      const filterParts: string[] = [];
+      if (this.lastPollTime) {
+        filterParts.push(`createTime > "${this.lastPollTime}"`);
+      }
+      const filter = filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+
+      const res = await this.chat.spaces.messages.list({
+        parent: `spaces/${this.spaceId}`,
+        filter: filter || undefined,
+        orderBy: 'createTime',
+        pageSize: 25,
+      });
+
+      const messages = res.data.messages || [];
+
+      for (const msg of messages) {
+        // Skip bot messages (our own replies)
+        if (msg.sender?.type === 'BOT') continue;
+
+        await this.processMessage(msg);
+      }
+
+      // Update the last poll timestamp to now
+      this.lastPollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+      this.consecutiveErrors = 0;
+    } catch (err) {
+      this.consecutiveErrors++;
+      const backoffMs = Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000);
+      logger.error({ err, consecutiveErrors: this.consecutiveErrors, nextPollMs: backoffMs }, 'Google Chat poll failed');
+    }
+  }
+
+  private async processMessage(msg: chat_v1.Schema$Message): Promise<void> {
+    const text = msg.text || '';
+    if (!text) return;
+
+    const senderName = msg.sender?.displayName || 'Unknown';
+    const createTime = msg.createTime || new Date().toISOString();
+    const messageName = msg.name || ''; // e.g. "spaces/xxx/messages/yyy"
+    const messageId = messageName.split('/').pop() || messageName;
+
+    const chatJid = `gchat:${this.spaceId}`;
+
+    // Store chat metadata for group discovery
+    this.opts.onChatMetadata(chatJid, createTime, `Google Chat DM`, 'googlechat', false);
+
+    // Find the main group to deliver the message
+    const groups = this.opts.registeredGroups();
+    const mainEntry = Object.entries(groups).find(
+      ([, g]) => g.folder === MAIN_GROUP_FOLDER,
+    );
+
+    if (!mainEntry) {
+      logger.debug(
+        { chatJid, text: text.slice(0, 50) },
+        'No main group registered, skipping Google Chat message',
+      );
+      return;
+    }
+
+    const mainJid = mainEntry[0];
+    const content = `[Google Chat from ${senderName}]\n\n${text}`;
+
+    this.opts.onMessage(mainJid, {
+      id: messageId,
+      chat_jid: mainJid,
+      sender: senderName,
+      sender_name: senderName,
+      content,
+      timestamp: createTime,
+      is_from_me: false,
+    });
+
+    logger.info(
+      { mainJid, from: senderName },
+      'Google Chat message delivered to main group',
+    );
+  }
+}

--- a/.claude/skills/add-google-chat/add/src/channels/googlechat.ts
+++ b/.claude/skills/add-google-chat/add/src/channels/googlechat.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import { google, chat_v1 } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 
-import { MAIN_GROUP_FOLDER } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import {
@@ -19,6 +18,16 @@ export interface GoogleChatChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  onSpaceDiscovered?: (jid: string, space: SpaceInfo) => void;
+  getState?: (key: string) => string | undefined;
+  setState?: (key: string, value: string) => void;
+}
+
+export interface SpaceInfo {
+  spaceId: string;
+  displayName: string;
+  spaceType: string; // DIRECT_MESSAGE, SPACE, GROUP_CHAT
+  lastPollTime: string | null;
 }
 
 export class GoogleChatChannel implements Channel {
@@ -29,15 +38,19 @@ export class GoogleChatChannel implements Channel {
   private opts: GoogleChatChannelOpts;
   private pollIntervalMs: number;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
-  private lastPollTime: string | null = null;
-  private spaceId: string;
+  private spaces: Map<string, SpaceInfo> = new Map();
   private consecutiveErrors = 0;
+  private filterSpaceId: string;
+  private botUserId: string | null = null;
+  private discoveryCounter = 0;
+  private readonly DISCOVERY_INTERVAL = 10; // re-discover every N poll cycles
 
   constructor(opts: GoogleChatChannelOpts, pollIntervalMs = 15000) {
     this.opts = opts;
     this.pollIntervalMs = pollIntervalMs;
     const envConfig = readEnvFile(['GOOGLE_CHAT_SPACE_ID']);
-    this.spaceId = process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
+    this.filterSpaceId =
+      process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
   }
 
   async connect(): Promise<void> {
@@ -48,13 +61,6 @@ export class GoogleChatChannel implements Channel {
     if (!fs.existsSync(keysPath) || !fs.existsSync(tokensPath)) {
       logger.warn(
         'Google Chat credentials not found in ~/.google-chat-mcp/. Skipping Google Chat channel. Run /add-google-chat to set up.',
-      );
-      return;
-    }
-
-    if (!this.spaceId) {
-      logger.warn(
-        'GOOGLE_CHAT_SPACE_ID not set. Skipping Google Chat channel. Set it in .env.',
       );
       return;
     }
@@ -85,13 +91,27 @@ export class GoogleChatChannel implements Channel {
 
     this.chat = google.chat({ version: 'v1', auth: this.oauth2Client });
 
-    logger.info({ spaceId: this.spaceId }, 'Google Chat channel connected');
+    // Discover spaces the bot belongs to
+    await this.discoverSpaces();
+
+    if (this.spaces.size === 0) {
+      logger.warn('Google Chat: no spaces discovered, channel idle');
+    } else {
+      logger.info(
+        { spaceCount: this.spaces.size },
+        'Google Chat channel connected',
+      );
+    }
 
     // Start polling with error backoff
     const schedulePoll = () => {
-      const backoffMs = this.consecutiveErrors > 0
-        ? Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000)
-        : this.pollIntervalMs;
+      const backoffMs =
+        this.consecutiveErrors > 0
+          ? Math.min(
+              this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+              30 * 60 * 1000,
+            )
+          : this.pollIntervalMs;
       this.pollTimer = setTimeout(() => {
         this.pollForMessages()
           .catch((err) => logger.error({ err }, 'Google Chat poll error'))
@@ -129,6 +149,11 @@ export class GoogleChatChannel implements Channel {
     return this.chat !== null;
   }
 
+  /** Returns all discovered spaces with their JIDs and metadata. */
+  getDiscoveredSpaces(): SpaceInfo[] {
+    return Array.from(this.spaces.values());
+  }
+
   ownsJid(jid: string): boolean {
     return jid.startsWith('gchat:');
   }
@@ -145,18 +170,122 @@ export class GoogleChatChannel implements Channel {
 
   // --- Private ---
 
+  private async discoverSpaces(): Promise<void> {
+    if (!this.chat) return;
+
+    try {
+      let pageToken: string | undefined;
+      const discovered: chat_v1.Schema$Space[] = [];
+
+      do {
+        const res = await this.chat.spaces.list({
+          pageSize: 100,
+          pageToken,
+        });
+        if (res.data.spaces) {
+          discovered.push(...res.data.spaces);
+        }
+        pageToken = res.data.nextPageToken || undefined;
+      } while (pageToken);
+
+      for (const space of discovered) {
+        const spaceId = space.name?.replace(/^spaces\//, '');
+        if (!spaceId) continue;
+
+        // If a filter is set, only include that specific space
+        if (this.filterSpaceId && spaceId !== this.filterSpaceId) continue;
+
+        const existing = this.spaces.get(spaceId);
+        if (!existing) {
+          const spaceType = space.spaceType || space.type || 'SPACE';
+          const isDm = spaceType === 'DIRECT_MESSAGE';
+          const displayName = isDm
+            ? 'Google Chat DM'
+            : space.displayName || `Space ${spaceId}`;
+
+          const savedPollTime =
+            this.opts.getState?.(`gchat:poll:${spaceId}`) ?? null;
+
+          this.spaces.set(spaceId, {
+            spaceId,
+            displayName,
+            spaceType,
+            lastPollTime: savedPollTime,
+          });
+
+          const chatJid = `gchat:${spaceId}`;
+
+          // Notify metadata callback so the space is tracked in the DB
+          this.opts.onChatMetadata(
+            chatJid,
+            new Date().toISOString(),
+            displayName,
+            'googlechat',
+            !isDm,
+          );
+
+          logger.info(
+            { spaceId, displayName, spaceType },
+            'Discovered new Google Chat space',
+          );
+
+          // Notify index.ts to register this space as a group
+          this.opts.onSpaceDiscovered?.(chatJid, this.spaces.get(spaceId)!);
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Failed to discover Google Chat spaces');
+    }
+  }
+
   private async pollForMessages(): Promise<void> {
+    if (!this.chat) return;
+
+    // Periodically re-discover spaces to pick up new rooms
+    this.discoveryCounter++;
+    if (this.discoveryCounter >= this.DISCOVERY_INTERVAL) {
+      this.discoveryCounter = 0;
+      await this.discoverSpaces();
+    }
+
+    try {
+      for (const [spaceId, spaceInfo] of this.spaces) {
+        await this.pollSpace(spaceId, spaceInfo);
+      }
+      this.consecutiveErrors = 0;
+    } catch (err) {
+      this.consecutiveErrors++;
+      const backoffMs = Math.min(
+        this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+        30 * 60 * 1000,
+      );
+      logger.error(
+        {
+          err,
+          consecutiveErrors: this.consecutiveErrors,
+          nextPollMs: backoffMs,
+        },
+        'Google Chat poll failed',
+      );
+    }
+  }
+
+  private async pollSpace(
+    spaceId: string,
+    spaceInfo: SpaceInfo,
+  ): Promise<void> {
     if (!this.chat) return;
 
     try {
       const filterParts: string[] = [];
-      if (this.lastPollTime) {
-        filterParts.push(`createTime > "${this.lastPollTime}"`);
+      if (spaceInfo.lastPollTime) {
+        filterParts.push(`createTime > "${spaceInfo.lastPollTime}"`);
       }
-      const filter = filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+      const filter =
+        filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
 
       const res = await this.chat.spaces.messages.list({
-        parent: `spaces/${this.spaceId}`,
+        parent: `spaces/${spaceId}`,
         filter: filter || undefined,
         orderBy: 'createTime',
         pageSize: 25,
@@ -168,64 +297,79 @@ export class GoogleChatChannel implements Channel {
         // Skip bot messages (our own replies)
         if (msg.sender?.type === 'BOT') continue;
 
-        await this.processMessage(msg);
+        // Track the bot's user ID from message annotations so we can strip self-mentions
+        if (!this.botUserId && msg.annotations) {
+          for (const ann of msg.annotations) {
+            if (ann.type === 'USER_MENTION' && ann.userMention?.user?.type === 'BOT') {
+              this.botUserId = ann.userMention.user.name || null;
+            }
+          }
+        }
+
+        await this.processMessage(msg, spaceId, spaceInfo);
       }
 
-      // Update the last poll timestamp to now
-      this.lastPollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-
-      this.consecutiveErrors = 0;
+      // Update the last poll timestamp for this space
+      const pollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+      spaceInfo.lastPollTime = pollTime;
+      this.opts.setState?.(`gchat:poll:${spaceId}`, pollTime);
     } catch (err) {
-      this.consecutiveErrors++;
-      const backoffMs = Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000);
-      logger.error({ err, consecutiveErrors: this.consecutiveErrors, nextPollMs: backoffMs }, 'Google Chat poll failed');
+      logger.error({ spaceId, err }, 'Failed to poll Google Chat space');
     }
   }
 
-  private async processMessage(msg: chat_v1.Schema$Message): Promise<void> {
-    const text = msg.text || '';
+  private async processMessage(
+    msg: chat_v1.Schema$Message,
+    spaceId: string,
+    spaceInfo: SpaceInfo,
+  ): Promise<void> {
+    let text = msg.text || '';
+    if (!text) return;
+
+    // Strip raw Google Chat mention markup (e.g. `<users/123456>`) but keep
+    // the human-readable `@Name` so the trigger pattern still matches.
+    if (this.botUserId) {
+      text = text.replace(new RegExp(`<${this.botUserId}>\\s*`, 'g'), '').trim();
+    }
+
     if (!text) return;
 
     const senderName = msg.sender?.displayName || 'Unknown';
+    if (!msg.sender?.displayName) {
+      logger.debug(
+        { sender: msg.sender, messageName: msg.name },
+        'Google Chat message has no sender displayName',
+      );
+    }
     const createTime = msg.createTime || new Date().toISOString();
     const messageName = msg.name || ''; // e.g. "spaces/xxx/messages/yyy"
     const messageId = messageName.split('/').pop() || messageName;
 
-    const chatJid = `gchat:${this.spaceId}`;
+    const chatJid = `gchat:${spaceId}`;
+    const isDm = spaceInfo.spaceType === 'DIRECT_MESSAGE';
 
-    // Store chat metadata for group discovery
-    this.opts.onChatMetadata(chatJid, createTime, `Google Chat DM`, 'googlechat', false);
-
-    // Find the main group to deliver the message
-    const groups = this.opts.registeredGroups();
-    const mainEntry = Object.entries(groups).find(
-      ([, g]) => g.folder === MAIN_GROUP_FOLDER,
+    // Store chat metadata
+    this.opts.onChatMetadata(
+      chatJid,
+      createTime,
+      spaceInfo.displayName,
+      'googlechat',
+      !isDm,
     );
 
-    if (!mainEntry) {
-      logger.debug(
-        { chatJid, text: text.slice(0, 50) },
-        'No main group registered, skipping Google Chat message',
-      );
-      return;
-    }
-
-    const mainJid = mainEntry[0];
-    const content = `[Google Chat from ${senderName}]\n\n${text}`;
-
-    this.opts.onMessage(mainJid, {
+    this.opts.onMessage(chatJid, {
       id: messageId,
-      chat_jid: mainJid,
+      chat_jid: chatJid,
       sender: senderName,
       sender_name: senderName,
-      content,
+      content: text,
       timestamp: createTime,
       is_from_me: false,
     });
 
     logger.info(
-      { mainJid, from: senderName },
-      'Google Chat message delivered to main group',
+      { chatJid, from: senderName, spaceType: spaceInfo.spaceType },
+      'Google Chat message delivered',
     );
   }
 }

--- a/.claude/skills/add-google-chat/manifest.yaml
+++ b/.claude/skills/add-google-chat/manifest.yaml
@@ -1,0 +1,16 @@
+skill: google-chat
+version: 1.0.0
+description: "Google Chat channel via Google Chat API"
+core_version: 0.1.0
+adds:
+  - src/channels/googlechat.ts
+  - src/channels/googlechat.test.ts
+modifies:
+  - src/index.ts
+  - src/container-runner.ts
+  - src/routing.test.ts
+structured:
+  npm_dependencies: {}
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/googlechat.test.ts"

--- a/.claude/skills/add-google-chat/modify/src/container-runner.ts
+++ b/.claude/skills/add-google-chat/modify/src/container-runner.ts
@@ -19,11 +19,7 @@ import {
 import { readEnvFile } from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
-import {
-  CONTAINER_RUNTIME_BIN,
-  readonlyMountArgs,
-  stopContainer,
-} from './container-runtime.js';
+import { CONTAINER_RUNTIME_BIN, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
@@ -76,17 +72,6 @@ function buildVolumeMounts(
       readonly: true,
     });
 
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Secrets are passed via stdin instead (see readSecrets()).
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: '/dev/null',
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
-
     // Main also gets its group folder as the working directory
     mounts.push({
       hostPath: groupDir,
@@ -124,26 +109,19 @@ function buildVolumeMounts(
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   if (!fs.existsSync(settingsFile)) {
-    fs.writeFileSync(
-      settingsFile,
-      JSON.stringify(
-        {
-          env: {
-            // Enable agent swarms (subagent orchestration)
-            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
-            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-            // Load CLAUDE.md from additional mounted directories
-            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
-            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-            // Enable Claude's memory feature (persists user preferences between sessions)
-            // https://code.claude.com/docs/en/memory#manage-auto-memory
-            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-          },
-        },
-        null,
-        2,
-      ) + '\n',
-    );
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      env: {
+        // Enable agent swarms (subagent orchestration)
+        // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+        // Load CLAUDE.md from additional mounted directories
+        // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        // Enable Claude's memory feature (persists user preferences between sessions)
+        // https://code.claude.com/docs/en/memory#manage-auto-memory
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+      },
+    }, null, 2) + '\n');
   }
 
   // Sync skills from container/skills/ into each group's .claude/skills/
@@ -198,18 +176,8 @@ function buildVolumeMounts(
   // Copy agent-runner source into a per-group writable location so agents
   // can customize it (add tools, change behavior) without affecting other
   // groups. Recompiled on container startup via entrypoint.sh.
-  const agentRunnerSrc = path.join(
-    projectRoot,
-    'container',
-    'agent-runner',
-    'src',
-  );
-  const groupAgentRunnerDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    'agent-runner-src',
-  );
+  const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
+  const groupAgentRunnerDir = path.join(DATA_DIR, 'sessions', group.folder, 'agent-runner-src');
   if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
@@ -237,18 +205,10 @@ function buildVolumeMounts(
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile([
-    'CLAUDE_CODE_OAUTH_TOKEN',
-    'ANTHROPIC_API_KEY',
-    'ANTHROPIC_BASE_URL',
-    'ANTHROPIC_AUTH_TOKEN',
-  ]);
+  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
 }
 
-function buildContainerArgs(
-  mounts: VolumeMount[],
-  containerName: string,
-): string[] {
+function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Pass host timezone so container's local time matches the user's
@@ -426,16 +386,10 @@ export async function runContainerAgent(
 
     const killOnTimeout = () => {
       timedOut = true;
-      logger.error(
-        { group: group.name, containerName },
-        'Container timeout, stopping gracefully',
-      );
+      logger.error({ group: group.name, containerName }, 'Container timeout, stopping gracefully');
       exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
         if (err) {
-          logger.warn(
-            { group: group.name, containerName, err },
-            'Graceful stop failed, force killing',
-          );
+          logger.warn({ group: group.name, containerName, err }, 'Graceful stop failed, force killing');
           container.kill('SIGKILL');
         }
       });
@@ -456,18 +410,15 @@ export async function runContainerAgent(
       if (timedOut) {
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         const timeoutLog = path.join(logsDir, `container-${ts}.log`);
-        fs.writeFileSync(
-          timeoutLog,
-          [
-            `=== Container Run Log (TIMEOUT) ===`,
-            `Timestamp: ${new Date().toISOString()}`,
-            `Group: ${group.name}`,
-            `Container: ${containerName}`,
-            `Duration: ${duration}ms`,
-            `Exit Code: ${code}`,
-            `Had Streaming Output: ${hadStreamingOutput}`,
-          ].join('\n'),
-        );
+        fs.writeFileSync(timeoutLog, [
+          `=== Container Run Log (TIMEOUT) ===`,
+          `Timestamp: ${new Date().toISOString()}`,
+          `Group: ${group.name}`,
+          `Container: ${containerName}`,
+          `Duration: ${duration}ms`,
+          `Exit Code: ${code}`,
+          `Had Streaming Output: ${hadStreamingOutput}`,
+        ].join('\n'));
 
         // Timeout after output = idle cleanup, not failure.
         // The agent already sent its response; this is just the
@@ -502,8 +453,7 @@ export async function runContainerAgent(
 
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const logFile = path.join(logsDir, `container-${timestamp}.log`);
-      const isVerbose =
-        process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+      const isVerbose = process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
 
       const logLines = [
         `=== Container Run Log ===`,
@@ -646,10 +596,7 @@ export async function runContainerAgent(
 
     container.on('error', (err) => {
       clearTimeout(timeout);
-      logger.error(
-        { group: group.name, containerName, error: err },
-        'Container spawn error',
-      );
+      logger.error({ group: group.name, containerName, error: err }, 'Container spawn error');
       resolve({
         status: 'error',
         result: null,

--- a/.claude/skills/add-google-chat/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/add-google-chat/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,34 @@
+# Intent: src/container-runner.ts modifications
+
+## What changed
+Added a volume mount for Google Chat OAuth credentials (`~/.google-chat-mcp/`) so token refresh works inside the container.
+
+## Key sections
+
+### buildVolumeMounts()
+- Added: Google Chat credentials mount after the Gmail credentials mount:
+  ```
+  const gchatDir = path.join(homeDir, '.google-chat-mcp');
+  if (fs.existsSync(gchatDir)) {
+    mounts.push({
+      hostPath: gchatDir,
+      containerPath: '/home/node/.google-chat-mcp',
+      readonly: false,  // OAuth token refresh
+    });
+  }
+  ```
+- Uses `os.homedir()` to resolve the home directory (already imported for Gmail)
+- Mount is read-write because OAuth tokens may need refreshing
+- Mount is conditional — only added if `~/.google-chat-mcp/` exists on the host
+
+## Invariants
+- All existing mounts are unchanged (including Gmail mount)
+- Mount ordering is preserved (Google Chat added after Gmail, before IPC)
+- The `buildContainerArgs`, `runContainerAgent`, and all other functions are untouched
+- Additional mount validation via `validateAdditionalMounts` is unchanged
+
+## Must-keep
+- All existing volume mounts (project root, group dir, global, sessions, Gmail, IPC, agent-runner, additional)
+- The mount security model (allowlist validation for additional mounts)
+- The `readSecrets` function and stdin-based secret passing
+- Container lifecycle (spawn, timeout, output parsing)

--- a/.claude/skills/add-google-chat/modify/src/index.ts
+++ b/.claude/skills/add-google-chat/modify/src/index.ts
@@ -9,7 +9,7 @@ import {
   TRIGGER_PATTERN,
 } from './config.js';
 import { GmailChannel } from './channels/gmail.js';
-import { GoogleChatChannel } from './channels/googlechat.js';
+import { GoogleChatChannel, SpaceInfo } from './channels/googlechat.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
 import {
   ContainerOutput,
@@ -459,7 +459,22 @@ async function main(): Promise<void> {
     logger.warn({ err }, 'Gmail channel failed to connect, continuing without it');
   }
 
-  const googlechat = new GoogleChatChannel(channelOpts);
+  const googlechat = new GoogleChatChannel({
+    ...channelOpts,
+    getState: getRouterState,
+    setState: setRouterState,
+    onSpaceDiscovered: (jid: string, space: SpaceInfo) => {
+      if (registeredGroups[jid]) return;
+      const isDm = space.spaceType === 'DIRECT_MESSAGE';
+      registerGroup(jid, {
+        name: space.displayName,
+        folder: MAIN_GROUP_FOLDER,
+        trigger: `@${ASSISTANT_NAME}`,
+        added_at: new Date().toISOString(),
+        requiresTrigger: !isDm,
+      });
+    },
+  });
   channels.push(googlechat);
   try {
     await googlechat.connect();

--- a/.claude/skills/add-google-chat/modify/src/index.ts
+++ b/.claude/skills/add-google-chat/modify/src/index.ts
@@ -17,10 +17,7 @@ import {
   writeGroupsSnapshot,
   writeTasksSnapshot,
 } from './container-runner.js';
-import {
-  cleanupOrphans,
-  ensureContainerRuntimeRunning,
-} from './container-runtime.js';
+import { cleanupOrphans, ensureContainerRuntimeRunning } from './container-runtime.js';
 import {
   getAllChats,
   getAllRegisteredGroups,
@@ -76,7 +73,10 @@ function loadState(): void {
 
 function saveState(): void {
   setRouterState('last_timestamp', lastTimestamp);
-  setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
+  setRouterState(
+    'last_agent_timestamp',
+    JSON.stringify(lastAgentTimestamp),
+  );
 }
 
 function registerGroup(jid: string, group: RegisteredGroup): void {
@@ -122,9 +122,7 @@ export function getAvailableGroups(): import('./container-runner.js').AvailableG
 }
 
 /** @internal - exported for testing */
-export function _setRegisteredGroups(
-  groups: Record<string, RegisteredGroup>,
-): void {
+export function _setRegisteredGroups(groups: Record<string, RegisteredGroup>): void {
   registeredGroups = groups;
 }
 
@@ -145,11 +143,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
 
   const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
-  const missedMessages = getMessagesSince(
-    chatJid,
-    sinceTimestamp,
-    ASSISTANT_NAME,
-  );
+  const missedMessages = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
 
   if (missedMessages.length === 0) return true;
 
@@ -181,10 +175,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const resetIdleTimer = () => {
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
-      logger.debug(
-        { group: group.name },
-        'Idle timeout, closing container stdin',
-      );
+      logger.debug({ group: group.name }, 'Idle timeout, closing container stdin');
       queue.closeStdin(chatJid);
     }, IDLE_TIMEOUT);
   };
@@ -196,10 +187,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const output = await runAgent(group, prompt, chatJid, async (result) => {
     // Streaming output callback — called for each agent result
     if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
+      const raw = typeof result.result === 'string' ? result.result : JSON.stringify(result.result);
       // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
@@ -227,19 +215,13 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     // If we already sent output to the user, don't roll back the cursor —
     // the user got their response and re-processing would send duplicates.
     if (outputSentToUser) {
-      logger.warn(
-        { group: group.name },
-        'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
-      );
+      logger.warn({ group: group.name }, 'Agent error after output was sent, skipping cursor rollback to prevent duplicates');
       return true;
     }
     // Roll back cursor so retries can re-process these messages
     lastAgentTimestamp[chatJid] = previousCursor;
     saveState();
-    logger.warn(
-      { group: group.name },
-      'Agent error, rolled back message cursor for retry',
-    );
+    logger.warn({ group: group.name }, 'Agent error, rolled back message cursor for retry');
     return false;
   }
 
@@ -302,8 +284,7 @@ async function runAgent(
         isMain,
         assistantName: ASSISTANT_NAME,
       },
-      (proc, containerName) =>
-        queue.registerProcess(chatJid, proc, containerName, group.folder),
+      (proc, containerName) => queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
     );
 
@@ -339,11 +320,7 @@ async function startMessageLoop(): Promise<void> {
   while (true) {
     try {
       const jids = Object.keys(registeredGroups);
-      const { messages, newTimestamp } = getNewMessages(
-        jids,
-        lastTimestamp,
-        ASSISTANT_NAME,
-      );
+      const { messages, newTimestamp } = getNewMessages(jids, lastTimestamp, ASSISTANT_NAME);
 
       if (messages.length > 0) {
         logger.info({ count: messages.length }, 'New messages');
@@ -369,9 +346,7 @@ async function startMessageLoop(): Promise<void> {
 
           const channel = findChannel(channels, chatJid);
           if (!channel) {
-            console.log(
-              `Warning: no channel owns JID ${chatJid}, skipping messages`,
-            );
+            console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
             continue;
           }
 
@@ -408,11 +383,9 @@ async function startMessageLoop(): Promise<void> {
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
             // Show typing indicator while the container processes the piped message
-            channel
-              .setTyping?.(chatJid, true)
-              ?.catch((err) =>
-                logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
-              );
+            channel.setTyping?.(chatJid, true)?.catch((err) =>
+              logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
+            );
           } else {
             // No active container — enqueue for a new one
             queue.enqueueMessageCheck(chatJid);
@@ -468,13 +441,8 @@ async function main(): Promise<void> {
   // Channel callbacks (shared by all channels)
   const channelOpts = {
     onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
-    onChatMetadata: (
-      chatJid: string,
-      timestamp: string,
-      name?: string,
-      channel?: string,
-      isGroup?: boolean,
-    ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+      storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
     registeredGroups: () => registeredGroups,
   };
 
@@ -488,28 +456,13 @@ async function main(): Promise<void> {
   try {
     await gmail.connect();
   } catch (err) {
-    logger.warn(
-      { err },
-      'Gmail channel failed to connect, continuing without it',
-    );
+    logger.warn({ err }, 'Gmail channel failed to connect, continuing without it');
   }
 
   const googlechat = new GoogleChatChannel(channelOpts);
   channels.push(googlechat);
   try {
     await googlechat.connect();
-    // Auto-register the Google Chat DM as a group pointing to main folder
-    // so messages route bidirectionally (replies go back to Chat, not WhatsApp)
-    const gchatJid = googlechat.getChatJid();
-    if (googlechat.isConnected() && gchatJid && !registeredGroups[gchatJid]) {
-      registerGroup(gchatJid, {
-        name: 'Google Chat DM',
-        folder: MAIN_GROUP_FOLDER,
-        trigger: `@${ASSISTANT_NAME}`,
-        added_at: new Date().toISOString(),
-        requiresTrigger: false,
-      });
-    }
   } catch (err) {
     logger.warn({ err }, 'Google Chat channel failed to connect, continuing without it');
   }
@@ -519,8 +472,7 @@ async function main(): Promise<void> {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,
     queue,
-    onProcess: (groupJid, proc, containerName, groupFolder) =>
-      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
     sendMessage: async (jid, rawText) => {
       const channel = findChannel(channels, jid);
       if (!channel) {
@@ -539,11 +491,9 @@ async function main(): Promise<void> {
     },
     registeredGroups: () => registeredGroups,
     registerGroup,
-    syncGroupMetadata: (force) =>
-      whatsapp?.syncGroupMetadata(force) ?? Promise.resolve(),
+    syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force) ?? Promise.resolve(),
     getAvailableGroups,
-    writeGroupsSnapshot: (gf, im, ag, rj) =>
-      writeGroupsSnapshot(gf, im, ag, rj),
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
@@ -556,8 +506,7 @@ async function main(): Promise<void> {
 // Guard: only run when executed directly, not when imported by tests
 const isDirectRun =
   process.argv[1] &&
-  new URL(import.meta.url).pathname ===
-    new URL(`file://${process.argv[1]}`).pathname;
+  new URL(import.meta.url).pathname === new URL(`file://${process.argv[1]}`).pathname;
 
 if (isDirectRun) {
   main().catch((err) => {

--- a/.claude/skills/add-google-chat/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-google-chat/modify/src/index.ts.intent.md
@@ -1,0 +1,42 @@
+# Intent: src/index.ts modifications
+
+## What changed
+
+Added Google Chat as a channel.
+
+## Key sections
+
+### Imports (top of file)
+
+- Added: `GoogleChatChannel` from `./channels/googlechat.js`
+
+### main()
+
+- Added Google Chat channel creation after Gmail:
+  ```
+  const googlechat = new GoogleChatChannel(channelOpts);
+  channels.push(googlechat);
+  try { await googlechat.connect(); } catch (err) {
+    logger.warn({ err }, 'Google Chat channel failed to connect, continuing without it');
+  }
+  ```
+- Google Chat uses the same `channelOpts` callbacks as other channels
+- Incoming messages are delivered to the main group (agent decides how to respond)
+
+## Invariants
+
+- All existing message processing logic (triggers, cursors, idle timers) is preserved
+- The `runAgent` function is completely unchanged
+- State management (loadState/saveState) is unchanged
+- Recovery logic is unchanged
+- Container runtime check is unchanged
+- Any other channel creation (WhatsApp, Gmail) is untouched
+- Shutdown iterates `channels` array (Google Chat is included automatically)
+
+## Must-keep
+
+- The `escapeXml` and `formatMessages` re-exports
+- The `_setRegisteredGroups` test helper
+- The `isDirectRun` guard at bottom
+- All error handling and cursor rollback logic in processGroupMessages
+- The outgoing queue flush and reconnection logic

--- a/.claude/skills/add-google-chat/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-google-chat/modify/src/index.ts.intent.md
@@ -2,26 +2,44 @@
 
 ## What changed
 
-Added Google Chat as a channel.
+Added Google Chat as a multi-space channel with automatic space discovery, state persistence, and dynamic group registration.
 
 ## Key sections
 
 ### Imports (top of file)
 
-- Added: `GoogleChatChannel` from `./channels/googlechat.js`
+- Added: `GoogleChatChannel, SpaceInfo` from `./channels/googlechat.js`
 
 ### main()
 
-- Added Google Chat channel creation after Gmail:
+- Added Google Chat channel creation after Gmail with `onSpaceDiscovered` callback:
   ```
-  const googlechat = new GoogleChatChannel(channelOpts);
+  const googlechat = new GoogleChatChannel({
+    ...channelOpts,
+    getState: getRouterState,
+    setState: setRouterState,
+    onSpaceDiscovered: (jid: string, space: SpaceInfo) => {
+      if (registeredGroups[jid]) return;
+      const isDm = space.spaceType === 'DIRECT_MESSAGE';
+      registerGroup(jid, {
+        name: space.displayName,
+        folder: MAIN_GROUP_FOLDER,
+        trigger: `@${ASSISTANT_NAME}`,
+        added_at: new Date().toISOString(),
+        requiresTrigger: !isDm,
+      });
+    },
+  });
   channels.push(googlechat);
   try { await googlechat.connect(); } catch (err) {
     logger.warn({ err }, 'Google Chat channel failed to connect, continuing without it');
   }
   ```
-- Google Chat uses the same `channelOpts` callbacks as other channels
-- Incoming messages are delivered to the main group (agent decides how to respond)
+- `getState`/`setState` callbacks use the existing `getRouterState`/`setRouterState` from db.ts to persist poll timestamps across restarts
+- `onSpaceDiscovered` callback auto-registers each discovered space as a group:
+  - DMs: `requiresTrigger: false` (no @mention needed)
+  - Rooms: `requiresTrigger: true` (needs @mention)
+  - All spaces route to `MAIN_GROUP_FOLDER`
 
 ## Invariants
 

--- a/.claude/skills/add-google-chat/modify/src/routing.test.ts
+++ b/.claude/skills/add-google-chat/modify/src/routing.test.ts
@@ -48,27 +48,9 @@ describe('JID ownership patterns', () => {
 
 describe('getAvailableGroups', () => {
   it('returns only groups, excludes DMs', () => {
-    storeChatMetadata(
-      'group1@g.us',
-      '2024-01-01T00:00:01.000Z',
-      'Group 1',
-      'whatsapp',
-      true,
-    );
-    storeChatMetadata(
-      'user@s.whatsapp.net',
-      '2024-01-01T00:00:02.000Z',
-      'User DM',
-      'whatsapp',
-      false,
-    );
-    storeChatMetadata(
-      'group2@g.us',
-      '2024-01-01T00:00:03.000Z',
-      'Group 2',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('group1@g.us', '2024-01-01T00:00:01.000Z', 'Group 1', 'whatsapp', true);
+    storeChatMetadata('user@s.whatsapp.net', '2024-01-01T00:00:02.000Z', 'User DM', 'whatsapp', false);
+    storeChatMetadata('group2@g.us', '2024-01-01T00:00:03.000Z', 'Group 2', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(2);
@@ -79,13 +61,7 @@ describe('getAvailableGroups', () => {
 
   it('excludes __group_sync__ sentinel', () => {
     storeChatMetadata('__group_sync__', '2024-01-01T00:00:00.000Z');
-    storeChatMetadata(
-      'group@g.us',
-      '2024-01-01T00:00:01.000Z',
-      'Group',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:01.000Z', 'Group', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(1);
@@ -93,20 +69,8 @@ describe('getAvailableGroups', () => {
   });
 
   it('marks registered groups correctly', () => {
-    storeChatMetadata(
-      'reg@g.us',
-      '2024-01-01T00:00:01.000Z',
-      'Registered',
-      'whatsapp',
-      true,
-    );
-    storeChatMetadata(
-      'unreg@g.us',
-      '2024-01-01T00:00:02.000Z',
-      'Unregistered',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('reg@g.us', '2024-01-01T00:00:01.000Z', 'Registered', 'whatsapp', true);
+    storeChatMetadata('unreg@g.us', '2024-01-01T00:00:02.000Z', 'Unregistered', 'whatsapp', true);
 
     _setRegisteredGroups({
       'reg@g.us': {
@@ -126,27 +90,9 @@ describe('getAvailableGroups', () => {
   });
 
   it('returns groups ordered by most recent activity', () => {
-    storeChatMetadata(
-      'old@g.us',
-      '2024-01-01T00:00:01.000Z',
-      'Old',
-      'whatsapp',
-      true,
-    );
-    storeChatMetadata(
-      'new@g.us',
-      '2024-01-01T00:00:05.000Z',
-      'New',
-      'whatsapp',
-      true,
-    );
-    storeChatMetadata(
-      'mid@g.us',
-      '2024-01-01T00:00:03.000Z',
-      'Mid',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('old@g.us', '2024-01-01T00:00:01.000Z', 'Old', 'whatsapp', true);
+    storeChatMetadata('new@g.us', '2024-01-01T00:00:05.000Z', 'New', 'whatsapp', true);
+    storeChatMetadata('mid@g.us', '2024-01-01T00:00:03.000Z', 'Mid', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups[0].jid).toBe('new@g.us');
@@ -156,27 +102,11 @@ describe('getAvailableGroups', () => {
 
   it('excludes non-group chats regardless of JID format', () => {
     // Unknown JID format stored without is_group should not appear
-    storeChatMetadata(
-      'unknown-format-123',
-      '2024-01-01T00:00:01.000Z',
-      'Unknown',
-    );
+    storeChatMetadata('unknown-format-123', '2024-01-01T00:00:01.000Z', 'Unknown');
     // Explicitly non-group with unusual JID
-    storeChatMetadata(
-      'custom:abc',
-      '2024-01-01T00:00:02.000Z',
-      'Custom DM',
-      'custom',
-      false,
-    );
+    storeChatMetadata('custom:abc', '2024-01-01T00:00:02.000Z', 'Custom DM', 'custom', false);
     // A real group for contrast
-    storeChatMetadata(
-      'group@g.us',
-      '2024-01-01T00:00:03.000Z',
-      'Group',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:03.000Z', 'Group', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(1);
@@ -189,20 +119,8 @@ describe('getAvailableGroups', () => {
   });
 
   it('excludes Gmail threads from group list (Gmail threads are not groups)', () => {
-    storeChatMetadata(
-      'gmail:abc123',
-      '2024-01-01T00:00:01.000Z',
-      'Email thread',
-      'gmail',
-      false,
-    );
-    storeChatMetadata(
-      'group@g.us',
-      '2024-01-01T00:00:02.000Z',
-      'Group',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('gmail:abc123', '2024-01-01T00:00:01.000Z', 'Email thread', 'gmail', false);
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:02.000Z', 'Group', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(1);
@@ -210,20 +128,8 @@ describe('getAvailableGroups', () => {
   });
 
   it('excludes Google Chat DMs from group list (Chat DMs are not groups)', () => {
-    storeChatMetadata(
-      'gchat:spaceABC',
-      '2024-01-01T00:00:01.000Z',
-      'Google Chat DM',
-      'googlechat',
-      false,
-    );
-    storeChatMetadata(
-      'group@g.us',
-      '2024-01-01T00:00:02.000Z',
-      'Group',
-      'whatsapp',
-      true,
-    );
+    storeChatMetadata('gchat:spaceABC', '2024-01-01T00:00:01.000Z', 'Google Chat DM', 'googlechat', false);
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:02.000Z', 'Group', 'whatsapp', true);
 
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(1);

--- a/.claude/skills/add-google-chat/modify/src/routing.test.ts.intent.md
+++ b/.claude/skills/add-google-chat/modify/src/routing.test.ts.intent.md
@@ -1,0 +1,27 @@
+# Intent: src/routing.test.ts modifications
+
+## What changed
+
+Added Google Chat JID pattern tests and group list exclusion tests.
+
+## Key sections
+
+### JID ownership patterns
+
+- Added two tests verifying `gchat:` prefix pattern for Google Chat JIDs (space IDs)
+
+### getAvailableGroups
+
+- Added test verifying Google Chat DMs (`is_group: false`) are excluded from the available groups list, same as Gmail threads and WhatsApp DMs
+
+## Invariants
+
+- All existing WhatsApp and Gmail JID pattern tests are unchanged
+- All existing getAvailableGroups tests are unchanged
+- Test setup (beforeEach with _initTestDatabase) is unchanged
+
+## Must-keep
+
+- The `beforeEach` block that initializes a fresh test database
+- All existing JID pattern tests (WhatsApp group, WhatsApp DM, Gmail)
+- All existing getAvailableGroups tests (ordering, registration marking, sentinel exclusion)

--- a/.claude/skills/add-google-chat/tests/googlechat.test.ts
+++ b/.claude/skills/add-google-chat/tests/googlechat.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GoogleChatChannel, GoogleChatChannelOpts } from '../add/src/channels/googlechat.js';
+
+function makeOpts(overrides?: Partial<GoogleChatChannelOpts>): GoogleChatChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: () => ({}),
+    ...overrides,
+  };
+}
+
+describe('GoogleChatChannel (skill test)', () => {
+  let channel: GoogleChatChannel;
+
+  beforeEach(() => {
+    channel = new GoogleChatChannel(makeOpts());
+  });
+
+  it('ownsJid returns true for gchat: JIDs', () => {
+    expect(channel.ownsJid('gchat:abc')).toBe(true);
+  });
+
+  it('ownsJid returns false for other JIDs', () => {
+    expect(channel.ownsJid('gmail:abc')).toBe(false);
+    expect(channel.ownsJid('123@g.us')).toBe(false);
+  });
+
+  it('name is googlechat', () => {
+    expect(channel.name).toBe('googlechat');
+  });
+
+  it('isConnected returns false before connect', () => {
+    expect(channel.isConnected()).toBe(false);
+  });
+});

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -432,7 +432,8 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
+        'mcp__gmail__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -447,6 +448,10 @@ async function runQuery(
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
+        },
+        gmail: {
+          command: 'npx',
+          args: ['-y', '@gongrzhe/server-gmail-autoauth-mcp'],
         },
       },
       hooks: {

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -43,6 +43,23 @@ When you learn something important:
 - Split files larger than 500 lines into folders
 - Keep an index in your memory for the files you create
 
+## Email Notifications
+
+When you receive an email notification (messages starting with `[Email from ...`), follow this protocol:
+
+**Emails from Mike (mike@sowbug.com):**
+- Ask Mike in this chat to confirm he sent it
+- Wait for confirmation before acting on it
+- Only proceed once Mike confirms
+
+**Emails from anyone else:**
+- Read the email immediately
+- Report the content to Mike in this chat
+- Propose what action to take
+- Wait for Mike's approval before acting
+
+You have Gmail tools available — use them only when explicitly asked or approved by Mike.
+
 ## WhatsApp Formatting (and other messaging apps)
 
 Do NOT use markdown headings (##) in WhatsApp messages. Only use:

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -60,6 +60,10 @@ When you receive an email notification (messages starting with `[Email from ...`
 
 You have Gmail tools available — use them only when explicitly asked or approved by Mike.
 
+## Google Chat
+
+Google Chat is a full bidirectional channel. Messages from Google Chat appear directly in your conversation (no `[Google Chat from ...]` prefix). Your replies are automatically sent back to Google Chat — you don't need to do anything special. Just respond normally.
+
 ## WhatsApp Formatting (and other messaging apps)
 
 Do NOT use markdown headings (##) in WhatsApp messages. Only use:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "googleapis": "^144.0.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "qrcode": "^1.5.4",
@@ -137,16 +138,6 @@
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.6.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -605,471 +596,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1809,6 +1335,15 @@
         }
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1904,6 +1439,15 @@
         "prebuild-install": "^7.1.1"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1948,6 +1492,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/cacheable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
@@ -1959,6 +1509,35 @@
         "hookified": "^1.15.0",
         "keyv": "^5.5.5",
         "qified": "^0.6.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -2122,6 +1701,29 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2137,12 +1739,42 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2220,6 +1852,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",
@@ -2309,6 +1947,45 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2316,6 +1993,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2337,6 +2051,87 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2345,6 +2140,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hashery": {
@@ -2357,6 +2164,18 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -2377,6 +2196,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -2435,6 +2267,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -2490,12 +2334,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2622,6 +2495,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -2730,6 +2612,38 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -2854,7 +2768,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3099,6 +3012,21 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -3285,49 +3213,76 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "peer": true,
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://opencollective.com/libvips"
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
       },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3599,6 +3554,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3611,7 +3572,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3670,11 +3630,30 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -3682,7 +3661,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3758,7 +3736,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3829,6 +3806,22 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-module": {
@@ -3912,7 +3905,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "googleapis": "^144.0.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "qrcode": "^1.5.4",

--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -90,7 +90,7 @@ async function syncGroups(projectRoot: string): Promise<void> {
   let syncOk = false;
   try {
     const syncScript = `
-import makeWASocket, { useMultiFileAuthState, makeCacheableSignalKeyStore, Browsers } from '@whiskeysockets/baileys';
+import makeWASocket, { useMultiFileAuthState, makeCacheableSignalKeyStore, Browsers, DisconnectReason, fetchLatestWaWebVersion } from '@whiskeysockets/baileys';
 import pino from 'pino';
 import path from 'path';
 import fs from 'fs';
@@ -113,60 +113,83 @@ const upsert = db.prepare(
   'INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?) ON CONFLICT(jid) DO UPDATE SET name = excluded.name'
 );
 
-const { state, saveCreds } = await useMultiFileAuthState(authDir);
+let retries = 0;
+const MAX_RETRIES = 3;
 
-const sock = makeWASocket({
-  auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
-  printQRInTerminal: false,
-  logger,
-  browser: Browsers.macOS('Chrome'),
-});
+const { version } = await fetchLatestWaWebVersion({}).catch(() => ({ version: undefined }));
 
-const timeout = setTimeout(() => {
-  console.error('TIMEOUT');
-  process.exit(1);
-}, 30000);
+async function connect() {
+  const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
-sock.ev.on('creds.update', saveCreds);
+  const sock = makeWASocket({
+    version,
+    auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
+    printQRInTerminal: false,
+    logger,
+    browser: Browsers.macOS('Chrome'),
+  });
 
-sock.ev.on('connection.update', async (update) => {
-  if (update.connection === 'open') {
-    try {
-      const groups = await sock.groupFetchAllParticipating();
-      const now = new Date().toISOString();
-      let count = 0;
-      for (const [jid, metadata] of Object.entries(groups)) {
-        if (metadata.subject) {
-          upsert.run(jid, metadata.subject, now);
-          count++;
-        }
-      }
-      console.log('SYNCED:' + count);
-    } catch (err) {
-      console.error('FETCH_ERROR:' + err.message);
-    } finally {
-      clearTimeout(timeout);
-      sock.end(undefined);
-      db.close();
-      process.exit(0);
-    }
-  } else if (update.connection === 'close') {
-    clearTimeout(timeout);
-    console.error('CONNECTION_CLOSED');
+  const timeout = setTimeout(() => {
+    console.error('TIMEOUT');
     process.exit(1);
-  }
-});
+  }, 45000);
+
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('connection.update', async (update) => {
+    if (update.connection === 'open') {
+      try {
+        const groups = await sock.groupFetchAllParticipating();
+        const now = new Date().toISOString();
+        let count = 0;
+        for (const [jid, metadata] of Object.entries(groups)) {
+          if (metadata.subject) {
+            upsert.run(jid, metadata.subject, now);
+            count++;
+          }
+        }
+        console.log('SYNCED:' + count);
+      } catch (err) {
+        console.error('FETCH_ERROR:' + err.message);
+      } finally {
+        clearTimeout(timeout);
+        sock.end(undefined);
+        db.close();
+        process.exit(0);
+      }
+    } else if (update.connection === 'close') {
+      clearTimeout(timeout);
+      const statusCode = update.lastDisconnect?.error?.output?.statusCode;
+      if (statusCode === DisconnectReason.loggedOut) {
+        console.error('LOGGED_OUT');
+        db.close();
+        process.exit(1);
+      }
+      retries++;
+      if (retries <= MAX_RETRIES) {
+        console.error('RETRY:' + retries + ':' + statusCode);
+        sock.end(undefined);
+        await new Promise(r => setTimeout(r, 2000 * retries));
+        connect();
+      } else {
+        console.error('CONNECTION_CLOSED:' + statusCode);
+        db.close();
+        process.exit(1);
+      }
+    }
+  });
+}
+
+connect();
 `;
 
-    const output = execSync(
-      `node --input-type=module -e ${JSON.stringify(syncScript)}`,
-      {
-        cwd: projectRoot,
-        encoding: 'utf-8',
-        timeout: 45000,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      },
-    );
+    const output = execSync('node --input-type=module', {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 45000,
+      input: syncScript,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     syncOk = output.includes('SYNCED:');
     logger.info({ output: output.trim() }, 'Sync output');
   } catch (err) {

--- a/src/channels/gmail.test.ts
+++ b/src/channels/gmail.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GmailChannel, GmailChannelOpts } from './gmail.js';
+
+function makeOpts(overrides?: Partial<GmailChannelOpts>): GmailChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: () => ({}),
+    ...overrides,
+  };
+}
+
+describe('GmailChannel', () => {
+  let channel: GmailChannel;
+
+  beforeEach(() => {
+    channel = new GmailChannel(makeOpts());
+  });
+
+  describe('ownsJid', () => {
+    it('returns true for gmail: prefixed JIDs', () => {
+      expect(channel.ownsJid('gmail:abc123')).toBe(true);
+      expect(channel.ownsJid('gmail:thread-id-456')).toBe(true);
+    });
+
+    it('returns false for non-gmail JIDs', () => {
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+      expect(channel.ownsJid('tg:123')).toBe(false);
+      expect(channel.ownsJid('dc:456')).toBe(false);
+      expect(channel.ownsJid('user@s.whatsapp.net')).toBe(false);
+    });
+  });
+
+  describe('name', () => {
+    it('is gmail', () => {
+      expect(channel.name).toBe('gmail');
+    });
+  });
+
+  describe('isConnected', () => {
+    it('returns false before connect', () => {
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('sets connected to false', async () => {
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('constructor options', () => {
+    it('accepts custom poll interval', () => {
+      const ch = new GmailChannel(makeOpts(), 30000);
+      expect(ch.name).toBe('gmail');
+    });
+
+    it('defaults to unread query when no filter configured', () => {
+      const ch = new GmailChannel(makeOpts());
+      const query = (
+        ch as unknown as { buildQuery: () => string }
+      ).buildQuery();
+      expect(query).toBe('is:unread category:primary');
+    });
+
+    it('defaults with no options provided', () => {
+      const ch = new GmailChannel(makeOpts());
+      expect(ch.name).toBe('gmail');
+    });
+  });
+});

--- a/src/channels/gmail.ts
+++ b/src/channels/gmail.ts
@@ -1,0 +1,353 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { google, gmail_v1 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+import { MAIN_GROUP_FOLDER } from '../config.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface GmailChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+interface ThreadMeta {
+  sender: string;
+  senderName: string;
+  subject: string;
+  messageId: string; // RFC 2822 Message-ID for In-Reply-To
+}
+
+export class GmailChannel implements Channel {
+  name = 'gmail';
+
+  private oauth2Client: OAuth2Client | null = null;
+  private gmail: gmail_v1.Gmail | null = null;
+  private opts: GmailChannelOpts;
+  private pollIntervalMs: number;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private processedIds = new Set<string>();
+  private threadMeta = new Map<string, ThreadMeta>();
+  private consecutiveErrors = 0;
+  private userEmail = '';
+
+  constructor(opts: GmailChannelOpts, pollIntervalMs = 60000) {
+    this.opts = opts;
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
+  async connect(): Promise<void> {
+    const credDir = path.join(os.homedir(), '.gmail-mcp');
+    const keysPath = path.join(credDir, 'gcp-oauth.keys.json');
+    const tokensPath = path.join(credDir, 'credentials.json');
+
+    if (!fs.existsSync(keysPath) || !fs.existsSync(tokensPath)) {
+      logger.warn(
+        'Gmail credentials not found in ~/.gmail-mcp/. Skipping Gmail channel. Run /add-gmail to set up.',
+      );
+      return;
+    }
+
+    const keys = JSON.parse(fs.readFileSync(keysPath, 'utf-8'));
+    const tokens = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+
+    const clientConfig = keys.installed || keys.web || keys;
+    const { client_id, client_secret, redirect_uris } = clientConfig;
+    this.oauth2Client = new google.auth.OAuth2(
+      client_id,
+      client_secret,
+      redirect_uris?.[0],
+    );
+    this.oauth2Client.setCredentials(tokens);
+
+    // Persist refreshed tokens
+    this.oauth2Client.on('tokens', (newTokens) => {
+      try {
+        const current = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+        Object.assign(current, newTokens);
+        fs.writeFileSync(tokensPath, JSON.stringify(current, null, 2));
+        logger.debug('Gmail OAuth tokens refreshed');
+      } catch (err) {
+        logger.warn({ err }, 'Failed to persist refreshed Gmail tokens');
+      }
+    });
+
+    this.gmail = google.gmail({ version: 'v1', auth: this.oauth2Client });
+
+    // Verify connection
+    const profile = await this.gmail.users.getProfile({ userId: 'me' });
+    this.userEmail = profile.data.emailAddress || '';
+    logger.info({ email: this.userEmail }, 'Gmail channel connected');
+
+    // Start polling with error backoff
+    const schedulePoll = () => {
+      const backoffMs =
+        this.consecutiveErrors > 0
+          ? Math.min(
+              this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+              30 * 60 * 1000,
+            )
+          : this.pollIntervalMs;
+      this.pollTimer = setTimeout(() => {
+        this.pollForMessages()
+          .catch((err) => logger.error({ err }, 'Gmail poll error'))
+          .finally(() => {
+            if (this.gmail) schedulePoll();
+          });
+      }, backoffMs);
+    };
+
+    // Initial poll
+    await this.pollForMessages();
+    schedulePoll();
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.gmail) {
+      logger.warn('Gmail not initialized');
+      return;
+    }
+
+    const threadId = jid.replace(/^gmail:/, '');
+    const meta = this.threadMeta.get(threadId);
+
+    if (!meta) {
+      logger.warn({ jid }, 'No thread metadata for reply, cannot send');
+      return;
+    }
+
+    const subject = meta.subject.startsWith('Re:')
+      ? meta.subject
+      : `Re: ${meta.subject}`;
+
+    const headers = [
+      `To: ${meta.sender}`,
+      `From: ${this.userEmail}`,
+      `Subject: ${subject}`,
+      `In-Reply-To: ${meta.messageId}`,
+      `References: ${meta.messageId}`,
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      text,
+    ].join('\r\n');
+
+    const encodedMessage = Buffer.from(headers)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    try {
+      await this.gmail.users.messages.send({
+        userId: 'me',
+        requestBody: {
+          raw: encodedMessage,
+          threadId,
+        },
+      });
+      logger.info({ to: meta.sender, threadId }, 'Gmail reply sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Gmail reply');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.gmail !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('gmail:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.gmail = null;
+    this.oauth2Client = null;
+    logger.info('Gmail channel stopped');
+  }
+
+  // --- Private ---
+
+  private buildQuery(): string {
+    return 'is:unread category:primary';
+  }
+
+  private async pollForMessages(): Promise<void> {
+    if (!this.gmail) return;
+
+    try {
+      const query = this.buildQuery();
+      const res = await this.gmail.users.messages.list({
+        userId: 'me',
+        q: query,
+        maxResults: 10,
+      });
+
+      const messages = res.data.messages || [];
+
+      for (const stub of messages) {
+        if (!stub.id || this.processedIds.has(stub.id)) continue;
+        this.processedIds.add(stub.id);
+
+        await this.processMessage(stub.id);
+      }
+
+      // Cap processed ID set to prevent unbounded growth
+      if (this.processedIds.size > 5000) {
+        const ids = [...this.processedIds];
+        this.processedIds = new Set(ids.slice(ids.length - 2500));
+      }
+
+      this.consecutiveErrors = 0;
+    } catch (err) {
+      this.consecutiveErrors++;
+      const backoffMs = Math.min(
+        this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+        30 * 60 * 1000,
+      );
+      logger.error(
+        {
+          err,
+          consecutiveErrors: this.consecutiveErrors,
+          nextPollMs: backoffMs,
+        },
+        'Gmail poll failed',
+      );
+    }
+  }
+
+  private async processMessage(messageId: string): Promise<void> {
+    if (!this.gmail) return;
+
+    const msg = await this.gmail.users.messages.get({
+      userId: 'me',
+      id: messageId,
+      format: 'full',
+    });
+
+    const headers = msg.data.payload?.headers || [];
+    const getHeader = (name: string) =>
+      headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())
+        ?.value || '';
+
+    const from = getHeader('From');
+    const subject = getHeader('Subject');
+    const rfc2822MessageId = getHeader('Message-ID');
+    const threadId = msg.data.threadId || messageId;
+    const timestamp = new Date(
+      parseInt(msg.data.internalDate || '0', 10),
+    ).toISOString();
+
+    // Extract sender name and email
+    const senderMatch = from.match(/^(.+?)\s*<(.+?)>$/);
+    const senderName = senderMatch ? senderMatch[1].replace(/"/g, '') : from;
+    const senderEmail = senderMatch ? senderMatch[2] : from;
+
+    // Skip emails from self (our own replies)
+    if (senderEmail === this.userEmail) return;
+
+    // Extract body text
+    const body = this.extractTextBody(msg.data.payload);
+
+    if (!body) {
+      logger.debug({ messageId, subject }, 'Skipping email with no text body');
+      return;
+    }
+
+    const chatJid = `gmail:${threadId}`;
+
+    // Cache thread metadata for replies
+    this.threadMeta.set(threadId, {
+      sender: senderEmail,
+      senderName,
+      subject,
+      messageId: rfc2822MessageId,
+    });
+
+    // Store chat metadata for group discovery
+    this.opts.onChatMetadata(chatJid, timestamp, subject, 'gmail', false);
+
+    // Find the main group to deliver the email notification
+    const groups = this.opts.registeredGroups();
+    const mainEntry = Object.entries(groups).find(
+      ([, g]) => g.folder === MAIN_GROUP_FOLDER,
+    );
+
+    if (!mainEntry) {
+      logger.debug(
+        { chatJid, subject },
+        'No main group registered, skipping email',
+      );
+      return;
+    }
+
+    const mainJid = mainEntry[0];
+    const content = `[Email from ${senderName} <${senderEmail}>]\nSubject: ${subject}\n\n${body}`;
+
+    this.opts.onMessage(mainJid, {
+      id: messageId,
+      chat_jid: mainJid,
+      sender: senderEmail,
+      sender_name: senderName,
+      content,
+      timestamp,
+      is_from_me: false,
+    });
+
+    // Mark as read
+    try {
+      await this.gmail.users.messages.modify({
+        userId: 'me',
+        id: messageId,
+        requestBody: { removeLabelIds: ['UNREAD'] },
+      });
+    } catch (err) {
+      logger.warn({ messageId, err }, 'Failed to mark email as read');
+    }
+
+    logger.info(
+      { mainJid, from: senderName, subject },
+      'Gmail email delivered to main group',
+    );
+  }
+
+  private extractTextBody(
+    payload: gmail_v1.Schema$MessagePart | undefined,
+  ): string {
+    if (!payload) return '';
+
+    // Direct text/plain body
+    if (payload.mimeType === 'text/plain' && payload.body?.data) {
+      return Buffer.from(payload.body.data, 'base64').toString('utf-8');
+    }
+
+    // Multipart: search parts recursively
+    if (payload.parts) {
+      // Prefer text/plain
+      for (const part of payload.parts) {
+        if (part.mimeType === 'text/plain' && part.body?.data) {
+          return Buffer.from(part.body.data, 'base64').toString('utf-8');
+        }
+      }
+      // Recurse into nested multipart
+      for (const part of payload.parts) {
+        const text = this.extractTextBody(part);
+        if (text) return text;
+      }
+    }
+
+    return '';
+  }
+}

--- a/src/channels/googlechat.test.ts
+++ b/src/channels/googlechat.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GoogleChatChannel, GoogleChatChannelOpts } from './googlechat.js';
+
+function makeOpts(overrides?: Partial<GoogleChatChannelOpts>): GoogleChatChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: () => ({}),
+    ...overrides,
+  };
+}
+
+describe('GoogleChatChannel', () => {
+  let channel: GoogleChatChannel;
+
+  beforeEach(() => {
+    channel = new GoogleChatChannel(makeOpts());
+  });
+
+  describe('ownsJid', () => {
+    it('returns true for gchat: prefixed JIDs', () => {
+      expect(channel.ownsJid('gchat:abc123')).toBe(true);
+      expect(channel.ownsJid('gchat:space-id-456')).toBe(true);
+    });
+
+    it('returns false for non-gchat JIDs', () => {
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+      expect(channel.ownsJid('gmail:abc123')).toBe(false);
+      expect(channel.ownsJid('tg:123')).toBe(false);
+      expect(channel.ownsJid('user@s.whatsapp.net')).toBe(false);
+    });
+  });
+
+  describe('name', () => {
+    it('is googlechat', () => {
+      expect(channel.name).toBe('googlechat');
+    });
+  });
+
+  describe('isConnected', () => {
+    it('returns false before connect', () => {
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('sets connected to false', async () => {
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('constructor options', () => {
+    it('accepts custom poll interval', () => {
+      const ch = new GoogleChatChannel(makeOpts(), 5000);
+      expect(ch.name).toBe('googlechat');
+    });
+  });
+});

--- a/src/channels/googlechat.test.ts
+++ b/src/channels/googlechat.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { GoogleChatChannel, GoogleChatChannelOpts } from './googlechat.js';
 
-function makeOpts(overrides?: Partial<GoogleChatChannelOpts>): GoogleChatChannelOpts {
+function makeOpts(
+  overrides?: Partial<GoogleChatChannelOpts>,
+): GoogleChatChannelOpts {
   return {
     onMessage: vi.fn(),
     onChatMetadata: vi.fn(),

--- a/src/channels/googlechat.ts
+++ b/src/channels/googlechat.ts
@@ -1,0 +1,221 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { google, chat_v1 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface GoogleChatChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class GoogleChatChannel implements Channel {
+  name = 'googlechat';
+
+  private oauth2Client: OAuth2Client | null = null;
+  private chat: chat_v1.Chat | null = null;
+  private opts: GoogleChatChannelOpts;
+  private pollIntervalMs: number;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastPollTime: string | null = null;
+  private spaceId: string;
+  private consecutiveErrors = 0;
+
+  constructor(opts: GoogleChatChannelOpts, pollIntervalMs = 15000) {
+    this.opts = opts;
+    this.pollIntervalMs = pollIntervalMs;
+    const envConfig = readEnvFile(['GOOGLE_CHAT_SPACE_ID']);
+    this.spaceId = process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
+  }
+
+  async connect(): Promise<void> {
+    const credDir = path.join(os.homedir(), '.google-chat-mcp');
+    const keysPath = path.join(credDir, 'gcp-oauth.keys.json');
+    const tokensPath = path.join(credDir, 'credentials.json');
+
+    if (!fs.existsSync(keysPath) || !fs.existsSync(tokensPath)) {
+      logger.warn(
+        'Google Chat credentials not found in ~/.google-chat-mcp/. Skipping Google Chat channel. Run /add-google-chat to set up.',
+      );
+      return;
+    }
+
+    if (!this.spaceId) {
+      logger.warn(
+        'GOOGLE_CHAT_SPACE_ID not set. Skipping Google Chat channel. Set it in .env.',
+      );
+      return;
+    }
+
+    const keys = JSON.parse(fs.readFileSync(keysPath, 'utf-8'));
+    const tokens = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+
+    const clientConfig = keys.installed || keys.web || keys;
+    const { client_id, client_secret, redirect_uris } = clientConfig;
+    this.oauth2Client = new google.auth.OAuth2(
+      client_id,
+      client_secret,
+      redirect_uris?.[0],
+    );
+    this.oauth2Client.setCredentials(tokens);
+
+    // Persist refreshed tokens
+    this.oauth2Client.on('tokens', (newTokens) => {
+      try {
+        const current = JSON.parse(fs.readFileSync(tokensPath, 'utf-8'));
+        Object.assign(current, newTokens);
+        fs.writeFileSync(tokensPath, JSON.stringify(current, null, 2));
+        logger.debug('Google Chat OAuth tokens refreshed');
+      } catch (err) {
+        logger.warn({ err }, 'Failed to persist refreshed Google Chat tokens');
+      }
+    });
+
+    this.chat = google.chat({ version: 'v1', auth: this.oauth2Client });
+
+    logger.info({ spaceId: this.spaceId }, 'Google Chat channel connected');
+
+    // Start polling with error backoff
+    const schedulePoll = () => {
+      const backoffMs = this.consecutiveErrors > 0
+        ? Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000)
+        : this.pollIntervalMs;
+      this.pollTimer = setTimeout(() => {
+        this.pollForMessages()
+          .catch((err) => logger.error({ err }, 'Google Chat poll error'))
+          .finally(() => {
+            if (this.chat) schedulePoll();
+          });
+      }, backoffMs);
+    };
+
+    // Initial poll
+    await this.pollForMessages();
+    schedulePoll();
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.chat) {
+      logger.warn('Google Chat not initialized');
+      return;
+    }
+
+    const spaceId = jid.replace(/^gchat:/, '');
+
+    try {
+      await this.chat.spaces.messages.create({
+        parent: `spaces/${spaceId}`,
+        requestBody: { text },
+      });
+      logger.info({ spaceId }, 'Google Chat message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Google Chat message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.chat !== null;
+  }
+
+  /** Returns the gchat: JID for the configured space, or empty if not configured. */
+  getChatJid(): string {
+    return this.spaceId ? `gchat:${this.spaceId}` : '';
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('gchat:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.chat = null;
+    this.oauth2Client = null;
+    logger.info('Google Chat channel stopped');
+  }
+
+  // --- Private ---
+
+  private async pollForMessages(): Promise<void> {
+    if (!this.chat) return;
+
+    try {
+      const filterParts: string[] = [];
+      if (this.lastPollTime) {
+        filterParts.push(`createTime > "${this.lastPollTime}"`);
+      }
+      const filter = filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+
+      const res = await this.chat.spaces.messages.list({
+        parent: `spaces/${this.spaceId}`,
+        filter: filter || undefined,
+        orderBy: 'createTime',
+        pageSize: 25,
+      });
+
+      const messages = res.data.messages || [];
+
+      for (const msg of messages) {
+        // Skip bot messages (our own replies)
+        if (msg.sender?.type === 'BOT') continue;
+
+        await this.processMessage(msg);
+      }
+
+      // Update the last poll timestamp to now
+      this.lastPollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+      this.consecutiveErrors = 0;
+    } catch (err) {
+      this.consecutiveErrors++;
+      const backoffMs = Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000);
+      logger.error({ err, consecutiveErrors: this.consecutiveErrors, nextPollMs: backoffMs }, 'Google Chat poll failed');
+    }
+  }
+
+  private async processMessage(msg: chat_v1.Schema$Message): Promise<void> {
+    const text = msg.text || '';
+    if (!text) return;
+
+    const senderName = msg.sender?.displayName || 'Unknown';
+    const createTime = msg.createTime || new Date().toISOString();
+    const messageName = msg.name || ''; // e.g. "spaces/xxx/messages/yyy"
+    const messageId = messageName.split('/').pop() || messageName;
+
+    const chatJid = `gchat:${this.spaceId}`;
+
+    // Store chat metadata
+    this.opts.onChatMetadata(chatJid, createTime, `Google Chat DM`, 'googlechat', false);
+
+    // Deliver under the gchat: JID so replies route back through Google Chat.
+    // The gchat: JID must be registered (pointing to the main folder) for
+    // the message loop to pick it up.
+    this.opts.onMessage(chatJid, {
+      id: messageId,
+      chat_jid: chatJid,
+      sender: senderName,
+      sender_name: senderName,
+      content: text,
+      timestamp: createTime,
+      is_from_me: false,
+    });
+
+    logger.info(
+      { chatJid, from: senderName },
+      'Google Chat message delivered',
+    );
+  }
+}

--- a/src/channels/googlechat.ts
+++ b/src/channels/googlechat.ts
@@ -36,7 +36,8 @@ export class GoogleChatChannel implements Channel {
     this.opts = opts;
     this.pollIntervalMs = pollIntervalMs;
     const envConfig = readEnvFile(['GOOGLE_CHAT_SPACE_ID']);
-    this.spaceId = process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
+    this.spaceId =
+      process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
   }
 
   async connect(): Promise<void> {
@@ -88,9 +89,13 @@ export class GoogleChatChannel implements Channel {
 
     // Start polling with error backoff
     const schedulePoll = () => {
-      const backoffMs = this.consecutiveErrors > 0
-        ? Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000)
-        : this.pollIntervalMs;
+      const backoffMs =
+        this.consecutiveErrors > 0
+          ? Math.min(
+              this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+              30 * 60 * 1000,
+            )
+          : this.pollIntervalMs;
       this.pollTimer = setTimeout(() => {
         this.pollForMessages()
           .catch((err) => logger.error({ err }, 'Google Chat poll error'))
@@ -157,7 +162,8 @@ export class GoogleChatChannel implements Channel {
       if (this.lastPollTime) {
         filterParts.push(`createTime > "${this.lastPollTime}"`);
       }
-      const filter = filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+      const filter =
+        filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
 
       const res = await this.chat.spaces.messages.list({
         parent: `spaces/${this.spaceId}`,
@@ -181,8 +187,18 @@ export class GoogleChatChannel implements Channel {
       this.consecutiveErrors = 0;
     } catch (err) {
       this.consecutiveErrors++;
-      const backoffMs = Math.min(this.pollIntervalMs * Math.pow(2, this.consecutiveErrors), 30 * 60 * 1000);
-      logger.error({ err, consecutiveErrors: this.consecutiveErrors, nextPollMs: backoffMs }, 'Google Chat poll failed');
+      const backoffMs = Math.min(
+        this.pollIntervalMs * Math.pow(2, this.consecutiveErrors),
+        30 * 60 * 1000,
+      );
+      logger.error(
+        {
+          err,
+          consecutiveErrors: this.consecutiveErrors,
+          nextPollMs: backoffMs,
+        },
+        'Google Chat poll failed',
+      );
     }
   }
 
@@ -198,7 +214,13 @@ export class GoogleChatChannel implements Channel {
     const chatJid = `gchat:${this.spaceId}`;
 
     // Store chat metadata
-    this.opts.onChatMetadata(chatJid, createTime, `Google Chat DM`, 'googlechat', false);
+    this.opts.onChatMetadata(
+      chatJid,
+      createTime,
+      `Google Chat DM`,
+      'googlechat',
+      false,
+    );
 
     // Deliver under the gchat: JID so replies route back through Google Chat.
     // The gchat: JID must be registered (pointing to the main folder) for
@@ -213,9 +235,6 @@ export class GoogleChatChannel implements Channel {
       is_from_me: false,
     });
 
-    logger.info(
-      { chatJid, from: senderName },
-      'Google Chat message delivered',
-    );
+    logger.info({ chatJid, from: senderName }, 'Google Chat message delivered');
   }
 }

--- a/src/channels/googlechat.ts
+++ b/src/channels/googlechat.ts
@@ -18,6 +18,16 @@ export interface GoogleChatChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  onSpaceDiscovered?: (jid: string, space: SpaceInfo) => void;
+  getState?: (key: string) => string | undefined;
+  setState?: (key: string, value: string) => void;
+}
+
+export interface SpaceInfo {
+  spaceId: string;
+  displayName: string;
+  spaceType: string; // DIRECT_MESSAGE, SPACE, GROUP_CHAT
+  lastPollTime: string | null;
 }
 
 export class GoogleChatChannel implements Channel {
@@ -28,15 +38,18 @@ export class GoogleChatChannel implements Channel {
   private opts: GoogleChatChannelOpts;
   private pollIntervalMs: number;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
-  private lastPollTime: string | null = null;
-  private spaceId: string;
+  private spaces: Map<string, SpaceInfo> = new Map();
   private consecutiveErrors = 0;
+  private filterSpaceId: string;
+  private botUserId: string | null = null;
+  private discoveryCounter = 0;
+  private readonly DISCOVERY_INTERVAL = 10; // re-discover every N poll cycles
 
   constructor(opts: GoogleChatChannelOpts, pollIntervalMs = 15000) {
     this.opts = opts;
     this.pollIntervalMs = pollIntervalMs;
     const envConfig = readEnvFile(['GOOGLE_CHAT_SPACE_ID']);
-    this.spaceId =
+    this.filterSpaceId =
       process.env.GOOGLE_CHAT_SPACE_ID || envConfig.GOOGLE_CHAT_SPACE_ID || '';
   }
 
@@ -48,13 +61,6 @@ export class GoogleChatChannel implements Channel {
     if (!fs.existsSync(keysPath) || !fs.existsSync(tokensPath)) {
       logger.warn(
         'Google Chat credentials not found in ~/.google-chat-mcp/. Skipping Google Chat channel. Run /add-google-chat to set up.',
-      );
-      return;
-    }
-
-    if (!this.spaceId) {
-      logger.warn(
-        'GOOGLE_CHAT_SPACE_ID not set. Skipping Google Chat channel. Set it in .env.',
       );
       return;
     }
@@ -85,7 +91,17 @@ export class GoogleChatChannel implements Channel {
 
     this.chat = google.chat({ version: 'v1', auth: this.oauth2Client });
 
-    logger.info({ spaceId: this.spaceId }, 'Google Chat channel connected');
+    // Discover spaces the bot belongs to
+    await this.discoverSpaces();
+
+    if (this.spaces.size === 0) {
+      logger.warn('Google Chat: no spaces discovered, channel idle');
+    } else {
+      logger.info(
+        { spaceCount: this.spaces.size },
+        'Google Chat channel connected',
+      );
+    }
 
     // Start polling with error backoff
     const schedulePoll = () => {
@@ -133,9 +149,9 @@ export class GoogleChatChannel implements Channel {
     return this.chat !== null;
   }
 
-  /** Returns the gchat: JID for the configured space, or empty if not configured. */
-  getChatJid(): string {
-    return this.spaceId ? `gchat:${this.spaceId}` : '';
+  /** Returns all discovered spaces with their JIDs and metadata. */
+  getDiscoveredSpaces(): SpaceInfo[] {
+    return Array.from(this.spaces.values());
   }
 
   ownsJid(jid: string): boolean {
@@ -154,36 +170,88 @@ export class GoogleChatChannel implements Channel {
 
   // --- Private ---
 
-  private async pollForMessages(): Promise<void> {
+  private async discoverSpaces(): Promise<void> {
     if (!this.chat) return;
 
     try {
-      const filterParts: string[] = [];
-      if (this.lastPollTime) {
-        filterParts.push(`createTime > "${this.lastPollTime}"`);
+      let pageToken: string | undefined;
+      const discovered: chat_v1.Schema$Space[] = [];
+
+      do {
+        const res = await this.chat.spaces.list({
+          pageSize: 100,
+          pageToken,
+        });
+        if (res.data.spaces) {
+          discovered.push(...res.data.spaces);
+        }
+        pageToken = res.data.nextPageToken || undefined;
+      } while (pageToken);
+
+      for (const space of discovered) {
+        const spaceId = space.name?.replace(/^spaces\//, '');
+        if (!spaceId) continue;
+
+        // If a filter is set, only include that specific space
+        if (this.filterSpaceId && spaceId !== this.filterSpaceId) continue;
+
+        const existing = this.spaces.get(spaceId);
+        if (!existing) {
+          const spaceType = space.spaceType || space.type || 'SPACE';
+          const isDm = spaceType === 'DIRECT_MESSAGE';
+          const displayName = isDm
+            ? 'Google Chat DM'
+            : space.displayName || `Space ${spaceId}`;
+
+          const savedPollTime =
+            this.opts.getState?.(`gchat:poll:${spaceId}`) ?? null;
+
+          this.spaces.set(spaceId, {
+            spaceId,
+            displayName,
+            spaceType,
+            lastPollTime: savedPollTime,
+          });
+
+          const chatJid = `gchat:${spaceId}`;
+
+          // Notify metadata callback so the space is tracked in the DB
+          this.opts.onChatMetadata(
+            chatJid,
+            new Date().toISOString(),
+            displayName,
+            'googlechat',
+            !isDm,
+          );
+
+          logger.info(
+            { spaceId, displayName, spaceType },
+            'Discovered new Google Chat space',
+          );
+
+          // Notify index.ts to register this space as a group
+          this.opts.onSpaceDiscovered?.(chatJid, this.spaces.get(spaceId)!);
+        }
       }
-      const filter =
-        filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+    } catch (err) {
+      logger.error({ err }, 'Failed to discover Google Chat spaces');
+    }
+  }
 
-      const res = await this.chat.spaces.messages.list({
-        parent: `spaces/${this.spaceId}`,
-        filter: filter || undefined,
-        orderBy: 'createTime',
-        pageSize: 25,
-      });
+  private async pollForMessages(): Promise<void> {
+    if (!this.chat) return;
 
-      const messages = res.data.messages || [];
+    // Periodically re-discover spaces to pick up new rooms
+    this.discoveryCounter++;
+    if (this.discoveryCounter >= this.DISCOVERY_INTERVAL) {
+      this.discoveryCounter = 0;
+      await this.discoverSpaces();
+    }
 
-      for (const msg of messages) {
-        // Skip bot messages (our own replies)
-        if (msg.sender?.type === 'BOT') continue;
-
-        await this.processMessage(msg);
+    try {
+      for (const [spaceId, spaceInfo] of this.spaces) {
+        await this.pollSpace(spaceId, spaceInfo);
       }
-
-      // Update the last poll timestamp to now
-      this.lastPollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-
       this.consecutiveErrors = 0;
     } catch (err) {
       this.consecutiveErrors++;
@@ -202,29 +270,98 @@ export class GoogleChatChannel implements Channel {
     }
   }
 
-  private async processMessage(msg: chat_v1.Schema$Message): Promise<void> {
-    const text = msg.text || '';
+  private async pollSpace(
+    spaceId: string,
+    spaceInfo: SpaceInfo,
+  ): Promise<void> {
+    if (!this.chat) return;
+
+    try {
+      const filterParts: string[] = [];
+      if (spaceInfo.lastPollTime) {
+        filterParts.push(`createTime > "${spaceInfo.lastPollTime}"`);
+      }
+      const filter =
+        filterParts.length > 0 ? filterParts.join(' AND ') : undefined;
+
+      const res = await this.chat.spaces.messages.list({
+        parent: `spaces/${spaceId}`,
+        filter: filter || undefined,
+        orderBy: 'createTime',
+        pageSize: 25,
+      });
+
+      const messages = res.data.messages || [];
+
+      for (const msg of messages) {
+        // Skip bot messages (our own replies)
+        if (msg.sender?.type === 'BOT') continue;
+
+        // Track the bot's user ID from message annotations so we can strip self-mentions
+        if (!this.botUserId && msg.annotations) {
+          for (const ann of msg.annotations) {
+            if (
+              ann.type === 'USER_MENTION' &&
+              ann.userMention?.user?.type === 'BOT'
+            ) {
+              this.botUserId = ann.userMention.user.name || null;
+            }
+          }
+        }
+
+        await this.processMessage(msg, spaceId, spaceInfo);
+      }
+
+      // Update the last poll timestamp for this space
+      const pollTime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+      spaceInfo.lastPollTime = pollTime;
+      this.opts.setState?.(`gchat:poll:${spaceId}`, pollTime);
+    } catch (err) {
+      logger.error({ spaceId, err }, 'Failed to poll Google Chat space');
+    }
+  }
+
+  private async processMessage(
+    msg: chat_v1.Schema$Message,
+    spaceId: string,
+    spaceInfo: SpaceInfo,
+  ): Promise<void> {
+    let text = msg.text || '';
+    if (!text) return;
+
+    // Strip raw Google Chat mention markup (e.g. `<users/123456>`) but keep
+    // the human-readable `@Name` so the trigger pattern still matches.
+    if (this.botUserId) {
+      text = text
+        .replace(new RegExp(`<${this.botUserId}>\\s*`, 'g'), '')
+        .trim();
+    }
+
     if (!text) return;
 
     const senderName = msg.sender?.displayName || 'Unknown';
+    if (!msg.sender?.displayName) {
+      logger.debug(
+        { sender: msg.sender, messageName: msg.name },
+        'Google Chat message has no sender displayName',
+      );
+    }
     const createTime = msg.createTime || new Date().toISOString();
     const messageName = msg.name || ''; // e.g. "spaces/xxx/messages/yyy"
     const messageId = messageName.split('/').pop() || messageName;
 
-    const chatJid = `gchat:${this.spaceId}`;
+    const chatJid = `gchat:${spaceId}`;
+    const isDm = spaceInfo.spaceType === 'DIRECT_MESSAGE';
 
     // Store chat metadata
     this.opts.onChatMetadata(
       chatJid,
       createTime,
-      `Google Chat DM`,
+      spaceInfo.displayName,
       'googlechat',
-      false,
+      !isDm,
     );
 
-    // Deliver under the gchat: JID so replies route back through Google Chat.
-    // The gchat: JID must be registered (pointing to the main folder) for
-    // the message loop to pick it up.
     this.opts.onMessage(chatJid, {
       id: messageId,
       chat_jid: chatJid,
@@ -235,6 +372,9 @@ export class GoogleChatChannel implements Channel {
       is_from_me: false,
     });
 
-    logger.info({ chatJid, from: senderName }, 'Google Chat message delivered');
+    logger.info(
+      { chatJid, from: senderName, spaceType: spaceInfo.spaceType },
+      'Google Chat message delivered',
+    );
   }
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, exec, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -60,6 +61,7 @@ function buildVolumeMounts(
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
+  const homeDir = os.homedir();
   const groupDir = resolveGroupFolderPath(group.folder);
 
   if (isMain) {
@@ -160,6 +162,16 @@ function buildVolumeMounts(
     containerPath: '/home/node/.claude',
     readonly: false,
   });
+
+  // Gmail credentials directory (for Gmail MCP inside the container)
+  const gmailDir = path.join(homeDir, '.gmail-mcp');
+  if (fs.existsSync(gmailDir)) {
+    mounts.push({
+      hostPath: gmailDir,
+      containerPath: '/home/node/.gmail-mcp',
+      readonly: false, // MCP may need to refresh OAuth tokens
+    });
+  }
 
   // Per-group IPC namespace: each group gets its own IPC directory
   // This prevents cross-group privilege escalation via IPC

--- a/src/index.ts
+++ b/src/index.ts
@@ -511,7 +511,10 @@ async function main(): Promise<void> {
       });
     }
   } catch (err) {
-    logger.warn({ err }, 'Google Chat channel failed to connect, continuing without it');
+    logger.warn(
+      { err },
+      'Google Chat channel failed to connect, continuing without it',
+    );
   }
 
   // Start subsystems (independently of connection handler)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   POLL_INTERVAL,
   TRIGGER_PATTERN,
 } from './config.js';
+import { GmailChannel } from './channels/gmail.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
 import {
   ContainerOutput,
@@ -136,7 +137,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   const channel = findChannel(channels, chatJid);
   if (!channel) {
-    logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+    console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
     return true;
   }
 
@@ -367,7 +368,9 @@ async function startMessageLoop(): Promise<void> {
 
           const channel = findChannel(channels, chatJid);
           if (!channel) {
-            logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+            console.log(
+              `Warning: no channel owns JID ${chatJid}, skipping messages`,
+            );
             continue;
           }
 
@@ -479,6 +482,17 @@ async function main(): Promise<void> {
   channels.push(whatsapp);
   await whatsapp.connect();
 
+  const gmail = new GmailChannel(channelOpts);
+  channels.push(gmail);
+  try {
+    await gmail.connect();
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Gmail channel failed to connect, continuing without it',
+    );
+  }
+
   // Start subsystems (independently of connection handler)
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
@@ -489,7 +503,7 @@ async function main(): Promise<void> {
     sendMessage: async (jid, rawText) => {
       const channel = findChannel(channels, jid);
       if (!channel) {
-        logger.warn({ jid }, 'No channel owns JID, cannot send message');
+        console.log(`Warning: no channel owns JID ${jid}, cannot send message`);
         return;
       }
       const text = formatOutbound(rawText);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   TRIGGER_PATTERN,
 } from './config.js';
 import { GmailChannel } from './channels/gmail.js';
-import { GoogleChatChannel } from './channels/googlechat.js';
+import { GoogleChatChannel, SpaceInfo } from './channels/googlechat.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
 import {
   ContainerOutput,
@@ -494,22 +494,25 @@ async function main(): Promise<void> {
     );
   }
 
-  const googlechat = new GoogleChatChannel(channelOpts);
-  channels.push(googlechat);
-  try {
-    await googlechat.connect();
-    // Auto-register the Google Chat DM as a group pointing to main folder
-    // so messages route bidirectionally (replies go back to Chat, not WhatsApp)
-    const gchatJid = googlechat.getChatJid();
-    if (googlechat.isConnected() && gchatJid && !registeredGroups[gchatJid]) {
-      registerGroup(gchatJid, {
-        name: 'Google Chat DM',
+  const googlechat = new GoogleChatChannel({
+    ...channelOpts,
+    getState: getRouterState,
+    setState: setRouterState,
+    onSpaceDiscovered: (jid: string, space: SpaceInfo) => {
+      if (registeredGroups[jid]) return;
+      const isDm = space.spaceType === 'DIRECT_MESSAGE';
+      registerGroup(jid, {
+        name: space.displayName,
         folder: MAIN_GROUP_FOLDER,
         trigger: `@${ASSISTANT_NAME}`,
         added_at: new Date().toISOString(),
-        requiresTrigger: false,
+        requiresTrigger: !isDm,
       });
-    }
+    },
+  });
+  channels.push(googlechat);
+  try {
+    await googlechat.connect();
   } catch (err) {
     logger.warn(
       { err },

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -22,6 +22,16 @@ describe('JID ownership patterns', () => {
     const jid = '12345678@s.whatsapp.net';
     expect(jid.endsWith('@s.whatsapp.net')).toBe(true);
   });
+
+  it('Gmail JID: starts with gmail:', () => {
+    const jid = 'gmail:abc123def';
+    expect(jid.startsWith('gmail:')).toBe(true);
+  });
+
+  it('Gmail thread JID: starts with gmail: followed by thread ID', () => {
+    const jid = 'gmail:18d3f4a5b6c7d8e9';
+    expect(jid.startsWith('gmail:')).toBe(true);
+  });
 });
 
 // --- getAvailableGroups ---
@@ -166,5 +176,26 @@ describe('getAvailableGroups', () => {
   it('returns empty array when no chats exist', () => {
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(0);
+  });
+
+  it('excludes Gmail threads from group list (Gmail threads are not groups)', () => {
+    storeChatMetadata(
+      'gmail:abc123',
+      '2024-01-01T00:00:01.000Z',
+      'Email thread',
+      'gmail',
+      false,
+    );
+    storeChatMetadata(
+      'group@g.us',
+      '2024-01-01T00:00:02.000Z',
+      'Group',
+      'whatsapp',
+      true,
+    );
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('group@g.us');
   });
 });


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Adds support for Google Chat. Similar to WhatsApp support. Tested on Google Workspace account; allows DM to nanoclaw agent, adding agent to chat rooms, and optional filtering on specific chat rooms/DMs. Through existing nanoclaw logic, agent can be configured to respond to every message in every room, only messages where agent is @-mentioned, or only where contextually appropriate to respond.

According to [Google Chat API documentation](https://developers.google.com/workspace/chat/overview), this should work with Gmail accounts as of recently. Previously, you needed a Workspace account to use the Chat API, but this has changed. **I haven't tested with a plain Gmail account.**

## For Skills

- [ ] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone

Note that source-code changes have been made to add channels/googlechat.ts and tests. This appears to be appropriate to do given that this is a new channel of communication that is neither Gmail nor WhatApp. If this is the wrong path to take, I'm sure you'll let me know.