### PR TITLE
feat: add WhatsApp image understanding skill

### DIFF
--- a/.claude/skills/add-whatsapp-image-understanding/SKILL.md
+++ b/.claude/skills/add-whatsapp-image-understanding/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: add-whatsapp-image-understanding
+description: Add WhatsApp image understanding to NanoClaw. Downloads WhatsApp images, saves them to group folders, and prompts the agent to read them using the Read tool.
+---
+
+# Add WhatsApp Image Understanding
+
+This skill adds image understanding to NanoClaw's WhatsApp channel. When an image arrives,
+it is downloaded via Baileys, saved to the group's images/ folder, and the agent receives
+a prompt like `[Image — view it by reading: /workspace/group/images/file.jpg]` so it can
+use the Read tool to view the image.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+Read `.nanoclaw/state.yaml`. If `image-understanding` is in `applied_skills`, skip to Phase 3.
+
+### Prerequisites
+- No additional API keys needed (uses Baileys' built-in media download)
+- Works with or without the voice-transcription skill
+
+## Phase 2: Apply Code Changes
+
+### Initialize skills system (if needed)
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-whatsapp-image-understanding
+```
+
+This deterministically:
+- Adds `src/image-handler.ts` (image download + save functions)
+- Adds `src/image-cleanup.ts` (weekly cleanup of old images)
+- Three-way merges image handling into `src/channels/whatsapp.ts`
+- Three-way merges image tests into `src/channels/whatsapp.test.ts`
+- Three-way merges cleanup timer into `src/index.ts`
+- Adds image instructions to `groups/global/CLAUDE.md`
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/channels/whatsapp.ts.intent.md`
+- `modify/src/channels/whatsapp.test.ts.intent.md`
+- `modify/src/index.ts.intent.md`
+- `modify/groups/global/CLAUDE.md.intent.md`
+
+### Validate code changes
+```bash
+npm test
+npm run build
+```
+
+## Phase 3: Configure
+
+No configuration needed. Image understanding uses Baileys' built-in media download — no API key required.
+
+### Sender allowlist (optional)
+By default, images from all senders are processed. To restrict which senders can send images,
+configure `sender-allowlist.json` (same file used for message allowlisting).
+
+### Build and restart
+```bash
+npm run build
+```
+
+## Phase 4: Verify
+
+### Test with an image
+Send an image in any registered WhatsApp chat. The agent should receive it as
+`[Image — view it by reading: /workspace/group/images/...]` and describe what it sees.
+
+### Check logs if needed
+```bash
+tail -f logs/nanoclaw.log | grep -i image
+```
+
+Look for:
+- `Downloaded and saved image` — successful download with size + mimetype
+- `Image download error` — media download failure
+- `Deleted old image` — cleanup running correctly
+
+## Troubleshooting
+
+### Agent says "Image - download failed"
+1. Check logs for the specific error
+2. Verify Baileys is connected (WhatsApp web session active)
+3. Media download may time out on slow connections — retry
+
+### Images not cleaned up
+1. Check logs for `Image cleanup` entries
+2. Cleanup runs at startup + every 7 days
+3. Only deletes images older than 30 days
+
+### Agent doesn't respond to images at all
+1. Verify the chat is registered
+2. Check sender-allowlist.json if configured
+3. Verify `groups/global/CLAUDE.md` contains the Images section

--- a/.claude/skills/add-whatsapp-image-understanding/add/src/image-cleanup.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/add/src/image-cleanup.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from './config.js';
+import { isValidGroupFolder } from './group-folder.js';
+import { logger } from './logger.js';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Delete images older than maxAgeMs from all group images/ directories.
+ * Returns the number of files deleted.
+ */
+export function cleanupOldImages(maxAgeMs = THIRTY_DAYS_MS): number {
+  const cutoff = Date.now() - maxAgeMs;
+  let deleted = 0;
+
+  let groupFolders: string[];
+  try {
+    groupFolders = fs.readdirSync(GROUPS_DIR);
+  } catch {
+    // groups/ dir doesn't exist yet — nothing to clean up
+    return 0;
+  }
+
+  for (const folder of groupFolders) {
+    if (!isValidGroupFolder(folder)) continue;
+
+    const imagesDir = path.join(GROUPS_DIR, folder, 'images');
+
+    let files: string[];
+    try {
+      files = fs.readdirSync(imagesDir);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      const filePath = path.join(imagesDir, file);
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(filePath);
+      } catch {
+        continue;
+      }
+
+      if (!stat.isFile()) continue;
+
+      if (stat.mtimeMs < cutoff) {
+        try {
+          fs.unlinkSync(filePath);
+          logger.info(
+            {
+              group: folder,
+              file,
+              agedays: Math.floor((Date.now() - stat.mtimeMs) / 86400000),
+            },
+            'Deleted old image',
+          );
+          deleted++;
+        } catch (err) {
+          logger.warn(
+            { group: folder, file, err },
+            'Failed to delete old image',
+          );
+        }
+      }
+    }
+  }
+
+  if (deleted > 0) {
+    logger.info({ deleted }, 'Image cleanup complete');
+  } else {
+    logger.debug('Image cleanup: no files to delete');
+  }
+
+  return deleted;
+}
+
+/**
+ * Start a weekly interval that deletes images older than 30 days.
+ * @returns Timer ID that can be cleared with clearInterval()
+ */
+export function startImageCleanup(): NodeJS.Timeout {
+  // Run once at startup (catches any backlog), then weekly
+  cleanupOldImages();
+
+  return setInterval(() => {
+    cleanupOldImages();
+  }, SEVEN_DAYS_MS);
+}

--- a/.claude/skills/add-whatsapp-image-understanding/add/src/image-handler.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/add/src/image-handler.ts
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  downloadMediaMessage,
+  normalizeMessageContent,
+  WAMessage,
+  WASocket,
+} from '@whiskeysockets/baileys';
+
+import { resolveGroupFolderPath } from './group-folder.js';
+
+/**
+ * Returns true if the message is an image (handles forwarded/wrapped messages via normalizeMessageContent).
+ */
+export function isImageMessage(msg: WAMessage): boolean {
+  const normalized = normalizeMessageContent(msg.message);
+  return normalized?.imageMessage != null;
+}
+
+/**
+ * Download the image from a WAMessage.
+ * Returns the buffer and mimetype, or null if download fails.
+ */
+export async function downloadImageMessage(
+  msg: WAMessage,
+  sock: WASocket,
+): Promise<{ buffer: Buffer; mimetype: string } | null> {
+  const normalized = normalizeMessageContent(msg.message);
+  const imageMsg = normalized?.imageMessage;
+  if (!imageMsg) return null;
+
+  const buffer = (await downloadMediaMessage(
+    msg,
+    'buffer',
+    {},
+    {
+      logger: console as any,
+      reuploadRequest: sock.updateMediaMessage,
+    },
+  )) as Buffer;
+
+  if (!buffer || buffer.length === 0) return null;
+
+  return {
+    buffer,
+    mimetype: imageMsg.mimetype || 'image/jpeg',
+  };
+}
+
+/**
+ * Save image buffer to the group's images/ directory.
+ * Returns the container-relative path: /workspace/group/images/<filename>
+ */
+export function saveImageToGroup(
+  groupFolder: string,
+  buffer: Buffer,
+  mimetype: string,
+  messageId: string,
+): string {
+  const ext =
+    mimetype === 'image/png'
+      ? 'png'
+      : mimetype === 'image/webp'
+        ? 'webp'
+        : mimetype === 'image/gif'
+          ? 'gif'
+          : 'jpg';
+  const safeId =
+    messageId.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) ||
+    `img-${Date.now()}`;
+  const filename = `${safeId}.${ext}`;
+  const groupDir = resolveGroupFolderPath(groupFolder);
+  const imagesDir = path.join(groupDir, 'images');
+  fs.mkdirSync(imagesDir, { recursive: true });
+  fs.writeFileSync(path.join(imagesDir, filename), buffer);
+  return `/workspace/group/images/${filename}`;
+}

--- a/.claude/skills/add-whatsapp-image-understanding/manifest.yaml
+++ b/.claude/skills/add-whatsapp-image-understanding/manifest.yaml
@@ -1,0 +1,18 @@
+skill: add-whatsapp-image-understanding
+version: 1.0.0
+description: "WhatsApp image understanding — download, save, and prompt agent to view WhatsApp images"
+core_version: 0.1.0
+adds:
+  - src/image-handler.ts
+  - src/image-cleanup.ts
+modifies:
+  - src/channels/whatsapp.ts
+  - src/channels/whatsapp.test.ts
+  - src/index.ts
+  - groups/global/CLAUDE.md
+structured:
+  npm_dependencies: {}
+  env_additions: []
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/whatsapp.test.ts"

--- a/.claude/skills/add-whatsapp-image-understanding/modify/groups/global/CLAUDE.md
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/groups/global/CLAUDE.md
@@ -1,0 +1,64 @@
+# Andy
+
+You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+
+## What You Can Do
+
+- Answer questions and have conversations
+- Search the web and fetch content from URLs
+- **Browse the web** with `agent-browser` — open pages, click, fill forms, take screenshots, extract data (run `agent-browser open <url>` to start, then `agent-browser snapshot -i` to see interactive elements)
+- Read and write files in your workspace
+- Run bash commands in your sandbox
+- Schedule tasks to run later or on a recurring basis
+- Send messages back to the chat
+
+## Communication
+
+Your output is sent to the user or group.
+
+You also have `mcp__nanoclaw__send_message` which sends a message immediately while you're still working. This is useful when you want to acknowledge a request before starting longer work.
+
+### Internal thoughts
+
+If part of your output is internal reasoning rather than something for the user, wrap it in `<internal>` tags:
+
+```
+<internal>Compiled all three reports, ready to summarize.</internal>
+
+Here are the key findings from the research...
+```
+
+Text inside `<internal>` tags is logged but not sent to the user. If you've already sent the key information via `send_message`, you can wrap the recap in `<internal>` to avoid sending it again.
+
+### Sub-agents and teammates
+
+When working as a sub-agent or teammate, only use `send_message` if instructed to by the main agent.
+
+## Your Workspace
+
+Files you create are saved in `/workspace/group/`. Use this for notes, research, or anything that should persist.
+
+## Memory
+
+The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
+
+When you learn something important:
+- Create files for structured data (e.g., `customers.md`, `preferences.md`)
+- Split files larger than 500 lines into folders
+- Keep an index in your memory for the files you create
+
+## Images
+
+When a user sends an image, you'll see a message like `[Image — view it by reading: /workspace/group/images/filename.jpg]`. Use the `Read` tool to view the image, then respond about what you see. If the message includes a caption (e.g. `[Image with caption: "What is this?" — view it by reading: ...]`), treat the caption as the user's question about the image.
+
+Images from unauthorized senders appear as `[Image from unauthorized sender]`. Let the user know the image could not be processed.
+
+## Message Formatting
+
+NEVER use markdown. Only use WhatsApp/Telegram formatting:
+- *single asterisks* for bold (NEVER **double asterisks**)
+- _underscores_ for italic
+- • bullet points
+- ```triple backticks``` for code
+
+No ## headings. No [links](url). No **double stars**.

--- a/.claude/skills/add-whatsapp-image-understanding/modify/groups/global/CLAUDE.md.intent.md
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/groups/global/CLAUDE.md.intent.md
@@ -1,0 +1,12 @@
+# Intent: groups/global/CLAUDE.md modifications
+
+## What changed
+Added an "Images" section that instructs the agent how to handle image messages
+(reading the file path, interpreting captions, handling unauthorized senders).
+
+## Key sections
+- Added: "## Images" section between "## Memory" and "## Message Formatting"
+
+## Invariants (must-keep)
+- All existing sections unchanged (assistant name, what you can do, communication, workspace, memory, message formatting)
+- No changes to assistant name or personality

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.test.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.test.ts
@@ -1,0 +1,1111 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// --- Mocks ---
+
+// Mock config
+vi.mock('../config.js', () => ({
+  STORE_DIR: '/tmp/nanoclaw-test-store',
+  ASSISTANT_NAME: 'Andy',
+  ASSISTANT_HAS_OWN_NUMBER: false,
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock db
+vi.mock('../db.js', () => ({
+  getLastGroupSync: vi.fn(() => null),
+  setLastGroupSync: vi.fn(),
+  updateChatName: vi.fn(),
+}));
+
+// Mock transcription
+vi.mock('../transcription.js', () => ({
+  isVoiceMessage: vi.fn((msg: any) => msg.message?.audioMessage?.ptt === true),
+  transcribeAudioMessage: vi.fn().mockResolvedValue('Hello this is a voice message'),
+}));
+
+// Mock image-handler
+vi.mock('../image-handler.js', () => ({
+  isImageMessage: vi.fn((msg: any) => msg.message?.imageMessage != null),
+  downloadImageMessage: vi.fn().mockResolvedValue({
+    buffer: Buffer.from('fake-image-data'),
+    mimetype: 'image/jpeg',
+  }),
+  saveImageToGroup: vi.fn().mockReturnValue('/workspace/group/images/test.jpg'),
+}));
+
+// Mock sender-allowlist
+vi.mock('../sender-allowlist.js', () => ({
+  isSenderAllowed: vi.fn(() => true),
+  loadSenderAllowlist: vi.fn(() => ({ default: { allow: '*', mode: 'trigger' }, chats: {}, logDenied: false })),
+}));
+
+// Mock fs
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+// Mock child_process (used for osascript notification)
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Build a fake WASocket that's an EventEmitter with the methods we need
+function createFakeSocket() {
+  const ev = new EventEmitter();
+  const sock = {
+    ev: {
+      on: (event: string, handler: (...args: unknown[]) => void) => {
+        ev.on(event, handler);
+      },
+    },
+    user: {
+      id: '1234567890:1@s.whatsapp.net',
+      lid: '9876543210:1@lid',
+    },
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+    groupFetchAllParticipating: vi.fn().mockResolvedValue({}),
+    end: vi.fn(),
+    // Expose the event emitter for triggering events in tests
+    _ev: ev,
+  };
+  return sock;
+}
+
+let fakeSocket: ReturnType<typeof createFakeSocket>;
+
+// Mock Baileys
+vi.mock('@whiskeysockets/baileys', () => {
+  return {
+    default: vi.fn(() => fakeSocket),
+    Browsers: { macOS: vi.fn(() => ['macOS', 'Chrome', '']) },
+    DisconnectReason: {
+      loggedOut: 401,
+      badSession: 500,
+      connectionClosed: 428,
+      connectionLost: 408,
+      connectionReplaced: 440,
+      timedOut: 408,
+      restartRequired: 515,
+    },
+    fetchLatestWaWebVersion: vi
+      .fn()
+      .mockResolvedValue({ version: [2, 3000, 0] }),
+    normalizeMessageContent: vi.fn((content: unknown) => content),
+    makeCacheableSignalKeyStore: vi.fn((keys: unknown) => keys),
+    useMultiFileAuthState: vi.fn().mockResolvedValue({
+      state: {
+        creds: {},
+        keys: {},
+      },
+      saveCreds: vi.fn(),
+    }),
+  };
+});
+
+import { WhatsAppChannel, WhatsAppChannelOpts } from './whatsapp.js';
+import { getLastGroupSync, updateChatName, setLastGroupSync } from '../db.js';
+import { transcribeAudioMessage } from '../transcription.js';
+import { downloadImageMessage, saveImageToGroup } from '../image-handler.js';
+import { isSenderAllowed } from '../sender-allowlist.js';
+
+// --- Test helpers ---
+
+function createTestOpts(overrides?: Partial<WhatsAppChannelOpts>): WhatsAppChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'registered@g.us': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function triggerConnection(state: string, extra?: Record<string, unknown>) {
+  fakeSocket._ev.emit('connection.update', { connection: state, ...extra });
+}
+
+function triggerDisconnect(statusCode: number) {
+  fakeSocket._ev.emit('connection.update', {
+    connection: 'close',
+    lastDisconnect: {
+      error: { output: { statusCode } },
+    },
+  });
+}
+
+async function triggerMessages(messages: unknown[]) {
+  fakeSocket._ev.emit('messages.upsert', { messages });
+  // Flush microtasks so the async messages.upsert handler completes
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// --- Tests ---
+
+describe('WhatsAppChannel', () => {
+  beforeEach(() => {
+    fakeSocket = createFakeSocket();
+    vi.mocked(getLastGroupSync).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper: start connect, flush microtasks so event handlers are registered,
+   * then trigger the connection open event. Returns the resolved promise.
+   */
+  async function connectChannel(channel: WhatsAppChannel): Promise<void> {
+    const p = channel.connect();
+    // Flush microtasks so connectInternal completes its await and registers handlers
+    await new Promise((r) => setTimeout(r, 0));
+    triggerConnection('open');
+    return p;
+  }
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when connection opens', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('sets up LID to phone mapping on open', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // The channel should have mapped the LID from sock.user
+      // We can verify by sending a message from a LID JID
+      // and checking the translated JID in the callback
+    });
+
+    it('flushes outgoing queue on reconnect', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect
+      (channel as any).connected = false;
+
+      // Queue a message while disconnected
+      await channel.sendMessage('test@g.us', 'Queued message');
+      expect(fakeSocket.sendMessage).not.toHaveBeenCalled();
+
+      // Reconnect
+      (channel as any).connected = true;
+      await (channel as any).flushOutgoingQueue();
+
+      // Group messages get prefixed when flushed
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith(
+        'test@g.us',
+        { text: 'Andy: Queued message' },
+      );
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+      expect(fakeSocket.end).toHaveBeenCalled();
+    });
+  });
+
+  // --- QR code and auth ---
+
+  describe('authentication', () => {
+    it('exits process when QR code is emitted (no auth state)', async () => {
+      vi.useFakeTimers();
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Start connect but don't await (it won't resolve - process exits)
+      channel.connect().catch(() => {});
+
+      // Flush microtasks so connectInternal registers handlers
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Emit QR code event
+      fakeSocket._ev.emit('connection.update', { qr: 'some-qr-data' });
+
+      // Advance timer past the 1000ms setTimeout before exit
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      mockExit.mockRestore();
+      vi.useRealTimers();
+    });
+  });
+
+  // --- Reconnection behavior ---
+
+  describe('reconnection', () => {
+    it('reconnects on non-loggedOut disconnect', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      expect(channel.isConnected()).toBe(true);
+
+      // Disconnect with a non-loggedOut reason (e.g., connectionClosed = 428)
+      triggerDisconnect(428);
+
+      expect(channel.isConnected()).toBe(false);
+      // The channel should attempt to reconnect (calls connectInternal again)
+    });
+
+    it('exits on loggedOut disconnect', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect with loggedOut reason (401)
+      triggerDisconnect(401);
+
+      expect(channel.isConnected()).toBe(false);
+      expect(mockExit).toHaveBeenCalledWith(0);
+      mockExit.mockRestore();
+    });
+
+    it('retries reconnection after 5s on failure', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect with stream error 515
+      triggerDisconnect(515);
+
+      // The channel sets a 5s retry — just verify it doesn't crash
+      await new Promise((r) => setTimeout(r, 100));
+    });
+  });
+
+  // --- Message handling ---
+
+  describe('message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-1',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Hello Andy' },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          id: 'msg-1',
+          content: 'Hello Andy',
+          sender_name: 'Alice',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered groups', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-2',
+            remoteJid: 'unregistered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Hello' },
+          pushName: 'Bob',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'unregistered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores status@broadcast messages', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-3',
+            remoteJid: 'status@broadcast',
+            fromMe: false,
+          },
+          message: { conversation: 'Status update' },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores messages with no content', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-4',
+            remoteJid: 'registered@g.us',
+            fromMe: false,
+          },
+          message: null,
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('extracts text from extendedTextMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-5',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: { text: 'A reply message' },
+          },
+          pushName: 'Charlie',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'A reply message' }),
+      );
+    });
+
+    it('downloads and saves image from allowed sender', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-1',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { mimetype: 'image/jpeg' },
+          },
+          pushName: 'Diana',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(downloadImageMessage).toHaveBeenCalled();
+      expect(saveImageToGroup).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image — view it by reading: /workspace/group/images/test.jpg]',
+        }),
+      );
+    });
+
+    it('includes caption alongside image path', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-2',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { caption: 'What is this?', mimetype: 'image/jpeg' },
+          },
+          pushName: 'Eve',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image with caption: "What is this?" — view it by reading: /workspace/group/images/test.jpg]',
+        }),
+      );
+    });
+
+    it('blocks image download from non-allowed sender', async () => {
+      vi.mocked(isSenderAllowed).mockReturnValueOnce(false);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-3',
+            remoteJid: 'registered@g.us',
+            participant: '5559999@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { mimetype: 'image/jpeg' },
+          },
+          pushName: 'Stranger',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(downloadImageMessage).not.toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image from unauthorized sender]',
+        }),
+      );
+    });
+
+    it('does not skip image without caption', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Image with no caption — content would be '' but isImageMessage returns true
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-nocap',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { mimetype: 'image/jpeg' },
+          },
+          pushName: 'Frank',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Should still be delivered (not skipped by content guard)
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back gracefully when image download fails', async () => {
+      vi.mocked(downloadImageMessage).mockRejectedValueOnce(new Error('Media download timeout'));
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-fail',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { mimetype: 'image/jpeg' },
+          },
+          pushName: 'Grace',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image - download failed]',
+        }),
+      );
+    });
+
+    it('extracts caption from videoMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-7',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            videoMessage: { caption: 'Watch this', mimetype: 'video/mp4' },
+          },
+          pushName: 'Eve',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'Watch this' }),
+      );
+    });
+
+    it('transcribes voice messages', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-8',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true },
+          },
+          pushName: 'Frank',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(transcribeAudioMessage).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: '[Voice: Hello this is a voice message]' }),
+      );
+    });
+
+    it('falls back when transcription returns null', async () => {
+      vi.mocked(transcribeAudioMessage).mockResolvedValueOnce(null);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-8b',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true },
+          },
+          pushName: 'Frank',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: '[Voice Message - transcription unavailable]' }),
+      );
+    });
+
+    it('falls back when transcription throws', async () => {
+      vi.mocked(transcribeAudioMessage).mockRejectedValueOnce(new Error('API error'));
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-8c',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true },
+          },
+          pushName: 'Frank',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: '[Voice Message - transcription failed]' }),
+      );
+    });
+
+    it('uses sender JID when pushName is absent', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-9',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'No push name' },
+          // pushName is undefined
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ sender_name: '5551234' }),
+      );
+    });
+  });
+
+  // --- LID ↔ JID translation ---
+
+  describe('LID to JID translation', () => {
+    it('translates known LID to phone JID', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          '1234567890@s.whatsapp.net': {
+            name: 'Self Chat',
+            folder: 'self-chat',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // The socket has lid '9876543210:1@lid' → phone '1234567890@s.whatsapp.net'
+      // Send a message from the LID
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-lid',
+            remoteJid: '9876543210@lid',
+            fromMe: false,
+          },
+          message: { conversation: 'From LID' },
+          pushName: 'Self',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Should be translated to phone JID
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        '1234567890@s.whatsapp.net',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        false,
+      );
+    });
+
+    it('passes through non-LID JIDs unchanged', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-normal',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Normal JID' },
+          pushName: 'Grace',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+    });
+
+    it('passes through unknown LID JIDs unchanged', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-unknown-lid',
+            remoteJid: '0000000000@lid',
+            fromMe: false,
+          },
+          message: { conversation: 'Unknown LID' },
+          pushName: 'Unknown',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Unknown LID passes through unchanged
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        '0000000000@lid',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        false,
+      );
+    });
+  });
+
+  // --- Outgoing message queue ---
+
+  describe('outgoing message queue', () => {
+    it('sends message directly when connected', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.sendMessage('test@g.us', 'Hello');
+      // Group messages get prefixed with assistant name
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith('test@g.us', { text: 'Andy: Hello' });
+    });
+
+    it('prefixes direct chat messages on shared number', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.sendMessage('123@s.whatsapp.net', 'Hello');
+      // Shared number: DMs also get prefixed (needed for self-chat distinction)
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith('123@s.whatsapp.net', { text: 'Andy: Hello' });
+    });
+
+    it('queues message when disconnected', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Don't connect — channel starts disconnected
+      await channel.sendMessage('test@g.us', 'Queued');
+      expect(fakeSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('queues message on send failure', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Make sendMessage fail
+      fakeSocket.sendMessage.mockRejectedValueOnce(new Error('Network error'));
+
+      await channel.sendMessage('test@g.us', 'Will fail');
+
+      // Should not throw, message queued for retry
+      // The queue should have the message
+    });
+
+    it('flushes multiple queued messages in order', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Queue messages while disconnected
+      await channel.sendMessage('test@g.us', 'First');
+      await channel.sendMessage('test@g.us', 'Second');
+      await channel.sendMessage('test@g.us', 'Third');
+
+      // Connect — flush happens automatically on open
+      await connectChannel(channel);
+
+      // Give the async flush time to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.sendMessage).toHaveBeenCalledTimes(3);
+      // Group messages get prefixed
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(1, 'test@g.us', { text: 'Andy: First' });
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(2, 'test@g.us', { text: 'Andy: Second' });
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(3, 'test@g.us', { text: 'Andy: Third' });
+    });
+  });
+
+  // --- Group metadata sync ---
+
+  describe('group metadata sync', () => {
+    it('syncs group metadata on first connection', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group1@g.us': { subject: 'Group One' },
+        'group2@g.us': { subject: 'Group Two' },
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Wait for async sync to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.groupFetchAllParticipating).toHaveBeenCalled();
+      expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Group One');
+      expect(updateChatName).toHaveBeenCalledWith('group2@g.us', 'Group Two');
+      expect(setLastGroupSync).toHaveBeenCalled();
+    });
+
+    it('skips sync when synced recently', async () => {
+      // Last sync was 1 hour ago (within 24h threshold)
+      vi.mocked(getLastGroupSync).mockReturnValue(
+        new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      );
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.groupFetchAllParticipating).not.toHaveBeenCalled();
+    });
+
+    it('forces sync regardless of cache', async () => {
+      vi.mocked(getLastGroupSync).mockReturnValue(
+        new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      );
+
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group@g.us': { subject: 'Forced Group' },
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.syncGroupMetadata(true);
+
+      expect(fakeSocket.groupFetchAllParticipating).toHaveBeenCalled();
+      expect(updateChatName).toHaveBeenCalledWith('group@g.us', 'Forced Group');
+    });
+
+    it('handles group sync failure gracefully', async () => {
+      fakeSocket.groupFetchAllParticipating.mockRejectedValue(
+        new Error('Network timeout'),
+      );
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Should not throw
+      await expect(channel.syncGroupMetadata(true)).resolves.toBeUndefined();
+    });
+
+    it('skips groups with no subject', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group1@g.us': { subject: 'Has Subject' },
+        'group2@g.us': { subject: '' },
+        'group3@g.us': {},
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Clear any calls from the automatic sync on connect
+      vi.mocked(updateChatName).mockClear();
+
+      await channel.syncGroupMetadata(true);
+
+      expect(updateChatName).toHaveBeenCalledTimes(1);
+      expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Has Subject');
+    });
+  });
+
+  // --- JID ownership ---
+
+  describe('ownsJid', () => {
+    it('owns @g.us JIDs (WhatsApp groups)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(true);
+    });
+
+    it('owns @s.whatsapp.net JIDs (WhatsApp DMs)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(true);
+    });
+
+    it('does not own Telegram JIDs', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('tg:12345')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- Typing indicator ---
+
+  describe('setTyping', () => {
+    it('sends composing presence when typing', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.setTyping('test@g.us', true);
+      expect(fakeSocket.sendPresenceUpdate).toHaveBeenCalledWith('composing', 'test@g.us');
+    });
+
+    it('sends paused presence when stopping', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.setTyping('test@g.us', false);
+      expect(fakeSocket.sendPresenceUpdate).toHaveBeenCalledWith('paused', 'test@g.us');
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      fakeSocket.sendPresenceUpdate.mockRejectedValueOnce(new Error('Failed'));
+
+      // Should not throw
+      await expect(channel.setTyping('test@g.us', true)).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "whatsapp"', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.name).toBe('whatsapp');
+    });
+
+    it('does not expose prefixAssistantName (prefix handled internally)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect('prefixAssistantName' in channel).toBe(false);
+    });
+  });
+});

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.test.ts.intent.md
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.test.ts.intent.md
@@ -1,0 +1,28 @@
+# Intent: src/channels/whatsapp.test.ts modifications
+
+## What changed
+Added mocks for image-handler and sender-allowlist modules, and 5 test cases for image handling.
+
+## Key sections
+
+### Mocks (top of file)
+- Added: `vi.mock('../image-handler.js', ...)` with isImageMessage, downloadImageMessage, saveImageToGroup
+- Added: `vi.mock('../sender-allowlist.js', ...)` with isSenderAllowed, loadSenderAllowlist
+- Added: imports for downloadImageMessage, saveImageToGroup, isSenderAllowed
+
+### Test cases (inside "message handling" describe block)
+- Added: "downloads and saves image from allowed sender"
+- Added: "includes caption alongside image path"
+- Added: "blocks image download from non-allowed sender"
+- Added: "does not skip image without caption"
+- Added: "falls back gracefully when image download fails"
+- Updated: "extracts caption from imageMessage" → replaced by image-aware tests above
+
+## Invariants (must-keep)
+- All existing test cases for text, extendedTextMessage, videoMessage unchanged
+- All voice transcription test cases unchanged
+- All connection lifecycle tests unchanged
+- All LID translation tests unchanged
+- All outgoing queue tests unchanged
+- All existing mocks (config, logger, db, fs, child_process, baileys, transcription) unchanged
+- Test helpers (createTestOpts, triggerConnection, triggerDisconnect, triggerMessages, connectChannel) unchanged

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.ts
@@ -1,0 +1,392 @@
+import { exec } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import makeWASocket, {
+  Browsers,
+  DisconnectReason,
+  WASocket,
+  fetchLatestWaWebVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+} from '@whiskeysockets/baileys';
+
+import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME, STORE_DIR } from '../config.js';
+import {
+  getLastGroupSync,
+  setLastGroupSync,
+  updateChatName,
+} from '../db.js';
+import { isImageMessage, downloadImageMessage, saveImageToGroup } from '../image-handler.js';
+import { logger } from '../logger.js';
+import { isSenderAllowed, loadSenderAllowlist } from '../sender-allowlist.js';
+import { isVoiceMessage, transcribeAudioMessage } from '../transcription.js';
+import { Channel, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
+
+const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface WhatsAppChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class WhatsAppChannel implements Channel {
+  name = 'whatsapp';
+
+  private sock!: WASocket;
+  private connected = false;
+  private lidToPhoneMap: Record<string, string> = {};
+  private outgoingQueue: Array<{ jid: string; text: string }> = [];
+  private flushing = false;
+  private groupSyncTimerStarted = false;
+
+  private opts: WhatsAppChannelOpts;
+
+  constructor(opts: WhatsAppChannelOpts) {
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.connectInternal(resolve).catch(reject);
+    });
+  }
+
+  private async connectInternal(onFirstOpen?: () => void): Promise<void> {
+    const authDir = path.join(STORE_DIR, 'auth');
+    fs.mkdirSync(authDir, { recursive: true });
+
+    const { state, saveCreds } = await useMultiFileAuthState(authDir);
+
+    const { version } = await fetchLatestWaWebVersion({}).catch((err) => {
+      logger.warn({ err }, 'Failed to fetch latest WA Web version, using default');
+      return { version: undefined };
+    });
+    this.sock = makeWASocket({
+      version,
+      auth: {
+        creds: state.creds,
+        keys: makeCacheableSignalKeyStore(state.keys, logger),
+      },
+      printQRInTerminal: false,
+      logger,
+      browser: Browsers.macOS('Chrome'),
+    });
+
+    this.sock.ev.on('connection.update', (update) => {
+      const { connection, lastDisconnect, qr } = update;
+
+      if (qr) {
+        const msg =
+          'WhatsApp authentication required. Run /setup in Claude Code.';
+        logger.error(msg);
+        exec(
+          `osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`,
+        );
+        setTimeout(() => process.exit(1), 1000);
+      }
+
+      if (connection === 'close') {
+        this.connected = false;
+        const reason = (lastDisconnect?.error as { output?: { statusCode?: number } })?.output?.statusCode;
+        const shouldReconnect = reason !== DisconnectReason.loggedOut;
+        logger.info({ reason, shouldReconnect, queuedMessages: this.outgoingQueue.length }, 'Connection closed');
+
+        if (shouldReconnect) {
+          logger.info('Reconnecting...');
+          this.connectInternal().catch((err) => {
+            logger.error({ err }, 'Failed to reconnect, retrying in 5s');
+            setTimeout(() => {
+              this.connectInternal().catch((err2) => {
+                logger.error({ err: err2 }, 'Reconnection retry failed');
+              });
+            }, 5000);
+          });
+        } else {
+          logger.info('Logged out. Run /setup to re-authenticate.');
+          process.exit(0);
+        }
+      } else if (connection === 'open') {
+        this.connected = true;
+        logger.info('Connected to WhatsApp');
+
+        // Announce availability so WhatsApp relays subsequent presence updates (typing indicators)
+        this.sock.sendPresenceUpdate('available').catch((err) => {
+          logger.warn({ err }, 'Failed to send presence update');
+        });
+
+        // Build LID to phone mapping from auth state for self-chat translation
+        if (this.sock.user) {
+          const phoneUser = this.sock.user.id.split(':')[0];
+          const lidUser = this.sock.user.lid?.split(':')[0];
+          if (lidUser && phoneUser) {
+            this.lidToPhoneMap[lidUser] = `${phoneUser}@s.whatsapp.net`;
+            logger.debug({ lidUser, phoneUser }, 'LID to phone mapping set');
+          }
+        }
+
+        // Flush any messages queued while disconnected
+        this.flushOutgoingQueue().catch((err) =>
+          logger.error({ err }, 'Failed to flush outgoing queue'),
+        );
+
+        // Sync group metadata on startup (respects 24h cache)
+        this.syncGroupMetadata().catch((err) =>
+          logger.error({ err }, 'Initial group sync failed'),
+        );
+        // Set up daily sync timer (only once)
+        if (!this.groupSyncTimerStarted) {
+          this.groupSyncTimerStarted = true;
+          setInterval(() => {
+            this.syncGroupMetadata().catch((err) =>
+              logger.error({ err }, 'Periodic group sync failed'),
+            );
+          }, GROUP_SYNC_INTERVAL_MS);
+        }
+
+        // Signal first connection to caller
+        if (onFirstOpen) {
+          onFirstOpen();
+          onFirstOpen = undefined;
+        }
+      }
+    });
+
+    this.sock.ev.on('creds.update', saveCreds);
+
+    this.sock.ev.on('messages.upsert', async ({ messages }) => {
+      for (const msg of messages) {
+        if (!msg.message) continue;
+        const rawJid = msg.key.remoteJid;
+        if (!rawJid || rawJid === 'status@broadcast') continue;
+
+        // Translate LID JID to phone JID if applicable
+        const chatJid = await this.translateJid(rawJid);
+
+        const timestamp = new Date(
+          Number(msg.messageTimestamp) * 1000,
+        ).toISOString();
+
+        // Always notify about chat metadata for group discovery
+        const isGroup = chatJid.endsWith('@g.us');
+        this.opts.onChatMetadata(chatJid, timestamp, undefined, 'whatsapp', isGroup);
+
+        // Only deliver full message for registered groups
+        const groups = this.opts.registeredGroups();
+        if (groups[chatJid]) {
+          const content =
+            msg.message?.conversation ||
+            msg.message?.extendedTextMessage?.text ||
+            msg.message?.imageMessage?.caption ||
+            msg.message?.videoMessage?.caption ||
+            '';
+
+          // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+          // but allow voice messages and image messages through for processing
+          if (!content && !isVoiceMessage(msg) && !isImageMessage(msg)) continue;
+
+          const sender = msg.key.participant || msg.key.remoteJid || '';
+          const senderName = msg.pushName || sender.split('@')[0];
+
+          const fromMe = msg.key.fromMe || false;
+          // Detect bot messages: with own number, fromMe is reliable
+          // since only the bot sends from that number.
+          // With shared number, bot messages carry the assistant name prefix
+          // (even in DMs/self-chat) so we check for that.
+          const isBotMessage = ASSISTANT_HAS_OWN_NUMBER
+            ? fromMe
+            : content.startsWith(`${ASSISTANT_NAME}:`);
+
+          // Transcribe voice messages before storing
+          let finalContent = content;
+          if (isVoiceMessage(msg)) {
+            try {
+              const transcript = await transcribeAudioMessage(msg, this.sock);
+              if (transcript) {
+                finalContent = `[Voice: ${transcript}]`;
+                logger.info({ chatJid, length: transcript.length }, 'Transcribed voice message');
+              } else {
+                finalContent = '[Voice Message - transcription unavailable]';
+              }
+            } catch (err) {
+              logger.error({ err }, 'Voice transcription error');
+              finalContent = '[Voice Message - transcription failed]';
+            }
+          }
+
+          // Handle image messages
+          if (isImageMessage(msg)) {
+            const imageSender = isGroup
+              ? msg.key.participant || msg.key.remoteJid || ''
+              : chatJid;
+            const allowlistCfg = loadSenderAllowlist();
+            const senderIsAllowed = isSenderAllowed(chatJid, imageSender, allowlistCfg);
+
+            if (senderIsAllowed) {
+              try {
+                const imageData = await downloadImageMessage(msg, this.sock);
+                if (imageData) {
+                  const group = groups[chatJid];
+                  if (group) {
+                    const imagePath = saveImageToGroup(
+                      group.folder, imageData.buffer, imageData.mimetype,
+                      msg.key.id || `img-${Date.now()}`
+                    );
+                    const caption = content ? ` with caption: "${content}"` : '';
+                    finalContent = `[Image${caption} — view it by reading: ${imagePath}]`;
+                    logger.info({ chatJid, sender: imageSender, size: imageData.buffer.length, mimetype: imageData.mimetype }, 'Downloaded and saved image');
+                  }
+                } else {
+                  finalContent = content || '[Image - download failed]';
+                }
+              } catch (err) {
+                logger.error({ err, chatJid }, 'Image download error');
+                finalContent = content || '[Image - download failed]';
+              }
+            } else {
+              finalContent = content || '[Image from unauthorized sender]';
+            }
+          }
+
+          this.opts.onMessage(chatJid, {
+            id: msg.key.id || '',
+            chat_jid: chatJid,
+            sender,
+            sender_name: senderName,
+            content: finalContent,
+            timestamp,
+            is_from_me: fromMe,
+            is_bot_message: isBotMessage,
+          });
+        }
+      }
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    // Prefix bot messages with assistant name so users know who's speaking.
+    // On a shared number, prefix is also needed in DMs (including self-chat)
+    // to distinguish bot output from user messages.
+    // Skip only when the assistant has its own dedicated phone number.
+    const prefixed = ASSISTANT_HAS_OWN_NUMBER
+      ? text
+      : `${ASSISTANT_NAME}: ${text}`;
+
+    if (!this.connected) {
+      this.outgoingQueue.push({ jid, text: prefixed });
+      logger.info({ jid, length: prefixed.length, queueSize: this.outgoingQueue.length }, 'WA disconnected, message queued');
+      return;
+    }
+    try {
+      await this.sock.sendMessage(jid, { text: prefixed });
+      logger.info({ jid, length: prefixed.length }, 'Message sent');
+    } catch (err) {
+      // If send fails, queue it for retry on reconnect
+      this.outgoingQueue.push({ jid, text: prefixed });
+      logger.warn({ jid, err, queueSize: this.outgoingQueue.length }, 'Failed to send, message queued');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.endsWith('@g.us') || jid.endsWith('@s.whatsapp.net');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.sock?.end(undefined);
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    try {
+      const status = isTyping ? 'composing' : 'paused';
+      logger.debug({ jid, status }, 'Sending presence update');
+      await this.sock.sendPresenceUpdate(status, jid);
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to update typing status');
+    }
+  }
+
+  /**
+   * Sync group metadata from WhatsApp.
+   * Fetches all participating groups and stores their names in the database.
+   * Called on startup, daily, and on-demand via IPC.
+   */
+  async syncGroupMetadata(force = false): Promise<void> {
+    if (!force) {
+      const lastSync = getLastGroupSync();
+      if (lastSync) {
+        const lastSyncTime = new Date(lastSync).getTime();
+        if (Date.now() - lastSyncTime < GROUP_SYNC_INTERVAL_MS) {
+          logger.debug({ lastSync }, 'Skipping group sync - synced recently');
+          return;
+        }
+      }
+    }
+
+    try {
+      logger.info('Syncing group metadata from WhatsApp...');
+      const groups = await this.sock.groupFetchAllParticipating();
+
+      let count = 0;
+      for (const [jid, metadata] of Object.entries(groups)) {
+        if (metadata.subject) {
+          updateChatName(jid, metadata.subject);
+          count++;
+        }
+      }
+
+      setLastGroupSync();
+      logger.info({ count }, 'Group metadata synced');
+    } catch (err) {
+      logger.error({ err }, 'Failed to sync group metadata');
+    }
+  }
+
+  private async translateJid(jid: string): Promise<string> {
+    if (!jid.endsWith('@lid')) return jid;
+    const lidUser = jid.split('@')[0].split(':')[0];
+
+    // Check local cache first
+    const cached = this.lidToPhoneMap[lidUser];
+    if (cached) {
+      logger.debug({ lidJid: jid, phoneJid: cached }, 'Translated LID to phone JID (cached)');
+      return cached;
+    }
+
+    // Query Baileys' signal repository for the mapping
+    try {
+      const pn = await this.sock.signalRepository?.lidMapping?.getPNForLID(jid);
+      if (pn) {
+        const phoneJid = `${pn.split('@')[0].split(':')[0]}@s.whatsapp.net`;
+        this.lidToPhoneMap[lidUser] = phoneJid;
+        logger.info({ lidJid: jid, phoneJid }, 'Translated LID to phone JID (signalRepository)');
+        return phoneJid;
+      }
+    } catch (err) {
+      logger.debug({ err, jid }, 'Failed to resolve LID via signalRepository');
+    }
+
+    return jid;
+  }
+
+  private async flushOutgoingQueue(): Promise<void> {
+    if (this.flushing || this.outgoingQueue.length === 0) return;
+    this.flushing = true;
+    try {
+      logger.info({ count: this.outgoingQueue.length }, 'Flushing outgoing message queue');
+      while (this.outgoingQueue.length > 0) {
+        const item = this.outgoingQueue.shift()!;
+        // Send directly — queued items are already prefixed by sendMessage
+        await this.sock.sendMessage(item.jid, { text: item.text });
+        logger.info({ jid: item.jid, length: item.text.length }, 'Queued message sent');
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+}

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.ts.intent.md
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/channels/whatsapp.ts.intent.md
@@ -1,0 +1,35 @@
+# Intent: src/channels/whatsapp.ts modifications
+
+## What changed
+Added image message handling. When an image arrives, it is downloaded via Baileys,
+saved to the group's images/ directory, and the agent receives a prompt to read the
+file path. Sender allowlist is checked before downloading.
+
+## Key sections
+
+### Imports (top of file)
+- Added: `isImageMessage`, `downloadImageMessage`, `saveImageToGroup` from `../image-handler.js`
+- Added: `isSenderAllowed`, `loadSenderAllowlist` from `../sender-allowlist.js`
+
+### Content skip guard
+- Changed: `if (!content && !isVoiceMessage(msg)) continue;`
+  → `if (!content && !isVoiceMessage(msg) && !isImageMessage(msg)) continue;`
+  (image messages may have no text content but should still be processed)
+
+### messages.upsert handler (after voice handling block)
+- Added: `isImageMessage(msg)` check
+- Added: sender allowlist check via `isSenderAllowed()`
+- Added: try/catch calling `downloadImageMessage()` + `saveImageToGroup()`
+  - Success: `finalContent = '[Image with caption: "..." — view it by reading: /workspace/group/images/file.jpg]'`
+  - Download fail: `finalContent = content || '[Image - download failed]'`
+  - Unauthorized: `finalContent = content || '[Image from unauthorized sender]'`
+
+## Invariants (must-keep)
+- All existing message handling (conversation, extendedTextMessage, videoMessage) unchanged
+- Voice transcription handling unchanged (isVoiceMessage block untouched)
+- Connection lifecycle (connect, reconnect, disconnect) unchanged
+- LID translation logic unchanged
+- Outgoing message queue unchanged
+- Group metadata sync unchanged
+- sendMessage prefix logic unchanged
+- setTyping, ownsJid, isConnected — all unchanged

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/index.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/index.ts
@@ -1,0 +1,592 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ASSISTANT_NAME,
+  IDLE_TIMEOUT,
+  POLL_INTERVAL,
+  TRIGGER_PATTERN,
+} from './config.js';
+import './channels/index.js';
+import {
+  getChannelFactory,
+  getRegisteredChannelNames,
+} from './channels/registry.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import {
+  cleanupOrphans,
+  ensureContainerRuntimeRunning,
+} from './container-runtime.js';
+import {
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getAllTasks,
+  getMessagesSince,
+  getNewMessages,
+  getRouterState,
+  initDatabase,
+  setRegisteredGroup,
+  setRouterState,
+  setSession,
+  storeChatMetadata,
+  storeMessage,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { startImageCleanup } from './image-cleanup.js';
+import { startIpcWatcher } from './ipc.js';
+import { findChannel, formatMessages, formatOutbound } from './router.js';
+import {
+  isSenderAllowed,
+  isTriggerAllowed,
+  loadSenderAllowlist,
+  shouldDropMessage,
+} from './sender-allowlist.js';
+import { startSchedulerLoop } from './task-scheduler.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { logger } from './logger.js';
+
+// Re-export for backwards compatibility during refactor
+export { escapeXml, formatMessages } from './router.js';
+
+let lastTimestamp = '';
+let sessions: Record<string, string> = {};
+let registeredGroups: Record<string, RegisteredGroup> = {};
+let lastAgentTimestamp: Record<string, string> = {};
+let messageLoopRunning = false;
+let imageCleanupTimer: NodeJS.Timeout | undefined;
+
+const channels: Channel[] = [];
+const queue = new GroupQueue();
+
+function loadState(): void {
+  lastTimestamp = getRouterState('last_timestamp') || '';
+  const agentTs = getRouterState('last_agent_timestamp');
+  try {
+    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+  } catch {
+    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+    lastAgentTimestamp = {};
+  }
+  sessions = getAllSessions();
+  registeredGroups = getAllRegisteredGroups();
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    'State loaded',
+  );
+}
+
+function saveState(): void {
+  setRouterState('last_timestamp', lastTimestamp);
+  setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
+}
+
+function registerGroup(jid: string, group: RegisteredGroup): void {
+  let groupDir: string;
+  try {
+    groupDir = resolveGroupFolderPath(group.folder);
+  } catch (err) {
+    logger.warn(
+      { jid, folder: group.folder, err },
+      'Rejecting group registration with invalid folder',
+    );
+    return;
+  }
+
+  registeredGroups[jid] = group;
+  setRegisteredGroup(jid, group);
+
+  // Create group folder
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    'Group registered',
+  );
+}
+
+/**
+ * Get available groups list for the agent.
+ * Returns groups ordered by most recent activity.
+ */
+export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}
+
+/** @internal - exported for testing */
+export function _setRegisteredGroups(
+  groups: Record<string, RegisteredGroup>,
+): void {
+  registeredGroups = groups;
+}
+
+/**
+ * Process all pending messages for a group.
+ * Called by the GroupQueue when it's this group's turn.
+ */
+async function processGroupMessages(chatJid: string): Promise<boolean> {
+  const group = registeredGroups[chatJid];
+  if (!group) return true;
+
+  const channel = findChannel(channels, chatJid);
+  if (!channel) {
+    logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+    return true;
+  }
+
+  const isMainGroup = group.isMain === true;
+
+  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+  const missedMessages = getMessagesSince(
+    chatJid,
+    sinceTimestamp,
+    ASSISTANT_NAME,
+  );
+
+  if (missedMessages.length === 0) return true;
+
+  // For non-main groups, check if trigger is required and present
+  if (!isMainGroup && group.requiresTrigger !== false) {
+    const allowlistCfg = loadSenderAllowlist();
+    const hasTrigger = missedMessages.some(
+      (m) =>
+        TRIGGER_PATTERN.test(m.content.trim()) &&
+        (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+    );
+    if (!hasTrigger) return true;
+  }
+
+  const prompt = formatMessages(missedMessages);
+
+  // Advance cursor so the piping path in startMessageLoop won't re-fetch
+  // these messages. Save the old cursor so we can roll back on error.
+  const previousCursor = lastAgentTimestamp[chatJid] || '';
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    'Processing messages',
+  );
+
+  // Track idle timer for closing stdin when agent is idle
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.debug(
+        { group: group.name },
+        'Idle timeout, closing container stdin',
+      );
+      queue.closeStdin(chatJid);
+    }, IDLE_TIMEOUT);
+  };
+
+  await channel.setTyping?.(chatJid, true);
+  let hadError = false;
+  let outputSentToUser = false;
+
+  const output = await runAgent(group, prompt, chatJid, async (result) => {
+    // Streaming output callback — called for each agent result
+    if (result.result) {
+      const raw =
+        typeof result.result === 'string'
+          ? result.result
+          : JSON.stringify(result.result);
+      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      if (text) {
+        await channel.sendMessage(chatJid, text);
+        outputSentToUser = true;
+      }
+      // Only reset idle timer on actual results, not session-update markers (result: null)
+      resetIdleTimer();
+    }
+
+    if (result.status === 'success') {
+      queue.notifyIdle(chatJid);
+    }
+
+    if (result.status === 'error') {
+      hadError = true;
+    }
+  });
+
+  await channel.setTyping?.(chatJid, false);
+  if (idleTimer) clearTimeout(idleTimer);
+
+  if (output === 'error' || hadError) {
+    // If we already sent output to the user, don't roll back the cursor —
+    // the user got their response and re-processing would send duplicates.
+    if (outputSentToUser) {
+      logger.warn(
+        { group: group.name },
+        'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+      );
+      return true;
+    }
+    // Roll back cursor so retries can re-process these messages
+    lastAgentTimestamp[chatJid] = previousCursor;
+    saveState();
+    logger.warn(
+      { group: group.name },
+      'Agent error, rolled back message cursor for retry',
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<'success' | 'error'> {
+  const isMain = group.isMain === true;
+  const sessionId = sessions[group.folder];
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Update available groups snapshot (main group only can see all groups)
+  const availableGroups = getAvailableGroups();
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
+
+  // Wrap onOutput to track session ID from streamed results
+  const wrappedOnOutput = onOutput
+    ? async (output: ContainerOutput) => {
+        if (output.newSessionId) {
+          sessions[group.folder] = output.newSessionId;
+          setSession(group.folder, output.newSessionId);
+        }
+        await onOutput(output);
+      }
+    : undefined;
+
+  try {
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        assistantName: ASSISTANT_NAME,
+      },
+      (proc, containerName) =>
+        queue.registerProcess(chatJid, proc, containerName, group.folder),
+      wrappedOnOutput,
+    );
+
+    if (output.newSessionId) {
+      sessions[group.folder] = output.newSessionId;
+      setSession(group.folder, output.newSessionId);
+    }
+
+    if (output.status === 'error') {
+      logger.error(
+        { group: group.name, error: output.error },
+        'Container agent error',
+      );
+      return 'error';
+    }
+
+    return 'success';
+  } catch (err) {
+    logger.error({ group: group.name, err }, 'Agent error');
+    return 'error';
+  }
+}
+
+async function startMessageLoop(): Promise<void> {
+  if (messageLoopRunning) {
+    logger.debug('Message loop already running, skipping duplicate start');
+    return;
+  }
+  messageLoopRunning = true;
+
+  logger.info(`NanoClaw running (trigger: @${ASSISTANT_NAME})`);
+
+  while (true) {
+    try {
+      const jids = Object.keys(registeredGroups);
+      const { messages, newTimestamp } = getNewMessages(
+        jids,
+        lastTimestamp,
+        ASSISTANT_NAME,
+      );
+
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
+
+        // Advance the "seen" cursor for all messages immediately
+        lastTimestamp = newTimestamp;
+        saveState();
+
+        // Deduplicate by group
+        const messagesByGroup = new Map<string, NewMessage[]>();
+        for (const msg of messages) {
+          const existing = messagesByGroup.get(msg.chat_jid);
+          if (existing) {
+            existing.push(msg);
+          } else {
+            messagesByGroup.set(msg.chat_jid, [msg]);
+          }
+        }
+
+        for (const [chatJid, groupMessages] of messagesByGroup) {
+          const group = registeredGroups[chatJid];
+          if (!group) continue;
+
+          const channel = findChannel(channels, chatJid);
+          if (!channel) {
+            logger.warn({ chatJid }, 'No channel owns JID, skipping messages');
+            continue;
+          }
+
+          const isMainGroup = group.isMain === true;
+          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
+          // For non-main groups, only act on trigger messages.
+          // Non-trigger messages accumulate in DB and get pulled as
+          // context when a trigger eventually arrives.
+          if (needsTrigger) {
+            const allowlistCfg = loadSenderAllowlist();
+            const hasTrigger = groupMessages.some(
+              (m) =>
+                TRIGGER_PATTERN.test(m.content.trim()) &&
+                (m.is_from_me ||
+                  isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
+            );
+            if (!hasTrigger) continue;
+          }
+
+          // Pull all messages since lastAgentTimestamp so non-trigger
+          // context that accumulated between triggers is included.
+          const allPending = getMessagesSince(
+            chatJid,
+            lastAgentTimestamp[chatJid] || '',
+            ASSISTANT_NAME,
+          );
+          const messagesToSend =
+            allPending.length > 0 ? allPending : groupMessages;
+          const formatted = formatMessages(messagesToSend);
+
+          if (queue.sendMessage(chatJid, formatted)) {
+            logger.debug(
+              { chatJid, count: messagesToSend.length },
+              'Piped messages to active container',
+            );
+            lastAgentTimestamp[chatJid] =
+              messagesToSend[messagesToSend.length - 1].timestamp;
+            saveState();
+            // Show typing indicator while the container processes the piped message
+            channel
+              .setTyping?.(chatJid, true)
+              ?.catch((err) =>
+                logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
+              );
+          } else {
+            // No active container — enqueue for a new one
+            queue.enqueueMessageCheck(chatJid);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in message loop');
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+/**
+ * Startup recovery: check for unprocessed messages in registered groups.
+ * Handles crash between advancing lastTimestamp and processing messages.
+ */
+function recoverPendingMessages(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+    if (pending.length > 0) {
+      logger.info(
+        { group: group.name, pendingCount: pending.length },
+        'Recovery: found unprocessed messages',
+      );
+      queue.enqueueMessageCheck(chatJid);
+    }
+  }
+}
+
+function ensureContainerSystemRunning(): void {
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
+}
+
+async function main(): Promise<void> {
+  ensureContainerSystemRunning();
+  initDatabase();
+  logger.info('Database initialized');
+  loadState();
+
+  // Graceful shutdown handlers
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    if (imageCleanupTimer) clearInterval(imageCleanupTimer);
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Channel callbacks (shared by all channels)
+  const channelOpts = {
+    onMessage: (chatJid: string, msg: NewMessage) => {
+      // Sender allowlist drop mode: discard messages from denied senders before storing
+      if (!msg.is_from_me && !msg.is_bot_message && registeredGroups[chatJid]) {
+        const cfg = loadSenderAllowlist();
+        if (
+          shouldDropMessage(chatJid, cfg) &&
+          !isSenderAllowed(chatJid, msg.sender, cfg)
+        ) {
+          if (cfg.logDenied) {
+            logger.debug(
+              { chatJid, sender: msg.sender },
+              'sender-allowlist: dropping message (drop mode)',
+            );
+          }
+          return;
+        }
+      }
+      storeMessage(msg);
+    },
+    onChatMetadata: (
+      chatJid: string,
+      timestamp: string,
+      name?: string,
+      channel?: string,
+      isGroup?: boolean,
+    ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create and connect all registered channels.
+  // Each channel self-registers via the barrel import above.
+  // Factories return null when credentials are missing, so unconfigured channels are skipped.
+  for (const channelName of getRegisteredChannelNames()) {
+    const factory = getChannelFactory(channelName)!;
+    const channel = factory(channelOpts);
+    if (!channel) {
+      logger.warn(
+        { channel: channelName },
+        'Channel installed but credentials missing — skipping. Check .env or re-run the channel skill.',
+      );
+      continue;
+    }
+    channels.push(channel);
+    await channel.connect();
+  }
+  if (channels.length === 0) {
+    logger.fatal('No channels connected');
+    process.exit(1);
+  }
+
+  // Start image cleanup timer (runs once at startup, then weekly)
+  imageCleanupTimer = startImageCleanup();
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) =>
+      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn({ jid }, 'No channel owns JID, cannot send message');
+        return;
+      }
+      const text = formatOutbound(rawText);
+      if (text) await channel.sendMessage(jid, text);
+    },
+  });
+  startIpcWatcher({
+    sendMessage: (jid, text) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      return channel.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroups: async (force: boolean) => {
+      await Promise.all(
+        channels
+          .filter((ch) => ch.syncGroups)
+          .map((ch) => ch.syncGroups!(force)),
+      );
+    },
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) =>
+      writeGroupsSnapshot(gf, im, ag, rj),
+  });
+  queue.setProcessMessagesFn(processGroupMessages);
+  recoverPendingMessages();
+  startMessageLoop().catch((err) => {
+    logger.fatal({ err }, 'Message loop crashed unexpectedly');
+    process.exit(1);
+  });
+}
+
+// Guard: only run when executed directly, not when imported by tests
+const isDirectRun =
+  process.argv[1] &&
+  new URL(import.meta.url).pathname ===
+    new URL(`file://${process.argv[1]}`).pathname;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    logger.error({ err }, 'Failed to start NanoClaw');
+    process.exit(1);
+  });
+}

--- a/.claude/skills/add-whatsapp-image-understanding/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-whatsapp-image-understanding/modify/src/index.ts.intent.md
@@ -1,0 +1,25 @@
+# Intent: src/index.ts modifications
+
+## What changed
+Added image cleanup lifecycle — starts a weekly timer that deletes images older than 30 days
+from all group images/ directories. Timer is cleared on shutdown.
+
+## Key sections
+
+### Imports
+- Added: `startImageCleanup` from `./image-cleanup.js`
+
+### Module-level state
+- Added: `let imageCleanupTimer: NodeJS.Timeout | undefined;`
+
+### Startup (inside main(), after channels connect)
+- Added: `imageCleanupTimer = startImageCleanup();` (runs cleanup once, then every 7 days)
+
+### Shutdown handler
+- Added: `if (imageCleanupTimer) clearInterval(imageCleanupTimer);`
+
+## Invariants (must-keep)
+- All existing imports unchanged
+- Channel registration, message loop, container runner — all unchanged
+- Task scheduler, IPC watcher — unchanged
+- All other shutdown cleanup — unchanged

--- a/.claude/skills/add-whatsapp-image-understanding/tests/image-understanding.test.ts
+++ b/.claude/skills/add-whatsapp-image-understanding/tests/image-understanding.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('add-whatsapp-image-understanding skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  it('has a valid manifest', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    expect(content).toContain('skill: add-whatsapp-image-understanding');
+    expect(content).toContain('version: 1.0.0');
+    // No npm dependencies or env additions needed
+    expect(content).not.toContain('OPENAI_API_KEY');
+  });
+
+  it('has all files declared in adds', () => {
+    const imageHandlerFile = path.join(skillDir, 'add', 'src', 'image-handler.ts');
+    const imageCleanupFile = path.join(skillDir, 'add', 'src', 'image-cleanup.ts');
+
+    expect(fs.existsSync(imageHandlerFile)).toBe(true);
+    expect(fs.existsSync(imageCleanupFile)).toBe(true);
+
+    const handlerContent = fs.readFileSync(imageHandlerFile, 'utf-8');
+    expect(handlerContent).toContain('isImageMessage');
+    expect(handlerContent).toContain('downloadImageMessage');
+    expect(handlerContent).toContain('saveImageToGroup');
+    expect(handlerContent).toContain('downloadMediaMessage');
+    expect(handlerContent).toContain('normalizeMessageContent');
+
+    const cleanupContent = fs.readFileSync(imageCleanupFile, 'utf-8');
+    expect(cleanupContent).toContain('cleanupOldImages');
+    expect(cleanupContent).toContain('startImageCleanup');
+  });
+
+  it('has all files declared in modifies', () => {
+    const whatsappFile = path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.ts');
+    const whatsappTestFile = path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.test.ts');
+    const indexFile = path.join(skillDir, 'modify', 'src', 'index.ts');
+    const claudeMdFile = path.join(skillDir, 'modify', 'groups', 'global', 'CLAUDE.md');
+
+    expect(fs.existsSync(whatsappFile)).toBe(true);
+    expect(fs.existsSync(whatsappTestFile)).toBe(true);
+    expect(fs.existsSync(indexFile)).toBe(true);
+    expect(fs.existsSync(claudeMdFile)).toBe(true);
+  });
+
+  it('has intent files for modified files', () => {
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.ts.intent.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.test.ts.intent.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'index.ts.intent.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'groups', 'global', 'CLAUDE.md.intent.md'))).toBe(true);
+  });
+
+  it('modified whatsapp.ts preserves core structure', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.ts'),
+      'utf-8',
+    );
+
+    // Core class and methods preserved
+    expect(content).toContain('class WhatsAppChannel');
+    expect(content).toContain('implements Channel');
+    expect(content).toContain('async connect()');
+    expect(content).toContain('async sendMessage(');
+    expect(content).toContain('isConnected()');
+    expect(content).toContain('ownsJid(');
+    expect(content).toContain('async disconnect()');
+    expect(content).toContain('async setTyping(');
+    expect(content).toContain('async syncGroupMetadata(');
+    expect(content).toContain('private async translateJid(');
+    expect(content).toContain('private async flushOutgoingQueue(');
+
+    // Core imports preserved
+    expect(content).toContain('ASSISTANT_HAS_OWN_NUMBER');
+    expect(content).toContain('ASSISTANT_NAME');
+    expect(content).toContain('STORE_DIR');
+  });
+
+  it('modified whatsapp.ts includes image handling', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.ts'),
+      'utf-8',
+    );
+
+    // Image handler imports
+    expect(content).toContain("import { isImageMessage, downloadImageMessage, saveImageToGroup } from '../image-handler.js'");
+    expect(content).toContain("import { isSenderAllowed, loadSenderAllowlist } from '../sender-allowlist.js'");
+
+    // Image message handling
+    expect(content).toContain('isImageMessage(msg)');
+    expect(content).toContain('downloadImageMessage(msg, this.sock)');
+    expect(content).toContain('saveImageToGroup(');
+    expect(content).toContain('isSenderAllowed(');
+    expect(content).toContain('[Image');
+    expect(content).toContain('[Image - download failed]');
+    expect(content).toContain('[Image from unauthorized sender]');
+
+    // Content skip guard includes image check
+    expect(content).toContain('!isImageMessage(msg)');
+  });
+
+  it('modified whatsapp.test.ts includes image mock and tests', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.test.ts'),
+      'utf-8',
+    );
+
+    // Image handler mock
+    expect(content).toContain("vi.mock('../image-handler.js'");
+    expect(content).toContain('isImageMessage');
+    expect(content).toContain('downloadImageMessage');
+    expect(content).toContain('saveImageToGroup');
+
+    // Sender allowlist mock
+    expect(content).toContain("vi.mock('../sender-allowlist.js'");
+    expect(content).toContain('isSenderAllowed');
+    expect(content).toContain('loadSenderAllowlist');
+
+    // Image test cases
+    expect(content).toContain('downloads and saves image from allowed sender');
+    expect(content).toContain('includes caption alongside image path');
+    expect(content).toContain('blocks image download from non-allowed sender');
+    expect(content).toContain('does not skip image without caption');
+    expect(content).toContain('falls back gracefully when image download fails');
+    expect(content).toContain('[Image — view it by reading: /workspace/group/images/test.jpg]');
+  });
+
+  it('modified whatsapp.test.ts preserves all existing test sections', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'channels', 'whatsapp.test.ts'),
+      'utf-8',
+    );
+
+    // All existing test describe blocks preserved
+    expect(content).toContain("describe('connection lifecycle'");
+    expect(content).toContain("describe('authentication'");
+    expect(content).toContain("describe('reconnection'");
+    expect(content).toContain("describe('message handling'");
+    expect(content).toContain("describe('LID to JID translation'");
+    expect(content).toContain("describe('outgoing message queue'");
+    expect(content).toContain("describe('group metadata sync'");
+    expect(content).toContain("describe('ownsJid'");
+    expect(content).toContain("describe('setTyping'");
+    expect(content).toContain("describe('channel properties'");
+  });
+
+  it('modified index.ts includes cleanup timer', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'index.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain("import { startImageCleanup } from './image-cleanup.js'");
+    expect(content).toContain('imageCleanupTimer');
+    expect(content).toContain('startImageCleanup()');
+    expect(content).toContain('clearInterval(imageCleanupTimer)');
+  });
+
+  it('modified global CLAUDE.md includes image instructions', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'groups', 'global', 'CLAUDE.md'),
+      'utf-8',
+    );
+
+    expect(content).toContain('## Images');
+    expect(content).toContain('view it by reading:');
+    expect(content).toContain('Read');
+    expect(content).toContain('[Image from unauthorized sender]');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'skills-engine/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'skills-engine/**/*.test.ts', '.claude/skills/**/*.test.ts'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'skills-engine/**/*.test.ts', '.claude/skills/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'skills-engine/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Adds a new skill `.claude/skills/add-whatsapp-image-understanding/` that gives NanoClaw the ability to understand images sent in WhatsApp.

When an image arrives:
1. Downloads via Baileys' built-in `downloadMediaMessage`
2. Saves to `groups/<folder>/images/<messageId>.jpg`
3. Injects prompt: `[Image with caption: "..." — view it by reading: /workspace/group/images/file.jpg]`
4. Agent uses the Read tool to view the image and respond

Also includes:
- Weekly cleanup of images older than 30 days (`src/image-cleanup.ts`)
- Sender allowlist integration (respects `sender-allowlist.json`)
- Agent instructions in `groups/global/CLAUDE.md`
- 5 test cases for image handling in `whatsapp.test.ts`
- No new npm dependencies or environment variables required

## Design

- Image functions live in `src/image-handler.ts` (NOT `transcription.ts`) to avoid conflicts with voice-transcription skill
- Uses upstream's `isSenderAllowed()` from `sender-allowlist.ts` for authorization
- `depends: []` — works independently, coexists with voice-transcription
- Content skip guard updated: `!isImageMessage(msg)` added alongside `!isVoiceMessage(msg)`

## Test plan

- [ ] `npx vitest run .claude/skills/add-whatsapp-image-understanding/tests/image-understanding.test.ts` passes (10/10)
- [ ] Apply skill to clean checkout: `npx tsx scripts/apply-skill.ts .claude/skills/add-whatsapp-image-understanding`
- [ ] `npm test` passes after apply
- [ ] `npm run build` succeeds after apply
- [ ] Send image in WhatsApp → agent receives `[Image — view it by reading: ...]` and describes image
- [ ] Send image with caption → caption appears in prompt
- [ ] Image from non-allowed sender → blocked message

🤖 Generated with [Claude Code](https://claude.com/claude-code)