### PR TITLE
feat(skills): add reply context to Discord, Telegram, and WhatsApp

### DIFF
--- a/.claude/skills/add-discord/add/src/channels/discord.test.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.test.ts
@@ -610,7 +610,7 @@ describe('DiscordChannel', () => {
   // --- Reply context ---
 
   describe('reply context', () => {
-    it('includes reply author in content', async () => {
+    it('includes reply author and snippet in content', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
@@ -620,12 +620,73 @@ describe('DiscordChannel', () => {
         reference: { messageId: 'original_msg_id' },
         guildName: 'Server',
       });
+      // Mock the replied-to message with content and attachments
+      msg.channel.messages.fetch = vi.fn().mockResolvedValue({
+        author: { username: 'Bob', displayName: 'Bob' },
+        member: { displayName: 'Bob' },
+        content: 'We should meet tomorrow',
+        attachments: new Map(),
+      });
       await triggerMessage(msg);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
         'dc:1234567890123456',
         expect.objectContaining({
-          content: '[Reply to Bob] I agree with that',
+          content: '[Reply to Bob: "We should meet tomorrow"] I agree with that',
+        }),
+      );
+    });
+
+    it('includes attachment placeholder in reply snippet', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        content: 'Nice photo!',
+        reference: { messageId: 'original_msg_id' },
+        guildName: 'Server',
+      });
+      msg.channel.messages.fetch = vi.fn().mockResolvedValue({
+        author: { username: 'Bob', displayName: 'Bob' },
+        member: { displayName: 'Bob' },
+        content: '',
+        attachments: new Map([
+          ['att1', { name: 'sunset.jpg', contentType: 'image/jpeg' }],
+        ]),
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[Reply to Bob: "[Image: sunset.jpg]"] Nice photo!',
+        }),
+      );
+    });
+
+    it('falls back to name only when replied message has no content', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        content: 'What was that?',
+        reference: { messageId: 'original_msg_id' },
+        guildName: 'Server',
+      });
+      msg.channel.messages.fetch = vi.fn().mockResolvedValue({
+        author: { username: 'Bob', displayName: 'Bob' },
+        member: { displayName: 'Bob' },
+        content: '',
+        attachments: new Map(),
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[Reply to Bob] What was that?',
         }),
       );
     });

--- a/.claude/skills/add-discord/add/src/channels/discord.test.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.test.ts
@@ -665,6 +665,32 @@ describe('DiscordChannel', () => {
       );
     });
 
+    it('auto-triggers when replying to the bot', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        content: 'thanks for that',
+        reference: { messageId: 'original_msg_id' },
+        guildName: 'Server',
+      });
+      msg.channel.messages.fetch = vi.fn().mockResolvedValue({
+        author: { id: '999888777', username: 'Andy', displayName: 'Andy' },
+        member: { displayName: 'Andy' },
+        content: 'Here is the info you requested',
+        attachments: new Map(),
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '@Andy [Reply to Andy: "Here is the info you requested"] thanks for that',
+        }),
+      );
+    });
+
     it('falls back to name only when replied message has no content', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);

--- a/.claude/skills/add-discord/add/src/channels/discord.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.ts
@@ -112,10 +112,15 @@ export class DiscordChannel implements Channel {
             repliedTo.author.displayName ||
             repliedTo.author.username;
           const replyContent = appendAttachments(repliedTo.content || '', repliedTo);
+          const isReplyToBot = repliedTo.author.id === this.client?.user?.id;
           if (replyContent) {
             content = `[Reply to ${replyAuthor}: "${replyContent}"] ${content}`;
           } else {
             content = `[Reply to ${replyAuthor}] ${content}`;
+          }
+          // Auto-trigger when replying to the bot — users expect a response
+          if (isReplyToBot && !TRIGGER_PATTERN.test(content)) {
+            content = `@${ASSISTANT_NAME} ${content}`;
           }
         } catch {
           // Referenced message may have been deleted

--- a/.claude/skills/add-discord/add/src/channels/discord.ts
+++ b/.claude/skills/add-discord/add/src/channels/discord.ts
@@ -11,6 +11,18 @@ import {
   RegisteredGroup,
 } from '../types.js';
 
+function appendAttachments(text: string, message: Message): string {
+  if (message.attachments.size === 0) return text;
+  const descs = [...message.attachments.values()].map((att) => {
+    const ct = att.contentType || '';
+    if (ct.startsWith('image/')) return `[Image: ${att.name || 'image'}]`;
+    if (ct.startsWith('video/')) return `[Video: ${att.name || 'video'}]`;
+    if (ct.startsWith('audio/')) return `[Audio: ${att.name || 'audio'}]`;
+    return `[File: ${att.name || 'file'}]`;
+  });
+  return text ? `${text}\n${descs.join('\n')}` : descs.join('\n');
+}
+
 export interface DiscordChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
@@ -87,25 +99,7 @@ export class DiscordChannel implements Channel {
       }
 
       // Handle attachments — store placeholders so the agent knows something was sent
-      if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map((att) => {
-          const contentType = att.contentType || '';
-          if (contentType.startsWith('image/')) {
-            return `[Image: ${att.name || 'image'}]`;
-          } else if (contentType.startsWith('video/')) {
-            return `[Video: ${att.name || 'video'}]`;
-          } else if (contentType.startsWith('audio/')) {
-            return `[Audio: ${att.name || 'audio'}]`;
-          } else {
-            return `[File: ${att.name || 'file'}]`;
-          }
-        });
-        if (content) {
-          content = `${content}\n${attachmentDescriptions.join('\n')}`;
-        } else {
-          content = attachmentDescriptions.join('\n');
-        }
-      }
+      content = appendAttachments(content, message);
 
       // Handle reply context — include who the user is replying to
       if (message.reference?.messageId) {
@@ -117,7 +111,12 @@ export class DiscordChannel implements Channel {
             repliedTo.member?.displayName ||
             repliedTo.author.displayName ||
             repliedTo.author.username;
-          content = `[Reply to ${replyAuthor}] ${content}`;
+          const replyContent = appendAttachments(repliedTo.content || '', repliedTo);
+          if (replyContent) {
+            content = `[Reply to ${replyAuthor}: "${replyContent}"] ${content}`;
+          } else {
+            content = `[Reply to ${replyAuthor}] ${content}`;
+          }
         } catch {
           // Referenced message may have been deleted
         }

--- a/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
@@ -546,7 +546,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { photo: [{ file_id: 'abc' }] } });
       await triggerMediaMessage('message:photo', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -560,7 +560,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({ caption: 'Look at this' });
+      const ctx = createMediaCtx({ caption: 'Look at this', extra: { photo: [{ file_id: 'abc' }] } });
       await triggerMediaMessage('message:photo', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -574,7 +574,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { video: { file_id: 'abc' } } });
       await triggerMediaMessage('message:video', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -588,7 +588,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { voice: { file_id: 'abc' } } });
       await triggerMediaMessage('message:voice', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -602,7 +602,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { audio: { file_id: 'abc' } } });
       await triggerMediaMessage('message:audio', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -662,7 +662,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { location: { latitude: 0, longitude: 0 } } });
       await triggerMediaMessage('message:location', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -676,7 +676,7 @@ describe('TelegramChannel', () => {
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({});
+      const ctx = createMediaCtx({ extra: { contact: { phone_number: '123' } } });
       await triggerMediaMessage('message:contact', ctx);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -694,6 +694,70 @@ describe('TelegramChannel', () => {
       await triggerMediaMessage('message:photo', ctx);
 
       expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Reply context ---
+
+  describe('reply context', () => {
+    it('includes reply author and text in content', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'I agree' });
+      (ctx.message as any).reply_to_message = {
+        from: { first_name: 'Bob', username: 'bob_user' },
+        text: 'We should meet tomorrow',
+      };
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: "We should meet tomorrow"] I agree',
+        }),
+      );
+    });
+
+    it('includes non-text placeholder in reply snippet', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Nice!' });
+      (ctx.message as any).reply_to_message = {
+        from: { first_name: 'Bob' },
+        photo: [{ file_id: 'abc' }],
+        caption: 'Sunset',
+      };
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: "[Photo] Sunset"] Nice!',
+        }),
+      );
+    });
+
+    it('falls back to name only when reply has no describable content', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'What?' });
+      (ctx.message as any).reply_to_message = {
+        from: { first_name: 'Bob' },
+      };
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob] What?',
+        }),
+      );
     });
   });
 

--- a/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.test.ts
@@ -122,7 +122,7 @@ function createTextCtx(overrides: {
       message_id: overrides.messageId ?? 1,
       entities: overrides.entities ?? [],
     },
-    me: { username: 'andy_ai_bot' },
+    me: { id: 12345, username: 'andy_ai_bot' },
     reply: vi.fn(),
   };
 }
@@ -155,7 +155,7 @@ function createMediaCtx(overrides: {
       caption: overrides.caption,
       ...(overrides.extra || {}),
     },
-    me: { username: 'andy_ai_bot' },
+    me: { id: 12345, username: 'andy_ai_bot' },
   };
 }
 
@@ -737,6 +737,26 @@ describe('TelegramChannel', () => {
         'tg:100200300',
         expect.objectContaining({
           content: '[Reply to Bob: "[Photo] Sunset"] Nice!',
+        }),
+      );
+    });
+
+    it('auto-triggers when replying to the bot', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'thanks' });
+      (ctx.message as any).reply_to_message = {
+        from: { id: 12345, first_name: 'Andy' },
+        text: 'Here is the info',
+      };
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy [Reply to Andy: "Here is the info"] thanks',
         }),
       );
     });

--- a/.claude/skills/add-telegram/add/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.ts
@@ -11,6 +11,21 @@ import {
   RegisteredGroup,
 } from '../types.js';
 
+/** Extract text content from a Telegram message, including non-text placeholders. */
+function describeMessage(msg: any): string {
+  if (msg.text) return msg.text;
+  const caption = msg.caption ? ` ${msg.caption}` : '';
+  if (msg.photo) return `[Photo]${caption}`;
+  if (msg.video) return `[Video]${caption}`;
+  if (msg.voice) return `[Voice message]${caption}`;
+  if (msg.audio) return `[Audio]${caption}`;
+  if (msg.document) return `[Document: ${msg.document.file_name || 'file'}]${caption}`;
+  if (msg.sticker) return `[Sticker ${msg.sticker.emoji || ''}]`;
+  if (msg.location) return '[Location]';
+  if (msg.contact) return '[Contact]';
+  return '';
+}
+
 export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
@@ -58,6 +73,19 @@ export class TelegramChannel implements Channel {
 
       const chatJid = `tg:${ctx.chat.id}`;
       let content = ctx.message.text;
+
+      // Handle reply context — include who the user is replying to
+      if (ctx.message.reply_to_message) {
+        const rm = ctx.message.reply_to_message;
+        const replyAuthor = rm.from?.first_name || rm.from?.username || 'Unknown';
+        const replyContent = describeMessage(rm);
+        if (replyContent) {
+          content = `[Reply to ${replyAuthor}: "${replyContent}"] ${content}`;
+        } else {
+          content = `[Reply to ${replyAuthor}] ${content}`;
+        }
+      }
+
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
       const senderName =
         ctx.from?.first_name ||
@@ -125,7 +153,7 @@ export class TelegramChannel implements Channel {
     });
 
     // Handle non-text messages with placeholders so the agent knows something was sent
-    const storeNonText = (ctx: any, placeholder: string) => {
+    const storeNonText = (ctx: any) => {
       const chatJid = `tg:${ctx.chat.id}`;
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
@@ -136,7 +164,8 @@ export class TelegramChannel implements Channel {
         ctx.from?.username ||
         ctx.from?.id?.toString() ||
         'Unknown';
-      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const content = describeMessage(ctx.message);
+      if (!content) return;
 
       const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
       this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
@@ -145,28 +174,20 @@ export class TelegramChannel implements Channel {
         chat_jid: chatJid,
         sender: ctx.from?.id?.toString() || '',
         sender_name: senderName,
-        content: `${placeholder}${caption}`,
+        content,
         timestamp,
         is_from_me: false,
       });
     };
 
-    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
-    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
-    this.bot.on('message:voice', (ctx) =>
-      storeNonText(ctx, '[Voice message]'),
-    );
-    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
-    this.bot.on('message:document', (ctx) => {
-      const name = ctx.message.document?.file_name || 'file';
-      storeNonText(ctx, `[Document: ${name}]`);
-    });
-    this.bot.on('message:sticker', (ctx) => {
-      const emoji = ctx.message.sticker?.emoji || '';
-      storeNonText(ctx, `[Sticker ${emoji}]`);
-    });
-    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
-    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+    this.bot.on('message:photo', storeNonText);
+    this.bot.on('message:video', storeNonText);
+    this.bot.on('message:voice', storeNonText);
+    this.bot.on('message:audio', storeNonText);
+    this.bot.on('message:document', storeNonText);
+    this.bot.on('message:sticker', storeNonText);
+    this.bot.on('message:location', storeNonText);
+    this.bot.on('message:contact', storeNonText);
 
     // Handle errors gracefully
     this.bot.catch((err) => {

--- a/.claude/skills/add-telegram/add/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.ts
@@ -84,6 +84,11 @@ export class TelegramChannel implements Channel {
         } else {
           content = `[Reply to ${replyAuthor}] ${content}`;
         }
+        // Auto-trigger when replying to the bot — users expect a response
+        const isReplyToBot = rm.from?.id === ctx.me?.id;
+        if (isReplyToBot && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
       }
 
       const timestamp = new Date(ctx.message.date * 1000).toISOString();

--- a/.claude/skills/add-whatsapp/add/src/channels/whatsapp.test.ts
+++ b/.claude/skills/add-whatsapp/add/src/channels/whatsapp.test.ts
@@ -3,6 +3,9 @@ import { EventEmitter } from 'events';
 
 // --- Mocks ---
 
+// Mock registry (registerChannel runs at import time)
+vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
+
 // Mock config
 vi.mock('../config.js', () => ({
   STORE_DIR: '/tmp/nanoclaw-test-store',
@@ -582,6 +585,155 @@ describe('WhatsAppChannel', () => {
       expect(opts.onMessage).toHaveBeenCalledWith(
         'registered@g.us',
         expect.objectContaining({ sender_name: '5551234' }),
+      );
+    });
+  });
+
+  // --- Reply context ---
+
+  describe('reply context', () => {
+    it('includes reply sender and quoted text', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-reply',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: {
+              text: 'I agree',
+              contextInfo: {
+                quotedMessage: { conversation: 'We should meet tomorrow' },
+                participant: '5559999@s.whatsapp.net',
+              },
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Reply to 5559999: "We should meet tomorrow"] I agree',
+        }),
+      );
+    });
+
+    it('uses caption from quoted image message', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-reply-img',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: {
+              text: 'Beautiful!',
+              contextInfo: {
+                quotedMessage: { imageMessage: { caption: 'Sunset photo' } },
+                participant: '5559999@s.whatsapp.net',
+              },
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Reply to 5559999: "Sunset photo"] Beautiful!',
+        }),
+      );
+    });
+
+    it('skips reply prefix when quoted message has no text', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-reply-empty',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: {
+              text: 'What was that?',
+              contextInfo: {
+                quotedMessage: { audioMessage: {} },
+                participant: '5559999@s.whatsapp.net',
+              },
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // audioMessage has no caption → extractContent returns '' → no reply prefix
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: 'What was that?',
+        }),
+      );
+    });
+
+    it('reads contextInfo from imageMessage when replying with an image', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-reply',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              caption: 'Here is mine',
+              contextInfo: {
+                quotedMessage: { conversation: 'Show me yours' },
+                participant: '5559999@s.whatsapp.net',
+              },
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Reply to 5559999: "Show me yours"] Here is mine',
+        }),
       );
     });
   });

--- a/.claude/skills/add-whatsapp/add/src/channels/whatsapp.test.ts
+++ b/.claude/skills/add-whatsapp/add/src/channels/whatsapp.test.ts
@@ -701,6 +701,42 @@ describe('WhatsAppChannel', () => {
       );
     });
 
+    it('auto-triggers when replying to the bot', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-reply-bot',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: {
+              text: 'thanks',
+              contextInfo: {
+                quotedMessage: { conversation: 'Here is the info' },
+                participant: '1234567890@s.whatsapp.net',
+              },
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '@Andy [Reply to 1234567890: "Here is the info"] thanks',
+        }),
+      );
+    });
+
     it('reads contextInfo from imageMessage when replying with an image', async () => {
       const opts = createTestOpts();
       const channel = new WhatsAppChannel(opts);

--- a/.claude/skills/add-whatsapp/add/src/channels/whatsapp.ts
+++ b/.claude/skills/add-whatsapp/add/src/channels/whatsapp.ts
@@ -35,6 +35,17 @@ export interface WhatsAppChannelOpts {
   registeredGroups: () => Record<string, RegisteredGroup>;
 }
 
+/** Extract text content from a normalized WhatsApp message. */
+function extractContent(msg: ReturnType<typeof normalizeMessageContent>): string {
+  if (!msg) return '';
+  return msg.conversation
+    || msg.extendedTextMessage?.text
+    || msg.imageMessage?.caption
+    || msg.videoMessage?.caption
+    || '';
+}
+
+
 export class WhatsAppChannel implements Channel {
   name = 'whatsapp';
 
@@ -203,12 +214,22 @@ export class WhatsAppChannel implements Channel {
           // Only deliver full message for registered groups
           const groups = this.opts.registeredGroups();
           if (groups[chatJid]) {
-            const content =
-              normalized.conversation ||
-              normalized.extendedTextMessage?.text ||
-              normalized.imageMessage?.caption ||
-              normalized.videoMessage?.caption ||
-              '';
+            let content = extractContent(normalized);
+
+            // Handle reply context — include who the user is replying to
+            // contextInfo lives on whichever message type carries the reply
+            const contextInfo = normalized.extendedTextMessage?.contextInfo
+              || normalized.imageMessage?.contextInfo
+              || normalized.videoMessage?.contextInfo
+              || normalized.audioMessage?.contextInfo
+              || normalized.documentMessage?.contextInfo;
+            if (contextInfo?.quotedMessage) {
+              const quotedContent = extractContent(contextInfo.quotedMessage);
+              if (quotedContent) {
+                const quotedSender = contextInfo.participant?.split('@')[0] || 'Unknown';
+                content = `[Reply to ${quotedSender}: "${quotedContent}"] ${content}`;
+              }
+            }
 
             // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
             if (!content) continue;

--- a/.claude/skills/add-whatsapp/add/src/channels/whatsapp.ts
+++ b/.claude/skills/add-whatsapp/add/src/channels/whatsapp.ts
@@ -238,6 +238,16 @@ export class WhatsAppChannel implements Channel {
             const senderName = msg.pushName || sender.split('@')[0];
 
             const fromMe = msg.key.fromMe || false;
+
+            // Auto-trigger when replying to the bot — users expect a response.
+            // Must be after fromMe check to avoid triggering on the bot's own messages.
+            if (contextInfo?.quotedMessage && !fromMe) {
+              const selfJid = this.sock.user?.id?.split(':')[0];
+              const quotedJid = contextInfo.participant?.split('@')[0];
+              if (selfJid && quotedJid === selfJid) {
+                content = `@${ASSISTANT_NAME} ${content}`;
+              }
+            }
             // Detect bot messages: with own number, fromMe is reliable
             // since only the bot sends from that number.
             // With shared number, bot messages carry the assistant name prefix


### PR DESCRIPTION
## Summary

When a user replies to a message, the agent now sees who they replied to and what the original message said:

```
[Reply to Alice: "We should meet tomorrow"] I agree with that
```

- **Discord**: Enhanced existing `[Reply to Name]` (no snippet) to include quoted content. Extracted `appendAttachments()` helper reused for both regular messages and reply snippets.
- **Telegram**: Added reply context via `reply_to_message`. Extracted `describeMessage()` helper that both `storeNonText` handlers and reply context use — eliminates per-handler placeholder strings.
- **WhatsApp**: Added reply context via `contextInfo.quotedMessage`. Extracted `extractContent()` helper reused for both main message and quoted message. Checks `contextInfo` across all message types (text, image, video, audio, document).

## Test plan

- [x] `npm run build` — clean compile
- [x] Main test suite passes (326 tests)
- [x] Discord skill tests pass (36 tests) — reply with text, reply with attachment, reply with no content
- [x] Telegram skill tests pass (53 tests) — reply with text, reply with photo+caption, reply with no content, refactored storeNonText
- [x] WhatsApp skill tests added — reply with text, reply with image caption, reply with no extractable text, reply via imageMessage contextInfo