### PR TITLE
feat: add QQ Bot channel with auto-registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 
+# QQ Bot (https://q.qq.com)
+QQ_BOT_APP_ID=
+QQ_BOT_APP_SECRET=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "nanoclaw",
       "version": "1.2.10",
       "dependencies": {
+        "@types/ws": "^8.18.1",
+        "axios": "^1.13.6",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
+        "ws": "^8.19.0",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
@@ -961,10 +964,18 @@
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1131,6 +1142,12 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1138,6 +1155,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -1215,6 +1243,19 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1236,6 +1277,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -1282,6 +1335,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1289,6 +1351,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/end-of-stream": {
@@ -1300,12 +1376,57 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1414,6 +1535,42 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -1435,6 +1592,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1454,6 +1657,18 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1462,6 +1677,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -1627,6 +1881,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -1740,7 +2024,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1903,6 +2186,12 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -2295,7 +2584,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2340,7 +2628,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
@@ -2355,7 +2642,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2431,7 +2717,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -2527,12 +2812,32 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@types/ws": "^8.18.1",
+    "axios": "^1.13.6",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
+    "ws": "^8.19.0",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -5,6 +5,9 @@
 
 // gmail
 
+// qq
+import './qq.js';
+
 // slack
 
 // telegram

--- a/src/channels/qq.ts
+++ b/src/channels/qq.ts
@@ -115,14 +115,14 @@ export class QQBotChannel implements Channel {
       this.handlePayload(payload);
     });
 
-    this.ws.on('close', (code) => {
+    this.ws.on('close', (code: number, _reason: Buffer) => {
       this.connected = false;
       this.clearHeartbeat();
       logger.warn({ code }, 'QQ Bot WebSocket closed, reconnecting in 5s');
       setTimeout(() => this.reconnect(), 5000);
     });
 
-    this.ws.on('error', (err) => {
+    this.ws.on('error', (err: Error) => {
       logger.error({ err }, 'QQ Bot WebSocket error');
     });
   }

--- a/src/channels/qq.ts
+++ b/src/channels/qq.ts
@@ -1,0 +1,427 @@
+import axios from 'axios';
+import WebSocket from 'ws';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { ChannelOpts, registerChannel } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+const TOKEN_URL = 'https://bots.qq.com/app/getAppAccessToken';
+const API_BASE = 'https://api.sgroup.qq.com';
+
+// Intents: GROUP_AT_MESSAGE_CREATE (1<<25) | C2C_MESSAGE_CREATE (1<<28)
+const INTENTS = (1 << 25) | (1 << 28);
+
+// WebSocket OpCodes
+const OP_DISPATCH = 0;
+const OP_HEARTBEAT = 1;
+const OP_IDENTIFY = 2;
+const OP_RESUME = 6;
+const OP_HELLO = 10;
+const OP_HEARTBEAT_ACK = 11;
+
+export interface QQBotChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  registerGroup?: (jid: string, group: RegisteredGroup) => void;
+}
+
+export class QQBotChannel implements Channel {
+  name = 'qq';
+
+  private appId: string;
+  private appSecret: string;
+  private opts: QQBotChannelOpts;
+
+  private accessToken = '';
+  private tokenExpiresAt = 0;
+
+  private ws: WebSocket | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private sessionId = '';
+  private lastSeq: number | null = null;
+  private connected = false;
+
+  // Dedup: track recently seen message IDs
+  private recentMsgIds = new Set<string>();
+
+  // Track last message/event ID per chat for passive replies
+  private lastMsgId = new Map<string, string>();
+  private lastEventId = new Map<string, string>();
+
+  constructor(appId: string, appSecret: string, opts: QQBotChannelOpts) {
+    this.appId = appId;
+    this.appSecret = appSecret;
+    this.opts = opts;
+  }
+
+  // ── Token management ──────────────────────────────────────────────────────
+
+  private async fetchToken(): Promise<void> {
+    const res = await axios.post(TOKEN_URL, {
+      appId: this.appId,
+      clientSecret: this.appSecret,
+    });
+    this.accessToken = res.data.access_token;
+    // Refresh 60s before expiry
+    this.tokenExpiresAt = Date.now() + (res.data.expires_in - 60) * 1000;
+    logger.info('QQ Bot access token refreshed');
+  }
+
+  private async ensureToken(): Promise<void> {
+    if (!this.accessToken || Date.now() >= this.tokenExpiresAt) {
+      await this.fetchToken();
+    }
+  }
+
+  private authHeader(): string {
+    return `QQBot ${this.accessToken}`;
+  }
+
+  // ── WebSocket connection ──────────────────────────────────────────────────
+
+  async connect(): Promise<void> {
+    await this.fetchToken();
+
+    const gwRes = await axios.get(`${API_BASE}/gateway`, {
+      headers: { Authorization: this.authHeader() },
+    });
+    const gatewayUrl: string = gwRes.data.url;
+
+    this.openWebSocket(gatewayUrl);
+  }
+
+  private openWebSocket(url: string): void {
+    this.ws = new WebSocket(url);
+
+    this.ws.on('open', () => {
+      logger.info('QQ Bot WebSocket connected');
+    });
+
+    this.ws.on('message', (raw: WebSocket.RawData) => {
+      let payload: any;
+      try {
+        payload = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      this.handlePayload(payload);
+    });
+
+    this.ws.on('close', (code) => {
+      this.connected = false;
+      this.clearHeartbeat();
+      logger.warn({ code }, 'QQ Bot WebSocket closed, reconnecting in 5s');
+      setTimeout(() => this.reconnect(), 5000);
+    });
+
+    this.ws.on('error', (err) => {
+      logger.error({ err }, 'QQ Bot WebSocket error');
+    });
+  }
+
+  private async reconnect(): Promise<void> {
+    try {
+      await this.ensureToken();
+      const gwRes = await axios.get(`${API_BASE}/gateway`, {
+        headers: { Authorization: this.authHeader() },
+      });
+      this.openWebSocket(gwRes.data.url);
+    } catch (err) {
+      logger.error({ err }, 'QQ Bot reconnect failed, retrying in 10s');
+      setTimeout(() => this.reconnect(), 10000);
+    }
+  }
+
+  private handlePayload(payload: any): void {
+    const { op, d, s, t } = payload;
+
+    if (s != null) this.lastSeq = s;
+
+    switch (op) {
+      case OP_HELLO:
+        this.startHeartbeat(d.heartbeat_interval);
+        if (this.sessionId && this.lastSeq != null) {
+          this.sendResume();
+        } else {
+          this.sendIdentify();
+        }
+        break;
+
+      case OP_HEARTBEAT_ACK:
+        logger.debug('QQ Bot heartbeat ACK');
+        break;
+
+      case OP_DISPATCH:
+        if (t === 'READY') {
+          this.sessionId = d.session_id;
+          this.connected = true;
+          logger.info({ sessionId: this.sessionId }, 'QQ Bot ready');
+          console.log('\n  QQ Bot connected');
+          console.log(
+            '  Any new chat will be auto-registered on first message\n',
+          );
+        } else if (t === 'RESUMED') {
+          this.connected = true;
+          logger.info('QQ Bot session resumed');
+        } else if (t === 'GROUP_AT_MESSAGE_CREATE') {
+          this.handleGroupMessage(d).catch((err) =>
+            logger.error({ err }, 'QQ group message error'),
+          );
+        } else if (t === 'C2C_MESSAGE_CREATE') {
+          this.handleC2CMessage(d).catch((err) =>
+            logger.error({ err }, 'QQ C2C message error'),
+          );
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private sendIdentify(): void {
+    this.send({
+      op: OP_IDENTIFY,
+      d: {
+        token: this.authHeader(),
+        intents: INTENTS,
+        shard: [0, 1],
+        properties: { $os: 'linux', $browser: 'nanoclaw', $device: 'nanoclaw' },
+      },
+    });
+  }
+
+  private sendResume(): void {
+    this.send({
+      op: OP_RESUME,
+      d: {
+        token: this.authHeader(),
+        session_id: this.sessionId,
+        seq: this.lastSeq,
+      },
+    });
+  }
+
+  private startHeartbeat(intervalMs: number): void {
+    this.clearHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.send({ op: OP_HEARTBEAT, d: this.lastSeq });
+    }, intervalMs);
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private send(payload: object): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+
+  // ── Message handlers ──────────────────────────────────────────────────────
+
+  private async handleGroupMessage(d: any): Promise<void> {
+    const msgId: string = d.id;
+    const groupOpenId: string = d.group_openid;
+    const memberOpenId: string = d.author?.member_openid || '';
+    const content: string = (d.content || '').trim();
+    const timestamp: string = d.timestamp || new Date().toISOString();
+
+    if (!groupOpenId) return;
+    if (this.deduplicate(msgId)) return;
+
+    const chatJid = `qq:group:${groupOpenId}`;
+    this.lastMsgId.set(chatJid, msgId);
+    this.lastEventId.set(chatJid, d.event_id || '');
+
+    this.opts.onChatMetadata(chatJid, timestamp, groupOpenId, 'qq', true);
+
+    // Strip @bot mention prefix, add trigger if needed
+    let text = content.replace(/^@\S+\s*/, '').trim();
+    if (!TRIGGER_PATTERN.test(text)) {
+      text = `@${ASSISTANT_NAME} ${text}`;
+    }
+
+    let group = this.opts.registeredGroups()[chatJid];
+    if (!group) {
+      if (!this.opts.registerGroup) {
+        logger.debug({ chatJid }, 'QQ group not registered');
+        return;
+      }
+      // Auto-register on first message
+      const folder = `qq_group-${groupOpenId.slice(0, 8).toLowerCase()}`;
+      group = {
+        name: `QQ Group ${groupOpenId.slice(0, 8)}`,
+        folder,
+        trigger: ASSISTANT_NAME,
+        added_at: timestamp,
+        requiresTrigger: true,
+      };
+      this.opts.registerGroup(chatJid, group);
+      logger.info({ chatJid, folder }, 'QQ group auto-registered');
+    }
+
+    this.opts.onMessage(chatJid, {
+      id: msgId,
+      chat_jid: chatJid,
+      sender: memberOpenId,
+      sender_name: memberOpenId,
+      content: text,
+      timestamp,
+      is_from_me: false,
+    });
+
+    logger.info({ chatJid, sender: memberOpenId }, 'QQ group message stored');
+  }
+
+  private async handleC2CMessage(d: any): Promise<void> {
+    const msgId: string = d.id;
+    const userOpenId: string = d.author?.user_openid || '';
+    const content: string = (d.content || '').trim();
+    const timestamp: string = d.timestamp || new Date().toISOString();
+
+    if (!userOpenId) return;
+    if (this.deduplicate(msgId)) return;
+
+    const chatJid = `qq:user:${userOpenId}`;
+    this.lastMsgId.set(chatJid, msgId);
+    this.lastEventId.set(chatJid, d.event_id || '');
+
+    this.opts.onChatMetadata(chatJid, timestamp, userOpenId, 'qq', false);
+
+    let text = content.trim();
+    if (!TRIGGER_PATTERN.test(text)) {
+      text = `@${ASSISTANT_NAME} ${text}`;
+    }
+
+    let group = this.opts.registeredGroups()[chatJid];
+    if (!group) {
+      if (!this.opts.registerGroup) {
+        logger.debug({ chatJid }, 'QQ C2C not registered');
+        return;
+      }
+      // Auto-register on first message
+      const folder = `qq_user-${userOpenId.slice(0, 8).toLowerCase()}`;
+      group = {
+        name: `QQ User ${userOpenId.slice(0, 8)}`,
+        folder,
+        trigger: ASSISTANT_NAME,
+        added_at: timestamp,
+        requiresTrigger: false,
+      };
+      this.opts.registerGroup(chatJid, group);
+      logger.info({ chatJid, folder }, 'QQ C2C auto-registered');
+    }
+
+    this.opts.onMessage(chatJid, {
+      id: msgId,
+      chat_jid: chatJid,
+      sender: userOpenId,
+      sender_name: userOpenId,
+      content: text,
+      timestamp,
+      is_from_me: false,
+    });
+
+    logger.info({ chatJid, sender: userOpenId }, 'QQ C2C message stored');
+  }
+
+  private deduplicate(msgId: string): boolean {
+    if (!msgId) return false;
+    if (this.recentMsgIds.has(msgId)) return true;
+    this.recentMsgIds.add(msgId);
+    setTimeout(() => this.recentMsgIds.delete(msgId), 10_000);
+    return false;
+  }
+
+  // ── Send message ──────────────────────────────────────────────────────────
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    try {
+      await this.ensureToken();
+
+      const msgId = this.lastMsgId.get(jid);
+      const eventId = this.lastEventId.get(jid);
+
+      const body: Record<string, any> = {
+        content: text,
+        msg_type: 0,
+      };
+
+      // Include passive reply IDs to bypass active message limits
+      if (msgId) body.msg_id = msgId;
+      if (eventId) body.event_id = eventId;
+
+      let url: string;
+      if (jid.startsWith('qq:group:')) {
+        const groupOpenId = jid.replace('qq:group:', '');
+        url = `${API_BASE}/v2/groups/${groupOpenId}/messages`;
+      } else if (jid.startsWith('qq:user:')) {
+        const userOpenId = jid.replace('qq:user:', '');
+        url = `${API_BASE}/v2/users/${userOpenId}/messages`;
+      } else {
+        logger.warn({ jid }, 'QQ sendMessage: unknown JID format');
+        return;
+      }
+
+      await axios.post(url, body, {
+        headers: { Authorization: this.authHeader() },
+      });
+
+      logger.info({ jid, length: text.length }, 'QQ message sent');
+    } catch (err: any) {
+      logger.error(
+        { jid, err: err?.response?.data || err?.message },
+        'Failed to send QQ message',
+      );
+    }
+  }
+
+  // ── Channel interface ─────────────────────────────────────────────────────
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('qq:');
+  }
+
+  async disconnect(): Promise<void> {
+    this.clearHeartbeat();
+    this.connected = false;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    logger.info('QQ Bot disconnected');
+  }
+
+  async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
+    // QQ Bot API does not support typing indicators
+  }
+}
+
+registerChannel('qq', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['QQ_BOT_APP_ID', 'QQ_BOT_APP_SECRET']);
+  const appId = process.env.QQ_BOT_APP_ID || envVars.QQ_BOT_APP_ID || '';
+  const appSecret =
+    process.env.QQ_BOT_APP_SECRET || envVars.QQ_BOT_APP_SECRET || '';
+  if (!appId || !appSecret) {
+    logger.warn('QQ Bot: QQ_BOT_APP_ID or QQ_BOT_APP_SECRET not set, skipping');
+    return null;
+  }
+  return new QQBotChannel(appId, appSecret, opts);
+});

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,7 @@ export interface ChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  registerGroup?: (jid: string, group: RegisteredGroup) => void;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,6 +507,7 @@ async function main(): Promise<void> {
       isGroup?: boolean,
     ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
     registeredGroups: () => registeredGroups,
+    registerGroup,
   };
 
   // Create and connect all registered channels.


### PR DESCRIPTION
Adds QQ Bot as a messaging channel using the QQ Bot API v2 WebSocket long connection. Works for both group (@bot) and C2C (private) messages.

  QQ is a widely-used instant messaging platform in China supporting text, voice, images, files, group chats, and channels — suitable for both personal and team use. This integration uses the platform's long-connection event subscription mechanism to receive message callbacks without exposing a public webhook address.

  Key features:
  - WebSocket long connection — no public URL or webhook required
  - Auto-registers new chats on first message (no manual join needed)
  - Session resume on reconnect for zero message loss
  - Access token auto-refresh (2h expiry)
  - Passive reply IDs included to bypass active message limits (4/month)
  - Full heartbeat lifecycle management

  Setup:
    Add to .env:
      QQ_BOT_APP_ID=your_app_id
      QQ_BOT_APP_SECRET=your_app_secret

    Register bot at https://q.qq.com and enable:
      - Group message capability (GROUP_AT_MESSAGE_CREATE)
      - C2C message capability (C2C_MESSAGE_CREATE)

  JID format:
    qq:group:{group_openid}   — group chats
    qq:user:{user_openid}     — private chats

  Reference: https://github.com/sliverp/qqbot
  QQ Open Platform: https://q.qq.com/#/apps

  ## Type of Change

  - [ ] **Skill** - adds a new skill in `.claude/skills/`
  - [x] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code

  ## Description

  Adds `src/channels/qq.ts` implementing the `Channel` interface for QQ Bot, following the same self-registration pattern as existing channels (Feishu,DingTalk, Telegram, etc.).

  Also extends `ChannelOpts` in `registry.ts` with an optional `registerGroup` callback, allowing channels to auto-register new chats on first contact without requiring manual IPC commands through the agent.

  Changes:
  - `src/channels/qq.ts` — new QQ Bot channel implementation
  - `src/channels/index.ts` — register QQ channel at startup
  - `src/channels/registry.ts` — add optional `registerGroup` to `ChannelOpts`
  - `src/index.ts` — pass `registerGroup` into channel opts
  - `.env.example` — document `QQ_BOT_APP_ID` and `QQ_BOT_APP_SECRET`

  ## For Skills

  N/A — this is a source code change, not a skill.