### PR TITLE
fix: handle undefined msg.user in Slack channel skill template

### DIFF
--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -102,7 +102,7 @@ export class SlackChannel implements Channel {
         senderName = ASSISTANT_NAME;
       } else {
         senderName =
-          (await this.resolveUserName(msg.user)) ||
+          (msg.user ? await this.resolveUserName(msg.user) : undefined) ||
           msg.user ||
           'unknown';
       }


### PR DESCRIPTION
## Summary
- `GenericMessageEvent.user` is `string | undefined`, but `resolveUserName()` expects `string`
- Guard with a ternary check to avoid passing `undefined`, fixing a TypeScript build error (TS2345) when the add-slack skill is applied

## Key Changes
- `.claude/skills/add-slack/add/src/channels/slack.ts`: line 105 — wrap `resolveUserName(msg.user)` call with `msg.user ?` guard

## Testing
- `npm run build` passes after applying the skill with this fix