### PR TITLE
fix(setup): support ANTHROPIC_AUTH_TOKEN verification

### DIFF
--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 
 import Database from 'better-sqlite3';
 
+import { CREDENTIALS_ENV_VAR_PATTERN } from './verify.js';
+
 /**
  * Tests for the environment check step.
  *
@@ -76,22 +78,25 @@ describe('credentials detection', () => {
   it('detects ANTHROPIC_API_KEY in env content', () => {
     const content =
       'SOME_KEY=value\nANTHROPIC_API_KEY=sk-ant-test123\nOTHER=foo';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+    const hasCredentials = CREDENTIALS_ENV_VAR_PATTERN.test(content);
     expect(hasCredentials).toBe(true);
   });
 
   it('detects CLAUDE_CODE_OAUTH_TOKEN in env content', () => {
     const content = 'CLAUDE_CODE_OAUTH_TOKEN=token123';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+    const hasCredentials = CREDENTIALS_ENV_VAR_PATTERN.test(content);
+    expect(hasCredentials).toBe(true);
+  });
+
+  it('detects ANTHROPIC_AUTH_TOKEN in env content', () => {
+    const content = 'ANTHROPIC_AUTH_TOKEN=token123';
+    const hasCredentials = CREDENTIALS_ENV_VAR_PATTERN.test(content);
     expect(hasCredentials).toBe(true);
   });
 
   it('returns false when no credentials', () => {
     const content = 'ASSISTANT_NAME="Andy"\nOTHER=foo';
-    const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+    const hasCredentials = CREDENTIALS_ENV_VAR_PATTERN.test(content);
     expect(hasCredentials).toBe(false);
   });
 });
@@ -118,4 +123,3 @@ describe('channel auth detection', () => {
     expect(hasAuth('/tmp/nonexistent_auth_dir_xyz')).toBe(false);
   });
 });
-

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -22,6 +22,9 @@ import {
 } from './platform.js';
 import { emitStatus } from './status.js';
 
+export const CREDENTIALS_ENV_VAR_PATTERN =
+  /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN)=/m;
+
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
   const platform = getPlatform();
@@ -101,7 +104,7 @@ export async function run(_args: string[]): Promise<void> {
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(envContent)) {
+    if (CREDENTIALS_ENV_VAR_PATTERN.test(envContent)) {
       credentials = 'configured';
     }
   }


### PR DESCRIPTION
## Summary
- recognize `ANTHROPIC_AUTH_TOKEN` during setup verification
- reuse a shared credential env-var regex in verification and tests
- add focused coverage for `ANTHROPIC_AUTH_TOKEN`

## Testing
- npm test -- setup/environment.test.ts
- npm run typecheck

Closes #853