### PR TITLE
fix: fallback to assistant message text when SDK result field is empty (OpenRouter compat)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -363,6 +363,7 @@ async function runQuery(
 
   let newSessionId: string | undefined;
   let lastAssistantUuid: string | undefined;
+  let lastAssistantText = '';
   let messageCount = 0;
   let resultCount = 0;
 
@@ -435,6 +436,15 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+      // Collect assistant text as fallback for non-Anthropic models that return empty result field
+      const assistantMsg = message as { message?: { content?: Array<{ type: string; text?: string }> } };
+      if (assistantMsg.message?.content) {
+        const texts = assistantMsg.message.content
+          .filter((c) => c.type === 'text' && c.text)
+          .map((c) => c.text!)
+          .join('');
+        if (texts) lastAssistantText = texts;
+      }
     }
 
     if (message.type === 'system' && message.subtype === 'init') {
@@ -450,10 +460,13 @@ async function runQuery(
     if (message.type === 'result') {
       resultCount++;
       const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      // Fallback: use last assistant text if result field is empty (non-Anthropic models via OpenRouter)
+      const finalResult = textResult || lastAssistantText || null;
+      lastAssistantText = ''; // reset for next query
+      log(`Result #${resultCount}: subtype=${message.subtype}${finalResult ? ` text=${finalResult.slice(0, 200)}` : ''}`);
       writeOutput({
         status: 'success',
-        result: textResult || null,
+        result: finalResult,
         newSessionId
       });
     }


### PR DESCRIPTION
## Problem

When using non-Anthropic models via OpenRouter (e.g. `minimax/minimax-m2.5`), the Claude Agent SDK emits a `result` message with `subtype=success` but an **empty `result` field**. The actual response text is present in the preceding `assistant` messages' content blocks, but the runner was discarding it — meaning users never received a reply.

## Root Cause

The SDK's `result.result` field is populated by the Claude CLI's own summarisation step. For third-party models routed through OpenRouter, this step produces an empty string instead of the assistant's actual output.

## Fix

Collect `text` content blocks from `assistant` messages during the query loop. When the `result` field is empty/null at the end of a query, fall back to the last accumulated assistant text.

**Backwards-compatible**: the original `result` field is still preferred and trusted. Standard Anthropic models that correctly populate `result` are completely unaffected.

## Test

Verified locally with `minimax/minimax-m2.5` via OpenRouter — the agent now correctly receives and forwards the assistant's reply text to Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)