### PR TITLE
fix: add PID lockfile to prevent multiple instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
+  DATA_DIR,
   IDLE_TIMEOUT,
   POLL_INTERVAL,
   TIMEZONE,
@@ -465,7 +466,73 @@ function ensureContainerSystemRunning(): void {
   cleanupOrphans();
 }
 
+/** PID lockfile path for single-instance enforcement */
+const PID_LOCKFILE = path.join(DATA_DIR, 'nanoclaw.pid');
+
+/**
+ * Check if a process with the given PID is alive.
+ * Uses process.kill(pid, 0) which doesn't send a signal but checks if process exists.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Acquire exclusive lock via PID file.
+ * Enforces single-instance behavior and prevents duplicate runs.
+ */
+function acquireLock(): void {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+
+  if (fs.existsSync(PID_LOCKFILE)) {
+    const existingPid = parseInt(
+      fs.readFileSync(PID_LOCKFILE, 'utf-8').trim(),
+      10,
+    );
+    if (!isNaN(existingPid) && isProcessAlive(existingPid)) {
+      console.error(
+        `\n╔════════════════════════════════════════════════════════════════╗
+║  ERROR: NanoClaw is already running (PID ${existingPid})           ║
+║                                                                ║
+║  Only one instance is allowed to run at a time.                  ║
+║  If you're sure this is an error, delete:                        ║
+║    ${PID_LOCKFILE}               ║
+╚════════════════════════════════════════════════════════════════╝\n`,
+      );
+      process.exit(1);
+    }
+    // Stale lockfile - process is dead, will be overwritten
+  }
+
+  // Write current PID with secure permissions (owner read/write only)
+  fs.writeFileSync(PID_LOCKFILE, String(process.pid), { mode: 0o600 });
+
+  // Release lock on exit
+  const releaseLockOnExit = () => {
+    if (fs.existsSync(PID_LOCKFILE)) {
+      const content = fs.readFileSync(PID_LOCKFILE, 'utf-8').trim();
+      if (parseInt(content, 10) === process.pid) {
+        fs.unlinkSync(PID_LOCKFILE);
+      }
+    }
+  };
+
+  // Register cleanup handlers for all exit scenarios
+  process.once('SIGTERM', releaseLockOnExit);
+  process.once('SIGINT', releaseLockOnExit);
+  process.once('exit', releaseLockOnExit);
+  process.once('uncaughtException', releaseLockOnExit);
+}
+
 async function main(): Promise<void> {
+  // Enforce single-instance behavior before any initialization
+  acquireLock();
+
   ensureContainerSystemRunning();
   initDatabase();
   logger.info('Database initialized');


### PR DESCRIPTION
Fixes #693

## Problem

When NanoClaw is restarted via environments that don't forward stop signals (e.g., `distrobox-enter`), the old Node.js process stays alive. Two instances run simultaneously, causing duplicate responses and race conditions.

## Solution

Added a PID lockfile mechanism (`data/nanoclaw.pid`):

### On Startup
1. Ensures `data/` directory exists
2. Checks if lockfile already exists
3. If exists:
   - Reads the PID from the lockfile
   - Checks if that process is alive using `process.kill(pid, 0)`
   - If alive: Exits with clear, user-friendly error message
   - If dead: Treats as stale lockfile, overwrites it
4. Writes current PID to lockfile with restrictive permissions (`0600`)

### Cleanup
Lockfile is automatically removed on all exit paths:
- `SIGTERM` (termination signal)
- `SIGINT` (interrupt from Ctrl+C)
- `exit` (normal process exit)
- `uncaughtException` (error cleanup)

## Changes

- `src/index.ts`:
  - Added `DATA_DIR` import
  - Added `isProcessAlive(pid)` helper function
  - Added `acquireLock()` function with full lockfile logic
  - Call `acquireLock()` at start of `main()`
  - Registered cleanup handlers for all exit signals