### PR TITLE
Fix OpenRouter non-Anthropic model routing in Anthropic SDK proxy flow (clean scope)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -456,9 +456,13 @@ async function buildContainerArgs(
 
   // Non-secret model configuration can be passed through safely.
   // This prevents SDK fallback to a default model when ANTHROPIC_MODEL is set on host.
-  const modelConfig = readEnvFile(['ANTHROPIC_MODEL']);
-  if (modelConfig.ANTHROPIC_MODEL) {
-    args.push('-e', `ANTHROPIC_MODEL=${modelConfig.ANTHROPIC_MODEL}`);
+  const envModel = process.env.ANTHROPIC_MODEL;
+  const fileModel = envModel
+    ? undefined
+    : readEnvFile(['ANTHROPIC_MODEL']).ANTHROPIC_MODEL;
+  const selectedModel = envModel ?? fileModel;
+  if (selectedModel) {
+    args.push('-e', `ANTHROPIC_MODEL=${selectedModel}`);
   }
 
   // User mapping

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -28,6 +28,7 @@ import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
+import { readEnvFile } from './env.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
 import './providers/index.js';
@@ -452,6 +453,13 @@ async function buildContainerArgs(
 
   // Host gateway
   args.push(...hostGatewayArgs());
+
+  // Non-secret model configuration can be passed through safely.
+  // This prevents SDK fallback to a default model when ANTHROPIC_MODEL is set on host.
+  const modelConfig = readEnvFile(['ANTHROPIC_MODEL']);
+  if (modelConfig.ANTHROPIC_MODEL) {
+    args.push('-e', `ANTHROPIC_MODEL=${modelConfig.ANTHROPIC_MODEL}`);
+  }
 
   // User mapping
   const hostUid = process.getuid?.();

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -457,9 +457,7 @@ async function buildContainerArgs(
   // Non-secret model configuration can be passed through safely.
   // This prevents SDK fallback to a default model when ANTHROPIC_MODEL is set on host.
   const envModel = process.env.ANTHROPIC_MODEL;
-  const fileModel = envModel
-    ? undefined
-    : readEnvFile(['ANTHROPIC_MODEL']).ANTHROPIC_MODEL;
+  const fileModel = envModel ? undefined : readEnvFile(['ANTHROPIC_MODEL']).ANTHROPIC_MODEL;
   const selectedModel = envModel ?? fileModel;
   if (selectedModel) {
     args.push('-e', `ANTHROPIC_MODEL=${selectedModel}`);

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -11,7 +11,7 @@ vi.mock('./logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
-import { startCredentialProxy } from './credential-proxy.js';
+import { detectAuthMode, startCredentialProxy } from './credential-proxy.js';
 
 function makeRequest(
   port: number,
@@ -222,7 +222,7 @@ describe('credential-proxy', () => {
   it('translates non-Anthropic OpenRouter models to chat completions', async () => {
     Object.assign(mockEnv, {
       OPENROUTER_API_KEY: 'sk-or-real-key',
-      ANTHROPIC_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
       ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api`,
     });
 
@@ -275,6 +275,7 @@ describe('credential-proxy', () => {
     );
 
     expect(lastUpstreamUrl).toBe('/api/v1/chat/completions');
+    expect(lastUpstreamHeaders['x-api-key']).toBe('sk-or-real-key');
     expect(JSON.parse(lastUpstreamBody)).toMatchObject({
       model: 'arcee-ai/trinity-large-preview:free',
       provider: { only: ['arcee-ai'], allow_fallbacks: false },
@@ -292,12 +293,13 @@ describe('credential-proxy', () => {
   it('synthesizes Anthropic streaming events for translated OpenRouter responses', async () => {
     Object.assign(mockEnv, {
       OPENROUTER_API_KEY: 'sk-or-real-key',
-      ANTHROPIC_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
       ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api`,
     });
 
     upstreamServer.close();
     upstreamServer = http.createServer((req, res) => {
+      lastUpstreamHeaders = { ...req.headers };
       const chunks: Buffer[] = [];
       req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
       req.on('end', () => {
@@ -363,5 +365,42 @@ describe('credential-proxy', () => {
     expect(res.body).toContain('input_json_delta');
     expect(res.body).toContain('tool_use');
     expect(res.body).toContain('event: message_stop');
+    expect(lastUpstreamHeaders['x-api-key']).toBe('sk-or-real-key');
+  });
+
+  it('keeps OAuth mode for non-OpenRouter upstream when only OPENROUTER_API_KEY exists', async () => {
+    proxyPort = await startProxy({
+      OPENROUTER_API_KEY: 'sk-or-real-key',
+      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/api/oauth/claude_cli/create_api_key',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe('Bearer real-oauth-token');
+    expect(lastUpstreamHeaders['x-api-key']).toBeUndefined();
+  });
+
+  it('detectAuthMode uses OPENROUTER_API_KEY only for OpenRouter upstream', () => {
+    Object.assign(mockEnv, {
+      OPENROUTER_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+    });
+    expect(detectAuthMode()).toBe('oauth');
+
+    Object.assign(mockEnv, {
+      ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+    });
+    expect(detectAuthMode()).toBe('api-key');
   });
 });

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -23,20 +23,17 @@ function makeRequest(
   headers: http.IncomingHttpHeaders;
 }> {
   return new Promise((resolve, reject) => {
-    const req = http.request(
-      { ...options, hostname: '127.0.0.1', port },
-      (res) => {
-        const chunks: Buffer[] = [];
-        res.on('data', (c) => chunks.push(c));
-        res.on('end', () => {
-          resolve({
-            statusCode: res.statusCode!,
-            body: Buffer.concat(chunks).toString(),
-            headers: res.headers,
-          });
+    const req = http.request({ ...options, hostname: '127.0.0.1', port }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode!,
+          body: Buffer.concat(chunks).toString(),
+          headers: res.headers,
         });
-      },
-    );
+      });
+    });
     req.on('error', reject);
     req.write(body);
     req.end();
@@ -66,9 +63,7 @@ describe('credential-proxy', () => {
         res.end(JSON.stringify({ ok: true }));
       });
     });
-    await new Promise<void>((resolve) =>
-      upstreamServer.listen(0, '127.0.0.1', resolve),
-    );
+    await new Promise<void>((resolve) => upstreamServer.listen(0, '127.0.0.1', resolve));
     upstreamPort = (upstreamServer.address() as AddressInfo).port;
   });
 
@@ -123,9 +118,7 @@ describe('credential-proxy', () => {
       '{}',
     );
 
-    expect(lastUpstreamHeaders['authorization']).toBe(
-      'Bearer real-oauth-token',
-    );
+    expect(lastUpstreamHeaders['authorization']).toBe('Bearer real-oauth-token');
   });
 
   it('OAuth mode does not inject Authorization when container omits it', async () => {
@@ -250,9 +243,7 @@ describe('credential-proxy', () => {
         );
       });
     });
-    await new Promise<void>((resolve) =>
-      upstreamServer.listen(upstreamPort, '127.0.0.1', resolve),
-    );
+    await new Promise<void>((resolve) => upstreamServer.listen(upstreamPort, '127.0.0.1', resolve));
 
     proxyServer = await startCredentialProxy(0);
     proxyPort = (proxyServer.address() as AddressInfo).port;
@@ -333,9 +324,7 @@ describe('credential-proxy', () => {
         );
       });
     });
-    await new Promise<void>((resolve) =>
-      upstreamServer.listen(upstreamPort, '127.0.0.1', resolve),
-    );
+    await new Promise<void>((resolve) => upstreamServer.listen(upstreamPort, '127.0.0.1', resolve));
 
     proxyServer = await startCredentialProxy(0);
     proxyPort = (proxyServer.address() as AddressInfo).port;

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockEnv: Record<string, string> = {};
+vi.mock('./env.js', () => ({
+  readEnvFile: vi.fn(() => ({ ...mockEnv })),
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { startCredentialProxy } from './credential-proxy.js';
+
+function makeRequest(
+  port: number,
+  options: http.RequestOptions,
+  body = '',
+): Promise<{
+  statusCode: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { ...options, hostname: '127.0.0.1', port },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe('credential-proxy', () => {
+  let proxyServer: http.Server;
+  let upstreamServer: http.Server;
+  let proxyPort: number;
+  let upstreamPort: number;
+  let lastUpstreamHeaders: http.IncomingHttpHeaders;
+  let lastUpstreamUrl: string;
+  let lastUpstreamBody = '';
+
+  beforeEach(async () => {
+    lastUpstreamHeaders = {};
+
+    upstreamServer = http.createServer((req, res) => {
+      lastUpstreamHeaders = { ...req.headers };
+      lastUpstreamUrl = req.url || '';
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        lastUpstreamBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(0, '127.0.0.1', resolve),
+    );
+    upstreamPort = (upstreamServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((r) => proxyServer?.close(() => r()));
+    await new Promise<void>((r) => upstreamServer?.close(() => r()));
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  async function startProxy(env: Record<string, string>): Promise<number> {
+    Object.assign(mockEnv, env, {
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxyServer = await startCredentialProxy(0);
+    return (proxyServer.address() as AddressInfo).port;
+  }
+
+  it('API-key mode injects x-api-key and strips placeholder', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['x-api-key']).toBe('sk-ant-real-key');
+  });
+
+  it('OAuth mode replaces Authorization when container sends one', async () => {
+    proxyPort = await startProxy({
+      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/api/oauth/claude_cli/create_api_key',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      'Bearer real-oauth-token',
+    );
+  });
+
+  it('OAuth mode does not inject Authorization when container omits it', async () => {
+    proxyPort = await startProxy({
+      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
+    });
+
+    // Post-exchange: container uses x-api-key only, no Authorization header
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'temp-key-from-exchange',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['x-api-key']).toBe('temp-key-from-exchange');
+    expect(lastUpstreamHeaders['authorization']).toBeUndefined();
+  });
+
+  it('strips hop-by-hop headers', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          connection: 'keep-alive',
+          'keep-alive': 'timeout=5',
+          'transfer-encoding': 'chunked',
+        },
+      },
+      '{}',
+    );
+
+    // Proxy strips client hop-by-hop headers. Node's HTTP client may re-add
+    // its own Connection header (standard HTTP/1.1 behavior), but the client's
+    // custom keep-alive and transfer-encoding must not be forwarded.
+    expect(lastUpstreamHeaders['keep-alive']).toBeUndefined();
+    expect(lastUpstreamHeaders['transfer-encoding']).toBeUndefined();
+  });
+
+  it('returns 502 when upstream is unreachable', async () => {
+    Object.assign(mockEnv, {
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:59999',
+    });
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toBe('Bad Gateway');
+  });
+
+  it('preserves upstream base path prefix when forwarding', async () => {
+    Object.assign(mockEnv, {
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api`,
+    });
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages?x=1',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamUrl).toBe('/api/v1/messages?x=1');
+  });
+
+  it('translates non-Anthropic OpenRouter models to chat completions', async () => {
+    Object.assign(mockEnv, {
+      OPENROUTER_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api`,
+    });
+
+    upstreamServer.close();
+    upstreamServer = http.createServer((req, res) => {
+      lastUpstreamHeaders = { ...req.headers };
+      lastUpstreamUrl = req.url || '';
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        lastUpstreamBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            id: 'gen_test',
+            model: 'arcee-ai/trinity-large-preview:free',
+            choices: [
+              {
+                finish_reason: 'stop',
+                message: { role: 'assistant', content: 'OK' },
+              },
+            ],
+            usage: { prompt_tokens: 11, completion_tokens: 2 },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(upstreamPort, '127.0.0.1', resolve),
+    );
+
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+        },
+      },
+      JSON.stringify({
+        model: 'arcee-ai/trinity-large-preview:free',
+        max_tokens: 32,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    );
+
+    expect(lastUpstreamUrl).toBe('/api/v1/chat/completions');
+    expect(JSON.parse(lastUpstreamBody)).toMatchObject({
+      model: 'arcee-ai/trinity-large-preview:free',
+      provider: { only: ['arcee-ai'], allow_fallbacks: false },
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(JSON.parse(res.body)).toMatchObject({
+      type: 'message',
+      model: 'arcee-ai/trinity-large-preview:free',
+      content: [{ type: 'text', text: 'OK' }],
+      usage: { input_tokens: 11, output_tokens: 2 },
+      stop_reason: 'end_turn',
+    });
+  });
+
+  it('synthesizes Anthropic streaming events for translated OpenRouter responses', async () => {
+    Object.assign(mockEnv, {
+      OPENROUTER_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_API_KEY: 'sk-or-real-key',
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api`,
+    });
+
+    upstreamServer.close();
+    upstreamServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        lastUpstreamBody = Buffer.concat(chunks).toString();
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            id: 'gen_tool',
+            model: 'arcee-ai/trinity-large-preview:free',
+            choices: [
+              {
+                finish_reason: 'tool_calls',
+                message: {
+                  role: 'assistant',
+                  content: 'Using tool',
+                  tool_calls: [
+                    {
+                      id: 'call_1',
+                      type: 'function',
+                      function: {
+                        name: 'lookup',
+                        arguments: '{"q":"abc"}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            usage: { prompt_tokens: 20, completion_tokens: 5 },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(upstreamPort, '127.0.0.1', resolve),
+    );
+
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+        },
+      },
+      JSON.stringify({
+        model: 'arcee-ai/trinity-large-preview:free',
+        max_tokens: 32,
+        stream: true,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    );
+
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.body).toContain('event: message_start');
+    expect(res.body).toContain('event: content_block_start');
+    expect(res.body).toContain('text_delta');
+    expect(res.body).toContain('input_json_delta');
+    expect(res.body).toContain('tool_use');
+    expect(res.body).toContain('event: message_stop');
+  });
+});

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -59,7 +59,8 @@ function buildForwardHeaders(
 
   if (authMode === 'api-key') {
     delete headers['x-api-key'];
-    headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
+    headers['x-api-key'] =
+      secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY;
   } else if (headers['authorization']) {
     const oauthToken =
       secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
@@ -80,8 +81,14 @@ function safeJsonParse(body: Buffer): JsonObject | null {
   }
 }
 
-function isOpenRouterUpstream(upstreamUrl: URL, secrets: Record<string, string>): boolean {
-  return upstreamUrl.hostname.includes('openrouter.ai') || Boolean(secrets.OPENROUTER_API_KEY);
+function isOpenRouterUpstream(
+  upstreamUrl: URL,
+  secrets: Record<string, string>,
+): boolean {
+  return (
+    upstreamUrl.hostname.includes('openrouter.ai') ||
+    Boolean(secrets.OPENROUTER_API_KEY)
+  );
 }
 
 function isMessagesEndpoint(url: string | undefined): boolean {
@@ -553,15 +560,16 @@ export function startCredentialProxy(
 ): Promise<Server> {
   const secrets = readEnvFile([
     'ANTHROPIC_API_KEY',
+    'OPENROUTER_API_KEY',
     'CLAUDE_CODE_OAUTH_TOKEN',
     'ANTHROPIC_AUTH_TOKEN',
     'ANTHROPIC_BASE_URL',
-    'OPENROUTER_API_KEY',
   ]);
 
-  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
-  const oauthToken =
-    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+  const authMode: AuthMode =
+    secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY
+      ? 'api-key'
+      : 'oauth';
 
   const upstreamUrl = new URL(
     secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
@@ -645,6 +653,8 @@ export function startCredentialProxy(
 
 /** Detect which auth mode the host is configured for. */
 export function detectAuthMode(): AuthMode {
-  const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
-  return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+  const secrets = readEnvFile(['ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY']);
+  return secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY
+    ? 'api-key'
+    : 'oauth';
 }

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -33,6 +33,43 @@ type JsonValue =
 
 type JsonObject = { [key: string]: JsonValue };
 
+function isOpenRouterHostname(hostname: string): boolean {
+  return /(^|\.)openrouter\.ai$/i.test(hostname);
+}
+
+function isLocalHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function isOpenRouterAuthTarget(
+  upstreamUrl: URL,
+): boolean {
+  return isOpenRouterHostname(upstreamUrl.hostname);
+}
+
+function isOpenRouterTranslationTarget(
+  upstreamUrl: URL,
+  secrets: Record<string, string>,
+): boolean {
+  if (isOpenRouterAuthTarget(upstreamUrl)) return true;
+  // Allow local test/proxy setups that emulate OpenRouter while still requiring
+  // explicit OpenRouter credentials to avoid false positives on Anthropic.
+  return isLocalHost(upstreamUrl.hostname) && Boolean(secrets.OPENROUTER_API_KEY);
+}
+
+function resolveAuthMode(
+  upstreamUrl: URL,
+  secrets: Record<string, string>,
+): AuthMode {
+  const hasAnthropicKey = Boolean(secrets.ANTHROPIC_API_KEY);
+  const hasOpenRouterKey = Boolean(secrets.OPENROUTER_API_KEY);
+  if (hasAnthropicKey) return 'api-key';
+  if (hasOpenRouterKey && isOpenRouterAuthTarget(upstreamUrl)) {
+    return 'api-key';
+  }
+  return 'oauth';
+}
+
 function buildUpstreamPath(upstream: URL, incomingPath: string): string {
   const basePath = upstream.pathname?.replace(/\/+$/, '') || '';
   const reqPath = incomingPath.startsWith('/') ? incomingPath : `/${incomingPath}`;
@@ -59,8 +96,12 @@ function buildForwardHeaders(
 
   if (authMode === 'api-key') {
     delete headers['x-api-key'];
-    headers['x-api-key'] =
-      secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY;
+    const apiKey = isOpenRouterTranslationTarget(upstreamUrl, secrets)
+      ? secrets.OPENROUTER_API_KEY || secrets.ANTHROPIC_API_KEY
+      : secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY;
+    if (apiKey) {
+      headers['x-api-key'] = apiKey;
+    }
   } else if (headers['authorization']) {
     const oauthToken =
       secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
@@ -85,10 +126,7 @@ function isOpenRouterUpstream(
   upstreamUrl: URL,
   secrets: Record<string, string>,
 ): boolean {
-  return (
-    upstreamUrl.hostname.includes('openrouter.ai') ||
-    Boolean(secrets.OPENROUTER_API_KEY)
-  );
+  return isOpenRouterTranslationTarget(upstreamUrl, secrets);
 }
 
 function isMessagesEndpoint(url: string | undefined): boolean {
@@ -566,14 +604,10 @@ export function startCredentialProxy(
     'ANTHROPIC_BASE_URL',
   ]);
 
-  const authMode: AuthMode =
-    secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY
-      ? 'api-key'
-      : 'oauth';
-
   const upstreamUrl = new URL(
     secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
   );
+  const authMode = resolveAuthMode(upstreamUrl, secrets);
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
@@ -653,8 +687,13 @@ export function startCredentialProxy(
 
 /** Detect which auth mode the host is configured for. */
 export function detectAuthMode(): AuthMode {
-  const secrets = readEnvFile(['ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY']);
-  return secrets.ANTHROPIC_API_KEY || secrets.OPENROUTER_API_KEY
-    ? 'api-key'
-    : 'oauth';
+  const secrets = readEnvFile([
+    'ANTHROPIC_API_KEY',
+    'OPENROUTER_API_KEY',
+    'ANTHROPIC_BASE_URL',
+  ]);
+  const upstreamUrl = new URL(
+    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
+  );
+  return resolveAuthMode(upstreamUrl, secrets);
 }

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -1,0 +1,650 @@
+/**
+ * Credential proxy for container isolation.
+ * Containers connect here instead of directly to the Anthropic API.
+ * The proxy injects real credentials so containers never see them.
+ *
+ * Two auth modes:
+ *   API key:  Proxy injects x-api-key on every request.
+ *   OAuth:    Container CLI exchanges its placeholder token for a temp
+ *             API key via /api/oauth/claude_cli/create_api_key.
+ *             Proxy injects real OAuth token on that exchange request;
+ *             subsequent requests carry the temp key which is valid as-is.
+ */
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { request as httpsRequest } from 'https';
+import { request as httpRequest, RequestOptions } from 'http';
+
+import { readEnvFile } from './env.js';
+import { logger } from './logger.js';
+
+export type AuthMode = 'api-key' | 'oauth';
+
+export interface ProxyConfig {
+  authMode: AuthMode;
+}
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type JsonObject = { [key: string]: JsonValue };
+
+function buildUpstreamPath(upstream: URL, incomingPath: string): string {
+  const basePath = upstream.pathname?.replace(/\/+$/, '') || '';
+  const reqPath = incomingPath.startsWith('/') ? incomingPath : `/${incomingPath}`;
+  if (!basePath || basePath === '/') return reqPath;
+  return `${basePath}${reqPath}`;
+}
+
+function buildForwardHeaders(
+  reqHeaders: IncomingMessage['headers'],
+  upstreamUrl: URL,
+  bodyLength: number,
+  authMode: AuthMode,
+  secrets: Record<string, string>,
+): Record<string, string | number | string[] | undefined> {
+  const headers: Record<string, string | number | string[] | undefined> = {
+    ...(reqHeaders as Record<string, string>),
+    host: upstreamUrl.host,
+    'content-length': bodyLength,
+  };
+
+  delete headers['connection'];
+  delete headers['keep-alive'];
+  delete headers['transfer-encoding'];
+
+  if (authMode === 'api-key') {
+    delete headers['x-api-key'];
+    headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
+  } else if (headers['authorization']) {
+    const oauthToken =
+      secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+    delete headers['authorization'];
+    if (oauthToken) {
+      headers['authorization'] = `Bearer ${oauthToken}`;
+    }
+  }
+
+  return headers;
+}
+
+function safeJsonParse(body: Buffer): JsonObject | null {
+  try {
+    return JSON.parse(body.toString('utf-8')) as JsonObject;
+  } catch {
+    return null;
+  }
+}
+
+function isOpenRouterUpstream(upstreamUrl: URL, secrets: Record<string, string>): boolean {
+  return upstreamUrl.hostname.includes('openrouter.ai') || Boolean(secrets.OPENROUTER_API_KEY);
+}
+
+function isMessagesEndpoint(url: string | undefined): boolean {
+  return /^\/v1\/messages(?:\?.*)?$/.test(url || '');
+}
+
+function getProviderFromModel(model: string): string | null {
+  const slashIndex = model.indexOf('/');
+  if (slashIndex <= 0) return null;
+  return model.slice(0, slashIndex);
+}
+
+function shouldTranslateToOpenRouterChat(
+  req: IncomingMessage,
+  body: JsonObject | null,
+  upstreamUrl: URL,
+  secrets: Record<string, string>,
+): body is JsonObject {
+  if (!isMessagesEndpoint(req.url) || req.method !== 'POST' || !body) return false;
+  if (!isOpenRouterUpstream(upstreamUrl, secrets)) return false;
+
+  const model = typeof body.model === 'string' ? body.model : '';
+  if (!model || model.startsWith('anthropic/')) return false;
+
+  return Boolean(getProviderFromModel(model));
+}
+
+function normalizeContentBlocks(content: JsonValue | undefined): JsonObject[] {
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content }] : [];
+  }
+  return Array.isArray(content)
+    ? content.filter((item): item is JsonObject => Boolean(item && typeof item === 'object' && !Array.isArray(item)))
+    : [];
+}
+
+function stringifyTextContent(content: JsonValue | undefined): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  return content
+    .map((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+      if (item.type === 'text' && typeof item.text === 'string') return item.text;
+      return '';
+    })
+    .join('');
+}
+
+function stringifyToolResultContent(content: JsonValue | undefined): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) return stringifyTextContent(content);
+  if (content && typeof content === 'object') return JSON.stringify(content);
+  return '';
+}
+
+function convertAnthropicMessagesToOpenRouter(body: JsonObject): JsonObject[] {
+  const messages: JsonObject[] = [];
+
+  const systemText = stringifyTextContent(body.system);
+  if (systemText) {
+    messages.push({ role: 'system', content: systemText });
+  }
+
+  const anthropicMessages = Array.isArray(body.messages) ? body.messages : [];
+  for (const entry of anthropicMessages) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const role = entry.role;
+    if (role !== 'user' && role !== 'assistant') continue;
+
+    const blocks = normalizeContentBlocks(entry.content);
+    if (role === 'assistant') {
+      const textParts: string[] = [];
+      const toolCalls: JsonObject[] = [];
+
+      for (const block of blocks) {
+        if (block.type === 'text' && typeof block.text === 'string') {
+          textParts.push(block.text);
+          continue;
+        }
+
+        if (block.type === 'tool_use' && typeof block.name === 'string') {
+          toolCalls.push({
+            id: typeof block.id === 'string' ? block.id : `tool_${toolCalls.length}`,
+            type: 'function',
+            function: {
+              name: block.name,
+              arguments: JSON.stringify(
+                block.input && typeof block.input === 'object' ? block.input : {},
+              ),
+            },
+          });
+        }
+      }
+
+      if (textParts.length > 0 || toolCalls.length > 0) {
+        messages.push({
+          role: 'assistant',
+          content: textParts.join('') || null,
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        });
+      }
+      continue;
+    }
+
+    let pendingText = '';
+    const flushUserText = () => {
+      if (!pendingText) return;
+      messages.push({ role: 'user', content: pendingText });
+      pendingText = '';
+    };
+
+    if (blocks.length === 0 && typeof entry.content === 'string' && entry.content) {
+      messages.push({ role: 'user', content: entry.content });
+      continue;
+    }
+
+    for (const block of blocks) {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        pendingText += block.text;
+        continue;
+      }
+
+      if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+        flushUserText();
+        messages.push({
+          role: 'tool',
+          tool_call_id: block.tool_use_id,
+          content: stringifyToolResultContent(block.content),
+        });
+      }
+    }
+
+    flushUserText();
+  }
+
+  return messages;
+}
+
+function convertAnthropicToolChoice(
+  toolChoice: JsonValue | undefined,
+): JsonValue | undefined {
+  if (!toolChoice || typeof toolChoice !== 'object' || Array.isArray(toolChoice)) {
+    return toolChoice;
+  }
+
+  if (toolChoice.type === 'any') return 'required';
+  if (toolChoice.type === 'auto') return 'auto';
+  if (toolChoice.type === 'tool' && typeof toolChoice.name === 'string') {
+    return {
+      type: 'function',
+      function: { name: toolChoice.name },
+    };
+  }
+
+  return toolChoice;
+}
+
+function compactObject(object: Record<string, JsonValue | undefined>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => value !== undefined),
+  ) as JsonObject;
+}
+
+function buildOpenRouterChatBody(body: JsonObject): JsonObject {
+  const model = body.model as string;
+  const provider = getProviderFromModel(model);
+
+  return compactObject({
+    model,
+    messages: convertAnthropicMessagesToOpenRouter(body),
+    max_tokens: body.max_tokens,
+    temperature: body.temperature,
+    top_p: body.top_p,
+    top_k: body.top_k,
+    stop: body.stop_sequences,
+    tools: Array.isArray(body.tools)
+      ? body.tools.map((tool) => {
+          if (!tool || typeof tool !== 'object' || Array.isArray(tool)) return tool;
+          return compactObject({
+            type: 'function',
+            function: compactObject({
+              name: tool.name,
+              description: tool.description,
+              parameters:
+                tool.input_schema && typeof tool.input_schema === 'object'
+                  ? (tool.input_schema as JsonObject)
+                  : undefined,
+            }),
+          });
+        })
+      : undefined,
+    tool_choice: convertAnthropicToolChoice(body.tool_choice),
+    provider: provider
+      ? {
+          only: [provider],
+          allow_fallbacks: false,
+        }
+      : undefined,
+    stream: false,
+  });
+}
+
+function parseToolArguments(argumentsText: unknown): JsonValue {
+  if (typeof argumentsText !== 'string' || !argumentsText) return {};
+  try {
+    return JSON.parse(argumentsText) as JsonValue;
+  } catch {
+    return {};
+  }
+}
+
+function mapFinishReason(reason: unknown): string | null {
+  switch (reason) {
+    case 'tool_calls':
+      return 'tool_use';
+    case 'length':
+      return 'max_tokens';
+    case 'stop':
+      return 'end_turn';
+    default:
+      return null;
+  }
+}
+
+function convertOpenRouterResponseToAnthropic(body: JsonObject): JsonObject {
+  const choice = Array.isArray(body.choices) && body.choices[0] && typeof body.choices[0] === 'object'
+    ? (body.choices[0] as JsonObject)
+    : {};
+  const message =
+    choice.message && typeof choice.message === 'object' && !Array.isArray(choice.message)
+      ? (choice.message as JsonObject)
+      : {};
+  const contentBlocks: JsonObject[] = [];
+
+  if (typeof message.content === 'string' && message.content) {
+    contentBlocks.push({ type: 'text', text: message.content });
+  }
+
+  if (Array.isArray(message.tool_calls)) {
+    for (const toolCall of message.tool_calls) {
+      if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) continue;
+      const fn =
+        toolCall.function && typeof toolCall.function === 'object' && !Array.isArray(toolCall.function)
+          ? (toolCall.function as JsonObject)
+          : {};
+      if (typeof fn.name !== 'string') continue;
+      contentBlocks.push({
+        type: 'tool_use',
+        id: typeof toolCall.id === 'string' ? toolCall.id : `tool_${contentBlocks.length}`,
+        name: fn.name,
+        input: parseToolArguments(fn.arguments),
+      });
+    }
+  }
+
+  const usage =
+    body.usage && typeof body.usage === 'object' && !Array.isArray(body.usage)
+      ? (body.usage as JsonObject)
+      : {};
+
+  return {
+    id: typeof body.id === 'string' ? body.id : `msg_${Date.now()}`,
+    type: 'message',
+    role: 'assistant',
+    content: contentBlocks,
+    model: typeof body.model === 'string' ? body.model : 'unknown',
+    stop_reason: mapFinishReason(choice.finish_reason),
+    stop_sequence: null,
+    usage: {
+      input_tokens:
+        typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0,
+      output_tokens:
+        typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
+    },
+  };
+}
+
+function writeSseEvent(
+  res: ServerResponse,
+  event: string,
+  payload: JsonObject,
+): void {
+  res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function writeAnthropicStreamingResponse(
+  res: ServerResponse,
+  anthropicMessage: JsonObject,
+): void {
+  const content = Array.isArray(anthropicMessage.content)
+    ? anthropicMessage.content.filter(
+        (block): block is JsonObject => Boolean(block && typeof block === 'object' && !Array.isArray(block)),
+      )
+    : [];
+  const usage =
+    anthropicMessage.usage && typeof anthropicMessage.usage === 'object' && !Array.isArray(anthropicMessage.usage)
+      ? (anthropicMessage.usage as JsonObject)
+      : {};
+
+  res.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  });
+
+  writeSseEvent(res, 'message_start', {
+    type: 'message_start',
+    message: {
+      ...anthropicMessage,
+      content: [],
+      usage: {
+        input_tokens:
+          typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
+        output_tokens: 0,
+      },
+    },
+  });
+
+  content.forEach((block, index) => {
+    if (block.type === 'text') {
+      writeSseEvent(res, 'content_block_start', {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'text', text: '' },
+      });
+      if (typeof block.text === 'string' && block.text) {
+        writeSseEvent(res, 'content_block_delta', {
+          type: 'content_block_delta',
+          index,
+          delta: { type: 'text_delta', text: block.text },
+        });
+      }
+      writeSseEvent(res, 'content_block_stop', {
+        type: 'content_block_stop',
+        index,
+      });
+      return;
+    }
+
+    if (block.type === 'tool_use') {
+      writeSseEvent(res, 'content_block_start', {
+        type: 'content_block_start',
+        index,
+        content_block: {
+          type: 'tool_use',
+          id: block.id,
+          name: block.name,
+          input: {},
+        },
+      });
+      writeSseEvent(res, 'content_block_delta', {
+        type: 'content_block_delta',
+        index,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: JSON.stringify(
+            block.input && typeof block.input === 'object' ? block.input : {},
+          ),
+        },
+      });
+      writeSseEvent(res, 'content_block_stop', {
+        type: 'content_block_stop',
+        index,
+      });
+    }
+  });
+
+  writeSseEvent(res, 'message_delta', {
+    type: 'message_delta',
+    delta: {
+      stop_reason: anthropicMessage.stop_reason,
+      stop_sequence: null,
+    },
+    usage: {
+      output_tokens:
+        typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
+    },
+  });
+  writeSseEvent(res, 'message_stop', { type: 'message_stop' });
+  res.end();
+}
+
+function forwardRequest(
+  makeRequest: typeof httpsRequest | typeof httpRequest,
+  options: RequestOptions,
+  body: Buffer,
+): Promise<{ statusCode: number; headers: IncomingMessage['headers']; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const upstream = makeRequest(options, (upRes) => {
+      const chunks: Buffer[] = [];
+      upRes.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      upRes.on('end', () => {
+        resolve({
+          statusCode: upRes.statusCode || 500,
+          headers: upRes.headers,
+          body: Buffer.concat(chunks),
+        });
+      });
+    });
+
+    upstream.on('error', reject);
+    upstream.write(body);
+    upstream.end();
+  });
+}
+
+async function handleTranslatedOpenRouterRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  makeRequest: typeof httpsRequest | typeof httpRequest,
+  upstreamUrl: URL,
+  authMode: AuthMode,
+  secrets: Record<string, string>,
+  bodyJson: JsonObject,
+): Promise<void> {
+  const translatedBody = Buffer.from(
+    JSON.stringify(buildOpenRouterChatBody(bodyJson)),
+    'utf-8',
+  );
+  const headers = buildForwardHeaders(
+    req.headers,
+    upstreamUrl,
+    translatedBody.length,
+    authMode,
+    secrets,
+  );
+  delete headers['anthropic-version'];
+  delete headers['anthropic-beta'];
+  // Ensure upstream returns plain JSON so translation can parse safely.
+  delete headers['accept-encoding'];
+  headers['accept-encoding'] = 'identity';
+
+  const upstreamResponse = await forwardRequest(
+    makeRequest,
+    {
+      hostname: upstreamUrl.hostname,
+      port: upstreamUrl.port || (upstreamUrl.protocol === 'https:' ? 443 : 80),
+      path: buildUpstreamPath(upstreamUrl, '/v1/chat/completions'),
+      method: 'POST',
+      headers,
+    } as RequestOptions,
+    translatedBody,
+  );
+
+  if (upstreamResponse.statusCode >= 400) {
+    res.writeHead(upstreamResponse.statusCode, upstreamResponse.headers);
+    res.end(upstreamResponse.body);
+    return;
+  }
+
+  const translatedResponse = convertOpenRouterResponseToAnthropic(
+    JSON.parse(upstreamResponse.body.toString('utf-8')) as JsonObject,
+  );
+  const wantsStream = bodyJson.stream === true;
+  if (wantsStream) {
+    writeAnthropicStreamingResponse(res, translatedResponse);
+    return;
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(translatedResponse));
+}
+
+export function startCredentialProxy(
+  port: number,
+  host = '127.0.0.1',
+): Promise<Server> {
+  const secrets = readEnvFile([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_BASE_URL',
+    'OPENROUTER_API_KEY',
+  ]);
+
+  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+  const oauthToken =
+    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+
+  const upstreamUrl = new URL(
+    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
+  );
+  const isHttps = upstreamUrl.protocol === 'https:';
+  const makeRequest = isHttps ? httpsRequest : httpRequest;
+
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        const body = Buffer.concat(chunks);
+        const bodyJson = safeJsonParse(body);
+
+        if (shouldTranslateToOpenRouterChat(req, bodyJson, upstreamUrl, secrets)) {
+          handleTranslatedOpenRouterRequest(
+            req,
+            res,
+            makeRequest,
+            upstreamUrl,
+            authMode,
+            secrets,
+            bodyJson,
+          ).catch((err) => {
+            logger.error({ err, url: req.url }, 'Credential proxy translation error');
+            if (!res.headersSent) {
+              res.writeHead(502);
+              res.end('Bad Gateway');
+            }
+          });
+          return;
+        }
+
+        const headers = buildForwardHeaders(
+          req.headers,
+          upstreamUrl,
+          body.length,
+          authMode,
+          secrets,
+        );
+
+        const upstream = makeRequest(
+          {
+            hostname: upstreamUrl.hostname,
+            port: upstreamUrl.port || (isHttps ? 443 : 80),
+            path: buildUpstreamPath(upstreamUrl, req.url || '/'),
+            method: req.method,
+            headers,
+          } as RequestOptions,
+          (upRes) => {
+            res.writeHead(upRes.statusCode!, upRes.headers);
+            upRes.pipe(res);
+          },
+        );
+
+        upstream.on('error', (err) => {
+          logger.error(
+            { err, url: req.url },
+            'Credential proxy upstream error',
+          );
+          if (!res.headersSent) {
+            res.writeHead(502);
+            res.end('Bad Gateway');
+          }
+        });
+
+        upstream.write(body);
+        upstream.end();
+      });
+    });
+
+    server.listen(port, host, () => {
+      logger.info({ port, host, authMode }, 'Credential proxy started');
+      resolve(server);
+    });
+
+    server.on('error', reject);
+  });
+}
+
+/** Detect which auth mode the host is configured for. */
+export function detectAuthMode(): AuthMode {
+  const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
+  return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+}

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -23,13 +23,7 @@ export interface ProxyConfig {
   authMode: AuthMode;
 }
 
-type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
 type JsonObject = { [key: string]: JsonValue };
 
@@ -41,26 +35,18 @@ function isLocalHost(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
 }
 
-function isOpenRouterAuthTarget(
-  upstreamUrl: URL,
-): boolean {
+function isOpenRouterAuthTarget(upstreamUrl: URL): boolean {
   return isOpenRouterHostname(upstreamUrl.hostname);
 }
 
-function isOpenRouterTranslationTarget(
-  upstreamUrl: URL,
-  secrets: Record<string, string>,
-): boolean {
+function isOpenRouterTranslationTarget(upstreamUrl: URL, secrets: Record<string, string>): boolean {
   if (isOpenRouterAuthTarget(upstreamUrl)) return true;
   // Allow local test/proxy setups that emulate OpenRouter while still requiring
   // explicit OpenRouter credentials to avoid false positives on Anthropic.
   return isLocalHost(upstreamUrl.hostname) && Boolean(secrets.OPENROUTER_API_KEY);
 }
 
-function resolveAuthMode(
-  upstreamUrl: URL,
-  secrets: Record<string, string>,
-): AuthMode {
+function resolveAuthMode(upstreamUrl: URL, secrets: Record<string, string>): AuthMode {
   const hasAnthropicKey = Boolean(secrets.ANTHROPIC_API_KEY);
   const hasOpenRouterKey = Boolean(secrets.OPENROUTER_API_KEY);
   if (hasAnthropicKey) return 'api-key';
@@ -103,8 +89,7 @@ function buildForwardHeaders(
       headers['x-api-key'] = apiKey;
     }
   } else if (headers['authorization']) {
-    const oauthToken =
-      secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+    const oauthToken = secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
     delete headers['authorization'];
     if (oauthToken) {
       headers['authorization'] = `Bearer ${oauthToken}`;
@@ -122,10 +107,7 @@ function safeJsonParse(body: Buffer): JsonObject | null {
   }
 }
 
-function isOpenRouterUpstream(
-  upstreamUrl: URL,
-  secrets: Record<string, string>,
-): boolean {
+function isOpenRouterUpstream(upstreamUrl: URL, secrets: Record<string, string>): boolean {
   return isOpenRouterTranslationTarget(upstreamUrl, secrets);
 }
 
@@ -214,9 +196,7 @@ function convertAnthropicMessagesToOpenRouter(body: JsonObject): JsonObject[] {
             type: 'function',
             function: {
               name: block.name,
-              arguments: JSON.stringify(
-                block.input && typeof block.input === 'object' ? block.input : {},
-              ),
+              arguments: JSON.stringify(block.input && typeof block.input === 'object' ? block.input : {}),
             },
           });
         }
@@ -266,9 +246,7 @@ function convertAnthropicMessagesToOpenRouter(body: JsonObject): JsonObject[] {
   return messages;
 }
 
-function convertAnthropicToolChoice(
-  toolChoice: JsonValue | undefined,
-): JsonValue | undefined {
+function convertAnthropicToolChoice(toolChoice: JsonValue | undefined): JsonValue | undefined {
   if (!toolChoice || typeof toolChoice !== 'object' || Array.isArray(toolChoice)) {
     return toolChoice;
   }
@@ -286,9 +264,7 @@ function convertAnthropicToolChoice(
 }
 
 function compactObject(object: Record<string, JsonValue | undefined>): JsonObject {
-  return Object.fromEntries(
-    Object.entries(object).filter(([, value]) => value !== undefined),
-  ) as JsonObject;
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined)) as JsonObject;
 }
 
 function buildOpenRouterChatBody(body: JsonObject): JsonObject {
@@ -353,9 +329,10 @@ function mapFinishReason(reason: unknown): string | null {
 }
 
 function convertOpenRouterResponseToAnthropic(body: JsonObject): JsonObject {
-  const choice = Array.isArray(body.choices) && body.choices[0] && typeof body.choices[0] === 'object'
-    ? (body.choices[0] as JsonObject)
-    : {};
+  const choice =
+    Array.isArray(body.choices) && body.choices[0] && typeof body.choices[0] === 'object'
+      ? (body.choices[0] as JsonObject)
+      : {};
   const message =
     choice.message && typeof choice.message === 'object' && !Array.isArray(choice.message)
       ? (choice.message as JsonObject)
@@ -384,9 +361,7 @@ function convertOpenRouterResponseToAnthropic(body: JsonObject): JsonObject {
   }
 
   const usage =
-    body.usage && typeof body.usage === 'object' && !Array.isArray(body.usage)
-      ? (body.usage as JsonObject)
-      : {};
+    body.usage && typeof body.usage === 'object' && !Array.isArray(body.usage) ? (body.usage as JsonObject) : {};
 
   return {
     id: typeof body.id === 'string' ? body.id : `msg_${Date.now()}`,
@@ -397,30 +372,21 @@ function convertOpenRouterResponseToAnthropic(body: JsonObject): JsonObject {
     stop_reason: mapFinishReason(choice.finish_reason),
     stop_sequence: null,
     usage: {
-      input_tokens:
-        typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0,
-      output_tokens:
-        typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
+      input_tokens: typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0,
+      output_tokens: typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
     },
   };
 }
 
-function writeSseEvent(
-  res: ServerResponse,
-  event: string,
-  payload: JsonObject,
-): void {
+function writeSseEvent(res: ServerResponse, event: string, payload: JsonObject): void {
   res.write(`event: ${event}\n`);
   res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
-function writeAnthropicStreamingResponse(
-  res: ServerResponse,
-  anthropicMessage: JsonObject,
-): void {
+function writeAnthropicStreamingResponse(res: ServerResponse, anthropicMessage: JsonObject): void {
   const content = Array.isArray(anthropicMessage.content)
-    ? anthropicMessage.content.filter(
-        (block): block is JsonObject => Boolean(block && typeof block === 'object' && !Array.isArray(block)),
+    ? anthropicMessage.content.filter((block): block is JsonObject =>
+        Boolean(block && typeof block === 'object' && !Array.isArray(block)),
       )
     : [];
   const usage =
@@ -440,8 +406,7 @@ function writeAnthropicStreamingResponse(
       ...anthropicMessage,
       content: [],
       usage: {
-        input_tokens:
-          typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
+        input_tokens: typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
         output_tokens: 0,
       },
     },
@@ -484,9 +449,7 @@ function writeAnthropicStreamingResponse(
         index,
         delta: {
           type: 'input_json_delta',
-          partial_json: JSON.stringify(
-            block.input && typeof block.input === 'object' ? block.input : {},
-          ),
+          partial_json: JSON.stringify(block.input && typeof block.input === 'object' ? block.input : {}),
         },
       });
       writeSseEvent(res, 'content_block_stop', {
@@ -503,8 +466,7 @@ function writeAnthropicStreamingResponse(
       stop_sequence: null,
     },
     usage: {
-      output_tokens:
-        typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
+      output_tokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
     },
   });
   writeSseEvent(res, 'message_stop', { type: 'message_stop' });
@@ -544,17 +506,8 @@ async function handleTranslatedOpenRouterRequest(
   secrets: Record<string, string>,
   bodyJson: JsonObject,
 ): Promise<void> {
-  const translatedBody = Buffer.from(
-    JSON.stringify(buildOpenRouterChatBody(bodyJson)),
-    'utf-8',
-  );
-  const headers = buildForwardHeaders(
-    req.headers,
-    upstreamUrl,
-    translatedBody.length,
-    authMode,
-    secrets,
-  );
+  const translatedBody = Buffer.from(JSON.stringify(buildOpenRouterChatBody(bodyJson)), 'utf-8');
+  const headers = buildForwardHeaders(req.headers, upstreamUrl, translatedBody.length, authMode, secrets);
   delete headers['anthropic-version'];
   delete headers['anthropic-beta'];
   // Ensure upstream returns plain JSON so translation can parse safely.
@@ -592,10 +545,7 @@ async function handleTranslatedOpenRouterRequest(
   res.end(JSON.stringify(translatedResponse));
 }
 
-export function startCredentialProxy(
-  port: number,
-  host = '127.0.0.1',
-): Promise<Server> {
+export function startCredentialProxy(port: number, host = '127.0.0.1'): Promise<Server> {
   const secrets = readEnvFile([
     'ANTHROPIC_API_KEY',
     'OPENROUTER_API_KEY',
@@ -604,9 +554,7 @@ export function startCredentialProxy(
     'ANTHROPIC_BASE_URL',
   ]);
 
-  const upstreamUrl = new URL(
-    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
-  );
+  const upstreamUrl = new URL(secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com');
   const authMode = resolveAuthMode(upstreamUrl, secrets);
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
@@ -620,31 +568,19 @@ export function startCredentialProxy(
         const bodyJson = safeJsonParse(body);
 
         if (shouldTranslateToOpenRouterChat(req, bodyJson, upstreamUrl, secrets)) {
-          handleTranslatedOpenRouterRequest(
-            req,
-            res,
-            makeRequest,
-            upstreamUrl,
-            authMode,
-            secrets,
-            bodyJson,
-          ).catch((err) => {
-            log.error('Credential proxy translation error', { err, url: req.url });
-            if (!res.headersSent) {
-              res.writeHead(502);
-              res.end('Bad Gateway');
-            }
-          });
+          handleTranslatedOpenRouterRequest(req, res, makeRequest, upstreamUrl, authMode, secrets, bodyJson).catch(
+            (err) => {
+              log.error('Credential proxy translation error', { err, url: req.url });
+              if (!res.headersSent) {
+                res.writeHead(502);
+                res.end('Bad Gateway');
+              }
+            },
+          );
           return;
         }
 
-        const headers = buildForwardHeaders(
-          req.headers,
-          upstreamUrl,
-          body.length,
-          authMode,
-          secrets,
-        );
+        const headers = buildForwardHeaders(req.headers, upstreamUrl, body.length, authMode, secrets);
 
         const upstream = makeRequest(
           {
@@ -684,13 +620,7 @@ export function startCredentialProxy(
 
 /** Detect which auth mode the host is configured for. */
 export function detectAuthMode(): AuthMode {
-  const secrets = readEnvFile([
-    'ANTHROPIC_API_KEY',
-    'OPENROUTER_API_KEY',
-    'ANTHROPIC_BASE_URL',
-  ]);
-  const upstreamUrl = new URL(
-    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
-  );
+  const secrets = readEnvFile(['ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']);
+  const upstreamUrl = new URL(secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com');
   return resolveAuthMode(upstreamUrl, secrets);
 }

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -15,7 +15,7 @@ import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { readEnvFile } from './env.js';
-import { logger } from './logger.js';
+import { log } from './log.js';
 
 export type AuthMode = 'api-key' | 'oauth';
 
@@ -629,7 +629,7 @@ export function startCredentialProxy(
             secrets,
             bodyJson,
           ).catch((err) => {
-            logger.error({ err, url: req.url }, 'Credential proxy translation error');
+            log.error('Credential proxy translation error', { err, url: req.url });
             if (!res.headersSent) {
               res.writeHead(502);
               res.end('Bad Gateway');
@@ -661,10 +661,7 @@ export function startCredentialProxy(
         );
 
         upstream.on('error', (err) => {
-          logger.error(
-            { err, url: req.url },
-            'Credential proxy upstream error',
-          );
+          log.error('Credential proxy upstream error', { err, url: req.url });
           if (!res.headersSent) {
             res.writeHead(502);
             res.end('Bad Gateway');
@@ -677,7 +674,7 @@ export function startCredentialProxy(
     });
 
     server.listen(port, host, () => {
-      logger.info({ port, host, authMode }, 'Credential proxy started');
+      log.info('Credential proxy started', { port, host, authMode });
       resolve(server);
     });
 


### PR DESCRIPTION
## Summary

Clean replacement for #951 with only the OpenRouter/Anthropic SDK compatibility changes.

This PR fixes NanoClaw behavior when using Anthropic SDK flow against OpenRouter with non-Anthropic model slugs (for example `arcee-ai/trinity-large-preview:free`), and fixes the no-reply regression caused by compressed translated responses.

## Scope (intentionally narrow)

Only these files are changed:
- `src/credential-proxy.ts`
- `src/credential-proxy.test.ts`
- `src/container-runner.ts`

No Discord-channel or workflow changes are included.

## What changed

1. `src/container-runner.ts`
- Forward `ANTHROPIC_MODEL` into container env.
- Prefer `process.env.ANTHROPIC_MODEL`; fallback to `.env` via `readEnvFile`.

2. `src/credential-proxy.ts`
- Preserve upstream base path when forwarding.
- Translate non-Anthropic `/v1/messages` requests (OpenRouter upstream) to `/v1/chat/completions`, then map responses back to Anthropic shape.
- Synthesize Anthropic-style SSE events for translated streaming responses.
- Force `accept-encoding: identity` in translated requests to avoid gzip JSON parse failures.
- Support `OPENROUTER_API_KEY` as real API-key auth input (not just a signal).
- Remove unused `oauthToken` startup variable.

3. `src/credential-proxy.test.ts`
- Add regression tests for base-path forwarding, translation behavior, and streaming synthesis.

## Reviewer concerns from #951 addressed

- PR scope narrowed to only relevant files.
- `OPENROUTER_API_KEY` now participates in auth-mode/header injection.
- `ANTHROPIC_MODEL` passthrough now supports process env and `.env` fallback.
- Unused variable cleanup included.

## Validation

Executed on this branch:
- `npx vitest run src/credential-proxy.test.ts src/container-runner.test.ts`
- `npm run build`

All passed.
