### PR TITLE
fix: security and reliability hardening across core modules

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -20,6 +20,13 @@ const chatJid = process.env.NANOCLAW_CHAT_JID!;
 const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
 const isMain = process.env.NANOCLAW_IS_MAIN === '1';
 
+// Rate-limit: prevent a single container session from flooding the task queue
+const MAX_TASKS_PER_SESSION = 100;
+let tasksCreatedThisSession = 0;
+
+// Valid JID pattern: alphanumerics, dots, hyphens, @, colons (covers WA, Telegram, Discord)
+const JID_PATTERN = /^[\w.@:\-]+$/;
+
 function writeIpcFile(dir: string, data: object): string {
   fs.mkdirSync(dir, { recursive: true });
 
@@ -127,9 +134,28 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       }
     }
 
+    // Rate limit: prevent task flooding
+    if (tasksCreatedThisSession >= MAX_TASKS_PER_SESSION) {
+      return {
+        content: [{ type: 'text' as const, text: `Task limit reached (${MAX_TASKS_PER_SESSION} tasks per session). Cannot create more tasks.` }],
+        isError: true,
+      };
+    }
+
+    // Validate target_group_jid format if provided
+    if (args.target_group_jid !== undefined) {
+      if (!JID_PATTERN.test(args.target_group_jid)) {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid target_group_jid format: "${args.target_group_jid}"` }],
+          isError: true,
+        };
+      }
+    }
+
     // Non-main groups can only schedule for themselves
     const targetJid = isMain && args.target_group_jid ? args.target_group_jid : chatJid;
 
+    tasksCreatedThisSession++;
     const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
     const data = {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+// Test the NaN-fallback pattern directly.
+// config.ts uses:  parseInt(value || 'default', 10) || fallback
+// This suite verifies that the pattern handles bad env values safely.
+function parseWithFallback(value: string | undefined, def: number): number {
+  return parseInt(value || String(def), 10) || def;
+}
+
+describe('config parseInt NaN fallback pattern', () => {
+  it('returns default when value is undefined', () => {
+    expect(parseWithFallback(undefined, 1800000)).toBe(1800000);
+  });
+
+  it('returns default when value is empty string', () => {
+    expect(parseWithFallback('', 1800000)).toBe(1800000);
+  });
+
+  it('returns default when value is non-numeric', () => {
+    expect(parseWithFallback('not-a-number', 1800000)).toBe(1800000);
+    expect(parseWithFallback('bad', 3001)).toBe(3001);
+    expect(parseWithFallback('abc', 10485760)).toBe(10485760);
+  });
+
+  it('returns parsed number when value is valid', () => {
+    expect(parseWithFallback('5000', 1800000)).toBe(5000);
+    expect(parseWithFallback('4000', 3001)).toBe(4000);
+  });
+
+  it('CONTAINER_TIMEOUT default is 1800000 (30 min in ms)', () => {
+    expect(parseWithFallback(undefined, 1800000)).toBe(1800000);
+  });
+
+  it('CONTAINER_MAX_OUTPUT_SIZE default is 10485760 (10 MB)', () => {
+    expect(parseWithFallback(undefined, 10485760)).toBe(10485760);
+  });
+
+  it('CREDENTIAL_PROXY_PORT default is 3001', () => {
+    expect(parseWithFallback(undefined, 3001)).toBe(3001);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,20 +39,15 @@ export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
-export const CONTAINER_TIMEOUT = parseInt(
-  process.env.CONTAINER_TIMEOUT || '1800000',
-  10,
-);
-export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
-  process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
-  10,
-); // 10MB default
-export const CREDENTIAL_PROXY_PORT = parseInt(
-  process.env.CREDENTIAL_PROXY_PORT || '3001',
-  10,
-);
+export const CONTAINER_TIMEOUT =
+  parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10) || 1800000;
+export const CONTAINER_MAX_OUTPUT_SIZE =
+  parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10) || 10485760; // 10MB default
+export const CREDENTIAL_PROXY_PORT =
+  parseInt(process.env.CREDENTIAL_PROXY_PORT || '3001', 10) || 3001;
 export const IPC_POLL_INTERVAL = 1000;
-export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const IDLE_TIMEOUT =
+  parseInt(process.env.IDLE_TIMEOUT || '1800000', 10) || 1800000; // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -347,6 +347,14 @@ export async function runContainerAgent(
       // Stream-parse for output markers
       if (onOutput) {
         parseBuffer += chunk;
+        // Guard against unbounded growth if OUTPUT_END never arrives
+        if (parseBuffer.length > CONTAINER_MAX_OUTPUT_SIZE * 2) {
+          logger.warn(
+            { group: group.name, size: parseBuffer.length },
+            'parseBuffer exceeded limit — clearing to prevent memory leak',
+          );
+          parseBuffer = '';
+        }
         let startIdx: number;
         while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
           const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -45,22 +45,31 @@ export function startCredentialProxy(
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
   return new Promise((resolve, reject) => {
+    const PROXY_TIMEOUT_MS = 30000;
+    // Only forward these headers to the upstream API — prevents header injection
+    const ALLOWED_HEADERS = new Set([
+      'content-type',
+      'accept',
+      'x-api-key',
+      'authorization',
+      'anthropic-version',
+      'anthropic-beta',
+    ]);
+
     const server = createServer((req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
         const body = Buffer.concat(chunks);
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
 
-        // Strip hop-by-hop headers that must not be forwarded by proxies
-        delete headers['connection'];
-        delete headers['keep-alive'];
-        delete headers['transfer-encoding'];
+        // Build headers from an explicit allowlist (prevents header injection)
+        const headers: Record<string, string | number | string[] | undefined> =
+          { host: upstreamUrl.host, 'content-length': body.length };
+        for (const [key, val] of Object.entries(req.headers)) {
+          if (ALLOWED_HEADERS.has(key.toLowerCase()) && val !== undefined) {
+            headers[key.toLowerCase()] = val as string | string[];
+          }
+        }
 
         if (authMode === 'api-key') {
           // API key mode: inject x-api-key on every request
@@ -86,12 +95,22 @@ export function startCredentialProxy(
             path: req.url,
             method: req.method,
             headers,
+            timeout: PROXY_TIMEOUT_MS,
           } as RequestOptions,
           (upRes) => {
             res.writeHead(upRes.statusCode!, upRes.headers);
             upRes.pipe(res);
           },
         );
+
+        upstream.on('timeout', () => {
+          logger.error({ url: req.url }, 'Credential proxy upstream timeout');
+          upstream.destroy();
+          if (!res.headersSent) {
+            res.writeHead(504);
+            res.end('Gateway Timeout');
+          }
+        });
 
         upstream.on('error', (err) => {
           logger.error(

--- a/src/db.ts
+++ b/src/db.ts
@@ -571,7 +571,17 @@ export function getRegisteredGroup(
     trigger: row.trigger_pattern,
     added_at: row.added_at,
     containerConfig: row.container_config
-      ? JSON.parse(row.container_config)
+      ? (() => {
+          try {
+            return JSON.parse(row.container_config);
+          } catch {
+            logger.warn(
+              { jid: row.jid },
+              'Corrupt container_config JSON in DB, ignoring',
+            );
+            return undefined;
+          }
+        })()
       : undefined,
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
@@ -624,7 +634,17 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       trigger: row.trigger_pattern,
       added_at: row.added_at,
       containerConfig: row.container_config
-        ? JSON.parse(row.container_config)
+        ? (() => {
+            try {
+              return JSON.parse(row.container_config);
+            } catch {
+              logger.warn(
+                { jid: row.jid },
+                'Corrupt container_config JSON in DB, ignoring',
+              );
+              return undefined;
+            }
+          })()
         : undefined,
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -53,6 +53,13 @@ describe('escapeXml', () => {
   it('handles empty string', () => {
     expect(escapeXml('')).toBe('');
   });
+
+  it('handles non-string input safely (runtime guard)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(escapeXml(null as any)).toBe('');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(escapeXml(undefined as any)).toBe('');
+  });
 });
 
 // --- formatMessages ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,11 @@ async function main(): Promise<void> {
           return;
         }
       }
-      storeMessage(msg);
+      try {
+        storeMessage(msg);
+      } catch (err) {
+        logger.error({ err, chatJid: msg.chat_jid }, 'Failed to store message');
+      }
     },
     onChatMetadata: (
       chatJid: string,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -71,16 +71,32 @@ export function startIpcWatcher(deps: IpcDeps): void {
             .filter((f) => f.endsWith('.json'));
           for (const file of messageFiles) {
             const filePath = path.join(messagesDir, file);
+            // Claim the file first (at-most-once delivery: prevents duplicate
+            // processing if this loop runs again before processing completes)
+            let data: Record<string, unknown>;
             try {
-              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              fs.unlinkSync(filePath);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error reading/claiming IPC message file',
+              );
+              continue;
+            }
+            // Process after claiming
+            try {
               if (data.type === 'message' && data.chatJid && data.text) {
                 // Authorization: verify this group can send to this chatJid
-                const targetGroup = registeredGroups[data.chatJid];
+                const targetGroup = registeredGroups[data.chatJid as string];
                 if (
                   isMain ||
                   (targetGroup && targetGroup.folder === sourceGroup)
                 ) {
-                  await deps.sendMessage(data.chatJid, data.text);
+                  await deps.sendMessage(
+                    data.chatJid as string,
+                    data.text as string,
+                  );
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup },
                     'IPC message sent',
@@ -92,17 +108,10 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   );
                 }
               }
-              fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
                 { file, sourceGroup, err },
-                'Error processing IPC message',
-              );
-              const errorDir = path.join(ipcBaseDir, 'errors');
-              fs.mkdirSync(errorDir, { recursive: true });
-              fs.renameSync(
-                filePath,
-                path.join(errorDir, `${sourceGroup}-${file}`),
+                'Error processing IPC message (file already consumed)',
               );
             }
           }
@@ -122,21 +131,26 @@ export function startIpcWatcher(deps: IpcDeps): void {
             .filter((f) => f.endsWith('.json'));
           for (const file of taskFiles) {
             const filePath = path.join(tasksDir, file);
+            // Claim the file first (at-most-once delivery)
+            let data: Record<string, unknown>;
             try {
-              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-              // Pass source group identity to processTaskIpc for authorization
-              await processTaskIpc(data, sourceGroup, isMain, deps);
+              data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
                 { file, sourceGroup, err },
-                'Error processing IPC task',
+                'Error reading/claiming IPC task file',
               );
-              const errorDir = path.join(ipcBaseDir, 'errors');
-              fs.mkdirSync(errorDir, { recursive: true });
-              fs.renameSync(
-                filePath,
-                path.join(errorDir, `${sourceGroup}-${file}`),
+              continue;
+            }
+            // Process after claiming
+            try {
+              // Pass source group identity to processTaskIpc for authorization
+              await processTaskIpc(data, sourceGroup, isMain, deps);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC task (file already consumed)',
               );
             }
           }
@@ -154,7 +168,15 @@ export function startIpcWatcher(deps: IpcDeps): void {
 }
 
 export async function processTaskIpc(
-  data: {
+  rawData: Record<string, unknown>,
+  sourceGroup: string, // Verified identity from IPC directory
+  isMain: boolean, // Verified from directory path
+  deps: IpcDeps,
+): Promise<void> {
+  // Cast to typed structure; all fields are validated at usage points below.
+  // We accept Record<string,unknown> so callers can pass JSON.parse() output
+  // without additional casts (at-most-once claim pattern in the caller).
+  const data = rawData as {
     type: string;
     taskId?: string;
     prompt?: string;
@@ -164,18 +186,13 @@ export async function processTaskIpc(
     groupFolder?: string;
     chatJid?: string;
     targetJid?: string;
-    // For register_group
     jid?: string;
     name?: string;
     folder?: string;
     trigger?: string;
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
-  },
-  sourceGroup: string, // Verified identity from IPC directory
-  isMain: boolean, // Verified from directory path
-  deps: IpcDeps,
-): Promise<void> {
+  };
   const registeredGroups = deps.registeredGroups();
 
   switch (data.type) {

--- a/src/mount-security.test.ts
+++ b/src/mount-security.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// We test matchesBlockedPattern via the validateMount path.
+// Direct unit test of the internals via monkey-patching is fragile; instead
+// we validate the observable behaviour that matters for security.
+
+// We mock the filesystem so we don't need real paths.
+vi.mock('fs');
+vi.mock('./config.js', () => ({
+  MOUNT_ALLOWLIST_PATH: '/fake/.config/nanoclaw/mount-allowlist.json',
+}));
+
+import fs from 'fs';
+
+const mockFs = fs as unknown as {
+  existsSync: ReturnType<typeof vi.fn>;
+  readFileSync: ReturnType<typeof vi.fn>;
+  realpathSync: ReturnType<typeof vi.fn>;
+};
+
+// Reset module cache between tests so cachedAllowlist is cleared
+describe('mount-security: matchesBlockedPattern (exact match)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+  });
+
+  async function makeValidateMount() {
+    // After resetting modules we need a fresh import
+    const mod = await import('./mount-security.js');
+    return mod;
+  }
+
+  it('blocks path whose component exactly equals a blocked pattern', async () => {
+    mockFs.existsSync = vi.fn().mockReturnValue(true);
+    mockFs.readFileSync = vi.fn().mockReturnValue(
+      JSON.stringify({
+        allowedRoots: [{ path: '/home/user/projects', allowReadWrite: true }],
+        blockedPatterns: [],
+        nonMainReadOnly: false,
+      }),
+    );
+    // realpathSync: first call for the mount path, second for allowedRoot
+    mockFs.realpathSync = vi
+      .fn()
+      .mockReturnValueOnce('/home/user/.ssh') // mount realpath
+      .mockReturnValueOnce('/home/user/projects'); // root realpath
+
+    const { validateMount } = await makeValidateMount();
+    const result = validateMount({ hostPath: '/home/user/.ssh' }, true);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('.ssh');
+  });
+
+  it('does NOT block a path that only contains the pattern as a substring', async () => {
+    // ".aws" should NOT block "/home/user/.awsome"
+    mockFs.existsSync = vi.fn().mockReturnValue(true);
+    mockFs.readFileSync = vi.fn().mockReturnValue(
+      JSON.stringify({
+        allowedRoots: [{ path: '/home/user', allowReadWrite: true }],
+        blockedPatterns: [],
+        nonMainReadOnly: false,
+      }),
+    );
+    mockFs.realpathSync = vi
+      .fn()
+      .mockReturnValueOnce('/home/user/.awsome') // mount realpath
+      .mockReturnValueOnce('/home/user'); // root realpath
+
+    const { validateMount } = await makeValidateMount();
+    // .aws is in DEFAULT_BLOCKED_PATTERNS but .awsome should NOT match
+    const result = validateMount({ hostPath: '/home/user/.awsome' }, true);
+    // The path component is ".awsome" which does NOT equal ".aws"
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks path with .aws directory component', async () => {
+    mockFs.existsSync = vi.fn().mockReturnValue(true);
+    mockFs.readFileSync = vi.fn().mockReturnValue(
+      JSON.stringify({
+        allowedRoots: [{ path: '/home/user', allowReadWrite: true }],
+        blockedPatterns: [],
+        nonMainReadOnly: false,
+      }),
+    );
+    mockFs.realpathSync = vi
+      .fn()
+      .mockReturnValueOnce('/home/user/.aws/credentials') // mount realpath
+      .mockReturnValueOnce('/home/user'); // root realpath
+
+    const { validateMount } = await makeValidateMount();
+    const result = validateMount({ hostPath: '/home/user/.aws/credentials' }, true);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('.aws');
+  });
+
+  it('blocks path when no allowlist file exists', async () => {
+    mockFs.existsSync = vi.fn().mockReturnValue(false);
+
+    const { validateMount } = await makeValidateMount();
+    const result = validateMount({ hostPath: '/home/user/project' }, true);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('No mount allowlist');
+  });
+});

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -154,16 +154,12 @@ function matchesBlockedPattern(
   const pathParts = realPath.split(path.sep);
 
   for (const pattern of blockedPatterns) {
-    // Check if any path component matches the pattern
+    // Check if any path component exactly matches the pattern.
+    // Exact match prevents false positives (e.g. ".aws" blocking ".awesome").
     for (const part of pathParts) {
-      if (part === pattern || part.includes(pattern)) {
+      if (part === pattern) {
         return pattern;
       }
-    }
-
-    // Also check if the full path contains the pattern
-    if (realPath.includes(pattern)) {
-      return pattern;
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@ import { Channel, NewMessage } from './types.js';
 import { formatLocalTime } from './timezone.js';
 
 export function escapeXml(s: string): string {
-  if (!s) return '';
+  if (!s || typeof s !== 'string') return '';
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')


### PR DESCRIPTION
## Summary

- **Security**: credential-proxy header allowlist + 30s timeout; mount-security exact pattern matching; ipc-mcp-stdio rate limit (100 tasks/session) + JID validation; db.ts JSON.parse error isolation
- **Reliability**: IPC at-most-once delivery (claim file before processing); parseBuffer memory leak cap; storeMessage wrapped in try-catch
- **Robustness**: parseInt NaN fallback in config.ts; escapeXml type guard in router.ts

## Changes

| File | Fix |
|------|-----|
| `src/credential-proxy.ts` | Header allowlist (6 headers), 30s upstream timeout |
| `src/mount-security.ts` | `part === pattern` instead of `part.includes(pattern)` |
| `container/agent-runner/src/ipc-mcp-stdio.ts` | 100 tasks/session rate limit, JID regex validation |
| `src/db.ts` | try-catch around `JSON.parse(row.container_config)` |
| `src/ipc.ts` | At-most-once: read+delete file, then process; `processTaskIpc` accepts `Record<string,unknown>` |
| `src/container-runner.ts` | `parseBuffer` capped at `2 × CONTAINER_MAX_OUTPUT_SIZE` |
| `src/index.ts` | `storeMessage()` wrapped in try-catch |
| `src/config.ts` | All `parseInt` calls have `|| default` NaN fallback |
| `src/router.ts` | `escapeXml` returns `''` for non-string input |
| `src/config.test.ts` | New — tests parseInt NaN fallback pattern |
| `src/mount-security.test.ts` | New — tests exact matching, false positive prevention |
| `src/formatting.test.ts` | Added non-string escapeXml test |

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx vitest run` — 335 passed, 8 pre-existing failures (unrelated, confirmed by `git stash` test)
- [x] New tests: 11 tests across 2 new files all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)