### PR TITLE
fix: container EACCES/ENOENT when host runs as root

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -122,6 +122,13 @@ function buildVolumeMounts(
     '.claude',
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });
+
+  // Pre-create debug directory with permissive permissions
+  // When host runs as root, container's node user (uid 1000) needs write access
+  const debugDir = path.join(groupSessionsDir, 'debug');
+  fs.mkdirSync(debugDir, { recursive: true });
+  fs.chmodSync(debugDir, 0o777);
+
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   if (!fs.existsSync(settingsFile)) {
     fs.writeFileSync(
@@ -169,6 +176,11 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+
+  // When host runs as root, container's node user needs write access for cleanup
+  fs.chmodSync(path.join(groupIpcDir, 'messages'), 0o777);
+  fs.chmodSync(path.join(groupIpcDir, 'tasks'), 0o777);
+  fs.chmodSync(path.join(groupIpcDir, 'input'), 0o777);
   mounts.push({
     hostPath: groupIpcDir,
     containerPath: '/workspace/ipc',


### PR DESCRIPTION
Fixes #777

## Problem

When NanoClaw runs as **root on Linux** (e.g., via systemd on VPS), containers crash or fail to process follow-up messages due to filesystem permission mismatches between host (uid 0) and container's `node` user (uid 1000).

## Bug 1: Agent SDK Crashes on Startup

**Symptoms:**
- Container exits with code 1 immediately after starting a query
- Rapid crash loop, all messages fail
- Error: `ENOENT` or `EACCES` on `/home/node/.claude/debug/.txt`

**Root Cause:**
The Claude Agent SDK writes debug trace files to `~/.claude/debug/`. The `groupSessionsDir` is created by the host as root, so the container's `node` user can't write to the `debug/` subdirectory.

**Fix:**
Pre-create the `debug/` directory and chmod it to 777 before mounting.

## Bug 2: Follow-up Messages Silently Dropped

**Symptoms:**
- Agent responds to the first message correctly (delivered via stdin)
- All subsequent messages are silently dropped
- Container logs show infinite retry loop: `EACCES: permission denied, unlink '/workspace/ipc/input/xxx.json'`

**Root Cause:**
IPC files in `data/ipc/{group}/input/` are written by the host (root). The agent-runner reads them successfully but cannot `unlink()` them after processing because the directory lacks write permissions for the `node` user.

**Fix:**
Chmod IPC subdirectories (`messages`, `tasks`, `input`) to 777 when creating them.

## Changes

- `src/container-runner.ts`:
  - Added `debug/` directory creation with chmod 777
  - Modified IPC subdirectory creation to chmod each to 777

## Testing

Original issue author provided reproduction steps on Linux VPS (Debian 13, kernel 6.12) running as root via systemd.