### PR TITLE
feat(signal): add channel-agnostic incoming attachment pipeline

### DIFF
--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -47,3 +47,22 @@ JID: signal:group:{base64-group-id}
 folder: signal_group-name
 trigger: @Bot
 ```
+
+## Attachments
+
+Incoming attachments (images, documents, voice notes, videos) are automatically handled:
+
+- **Metadata** is extracted and shown in message context:
+  `[attachment: photo.jpg (image/jpeg, 357KB 1440x2560)]`
+
+- **Files** are downloaded to the group's `attachments/` directory and the path
+  is included in context:
+  `[file: /workspace/group/attachments/12345678901234-photo.jpg]`
+
+- The agent can use its Read tool to view images or PDFs directly.
+
+- Attachment-only messages (no text/caption) are supported.
+
+- Downloads are idempotent — re-processing won't re-fetch existing files.
+
+Outbound attachments (sending files) are not yet supported.

--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: add-signal
+description: Add Signal as a channel via signal-cli JSON-RPC daemon. Supports messages, reactions, typing indicators, and reply threading.
+---
+
+# Add Signal Channel
+
+This skill adds Signal messaging support to NanoClaw using the signal-cli daemon in JSON-RPC mode over a Unix socket.
+
+## Prerequisites
+
+1. **signal-cli** installed and registered with a phone number
+2. signal-cli running in JSON-RPC daemon mode:
+   ```bash
+   signal-cli -a +1234567890 daemon --socket /tmp/signal-cli.sock
+   ```
+
+## Apply
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-signal
+npm run build
+```
+
+## Configuration
+
+Add to `.env`:
+```
+SIGNAL_ACCOUNT_NUMBER=+1234567890
+SIGNAL_SOCKET_PATH=/tmp/signal-cli.sock   # optional, this is the default
+```
+
+## How It Works
+
+- Connects to signal-cli via Unix socket using JSON-RPC protocol
+- Listens for `receive` and `sync` notifications for incoming messages
+- JID format: `signal:+1234567890` (DM) or `signal:group:{groupId}` (group)
+- Supports reactions via `sendReaction` RPC call
+- Auto-reconnects with exponential backoff on disconnect
+- Syncs group metadata on connect
+
+## Register a Signal Group
+
+From the main group, use the `register_group` tool:
+```
+JID: signal:group:{base64-group-id}
+folder: signal_group-name
+trigger: @Bot
+```

--- a/.claude/skills/add-signal/add/src/channels/signal.test.ts
+++ b/.claude/skills/add-signal/add/src/channels/signal.test.ts
@@ -1,0 +1,380 @@
+import net from 'net';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock dependencies before importing SignalChannel
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'TestBot',
+}));
+
+vi.mock('../db.js', () => ({
+  getLatestMessage: vi.fn(),
+  getMessageById: vi.fn(),
+  storeReaction: vi.fn(),
+}));
+
+vi.mock('../env.js', () => ({
+  readEnvFile: vi.fn(() => ({
+    SIGNAL_ACCOUNT_NUMBER: '+1234567890',
+    SIGNAL_SOCKET_PATH: '',
+  })),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock registry to capture the factory
+const { capturedFactory } = vi.hoisted(() => {
+  const ref: { current: ((opts: unknown) => unknown) | null } = { current: null };
+  return { capturedFactory: ref };
+});
+vi.mock('./registry.js', () => ({
+  registerChannel: vi.fn((_name: string, factory: (opts: unknown) => unknown) => {
+    capturedFactory.current = factory;
+  }),
+  ChannelOpts: {},
+}));
+
+import { SignalChannel } from './signal.js';
+import { getLatestMessage, getMessageById } from '../db.js';
+import type { OnInboundMessage, OnChatMetadata } from '../types.js';
+
+describe('SignalChannel', () => {
+  let socketPath: string;
+  let server: net.Server;
+  let channel: SignalChannel;
+  let onMessage: ReturnType<typeof vi.fn<OnInboundMessage>>;
+  let onChatMetadata: ReturnType<typeof vi.fn<OnChatMetadata>>;
+
+  beforeEach(async () => {
+    socketPath = path.join(
+      os.tmpdir(),
+      `signal-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`,
+    );
+
+    onMessage = vi.fn<OnInboundMessage>();
+    onChatMetadata = vi.fn<OnChatMetadata>();
+
+    // Create a mock signal-cli server
+    server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    channel = new SignalChannel(
+      {
+        onMessage,
+        onChatMetadata,
+        registeredGroups: () => ({
+          'signal:+9876543210': {
+            name: 'Test DM',
+            folder: 'signal_test-dm',
+            trigger: '@Bot',
+            added_at: new Date().toISOString(),
+          },
+          'signal:group:testgroup123': {
+            name: 'Test Group',
+            folder: 'signal_test-group',
+            trigger: '@Bot',
+            added_at: new Date().toISOString(),
+          },
+        }),
+      },
+      '+1234567890',
+      socketPath,
+    );
+  });
+
+  afterEach(async () => {
+    await channel.disconnect();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      // already cleaned up
+    }
+  });
+
+  it('connects to signal-cli socket', async () => {
+    // Accept connection and send a listGroups response
+    server.on('connection', (sock) => {
+      sock.on('error', () => {}); // ignore EPIPE during teardown
+      sock.on('data', (data) => {
+        const parsed = JSON.parse(data.toString().trim());
+        if (parsed.method === 'listGroups') {
+          sock.write(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: parsed.id,
+              result: [],
+            }) + '\n',
+          );
+        }
+      });
+    });
+
+    await channel.connect();
+    expect(channel.isConnected()).toBe(true);
+  });
+
+  it('owns signal: JIDs', () => {
+    expect(channel.ownsJid('signal:+1234567890')).toBe(true);
+    expect(channel.ownsJid('signal:group:abc123')).toBe(true);
+    expect(channel.ownsJid('120363@g.us')).toBe(false);
+    expect(channel.ownsJid('tg:-100123')).toBe(false);
+  });
+
+  it('sends DM messages', async () => {
+    let sentMessage: unknown = null;
+
+    server.on('connection', (sock) => {
+      sock.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const parsed = JSON.parse(line);
+          if (parsed.method === 'listGroups') {
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: [] }) +
+                '\n',
+            );
+          } else if (parsed.method === 'send') {
+            sentMessage = parsed.params;
+            sock.write(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: parsed.id,
+                result: { timestamp: Date.now() },
+              }) + '\n',
+            );
+          }
+        }
+      });
+    });
+
+    await channel.connect();
+    await channel.sendMessage('signal:+9876543210', 'Hello!');
+
+    expect(sentMessage).toMatchObject({
+      account: '+1234567890',
+      recipient: ['+9876543210'],
+      message: 'TestBot: Hello!',
+    });
+  });
+
+  it('sends group messages', async () => {
+    let sentMessage: unknown = null;
+
+    server.on('connection', (sock) => {
+      sock.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const parsed = JSON.parse(line);
+          if (parsed.method === 'listGroups') {
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: [] }) +
+                '\n',
+            );
+          } else if (parsed.method === 'send') {
+            sentMessage = parsed.params;
+            sock.write(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: parsed.id,
+                result: { timestamp: Date.now() },
+              }) + '\n',
+            );
+          }
+        }
+      });
+    });
+
+    await channel.connect();
+    await channel.sendMessage(
+      'signal:group:testgroup123',
+      'Hello group!',
+    );
+
+    expect(sentMessage).toMatchObject({
+      account: '+1234567890',
+      groupId: 'testgroup123',
+      message: 'TestBot: Hello group!',
+    });
+  });
+
+  it('handles incoming DM notification', async () => {
+    let clientSocket: net.Socket | null = null;
+
+    server.on('connection', (sock) => {
+      clientSocket = sock;
+      sock.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const parsed = JSON.parse(line);
+          if (parsed.method === 'listGroups') {
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: [] }) +
+                '\n',
+            );
+          }
+        }
+      });
+    });
+
+    await channel.connect();
+
+    // Wait for listGroups to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Send a notification
+    clientSocket!.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'receive',
+        params: {
+          envelope: {
+            sourceNumber: '+9876543210',
+            sourceName: 'Alice',
+            dataMessage: {
+              timestamp: 1700000000000,
+              message: 'Hi there!',
+            },
+          },
+        },
+      }) + '\n',
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(onChatMetadata).toHaveBeenCalledWith(
+      'signal:+9876543210',
+      expect.any(String),
+      undefined,
+      'signal',
+      false,
+    );
+
+    expect(onMessage).toHaveBeenCalledWith(
+      'signal:+9876543210',
+      expect.objectContaining({
+        id: 'signal-1700000000000',
+        chat_jid: 'signal:+9876543210',
+        sender: '+9876543210',
+        sender_name: 'Alice',
+        content: 'Hi there!',
+        is_from_me: false,
+      }),
+    );
+  });
+
+  it('handles incoming group notification with quote', async () => {
+    let clientSocket: net.Socket | null = null;
+
+    server.on('connection', (sock) => {
+      clientSocket = sock;
+      sock.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const parsed = JSON.parse(line);
+          if (parsed.method === 'listGroups') {
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: [] }) +
+                '\n',
+            );
+          }
+        }
+      });
+    });
+
+    await channel.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    clientSocket!.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'receive',
+        params: {
+          envelope: {
+            sourceNumber: '+9876543210',
+            sourceName: 'Alice',
+            dataMessage: {
+              timestamp: 1700000000000,
+              message: 'Replying to you',
+              groupInfo: { groupId: 'testgroup123' },
+              quote: {
+                id: 1699999999000,
+                authorName: 'Bob',
+                text: 'Original message',
+              },
+            },
+          },
+        },
+      }) + '\n',
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(onMessage).toHaveBeenCalledWith(
+      'signal:group:testgroup123',
+      expect.objectContaining({
+        quoted_message_id: 'signal-1699999999000',
+        quote_sender_name: 'Bob',
+        quote_content: 'Original message',
+      }),
+    );
+  });
+
+  it('reacts to latest message', async () => {
+    let reactionParams: unknown = null;
+
+    vi.mocked(getLatestMessage).mockReturnValue({
+      id: 'signal-1700000000000',
+      sender: '+9876543210',
+      sender_name: 'Alice',
+      is_from_me: false,
+    });
+
+    server.on('connection', (sock) => {
+      sock.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const parsed = JSON.parse(line);
+          if (parsed.method === 'listGroups') {
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: [] }) +
+                '\n',
+            );
+          } else if (parsed.method === 'sendReaction') {
+            reactionParams = parsed.params;
+            sock.write(
+              JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: {} }) +
+                '\n',
+            );
+          }
+        }
+      });
+    });
+
+    await channel.connect();
+    await channel.reactToLatestMessage('signal:+9876543210', '👍');
+
+    expect(reactionParams).toMatchObject({
+      account: '+1234567890',
+      emoji: '👍',
+      targetAuthor: '+9876543210',
+      targetTimestamp: 1700000000000,
+      recipient: ['+9876543210'],
+    });
+  });
+
+  it('registers with channel registry', async () => {
+    // Import triggers the registerChannel call
+    await import('./signal.js');
+    expect(capturedFactory.current).toBeTruthy();
+  });
+});

--- a/.claude/skills/add-signal/add/src/channels/signal.ts
+++ b/.claude/skills/add-signal/add/src/channels/signal.ts
@@ -74,6 +74,7 @@ export class SignalChannel implements Channel {
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
   private buffer = '';
+  private lastSentTimestamps: Map<string, number> = new Map();
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shuttingDown = false;
@@ -154,22 +155,53 @@ export class SignalChannel implements Channel {
   async sendMessage(jid: string, text: string): Promise<void> {
     const prefixed = `${ASSISTANT_NAME}: ${text}`;
 
+    let result: { timestamp?: number } | null = null;
     if (jid.startsWith('signal:group:')) {
       const groupId = jid.slice('signal:group:'.length);
-      await this.rpcCall('send', {
+      result = (await this.rpcCall('send', {
         account: this.accountNumber,
         groupId,
         message: prefixed,
-      });
+      })) as { timestamp?: number } | null;
     } else {
       const recipient = jid.slice('signal:'.length);
-      await this.rpcCall('send', {
+      result = (await this.rpcCall('send', {
         account: this.accountNumber,
         recipient: [recipient],
         message: prefixed,
-      });
+      })) as { timestamp?: number } | null;
+    }
+    if (result?.timestamp) {
+      this.lastSentTimestamps.set(jid, result.timestamp);
     }
     logger.info({ jid, length: prefixed.length }, 'Signal message sent');
+  }
+
+  async editMessage(
+    jid: string,
+    newText: string,
+    originalTimestamp?: number,
+  ): Promise<number> {
+    const editTimestamp = originalTimestamp ?? this.lastSentTimestamps.get(jid);
+    if (!editTimestamp) {
+      throw new Error('No message to edit — no stored timestamp for this chat');
+    }
+
+    const params: Record<string, unknown> = {
+      account: this.accountNumber,
+      message: `${ASSISTANT_NAME}: ${newText}`,
+      editTimestamp,
+    };
+
+    if (jid.startsWith('signal:group:')) {
+      params.groupId = jid.slice('signal:group:'.length);
+    } else {
+      params.recipient = [jid.slice('signal:'.length)];
+    }
+
+    await this.rpcCall('send', params);
+    logger.info({ jid, editTimestamp }, 'Signal message edited');
+    return editTimestamp;
   }
 
   isConnected(): boolean {

--- a/.claude/skills/add-signal/add/src/channels/signal.ts
+++ b/.claude/skills/add-signal/add/src/channels/signal.ts
@@ -1,0 +1,502 @@
+import net from 'net';
+
+import { ASSISTANT_NAME } from '../config.js';
+import { getLatestMessage, getMessageById, storeReaction } from '../db.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+
+interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface SignalQuote {
+  id?: number;
+  author?: string;
+  authorName?: string;
+  text?: string;
+}
+
+interface SignalDataMessage {
+  timestamp?: number;
+  message?: string;
+  groupInfo?: { groupId: string; type?: string };
+  quote?: SignalQuote;
+}
+
+interface SignalEnvelope {
+  source?: string;
+  sourceName?: string;
+  sourceNumber?: string;
+  timestamp?: number;
+  dataMessage?: SignalDataMessage;
+  syncMessage?: {
+    sentMessage?: SignalDataMessage;
+  };
+  typingMessage?: {
+    action?: string;
+    groupId?: string;
+  };
+}
+
+const DEFAULT_SOCKET_PATH = '/tmp/signal-cli.sock';
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 60000;
+
+export class SignalChannel implements Channel {
+  name = 'signal';
+
+  private socket: net.Socket | null = null;
+  private connected = false;
+  private onMessage: OnInboundMessage;
+  private onChatMetadata: OnChatMetadata;
+  private registeredGroups: () => Record<string, RegisteredGroup>;
+  private accountNumber: string;
+  private socketPath: string;
+  private rpcId = 0;
+  private pendingRpc = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private buffer = '';
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shuttingDown = false;
+
+  constructor(
+    opts: ChannelOpts,
+    accountNumber: string,
+    socketPath?: string,
+  ) {
+    this.onMessage = opts.onMessage;
+    this.onChatMetadata = opts.onChatMetadata;
+    this.registeredGroups = opts.registeredGroups;
+    this.accountNumber = accountNumber;
+    this.socketPath = socketPath || DEFAULT_SOCKET_PATH;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.connectInternal(resolve, reject);
+    });
+  }
+
+  private connectInternal(
+    onFirstOpen?: () => void,
+    onFirstError?: (err: Error) => void,
+  ): void {
+    const sock = net.createConnection({ path: this.socketPath });
+    this.socket = sock;
+
+    sock.on('connect', () => {
+      this.connected = true;
+      this.reconnectAttempts = 0;
+      logger.info(
+        { socketPath: this.socketPath },
+        'Connected to signal-cli daemon',
+      );
+
+      // Sync group metadata on connect
+      this.syncGroupMetadata().catch((err) =>
+        logger.warn({ err }, 'Signal group sync failed'),
+      );
+
+      if (onFirstOpen) {
+        onFirstOpen();
+        onFirstOpen = undefined;
+        onFirstError = undefined;
+      }
+    });
+
+    sock.on('data', (data) => {
+      this.buffer += data.toString();
+      this.processBuffer();
+    });
+
+    sock.on('error', (err) => {
+      logger.error({ err }, 'Signal socket error');
+      if (onFirstError) {
+        onFirstError(err);
+        onFirstError = undefined;
+        onFirstOpen = undefined;
+      }
+    });
+
+    sock.on('close', () => {
+      this.connected = false;
+      // Reject any pending RPCs
+      for (const [id, pending] of this.pendingRpc) {
+        pending.reject(new Error('Socket closed'));
+        this.pendingRpc.delete(id);
+      }
+
+      if (!this.shuttingDown) {
+        this.scheduleReconnect();
+      }
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const prefixed = `${ASSISTANT_NAME}: ${text}`;
+
+    if (jid.startsWith('signal:group:')) {
+      const groupId = jid.slice('signal:group:'.length);
+      await this.rpcCall('send', {
+        account: this.accountNumber,
+        groupId,
+        message: prefixed,
+      });
+    } else {
+      const recipient = jid.slice('signal:'.length);
+      await this.rpcCall('send', {
+        account: this.accountNumber,
+        recipient: [recipient],
+        message: prefixed,
+      });
+    }
+    logger.info({ jid, length: prefixed.length }, 'Signal message sent');
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('signal:');
+  }
+
+  async disconnect(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.connected = false;
+    this.socket?.destroy();
+    this.socket = null;
+    logger.info('Signal channel disconnected');
+  }
+
+  async sendReaction(
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void> {
+    // messageId format: "signal-{timestamp}"
+    const ts = messageId.startsWith('signal-')
+      ? parseInt(messageId.slice('signal-'.length), 10)
+      : parseInt(messageId, 10);
+    if (!ts || isNaN(ts)) {
+      logger.warn(
+        { jid, messageId },
+        'Cannot send Signal reaction: invalid message ID',
+      );
+      return;
+    }
+
+    const msg = getMessageById(messageId);
+    const targetAuthor = msg
+      ? msg.is_from_me
+        ? this.accountNumber
+        : msg.sender
+      : this.accountNumber;
+
+    await this.cliSendReaction(jid, emoji, targetAuthor, ts, messageId);
+  }
+
+  private async cliSendReaction(
+    jid: string,
+    emoji: string,
+    targetAuthor: string,
+    targetTimestamp: number,
+    messageId: string,
+  ): Promise<void> {
+    const params: Record<string, unknown> = {
+      account: this.accountNumber,
+      emoji,
+      targetAuthor,
+      targetTimestamp,
+    };
+
+    if (jid.startsWith('signal:group:')) {
+      params.groupId = jid.slice('signal:group:'.length);
+    } else {
+      params.recipient = [jid.slice('signal:'.length)];
+    }
+
+    try {
+      await this.rpcCall('sendReaction', params);
+      storeReaction({
+        chatJid: jid,
+        messageId,
+        emoji,
+        timestamp: new Date().toISOString(),
+      });
+      logger.debug({ jid, messageId, emoji }, 'Signal reaction sent');
+    } catch (err) {
+      logger.warn(
+        { jid, messageId, emoji, err },
+        'Failed to send Signal reaction',
+      );
+    }
+  }
+
+  async reactToLatestMessage(jid: string, emoji: string): Promise<void> {
+    const latest = getLatestMessage(jid);
+    if (!latest) {
+      logger.warn({ jid }, 'No latest message in DB for reaction');
+      return;
+    }
+
+    // Determine the author of the message being reacted to
+    const targetAuthor = latest.is_from_me
+      ? this.accountNumber
+      : latest.sender;
+
+    const ts = latest.id.startsWith('signal-')
+      ? parseInt(latest.id.slice('signal-'.length), 10)
+      : parseInt(latest.id, 10);
+    if (!ts || isNaN(ts)) {
+      logger.warn(
+        { jid, id: latest.id },
+        'Cannot parse timestamp from message ID',
+      );
+      return;
+    }
+
+    await this.cliSendReaction(jid, emoji, targetAuthor, ts, latest.id);
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    try {
+      if (jid.startsWith('signal:group:')) {
+        const groupId = jid.slice('signal:group:'.length);
+        await this.rpcCall('sendTyping', {
+          account: this.accountNumber,
+          groupId,
+          stop: !isTyping,
+        });
+      } else {
+        const recipient = jid.slice('signal:'.length);
+        await this.rpcCall('sendTyping', {
+          account: this.accountNumber,
+          recipient: [recipient],
+          stop: !isTyping,
+        });
+      }
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Signal typing indicator');
+    }
+  }
+
+  // --- Private ---
+
+  private async syncGroupMetadata(): Promise<void> {
+    try {
+      const result = (await this.rpcCall('listGroups', {
+        account: this.accountNumber,
+      })) as Array<{ id: string; name?: string }>;
+
+      if (!Array.isArray(result)) return;
+
+      for (const group of result) {
+        if (group.id && group.name) {
+          const chatJid = `signal:group:${group.id}`;
+          this.onChatMetadata(
+            chatJid,
+            new Date().toISOString(),
+            group.name,
+            'signal',
+            true,
+          );
+        }
+      }
+      logger.info({ count: result.length }, 'Signal group metadata synced');
+    } catch (err) {
+      logger.warn({ err }, 'Failed to list Signal groups');
+    }
+  }
+
+  private processBuffer(): void {
+    const lines = this.buffer.split('\n');
+    // Keep the last (potentially incomplete) line in the buffer
+    this.buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed.id !== undefined && this.pendingRpc.has(parsed.id)) {
+          // RPC response
+          const pending = this.pendingRpc.get(parsed.id)!;
+          this.pendingRpc.delete(parsed.id);
+          const resp = parsed as JsonRpcResponse;
+          if (resp.error) {
+            pending.reject(
+              new Error(`RPC error ${resp.error.code}: ${resp.error.message}`),
+            );
+          } else {
+            pending.resolve(resp.result);
+          }
+        } else if (parsed.method) {
+          // Notification
+          this.handleNotification(parsed as JsonRpcNotification);
+        }
+      } catch (err) {
+        logger.debug({ line: trimmed, err }, 'Failed to parse signal-cli JSON');
+      }
+    }
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    if (notification.method !== 'receive' && notification.method !== 'sync')
+      return;
+
+    const envelope = notification.params?.envelope as
+      | SignalEnvelope
+      | undefined;
+    if (!envelope) return;
+
+    // Handle both regular messages and sync messages (self-sent)
+    let dataMessage;
+    let source;
+    let senderName;
+
+    if (envelope.syncMessage?.sentMessage) {
+      // Sync message (your own message from another device)
+      dataMessage = envelope.syncMessage.sentMessage;
+      source = this.accountNumber; // It's from you
+      senderName = 'You';
+    } else if (envelope.dataMessage) {
+      // Regular message from someone else
+      dataMessage = envelope.dataMessage;
+      source = envelope.sourceNumber || envelope.source || '';
+      senderName = envelope.sourceName || source;
+    } else {
+      return;
+    }
+
+    if (!dataMessage?.message) return;
+
+    const groupId = dataMessage.groupInfo?.groupId;
+    const chatJid = groupId ? `signal:group:${groupId}` : `signal:${source}`;
+    const isGroup = !!groupId;
+
+    const timestamp = dataMessage.timestamp
+      ? new Date(dataMessage.timestamp).toISOString()
+      : new Date().toISOString();
+
+    // Always emit chat metadata for discovery
+    this.onChatMetadata(chatJid, timestamp, undefined, 'signal', isGroup);
+
+    // Extract reply-threading quote fields if present
+    const quote = dataMessage.quote;
+    const quotedMessageId =
+      quote?.id != null ? `signal-${quote.id}` : undefined;
+    const quoteSenderName = quote?.authorName || quote?.author || undefined;
+    const quoteContent = quote?.text || undefined;
+
+    // Deliver message for registered groups
+    const groups = this.registeredGroups();
+    if (groups[chatJid]) {
+      this.onMessage(chatJid, {
+        id: `signal-${dataMessage.timestamp || Date.now()}`,
+        chat_jid: chatJid,
+        sender: source,
+        sender_name: senderName,
+        content: dataMessage.message,
+        timestamp,
+        is_from_me: source === this.accountNumber,
+        is_bot_message: false,
+        quoted_message_id: quotedMessageId,
+        quote_sender_name: quoteSenderName,
+        quote_content: quoteContent,
+      });
+    }
+  }
+
+  private rpcCall(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.connected) {
+        reject(new Error('Signal socket not connected'));
+        return;
+      }
+
+      const id = ++this.rpcId;
+      const request = JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params,
+      });
+
+      this.pendingRpc.set(id, { resolve, reject });
+
+      this.socket.write(request + '\n', (err) => {
+        if (err) {
+          this.pendingRpc.delete(id);
+          reject(err);
+        }
+      });
+
+      // Timeout pending RPCs after 30s
+      setTimeout(() => {
+        if (this.pendingRpc.has(id)) {
+          this.pendingRpc.delete(id);
+          reject(new Error(`RPC timeout for ${method}`));
+        }
+      }, 30000);
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown) return;
+
+    const delay = Math.min(
+      RECONNECT_BASE_MS * Math.pow(2, this.reconnectAttempts),
+      RECONNECT_MAX_MS,
+    );
+    this.reconnectAttempts++;
+
+    logger.info(
+      { attempt: this.reconnectAttempts, delayMs: delay },
+      'Scheduling Signal reconnect',
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      logger.info('Reconnecting to signal-cli daemon...');
+      this.connectInternal();
+    }, delay);
+  }
+}
+
+registerChannel('signal', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['SIGNAL_ACCOUNT_NUMBER', 'SIGNAL_SOCKET_PATH']);
+  const accountNumber = envVars.SIGNAL_ACCOUNT_NUMBER;
+  if (!accountNumber) {
+    logger.info('SIGNAL_ACCOUNT_NUMBER not set, skipping Signal channel');
+    return null;
+  }
+  return new SignalChannel(opts, accountNumber, envVars.SIGNAL_SOCKET_PATH);
+});

--- a/.claude/skills/add-signal/manifest.yaml
+++ b/.claude/skills/add-signal/manifest.yaml
@@ -1,0 +1,17 @@
+skill: signal
+version: 1.0.0
+description: "Signal channel via signal-cli JSON-RPC daemon"
+core_version: 0.1.0
+adds:
+  - src/channels/signal.ts
+  - src/channels/signal.test.ts
+modifies:
+  - src/channels/index.ts
+structured:
+  env_additions:
+    - SIGNAL_ACCOUNT_NUMBER
+    - SIGNAL_SOCKET_PATH
+conflicts: []
+depends:
+  - reactions
+test: "npx vitest run src/channels/signal.test.ts"

--- a/.claude/skills/add-signal/modify/src/channels/index.ts
+++ b/.claude/skills/add-signal/modify/src/channels/index.ts
@@ -1,0 +1,15 @@
+// Channel self-registration barrel file.
+// Each import triggers the channel module's registerChannel() call.
+
+// discord
+
+// gmail
+
+// signal
+import './signal.js';
+
+// slack
+
+// telegram
+
+// whatsapp

--- a/.claude/skills/add-signal/modify/src/channels/index.ts.intent.md
+++ b/.claude/skills/add-signal/modify/src/channels/index.ts.intent.md
@@ -1,0 +1,7 @@
+# Intent: Add Signal channel import
+
+Add `import './signal.js';` to the channel barrel file so the Signal
+module self-registers with the channel registry on startup.
+
+This is an append-only change — existing import lines for other channels
+must be preserved.

--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SignalChannel, SignalChannelOpts } from './signal.js';
+
+function makeOpts(overrides?: Partial<SignalChannelOpts>): SignalChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: () => ({
+      'signal:group:abc': {
+        name: 'Test',
+        folder: 'test',
+        trigger: '@Andy',
+        added_at: '',
+      },
+    }),
+    accountNumber: '+15550001111',
+    ...overrides,
+  };
+}
+
+// Drive handleNotification via private cast
+function notify(channel: SignalChannel, method: string, params: object) {
+  (channel as any).handleNotification({ jsonrpc: '2.0', method, params });
+}
+
+describe('SignalChannel attachment parsing', () => {
+  let opts: SignalChannelOpts;
+  let channel: SignalChannel;
+
+  beforeEach(() => {
+    opts = makeOpts();
+    channel = new SignalChannel(opts);
+  });
+
+  it('parses image attachment and builds description in content', () => {
+    notify(channel, 'receive', {
+      envelope: {
+        sourceNumber: '+15550002222',
+        sourceName: 'Alice',
+        timestamp: 1700000000000,
+        dataMessage: {
+          timestamp: 1700000000000,
+          message: 'Check this out',
+          groupInfo: { groupId: 'abc' },
+          attachments: [
+            {
+              id: 9876543210,
+              contentType: 'image/jpeg',
+              filename: 'photo.jpg',
+              size: 365568,
+              width: 1440,
+              height: 2560,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(opts.onMessage).toHaveBeenCalledOnce();
+    const msg = (opts.onMessage as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(msg.content).toContain('Check this out');
+    expect(msg.content).toContain(
+      '[attachment: photo.jpg (image/jpeg, 357KB 1440x2560)]',
+    );
+    expect(msg.attachments).toHaveLength(1);
+    expect(msg.attachments[0]).toMatchObject({
+      id: '9876543210',
+      contentType: 'image/jpeg',
+      filename: 'photo.jpg',
+      size: 365568,
+      width: 1440,
+      height: 2560,
+    });
+  });
+
+  it('passes attachment-only message (no caption text)', () => {
+    notify(channel, 'receive', {
+      envelope: {
+        sourceNumber: '+15550002222',
+        sourceName: 'Alice',
+        timestamp: 1700000000001,
+        dataMessage: {
+          timestamp: 1700000000001,
+          // no message field
+          groupInfo: { groupId: 'abc' },
+          attachments: [
+            {
+              id: 1111,
+              contentType: 'image/png',
+              size: 102400,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(opts.onMessage).toHaveBeenCalledOnce();
+    const msg = (opts.onMessage as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(msg.content).toContain('[attachment: unnamed (image/png,');
+    expect(msg.attachments).toHaveLength(1);
+  });
+
+  it('drops messages with no text and no attachments', () => {
+    notify(channel, 'receive', {
+      envelope: {
+        sourceNumber: '+15550002222',
+        timestamp: 1700000000002,
+        dataMessage: {
+          timestamp: 1700000000002,
+          groupInfo: { groupId: 'abc' },
+        },
+      },
+    });
+
+    expect(opts.onMessage).not.toHaveBeenCalled();
+  });
+
+  it('marks voice note with (voice note) suffix', () => {
+    notify(channel, 'receive', {
+      envelope: {
+        sourceNumber: '+15550002222',
+        timestamp: 1700000000003,
+        dataMessage: {
+          timestamp: 1700000000003,
+          groupInfo: { groupId: 'abc' },
+          attachments: [
+            {
+              id: 2222,
+              contentType: 'audio/ogg',
+              size: 8192,
+              voiceNote: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(opts.onMessage).toHaveBeenCalledOnce();
+    const msg = (opts.onMessage as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(msg.content).toContain('(voice note)');
+    expect(msg.attachments[0].isVoiceNote).toBe(true);
+  });
+
+  it('omits dimensions when width/height absent', () => {
+    notify(channel, 'receive', {
+      envelope: {
+        sourceNumber: '+15550002222',
+        timestamp: 1700000000004,
+        dataMessage: {
+          timestamp: 1700000000004,
+          groupInfo: { groupId: 'abc' },
+          attachments: [
+            {
+              id: 3333,
+              contentType: 'application/pdf',
+              filename: 'doc.pdf',
+              size: 204800,
+            },
+          ],
+        },
+      },
+    });
+
+    const msg = (opts.onMessage as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(msg.content).toBe('[attachment: doc.pdf (application/pdf, 200KB)]');
+  });
+});
+
+describe('SignalChannel downloadAttachment', () => {
+  it('skips RPC and returns existing path if file already on disk', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'signal-att-test-'));
+    const channel = new SignalChannel(makeOpts());
+    const rpcSpy = vi.spyOn(channel as any, 'rpcCall');
+
+    // Pre-create the file that downloadAttachment would write
+    const expectedPath = path.join(tmpDir, '9999-photo.jpg');
+    writeFileSync(expectedPath, 'existing');
+
+    const result = await channel.downloadAttachment(
+      { id: '9999', contentType: 'image/jpeg', filename: 'photo.jpg' },
+      tmpDir,
+    );
+
+    expect(rpcSpy).not.toHaveBeenCalled();
+    expect(result).toBe(expectedPath);
+  });
+
+  it('returns null when RPC returns no data', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'signal-att-test-'));
+    const channel = new SignalChannel(makeOpts());
+    vi.spyOn(channel as any, 'rpcCall').mockResolvedValue(null);
+
+    const result = await channel.downloadAttachment(
+      { id: '1234', contentType: 'image/jpeg' },
+      tmpDir,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -1,0 +1,652 @@
+import { existsSync } from 'fs';
+import fs from 'fs/promises';
+import net from 'net';
+import path from 'path';
+
+import { ASSISTANT_NAME } from '../config.js';
+import {
+  deleteReactionByTarget,
+  getLatestMessage,
+  getMessageById,
+  storeReaction,
+} from '../db.js';
+import { logger } from '../logger.js';
+import {
+  Attachment,
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface SignalChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  accountNumber: string;
+  socketPath?: string;
+}
+
+interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface SignalQuote {
+  id?: number;
+  author?: string;
+  authorName?: string;
+  text?: string;
+}
+
+interface SignalRawAttachment {
+  id: number | string;
+  contentType: string;
+  filename?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+  voiceNote?: boolean;
+  caption?: string;
+}
+
+interface SignalDataMessage {
+  timestamp?: number;
+  message?: string;
+  groupInfo?: { groupId: string; type?: string };
+  quote?: SignalQuote;
+  reaction?: {
+    emoji: string;
+    targetAuthor: string;
+    targetSentTimestamp: number;
+    isRemove: boolean;
+  };
+  attachments?: SignalRawAttachment[];
+}
+
+interface SignalEnvelope {
+  source?: string;
+  sourceName?: string;
+  sourceNumber?: string;
+  timestamp?: number;
+  dataMessage?: SignalDataMessage;
+  syncMessage?: {
+    sentMessage?: SignalDataMessage;
+  };
+  typingMessage?: {
+    action?: string;
+    groupId?: string;
+  };
+}
+
+const DEFAULT_SOCKET_PATH = '/tmp/signal-cli.sock';
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 60000;
+
+export class SignalChannel implements Channel {
+  name = 'signal';
+
+  private socket: net.Socket | null = null;
+  private connected = false;
+  private lastSentTimestamps: Map<string, number> = new Map();
+  private opts: SignalChannelOpts;
+  private socketPath: string;
+  private rpcId = 0;
+  private pendingRpc = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private buffer = '';
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shuttingDown = false;
+
+  constructor(opts: SignalChannelOpts) {
+    this.opts = opts;
+    this.socketPath = opts.socketPath || DEFAULT_SOCKET_PATH;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.connectInternal(resolve, reject);
+    });
+  }
+
+  private connectInternal(
+    onFirstOpen?: () => void,
+    onFirstError?: (err: Error) => void,
+  ): void {
+    const sock = net.createConnection({ path: this.socketPath });
+    this.socket = sock;
+
+    sock.on('connect', () => {
+      this.connected = true;
+      this.reconnectAttempts = 0;
+      logger.info(
+        { socketPath: this.socketPath },
+        'Connected to signal-cli daemon',
+      );
+
+      // Sync group metadata on connect
+      this.syncGroupMetadata().catch((err) =>
+        logger.warn({ err }, 'Signal group sync failed'),
+      );
+
+      if (onFirstOpen) {
+        onFirstOpen();
+        onFirstOpen = undefined;
+        onFirstError = undefined;
+      }
+    });
+
+    sock.on('data', (data) => {
+      this.buffer += data.toString();
+      this.processBuffer();
+    });
+
+    sock.on('error', (err) => {
+      logger.error({ err }, 'Signal socket error');
+      if (onFirstError) {
+        onFirstError(err);
+        onFirstError = undefined;
+        onFirstOpen = undefined;
+      }
+    });
+
+    sock.on('close', () => {
+      this.connected = false;
+      // Reject any pending RPCs
+      for (const [id, pending] of this.pendingRpc) {
+        pending.reject(new Error('Socket closed'));
+        this.pendingRpc.delete(id);
+      }
+
+      if (!this.shuttingDown) {
+        this.scheduleReconnect();
+      }
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const prefixed = `${ASSISTANT_NAME}: ${text}`;
+
+    let result: { timestamp?: number } | null = null;
+    if (jid.startsWith('signal:group:')) {
+      const groupId = jid.slice('signal:group:'.length);
+      result = (await this.rpcCall('send', {
+        account: this.opts.accountNumber,
+        groupId,
+        message: prefixed,
+      })) as { timestamp?: number } | null;
+    } else {
+      const recipient = jid.slice('signal:'.length);
+      result = (await this.rpcCall('send', {
+        account: this.opts.accountNumber,
+        recipient: [recipient],
+        message: prefixed,
+      })) as { timestamp?: number } | null;
+    }
+    if (result?.timestamp) {
+      this.lastSentTimestamps.set(jid, result.timestamp);
+    }
+    logger.info({ jid, length: prefixed.length }, 'Signal message sent');
+  }
+
+  async editMessage(
+    jid: string,
+    newText: string,
+    originalTimestamp?: number,
+  ): Promise<number> {
+    const editTimestamp = originalTimestamp ?? this.lastSentTimestamps.get(jid);
+    if (!editTimestamp) {
+      throw new Error('No message to edit — no stored timestamp for this chat');
+    }
+
+    const params: Record<string, unknown> = {
+      account: this.opts.accountNumber,
+      message: `${ASSISTANT_NAME}: ${newText}`,
+      editTimestamp,
+    };
+
+    if (jid.startsWith('signal:group:')) {
+      params.groupId = jid.slice('signal:group:'.length);
+    } else {
+      params.recipient = [jid.slice('signal:'.length)];
+    }
+
+    await this.rpcCall('send', params);
+    logger.info({ jid, editTimestamp }, 'Signal message edited');
+    return editTimestamp;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('signal:');
+  }
+
+  async disconnect(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.connected = false;
+    this.socket?.destroy();
+    this.socket = null;
+    logger.info('Signal channel disconnected');
+  }
+
+  async sendReaction(
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void> {
+    // messageId format: "signal-{timestamp}"
+    const ts = messageId.startsWith('signal-')
+      ? parseInt(messageId.slice('signal-'.length), 10)
+      : parseInt(messageId, 10);
+    if (!ts || isNaN(ts)) {
+      logger.warn(
+        { jid, messageId },
+        'Cannot send Signal reaction: invalid message ID',
+      );
+      return;
+    }
+
+    const msg = getMessageById(messageId);
+    const targetAuthor = msg
+      ? msg.is_from_me
+        ? this.opts.accountNumber
+        : msg.sender
+      : this.opts.accountNumber;
+
+    await this.cliSendReaction(jid, emoji, targetAuthor, ts, messageId);
+  }
+
+  private async cliSendReaction(
+    jid: string,
+    emoji: string,
+    targetAuthor: string,
+    targetTimestamp: number,
+    messageId: string,
+  ): Promise<void> {
+    const params: Record<string, unknown> = {
+      account: this.opts.accountNumber,
+      emoji,
+      targetAuthor,
+      targetTimestamp,
+    };
+
+    if (jid.startsWith('signal:group:')) {
+      params.groupId = jid.slice('signal:group:'.length);
+    } else {
+      params.recipient = [jid.slice('signal:'.length)];
+    }
+
+    try {
+      await this.rpcCall('sendReaction', params);
+      storeReaction({
+        chatJid: jid,
+        messageId,
+        emoji,
+        timestamp: new Date().toISOString(),
+      });
+      logger.debug({ jid, messageId, emoji }, 'Signal reaction sent');
+    } catch (err) {
+      logger.warn(
+        { jid, messageId, emoji, err },
+        'Failed to send Signal reaction',
+      );
+    }
+  }
+
+  async reactToLatestMessage(jid: string, emoji: string): Promise<void> {
+    const latest = getLatestMessage(jid);
+    if (!latest) {
+      logger.warn({ jid }, 'No latest message in DB for reaction');
+      return;
+    }
+
+    // Determine the author of the message being reacted to
+    const targetAuthor = latest.is_from_me
+      ? this.opts.accountNumber
+      : latest.sender;
+
+    const ts = latest.id.startsWith('signal-')
+      ? parseInt(latest.id.slice('signal-'.length), 10)
+      : parseInt(latest.id, 10);
+    if (!ts || isNaN(ts)) {
+      logger.warn(
+        { jid, id: latest.id },
+        'Cannot parse timestamp from message ID',
+      );
+      return;
+    }
+
+    await this.cliSendReaction(jid, emoji, targetAuthor, ts, latest.id);
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    try {
+      if (jid.startsWith('signal:group:')) {
+        const groupId = jid.slice('signal:group:'.length);
+        await this.rpcCall('sendTyping', {
+          account: this.opts.accountNumber,
+          groupId,
+          stop: !isTyping,
+        });
+      } else {
+        const recipient = jid.slice('signal:'.length);
+        await this.rpcCall('sendTyping', {
+          account: this.opts.accountNumber,
+          recipient: [recipient],
+          stop: !isTyping,
+        });
+      }
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Signal typing indicator');
+    }
+  }
+
+  // --- Private ---
+
+  private async syncGroupMetadata(): Promise<void> {
+    try {
+      const result = (await this.rpcCall('listGroups', {
+        account: this.opts.accountNumber,
+      })) as Array<{ id: string; name?: string }>;
+
+      if (!Array.isArray(result)) return;
+
+      for (const group of result) {
+        if (group.id && group.name) {
+          const chatJid = `signal:group:${group.id}`;
+          this.opts.onChatMetadata(
+            chatJid,
+            new Date().toISOString(),
+            group.name,
+            'signal',
+            true,
+          );
+        }
+      }
+      logger.info({ count: result.length }, 'Signal group metadata synced');
+    } catch (err) {
+      logger.warn({ err }, 'Failed to list Signal groups');
+    }
+  }
+
+  private processBuffer(): void {
+    const lines = this.buffer.split('\n');
+    // Keep the last (potentially incomplete) line in the buffer
+    this.buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed.id !== undefined && this.pendingRpc.has(parsed.id)) {
+          // RPC response
+          const pending = this.pendingRpc.get(parsed.id)!;
+          this.pendingRpc.delete(parsed.id);
+          const resp = parsed as JsonRpcResponse;
+          if (resp.error) {
+            pending.reject(
+              new Error(`RPC error ${resp.error.code}: ${resp.error.message}`),
+            );
+          } else {
+            pending.resolve(resp.result);
+          }
+        } else if (parsed.method) {
+          // Notification
+          this.handleNotification(parsed as JsonRpcNotification);
+        }
+      } catch (err) {
+        logger.debug({ line: trimmed, err }, 'Failed to parse signal-cli JSON');
+      }
+    }
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    if (notification.method !== 'receive' && notification.method !== 'sync')
+      return;
+
+    const envelope = notification.params?.envelope as
+      | SignalEnvelope
+      | undefined;
+    if (!envelope) return;
+
+    // Handle both regular messages and sync messages (self-sent)
+    let dataMessage;
+    let source;
+    let senderName;
+
+    if (envelope.syncMessage?.sentMessage) {
+      // Sync message (your own message from another device)
+      dataMessage = envelope.syncMessage.sentMessage;
+      source = this.opts.accountNumber; // It's from you
+      senderName = 'You';
+    } else if (envelope.dataMessage) {
+      // Regular message from someone else
+      dataMessage = envelope.dataMessage;
+      source = envelope.sourceNumber || envelope.source || '';
+      senderName = envelope.sourceName || source;
+    } else {
+      return;
+    }
+
+    // Handle incoming reactions before regular message processing
+    const reaction = dataMessage?.reaction;
+    if (reaction) {
+      const groupId = dataMessage.groupInfo?.groupId;
+      const chatJid = groupId ? `signal:group:${groupId}` : `signal:${source}`;
+      const timestamp = envelope.timestamp
+        ? new Date(envelope.timestamp).toISOString()
+        : new Date().toISOString();
+      const groups = this.opts.registeredGroups();
+      if (groups[chatJid]) {
+        if (reaction.isRemove) {
+          deleteReactionByTarget(chatJid, reaction.targetSentTimestamp, source);
+        } else {
+          this.opts.onMessage(chatJid, {
+            id: `reaction-${source}-${envelope.timestamp ?? Date.now()}`,
+            chat_jid: chatJid,
+            sender: source,
+            sender_name: senderName,
+            content: `[reacted ${reaction.emoji} to a message]`,
+            timestamp,
+            is_from_me: source === this.opts.accountNumber,
+            is_bot_message: false,
+            is_reaction: true,
+            reaction_emoji: reaction.emoji,
+            reaction_target_timestamp: String(reaction.targetSentTimestamp),
+            reaction_target_author: reaction.targetAuthor,
+          });
+        }
+      }
+      return;
+    }
+
+    const rawAttachments = dataMessage?.attachments;
+    if (!dataMessage?.message && !rawAttachments?.length) return;
+
+    const groupId = dataMessage.groupInfo?.groupId;
+    const chatJid = groupId ? `signal:group:${groupId}` : `signal:${source}`;
+    const isGroup = !!groupId;
+
+    const timestamp = dataMessage.timestamp
+      ? new Date(dataMessage.timestamp).toISOString()
+      : new Date().toISOString();
+
+    // Always emit chat metadata for discovery
+    this.opts.onChatMetadata(chatJid, timestamp, undefined, 'signal', isGroup);
+
+    // Extract reply-threading quote fields if present
+    const quote = dataMessage.quote;
+    const quotedMessageId =
+      quote?.id != null ? `signal-${quote.id}` : undefined;
+    const quoteSenderName = quote?.authorName || quote?.author || undefined;
+    const quoteContent = quote?.text || undefined;
+
+    // Parse attachments and build human-readable descriptions
+    let attachments: Attachment[] | undefined;
+    let content = dataMessage.message || '';
+
+    if (rawAttachments?.length) {
+      attachments = rawAttachments.map((a) => ({
+        id: String(a.id),
+        contentType: a.contentType,
+        filename: a.filename || undefined,
+        size: a.size,
+        width: a.width,
+        height: a.height,
+        isVoiceNote: a.voiceNote || false,
+        caption: a.caption || undefined,
+      }));
+
+      const descriptions = attachments
+        .map((a) => {
+          const sizeKB = Math.round((a.size || 0) / 1024);
+          const name = a.filename || 'unnamed';
+          const dims = a.width && a.height ? ` ${a.width}x${a.height}` : '';
+          const voice = a.isVoiceNote ? ' (voice note)' : '';
+          return `[attachment: ${name} (${a.contentType}, ${sizeKB}KB${dims}${voice})]`;
+        })
+        .join('\n');
+
+      content = content ? `${content}\n${descriptions}` : descriptions;
+    }
+
+    // Deliver message for registered groups
+    const groups = this.opts.registeredGroups();
+    if (groups[chatJid]) {
+      this.opts.onMessage(chatJid, {
+        id: `signal-${dataMessage.timestamp || Date.now()}`,
+        chat_jid: chatJid,
+        sender: source,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: source === this.opts.accountNumber,
+        is_bot_message: false,
+        quoted_message_id: quotedMessageId,
+        quote_sender_name: quoteSenderName,
+        quote_content: quoteContent,
+        attachments,
+      });
+    }
+  }
+
+  private rpcCall(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs = 30_000,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || !this.connected) {
+        reject(new Error('Signal socket not connected'));
+        return;
+      }
+
+      const id = ++this.rpcId;
+      const request = JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params,
+      });
+
+      this.pendingRpc.set(id, { resolve, reject });
+
+      this.socket.write(request + '\n', (err) => {
+        if (err) {
+          this.pendingRpc.delete(id);
+          reject(err);
+        }
+      });
+
+      setTimeout(() => {
+        if (this.pendingRpc.has(id)) {
+          this.pendingRpc.delete(id);
+          reject(new Error(`RPC timeout for ${method}`));
+        }
+      }, timeoutMs);
+    });
+  }
+
+  async downloadAttachment(
+    attachment: Attachment,
+    destDir: string,
+  ): Promise<string | null> {
+    const safeName = (
+      attachment.filename || `attachment.${mimeToExt(attachment.contentType)}`
+    ).replace(/[^a-zA-Z0-9._-]/g, '_');
+    const filePath = path.join(destDir, `${attachment.id}-${safeName}`);
+    if (existsSync(filePath)) return filePath;
+
+    const result = (await this.rpcCall(
+      'getAttachment',
+      { account: this.opts.accountNumber, id: attachment.id },
+      120_000,
+    )) as { data?: string } | null;
+    if (!result?.data) return null;
+
+    const buffer = Buffer.from(result.data, 'base64');
+    await fs.mkdir(destDir, { recursive: true });
+    await fs.writeFile(filePath, buffer);
+
+    return filePath;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown) return;
+
+    const delay = Math.min(
+      RECONNECT_BASE_MS * Math.pow(2, this.reconnectAttempts),
+      RECONNECT_MAX_MS,
+    );
+    this.reconnectAttempts++;
+
+    logger.info(
+      { attempt: this.reconnectAttempts, delayMs: delay },
+      'Scheduling Signal reconnect',
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      logger.info('Reconnecting to signal-cli daemon...');
+      this.connectInternal();
+    }, delay);
+  }
+}
+
+function mimeToExt(contentType: string): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/heic': 'heic',
+    'video/mp4': 'mp4',
+    'video/quicktime': 'mov',
+    'audio/mpeg': 'mp3',
+    'audio/ogg': 'ogg',
+    'audio/aac': 'aac',
+    'audio/mp4': 'm4a',
+    'application/pdf': 'pdf',
+  };
+  return map[contentType] || 'bin';
+}

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -138,6 +138,67 @@ describe('storeMessage', () => {
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe('updated');
   });
+
+  it('stores and round-trips attachments_json via getMessagesSince', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'msg-att',
+      chat_jid: 'group@g.us',
+      sender: '123@s.whatsapp.net',
+      sender_name: 'Alice',
+      content:
+        'here is a photo\n[attachment: photo.jpg (image/jpeg, 357KB 1440x2560)]',
+      timestamp: '2024-01-01T00:00:10.000Z',
+      is_from_me: false,
+      attachments: [
+        {
+          id: '9876543210',
+          contentType: 'image/jpeg',
+          filename: 'photo.jpg',
+          size: 365568,
+          width: 1440,
+          height: 2560,
+        },
+      ],
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toHaveLength(1);
+    expect(messages[0].attachments![0]).toMatchObject({
+      id: '9876543210',
+      contentType: 'image/jpeg',
+      filename: 'photo.jpg',
+      width: 1440,
+      height: 2560,
+    });
+  });
+
+  it('returns undefined attachments for messages stored without attachments', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    store({
+      id: 'msg-no-att',
+      chat_jid: 'group@g.us',
+      sender: '123@s.whatsapp.net',
+      sender_name: 'Alice',
+      content: 'plain text',
+      timestamp: '2024-01-01T00:00:11.000Z',
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toBeUndefined();
+  });
 });
 
 // --- getMessagesSince ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,7 @@ import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
   NewMessage,
+  Reaction,
   RegisteredGroup,
   ScheduledTask,
   TaskRunLog,
@@ -32,10 +33,21 @@ function createSchema(database: Database.Database): void {
       timestamp TEXT,
       is_from_me INTEGER,
       is_bot_message INTEGER DEFAULT 0,
+      quoted_message_id TEXT,
+      quote_sender_name TEXT,
+      quote_content TEXT,
       PRIMARY KEY (id, chat_jid),
       FOREIGN KEY (chat_jid) REFERENCES chats(jid)
     );
     CREATE INDEX IF NOT EXISTS idx_timestamp ON messages(timestamp);
+
+    CREATE TABLE IF NOT EXISTS reactions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      chat_jid TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      emoji TEXT NOT NULL,
+      timestamp TEXT NOT NULL
+    );
 
     CREATE TABLE IF NOT EXISTS scheduled_tasks (
       id TEXT PRIMARY KEY,
@@ -106,6 +118,15 @@ function createSchema(database: Database.Database): void {
     /* column already exists */
   }
 
+  // Add quote columns if they don't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN quoted_message_id TEXT`);
+    database.exec(`ALTER TABLE messages ADD COLUMN quote_sender_name TEXT`);
+    database.exec(`ALTER TABLE messages ADD COLUMN quote_content TEXT`);
+  } catch {
+    /* columns already exist */
+  }
+
   // Add is_main column if it doesn't exist (migration for existing DBs)
   try {
     database.exec(
@@ -117,6 +138,29 @@ function createSchema(database: Database.Database): void {
     );
   } catch {
     /* column already exists */
+  }
+
+  // Add attachments_json column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN attachments_json TEXT`);
+  } catch {
+    /* column already exists */
+  }
+
+  // Add reaction columns to messages if they don't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN is_reaction INTEGER DEFAULT 0`,
+    );
+    database.exec(`ALTER TABLE messages ADD COLUMN reaction_emoji TEXT`);
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN reaction_target_timestamp TEXT`,
+    );
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN reaction_target_author TEXT`,
+    );
+  } catch {
+    /* columns already exist */
   }
 
   // Add channel and is_group columns if they don't exist (migration for existing DBs)
@@ -138,6 +182,29 @@ function createSchema(database: Database.Database): void {
     );
   } catch {
     /* columns already exist */
+  }
+
+  // Recreate reactions table with new schema (old table was for incoming WhatsApp reactions)
+  try {
+    const info = database
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type='table' AND name='reactions'`,
+      )
+      .get() as { sql: string } | undefined;
+    if (info && info.sql.includes('reactor_jid')) {
+      database.exec('DROP TABLE reactions');
+      database.exec(`
+        CREATE TABLE reactions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          chat_jid TEXT NOT NULL,
+          message_id TEXT NOT NULL,
+          emoji TEXT NOT NULL,
+          timestamp TEXT NOT NULL
+        )
+      `);
+    }
+  } catch {
+    /* table doesn't exist yet, will be created by CREATE TABLE IF NOT EXISTS */
   }
 }
 
@@ -262,7 +329,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, quoted_message_id, quote_sender_name, quote_content, is_reaction, reaction_emoji, reaction_target_timestamp, reaction_target_author, attachments_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -272,7 +339,25 @@ export function storeMessage(msg: NewMessage): void {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.quoted_message_id || null,
+    msg.quote_sender_name || null,
+    msg.quote_content || null,
+    msg.is_reaction ? 1 : 0,
+    msg.reaction_emoji || null,
+    msg.reaction_target_timestamp ?? null,
+    msg.reaction_target_author || null,
+    msg.attachments ? JSON.stringify(msg.attachments) : null,
   );
+}
+
+export function deleteReactionByTarget(
+  chatJid: string,
+  targetTimestamp: number | string,
+  senderJid: string,
+): void {
+  db.prepare(
+    `DELETE FROM messages WHERE chat_jid = ? AND sender = ? AND reaction_target_timestamp = ? AND is_reaction = 1`,
+  ).run(chatJid, senderJid, String(targetTimestamp));
 }
 
 /**
@@ -316,7 +401,7 @@ export function getNewMessages(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, quoted_message_id, quote_sender_name, quote_content, is_reaction, reaction_emoji, reaction_target_timestamp, reaction_target_author, attachments_json
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -328,11 +413,20 @@ export function getNewMessages(
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as (NewMessage & {
+    attachments_json?: string;
+  })[];
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
     if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+    if (row.attachments_json) {
+      try {
+        row.attachments = JSON.parse(row.attachments_json);
+      } catch {
+        /* ignore */
+      }
+    }
   }
 
   return { messages: rows, newTimestamp };
@@ -349,7 +443,7 @@ export function getMessagesSince(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, quoted_message_id, quote_sender_name, quote_content, is_reaction, reaction_emoji, reaction_target_timestamp, reaction_target_author, attachments_json
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -358,9 +452,21 @@ export function getMessagesSince(
       LIMIT ?
     ) ORDER BY timestamp
   `;
-  return db
+  const rows = db
     .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as (NewMessage & {
+    attachments_json?: string;
+  })[];
+  for (const row of rows) {
+    if (row.attachments_json) {
+      try {
+        row.attachments = JSON.parse(row.attachments_json);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return rows;
 }
 
 export function createTask(
@@ -494,6 +600,49 @@ export function logTaskRun(log: TaskRunLog): void {
     log.result,
     log.error,
   );
+}
+
+// --- Reaction accessors ---
+
+export function storeReaction(reaction: Reaction): void {
+  db.prepare(
+    `INSERT INTO reactions (chat_jid, message_id, emoji, timestamp) VALUES (?, ?, ?, ?)`,
+  ).run(
+    reaction.chatJid,
+    reaction.messageId,
+    reaction.emoji,
+    reaction.timestamp,
+  );
+}
+
+/**
+ * Get the most recent message for a chat (any sender, including bot messages).
+ * Used by channels to find the message to react to.
+ */
+export function getLatestMessage(
+  chatJid: string,
+):
+  | { id: string; sender: string; sender_name: string; is_from_me: boolean }
+  | undefined {
+  const row = db
+    .prepare(
+      `SELECT id, sender, sender_name, is_from_me FROM messages WHERE chat_jid = ? ORDER BY timestamp DESC LIMIT 1`,
+    )
+    .get(chatJid) as
+    | { id: string; sender: string; sender_name: string; is_from_me: number }
+    | undefined;
+  if (!row) return undefined;
+  return { ...row, is_from_me: row.is_from_me === 1 };
+}
+
+export function getMessageById(
+  messageId: string,
+): { sender: string; is_from_me: boolean } | undefined {
+  const row = db
+    .prepare('SELECT sender, is_from_me FROM messages WHERE id = ?')
+    .get(messageId) as { sender: string; is_from_me: number } | undefined;
+  if (!row) return undefined;
+  return { ...row, is_from_me: row.is_from_me === 1 };
 }
 
 // --- Router state accessors ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,36 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
+  // Download attachments before formatting messages for the agent
+  if (channel.downloadAttachment) {
+    const groupDir = resolveGroupFolderPath(group.folder);
+    const destDir = path.join(groupDir, 'attachments');
+
+    for (const msg of missedMessages) {
+      if (!msg.attachments?.length) continue;
+      for (const att of msg.attachments) {
+        if (att.localPath) continue; // already downloaded
+        try {
+          const localPath = await channel.downloadAttachment(att, destDir);
+          if (localPath) att.localPath = localPath;
+        } catch (err) {
+          logger.warn(
+            { attachmentId: att.id, err },
+            'Failed to download attachment',
+          );
+        }
+      }
+      const paths = msg.attachments
+        .filter((a) => a.localPath)
+        .map((a) => `[file: ${a.localPath}]`);
+      if (paths.length) {
+        msg.content = msg.content
+          ? `${msg.content}\n${paths.join('\n')}`
+          : paths.join('\n');
+      }
+    }
+  }
+
   const prompt = formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,20 @@ export interface RegisteredGroup {
   isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
 }
 
+/** Channel-agnostic attachment metadata */
+export interface Attachment {
+  id: string; // Channel-specific ID (signal attachment ID, WhatsApp mediaKey, Telegram file_id)
+  contentType: string; // MIME type
+  filename?: string; // Original filename if available
+  size?: number; // Bytes
+  width?: number; // Pixels (images/video)
+  height?: number; // Pixels (images/video)
+  duration?: number; // Seconds (audio/video)
+  isVoiceNote?: boolean; // Audio recorded as voice note
+  caption?: string; // Caption text (WhatsApp/Telegram support this natively)
+  localPath?: string; // Host path after download (set by orchestrator)
+}
+
 export interface NewMessage {
   id: string;
   chat_jid: string;
@@ -51,6 +65,21 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  quoted_message_id?: string;
+  quote_sender_name?: string;
+  quote_content?: string;
+  is_reaction?: boolean;
+  reaction_emoji?: string;
+  reaction_target_timestamp?: string;
+  reaction_target_author?: string;
+  attachments?: Attachment[];
+}
+
+export interface Reaction {
+  chatJid: string;
+  messageId: string;
+  emoji: string;
+  timestamp: string;
 }
 
 export interface ScheduledTask {
@@ -90,6 +119,25 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send a reaction to a specific message.
+  sendReaction?(
+    chatJid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void>;
+  // Optional: react to the most recent message in the chat.
+  reactToLatestMessage?(chatJid: string, emoji: string): Promise<void>;
+  // Optional: edit a previously sent message.
+  editMessage?(
+    jid: string,
+    newText: string,
+    originalTimestamp?: number,
+  ): Promise<number>;
+  // Optional: download an inbound attachment to a local directory. Returns host path or null on failure.
+  downloadAttachment?(
+    attachment: Attachment,
+    destDir: string,
+  ): Promise<string | null>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
Follow-up to #784. Adds channel-agnostic inbound attachment handling, implemented first for Signal. This is the attachment side of the same abstraction #784 introduces for reactions — a shared interface on `Channel`, with channel-specific implementations underneath.

## What this adds

**Shared `Attachment` interface** (`src/types.ts`) — Common type covering contentType, filename, size, dimensions, duration, voiceNote, and caption. WhatsApp and Telegram can map their native formats to the same interface when the time comes.

**Optional `downloadAttachment?` on `Channel`** (`src/types.ts`) — Same pattern as the optional reaction methods in #784. Any channel that implements it gets automatic file delivery through the orchestrator. Channels that don't are unaffected.

**Signal metadata parsing** (`src/channels/signal.ts`) — Attachment-only messages (no caption text) were previously dropped by an early-exit guard. Fixed. Signal attachments are now parsed into the shared interface and rendered in message context:
```
[attachment: photo.jpg (image/jpeg, 357KB 1440x2560)]
```

**Signal `downloadAttachment`** (`src/channels/signal.ts`) — Uses `getAttachment` JSON-RPC to fetch files into the group workspace. `rpcCall` gains an optional `timeoutMs` param (default 30s, overridden to 2min for downloads). Downloads are idempotent — re-processing a message after a cursor rollback won't re-fetch files already on disk.

**DB migration** (`src/db.ts`) — `attachments_json TEXT` column added via the existing try/catch migration pattern. `storeMessage`, `getNewMessages`, and `getMessagesSince` updated to persist and round-trip attachment metadata.

**Orchestrator wiring** (`src/index.ts`) — Download loop runs in `processGroupMessages` after `getMessagesSince`, before `formatMessages`. File paths are appended to message content so agents can read them directly:
```
[file: /workspace/group/attachments/12345678901234-photo.jpg]
```

Agents receive context like:
```xml
<message sender="Ken" time="...">Check this out
[attachment: photo.jpg (image/jpeg, 357KB 1440x2560)]
[file: /workspace/group/attachments/12345678901234-photo.jpg]</message>
```

## Adding other channels later

WhatsApp and Telegram just need to:
1. Map their native attachment format → `Attachment` in the receive handler
2. Implement `downloadAttachment()` on the channel class

The orchestrator wiring is already there and channel-agnostic.

## Tests

- Signal attachment parsing: image with text+attachment, attachment-only (no caption), voice note flag, dimensions omitted when absent
- `downloadAttachment`: idempotent (returns existing file without RPC call), null on empty RPC response
- DB round-trip: attachments serialized/deserialized via `getMessagesSince`

No new dependencies. ~115 lines across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)