### PR TITLE
fix: pause task on group-not-found to prevent infinite retry

### DIFF
--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -52,6 +52,40 @@ describe('task scheduler', () => {
     expect(task?.status).toBe('paused');
   });
 
+  it('pauses due tasks when group is not found to prevent retry churn', async () => {
+    createTask({
+      id: 'task-no-group',
+      group_folder: 'nonexistent-group',
+      chat_jid: 'test@g.us',
+      prompt: 'run',
+      schedule_type: 'once',
+      schedule_value: '2026-02-22T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      created_at: '2026-02-22T00:00:00.000Z',
+    });
+
+    const enqueueTask = vi.fn(
+      (_groupJid: string, _taskId: string, fn: () => Promise<void>) => {
+        void fn();
+      },
+    );
+
+    startSchedulerLoop({
+      registeredGroups: () => ({}),
+      getSessions: () => ({}),
+      queue: { enqueueTask } as any,
+      onProcess: () => {},
+      sendMessage: async () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    const task = getTaskById('task-no-group');
+    expect(task?.status).toBe('paused');
+  });
+
   it('computeNextRun anchors interval tasks to scheduled time to prevent drift', () => {
     const scheduledTime = new Date(Date.now() - 2000).toISOString(); // 2s ago
     const task = {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -114,6 +114,8 @@ async function runTask(
   );
 
   if (!group) {
+    // Stop retry churn — group won't reappear without manual intervention.
+    updateTask(task.id, { status: 'paused' });
     logger.error(
       { taskId: task.id, groupFolder: task.group_folder },
       'Group not found for task',


### PR DESCRIPTION
## Summary

- When a scheduled task references a `group_folder` that no longer matches any registered group, `runTask()` returns early without updating the task's status or `next_run`
- This causes the scheduler to re-enqueue the task every poll cycle (60s), each time preempting the idle container via `closeStdin()`, effectively killing user containers after every conversation
- Add `updateTask(task.id, { status: 'paused' })` to the group-not-found branch, consistent with the existing `resolveGroupFolderPath` error handler above it

## Test plan

- [x] Verify a task with a non-existent `group_folder` gets paused after one attempt instead of retrying every minute
- [x] Verify existing tasks with valid groups continue to run normally
- [x] All 5 tests in `task-scheduler.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)