### PR TITLE
fix(container-runner): refresh agent runner source

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -184,7 +184,6 @@ describe('container-runner timeout behavior', () => {
     expect(onOutput).not.toHaveBeenCalled();
   });
 
-
   it('refreshes agent-runner source even when group copy already exists', async () => {
     const projectRoot = process.cwd();
     const agentRunnerSrc = path.join(
@@ -213,15 +212,56 @@ describe('container-runner timeout behavior', () => {
       vi.fn(async () => {}),
     );
 
-    expect(fs.cpSync).toHaveBeenCalledWith(agentRunnerSrc, groupAgentRunnerDir, {
-      recursive: true,
-    });
-
-    const spawnArgs = vi.mocked(spawn).mock.calls[0]?.[1] ?? [];
-    expect(spawnArgs).toContain(
-      `-v ${groupAgentRunnerDir}:/app/src`.split(' ')[0],
+    expect(fs.cpSync).toHaveBeenCalledWith(
+      agentRunnerSrc,
+      groupAgentRunnerDir,
+      {
+        recursive: true,
+      },
     );
-    expect(spawnArgs).toContain(`${groupAgentRunnerDir}:/app/src`);
+
+    fakeProc.emit('close', 0);
+    await expect(resultPromise).resolves.toMatchObject({ status: 'success' });
+  });
+
+  it('mounts /app/src from the per-group agent-runner directory', async () => {
+    const group = {
+      ...testGroup,
+      name: 'Other Group',
+      folder: 'other-group',
+    };
+    const input = {
+      ...testInput,
+      groupFolder: group.folder,
+    };
+    const agentRunnerSrc = path.join(
+      process.cwd(),
+      'container',
+      'agent-runner',
+      'src',
+    );
+    const groupAgentRunnerDir = path.join(
+      '/tmp/nanoclaw-test-data',
+      'sessions',
+      group.folder,
+      'agent-runner-src',
+    );
+
+    vi.mocked(fs.existsSync).mockImplementation(
+      (target) => String(target) === agentRunnerSrc,
+    );
+
+    const resultPromise = runContainerAgent(
+      group,
+      input,
+      () => {},
+      vi.fn(async () => {}),
+    );
+    const spawnArgs = vi.mocked(spawn).mock.calls.at(-1)?.[1] ?? [];
+
+    expect(spawnArgs).toEqual(
+      expect.arrayContaining(['-v', `${groupAgentRunnerDir}:/app/src`]),
+    );
 
     fakeProc.emit('close', 0);
     await expect(resultPromise).resolves.toMatchObject({ status: 'success' });

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
+import { spawn } from 'child_process';
 
 // Sentinel markers must match container-runner.ts
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -41,6 +44,7 @@ vi.mock('fs', async () => {
       readFileSync: vi.fn(() => ''),
       readdirSync: vi.fn(() => []),
       statSync: vi.fn(() => ({ isDirectory: () => false })),
+      cpSync: vi.fn(),
       copyFileSync: vi.fn(),
     },
   };
@@ -178,6 +182,49 @@ describe('container-runner timeout behavior', () => {
     expect(result.status).toBe('error');
     expect(result.error).toContain('timed out');
     expect(onOutput).not.toHaveBeenCalled();
+  });
+
+
+  it('refreshes agent-runner source even when group copy already exists', async () => {
+    const projectRoot = process.cwd();
+    const agentRunnerSrc = path.join(
+      projectRoot,
+      'container',
+      'agent-runner',
+      'src',
+    );
+    const groupAgentRunnerDir = path.join(
+      '/tmp/nanoclaw-test-data',
+      'sessions',
+      testGroup.folder,
+      'agent-runner-src',
+    );
+
+    vi.mocked(fs.existsSync).mockImplementation((target) => {
+      if (target === agentRunnerSrc) return true;
+      if (target === groupAgentRunnerDir) return true;
+      return false;
+    });
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      vi.fn(async () => {}),
+    );
+
+    expect(fs.cpSync).toHaveBeenCalledWith(agentRunnerSrc, groupAgentRunnerDir, {
+      recursive: true,
+    });
+
+    const spawnArgs = vi.mocked(spawn).mock.calls[0]?.[1] ?? [];
+    expect(spawnArgs).toContain(
+      `-v ${groupAgentRunnerDir}:/app/src`.split(' ')[0],
+    );
+    expect(spawnArgs).toContain(`${groupAgentRunnerDir}:/app/src`);
+
+    fakeProc.emit('close', 0);
+    await expect(resultPromise).resolves.toMatchObject({ status: 'success' });
   });
 
   it('normal exit after output resolves as success', async () => {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -190,7 +190,7 @@ function buildVolumeMounts(
     group.folder,
     'agent-runner-src',
   );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+  if (fs.existsSync(agentRunnerSrc)) {
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
   mounts.push({


### PR DESCRIPTION
## What?
Refresh the per-group `agent-runner-src` copy every time container mounts are built so newly added or updated agent-runner files propagate into running sessions.

## Why?
`src/container-runner.ts` only copied `container/agent-runner/src` when the destination directory did not exist, which left stale per-group mounts after the first bootstrap.

## How?
- remove the destination-exists guard and copy whenever the source directory exists
- add a focused unit test that covers an already-existing group copy and verifies the `/app/src` mount remains pointed at the per-group directory

## Testing
- `npm test -- src/container-runner.test.ts`
- `npm run typecheck`

Closes #905