### PR TITLE
fix: support ANTHROPIC_AUTH_TOKEN in setup verification

### DIFF
--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -101,7 +101,7 @@ export async function run(_args: string[]): Promise<void> {
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(envContent)) {
+    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN)=/m.test(envContent)) {
       credentials = 'configured';
     }
   }


### PR DESCRIPTION
## Description

This PR adds support for `ANTHROPIC_AUTH_TOKEN` in the setup verification step, improving compatibility with Claude Code CLI's standard authentication method.

## Changes

- Updated `setup/verify.ts` to recognize `ANTHROPIC_AUTH_TOKEN` as a valid credential environment variable
- Added `ANTHROPIC_AUTH_TOKEN` to the regex pattern alongside existing `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`

## Motivation

Claude Code CLI uses `ANTHROPIC_AUTH_TOKEN` for authentication (set via `claude setup-token`). Users who authenticate this way currently see a false "CREDENTIALS: missing" error during setup verification, even though their credentials are properly configured and working.

## Impact

- ✅ No breaking changes
- ✅ Backward compatible
- ✅ Improves user experience for Claude Code CLI users
- ✅ Allows using the same credentials for both Claude Code and NanoClaw

## Testing

Verified that the regex pattern correctly matches all three credential formats:
- `CLAUDE_CODE_OAUTH_TOKEN=...`
- `ANTHROPIC_API_KEY=...`
- `ANTHROPIC_AUTH_TOKEN=...`

Fixes #853