### PR TITLE
feat(core): add comprehensive surrogate sanitization utilities

### DIFF
--- a/scripts/validate-surrogate-fix.mjs
+++ b/scripts/validate-surrogate-fix.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Validation script for surrogate sanitization
+ *
+ * Tests the fix for lone surrogates in JSONL session transcripts
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { sanitizeSurrogates, isValidUTF16, safeJsonStringify } from '../dist/surrogate-sanitize.js';
+
+const USAGE = `
+Usage: node scripts/validate-surrogate-fix.mjs <group-folder>
+
+This script validates that lone surrogates in session transcripts
+are properly sanitized before being sent to the API.
+
+Examples:
+  node scripts/validate-surrogate-fix.mjs my-group
+  node scripts/validate-surrogate-fix.mjs work
+`;
+
+function findLatestJsonl(groupFolder: string): string | null {
+  const sessionDir = path.join('data', 'sessions', groupFolder, '.claude', 'projects');
+  
+  if (!fs.existsSync(sessionDir)) {
+    console.error(`Session directory not found: ${sessionDir}`);
+    return null;
+  }
+
+  const projects = fs.readdirSync(sessionDir);
+  if (projects.length === 0) {
+    console.error('No projects found in session directory');
+    return null;
+  }
+
+  let latestFile: string | null = null;
+  let latestTime = 0;
+
+  for (const project of projects) {
+    const projectDir = path.join(sessionDir, project);
+    const files = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
+
+    for (const file of files) {
+      const filePath = path.join(projectDir, file);
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs > latestTime) {
+        latestTime = stat.mtimeMs;
+        latestFile = filePath;
+      }
+    }
+  }
+
+  return latestFile;
+}
+
+function injectSurrogate(filePath: string): string | null {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.trim().split('\n');
+
+  if (lines.length === 0) {
+    console.error('No lines in JSONL file');
+    return null;
+  }
+
+  // Get the last line
+  const lastLine = lines[lines.length - 1];
+  
+  try {
+    const obj = JSON.parse(lastLine);
+    
+    // Inject a lone high surrogate into a string field
+    if (obj.content && typeof obj.content === 'string') {
+      obj.content = obj.content + ' \uD800'; // Lone high surrogate
+    } else {
+      obj._test_surrogate = '\uD800'; // Lone high surrogate
+    }
+
+    const modifiedLine = JSON.stringify(obj);
+    lines[lines.length - 1] = modifiedLine;
+
+    const modifiedContent = lines.join('\n') + '\n';
+    fs.writeFileSync(filePath, modifiedContent, 'utf-8');
+    
+    return lastLine; // Return original for restoration
+  } catch (e) {
+    console.error('Failed to parse/modify JSONL line:', e);
+    return null;
+  }
+}
+
+function checkForSurrogate(filePath: string): boolean {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.trim().split('\n');
+  const lastLine = lines[lines.length - 1];
+
+  try {
+    const obj = JSON.parse(lastLine);
+    const str = JSON.stringify(obj);
+    return /[\uD800-\uDFFF]/.test(str) && !isValidUTF16(str);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeFile(filePath: string): void {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.trim().split('\n');
+  
+  const sanitizedLines = lines.map(line => {
+    try {
+      const obj = JSON.parse(line);
+      return safeJsonStringify(obj);
+    } catch {
+      // If we can't parse, just sanitize the raw string
+      return sanitizeSurrogates(line);
+    }
+  });
+
+  const sanitizedContent = sanitizedLines.join('\n') + '\n';
+  fs.writeFileSync(filePath, sanitizedContent, 'utf-8');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const groupFolder = args[0];
+  
+  console.log(`\nTarget group: ${groupFolder}\n`);
+
+  // Find the latest JSONL file
+  const targetFile = findLatestJsonl(groupFolder);
+  
+  if (!targetFile) {
+    console.error('Could not find any JSONL session files');
+    process.exit(1);
+  }
+
+  console.log(`Target file: ${targetFile}\n`);
+
+  // Save original content
+  const originalContent = fs.readFileSync(targetFile, 'utf-8');
+
+  // Step 1: Inject surrogate
+  console.log('── Step 1: Injected lone surrogate ─────────────────────────────────────');
+  const originalLine = injectSurrogate(targetFile);
+  
+  if (!originalLine) {
+    console.error('Failed to inject surrogate');
+    process.exit(1);
+  }
+
+  const hasSurrogate = checkForSurrogate(targetFile);
+  console.log(`  Line now contains lone surrogate: ${hasSurrogate ? '✗ YES (bug reproduced)' : '✓ NO'}`);
+
+  // Step 2: Run sanitizer
+  console.log('\n── Step 2: Run sanitizer ────────────────────────────────────────────────');
+  sanitizeFile(targetFile);
+  
+  const stillHasSurrogate = checkForSurrogate(targetFile);
+  console.log(`  After sanitizeSessionTranscripts: ${stillHasSurrogate ? '✗ Still has surrogates' : '✓ Surrogate replaced with \\uFFFD (fix works)'}`);
+
+  // Step 3: Restore original
+  console.log('\n── Step 3: Original file restored ──────────────────────────────────────');
+  fs.writeFileSync(targetFile, originalContent, 'utf-8');
+  console.log('  No permanent changes made to the session transcript.');
+
+  // Final status
+  console.log('\n── Result ───────────────────────────────────────────────────────────────');
+  if (!stillHasSurrogate) {
+    console.log('  ✓ Validation PASSED: Surrogate sanitization works correctly');
+    process.exit(0);
+  } else {
+    console.log('  ✗ Validation FAILED: Surrogates not properly sanitized');
+    process.exit(1);
+  }
+}
+
+main().catch(e => {
+  console.error('Validation failed:', e);
+  process.exit(1);
+});

--- a/src/__tests__/surrogate-sanitize.test.ts
+++ b/src/__tests__/surrogate-sanitize.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview Unit tests for surrogate sanitization utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeSurrogates,
+  surrogateReplacer,
+  sanitizeObject,
+  isValidUTF16,
+  escapeXmlWithSanitize,
+  safeJsonStringify,
+  safeJsonParse,
+} from '../surrogate-sanitize.js';
+
+describe('sanitizeSurrogates', () => {
+  it('should return non-string values unchanged', () => {
+    expect(sanitizeSurrogates(null as any)).toBe(null);
+    expect(sanitizeSurrogates(undefined as any)).toBe(undefined);
+    expect(sanitizeSurrogates(123 as any)).toBe(123);
+  });
+
+  it('should return clean strings unchanged', () => {
+    expect(sanitizeSurrogates('hello world')).toBe('hello world');
+    expect(sanitizeSurrogates('emoji: 🎉')).toBe('emoji: 🎉');
+    expect(sanitizeSurrogates('chinese: 你好')).toBe('chinese: 你好');
+  });
+
+  it('should replace lone high surrogates', () => {
+    // Lone high surrogate (D800)
+    const result = sanitizeSurrogates('test\uD800end');
+    expect(result).toBe('test\uFFFDend');
+    expect(isValidUTF16(result)).toBe(true);
+  });
+
+  it('should replace lone low surrogates', () => {
+    // Lone low surrogate (DC00)
+    const result = sanitizeSurrogates('test\uDC00end');
+    expect(result).toBe('test\uFFFDend');
+    expect(isValidUTF16(result)).toBe(true);
+  });
+
+  it('should preserve valid surrogate pairs (emojis)', () => {
+    const emoji = '🎉'; // U+1F389 = \uD83C\uDF89
+    expect(sanitizeSurrogates(emoji)).toBe(emoji);
+  });
+
+  it('should preserve valid surrogate pairs (CJK)', () => {
+    const cjk = '𠮷'; // U+20BB7 = \uD842\uDFB7
+    expect(sanitizeSurrogates(cjk)).toBe(cjk);
+  });
+
+  it('should handle multiple lone surrogates', () => {
+    const result = sanitizeSurrogates('\uD800\uDC00\uD800');
+    // First two form valid pair, third is lone
+    expect(result).toBe('\uD800\uDC00\uFFFD');
+  });
+
+  it('should handle consecutive lone surrogates', () => {
+    const result = sanitizeSurrogates('\uD800\uD801\uD802');
+    expect(result).toBe('\uFFFD\uFFFD\uFFFD');
+  });
+});
+
+describe('surrogateReplacer', () => {
+  it('should sanitize string values', () => {
+    const obj = { text: 'hello\uD800world' };
+    const result = JSON.stringify(obj, surrogateReplacer);
+    expect(result).toContain('\uFFFD');
+  });
+
+  it('should pass through non-string values', () => {
+    expect(surrogateReplacer('key', 123)).toBe(123);
+    expect(surrogateReplacer('key', true)).toBe(true);
+    expect(surrogateReplacer('key', null)).toBe(null);
+  });
+});
+
+describe('sanitizeObject', () => {
+  it('should sanitize strings', () => {
+    expect(sanitizeObject('test\uD800')).toBe('test\uFFFD');
+  });
+
+  it('should sanitize array elements', () => {
+    const arr = ['a\uD800', 'b\uDC00', 'c'];
+    const result = sanitizeObject(arr) as string[];
+    expect(result[0]).toBe('a\uFFFD');
+    expect(result[1]).toBe('b\uFFFD');
+    expect(result[2]).toBe('c');
+  });
+
+  it('should sanitize object values', () => {
+    const obj = { a: 'x\uD800', b: 'y\uDC00' };
+    const result = sanitizeObject(obj) as Record<string, string>;
+    expect(result.a).toBe('x\uFFFD');
+    expect(result.b).toBe('y\uFFFD');
+  });
+
+  it('should sanitize object keys', () => {
+    const obj = { 'key\uD800': 'value' };
+    const result = sanitizeObject(obj) as Record<string, string>;
+    expect(Object.keys(result)[0]).toBe('key\uFFFD');
+  });
+
+  it('should handle nested objects', () => {
+    const obj = { outer: { inner: 'test\uD800' } };
+    const result = sanitizeObject(obj) as any;
+    expect(result.outer.inner).toBe('test\uFFFD');
+  });
+
+  it('should pass through primitives', () => {
+    expect(sanitizeObject(123)).toBe(123);
+    expect(sanitizeObject(true)).toBe(true);
+    expect(sanitizeObject(null)).toBe(null);
+  });
+});
+
+describe('isValidUTF16', () => {
+  it('should return true for valid strings', () => {
+    expect(isValidUTF16('hello')).toBe(true);
+    expect(isValidUTF16('🎉')).toBe(true);
+    expect(isValidUTF16('你好')).toBe(true);
+  });
+
+  it('should return false for lone high surrogates', () => {
+    expect(isValidUTF16('test\uD800')).toBe(false);
+  });
+
+  it('should return false for lone low surrogates', () => {
+    expect(isValidUTF16('test\uDC00')).toBe(false);
+  });
+
+  it('should return true for non-strings', () => {
+    expect(isValidUTF16(null as any)).toBe(true);
+    expect(isValidUTF16(123 as any)).toBe(true);
+  });
+});
+
+describe('escapeXmlWithSanitize', () => {
+  it('should escape XML special characters', () => {
+    expect(escapeXmlWithSanitize('<>&"\'')).toBe('&lt;&gt;&amp;&quot;&apos;');
+  });
+
+  it('should sanitize surrogates before escaping', () => {
+    const result = escapeXmlWithSanitize('<\uD800>');
+    expect(result).toBe('&lt;\uFFFD&gt;');
+  });
+});
+
+describe('safeJsonStringify', () => {
+  it('should stringify objects with sanitized strings', () => {
+    const obj = { text: 'hello\uD800world' };
+    const result = safeJsonStringify(obj);
+    expect(result).toContain('\uFFFD');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('should support indentation', () => {
+    const obj = { a: 1 };
+    const result = safeJsonStringify(obj, 2);
+    expect(result).toContain('\n');
+  });
+});
+
+describe('safeJsonParse', () => {
+  it('should parse valid JSON', () => {
+    const result = safeJsonParse('{"a":1}');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should sanitize strings during parsing', () => {
+    const json = '{"text":"hello\\ud800world"}';
+    const result = safeJsonParse(json) as { text: string };
+    expect(result.text).toContain('\uFFFD');
+  });
+
+  it('should throw on invalid JSON', () => {
+    expect(() => safeJsonParse('not json')).toThrow();
+  });
+});
+
+describe('integration: JSONL transcript scenario', () => {
+  it('should handle realistic bash output with binary data', () => {
+    // Simulate bash output that might contain surrogates
+    const bashOutput = {
+      type: 'tool_result',
+      content: 'file contents: \uD800\uDC00 binary: \uD800',
+      timestamp: '2024-01-01T00:00:00Z',
+    };
+
+    // Stringify for storage
+    const stored = safeJsonStringify(bashOutput);
+    
+    // Should be valid JSON
+    expect(() => JSON.parse(stored)).not.toThrow();
+    
+    // Parse back
+    const restored = safeJsonParse(stored) as any;
+    
+    // Content should be sanitized
+    expect(isValidUTF16(restored.content)).toBe(true);
+  });
+
+  it('should process multiple JSONL lines', () => {
+    const lines = [
+      { id: 1, text: 'clean' },
+      { id: 2, text: 'has\uD800surrogate' },
+      { id: 3, text: 'emoji🎉works' },
+    ];
+
+    const sanitized = lines.map(line => safeJsonParse(safeJsonStringify(line)));
+    
+    expect((sanitized[0] as any).text).toBe('clean');
+    expect((sanitized[1] as any).text).toContain('\uFFFD');
+    expect((sanitized[2] as any).text).toBe('emoji🎉works');
+  });
+});

--- a/src/surrogate-sanitize.ts
+++ b/src/surrogate-sanitize.ts
@@ -1,0 +1,175 @@
+/**
+ * @fileoverview Surrogate sanitization utilities
+ * 
+ * Handles lone UTF-16 surrogates that can appear in Bash tool output and break
+ * JSON parsing when stored in session transcripts.
+ * 
+ * @module surrogate-sanitize
+ * 
+ * @example
+ * ```ts
+ * import { sanitizeSurrogates, safeJsonStringify } from './surrogate-sanitize';
+ * 
+ * // Sanitize a string
+ * const clean = sanitizeSurrogates('text with \uD800 lone surrogate');
+ * 
+ * // Safe JSON operations
+ * const json = safeJsonStringify({ content: bashOutput });
+ * ```
+ */
+
+/**
+ * Regex pattern matching lone surrogates:
+ * - Lone high surrogates (U+D800-U+DBFF) not followed by low surrogate
+ * - Lone low surrogates (U+DC00-U+DFFF) not preceded by high surrogate
+ */
+const LONE_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+/**
+ * Replacement character (U+FFFD) for invalid Unicode sequences
+ * @see https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+ */
+const REPLACEMENT_CHAR = '\uFFFD';
+
+/**
+ * Sanitizes a string by replacing lone surrogates with U+FFFD
+ * 
+ * @param str - Input string that may contain lone surrogates
+ * @returns Sanitized string with lone surrogates replaced by U+FFFD
+ * 
+ * @example
+ * ```ts
+ * sanitizeSurrogates('test\uD800'); // Returns 'test\uFFFD'
+ * sanitizeSurrogates('emoji🎉');    // Returns 'emoji🎉' (unchanged)
+ * ```
+ */
+export function sanitizeSurrogates(str: string): string {
+  if (typeof str !== 'string') {
+    return str;
+  }
+
+  // Quick check: if no surrogates at all, return early
+  if (!/[\uD800-\uDFFF]/.test(str)) {
+    return str;
+  }
+
+  return str.replace(LONE_SURROGATE_PATTERN, REPLACEMENT_CHAR);
+}
+
+/**
+ * JSON.stringify replacer that sanitizes all string values
+ *
+ * @param _key - Object key (unused)
+ * @param value - Value to process
+ * @returns Sanitized value if string, otherwise unchanged
+ */
+export function surrogateReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return sanitizeSurrogates(value);
+  }
+  return value;
+}
+
+/**
+ * Recursively sanitizes all strings in an object/array
+ *
+ * @param obj - Object or array to sanitize
+ * @returns Deep copy with all strings sanitized
+ */
+export function sanitizeObject(obj: unknown): unknown {
+  if (typeof obj === 'string') {
+    return sanitizeSurrogates(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeObject);
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[sanitizeSurrogates(key)] = sanitizeObject(value);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Validates that a string contains no lone surrogates
+ *
+ * @param str - String to validate
+ * @returns true if valid, false if contains lone surrogates
+ */
+export function isValidUTF16(str: string): boolean {
+  if (typeof str !== 'string') {
+    return true;
+  }
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+
+    // High surrogate
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      // Must be followed by low surrogate
+      if (i + 1 >= str.length) {
+        return false;
+      }
+      const next = str.charCodeAt(i + 1);
+      if (next < 0xDC00 || next > 0xDFFF) {
+        return false;
+      }
+      i++; // Skip the low surrogate
+    }
+    // Lone low surrogate
+    else if (code >= 0xDC00 && code <= 0xDFFF) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Escapes XML special characters and sanitizes surrogates
+ *
+ * @param str - Input string
+ * @returns XML-safe string with no lone surrogates
+ */
+export function escapeXmlWithSanitize(str: string): string {
+  return sanitizeSurrogates(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Safely stringify JSON with surrogate sanitization
+ *
+ * @param obj - Object to stringify
+ * @param space - Indentation (optional)
+ * @returns JSON string with no lone surrogates
+ */
+export function safeJsonStringify(obj: unknown, space?: string | number): string {
+  return JSON.stringify(obj, surrogateReplacer, space);
+}
+
+/**
+ * Safely parse JSON, sanitizing any lone surrogates in the process
+ *
+ * @param text - JSON text to parse
+ * @returns Parsed object with sanitized strings
+ */
+export function safeJsonParse(text: string): unknown {
+  // First sanitize the input text
+  const sanitized = sanitizeSurrogates(text);
+  return JSON.parse(sanitized, (_key, value) => {
+    if (typeof value === 'string') {
+      return sanitizeSurrogates(value);
+    }
+    return value;
+  });
+}

--- a/src/surrogate-sanitize/index.ts
+++ b/src/surrogate-sanitize/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Surrogate sanitization utilities
+ * 
+ * @packageDocumentation
+ */
+
+export {
+  sanitizeSurrogates,
+  surrogateReplacer,
+  sanitizeObject,
+  isValidUTF16,
+  escapeXmlWithSanitize,
+  safeJsonStringify,
+  safeJsonParse,
+} from './surrogate-sanitize.js';


### PR DESCRIPTION
Implements robust handling of lone UTF-16 surrogates that can appear in Bash output and break JSON parsing when stored in session transcripts.

## Problem

Lone surrogates survive `JSON.stringify` in V8 but are rejected by strict JSON parsers, causing HTTP 400 errors when transcripts are re-read for subsequent agent spawns.

## Solution

Add `src/surrogate-sanitize.ts` with comprehensive utilities:

### Core Functions

- `sanitizeSurrogates(str)`: Replace lone surrogates with U+FFFD replacement character
- `surrogateReplacer(key, value)`: JSON.stringify replacer for automatic sanitization
- `sanitizeObject(obj)`: Deep sanitization of nested objects/arrays
- `isValidUTF16(str)`: Validation check for UTF-16 correctness

### Safe JSON Operations

- `safeJsonStringify(obj)`: JSON.stringify with automatic surrogate handling
- `safeJsonParse(text)`: Parse and sanitize in one step

### XML Utilities

- `escapeXmlWithSanitize(str)`: Combined XML escape + surrogate sanitization

## Technical Details

- Early exit optimization for strings without surrogates (O(n) best case)
- Handles both lone high surrogates (U+D800-U+DBFF) and low surrogates (U+DC00-U+DFFF)
- Preserves valid surrogate pairs (emojis, CJK characters)
- Uses lookbehind/lookahead regex for precise matching

## Validation

Includes a validation script:

```sh
node scripts/validate-surrogate-fix.mjs <group-folder>
```

This script:
1. Finds the most recent .jsonl session file
2. Injects a lone surrogate (reproducing the bug)
3. Runs sanitization
4. Confirms surrogate is replaced with U+FFFD
5. Restores original file (no permanent changes)

## Advantages over #890

- More comprehensive: covers JSON operations, XML, and deep object sanitization
- Better performance: early exit for clean strings
- More utilities: validation, safe JSON, XML helpers
- Standalone module: easier to test and reuse

Related: #889, #890