### PR TITLE
feat(telegram): add Deepgram voice transcription to add-telegram skill

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -87,6 +87,16 @@ TELEGRAM_BOT_TOKEN=<their-token>
 
 Channels auto-enable when their credentials are present — no extra configuration needed.
 
+### Voice message transcription (optional)
+
+To enable automatic transcription of voice messages, add a [Deepgram](https://console.deepgram.com) API key:
+
+```bash
+DEEPGRAM_API_KEY=<your-key>
+```
+
+Deepgram offers a free tier (12,000 minutes/month). Without the key, voice messages appear as `[Voice message]` — the bot still works, transcription is silently skipped.
+
 Sync to container environment:
 
 ```bash

--- a/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
@@ -8,6 +8,8 @@ vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
 // Mock env reader (used by the factory, not needed in unit tests)
 vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 
+import { readEnvFile } from '../env.js';
+
 // Mock config
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
@@ -583,12 +585,90 @@ describe('TelegramChannel', () => {
       );
     });
 
-    it('stores voice message with placeholder', async () => {
+    it('stores voice message with placeholder when no Deepgram key', async () => {
       const opts = createTestOpts();
+      // No deepgramApiKey passed — defaults to ''
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'tg-file-001' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Voice message]' }),
+      );
+    });
+
+    it('transcribes voice message when Deepgram key is set', async () => {
+      vi.spyOn(global, 'fetch' as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            result: { file_path: 'voice/file.ogg' },
+          }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => '100' },
+          arrayBuffer: async () => new ArrayBuffer(100),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            results: {
+              channels: [{ alternatives: [{ transcript: 'Hello world' }] }],
+            },
+          }),
+        } as any);
+
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts, 'test-dg-key');
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'tg-file-001' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Voice: Hello world]' }),
+      );
+    });
+
+    it('falls back to placeholder when Deepgram API call fails', async () => {
+      vi.mocked(readEnvFile).mockReturnValue({
+        DEEPGRAM_API_KEY: 'test-dg-key',
+      });
+      vi.spyOn(global, 'fetch' as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            result: { file_path: 'voice/file.ogg' },
+          }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => '100' },
+          arrayBuffer: async () => new ArrayBuffer(100),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+        } as any);
+
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts, 'test-dg-key');
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'tg-file-001' } },
+      });
       await triggerMediaMessage('message:voice', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(

--- a/.claude/skills/add-telegram/add/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.ts
@@ -11,6 +11,68 @@ import {
   RegisteredGroup,
 } from '../types.js';
 
+const MAX_VOICE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+async function transcribeVoiceWithDeepgram(
+  fileId: string,
+  botToken: string,
+  apiKey: string,
+): Promise<string | null> {
+  try {
+    // Resolve Telegram file path
+    const fileRes = await fetch(
+      `https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`,
+    );
+    const fileData = (await fileRes.json()) as any;
+    if (!fileData.ok) return null;
+    const filePath: string = fileData.result.file_path;
+
+    // Download audio bytes — reject oversized files before buffering
+    const audioRes = await fetch(
+      `https://api.telegram.org/file/bot${botToken}/${filePath}`,
+    );
+    if (!audioRes.ok) return null;
+    const contentLength = Number(audioRes.headers.get('content-length') ?? 0);
+    if (contentLength > MAX_VOICE_BYTES) {
+      logger.warn({ contentLength }, 'Voice file too large to transcribe, skipping');
+      return null;
+    }
+    const audioBuffer = await audioRes.arrayBuffer();
+    if (audioBuffer.byteLength > MAX_VOICE_BYTES) {
+      logger.warn({ bytes: audioBuffer.byteLength }, 'Voice file too large to transcribe, skipping');
+      return null;
+    }
+
+    // Transcribe with Deepgram Nova-2, auto-detect language
+    const dgAbort = AbortSignal.timeout(60_000);
+    const dgRes = await fetch(
+      'https://api.deepgram.com/v1/listen?model=nova-2&detect_language=true&smart_format=true',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Token ${apiKey}`,
+          'Content-Type': 'audio/ogg',
+        },
+        body: audioBuffer,
+        signal: dgAbort,
+      },
+    );
+
+    if (!dgRes.ok) {
+      logger.warn({ status: dgRes.status }, 'Deepgram transcription failed');
+      return null;
+    }
+
+    const data = (await dgRes.json()) as any;
+    const transcript: string =
+      data?.results?.channels?.[0]?.alternatives?.[0]?.transcript?.trim() ?? '';
+    return transcript || null;
+  } catch (err) {
+    logger.error({ err }, 'Deepgram voice transcription error');
+    return null;
+  }
+}
+
 export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
@@ -23,10 +85,12 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private deepgramApiKey: string;
 
-  constructor(botToken: string, opts: TelegramChannelOpts) {
+  constructor(botToken: string, opts: TelegramChannelOpts, deepgramApiKey = '') {
     this.botToken = botToken;
     this.opts = opts;
+    this.deepgramApiKey = deepgramApiKey;
   }
 
   async connect(): Promise<void> {
@@ -94,8 +158,15 @@ export class TelegramChannel implements Channel {
       }
 
       // Store chat metadata for discovery
-      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
-      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'telegram', isGroup);
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'telegram',
+        isGroup,
+      );
 
       // Only deliver full message for registered groups
       const group = this.opts.registeredGroups()[chatJid];
@@ -138,8 +209,15 @@ export class TelegramChannel implements Channel {
         'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
 
-      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
-      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
       this.opts.onMessage(chatJid, {
         id: ctx.message.message_id.toString(),
         chat_jid: chatJid,
@@ -153,9 +231,53 @@ export class TelegramChannel implements Channel {
 
     this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
     this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
-    this.bot.on('message:voice', (ctx) =>
-      storeNonText(ctx, '[Voice message]'),
-    );
+    this.bot.on('message:voice', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+
+      let content = '[Voice message]';
+      if (this.deepgramApiKey) {
+        const transcript = await transcribeVoiceWithDeepgram(
+          ctx.message.voice.file_id,
+          this.botToken,
+          this.deepgramApiKey,
+        );
+        if (transcript) {
+          content = `[Voice: ${transcript}]`;
+          logger.info({ chatJid, sender: senderName }, 'Voice message transcribed');
+        }
+      } else {
+        logger.debug({ chatJid }, 'DEEPGRAM_API_KEY not set, voice message not transcribed');
+      }
+
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+    });
     this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
     this.bot.on('message:document', (ctx) => {
       const name = ctx.message.document?.file_name || 'file';
@@ -246,12 +368,14 @@ export class TelegramChannel implements Channel {
 }
 
 registerChannel('telegram', (opts: ChannelOpts) => {
-  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN', 'DEEPGRAM_API_KEY']);
   const token =
     process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
   if (!token) {
     logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
     return null;
   }
-  return new TelegramChannel(token, opts);
+  const deepgramApiKey =
+    process.env.DEEPGRAM_API_KEY || envVars.DEEPGRAM_API_KEY || '';
+  return new TelegramChannel(token, opts, deepgramApiKey);
 });

--- a/.claude/skills/add-telegram/manifest.yaml
+++ b/.claude/skills/add-telegram/manifest.yaml
@@ -12,6 +12,7 @@ structured:
     grammy: "^1.39.3"
   env_additions:
     - TELEGRAM_BOT_TOKEN
+    - DEEPGRAM_API_KEY  # optional: enables voice message transcription
 conflicts: []
 depends: []
 test: "npx vitest run src/channels/telegram.test.ts"


### PR DESCRIPTION
## Summary

- Adds optional voice message transcription to the `add-telegram` skill using the [Deepgram](https://deepgram.com) Nova-2 API
- Transcription is **opt-in via `DEEPGRAM_API_KEY`** — degrades gracefully to `[Voice message]` placeholder when the key is absent, so existing installs are unaffected
- No new npm dependencies — uses Node 22 native `fetch` + `FormData`

## How it works

When a Telegram voice message arrives:
1. Resolves the file path via Telegram Bot API `getFile`
2. Downloads the OGG audio bytes
3. POSTs to `https://api.deepgram.com/v1/listen?model=nova-2&detect_language=true`
4. Delivers `[Voice: <transcript>]` to the agent (or `[Voice message]` on failure)

## Why Deepgram

- Free tier: 12,000 min/month
- Single HTTP POST, no SDK required
- Nova-2 accuracy is best-in-class

## Changes

| File | Change |
|------|--------|
| `add/src/channels/telegram.ts` | `transcribeVoiceWithDeepgram()` helper + async `message:voice` handler |
| `add/src/channels/telegram.test.ts` | 3 new tests: no-key fallback, successful transcription, API failure |
| `manifest.yaml` | `DEEPGRAM_API_KEY` added to `env_additions` (optional) |
| `SKILL.md` | Documents optional voice transcription setup |

## Test plan

- [ ] Apply `add-telegram` skill on a fresh install, confirm build passes and all 52 tests green
- [ ] Without `DEEPGRAM_API_KEY`: voice messages arrive as `[Voice message]`
- [ ] With `DEEPGRAM_API_KEY`: voice messages arrive as `[Voice: <transcript>]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)