### PR TITLE
fix(setup): sync mount allowlist to group container_config

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -116,6 +116,10 @@ AskUserQuestion: Agent access to external directories?
 **No:** `npx tsx setup/index.ts --step mounts -- --empty`
 **Yes:** Collect paths/permissions. `npx tsx setup/index.ts --step mounts -- --json '{"allowedRoots":[...],"blockedPatterns":[],"nonMainReadOnly":true}'`
 
+The mounts step writes the allowlist AND syncs `additionalMounts` to all registered groups' `container_config`. Check `GROUPS_UPDATED` in the status block to confirm groups were updated. If no groups are registered yet (step 5 hasn't run), that's fine — re-run the mounts step after step 5 completes.
+
+**If step 6 runs before step 5** (no registered groups yet): After step 5 completes and groups are registered, re-run the mounts step to sync mounts to the newly registered groups: `npx tsx setup/index.ts --step mounts -- --json '<same json>'`
+
 ## 7. Start Service
 
 If service already running: unload first.

--- a/setup/mounts.ts
+++ b/setup/mounts.ts
@@ -1,11 +1,18 @@
 /**
- * Step: mounts — Write mount allowlist config file.
- * Replaces 07-configure-mounts.sh
+ * Step: mounts — Write mount allowlist config file and sync to registered groups.
+ *
+ * The allowlist (security gate) defines which host paths MAY be mounted.
+ * Each group's container_config.additionalMounts (mount request) defines which
+ * paths ARE mounted.  This step writes BOTH so that configured directories
+ * actually appear inside the container.
  */
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
+import Database from 'better-sqlite3';
+
+import { STORE_DIR } from '../src/config.js';
 import { logger } from '../src/logger.js';
 import { isRoot } from './platform.js';
 import { emitStatus } from './status.js';
@@ -64,7 +71,6 @@ export async function run(args: string[]): Promise<void> {
         LOG: 'logs/setup.log',
       });
       process.exit(4);
-      return; // unreachable but satisfies TS
     }
 
     fs.writeFileSync(configFile, JSON.stringify(parsed, null, 2) + '\n');
@@ -90,7 +96,6 @@ export async function run(args: string[]): Promise<void> {
         LOG: 'logs/setup.log',
       });
       process.exit(4);
-      return;
     }
 
     fs.writeFileSync(configFile, JSON.stringify(parsed, null, 2) + '\n');
@@ -105,11 +110,80 @@ export async function run(args: string[]): Promise<void> {
     'Allowlist configured',
   );
 
+  // Sync additionalMounts to all registered groups so the container actually
+  // mounts the allowed directories.
+  const groupsUpdated = syncMountsToGroups(configFile);
+
   emitStatus('CONFIGURE_MOUNTS', {
     PATH: configFile,
     ALLOWED_ROOTS: allowedRoots,
     NON_MAIN_READ_ONLY: nonMainReadOnly,
+    GROUPS_UPDATED: groupsUpdated,
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
+}
+
+/**
+ * Read the allowlist and derive additionalMounts from its allowedRoots,
+ * then update every registered group's container_config so the
+ * container-runner will mount those directories.
+ */
+function syncMountsToGroups(allowlistPath: string): number {
+  const dbPath = path.join(STORE_DIR, 'messages.db');
+  if (!fs.existsSync(dbPath)) {
+    logger.info('No database yet — skipping mount sync to groups');
+    return 0;
+  }
+
+  let allowlist: {
+    allowedRoots?: Array<string | { path: string; allowReadWrite?: boolean }>;
+  };
+  try {
+    allowlist = JSON.parse(fs.readFileSync(allowlistPath, 'utf-8'));
+  } catch {
+    return 0;
+  }
+
+  const roots = allowlist.allowedRoots;
+  if (!Array.isArray(roots) || roots.length === 0) {
+    return 0;
+  }
+
+  // Build additionalMounts from allowedRoots
+  const additionalMounts = roots.map((root) => {
+    const rootPath = typeof root === 'string' ? root : root.path;
+    const readWrite =
+      typeof root === 'object' && root.allowReadWrite === true;
+    return {
+      hostPath: rootPath,
+      readonly: !readWrite,
+    };
+  });
+
+  const db = new Database(dbPath);
+  try {
+    const rows = db
+      .prepare('SELECT jid, container_config FROM registered_groups')
+      .all() as Array<{ jid: string; container_config: string | null }>;
+
+    const stmt = db.prepare(
+      'UPDATE registered_groups SET container_config = ? WHERE jid = ?',
+    );
+
+    let count = 0;
+    for (const row of rows) {
+      const existing = row.container_config
+        ? JSON.parse(row.container_config)
+        : {};
+      existing.additionalMounts = additionalMounts;
+      stmt.run(JSON.stringify(existing), row.jid);
+      count++;
+    }
+
+    logger.info({ count }, 'Synced additionalMounts to registered groups');
+    return count;
+  } finally {
+    db.close();
+  }
 }


### PR DESCRIPTION
## Summary

- The mounts setup step only wrote the allowlist file (`~/.config/nanoclaw/mount-allowlist.json`) but never updated registered groups' `container_config.additionalMounts`. This meant directories configured during setup were **allowed** but never actually **mounted** into containers.
- Added `syncMountsToGroups()` that derives `additionalMounts` from `allowedRoots` and writes them to every registered group after saving the allowlist.
- Updated setup SKILL.md to document the sync behavior and edge case when mounts step runs before group registration.

## Test plan

- [x] All existing tests pass (326/326)
- [x] TypeScript build passes with no errors
- [ ] Run `npx tsx setup/index.ts --step mounts -- --json '{"allowedRoots":["~/Code"],...}'` and verify `GROUPS_UPDATED` appears in status output
- [ ] Verify `container_config` in SQLite is populated with `additionalMounts` after running the mounts step
- [ ] Verify the configured directory appears at `/workspace/extra/Code` inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)