### PR TITLE
fix: prevent message loss when new message arrives as idle timeout fires

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -433,6 +433,53 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
   });
 
+  // --- Race condition: closeStdin then sendMessage (c98a3e3) ---
+
+  it('sendMessage returns false after closeStdin is called (race: idle timeout fires before container exits)', async () => {
+    const fs = await import('fs');
+    let resolveProcess: () => void;
+
+    const processMessages = vi.fn(async () => {
+      // Block until we manually release — simulates container still running
+      await new Promise<void>((resolve) => {
+        resolveProcess = resolve;
+      });
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+
+    // Container starts (state.active = true)
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Register process with a groupFolder so closeStdin/sendMessage can both act
+    queue.registerProcess('group1@g.us', {} as any, 'container-1', 'test-group');
+
+    // Idle timer fires — signals container to wind down (state.closing = true)
+    queue.closeStdin('group1@g.us');
+
+    // New message arrives before container actually exits (state.active still true)
+    // Without the fix, sendMessage() would return true and write to the dead container.
+    // With the fix, it must return false.
+    const writeFileSync = vi.mocked(fs.default.writeFileSync);
+    writeFileSync.mockClear();
+
+    const result = queue.sendMessage('group1@g.us', 'hello after close');
+
+    expect(result).toBe(false);
+
+    // No IPC .json file should have been written
+    const ipcWrites = writeFileSync.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).endsWith('.json'),
+    );
+    expect(ipcWrites).toHaveLength(0);
+
+    // Let container finish
+    resolveProcess!();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+
   it('preempts when idle arrives with pending tasks', async () => {
     const fs = await import('fs');
     let resolveProcess: () => void;

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -25,6 +25,7 @@ interface GroupState {
   containerName: string | null;
   groupFolder: string | null;
   retryCount: number;
+  closing: boolean; // true once closeStdin has been called; prevents sendMessage from piping to a shutting-down container
 }
 
 export class GroupQueue {
@@ -49,6 +50,7 @@ export class GroupQueue {
         containerName: null,
         groupFolder: null,
         retryCount: 0,
+        closing: false,
       };
       this.groups.set(groupJid, state);
     }
@@ -159,7 +161,7 @@ export class GroupQueue {
    */
   sendMessage(groupJid: string, text: string): boolean {
     const state = this.getGroup(groupJid);
-    if (!state.active || !state.groupFolder || state.isTaskContainer)
+    if (!state.active || !state.groupFolder || state.isTaskContainer || state.closing)
       return false;
     state.idleWaiting = false; // Agent is about to receive work, no longer idle
 
@@ -184,6 +186,7 @@ export class GroupQueue {
     const state = this.getGroup(groupJid);
     if (!state.active || !state.groupFolder) return;
 
+    state.closing = true;
     const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
@@ -202,6 +205,7 @@ export class GroupQueue {
     state.idleWaiting = false;
     state.isTaskContainer = false;
     state.pendingMessages = false;
+    state.closing = false;
     this.activeCount++;
 
     logger.debug(


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

I added added support for agents to respond to webhooks and found a race condition. GroupQueue.sendMessage() could silently drop incoming messages.

### Sequence:

1. Container is active processing messages (state.active = true)
2. Agent finishes its turn and enters idle-wait — the orchestrator's idle timer fires and calls closeStdin(), which writes a _close sentinel to the IPC directory and signals the container to wind down
3. A new user message arrives before the container process has actually exited — state.active is still true
4. sendMessage() passes its guard (!state.active || !state.groupFolder || !state.isTaskContainer) and writes the new message's IPC file into the input directory
5. The container reads _close, exits — the IPC file is never processed. Message silently lost.

### Fix

Add a closing: boolean flag to GroupState. closeStdin() sets it; notifyContainerStart() clears it (reset for the next run). The sendMessage() guard gains || state.closing, making it return false during the window between idle-timeout and container exit. The caller then treats this as a queued pending message, which is processed in the next container run.

### Evidence

The regression test in this PR (src/group-queue.test.ts) was written to fail on unfixed code and pass on the fix.

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
