### PR TITLE
feat: progressive message streaming for edit-capable channels

### DIFF
--- a/.claude/skills/add-telegram/add/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram/add/src/channels/telegram.ts
@@ -1,6 +1,7 @@
 import { Bot } from 'grammy';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { createDraftStream, DraftStream } from '../draft-stream.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -242,6 +243,26 @@ export class TelegramChannel implements Channel {
     } catch (err) {
       logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
     }
+  }
+
+  createDraftStream(jid: string): DraftStream {
+    const bot = this.bot!;
+    const numericId = jid.replace(/^tg:/, '');
+    return createDraftStream({
+      sendMessage: async (text: string) => {
+        const sent = await bot.api.sendMessage(numericId, text);
+        return sent.message_id;
+      },
+      editMessage: async (messageId: number, text: string) => {
+        await bot.api.editMessageText(numericId, messageId, text);
+      },
+      deleteMessage: async (messageId: number) => {
+        await bot.api.deleteMessage(numericId, messageId);
+      },
+      throttleMs: 1000,
+      maxLength: 4096,
+      minInitialChars: 30,
+    });
   }
 }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -35,6 +35,8 @@ interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  /** Partial text for streaming updates (progressive message editing). */
+  streamText?: string;
 }
 
 interface SessionEntry {
@@ -391,6 +393,14 @@ async function runQuery(
   let messageCount = 0;
   let resultCount = 0;
 
+  // Token-level streaming state.
+  // The agent-runner throttles at 300ms to reduce Docker stdout noise.
+  // The host-side draft-stream throttles again at ~1000ms for Telegram API limits.
+  // Both layers are intentional: inner reduces IPC volume, outer reduces API calls.
+  const STREAM_THROTTLE_MS = 300;
+  let streamingTextAccum = '';
+  let lastStreamEmitAt = 0;
+
   // Load global CLAUDE.md as additional system context (shared across all groups)
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
@@ -449,6 +459,7 @@ async function runQuery(
           },
         },
       },
+      includePartialMessages: true,
       hooks: {
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
         PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
@@ -457,10 +468,33 @@ async function runQuery(
   })) {
     messageCount++;
     const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+
+    // Token-level streaming: accumulate text deltas and emit periodically
+    if (message.type === 'stream_event') {
+      const event = (message as { event: { type: string; delta?: { type: string; text?: string } } }).event;
+      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta' && event.delta.text) {
+        streamingTextAccum += event.delta.text;
+        const now = Date.now();
+        if (now - lastStreamEmitAt >= STREAM_THROTTLE_MS && streamingTextAccum.length >= 20) {
+          writeOutput({ status: 'success', result: null, streamText: streamingTextAccum });
+          lastStreamEmitAt = now;
+        }
+      }
+      continue;
+    }
+
     log(`[msg #${messageCount}] type=${msgType}`);
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    // When a complete assistant message arrives, flush any remaining
+    // accumulated streaming text and reset for the next turn.
+    if (message.type === 'assistant' && 'message' in message && streamingTextAccum) {
+      writeOutput({ status: 'success', result: null, streamText: streamingTextAccum });
+      streamingTextAccum = '';
+      lastStreamEmitAt = 0;
     }
 
     if (message.type === 'system' && message.subtype === 'init') {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -46,6 +46,8 @@ export interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  /** Partial text for streaming updates (progressive message editing). */
+  streamText?: string;
 }
 
 interface VolumeMount {

--- a/src/draft-stream.ts
+++ b/src/draft-stream.ts
@@ -144,25 +144,40 @@ export function createDraftStream(opts: DraftStreamOpts): DraftStream {
     },
 
     async finish(text: string): Promise<boolean> {
-      // Re-enable sending for the final flush even if previously stopped
-      // due to length (the final text might be shorter/different).
-      const wasStopped = stopped;
-      stopped = false;
-      pendingText = text;
-      await flush();
+      // Immediately lock out update() to prevent race conditions where
+      // streamText from a new agent turn sneaks in during our async work.
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (inFlight) await inFlight;
 
-      // If we never managed to send anything (debounce or earlier failure),
-      // try one direct send now.
-      if (messageId === undefined && text.trim()) {
-        const ok = await doSendOrEdit(text);
-        stopped = true;
-        return ok;
+      const trimmed = text.trimEnd();
+      if (!trimmed) {
+        // Empty text — preserve any existing message (don't delete it).
+        return messageId !== undefined;
+      }
+      if (trimmed.length > maxLength) {
+        return false; // Too long — caller should fall back to sendMessage
       }
 
-      stopped = true;
-      // If the stream was stopped due to length and we couldn't edit, report failure
-      if (wasStopped && messageId === undefined) return false;
-      return true;
+      try {
+        if (messageId !== undefined) {
+          // Edit existing draft with final text
+          if (trimmed !== lastSentText) {
+            await opts.editMessage(messageId, trimmed);
+          }
+          return true;
+        } else {
+          // Never managed to send (debounce threshold) — try direct send
+          messageId = await opts.sendMessage(trimmed);
+          return messageId !== undefined;
+        }
+      } catch (err) {
+        logger.debug({ err }, 'Draft stream finish failed');
+        return false;
+      }
     },
 
     async cancel(): Promise<void> {

--- a/src/draft-stream.ts
+++ b/src/draft-stream.ts
@@ -1,0 +1,184 @@
+/**
+ * Draft Stream — progressive message editing for streaming responses.
+ *
+ * Sends an initial message, then throttles subsequent edits so Telegram
+ * (or any channel with edit support) isn't hammered with API calls.
+ *
+ * Based on the draft-stream pattern from AtomicBot.
+ */
+
+import { logger } from './logger.js';
+
+export interface DraftStream {
+  /** Update the streaming preview with new text (throttled). */
+  update(text: string): void;
+  /**
+   * Finalize the stream with the final text.
+   * Returns true if delivered via the draft stream (edit or new send).
+   * Returns false if the text was too long or the stream failed — caller
+   * should fall back to channel.sendMessage().
+   */
+  finish(text: string): Promise<boolean>;
+  /** Cancel the stream and delete the preview message if any. */
+  cancel(): Promise<void>;
+}
+
+export interface DraftStreamOpts {
+  /** Send a new message, return its platform message ID. */
+  sendMessage(text: string): Promise<number | undefined>;
+  /** Edit an existing message by ID. */
+  editMessage(messageId: number, text: string): Promise<void>;
+  /** Delete a message by ID. */
+  deleteMessage(messageId: number): Promise<void>;
+  /** Throttle interval in ms (default 1000). */
+  throttleMs?: number;
+  /** Max message length (default 4096 for Telegram). */
+  maxLength?: number;
+  /** Minimum chars before sending first message (debounce for push notifications). */
+  minInitialChars?: number;
+}
+
+export function createDraftStream(opts: DraftStreamOpts): DraftStream {
+  const throttleMs = Math.max(250, opts.throttleMs ?? 1000);
+  const maxLength = opts.maxLength ?? 4096;
+  const minInitialChars = opts.minInitialChars ?? 30;
+
+  let messageId: number | undefined;
+  let lastSentText = '';
+  let pendingText = '';
+  let stopped = false;
+  let inFlight: Promise<boolean> | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let lastSentAt = 0;
+
+  const doSendOrEdit = async (text: string): Promise<boolean> => {
+    if (stopped) return false;
+    const trimmed = text.trimEnd();
+    if (!trimmed || trimmed === lastSentText) return true;
+    if (trimmed.length > maxLength) {
+      // Text exceeds platform limit — stop streaming, caller will handle.
+      stopped = true;
+      logger.debug(
+        { length: trimmed.length, maxLength },
+        'Draft stream stopped: text exceeds max length',
+      );
+      return false;
+    }
+
+    // Debounce first message to avoid noisy push notifications for short prefixes.
+    if (messageId === undefined && trimmed.length < minInitialChars) {
+      return false;
+    }
+
+    lastSentText = trimmed;
+    try {
+      if (messageId !== undefined) {
+        await opts.editMessage(messageId, trimmed);
+      } else {
+        messageId = await opts.sendMessage(trimmed);
+        if (messageId === undefined) {
+          stopped = true;
+          return false;
+        }
+      }
+      return true;
+    } catch (err) {
+      logger.debug({ err }, 'Draft stream send/edit failed');
+      stopped = true;
+      return false;
+    }
+  };
+
+  const flush = async (): Promise<void> => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    while (!stopped) {
+      if (inFlight) {
+        await inFlight;
+        continue;
+      }
+      const text = pendingText;
+      if (!text.trim()) {
+        pendingText = '';
+        return;
+      }
+      pendingText = '';
+      const p = doSendOrEdit(text).finally(() => {
+        if (inFlight === p) inFlight = undefined;
+      });
+      inFlight = p;
+      const ok = await p;
+      if (!ok) {
+        pendingText = text;
+        return;
+      }
+      lastSentAt = Date.now();
+      if (!pendingText) return;
+    }
+  };
+
+  const schedule = (): void => {
+    if (timer) return;
+    const delay = Math.max(0, throttleMs - (Date.now() - lastSentAt));
+    timer = setTimeout(() => {
+      timer = undefined;
+      void flush();
+    }, delay);
+  };
+
+  return {
+    update(text: string): void {
+      if (stopped) return;
+      pendingText = text;
+      if (inFlight) {
+        schedule();
+        return;
+      }
+      if (!timer && Date.now() - lastSentAt >= throttleMs) {
+        void flush();
+        return;
+      }
+      schedule();
+    },
+
+    async finish(text: string): Promise<boolean> {
+      // Re-enable sending for the final flush even if previously stopped
+      // due to length (the final text might be shorter/different).
+      const wasStopped = stopped;
+      stopped = false;
+      pendingText = text;
+      await flush();
+
+      // If we never managed to send anything (debounce or earlier failure),
+      // try one direct send now.
+      if (messageId === undefined && text.trim()) {
+        const ok = await doSendOrEdit(text);
+        stopped = true;
+        return ok;
+      }
+
+      stopped = true;
+      // If the stream was stopped due to length and we couldn't edit, report failure
+      if (wasStopped && messageId === undefined) return false;
+      return true;
+    },
+
+    async cancel(): Promise<void> {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (inFlight) await inFlight;
+      if (messageId !== undefined) {
+        try {
+          await opts.deleteMessage(messageId);
+        } catch (err) {
+          logger.debug({ err }, 'Draft stream cleanup failed');
+        }
+      }
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,8 +204,26 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
+  // Create draft stream for channels that support progressive message editing
+  const draftStream = channel.createDraftStream?.(chatJid);
+  let draftStreamUsed = false;
+
   const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
+    // Streaming text update — route to draft stream for progressive editing.
+    // Channels without createDraftStream ignore these (draftStream is undefined).
+    if (result.streamText && draftStream) {
+      const text = result.streamText
+        .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+        .trim();
+      if (text) {
+        draftStream.update(text);
+        draftStreamUsed = true;
+      }
+      resetIdleTimer();
+      return;
+    }
+
+    // Final result — called for each agent result
     if (result.result) {
       const raw =
         typeof result.result === 'string'
@@ -215,7 +233,16 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
       if (text) {
-        await channel.sendMessage(chatJid, text);
+        // If we were streaming a draft, finalize it with the final text.
+        // Falls back to sendMessage if the draft stream can't deliver.
+        let sentViaDraft = false;
+        if (draftStream && draftStreamUsed) {
+          sentViaDraft = await draftStream.finish(text);
+          draftStreamUsed = false; // Reset so subsequent results send new messages
+        }
+        if (!sentViaDraft) {
+          await channel.sendMessage(chatJid, text);
+        }
         outputSentToUser = true;
       }
       // Only reset idle timer on actual results, not session-update markers (result: null)
@@ -230,6 +257,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       hadError = true;
     }
   });
+
+  // Clean up draft stream if it was never finalized.
+  // Don't cancel (delete) if we've already shown text — the user already saw it.
+  if (draftStream && !outputSentToUser) {
+    if (draftStreamUsed) {
+      // Text was shown — preserve the message rather than deleting
+      await draftStream.finish('').catch(() => {});
+    } else {
+      await draftStream.cancel();
+    }
+  }
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,9 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: streaming draft support. Channels that can edit messages
+  // (like Telegram) implement this for progressive response streaming.
+  createDraftStream?(jid: string): import('./draft-stream.js').DraftStream;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

- Adds a **draft stream** abstraction (`src/draft-stream.ts`) for channels that support message editing (e.g., Telegram). As the agent generates a response, the user sees text appearing progressively in a single message that gets edited in real-time.
- Token-level deltas from the Claude Agent SDK (`includePartialMessages: true`) are accumulated in the container agent-runner (300ms throttle to reduce Docker stdout noise), then forwarded to the host-side draft stream which throttles Telegram API edits at ~1000ms.
- Adds optional `createDraftStream()` to the `Channel` interface — channels that don't implement it are completely unaffected (streaming output is silently ignored).
- Updates the `/add-telegram` skill package so `TelegramChannel` includes `createDraftStream()` out of the box.

## How it works

1. **Agent-runner** (container): Handles `stream_event` → `content_block_delta` → `text_delta` tokens, accumulates them, and emits `{ streamText }` markers via the existing output protocol at 300ms intervals.
2. **Host orchestrator** (`src/index.ts`): Creates a draft stream if the channel supports it, routes `streamText` updates to `draftStream.update()`, and finalizes with `draftStream.finish(finalText)` when the result arrives.
3. **Draft stream** (`src/draft-stream.ts`): Sends an initial message, then throttles edits. Handles max length overflow, debounces first send (30 chars min to avoid noisy push notifications), and gracefully handles errors.

## Files changed

| File | Change |
|------|--------|
| `src/draft-stream.ts` | New — channel-agnostic throttled edit loop |
| `src/types.ts` | Added optional `createDraftStream` to `Channel` interface |
| `src/container-runner.ts` | Added `streamText` to `ContainerOutput` |
| `container/agent-runner/src/index.ts` | `includePartialMessages: true` + stream_event handler |
| `src/index.ts` | Draft stream integration in `processGroupMessages` |
| `.claude/skills/add-telegram/add/src/channels/telegram.ts` | Added `createDraftStream` to skill template |

## Test plan

- [x] TypeScript build passes cleanly
- [x] Tested with Telegram channel — messages stream progressively
- [x] Verified non-streaming channels (WhatsApp) are unaffected — `streamText` output is silently ignored when `createDraftStream` is not implemented
- [x] Handles container kills mid-stream gracefully (preserves partially shown text instead of deleting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)