### PR TITLE
feat: add /add-feishu skill for Feishu (Lark) channel

### DIFF
--- a/.claude/skills/add-feishu/FEISHU_SETUP.md
+++ b/.claude/skills/add-feishu/FEISHU_SETUP.md
@@ -1,0 +1,137 @@
+# Feishu (Lark) Bot Setup Guide
+
+This guide walks you through creating and configuring a Feishu custom app to use as an NanoClaw channel.
+
+---
+
+## Step 1: Create a Feishu Custom App
+
+### For Mainland China users:
+1. Go to [open.feishu.cn/app](https://open.feishu.cn/app)
+
+### For international (Lark) users:
+1. Go to [open.larksuite.com/app](https://open.larksuite.com/app)
+
+2. Log in with your Feishu / Lark account
+3. Click **Create Custom App**
+4. Give the app a name (e.g., "NanoClaw") and description
+5. Click **Create**
+
+---
+
+## Step 2: Enable Bot Capability
+
+1. In your app's dashboard, go to **Add Capabilities**
+2. Select **Bot** and enable it
+3. Optionally configure the bot's name and avatar
+
+---
+
+## Step 3: Configure Event Subscriptions
+
+1. Go to **Event Subscriptions** in the left menu
+2. Set **Request URL Verification** mode to **WebSocket (Long Connection)**
+   - This means NO public URL is required!
+3. In the **Add Event** section, enable these events:
+   - `im.message.receive_v1` — Receive messages (**required**)
+   - `im.chat.member.bot.added_v1` — Bot added to group (optional, for logging)
+   - `im.chat.member.bot.deleted_v1` — Bot removed from group (optional, for logging)
+
+---
+
+## Step 4: Configure Permissions
+
+1. Go to **Permissions & Scopes** (or **OAuth Scopes**)
+2. Add these permissions:
+   - `im:message` — Read and send messages (**required**)
+   - `im:message.group_at_msg` — Receive @ messages in groups
+   - `im:chat` — Access chat information (for fetching group names)
+   - `contact:user.base:readonly` — Read user basic info (for resolving sender names)
+
+---
+
+## Step 5: Get Credentials
+
+1. Go to **Credentials & Basic Info** in the left menu
+2. Copy:
+   - **App ID** (format: `cli_xxxxxxxxxx`)  
+   - **App Secret** (click "View" to reveal)
+
+Keep these safe — you'll need them in the next step.
+
+---
+
+## Step 6: Publish the App
+
+For the bot to receive messages, the app must be published to your workspace:
+
+1. Go to **Version Management & Release**
+2. Click **Create Version**
+3. Fill in version info and click **Save**
+4. Click **Request Release** (for enterprise) or **Publish** (for self-built)
+5. If enterprise approval is needed, ask your admin to approve it
+
+**Self-built apps** in Feishu can usually be published immediately without approval.
+
+---
+
+## Step 7: Add Bot to Groups
+
+1. Open the Feishu group where you want the bot to work
+2. Click the group settings → **Members** → **Add Members**
+3. Search for your app name and add it
+4. The bot is now a member of the group
+
+---
+
+## Token Reference
+
+| Credential | Format | Where to find |
+|------------|--------|---------------|
+| App ID | `cli_xxxxxxxxxx` | Credentials & Basic Info page |
+| App Secret | Long random string | Credentials & Basic Info page (click View) |
+| Encrypt Key | Optional | Event Subscriptions → Security Settings |
+| Verification Token | Optional | Event Subscriptions → Security Settings |
+
+---
+
+## Finding Chat IDs
+
+### Method 1: From NanoClaw logs
+After adding the bot to a group and sending a message, check the logs:
+```bash
+tail -f logs/nanoclaw.log | grep "onChatMetadata"
+```
+The `jid` field in the log is the chat ID.
+
+### Method 2: Via Feishu API
+```bash
+# Get all group chats the bot is in
+curl -H "Authorization: Bearer $(cat store/feishu-token.txt)" \
+  "https://open.feishu.cn/open-apis/im/v1/chats?bot_open_id=<BOT_OPEN_ID>"
+```
+
+### Chat ID Formats
+- `oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` — Group chat
+- `ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` — Direct message (user open_id)
+
+---
+
+## Troubleshooting
+
+### "App not found" when adding to group
+- Make sure the app is published to your workspace
+- Self-built apps must be published even if just to your own workspace
+
+### "Insufficient permissions" errors
+- Go back to Permissions & Scopes and add missing permissions
+- After adding permissions, **re-publish the app** (permission changes require republishing)
+
+### Events not received
+- Verify Event Subscriptions are enabled and the WebSocket mode is selected
+- Check that the required events are added under "subscribed events"
+- Verify the app is published
+
+### Bot responds but messages aren't stored
+- The chat must be registered in NanoClaw first
+- Run the registration step in Phase 4 of the skill

--- a/.claude/skills/add-feishu/SKILL.md
+++ b/.claude/skills/add-feishu/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: add-feishu
+description: Add Feishu (Lark) as a channel. Uses WebSocket long-connection mode (no public URL needed). Can run alongside WhatsApp or other channels.
+---
+
+# Add Feishu Channel
+
+This skill adds Feishu (Lark) support to NanoClaw using the skills engine for deterministic code changes, then walks through interactive setup.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `feishu` is in `applied_skills`, skip to Phase 3 (Setup). The code changes are already in place.
+
+### Ask the user
+
+**Do they already have a Feishu app configured?** If yes, collect the App ID and App Secret now. If no, we'll create one in Phase 3.
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-feishu
+```
+
+This deterministically:
+- Adds `src/channels/feishu.ts` (FeishuChannel class with self-registration via `registerChannel`)
+- Adds `src/feishu-auth.ts` (interactive credentials setup script)
+- Appends `import './feishu.js'` to the channel barrel file `src/channels/index.ts`
+- Installs the `@larksuiteoapi/node-sdk` npm dependency
+- Adds `"auth:feishu": "tsx src/feishu-auth.ts"` to `package.json` scripts
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent file:
+- `modify/src/channels/index.ts.intent.md` — what changed and invariants
+
+### Validate code changes
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Create Feishu App (if needed)
+
+Share [FEISHU_SETUP.md](FEISHU_SETUP.md) which has step-by-step setup instructions.
+
+Quick summary of what's needed:
+1. Go to [open.feishu.cn/app](https://open.feishu.cn/app) (or [open.larksuite.com/app](https://open.larksuite.com/app) for outside China)
+2. Create a custom app and enable the **Bot** capability
+3. In **Event Subscriptions**, enable: `im.message.receive_v1`, `im.chat.member.bot.added_v1`, `im.chat.member.bot.deleted_v1`
+4. Set the connection mode to **WebSocket (Long Connection)** — no public URL needed!
+5. Copy the **App ID** and **App Secret** from the Credentials & Basic Info page
+6. Publish the app (even just to your own workspace)
+
+Wait for the user to provide App ID and App Secret.
+
+### Configure credentials
+
+Run the interactive setup script:
+
+```bash
+npm run auth:feishu
+```
+
+This will:
+- Prompt for App ID and App Secret
+- Test the connection to Feishu API
+- Save credentials to `store/feishu-credentials.json` with restricted permissions (600)
+
+### Build and restart
+
+```bash
+npm run build
+npm run dev
+```
+
+Or if running as a service:
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 4: Register a Feishu Group
+
+### Find the Chat ID
+
+Feishu uses two chat ID formats:
+- `oc_xxxxxxxx` — Group chats (open_chat_id)
+- `ou_xxxxxxxx` — Direct messages (open_id)
+
+To find the chat ID:
+1. Add the bot to your Feishu group (search for your app name in the group members)
+2. Send any message in the group — NanoClaw will log the `chat_jid` in its logs
+3. Check logs: `tail -f logs/nanoclaw.log | grep "onChatMetadata"`
+
+The JID format for NanoClaw is the raw Feishu chat_id: `oc_xxxxxxxx` or `ou_xxxxxxxx`
+
+Wait for the user to provide the Feishu chat ID.
+
+### Register the group
+
+Use the main group to register the Feishu group via IPC, or register directly.
+
+For a group where the bot responds to all messages:
+```typescript
+registerGroup("oc_<chat-id>", {
+  name: "<group-name>",
+  folder: "feishu_main",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: false,
+  isMain: true,
+});
+```
+
+For a group that requires trigger:
+```typescript
+registerGroup("oc_<chat-id>", {
+  name: "<group-name>",
+  folder: "feishu_<group-name>",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: true,
+});
+```
+
+## Phase 5: Verify
+
+### Test the connection
+
+Tell the user:
+
+> 1. Send a message in your registered Feishu group
+> 2. For main channel: any message works
+> 3. For non-main: message with trigger word (e.g. `@Andy hello`)
+>
+> The bot should respond within a few seconds.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log | grep -i feishu
+```
+
+## Troubleshooting
+
+### Bot not responding
+
+1. Check `store/feishu-credentials.json` exists and is valid JSON
+2. Check channel is registered: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'oc_%' OR jid LIKE 'ou_%'"`
+3. Check NanoClaw logs for WebSocket connection status
+4. Verify Event Subscriptions are enabled in Feishu app settings
+
+### WebSocket connection fails
+
+1. Verify App ID and App Secret are correct (re-run `npm run auth:feishu`)
+2. Check that the app is published to your workspace
+3. Verify the app has bot capability enabled
+4. Check internet connectivity to `open.feishu.cn` (or `open.larksuite.com`)
+
+### Messages received but not forwarded
+
+1. The chat must be registered in `data/registered_groups.json`
+2. For group chats: the bot must be added as a member of the group
+3. For DMs: send a message directly to the bot in Feishu
+
+### Bot sends messages but they don't appear
+
+1. Check `receive_id_type` — `chat_id` for groups (`oc_`), `open_id` for DMs (`ou_`)
+2. Feishu uses "post" message type for markdown — ensure the app has message sending permission
+
+## After Setup
+
+The Feishu channel supports:
+- **Group chats** — Bot must be added as a group member
+- **Direct messages** — Users can DM the bot directly
+- **Multi-channel** — Can run alongside WhatsApp or other channels (auto-enabled when credentials exist)
+
+## Known Limitations
+
+- **No typing indicator** — Feishu bot API does not expose a typing indicator. The `setTyping()` method is a no-op.
+- **No group sync** — Unlike WhatsApp, Feishu does not batch-sync group metadata. Chat names are fetched on-demand when a message is received.
+- **No file/image handling** — The bot only processes text content. File uploads, images, and other media are represented as placeholder text (e.g., `<media:image>`).
+- **Post message format** — Messages are sent as Feishu "post" type with markdown. Very long messages may be truncated by Feishu's limits.
+- **Domestic vs international** — The SDK endpoint differs for domestic (open.feishu.cn) vs international (open.larksuite.com) deployments. The SDK handles this automatically based on the app credentials.

--- a/.claude/skills/add-feishu/add/src/channels/feishu.ts
+++ b/.claude/skills/add-feishu/add/src/channels/feishu.ts
@@ -1,0 +1,386 @@
+/**
+ * Feishu (Lark) Channel Implementation for NanoClaw
+ * Handles Feishu bot communication using WebSocket (long connection mode)
+ * Self-registers via registerChannel() — no core file modifications required.
+ */
+
+import * as Lark from '@larksuiteoapi/node-sdk';
+import fs from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+
+import { STORE_DIR, ASSISTANT_NAME } from '../config.js';
+import { storeChatMetadata, updateChatName } from '../db.js';
+import { logger } from '../logger.js';
+import {
+    Channel,
+    OnInboundMessage,
+    OnChatMetadata,
+    RegisteredGroup,
+} from '../types.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+
+// --- Types ---
+
+interface FeishuCredentials {
+    appId: string;
+    appSecret: string;
+    encryptKey?: string;
+    verificationToken?: string;
+}
+
+interface FeishuMessageEvent {
+    event_id?: string;
+    sender: {
+        sender_id: {
+            open_id?: string;
+            user_id?: string;
+            union_id?: string;
+        };
+        sender_type?: string;
+        tenant_key?: string;
+    };
+    message: {
+        message_id: string;
+        root_id?: string;
+        parent_id?: string;
+        chat_id: string;
+        chat_type: 'p2p' | 'group';
+        message_type: string;
+        content: string;
+        create_time?: string;
+        mentions?: Array<{
+            key: string;
+            id: { open_id?: string; user_id?: string; union_id?: string };
+            name: string;
+        }>;
+    };
+}
+
+// --- FeishuChannel class ---
+
+export class FeishuChannel implements Channel {
+    name = 'feishu';
+
+    private client: Lark.Client | null = null;
+    private wsClient: Lark.WSClient | null = null;
+    private eventDispatcher: Lark.EventDispatcher | null = null;
+    private credentials: FeishuCredentials | null = null;
+    private botOpenId: string | null = null;
+    private connected = false;
+
+    private opts: ChannelOpts;
+
+    constructor(opts: ChannelOpts) {
+        this.opts = opts;
+    }
+
+    // --- Public Channel interface ---
+
+    async connect(): Promise<void> {
+        const credsPath = path.join(STORE_DIR, 'feishu-credentials.json');
+
+        if (!fs.existsSync(credsPath)) {
+            const msg =
+                'Feishu credentials not found. Run `npm run auth:feishu` first.';
+            logger.error(msg);
+            exec(
+                `osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`,
+            );
+            // Feishu is optional — do not crash if credentials are missing.
+            // The channel simply won't receive/send messages.
+            return;
+        }
+
+        try {
+            this.credentials = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+        } catch (err) {
+            logger.error({ err }, 'Failed to parse Feishu credentials');
+            return;
+        }
+
+        if (!this.credentials?.appId || !this.credentials?.appSecret) {
+            logger.error('Feishu credentials missing appId or appSecret');
+            return;
+        }
+
+        // REST client for API calls (send messages, lookup user/chat info)
+        this.client = new Lark.Client({
+            appId: this.credentials.appId,
+            appSecret: this.credentials.appSecret,
+            appType: Lark.AppType.SelfBuild,
+        });
+
+        // Verify credentials & get bot open_id for self-message filtering
+        try {
+            const response = await (this.client as any).request({
+                method: 'GET',
+                url: '/open-apis/bot/v3/info',
+            });
+            if (response.code === 0 && response.bot) {
+                this.botOpenId = response.bot.open_id || null;
+                logger.info(
+                    { botName: response.bot.bot_name, botOpenId: this.botOpenId },
+                    'Connected to Feishu',
+                );
+            }
+        } catch (err) {
+            logger.error({ err }, 'Failed to verify Feishu connection');
+            return;
+        }
+
+        await this.setupWebSocket();
+        this.connected = true;
+    }
+
+    async sendMessage(jid: string, text: string): Promise<void> {
+        if (!this.client) {
+            logger.warn({ jid }, 'Feishu: cannot send — client not connected');
+            return;
+        }
+
+        // oc_ = group chat or p2p DM, ou_ = user open_id (legacy fallback)
+        if (!jid.startsWith('oc_') && !jid.startsWith('ou_')) {
+            logger.warn({ jid }, 'Feishu: invalid chat_id format, skipping send');
+            return;
+        }
+
+        const receiveIdType = jid.startsWith('oc_') ? 'chat_id' : 'open_id';
+
+        try {
+            // Use markdown post message for richer formatting
+            const content = JSON.stringify({
+                zh_cn: {
+                    content: [[{ tag: 'md', text: `${ASSISTANT_NAME}: ${text}` }]],
+                },
+            });
+
+            const response = await this.client.im.message.create({
+                params: { receive_id_type: receiveIdType },
+                data: {
+                    receive_id: jid,
+                    content,
+                    msg_type: 'post',
+                },
+            });
+
+            if (response.code !== 0) {
+                throw new Error(
+                    `Feishu send failed: ${response.msg || `code ${response.code}`}`,
+                );
+            }
+
+            logger.info({ jid, messageId: response.data?.message_id }, 'Feishu: message sent');
+        } catch (err) {
+            logger.error({ jid, err }, 'Feishu: failed to send message');
+        }
+    }
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    ownsJid(jid: string): boolean {
+        // Feishu chat IDs start with oc_ for both group chats and p2p DMs.
+        // ou_ (open_id) is accepted as a fallback.
+        return jid.startsWith('oc_') || jid.startsWith('ou_');
+    }
+
+    async disconnect(): Promise<void> {
+        this.connected = false;
+        // Lark SDK WSClient doesn't expose a stop() method; process will clean up on exit.
+    }
+
+    async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
+        // Feishu bot API does not expose a typing indicator.
+    }
+
+    async syncGroups(_force: boolean): Promise<void> {
+        // Feishu group metadata is fetched on-demand during message handling.
+        logger.debug('Feishu: syncGroups is a no-op (metadata fetched on demand)');
+    }
+
+    // --- Private helpers ---
+
+    private async setupWebSocket(): Promise<void> {
+        if (!this.credentials) return;
+
+        this.wsClient = new Lark.WSClient({
+            appId: this.credentials.appId,
+            appSecret: this.credentials.appSecret,
+            loggerLevel: Lark.LoggerLevel.warn,
+        });
+
+        this.eventDispatcher = new Lark.EventDispatcher({
+            encryptKey: this.credentials.encryptKey,
+            verificationToken: this.credentials.verificationToken,
+        });
+
+        this.eventDispatcher.register({
+            'im.message.receive_v1': async (data) => {
+                try {
+                    await this.handleMessageEvent(data as unknown as FeishuMessageEvent);
+                } catch (err) {
+                    logger.error({ err }, 'Feishu: error handling message event');
+                }
+            },
+            'im.message.message_read_v1': async (_data) => {
+                // Ignore read receipts
+            },
+            'im.chat.member.bot.added_v1': async (data) => {
+                const event = data as unknown as { chat_id: string };
+                logger.info({ chatId: event.chat_id }, 'Feishu: bot added to chat');
+            },
+            'im.chat.member.bot.deleted_v1': async (data) => {
+                const event = data as unknown as { chat_id: string };
+                logger.info({ chatId: event.chat_id }, 'Feishu: bot removed from chat');
+            },
+        });
+
+        this.wsClient.start({ eventDispatcher: this.eventDispatcher });
+        logger.info('Feishu: WebSocket client started');
+    }
+
+    private async handleMessageEvent(event: FeishuMessageEvent): Promise<void> {
+        const chatId = event.message.chat_id;
+        const senderOpenId = event.sender.sender_id.open_id;
+        const senderUserId = event.sender.sender_id.user_id;
+
+        // Skip bot's own messages
+        if (
+            (senderOpenId && senderOpenId === this.botOpenId) ||
+            (senderUserId && senderUserId === this.botOpenId)
+        ) {
+            return;
+        }
+
+        // Sanity check: only process valid Feishu chat IDs
+        if (!chatId.startsWith('oc_') && !chatId.startsWith('ou_')) {
+            logger.warn({ chatId }, 'Feishu: invalid chat_id, skipping');
+            return;
+        }
+
+        const messageType = event.message.message_type;
+        const timestamp = event.message.create_time
+            ? new Date(parseInt(event.message.create_time, 10)).toISOString()
+            : new Date().toISOString();
+
+        const { text: content } = this.parseContent(
+            event.message.content,
+            messageType,
+        );
+
+        const senderName = await this.resolveSenderName(senderOpenId || '');
+        const chatName = await this.getChatName(chatId);
+        const isGroup = event.message.chat_type === 'group';
+
+        // Notify host of chat metadata (for group discovery)
+        this.opts.onChatMetadata(chatId, timestamp, chatName, 'feishu', isGroup);
+
+        // Only deliver full message for registered groups
+        const groups = this.opts.registeredGroups();
+        if (groups[chatId]) {
+            this.opts.onMessage(chatId, {
+                id: event.message.message_id,
+                chat_jid: chatId,
+                sender: senderOpenId || senderUserId || 'unknown',
+                sender_name: senderName,
+                content,
+                timestamp,
+                is_from_me: false,
+                is_bot_message: false,
+            });
+        }
+    }
+
+    private parseContent(
+        rawContent: string,
+        messageType: string,
+    ): { text: string } {
+        try {
+            const parsed = JSON.parse(rawContent);
+            switch (messageType) {
+                case 'text':
+                    return { text: parsed.text || '' };
+                case 'post': {
+                    const title =
+                        parsed.zh_cn?.title ||
+                        parsed.en_us?.title ||
+                        parsed.title ||
+                        '';
+                    const blocks =
+                        parsed.zh_cn?.content ||
+                        parsed.en_us?.content ||
+                        parsed.content ||
+                        [];
+                    let text = title ? `${title}\n\n` : '';
+                    for (const paragraph of blocks) {
+                        if (Array.isArray(paragraph)) {
+                            for (const el of paragraph) {
+                                if (el.tag === 'text') text += el.text || '';
+                                else if (el.tag === 'a') text += el.text || el.href || '';
+                                else if (el.tag === 'at')
+                                    text += `@${el.user_name || el.user_id || ''}`;
+                                else if (el.tag === 'img') text += '<media:image>';
+                            }
+                            text += '\n';
+                        }
+                    }
+                    return { text: text.trim() || '[Rich Text]' };
+                }
+                case 'image':
+                    return { text: '<media:image>' };
+                case 'file':
+                    return { text: `<media:file:${parsed.file_name || 'unknown'}>` };
+                case 'audio':
+                    return { text: '<media:audio>' };
+                case 'video':
+                    return { text: '<media:video>' };
+                case 'sticker':
+                    return { text: '<media:sticker>' };
+                default:
+                    return { text: `[${messageType}]` };
+            }
+        } catch {
+            return { text: rawContent };
+        }
+    }
+
+    private async resolveSenderName(openId: string): Promise<string> {
+        if (!this.client || !openId) return 'Unknown';
+        try {
+            const res = await this.client.contact.user.get({
+                path: { user_id: openId },
+                params: { user_id_type: 'open_id' },
+            });
+            const user = res.data?.user;
+            if (user) return user.name || user.en_name || openId;
+        } catch {
+            // Best effort
+        }
+        return openId;
+    }
+
+    private async getChatName(chatId: string): Promise<string> {
+        if (!this.client) return chatId;
+        try {
+            const res = await this.client.im.chat.get({
+                path: { chat_id: chatId },
+            });
+            return res.data?.name || chatId;
+        } catch {
+            return chatId;
+        }
+    }
+}
+
+// Self-register the channel — triggers when this module is imported.
+// Returns null if FEISHU credentials are absent (graceful no-op).
+registerChannel('feishu', (opts: ChannelOpts) => {
+    const credsPath = path.join(STORE_DIR, 'feishu-credentials.json');
+    if (!fs.existsSync(credsPath)) {
+        logger.debug('Feishu credentials not found — channel not registered');
+        return null;
+    }
+    return new FeishuChannel(opts);
+});

--- a/.claude/skills/add-feishu/add/src/feishu-auth.ts
+++ b/.claude/skills/add-feishu/add/src/feishu-auth.ts
@@ -1,0 +1,169 @@
+/**
+ * Feishu Bot Authentication Setup
+ * Interactive script to configure Feishu (Lark) bot credentials.
+ * Run: npm run auth:feishu
+ */
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import * as Lark from '@larksuiteoapi/node-sdk';
+
+const STORE_DIR = path.join(process.cwd(), 'store');
+const CREDS_PATH = path.join(STORE_DIR, 'feishu-credentials.json');
+
+interface FeishuCredentials {
+    appId: string;
+    appSecret: string;
+    encryptKey?: string;
+    verificationToken?: string;
+}
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+
+function ask(question: string): Promise<string> {
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => resolve(answer.trim()));
+    });
+}
+
+async function testConnection(
+    creds: FeishuCredentials,
+): Promise<{ success: boolean; botName?: string; error?: string }> {
+    try {
+        const client = new Lark.Client({
+            appId: creds.appId,
+            appSecret: creds.appSecret,
+            appType: Lark.AppType.SelfBuild,
+        });
+
+        const response = await (client as any).request({
+            method: 'GET',
+            url: '/open-apis/bot/v3/info',
+        });
+
+        if (response.code === 0 && response.bot) {
+            return { success: true, botName: response.bot.bot_name };
+        }
+        return {
+            success: false,
+            error: response.msg || `Error code: ${response.code}`,
+        };
+    } catch (err) {
+        return {
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+
+async function main(): Promise<void> {
+    console.log('╔════════════════════════════════════════════════════════════╗');
+    console.log('║           Feishu (Lark) Bot Authentication Setup           ║');
+    console.log('╚════════════════════════════════════════════════════════════╝');
+    console.log('');
+    console.log('Setup Instructions:');
+    console.log('1. Go to https://open.feishu.cn/app');
+    console.log('2. Click "Create Custom App"');
+    console.log('3. Enable "Bot" capability in the app settings');
+    console.log('4. Copy the App ID and App Secret from the credentials page');
+    console.log(
+        '5. In "Event Subscriptions", enable: im.message.receive_v1',
+    );
+    console.log('6. Set the connection mode to "WebSocket (Long Connection)"');
+    console.log('7. Add bot to your Feishu group or direct message');
+    console.log('');
+
+    // Check for existing credentials
+    if (fs.existsSync(CREDS_PATH)) {
+        try {
+            const existing: FeishuCredentials = JSON.parse(
+                fs.readFileSync(CREDS_PATH, 'utf-8'),
+            );
+            console.log('⚠️  Existing credentials found.');
+            const overwrite = await ask('Overwrite? (y/N): ');
+            if (overwrite.toLowerCase() !== 'y') {
+                console.log('Keeping existing credentials.');
+                const testResult = await testConnection(existing);
+                if (!testResult.success) {
+                    console.error('❌ Connection failed:', testResult.error);
+                    rl.close();
+                    process.exit(1);
+                }
+                console.log(
+                    `✅ Connection successful! Bot: ${testResult.botName || 'Unknown'}`,
+                );
+                rl.close();
+                process.exit(0);
+            }
+        } catch {
+            // Invalid existing file — continue to collect new credentials
+        }
+    }
+
+    const appId = await ask('App ID: ');
+    if (!appId) {
+        console.error('❌ App ID is required');
+        rl.close();
+        process.exit(1);
+    }
+
+    const appSecret = await ask('App Secret: ');
+    if (!appSecret) {
+        console.error('❌ App Secret is required');
+        rl.close();
+        process.exit(1);
+    }
+
+    console.log('');
+    console.log('Optional security settings (press Enter to skip):');
+    const encryptKey = await ask('Encrypt Key (optional): ');
+    const verificationToken = await ask('Verification Token (optional): ');
+
+    const creds: FeishuCredentials = {
+        appId,
+        appSecret,
+        ...(encryptKey && { encryptKey }),
+        ...(verificationToken && { verificationToken }),
+    };
+
+    console.log('');
+    console.log('🔄 Testing connection to Feishu API...');
+
+    const testResult = await testConnection(creds);
+    if (!testResult.success) {
+        console.error('❌ Connection failed:', testResult.error);
+        console.log('Please check your App ID and App Secret and try again.');
+        rl.close();
+        process.exit(1);
+    }
+
+    console.log(`✅ Connection successful! Bot: ${testResult.botName}`);
+
+    fs.mkdirSync(STORE_DIR, { recursive: true });
+    fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, 2));
+    fs.chmodSync(CREDS_PATH, 0o600);
+
+    console.log('');
+    console.log(`✅ Credentials saved to: ${CREDS_PATH}`);
+    console.log('');
+    console.log('Next steps:');
+    console.log('1. Add the bot to your Feishu group or DM');
+    console.log(
+        '2. Register the chat with NanoClaw by sending a message from the main group:',
+    );
+    console.log('   Ask it to add the Feishu group using register_group IPC');
+    console.log('3. Restart NanoClaw: npm run dev');
+
+    rl.close();
+    process.exit(0);
+}
+
+main().catch((err) => {
+    console.error('Error:', err);
+    rl.close();
+    process.exit(1);
+});

--- a/.claude/skills/add-feishu/manifest.yaml
+++ b/.claude/skills/add-feishu/manifest.yaml
@@ -1,0 +1,19 @@
+skill: feishu
+version: 1.0.0
+description: "Feishu (Lark) channel integration via WebSocket long-connection mode. No public URL needed."
+core_version: 1.2.1
+adds:
+  - src/channels/feishu.ts
+  - src/feishu-auth.ts
+modifies:
+  - src/channels/index.ts
+structured:
+  npm_dependencies:
+    "@larksuiteoapi/node-sdk": "^1.58.0"
+  package_json_scripts:
+    auth:feishu: "tsx src/feishu-auth.ts"
+  env_additions:
+    - FEISHU_APP_ID
+    - FEISHU_APP_SECRET
+conflicts: []
+depends: []

--- a/.claude/skills/add-feishu/modify/src/channels/index.ts
+++ b/.claude/skills/add-feishu/modify/src/channels/index.ts
@@ -1,0 +1,15 @@
+// Channel self-registration barrel file.
+// Each import triggers the channel module's registerChannel() call.
+
+// discord
+
+// feishu
+import './feishu.js';
+
+// gmail
+
+// slack
+
+// telegram
+
+// whatsapp

--- a/.claude/skills/add-feishu/modify/src/channels/index.ts.intent.md
+++ b/.claude/skills/add-feishu/modify/src/channels/index.ts.intent.md
@@ -1,0 +1,13 @@
+## Intent
+
+Append `import './feishu.js'` to the channel barrel.
+
+This single-line addition causes the Feishu channel module to self-register
+via `registerChannel('feishu', ...)` when the application starts.
+
+## Invariants
+
+- The file must end with `import './feishu.js'` on its own line.
+- No other imports or code should be changed.
+- If any other channel barrel import already exists (e.g. `import './slack.js'`),
+  the new line should be appended after it, not before.


### PR DESCRIPTION
Adds WebSocket long-connection based Feishu (Lark) support as a skill package. No public URL required.

- src/channels/feishu.ts: FeishuChannel class with self-registration
- src/feishu-auth.ts: interactive credentials setup script
- Modifies src/channels/index.ts to import feishu channel
- Installs @larksuiteoapi/node-sdk
- Adds npm run auth:feishu script

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
