### PR TITLE
fix(container): set UTF-8 locale for multi-byte args

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -26,6 +26,11 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
+# Set UTF-8 locale so Chinese and other multi-byte characters are handled correctly
+# C.UTF-8 is built into glibc and always available without locale-gen
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 # Set Chromium path for agent-browser
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium


### PR DESCRIPTION
## Summary
Set container locale defaults to UTF-8 so process arguments with multi-byte characters (for example Chinese) are displayed and handled correctly.

## Changes
- Set `LANG=C.UTF-8`
- Set `LC_ALL=C.UTF-8`

These defaults are applied in the agent container image, which avoids needing manual `export LANG/LC_ALL` inside running containers.

## Verification
Reproduced in old `nanoclaw-agent` image:
1. Run script with Chinese argument in background.
2. `ps aux` showed garbled argument (`??????`).
3. After `export LANG=C.UTF-8` and `export LC_ALL=C.UTF-8`, `ps aux` correctly showed `你好`.

With this change, UTF-8 locale is configured by default in the container, so the argument is shown correctly without manual exports.
