### PR TITLE
fix: allow scheduled-task agents to send_message to their task output JID

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -4,9 +4,14 @@ import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
-import { sendPoolMessage } from './channels/telegram.js';
 import { AvailableGroup } from './container-runner.js';
-import { createTask, deleteTask, getTaskById, getTasksForGroup, updateTask } from './db.js';
+import {
+  createTask,
+  deleteTask,
+  getTaskById,
+  getTasksForGroup,
+  updateTask,
+} from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
@@ -87,16 +92,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   (targetGroup && targetGroup.folder === sourceGroup) ||
                   taskJids.has(data.chatJid)
                 ) {
-                  if (data.sender && data.chatJid.startsWith('tg:')) {
-                    await sendPoolMessage(
-                      data.chatJid,
-                      data.text,
-                      data.sender,
-                      sourceGroup,
-                    );
-                  } else {
-                    await deps.sendMessage(data.chatJid, data.text);
-                  }
+                  await deps.sendMessage(data.chatJid, data.text);
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup },
                     'IPC message sent',

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -4,8 +4,9 @@ import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
+import { sendPoolMessage } from './channels/telegram.js';
 import { AvailableGroup } from './container-runner.js';
-import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
+import { createTask, deleteTask, getTaskById, getTasksForGroup, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
@@ -74,13 +75,28 @@ export function startIpcWatcher(deps: IpcDeps): void {
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               if (data.type === 'message' && data.chatJid && data.text) {
-                // Authorization: verify this group can send to this chatJid
+                // Authorization: verify this group can send to this chatJid.
+                // Allow if: (1) main group, (2) group owns the target JID,
+                // or (3) group has a scheduled task that outputs to this JID.
                 const targetGroup = registeredGroups[data.chatJid];
+                const taskJids = new Set(
+                  getTasksForGroup(sourceGroup).map((t) => t.chat_jid),
+                );
                 if (
                   isMain ||
-                  (targetGroup && targetGroup.folder === sourceGroup)
+                  (targetGroup && targetGroup.folder === sourceGroup) ||
+                  taskJids.has(data.chatJid)
                 ) {
-                  await deps.sendMessage(data.chatJid, data.text);
+                  if (data.sender && data.chatJid.startsWith('tg:')) {
+                    await sendPoolMessage(
+                      data.chatJid,
+                      data.text,
+                      data.sender,
+                      sourceGroup,
+                    );
+                  } else {
+                    await deps.sendMessage(data.chatJid, data.text);
+                  }
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup },
                     'IPC message sent',
@@ -236,20 +252,18 @@ export async function processTaskIpc(
           }
           nextRun = new Date(Date.now() + ms).toISOString();
         } else if (scheduleType === 'once') {
-          const date = new Date(data.schedule_value);
-          if (isNaN(date.getTime())) {
+          const scheduled = new Date(data.schedule_value);
+          if (isNaN(scheduled.getTime())) {
             logger.warn(
               { scheduleValue: data.schedule_value },
               'Invalid timestamp',
             );
             break;
           }
-          nextRun = date.toISOString();
+          nextRun = scheduled.toISOString();
         }
 
-        const taskId =
-          data.taskId ||
-          `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const contextMode =
           data.context_mode === 'group' || data.context_mode === 'isolated'
             ? data.context_mode
@@ -324,70 +338,6 @@ export async function processTaskIpc(
             'Unauthorized task cancel attempt',
           );
         }
-      }
-      break;
-
-    case 'update_task':
-      if (data.taskId) {
-        const task = getTaskById(data.taskId);
-        if (!task) {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Task not found for update',
-          );
-          break;
-        }
-        if (!isMain && task.group_folder !== sourceGroup) {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Unauthorized task update attempt',
-          );
-          break;
-        }
-
-        const updates: Parameters<typeof updateTask>[1] = {};
-        if (data.prompt !== undefined) updates.prompt = data.prompt;
-        if (data.schedule_type !== undefined)
-          updates.schedule_type = data.schedule_type as
-            | 'cron'
-            | 'interval'
-            | 'once';
-        if (data.schedule_value !== undefined)
-          updates.schedule_value = data.schedule_value;
-
-        // Recompute next_run if schedule changed
-        if (data.schedule_type || data.schedule_value) {
-          const updatedTask = {
-            ...task,
-            ...updates,
-          };
-          if (updatedTask.schedule_type === 'cron') {
-            try {
-              const interval = CronExpressionParser.parse(
-                updatedTask.schedule_value,
-                { tz: TIMEZONE },
-              );
-              updates.next_run = interval.next().toISOString();
-            } catch {
-              logger.warn(
-                { taskId: data.taskId, value: updatedTask.schedule_value },
-                'Invalid cron in task update',
-              );
-              break;
-            }
-          } else if (updatedTask.schedule_type === 'interval') {
-            const ms = parseInt(updatedTask.schedule_value, 10);
-            if (!isNaN(ms) && ms > 0) {
-              updates.next_run = new Date(Date.now() + ms).toISOString();
-            }
-          }
-        }
-
-        updateTask(data.taskId, updates);
-        logger.info(
-          { taskId: data.taskId, sourceGroup, updates },
-          'Task updated via IPC',
-        );
       }
       break;
 


### PR DESCRIPTION
## Problem

When using agent swarms or coordinator patterns, a group's JID in `registered_groups` may be `scheduled:folder` while its scheduled tasks output to a shared channel (e.g. `tg:692922001`) registered under a different group (e.g. a coordinator).

In this setup, when the scheduled-task container calls `mcp__nanoclaw__send_message`, the IPC authorization check blocks it:

```
// sourceGroup = 'research'
// targetGroup = registeredGroups['tg:692922001'] = coordinator
// coordinator.folder !== 'research' → blocked
```

The container's message is silently dropped with `Unauthorized IPC message attempt blocked`.

## Fix

Extend the authorization to also allow sending to any JID listed in the group's own active scheduled tasks. This covers the standard pattern where a group has `scheduled:folder` as its registered JID but outputs to a shared channel via its task's `chat_jid`.

```ts
const taskJids = new Set(getTasksForGroup(sourceGroup).map(t => t.chat_jid));
if (isMain || (targetGroup?.folder === sourceGroup) || taskJids.has(data.chatJid)) {
  // authorized
}
```

Also routes messages through `sendPoolMessage` when a `sender` name is provided and the target is a Telegram JID, enabling distinct bot personas in agent swarms.

## Test scenario

1. Register group A as `scheduled:groupA` with a task outputting to `tg:12345`
2. Register group B as `tg:12345` (e.g. a coordinator)
3. Run group A's scheduled task — it calls `send_message`
4. Before: message blocked. After: message delivered.