### PR TITLE
feat: channel-agnostic attachment interface and download pipeline

### DIFF
--- a/src/attachments.test.ts
+++ b/src/attachments.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { buildAttachmentFilename, mimeToExt } from './utils.js';
-import { _initTestDatabase, storeMessage, getMessagesSince, storeChatMetadata } from './db.js';
+import {
+  _initTestDatabase,
+  storeMessage,
+  getMessagesSince,
+  storeChatMetadata,
+} from './db.js';
 
 describe('mimeToExt', () => {
   it('returns known extensions', () => {
@@ -15,19 +20,33 @@ describe('mimeToExt', () => {
 
 describe('buildAttachmentFilename', () => {
   it('prefixes ID when filename provided', () => {
-    const result = buildAttachmentFilename({ id: 'abc123', contentType: 'image/jpeg', filename: 'photo.jpg' });
+    const result = buildAttachmentFilename({
+      id: 'abc123',
+      contentType: 'image/jpeg',
+      filename: 'photo.jpg',
+    });
     expect(result).toBe('abc123-photo.jpg');
   });
   it('uses sanitized ID when ID has extension', () => {
-    const result = buildAttachmentFilename({ id: 'pfZsYQLdsQM4.webp', contentType: 'image/webp' });
+    const result = buildAttachmentFilename({
+      id: 'pfZsYQLdsQM4.webp',
+      contentType: 'image/webp',
+    });
     expect(result).toBe('pfZsYQLdsQM4.webp');
   });
   it('appends mime extension when no filename and no extension in ID', () => {
-    const result = buildAttachmentFilename({ id: 'abc123', contentType: 'image/png' });
+    const result = buildAttachmentFilename({
+      id: 'abc123',
+      contentType: 'image/png',
+    });
     expect(result).toBe('abc123-attachment.png');
   });
   it('sanitizes special characters in ID and filename', () => {
-    const result = buildAttachmentFilename({ id: 'abc/123', contentType: 'image/jpeg', filename: 'my photo!.jpg' });
+    const result = buildAttachmentFilename({
+      id: 'abc/123',
+      contentType: 'image/jpeg',
+      filename: 'my photo!.jpg',
+    });
     expect(result).toBe('abc_123-my_photo_.jpg');
   });
 });
@@ -51,7 +70,9 @@ describe('db round-trip', () => {
 
     const rows = getMessagesSince('g@g.us', '2024-01-01T00:00:00.000Z', 'Bot');
     expect(rows).toHaveLength(1);
-    expect(rows[0].attachments).toEqual([{ id: 'att-1', contentType: 'image/jpeg', size: 12345 }]);
+    expect(rows[0].attachments).toEqual([
+      { id: 'att-1', contentType: 'image/jpeg', size: 12345 },
+    ]);
   });
 
   it('handles missing attachments_json gracefully', () => {
@@ -77,5 +98,7 @@ describe('orchestrator download loop', () => {
   it.todo('logs warning and continues if downloadAttachment throws');
   it.todo('appends [file: ...] lines to message content');
   it.todo('does not modify content if no downloads succeeded');
-  it.todo('skips download loop entirely for channels without downloadAttachment');
+  it.todo(
+    'skips download loop entirely for channels without downloadAttachment',
+  );
 });

--- a/src/attachments.test.ts
+++ b/src/attachments.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { buildAttachmentFilename, mimeToExt } from './utils.js';
+import { _initTestDatabase, storeMessage, getMessagesSince, storeChatMetadata } from './db.js';
+
+describe('mimeToExt', () => {
+  it('returns known extensions', () => {
+    expect(mimeToExt('image/jpeg')).toBe('jpg');
+    expect(mimeToExt('audio/mp4')).toBe('m4a');
+  });
+  it('returns bin for unknown types', () => {
+    expect(mimeToExt('application/x-custom')).toBe('bin');
+  });
+});
+
+describe('buildAttachmentFilename', () => {
+  it('prefixes ID when filename provided', () => {
+    const result = buildAttachmentFilename({ id: 'abc123', contentType: 'image/jpeg', filename: 'photo.jpg' });
+    expect(result).toBe('abc123-photo.jpg');
+  });
+  it('uses sanitized ID when ID has extension', () => {
+    const result = buildAttachmentFilename({ id: 'pfZsYQLdsQM4.webp', contentType: 'image/webp' });
+    expect(result).toBe('pfZsYQLdsQM4.webp');
+  });
+  it('appends mime extension when no filename and no extension in ID', () => {
+    const result = buildAttachmentFilename({ id: 'abc123', contentType: 'image/png' });
+    expect(result).toBe('abc123-attachment.png');
+  });
+  it('sanitizes special characters in ID and filename', () => {
+    const result = buildAttachmentFilename({ id: 'abc/123', contentType: 'image/jpeg', filename: 'my photo!.jpg' });
+    expect(result).toBe('abc_123-my_photo_.jpg');
+  });
+});
+
+describe('db round-trip', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+  });
+
+  it('stores attachments_json and deserializes on read', () => {
+    storeChatMetadata('g@g.us', '2024-01-01T00:00:00.000Z');
+    storeMessage({
+      id: 'msg-1',
+      chat_jid: 'g@g.us',
+      sender: 'alice',
+      sender_name: 'Alice',
+      content: 'check this',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      attachments: [{ id: 'att-1', contentType: 'image/jpeg', size: 12345 }],
+    });
+
+    const rows = getMessagesSince('g@g.us', '2024-01-01T00:00:00.000Z', 'Bot');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attachments).toEqual([{ id: 'att-1', contentType: 'image/jpeg', size: 12345 }]);
+  });
+
+  it('handles missing attachments_json gracefully', () => {
+    storeChatMetadata('g@g.us', '2024-01-01T00:00:00.000Z');
+    storeMessage({
+      id: 'msg-2',
+      chat_jid: 'g@g.us',
+      sender: 'alice',
+      sender_name: 'Alice',
+      content: 'no attachments',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+
+    const rows = getMessagesSince('g@g.us', '2024-01-01T00:00:00.000Z', 'Bot');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attachments).toBeUndefined();
+  });
+});
+
+describe('orchestrator download loop', () => {
+  it.todo('calls downloadAttachment for each attachment');
+  it.todo('skips attachment with localPath already set (idempotent)');
+  it.todo('logs warning and continues if downloadAttachment throws');
+  it.todo('appends [file: ...] lines to message content');
+  it.todo('does not modify content if no downloads succeeded');
+  it.todo('skips download loop entirely for channels without downloadAttachment');
+});

--- a/src/db.ts
+++ b/src/db.ts
@@ -336,7 +336,9 @@ export function getNewMessages(
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as (NewMessage & { attachments_json?: string })[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as (NewMessage & {
+    attachments_json?: string;
+  })[];
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
@@ -344,7 +346,9 @@ export function getNewMessages(
     if (row.attachments_json) {
       try {
         row.attachments = JSON.parse(row.attachments_json);
-      } catch { /* ignore malformed JSON */ }
+      } catch {
+        /* ignore malformed JSON */
+      }
     }
   }
 
@@ -373,12 +377,16 @@ export function getMessagesSince(
   `;
   const rows = db
     .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as (NewMessage & { attachments_json?: string })[];
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as (NewMessage & {
+    attachments_json?: string;
+  })[];
   for (const row of rows) {
     if (row.attachments_json) {
       try {
         row.attachments = JSON.parse(row.attachments_json);
-      } catch { /* ignore malformed JSON */ }
+      } catch {
+        /* ignore malformed JSON */
+      }
     }
   }
   return rows;

--- a/src/db.ts
+++ b/src/db.ts
@@ -119,6 +119,13 @@ function createSchema(database: Database.Database): void {
     /* column already exists */
   }
 
+  // Add attachments_json column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN attachments_json TEXT`);
+  } catch {
+    /* column already exists */
+  }
+
   // Add channel and is_group columns if they don't exist (migration for existing DBs)
   try {
     database.exec(`ALTER TABLE chats ADD COLUMN channel TEXT`);
@@ -262,7 +269,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, attachments_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -272,6 +279,7 @@ export function storeMessage(msg: NewMessage): void {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.attachments ? JSON.stringify(msg.attachments) : null,
   );
 }
 
@@ -316,7 +324,7 @@ export function getNewMessages(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, attachments_json
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -328,11 +336,16 @@ export function getNewMessages(
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as (NewMessage & { attachments_json?: string })[];
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
     if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+    if (row.attachments_json) {
+      try {
+        row.attachments = JSON.parse(row.attachments_json);
+      } catch { /* ignore malformed JSON */ }
+    }
   }
 
   return { messages: rows, newTimestamp };
@@ -349,7 +362,7 @@ export function getMessagesSince(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, attachments_json
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -358,9 +371,17 @@ export function getMessagesSince(
       LIMIT ?
     ) ORDER BY timestamp
   `;
-  return db
+  const rows = db
     .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as (NewMessage & { attachments_json?: string })[];
+  for (const row of rows) {
+    if (row.attachments_json) {
+      try {
+        row.attachments = JSON.parse(row.attachments_json);
+      } catch { /* ignore malformed JSON */ }
+    }
+  }
+  return rows;
 }
 
 export function createTask(

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   // Download attachments for any channel that supports it
   if (channel.downloadAttachment) {
-    const destDir = path.join(resolveGroupFolderPath(group.folder), 'attachments');
+    const destDir = path.join(
+      resolveGroupFolderPath(group.folder),
+      'attachments',
+    );
 
     for (const msg of missedMessages) {
       if (!msg.attachments?.length) continue;
@@ -217,7 +220,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           const localPath = await channel.downloadAttachment(att, destDir);
           if (localPath) att.localPath = localPath;
         } catch (err) {
-          logger.warn({ attachmentId: att.id, err }, 'Failed to download attachment');
+          logger.warn(
+            { attachmentId: att.id, err },
+            'Failed to download attachment',
+          );
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,36 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
+  // Download attachments for any channel that supports it
+  if (channel.downloadAttachment) {
+    const destDir = path.join(resolveGroupFolderPath(group.folder), 'attachments');
+
+    for (const msg of missedMessages) {
+      if (!msg.attachments?.length) continue;
+
+      for (const att of msg.attachments) {
+        if (att.localPath) continue; // idempotent across cursor rollbacks
+
+        try {
+          const localPath = await channel.downloadAttachment(att, destDir);
+          if (localPath) att.localPath = localPath;
+        } catch (err) {
+          logger.warn({ attachmentId: att.id, err }, 'Failed to download attachment');
+        }
+      }
+
+      // Append downloaded file paths to message content for agent context
+      const paths = msg.attachments
+        .filter((a) => a.localPath)
+        .map((a) => `[file: ${a.localPath}]`);
+      if (paths.length) {
+        msg.content = msg.content
+          ? `${msg.content}\n${paths.join('\n')}`
+          : paths.join('\n');
+      }
+    }
+  }
+
   const prompt = formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,20 @@ export interface RegisteredGroup {
   isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
 }
 
+/** Channel-agnostic attachment metadata */
+export interface Attachment {
+  id: string;            // Channel-specific ID (signal-cli long, WhatsApp mediaKey, Telegram file_id)
+  contentType: string;   // MIME type
+  filename?: string;     // Original filename if provided by sender
+  size?: number;         // Bytes
+  width?: number;        // Pixels (images/video)
+  height?: number;       // Pixels (images/video)
+  duration?: number;     // Seconds (audio/video)
+  isVoiceNote?: boolean; // Audio recorded in-app as voice note
+  caption?: string;      // Caption text (WhatsApp/Telegram support this natively)
+  localPath?: string;    // Absolute path after download; set by orchestrator
+}
+
 export interface NewMessage {
   id: string;
   chat_jid: string;
@@ -51,6 +65,7 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  attachments?: Attachment[];
 }
 
 export interface ScheduledTask {
@@ -90,6 +105,12 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  /**
+   * Download an attachment to destDir and return the local path.
+   * Return null if the attachment cannot be fetched.
+   * The orchestrator calls this after getMessagesSince, before formatMessages.
+   */
+  downloadAttachment?(attachment: Attachment, destDir: string): Promise<string | null>;
 }
 
 // Callback type that channels use to deliver inbound messages

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,16 +44,16 @@ export interface RegisteredGroup {
 
 /** Channel-agnostic attachment metadata */
 export interface Attachment {
-  id: string;            // Channel-specific ID (signal-cli long, WhatsApp mediaKey, Telegram file_id)
-  contentType: string;   // MIME type
-  filename?: string;     // Original filename if provided by sender
-  size?: number;         // Bytes
-  width?: number;        // Pixels (images/video)
-  height?: number;       // Pixels (images/video)
-  duration?: number;     // Seconds (audio/video)
+  id: string; // Channel-specific ID (signal-cli long, WhatsApp mediaKey, Telegram file_id)
+  contentType: string; // MIME type
+  filename?: string; // Original filename if provided by sender
+  size?: number; // Bytes
+  width?: number; // Pixels (images/video)
+  height?: number; // Pixels (images/video)
+  duration?: number; // Seconds (audio/video)
   isVoiceNote?: boolean; // Audio recorded in-app as voice note
-  caption?: string;      // Caption text (WhatsApp/Telegram support this natively)
-  localPath?: string;    // Absolute path after download; set by orchestrator
+  caption?: string; // Caption text (WhatsApp/Telegram support this natively)
+  localPath?: string; // Absolute path after download; set by orchestrator
 }
 
 export interface NewMessage {
@@ -110,7 +110,10 @@ export interface Channel {
    * Return null if the attachment cannot be fetched.
    * The orchestrator calls this after getMessagesSince, before formatMessages.
    */
-  downloadAttachment?(attachment: Attachment, destDir: string): Promise<string | null>;
+  downloadAttachment?(
+    attachment: Attachment,
+    destDir: string,
+  ): Promise<string | null>;
 }
 
 // Callback type that channels use to deliver inbound messages

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,42 @@
+import { Attachment } from './types.js';
+
+/**
+ * Build a safe, unique filename for a downloaded attachment.
+ *
+ * Logic:
+ * - If sender provided a filename, prefix with sanitized ID to avoid collisions
+ * - If the attachment ID already has a recognized extension (some channels
+ *   include it), use the sanitized ID as-is
+ * - Otherwise: sanitized ID + MIME-derived extension
+ */
+export function buildAttachmentFilename(attachment: Attachment): string {
+  const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, '_');
+
+  if (attachment.filename) {
+    return `${sanitize(attachment.id)}-${sanitize(attachment.filename)}`;
+  }
+
+  if (/\.\w{2,5}$/.test(attachment.id)) {
+    return sanitize(attachment.id);
+  }
+
+  return `${sanitize(attachment.id)}-attachment.${mimeToExt(attachment.contentType)}`;
+}
+
+export function mimeToExt(contentType: string): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/heic': 'heic',
+    'video/mp4': 'mp4',
+    'video/quicktime': 'mov',
+    'audio/mpeg': 'mp3',
+    'audio/ogg': 'ogg',
+    'audio/aac': 'aac',
+    'audio/mp4': 'm4a',
+    'application/pdf': 'pdf',
+  };
+  return map[contentType] || 'bin';
+}


### PR DESCRIPTION
### Channel-Agnostic Attachment Infrastructure

Multiple contributors are currently implementing platform-specific attachment
handling with no shared interface. This PR establishes the canonical types
and pipeline so each channel only needs to map its native format and implement
one method.

**`Attachment` interface** (`src/types.ts`) — Shared metadata type with fields
covering all channels:

| Field | Signal | WhatsApp (Baileys) | Telegram |
|-------|--------|--------------------|----------|
| `id` | `attachment.id` | `message.mediaKey` | `file_id` |
| `contentType` | `attachment.contentType` | `mimetype` | inferred |
| `filename` | `attachment.filename` | `fileName` | `file_name` |
| `size` | `attachment.size` | `fileLength` | `file_size` |
| `width/height` | `attachment.width/height` | `width/height` | `width/height` |
| `duration` | — | `seconds` | `duration` |
| `isVoiceNote` | `attachment.voiceNote` | `ptt` | `voice` message type |
| `caption` | `attachment.caption` | `caption` | `caption` |

**`Channel.downloadAttachment?`** — Optional method on the Channel interface.
The orchestrator checks for it and skips download for channels that don't
implement it. Fully backwards compatible.

**`src/utils.ts`** — `buildAttachmentFilename` and `mimeToExt` helpers,
exported for channel implementations to import.

**DB: `attachments_json`** — try/catch migration (matches existing pattern).
Stored on write, deserialized on read in `getNewMessages` and
`getMessagesSince`.

**Orchestrator download loop** (`processGroupMessages`) — Runs after
`getMessagesSince`, before `formatMessages`. Downloads are idempotent (skips
if `localPath` already set). Failed downloads log a warning and don't
interrupt message processing. File paths appended to message content as
`[file: /workspace/group/attachments/<filename>]` for agent visibility.

**What this PR does NOT include:**
- Any channel-specific attachment parsing or download logic
- Changes to receive handlers
- New dependencies

#### Adding attachment support to a channel

```typescript
// 1. In receive handler — map native format to Attachment[]
const attachments: Attachment[] = [{
  id: msg.key.id!,
  contentType: msg.message.imageMessage.mimetype,
  filename: msg.message.imageMessage.fileName,
  size: Number(msg.message.imageMessage.fileLength),
  width: msg.message.imageMessage.width,
  height: msg.message.imageMessage.height,
  caption: msg.message.imageMessage.caption,
}];
// Add attachments to NewMessage passed to opts.onMessage()

// 2. Implement downloadAttachment() on your Channel class
async downloadAttachment(attachment: Attachment, destDir: string): Promise<string | null> {
  const filename = buildAttachmentFilename(attachment); // from utils.ts
  const filePath = path.join(destDir, filename);
  if (existsSync(filePath)) return filePath; // idempotent

  // ... channel-specific fetch logic ...

  await mkdir(destDir, { recursive: true });
  await writeFile(filePath, buffer);
  return filePath;
}
```

Agents will then see:
```xml
<message sender="Ken" time="...">Check this out
[file: /workspace/group/attachments/12345678901234-photo.jpg]</message>
```

No new dependencies. ~110 lines across 5 files (types, utils, db, index, tests).

**Signal implementation:** #844 (branched from #784)