### PR TITLE
feat(skills): add docker-cli skill for host container management

### DIFF
--- a/.claude/skills/add-docker-cli/SKILL.md
+++ b/.claude/skills/add-docker-cli/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: add-docker-cli
+description: Add Docker CLI access so the container agent can manage host containers. Monitor, start, stop, inspect, and view logs of Docker containers running on the host machine.
+---
+
+# Add Docker CLI
+
+Gives the container agent full Docker CLI access to the host's Docker daemon via socket mount. The agent can monitor containers, view logs, start/stop services, and more.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `add-docker-cli` is in `applied_skills`, skip to Phase 3 (Verify).
+
+## Security Notice
+
+**STOP — Read this before proceeding.**
+
+This skill mounts the host's Docker socket (`/var/run/docker.sock`) into the container agent. This gives the agent **full control over Docker on the host machine**, including the ability to:
+
+- Start, stop, and remove any container
+- Pull and delete images
+- Inspect container environments (which may contain secrets)
+- Run new containers with arbitrary mounts (potential host filesystem access)
+
+The socket is only mounted for the **main group** — non-main groups do not get Docker access. The agent-facing instructions include a "Never Run" list for destructive commands, but this is advisory, not enforced.
+
+**Only apply this skill if you trust your main group agent with Docker-level access to your host.**
+
+Confirm with the user that they understand these implications before continuing.
+
+## Phase 2: Apply Code Changes
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-docker-cli
+```
+
+This deterministically:
+- Adds `container/skills/docker/SKILL.md` (agent-facing documentation)
+- Three-way merges Docker CLI install into `container/Dockerfile`
+- Three-way merges Docker socket mount + group-add into `src/container-runner.ts`
+- Records application in `.nanoclaw/state.yaml`
+
+If merge conflicts occur, read the intent files:
+- `modify/container/Dockerfile.intent.md`
+- `modify/src/container-runner.ts.intent.md`
+
+### Validate
+
+```bash
+npm test
+npm run build
+```
+
+### Rebuild container
+
+```bash
+./container/build.sh
+```
+
+### Restart service
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 3: Verify
+
+### Test Docker access
+
+Ask the agent to list running containers:
+
+> What Docker containers are running right now?
+
+The agent should be able to run `docker ps` and return results.
+
+### Test container inspection
+
+Ask the agent to check logs of a specific container:
+
+> Show me the last 20 lines of logs from the redis container
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log | grep -i docker
+```
+
+Look for:
+- Mount configuration showing `/var/run/docker.sock` — socket is mounted
+- No permission errors in container output
+
+## Troubleshooting
+
+### Agent says "docker: command not found"
+
+Container needs rebuilding. Run `./container/build.sh` and restart the service.
+
+### Permission denied on Docker socket
+
+The container needs `--group-add 0` to access the socket (Docker Desktop maps it to root:root inside Linux containers). Verify `src/container-runner.ts` includes the group-add logic. On native Linux, the socket may be owned by a `docker` group with a different GID — you may need to change `'0'` to the actual GID (find it with `stat -c '%g' /var/run/docker.sock`).
+
+### Docker socket not found
+
+Docker Desktop must be running. The socket at `/var/run/docker.sock` must exist on the host.
+
+### Only works for main group
+
+By design, only the main group gets Docker socket access. Non-main groups are sandboxed and should not have host-level container control.
+
+## Advanced: Remote Docker
+
+The Docker CLI supports remote hosts via `DOCKER_HOST`. To connect to remote machines:
+
+- **SSH**: `DOCKER_HOST=ssh://user@remote-server docker ps` (requires SSH keys mounted into the container via `additionalMounts`)
+- **TCP+TLS**: `DOCKER_HOST=tcp://remote:2376 docker ps` (requires TLS certs)
+
+These require additional mount configuration beyond this skill's scope.

--- a/.claude/skills/add-docker-cli/add/container/skills/docker/SKILL.md
+++ b/.claude/skills/add-docker-cli/add/container/skills/docker/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: docker
+description: Manage Docker containers on the host machine
+allowed-tools: Bash(docker:*)
+---
+
+# Docker
+
+You have access to the Docker CLI connected to the host machine's Docker daemon.
+
+## Available Commands
+
+### List containers
+```bash
+docker ps                          # Running containers
+docker ps -a                       # All containers (including stopped)
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+```
+
+### Container logs
+```bash
+docker logs <container>            # Full logs
+docker logs --tail 50 <container>  # Last 50 lines
+docker logs --since 1h <container> # Last hour
+docker logs -f <container>         # Follow (stream) — use with timeout
+```
+
+### Container inspection
+```bash
+docker inspect <container>         # Full details (JSON)
+docker stats --no-stream           # Resource usage snapshot
+docker top <container>             # Running processes
+```
+
+### Container lifecycle
+```bash
+docker start <container>
+docker stop <container>
+docker restart <container>
+docker rm <container>              # Remove stopped container
+```
+
+### Images
+```bash
+docker images                      # List images
+docker pull <image>                # Pull an image
+```
+
+### Running new containers
+```bash
+docker run -d --name <name> <image>           # Detached
+docker run -d --name <name> -p 8080:80 <image> # With port mapping
+docker run -d --name <name> --restart unless-stopped <image>  # Auto-restart
+```
+
+### Run a command in a container
+```bash
+docker exec <container> <command>
+```
+
+### Docker Compose (if available)
+```bash
+docker compose ps
+docker compose up -d
+docker compose down
+docker compose logs <service>
+```
+
+## Monitoring Pattern
+
+When asked to monitor containers, check their health status:
+
+```bash
+docker ps --format '{{.Names}}\t{{.Status}}' | grep -v "Up"
+```
+
+If any containers have exited or are unhealthy, pull their logs to diagnose:
+
+```bash
+docker logs --tail 100 <failed-container>
+```
+
+## Never Run These Commands
+
+These are destructive and affect the host machine — do not run them:
+
+- `docker system prune` — deletes unused images, containers, networks
+- `docker volume prune` — deletes unused volumes (data loss)
+- `docker rmi` — removes images needed by other containers
+- `docker rm -f` — force-kills and removes running containers
+- `docker network rm` — removes networks other containers depend on
+
+## Important Notes
+
+- Containers you see are running on the **host machine**, not inside your own container
+- `docker logs -f` (follow mode) will block — always use `--tail` or `--since` instead
+- For long-running monitoring, use scheduled tasks rather than continuous polling

--- a/.claude/skills/add-docker-cli/manifest.yaml
+++ b/.claude/skills/add-docker-cli/manifest.yaml
@@ -1,0 +1,15 @@
+skill: add-docker-cli
+version: 1.0.0
+description: "Add Docker CLI access so the container agent can manage host containers"
+core_version: 1.2.10
+adds:
+  - container/skills/docker/SKILL.md
+modifies:
+  - container/Dockerfile
+  - src/container-runner.ts
+structured:
+  npm_dependencies: {}
+  env_additions: []
+conflicts: []
+depends: []
+test: "npx vitest run --config vitest.skills.config.ts .claude/skills/add-docker-cli/tests/docker-cli.test.ts"

--- a/.claude/skills/add-docker-cli/modify/container/Dockerfile
+++ b/.claude/skills/add-docker-cli/modify/container/Dockerfile
@@ -1,0 +1,75 @@
+# NanoClaw Agent Container
+# Runs Claude Agent SDK in isolated Linux VM with browser automation
+
+FROM node:22-slim
+
+# Install system dependencies for Chromium
+RUN apt-get update && apt-get install -y \
+    chromium \
+    fonts-liberation \
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    libgbm1 \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxshmfence1 \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker CLI (static binary, no daemon) for host container management
+RUN ARCH=$(uname -m) \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-27.5.1.tgz" -o /tmp/docker.tgz \
+    && tar -xzf /tmp/docker.tgz --strip-components=1 -C /usr/local/bin docker/docker \
+    && rm /tmp/docker.tgz
+
+# Set Chromium path for agent-browser
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Install agent-browser and claude-code globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files first for better caching
+COPY agent-runner/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY agent-runner/ ./
+
+# Build TypeScript
+RUN npm run build
+
+# Create workspace directories
+RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
+
+# Create entrypoint script
+# Secrets are passed via stdin JSON — temp file is deleted immediately after Node reads it
+# Follow-up messages arrive via IPC files in /workspace/ipc/input/
+RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+
+# Set ownership to node user (non-root) for writable directories
+RUN chown -R node:node /workspace && chmod 777 /home/node
+
+# Switch to non-root user (required for --dangerously-skip-permissions)
+USER node
+
+# Set working directory to group workspace
+WORKDIR /workspace/group
+
+# Entry point reads JSON from stdin, outputs JSON to stdout
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/.claude/skills/add-docker-cli/modify/container/Dockerfile.intent.md
+++ b/.claude/skills/add-docker-cli/modify/container/Dockerfile.intent.md
@@ -1,0 +1,21 @@
+# Intent: container/Dockerfile modifications
+
+## What changed
+Added Docker CLI (static binary) so the container agent can manage host Docker containers.
+
+## Key sections
+
+### After apt-get install block
+- Added: New `RUN` step that downloads Docker CLI static binary from download.docker.com
+- Uses `uname -m` for architecture detection (works for both x86_64 and aarch64)
+- Only installs the CLI binary (`docker/docker` from the tarball), not the daemon
+- Version pinned to 27.5.1
+
+## Invariants (must-keep)
+- All Chromium dependencies unchanged
+- agent-browser and claude-code npm global installs unchanged
+- WORKDIR, COPY agent-runner, npm install, npm run build sequence unchanged
+- Workspace directory creation unchanged
+- Entrypoint script unchanged
+- User switching (node user) unchanged
+- ENTRYPOINT unchanged

--- a/.claude/skills/add-docker-cli/modify/src/container-runner.ts
+++ b/.claude/skills/add-docker-cli/modify/src/container-runner.ts
@@ -1,0 +1,722 @@
+/**
+ * Container Runner for NanoClaw
+ * Spawns agent execution in containers and handles IPC
+ */
+import { ChildProcess, exec, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  CONTAINER_IMAGE,
+  CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_TIMEOUT,
+  DATA_DIR,
+  GROUPS_DIR,
+  IDLE_TIMEOUT,
+  TIMEZONE,
+} from './config.js';
+import { readEnvFile } from './env.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+
+// Sentinel markers for robust output parsing (must match agent-runner)
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+function buildVolumeMounts(
+  group: RegisteredGroup,
+  isMain: boolean,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+  const projectRoot = process.cwd();
+  const groupDir = resolveGroupFolderPath(group.folder);
+
+  if (isMain) {
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart.
+    mounts.push({
+      hostPath: projectRoot,
+      containerPath: '/workspace/project',
+      readonly: true,
+    });
+
+    // Shadow .env so the agent cannot read secrets from the mounted project root.
+    // Secrets are passed via stdin instead (see readSecrets()).
+    const envFile = path.join(projectRoot, '.env');
+    if (fs.existsSync(envFile)) {
+      mounts.push({
+        hostPath: '/dev/null',
+        containerPath: '/workspace/project/.env',
+        readonly: true,
+      });
+    }
+
+    // Main also gets its group folder as the working directory
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+  } else {
+    // Other groups only get their own folder
+    mounts.push({
+      hostPath: groupDir,
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+  }
+
+  // Per-group Claude sessions directory (isolated from other groups)
+  // Each group gets their own .claude/ to prevent cross-group session access
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(
+        {
+          env: {
+            // Enable agent swarms (subagent orchestration)
+            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            // Load CLAUDE.md from additional mounted directories
+            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+            // Enable Claude's memory feature (persists user preferences between sessions)
+            // https://code.claude.com/docs/en/memory#manage-auto-memory
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+
+  // Sync skills from container/skills/ into each group's .claude/skills/
+  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsDst = path.join(groupSessionsDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    for (const skillDir of fs.readdirSync(skillsSrc)) {
+      const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.statSync(srcDir).isDirectory()) continue;
+      const dstDir = path.join(skillsDst, skillDir);
+      fs.cpSync(srcDir, dstDir, { recursive: true });
+    }
+  }
+  mounts.push({
+    hostPath: groupSessionsDir,
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Per-group IPC namespace: each group gets its own IPC directory
+  // This prevents cross-group privilege escalation via IPC
+  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  mounts.push({
+    hostPath: groupIpcDir,
+    containerPath: '/workspace/ipc',
+    readonly: false,
+  });
+
+  // Copy agent-runner source into a per-group writable location so agents
+  // can customize it (add tools, change behavior) without affecting other
+  // groups. Recompiled on container startup via entrypoint.sh.
+  const agentRunnerSrc = path.join(
+    projectRoot,
+    'container',
+    'agent-runner',
+    'src',
+  );
+  const groupAgentRunnerDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    'agent-runner-src',
+  );
+  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
+  mounts.push({
+    hostPath: groupAgentRunnerDir,
+    containerPath: '/app/src',
+    readonly: false,
+  });
+
+  // Docker socket mount (main only) — lets the agent manage host containers
+  const dockerSock = '/var/run/docker.sock';
+  const hasDockerSocket = isMain && fs.existsSync(dockerSock);
+  if (hasDockerSocket) {
+    mounts.push({
+      hostPath: dockerSock,
+      containerPath: '/var/run/docker.sock',
+      readonly: false,
+    });
+  }
+
+  // Additional mounts validated against external allowlist (tamper-proof from containers)
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isMain,
+    );
+    mounts.push(...validatedMounts);
+  }
+
+  return mounts;
+}
+
+/**
+ * Read allowed secrets from .env for passing to the container via stdin.
+ * Secrets are never written to disk or mounted as files.
+ */
+function readSecrets(): Record<string, string> {
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_AUTH_TOKEN',
+  ]);
+}
+
+function buildContainerArgs(
+  mounts: VolumeMount[],
+  containerName: string,
+): string[] {
+  const args: string[] = ['run', '-i', '--rm', '--name', containerName];
+
+  // Pass host timezone so container's local time matches the user's
+  args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Run as host user so bind-mounted files are accessible.
+  // Skip when running as root (uid 0), as the container's node user (uid 1000),
+  // or when getuid is unavailable (native Windows without WSL).
+  const hostUid = process.getuid?.();
+  const hostGid = process.getgid?.();
+  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+    args.push('--user', `${hostUid}:${hostGid}`);
+    args.push('-e', 'HOME=/home/node');
+  }
+
+  // Docker socket access: add root group so the container user can read the socket
+  // (Docker Desktop's VM maps the socket to root:root inside Linux containers)
+  const hasDockerSocket = mounts.some(
+    (m) => m.containerPath === '/var/run/docker.sock',
+  );
+  if (hasDockerSocket) {
+    args.push('--group-add', '0');
+  }
+
+  for (const mount of mounts) {
+    if (mount.readonly) {
+      args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
+    } else {
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  args.push(CONTAINER_IMAGE);
+
+  return args;
+}
+
+export async function runContainerAgent(
+  group: RegisteredGroup,
+  input: ContainerInput,
+  onProcess: (proc: ChildProcess, containerName: string) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+
+  const groupDir = resolveGroupFolderPath(group.folder);
+  fs.mkdirSync(groupDir, { recursive: true });
+
+  const mounts = buildVolumeMounts(group, input.isMain);
+  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const containerArgs = buildContainerArgs(mounts, containerName);
+
+  logger.debug(
+    {
+      group: group.name,
+      containerName,
+      mounts: mounts.map(
+        (m) =>
+          `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+      ),
+      containerArgs: containerArgs.join(' '),
+    },
+    'Container mount configuration',
+  );
+
+  logger.info(
+    {
+      group: group.name,
+      containerName,
+      mountCount: mounts.length,
+      isMain: input.isMain,
+    },
+    'Spawning container agent',
+  );
+
+  const logsDir = path.join(groupDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  return new Promise((resolve) => {
+    const container = spawn(CONTAINER_RUNTIME_BIN, containerArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    onProcess(container, containerName);
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    // Pass secrets via stdin (never written to disk or mounted as files)
+    input.secrets = readSecrets();
+    container.stdin.write(JSON.stringify(input));
+    container.stdin.end();
+    // Remove secrets from input so they don't appear in logs
+    delete input.secrets;
+
+    // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
+    let parseBuffer = '';
+    let newSessionId: string | undefined;
+    let outputChain = Promise.resolve();
+
+    container.stdout.on('data', (data) => {
+      const chunk = data.toString();
+
+      // Always accumulate for logging
+      if (!stdoutTruncated) {
+        const remaining = CONTAINER_MAX_OUTPUT_SIZE - stdout.length;
+        if (chunk.length > remaining) {
+          stdout += chunk.slice(0, remaining);
+          stdoutTruncated = true;
+          logger.warn(
+            { group: group.name, size: stdout.length },
+            'Container stdout truncated due to size limit',
+          );
+        } else {
+          stdout += chunk;
+        }
+      }
+
+      // Stream-parse for output markers
+      if (onOutput) {
+        parseBuffer += chunk;
+        let startIdx: number;
+        while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
+          const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);
+          if (endIdx === -1) break; // Incomplete pair, wait for more data
+
+          const jsonStr = parseBuffer
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+          parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
+
+          try {
+            const parsed: ContainerOutput = JSON.parse(jsonStr);
+            if (parsed.newSessionId) {
+              newSessionId = parsed.newSessionId;
+            }
+            hadStreamingOutput = true;
+            // Activity detected — reset the hard timeout
+            resetTimeout();
+            // Call onOutput for all markers (including null results)
+            // so idle timers start even for "silent" query completions.
+            outputChain = outputChain.then(() => onOutput(parsed));
+          } catch (err) {
+            logger.warn(
+              { group: group.name, error: err },
+              'Failed to parse streamed output chunk',
+            );
+          }
+        }
+      }
+    });
+
+    container.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      const lines = chunk.trim().split('\n');
+      for (const line of lines) {
+        if (line) logger.debug({ container: group.folder }, line);
+      }
+      // Don't reset timeout on stderr — SDK writes debug logs continuously.
+      // Timeout only resets on actual output (OUTPUT_MARKER in stdout).
+      if (stderrTruncated) return;
+      const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
+      if (chunk.length > remaining) {
+        stderr += chunk.slice(0, remaining);
+        stderrTruncated = true;
+        logger.warn(
+          { group: group.name, size: stderr.length },
+          'Container stderr truncated due to size limit',
+        );
+      } else {
+        stderr += chunk;
+      }
+    });
+
+    let timedOut = false;
+    let hadStreamingOutput = false;
+    const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+    // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
+    // graceful _close sentinel has time to trigger before the hard kill fires.
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const killOnTimeout = () => {
+      timedOut = true;
+      logger.error(
+        { group: group.name, containerName },
+        'Container timeout, stopping gracefully',
+      );
+      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+        if (err) {
+          logger.warn(
+            { group: group.name, containerName, err },
+            'Graceful stop failed, force killing',
+          );
+          container.kill('SIGKILL');
+        }
+      });
+    };
+
+    let timeout = setTimeout(killOnTimeout, timeoutMs);
+
+    // Reset the timeout whenever there's activity (streaming output)
+    const resetTimeout = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(killOnTimeout, timeoutMs);
+    };
+
+    container.on('close', (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      if (timedOut) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const timeoutLog = path.join(logsDir, `container-${ts}.log`);
+        fs.writeFileSync(
+          timeoutLog,
+          [
+            `=== Container Run Log (TIMEOUT) ===`,
+            `Timestamp: ${new Date().toISOString()}`,
+            `Group: ${group.name}`,
+            `Container: ${containerName}`,
+            `Duration: ${duration}ms`,
+            `Exit Code: ${code}`,
+            `Had Streaming Output: ${hadStreamingOutput}`,
+          ].join('\n'),
+        );
+
+        // Timeout after output = idle cleanup, not failure.
+        // The agent already sent its response; this is just the
+        // container being reaped after the idle period expired.
+        if (hadStreamingOutput) {
+          logger.info(
+            { group: group.name, containerName, duration, code },
+            'Container timed out after output (idle cleanup)',
+          );
+          outputChain.then(() => {
+            resolve({
+              status: 'success',
+              result: null,
+              newSessionId,
+            });
+          });
+          return;
+        }
+
+        logger.error(
+          { group: group.name, containerName, duration, code },
+          'Container timed out with no output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const logFile = path.join(logsDir, `container-${timestamp}.log`);
+      const isVerbose =
+        process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+
+      const logLines = [
+        `=== Container Run Log ===`,
+        `Timestamp: ${new Date().toISOString()}`,
+        `Group: ${group.name}`,
+        `IsMain: ${input.isMain}`,
+        `Duration: ${duration}ms`,
+        `Exit Code: ${code}`,
+        `Stdout Truncated: ${stdoutTruncated}`,
+        `Stderr Truncated: ${stderrTruncated}`,
+        ``,
+      ];
+
+      const isError = code !== 0;
+
+      if (isVerbose || isError) {
+        logLines.push(
+          `=== Input ===`,
+          JSON.stringify(input, null, 2),
+          ``,
+          `=== Container Args ===`,
+          containerArgs.join(' '),
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map(
+              (m) =>
+                `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+            )
+            .join('\n'),
+          ``,
+          `=== Stderr${stderrTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stderr,
+          ``,
+          `=== Stdout${stdoutTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stdout,
+        );
+      } else {
+        logLines.push(
+          `=== Input Summary ===`,
+          `Prompt length: ${input.prompt.length} chars`,
+          `Session ID: ${input.sessionId || 'new'}`,
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
+            .join('\n'),
+          ``,
+        );
+      }
+
+      fs.writeFileSync(logFile, logLines.join('\n'));
+      logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
+
+      if (code !== 0) {
+        logger.error(
+          {
+            group: group.name,
+            code,
+            duration,
+            stderr,
+            stdout,
+            logFile,
+          },
+          'Container exited with error',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container exited with code ${code}: ${stderr.slice(-200)}`,
+        });
+        return;
+      }
+
+      // Streaming mode: wait for output chain to settle, return completion marker
+      if (onOutput) {
+        outputChain.then(() => {
+          logger.info(
+            { group: group.name, duration, newSessionId },
+            'Container completed (streaming mode)',
+          );
+          resolve({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        });
+        return;
+      }
+
+      // Legacy mode: parse the last output marker pair from accumulated stdout
+      try {
+        // Extract JSON between sentinel markers for robust parsing
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          // Fallback: last non-empty line (backwards compatibility)
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+
+        const output: ContainerOutput = JSON.parse(jsonLine);
+
+        logger.info(
+          {
+            group: group.name,
+            duration,
+            status: output.status,
+            hasResult: !!output.result,
+          },
+          'Container completed',
+        );
+
+        resolve(output);
+      } catch (err) {
+        logger.error(
+          {
+            group: group.name,
+            stdout,
+            stderr,
+            error: err,
+          },
+          'Failed to parse container output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Failed to parse container output: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+
+    container.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error(
+        { group: group.name, containerName, error: err },
+        'Container spawn error',
+      );
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Container spawn error: ${err.message}`,
+      });
+    });
+  });
+}
+
+export function writeTasksSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  tasks: Array<{
+    id: string;
+    groupFolder: string;
+    prompt: string;
+    schedule_type: string;
+    schedule_value: string;
+    status: string;
+    next_run: string | null;
+  }>,
+): void {
+  // Write filtered tasks to the group's IPC directory
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all tasks, others only see their own
+  const filteredTasks = isMain
+    ? tasks
+    : tasks.filter((t) => t.groupFolder === groupFolder);
+
+  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
+  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
+}
+
+export interface AvailableGroup {
+  jid: string;
+  name: string;
+  lastActivity: string;
+  isRegistered: boolean;
+}
+
+/**
+ * Write available groups snapshot for the container to read.
+ * Only main group can see all available groups (for activation).
+ * Non-main groups only see their own registration status.
+ */
+export function writeGroupsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  groups: AvailableGroup[],
+  registeredJids: Set<string>,
+): void {
+  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all groups; others see nothing (they can't activate groups)
+  const visibleGroups = isMain ? groups : [];
+
+  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
+  fs.writeFileSync(
+    groupsFile,
+    JSON.stringify(
+      {
+        groups: visibleGroups,
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/.claude/skills/add-docker-cli/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/add-docker-cli/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,24 @@
+# Intent: src/container-runner.ts modifications
+
+## What changed
+Added Docker socket mount and container group permissions so the agent can manage host Docker containers.
+
+## Key sections
+
+### buildVolumeMounts() — after agent-runner mount, before additionalMounts
+- Added: Docker socket mount block that checks for `/var/run/docker.sock` existence
+- Only mounts for main group (`isMain === true`) — non-main groups are sandboxed
+- The socket is mounted read-write (Docker CLI needs write access to communicate with the daemon)
+
+### buildContainerArgs() — after --user block, before mount loop
+- Added: Detection of Docker socket in mount list via `mounts.some(m => m.containerPath === '/var/run/docker.sock')`
+- Added: `--group-add 0` flag when Docker socket is present
+- This is needed because Docker Desktop's Linux VM maps the socket to `root:root` inside containers
+- Adding group 0 (root) gives the container user read/write access to the socket
+
+## Invariants (must-keep)
+- All existing mount logic unchanged (project root, .env shadow, group folder, sessions, IPC, agent-runner)
+- User switching logic unchanged
+- Additional mounts validation unchanged
+- Container spawn, output parsing, timeout logic unchanged
+- All exports unchanged

--- a/.claude/skills/add-docker-cli/tests/docker-cli.test.ts
+++ b/.claude/skills/add-docker-cli/tests/docker-cli.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('docker skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  it('has a valid manifest', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    expect(content).toContain('skill: add-docker-cli');
+    expect(content).toContain('version: 1.0.0');
+    expect(content).toContain('container/Dockerfile');
+    expect(content).toContain('src/container-runner.ts');
+  });
+
+  it('has all files declared in adds', () => {
+    const skillMd = path.join(
+      skillDir,
+      'add',
+      'container',
+      'skills',
+      'docker',
+      'SKILL.md',
+    );
+    expect(fs.existsSync(skillMd)).toBe(true);
+  });
+
+  it('container skill SKILL.md has correct frontmatter', () => {
+    const skillMdPath = path.join(
+      skillDir,
+      'add',
+      'container',
+      'skills',
+      'docker',
+      'SKILL.md',
+    );
+    const content = fs.readFileSync(skillMdPath, 'utf-8');
+
+    expect(content).toContain('name: docker');
+    expect(content).toContain('allowed-tools: Bash(docker:*)');
+    expect(content).toContain('docker ps');
+    expect(content).toContain('docker logs');
+    expect(content).toContain('docker inspect');
+    expect(content).toContain('docker start');
+    expect(content).toContain('docker stop');
+  });
+
+  it('has all files declared in modifies', () => {
+    const dockerfile = path.join(skillDir, 'modify', 'container', 'Dockerfile');
+    const containerRunner = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'container-runner.ts',
+    );
+
+    expect(fs.existsSync(dockerfile)).toBe(true);
+    expect(fs.existsSync(containerRunner)).toBe(true);
+  });
+
+  it('has intent files for all modified files', () => {
+    expect(
+      fs.existsSync(
+        path.join(skillDir, 'modify', 'container', 'Dockerfile.intent.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          skillDir,
+          'modify',
+          'src',
+          'container-runner.ts.intent.md',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('modified Dockerfile includes Docker CLI installation', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'container', 'Dockerfile'),
+      'utf-8',
+    );
+
+    expect(content).toContain('docker-27.5.1.tgz');
+    expect(content).toContain('/usr/local/bin');
+    expect(content).toContain('uname -m');
+  });
+
+  it('modified Dockerfile preserves core structure', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'container', 'Dockerfile'),
+      'utf-8',
+    );
+
+    expect(content).toContain('FROM node:22-slim');
+    expect(content).toContain('chromium');
+    expect(content).toContain('agent-browser');
+    expect(content).toContain('WORKDIR /app');
+    expect(content).toContain('COPY agent-runner/');
+    expect(content).toContain('ENTRYPOINT');
+    expect(content).toContain('/workspace/group');
+    expect(content).toContain('USER node');
+  });
+
+  it('modified container-runner.ts includes Docker socket mount', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'container-runner.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain('/var/run/docker.sock');
+    expect(content).toContain('hasDockerSocket');
+    expect(content).toContain('--group-add');
+  });
+
+  it('modified container-runner.ts only mounts Docker socket for main group', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'container-runner.ts'),
+      'utf-8',
+    );
+
+    // Docker socket mount is gated on isMain
+    expect(content).toContain('isMain && fs.existsSync(dockerSock)');
+  });
+
+  it('modified container-runner.ts preserves core structure', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'container-runner.ts'),
+      'utf-8',
+    );
+
+    // Core functions preserved
+    expect(content).toContain('function buildVolumeMounts(');
+    expect(content).toContain('function buildContainerArgs(');
+    expect(content).toContain('function readSecrets(');
+
+    // Core mounts preserved
+    expect(content).toContain('/workspace/project');
+    expect(content).toContain('/workspace/group');
+    expect(content).toContain('/workspace/ipc');
+    expect(content).toContain('/home/node/.claude');
+    expect(content).toContain('/app/src');
+
+    // Security features preserved
+    expect(content).toContain('validateAdditionalMounts');
+    expect(content).toContain('/dev/null');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `add-docker-cli` skill that gives the container agent Docker CLI access to the host machine via socket mount
- Installs Docker CLI static binary (27.5.1) in the container image — no daemon, just the CLI (~50MB)
- Mounts `/var/run/docker.sock` for main group only (non-main groups remain sandboxed)
- Adds `--group-add 0` for Docker Desktop socket permissions (root:root inside Linux containers)
- Includes security notice in SKILL.md requiring user confirmation before install
- Agent-facing docs include a "Never Run" list for destructive commands (`prune`, `rmi`, `rm -f`, etc.)
- Full skill package following existing patterns: manifest, modify files with intents, agent skill, 10 passing tests

## Motivation

Users running long-lived Docker containers on the host (e.g. trading systems, databases) want their NanoClaw agent to monitor container health and alert on failures, inspect logs for diagnosis, and manage container lifecycle — all via natural language over WhatsApp/Telegram.

## Test plan

- [x] `npm run build` passes
- [x] `./container/build.sh` succeeds
- [x] Docker CLI available inside container (`docker --version` returns 27.5.1)
- [x] Socket mount works — `docker ps` from inside container lists host containers
- [x] Permission fix verified — `--group-add 0` resolves Docker Desktop socket access
- [x] Main group only — socket not mounted for non-main groups
- [x] Skill tests pass (10/10): `npx vitest run --config vitest.skills.config.ts .claude/skills/add-docker-cli/tests/docker-cli.test.ts`