### PR TITLE
fix(auth): read OAuth token from ~/.claude/.credentials.json to fix daily 401s

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -27,6 +27,11 @@ vi.mock('./logger.js', () => ({
   },
 }));
 
+// Mock os
+vi.mock('os', () => ({
+  default: { homedir: vi.fn(() => '/home/testuser') },
+}));
+
 // Mock fs
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -82,6 +87,7 @@ vi.mock('child_process', async () => {
   };
 });
 
+import fs from 'fs';
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
 import type { RegisteredGroup } from './types.js';
 
@@ -199,5 +205,87 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+// Helper: collect everything written to stdin before the container closes
+async function captureStdinPayload(
+  group: RegisteredGroup,
+  input: Parameters<typeof runContainerAgent>[1],
+): Promise<Record<string, unknown>> {
+  let stdinData = '';
+  fakeProc.stdin.on('data', (chunk: Buffer) => {
+    stdinData += chunk.toString();
+  });
+
+  const resultPromise = runContainerAgent(group, { ...input }, () => {});
+  fakeProc.emit('close', 0);
+  await resultPromise;
+
+  return JSON.parse(stdinData);
+}
+
+describe('readSecrets — OAuth token resolution', () => {
+  const credPath = '/home/testuser/.claude/.credentials.json';
+  const futureExpiry = Date.now() + 3600_000;
+  const pastExpiry = Date.now() - 3600_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    // Default: no .env content, no credentials file
+    vi.mocked(fs.readFileSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('uses token from credentials.json when .env has a stale token', async () => {
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (String(filePath).endsWith('.env')) return 'CLAUDE_CODE_OAUTH_TOKEN=stale-token';
+      if (String(filePath) === credPath)
+        return JSON.stringify({ claudeAiOauth: { accessToken: 'fresh-token', expiresAt: futureExpiry } });
+      return '';
+    });
+
+    const payload = await captureStdinPayload(testGroup, testInput);
+    expect(payload.secrets).toEqual(expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'fresh-token' }));
+  });
+
+  it('falls back to .env when credentials.json is missing', async () => {
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (String(filePath).endsWith('.env')) return 'CLAUDE_CODE_OAUTH_TOKEN=env-token';
+      if (String(filePath) === credPath) throw new Error('ENOENT');
+      return '';
+    });
+
+    const payload = await captureStdinPayload(testGroup, testInput);
+    expect(payload.secrets).toEqual(expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'env-token' }));
+  });
+
+  it('falls back to .env when credentials.json token is expired', async () => {
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (String(filePath).endsWith('.env')) return 'CLAUDE_CODE_OAUTH_TOKEN=env-token';
+      if (String(filePath) === credPath)
+        return JSON.stringify({ claudeAiOauth: { accessToken: 'expired-token', expiresAt: pastExpiry } });
+      return '';
+    });
+
+    const payload = await captureStdinPayload(testGroup, testInput);
+    expect(payload.secrets).toEqual(expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'env-token' }));
+  });
+
+  it('skips credentials.json entirely when ANTHROPIC_API_KEY is set', async () => {
+    const credReadSpy = vi.fn();
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (String(filePath).endsWith('.env')) return 'ANTHROPIC_API_KEY=sk-ant-key';
+      if (String(filePath) === credPath) { credReadSpy(); return '{}'; }
+      return '';
+    });
+
+    await captureStdinPayload(testGroup, testInput);
+    expect(credReadSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, exec, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -178,12 +179,57 @@ function buildVolumeMounts(
   return mounts;
 }
 
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    accessToken?: string;
+    expiresAt?: number;
+  };
+}
+
 /**
- * Read allowed secrets from .env for passing to the container via stdin.
+ * Try to get a fresh OAuth token from ~/.claude/.credentials.json.
+ * Claude Code keeps this file up to date automatically, so it will always
+ * have a newer token than whatever was written to .env at setup time.
+ * Returns null if the file is missing, unreadable, or the token is expired.
+ */
+function getFreshOAuthToken(): string | null {
+  try {
+    const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
+    const raw = fs.readFileSync(credPath, 'utf-8');
+    const creds: ClaudeCredentials = JSON.parse(raw);
+    const token = creds.claudeAiOauth?.accessToken;
+    const expiresAt = creds.claudeAiOauth?.expiresAt;
+    if (!token) return null;
+    if (expiresAt != null && Date.now() >= expiresAt) {
+      logger.warn(
+        { expiresAt },
+        'OAuth token in ~/.claude/.credentials.json is expired — falling back to .env',
+      );
+      return null;
+    }
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read allowed secrets for passing to the container via stdin.
+ * Prefers the OAuth token from ~/.claude/.credentials.json (kept fresh by
+ * Claude Code) over the potentially stale token in .env. Falls back to .env
+ * for all values if no credentials file is found.
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  const secrets = readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  // Only attempt credentials.json refresh when using OAuth (not API key)
+  if (!secrets['ANTHROPIC_API_KEY']) {
+    const freshToken = getFreshOAuthToken();
+    if (freshToken) {
+      secrets['CLAUDE_CODE_OAUTH_TOKEN'] = freshToken;
+    }
+  }
+  return secrets;
 }
 
 function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {


### PR DESCRIPTION
## Summary

- **Problem:** Containers fail with `401 authentication_error: OAuth token has expired` every morning. `readSecrets()` reads `CLAUDE_CODE_OAUTH_TOKEN` from `.env`, which holds the token from initial setup — but OAuth tokens expire after a few hours.
- **Why it matters:** Every user running NanoClaw via Claude Code CLI (the default setup path) hits a broken assistant overnight with no clear error message. The workaround is switching to an API key, which not everyone can or wants to do.
- **Root cause:** Claude Code already keeps a fresh token in `~/.claude/.credentials.json` and refreshes it automatically. NanoClaw never reads from there.
- **Fix:** Before each container spawn, check `~/.claude/.credentials.json` for a valid token. If found and unexpired, use it. Fall back to `.env` if the file is missing, unreadable, or the token is expired.
- **What did NOT change:** All existing fallback behavior is preserved. ANTHROPIC_API_KEY users are unaffected (credentials.json is skipped entirely when an API key is set). No new dependencies.

Closes #730.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Closes #730

## User-visible / Behavior Changes

Containers get a fresh OAuth token on every spawn without any user action. The daily manual workaround (restarting with a new token) is no longer needed.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — reads an additional credentials file, but the token is already read from `.env`. No new attack surface; the file is on the local filesystem under the user's home directory.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Set up NanoClaw using Claude Code CLI (CLAUDE_CODE_OAUTH_TOKEN in .env)
2. Wait for the token to expire (~4-8 hours)
3. Send a message — container fails with 401

### Expected (after fix)

Message handled normally. Fresh token read from `~/.claude/.credentials.json`.

### Actual (before fix)

```
Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired."}}
```

## Evidence

- [x] 4 new tests covering: fresh token used over stale .env token, fallback on missing file, fallback on expired token, API key path skips credentials.json entirely.

```
✓ src/container-runner.test.ts (7 tests) 24ms
```

## Human Verification

- Verified `~/.claude/.credentials.json` exists and contains `claudeAiOauth.accessToken` / `expiresAt` on a standard Claude Code installation.
- Verified `ANTHROPIC_API_KEY` path is unaffected by reading the test output.
- Did not verify with a live expired token (would require waiting hours).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — existing `.env` setup continues to work as fallback

## Failure Recovery

- If credentials.json parsing fails for any reason, the code silently falls back to `.env`. No regression from current behavior.
- Revert: remove `getFreshOAuthToken()` and the call in `readSecrets()`, revert the `os` import.

## Risks and Mitigations

- Risk: `~/.claude/.credentials.json` format changes in a future Claude Code release.
  - Mitigation: The read is wrapped in try/catch. Any parse error or missing field falls back to `.env` gracefully.