### PR TITLE
fix: align once schedule validation and docs

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -115,7 +115,7 @@ A personal Claude assistant accessible via WhatsApp, with minimal custom code.
 - Tasks have access to all tools including Bash (safe in container)
 - Tasks can optionally send messages to their group via `send_message` tool, or complete silently
 - Task runs are logged to the database with duration and result
-- Schedule types: cron expressions, intervals (ms), or one-time (ISO timestamp)
+- Schedule types: cron expressions, intervals (ms), or one-time (local timestamp without timezone suffix)
 - From main: can schedule tasks for any group, view/manage all tasks
 - From other groups: can only manage that group's tasks
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -570,7 +570,7 @@ NanoClaw has a built-in scheduler that runs tasks as full agents in their group'
 |------|--------------|---------|
 | `cron` | Cron expression | `0 9 * * 1` (Mondays at 9am) |
 | `interval` | Milliseconds | `3600000` (every hour) |
-| `once` | ISO timestamp | `2024-12-25T09:00:00Z` |
+| `once` | Local timestamp (no timezone suffix) | `2024-12-25T09:00:00` |
 
 ### Creating a Task
 

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -37,6 +37,14 @@ const THIRD_GROUP: RegisteredGroup = {
 let groups: Record<string, RegisteredGroup>;
 let deps: IpcDeps;
 
+const futureOnce = (): string => {
+  const local = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  local.setMilliseconds(0);
+  return new Date(local.getTime() - local.getTimezoneOffset() * 60_000)
+    .toISOString()
+    .slice(0, 19);
+};
+
 beforeEach(() => {
   _initTestDatabase();
 
@@ -74,7 +82,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'do something',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         targetJid: 'other@g.us',
       },
       'whatsapp_main',
@@ -94,7 +102,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'self task',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         targetJid: 'other@g.us',
       },
       'other-group',
@@ -113,7 +121,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'unauthorized',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         targetJid: 'main@g.us',
       },
       'other-group',
@@ -131,7 +139,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'no target',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         targetJid: 'unknown@g.us',
       },
       'whatsapp_main',
@@ -154,7 +162,7 @@ describe('pause_task authorization', () => {
       chat_jid: 'main@g.us',
       prompt: 'main task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'active',
@@ -166,7 +174,7 @@ describe('pause_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'other task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'active',
@@ -215,7 +223,7 @@ describe('resume_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'paused task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'paused',
@@ -264,7 +272,7 @@ describe('cancel_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'cancel me',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -287,7 +295,7 @@ describe('cancel_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'my task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -310,7 +318,7 @@ describe('cancel_task authorization', () => {
       chat_jid: 'main@g.us',
       prompt: 'not yours',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: futureOnce(),
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -554,6 +562,48 @@ describe('schedule_task schedule types', () => {
 
     expect(getAllTasks()).toHaveLength(0);
   });
+
+  it('rejects once timestamp with timezone suffix', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'zulu once',
+        schedule_type: 'once',
+        schedule_value: '2026-12-25T09:00:00Z',
+        targetJid: 'other@g.us',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    expect(getAllTasks()).toHaveLength(0);
+  });
+
+  it('rejects once timestamp in the past', async () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    yesterday.setMilliseconds(0);
+    const pastLocal = new Date(
+      yesterday.getTime() - yesterday.getTimezoneOffset() * 60_000,
+    )
+      .toISOString()
+      .slice(0, 19);
+
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'past once',
+        schedule_type: 'once',
+        schedule_value: pastLocal,
+        targetJid: 'other@g.us',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    expect(getAllTasks()).toHaveLength(0);
+  });
 });
 
 // --- context_mode defaulting ---
@@ -565,7 +615,7 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'group context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         context_mode: 'group',
         targetJid: 'other@g.us',
       },
@@ -584,7 +634,7 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'isolated context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         context_mode: 'isolated',
         targetJid: 'other@g.us',
       },
@@ -603,7 +653,7 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'bad context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         context_mode: 'bogus' as any,
         targetJid: 'other@g.us',
       },
@@ -622,7 +672,7 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'no context mode',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: futureOnce(),
         targetJid: 'other@g.us',
       },
       'whatsapp_main',

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -26,6 +26,23 @@ export interface IpcDeps {
 
 let ipcWatcherRunning = false;
 
+function parseLocalOnceScheduleValue(value: string): Date | null {
+  if (/[Zz]$/.test(value) || /[+-]\d{2}:\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return null;
+  }
+
+  if (date.getTime() <= Date.now()) {
+    return null;
+  }
+
+  return date;
+}
+
 export function startIpcWatcher(deps: IpcDeps): void {
   if (ipcWatcherRunning) {
     logger.debug('IPC watcher already running, skipping duplicate start');
@@ -236,11 +253,11 @@ export async function processTaskIpc(
           }
           nextRun = new Date(Date.now() + ms).toISOString();
         } else if (scheduleType === 'once') {
-          const date = new Date(data.schedule_value);
-          if (isNaN(date.getTime())) {
+          const date = parseLocalOnceScheduleValue(data.schedule_value);
+          if (!date) {
             logger.warn(
               { scheduleValue: data.schedule_value },
-              'Invalid timestamp',
+              'Invalid once timestamp',
             );
             break;
           }
@@ -380,6 +397,18 @@ export async function processTaskIpc(
             if (!isNaN(ms) && ms > 0) {
               updates.next_run = new Date(Date.now() + ms).toISOString();
             }
+          } else if (updatedTask.schedule_type === 'once') {
+            const date = parseLocalOnceScheduleValue(
+              updatedTask.schedule_value,
+            );
+            if (!date) {
+              logger.warn(
+                { taskId: data.taskId, value: updatedTask.schedule_value },
+                'Invalid once timestamp in task update',
+              );
+              break;
+            }
+            updates.next_run = date.toISOString();
           }
         }
 


### PR DESCRIPTION
## Summary
- align one-time task docs with the actual local-time contract (no timezone suffix)
- enforce the same validation in the host IPC layer for create/update flows
- reject past `once` timestamps and add focused regression coverage

## Why
The scheduler contract had drifted in a few places:
- some docs still described `once` as a generic ISO timestamp and showed `...Z` examples
- the tool layer already guided agents to use local timestamps without timezone suffix
- the host IPC layer was more permissive than the tool layer

This PR makes the behavior and docs consistent and prevents invalid / already-expired one-time tasks from being accepted through IPC.

## Testing
- `npm test -- --run src/ipc-auth.test.ts`
- `npm run typecheck`
