### PR TITLE
feat: add Feishu/Lark channel

### DIFF
--- a/.claude/skills/add-feishu/SKILL.md
+++ b/.claude/skills/add-feishu/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: add-feishu
+description: Add Feishu (飞书) or Lark as a channel. Supports both Feishu (China, open.feishu.cn) and Lark (International, open.larksuite.com). Uses WebSocket event subscription — no public URL required.
+---
+
+# Add Feishu / Lark Channel
+
+## Phase 1: Pre-flight
+
+Check if Feishu is already configured:
+
+```bash
+grep -q "FEISHU_APP_ID" .env 2>/dev/null && echo "Already configured" || echo "Not configured"
+```
+
+If already configured, skip to Phase 4.
+
+Ask the user: **Which platform?**
+- **Feishu (飞书, China)** — `open.feishu.cn`
+- **Lark (International)** — `open.larksuite.com`
+
+## Phase 2: Create the Feishu/Lark App
+
+Tell the user:
+
+> **Step 1 — Open the developer portal:**
+> - Feishu: https://open.feishu.cn/app
+> - Lark: https://open.larksuite.com/app
+>
+> **Step 2 — Create a custom app:**
+> - Click **创建企业自建应用** (Create Custom App)
+> - Name it (e.g. "NanoClaw Assistant")
+>
+> **Step 3 — Enable the Bot feature:**
+> - Go to **应用功能 → 机器人** and enable it
+>
+> **Step 4 — Add permissions** (权限管理):
+> - `im:message:read_basic` — read messages
+> - `im:message.receive_v1` — receive message events
+> - `im:message:send_basic` — send messages
+>
+> **Step 5 — Subscribe to events** (事件订阅):
+> - Add event: `im.message.receive_v1`
+> - Set connection mode to **长连接 (WebSocket / Long Connection)**
+>   *(No public URL needed — NanoClaw connects outbound)*
+>
+> **Step 6 — Publish a version** and wait for approval (enterprise) or self-approve (personal)
+
+Ask: **Do you have your App ID and App Secret ready?**
+
+Collect:
+- App ID (e.g. `cli_xxxxxxxxxx`)
+- App Secret (sensitive)
+
+## Phase 3: Write credentials to .env
+
+```bash
+cat >> .env << 'EOF'
+
+# Feishu / Lark channel
+FEISHU_APP_ID=<app-id>
+FEISHU_APP_SECRET=<app-secret>
+FEISHU_PLATFORM=feishu   # change to 'lark' for International
+EOF
+```
+
+Install and build:
+
+```bash
+npm install && npm run build
+```
+
+Verify build succeeds (exit 0) before continuing.
+
+## Phase 4: Register a chat
+
+Ask: **Group chat or direct message?**
+
+**For group chat:**
+1. Add the bot to the group in Feishu/Lark
+2. Get the group Chat ID — it starts with `oc_` (visible in group settings or URL)
+3. Construct the JID: `<chat_id>@feishu` (e.g. `oc_abc123@feishu`)
+
+**For direct message:**
+1. Open a DM with the bot
+2. The chat ID (JID) can be found in the startup logs after the next step — search for `onChatMetadata` with `@feishu`
+
+Register the chat:
+
+```bash
+npx tsx src/cli.ts register --jid "<chat-id>@feishu" --name "<chat-name>"
+```
+
+For the main group (no trigger required):
+
+```bash
+npx tsx src/cli.ts register --jid "<chat-id>@feishu" --name "<chat-name>" --is-main
+```
+
+## Phase 5: Restart and verify
+
+Restart the service:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux
+systemctl --user restart nanoclaw
+```
+
+Send a test message in Feishu:
+- Main/DM group: any message
+- Non-main group: use the trigger word (default: `@Andy`)
+
+Check logs if no response:
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Troubleshooting
+
+**No messages arriving:**
+- Confirm the bot has the `im:message.receive_v1` event subscription
+- Confirm connection mode is set to **Long Connection (WebSocket)** in the portal
+- Check logs for `Connected to Feishu via WebSocket`
+
+**Auth errors:**
+- Double-check App ID and App Secret in `.env`
+- Make sure the app version is published and approved
+
+**Bot sends but doesn't receive:**
+- Confirm the bot is added to the group/DM
+- Confirm `FEISHU_APP_ID` and `FEISHU_APP_SECRET` are non-empty in `.env`
+
+**Wrong platform (Feishu vs Lark):**
+- Set `FEISHU_PLATFORM=lark` in `.env` for International, `feishu` for China
+- Rebuild and restart after changing
+
+## Removal
+
+```bash
+# Remove credentials from .env (edit manually, remove FEISHU_* lines)
+# Remove registered groups
+sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE '%@feishu'"
+# Rebuild
+npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 # Container build mirrors (China-optimized defaults, leave empty for international)
 APT_MIRROR=mirrors.ustc.edu.cn
 NPM_REGISTRY=https://registry.npmmirror.com
+
+# Feishu / Lark channel
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+# FEISHU_PLATFORM=feishu   # 'feishu' (China, default) or 'lark' (International)

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 
 # Container build mirrors (China-optimized defaults, leave empty for international)
 APT_MIRROR=mirrors.ustc.edu.cn
-NPM_REGISTRY=https://registry.npmmirror.com
+NPM_REGISTRY=https://mirrors.huaweicloud.com/repository/npm/
 
 # Feishu / Lark channel
 FEISHU_APP_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 
+# Container build mirrors (China-optimized defaults, leave empty for international)
+APT_MIRROR=mirrors.ustc.edu.cn
+NPM_REGISTRY=https://registry.npmmirror.com

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,8 +3,16 @@
 
 FROM node:22-slim
 
-# Install system dependencies for Chromium
-RUN apt-get update && apt-get install -y \
+# Build-time mirror configuration (leave empty for international defaults)
+ARG APT_MIRROR=
+ARG NPM_REGISTRY=
+
+# Configure apt mirror and install system dependencies for Chromium
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|deb.debian.org|${APT_MIRROR}|g; s|security.debian.org|${APT_MIRROR}|g" \
+        /etc/apt/sources.list.d/debian.sources; \
+    fi && \
+    apt-get update && apt-get install -y \
     chromium \
     fonts-liberation \
     fonts-noto-cjk \
@@ -29,6 +37,9 @@ RUN apt-get update && apt-get install -y \
 # Set Chromium path for agent-browser
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Configure npm registry if specified
+RUN if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi
 
 # Install agent-browser and claude-code globally
 RUN npm install -g agent-browser @anthropic-ai/claude-code

--- a/container/build.sh
+++ b/container/build.sh
@@ -10,10 +10,22 @@ IMAGE_NAME="nanoclaw-agent"
 TAG="${1:-latest}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
+# Load .env from project root for mirror configuration
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a && source "$ROOT_DIR/.env" && set +a
+fi
+
+# Collect build args for mirror configuration
+BUILD_ARGS=""
+[ -n "${APT_MIRROR:-}" ]   && BUILD_ARGS="$BUILD_ARGS --build-arg APT_MIRROR=$APT_MIRROR"
+[ -n "${NPM_REGISTRY:-}" ] && BUILD_ARGS="$BUILD_ARGS --build-arg NPM_REGISTRY=$NPM_REGISTRY"
+
 echo "Building NanoClaw agent container image..."
 echo "Image: ${IMAGE_NAME}:${TAG}"
+[ -n "$BUILD_ARGS" ] && echo "Build args:$BUILD_ARGS"
 
-${CONTAINER_RUNTIME} build -t "${IMAGE_NAME}:${TAG}" .
+${CONTAINER_RUNTIME} build $BUILD_ARGS -t "${IMAGE_NAME}:${TAG}" .
 
 echo ""
 echo "Build complete!"

--- a/docs/plans/2026-03-11-container-build-mirror-acceleration.md
+++ b/docs/plans/2026-03-11-container-build-mirror-acceleration.md
@@ -1,0 +1,123 @@
+# Container Build Mirror Acceleration
+
+**Date:** 2026-03-11
+**Status:** Approved
+**Branch:** `feat/container-build-mirrors`
+
+## Problem
+
+Building the NanoClaw agent container in China is slow because:
+1. `apt-get install` pulls from `deb.debian.org` (international)
+2. `npm install` pulls from `registry.npmjs.org` (international)
+
+## Goal
+
+Allow apt and npm mirror sources to be configured via `.env` variables, with China-optimized mirrors set as the default values in `.env.example`.
+
+## Design
+
+### Approach: Build ARGs injected from `.env`
+
+- `.env` (and `.env.example`) define mirror variables
+- `container/build.sh` reads `.env` and passes values as `--build-arg`
+- `Dockerfile` accepts ARGs and applies mirrors conditionally before each install step
+- Empty value = upstream default (safe for international use, no code changes required)
+
+---
+
+## Variables
+
+| Variable | Default in `.env.example` | Description |
+|---|---|---|
+| `APT_MIRROR` | `mirrors.ustc.edu.cn` | Debian apt mirror hostname. Replaces `deb.debian.org` and `security.debian.org` in `/etc/apt/sources.list.d/debian.sources`. |
+| `NPM_REGISTRY` | `https://registry.npmmirror.com` | npm registry URL. Set via `npm config set registry` before all npm install steps. |
+
+Both variables are optional. Leaving either unset or empty falls back to upstream defaults.
+
+**Mirror rationale:**
+- **USTC** (`mirrors.ustc.edu.cn`): University of Science and Technology of China. Stable, fast, well-maintained. Hosts Debian, Ubuntu, and other distros.
+- **npmmirror** (`registry.npmmirror.com`): Official Taobao/Alibaba npm mirror for China. Syncs from npm every 10 minutes.
+
+---
+
+## File Changes
+
+### `.env.example`
+
+```env
+# Container build mirrors (China-optimized defaults, leave empty for international)
+APT_MIRROR=mirrors.ustc.edu.cn
+NPM_REGISTRY=https://registry.npmmirror.com
+```
+
+### `container/Dockerfile`
+
+Add ARG declarations after `FROM`, then apply mirrors inline before each install step:
+
+```dockerfile
+FROM node:22-slim
+
+# Build-time mirror configuration (leave empty for international defaults)
+ARG APT_MIRROR=
+ARG NPM_REGISTRY=
+
+# Configure apt mirror and install system dependencies
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|deb.debian.org|${APT_MIRROR}|g; s|security.debian.org|${APT_MIRROR}|g" \
+        /etc/apt/sources.list.d/debian.sources; \
+    fi && \
+    apt-get update && apt-get install -y \
+    chromium \
+    fonts-liberation \
+    ... \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure npm registry
+RUN if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi
+
+# Install agent-browser and claude-code globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code
+# (remaining steps unchanged)
+```
+
+Notes:
+- `node:22-slim` is Debian Bookworm, which uses DEB822 format at `/etc/apt/sources.list.d/debian.sources`
+- The `npm config set registry` RUN writes to `/root/.npmrc`, which persists across all subsequent npm install layers
+- ARG values are build-time only — not embedded in the final image environment
+
+### `container/build.sh`
+
+Load `.env` from the project root and pass non-empty mirror vars as `--build-arg`:
+
+```bash
+# Load .env from project root
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a && source "$ROOT_DIR/.env" && set +a
+fi
+
+# Collect build args for mirror configuration
+BUILD_ARGS=""
+[ -n "${APT_MIRROR:-}" ]    && BUILD_ARGS="$BUILD_ARGS --build-arg APT_MIRROR=$APT_MIRROR"
+[ -n "${NPM_REGISTRY:-}" ]  && BUILD_ARGS="$BUILD_ARGS --build-arg NPM_REGISTRY=$NPM_REGISTRY"
+
+${CONTAINER_RUNTIME} build $BUILD_ARGS -t "${IMAGE_NAME}:${TAG}" .
+```
+
+---
+
+## Behavior Summary
+
+| Scenario | APT_MIRROR | NPM_REGISTRY | Result |
+|---|---|---|---|
+| China (default) | `mirrors.ustc.edu.cn` | `https://registry.npmmirror.com` | Fast build |
+| International | (empty) | (empty) | Upstream defaults |
+| Custom | any hostname | any URL | Respected |
+
+---
+
+## Out of Scope
+
+- Runtime mirror configuration (these are build-time only)
+- Auto-detection of network location
+- pip/other package managers (not used in this container)

--- a/docs/plans/2026-03-11-feishu-channel-impl.md
+++ b/docs/plans/2026-03-11-feishu-channel-impl.md
@@ -1,0 +1,519 @@
+# Feishu Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Feishu/Lark as a built-in NanoClaw channel, activated by env vars, following the same pattern as Slack and Discord.
+
+**Architecture:** Port `FeishuChannel` from `feature/network-environment-customization` into `main`. Wire up self-registration via `src/channels/index.ts`. Add `@larksuiteoapi/node-sdk` dependency. Provide `/add-feishu` setup skill.
+
+**Tech Stack:** TypeScript, `@larksuiteoapi/node-sdk` v1.59.0, WebSocket event subscription (`im.message.receive_v1`)
+
+---
+
+## Chunk 1: Channel code, dependency, registration, env, skill
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to feature branch**
+
+```bash
+git checkout -b feat/feishu-channel
+```
+
+Expected: `Switched to a new branch 'feat/feishu-channel'`
+
+---
+
+### Task 2: Add `@larksuiteoapi/node-sdk` dependency
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the SDK**
+
+```bash
+npm install @larksuiteoapi/node-sdk@^1.59.0
+```
+
+Expected: package added to `package.json` and `package-lock.json` updated, no errors.
+
+- [ ] **Step 2: Verify it appears in package.json**
+
+```bash
+grep larksuite package.json
+```
+
+Expected: `"@larksuiteoapi/node-sdk": "^1.59.0"` (or similar version)
+
+---
+
+### Task 3: Create `src/channels/feishu.ts`
+
+**Files:**
+- Create: `src/channels/feishu.ts`
+
+- [ ] **Step 1: Create the file with the full implementation**
+
+Write `src/channels/feishu.ts` with this exact content:
+
+```typescript
+/**
+ * Feishu (Lark) Channel for NanoClaw
+ * Supports both Feishu (China) and Lark (International) platforms
+ *
+ * Uses official @larksuiteoapi/node-sdk for WebSocket event handling
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { ASSISTANT_NAME } from '../config.js';
+import { logger } from '../logger.js';
+import { Channel } from '../types.js';
+import { readEnvFile } from '../env.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+
+export class FeishuChannel implements Channel {
+  name = 'feishu';
+
+  private client!: lark.Client;
+  private connected = false;
+  private botOpenId: string | undefined;
+  private opts: ChannelOpts;
+  private appId: string;
+  private appSecret: string;
+  private domain: lark.Domain;
+
+  constructor(opts: ChannelOpts) {
+    this.opts = opts;
+    const env = readEnvFile([
+      'FEISHU_APP_ID',
+      'FEISHU_APP_SECRET',
+      'FEISHU_PLATFORM',
+    ]);
+    this.appId = env.FEISHU_APP_ID || '';
+    this.appSecret = env.FEISHU_APP_SECRET || '';
+    this.domain =
+      env.FEISHU_PLATFORM === 'lark' ? lark.Domain.Lark : lark.Domain.Feishu;
+  }
+
+  async connect(): Promise<void> {
+    const { appId, appSecret, domain } = this;
+
+    this.client = new lark.Client({ appId, appSecret, domain });
+
+    // Fetch bot's own open_id so we can detect our own messages
+    try {
+      const resp = await this.client.request({
+        method: 'GET',
+        url: 'https://open.feishu.cn/open-apis/bot/v3/info',
+      });
+      this.botOpenId = (resp as any)?.bot?.open_id;
+      logger.info({ botOpenId: this.botOpenId }, 'Feishu bot info fetched');
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Failed to fetch Feishu bot info, bot message detection may not work',
+      );
+    }
+
+    const wsClient = new lark.WSClient({
+      appId,
+      appSecret,
+      domain,
+      loggerLevel: lark.LoggerLevel.warn,
+    });
+
+    const eventDispatcher = new lark.EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: any) => {
+        await this.handleMessage(data);
+      },
+    });
+
+    wsClient.start({ eventDispatcher });
+    this.connected = true;
+    logger.info({ domain }, 'Connected to Feishu via WebSocket');
+  }
+
+  private async handleMessage(data: any): Promise<void> {
+    // SDK may pass data as {event: {message, sender}} or directly as {message, sender}
+    const msg = data?.message || data?.event?.message;
+    const sender = data?.sender || data?.event?.sender;
+    if (!msg) return;
+
+    // Skip bot's own messages
+    if (
+      sender?.sender_id?.open_id &&
+      sender.sender_id.open_id === this.botOpenId
+    )
+      return;
+
+    const chatId = msg.chat_id;
+    if (!chatId) return;
+
+    // Only handle text messages
+    if (msg.message_type !== 'text') return;
+
+    let content = '';
+    try {
+      const parsed = JSON.parse(msg.content || '{}');
+      content = parsed.text || '';
+    } catch {
+      return;
+    }
+    if (!content) return;
+
+    const chatJid = `${chatId}@feishu`;
+    const timestamp = new Date(Number(msg.create_time)).toISOString();
+    const senderName = sender?.sender_id?.open_id || 'unknown';
+
+    // Notify chat metadata
+    const isGroup = msg.chat_type === 'group';
+    this.opts.onChatMetadata(chatJid, timestamp, undefined, 'feishu', isGroup);
+
+    // Deliver message only if this chat is registered
+    const groups = this.opts.registeredGroups();
+    if (groups[chatJid]) {
+      this.opts.onMessage(chatJid, {
+        id: msg.message_id || '',
+        chat_jid: chatJid,
+        sender: sender?.sender_id?.open_id || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+        is_bot_message: false,
+      });
+    }
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const chatId = jid.replace(/@feishu$/, '');
+    const prefixed = `${ASSISTANT_NAME}: ${text}`;
+    try {
+      await this.client.im.v1.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'text',
+          content: JSON.stringify({ text: prefixed }),
+        },
+      });
+      logger.info({ jid, length: prefixed.length }, 'Feishu message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Feishu message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.endsWith('@feishu');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+}
+
+// Auto-register the channel if credentials are configured
+export function createFeishuChannel(opts: ChannelOpts): Channel | null {
+  const env = readEnvFile(['FEISHU_APP_ID', 'FEISHU_APP_SECRET']);
+  if (!env.FEISHU_APP_ID || !env.FEISHU_APP_SECRET) {
+    logger.warn(
+      { hasId: !!env.FEISHU_APP_ID, hasSecret: !!env.FEISHU_APP_SECRET },
+      'Feishu channel credentials missing — skipping',
+    );
+    return null;
+  }
+
+  try {
+    const channel = new FeishuChannel(opts);
+    logger.info('Feishu channel created successfully');
+    return channel;
+  } catch (error) {
+    logger.warn({ error }, 'Feishu channel not enabled (constructor error)');
+    return null;
+  }
+}
+
+// Self-register with the channel registry
+registerChannel('feishu', createFeishuChannel);
+```
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls src/channels/feishu.ts
+```
+
+Expected: file listed.
+
+---
+
+### Task 4: Register Feishu in the channel barrel file
+
+**Files:**
+- Modify: `src/channels/index.ts`
+
+- [ ] **Step 1: Add the feishu import**
+
+Append to `src/channels/index.ts`:
+
+```typescript
+import './feishu.js';
+```
+
+- [ ] **Step 2: Verify the import is present**
+
+```bash
+grep feishu src/channels/index.ts
+```
+
+Expected: `import './feishu.js';`
+
+---
+
+### Task 5: Update `.env.example`
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add Feishu vars**
+
+Append to `.env.example`:
+
+```env
+# Feishu / Lark channel
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+# FEISHU_PLATFORM=feishu   # 'feishu' (China, default) or 'lark' (International)
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep FEISHU .env.example
+```
+
+Expected: three lines — `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_PLATFORM` (commented).
+
+---
+
+### Task 6: Create `/add-feishu` setup skill
+
+**Files:**
+- Create: `.claude/skills/add-feishu/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p .claude/skills/add-feishu
+```
+
+- [ ] **Step 2: Write SKILL.md**
+
+Write `.claude/skills/add-feishu/SKILL.md` with this content:
+
+```markdown
+---
+name: add-feishu
+description: Add Feishu (飞书) or Lark as a channel. Supports both Feishu (China, open.feishu.cn) and Lark (International, open.larksuite.com). Uses WebSocket event subscription — no public URL required.
+---
+
+# Add Feishu / Lark Channel
+
+## Phase 1: Pre-flight
+
+Check if Feishu is already configured:
+
+```bash
+grep -q "FEISHU_APP_ID" .env 2>/dev/null && echo "Already configured" || echo "Not configured"
+```
+
+If already configured, skip to Phase 4.
+
+Ask the user: **Which platform?**
+- **Feishu (飞书, China)** — `open.feishu.cn`
+- **Lark (International)** — `open.larksuite.com`
+
+## Phase 2: Create the Feishu/Lark App
+
+Tell the user:
+
+> **Step 1 — Open the developer portal:**
+> - Feishu: https://open.feishu.cn/app
+> - Lark: https://open.larksuite.com/app
+>
+> **Step 2 — Create a custom app:**
+> - Click **创建企业自建应用** (Create Custom App)
+> - Name it (e.g. "NanoClaw Assistant")
+>
+> **Step 3 — Enable the Bot feature:**
+> - Go to **应用功能 → 机器人** and enable it
+>
+> **Step 4 — Add permissions** (权限管理):
+> - `im:message:read_basic` — read messages
+> - `im:message.receive_v1` — receive message events
+> - `im:message:send_basic` — send messages
+>
+> **Step 5 — Subscribe to events** (事件订阅):
+> - Add event: `im.message.receive_v1`
+> - Set connection mode to **长连接 (WebSocket / Long Connection)**
+>   *(No public URL needed — NanoClaw connects outbound)*
+>
+> **Step 6 — Publish a version** and wait for approval (enterprise) or self-approve (personal)
+
+Ask: **Do you have your App ID and App Secret ready?**
+
+Collect:
+- App ID (e.g. `cli_xxxxxxxxxx`)
+- App Secret (sensitive)
+
+## Phase 3: Write credentials to .env
+
+```bash
+cat >> .env << 'EOF'
+
+# Feishu / Lark channel
+FEISHU_APP_ID=<app-id>
+FEISHU_APP_SECRET=<app-secret>
+FEISHU_PLATFORM=feishu   # change to 'lark' for International
+EOF
+```
+
+Install and build:
+
+```bash
+npm install && npm run build
+```
+
+Verify build succeeds (exit 0) before continuing.
+
+## Phase 4: Register a chat
+
+Ask: **Group chat or direct message?**
+
+**For group chat:**
+1. Add the bot to the group in Feishu/Lark
+2. Get the group Chat ID — it starts with `oc_` (visible in group settings or URL)
+3. Construct the JID: `<chat_id>@feishu` (e.g. `oc_abc123@feishu`)
+
+**For direct message:**
+1. Open a DM with the bot
+2. The chat ID (JID) can be found in the startup logs after the next step — search for `onChatMetadata` with `@feishu`
+
+Register the chat:
+
+```bash
+npx tsx src/cli.ts register --jid "<chat-id>@feishu" --name "<chat-name>"
+```
+
+For the main group (no trigger required):
+
+```bash
+npx tsx src/cli.ts register --jid "<chat-id>@feishu" --name "<chat-name>" --is-main
+```
+
+## Phase 5: Restart and verify
+
+Restart the service:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux
+systemctl --user restart nanoclaw
+```
+
+Send a test message in Feishu:
+- Main/DM group: any message
+- Non-main group: use the trigger word (default: `@Andy`)
+
+Check logs if no response:
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Troubleshooting
+
+**No messages arriving:**
+- Confirm the bot has the `im:message.receive_v1` event subscription
+- Confirm connection mode is set to **Long Connection (WebSocket)** in the portal
+- Check logs for `Connected to Feishu via WebSocket`
+
+**Auth errors:**
+- Double-check App ID and App Secret in `.env`
+- Make sure the app version is published and approved
+
+**Bot sends but doesn't receive:**
+- Confirm the bot is added to the group/DM
+- Confirm `FEISHU_APP_ID` and `FEISHU_APP_SECRET` are non-empty in `.env`
+
+**Wrong platform (Feishu vs Lark):**
+- Set `FEISHU_PLATFORM=lark` in `.env` for International, `feishu` for China
+- Rebuild and restart after changing
+
+## Removal
+
+```bash
+# Remove credentials from .env (edit manually, remove FEISHU_* lines)
+# Remove registered groups
+sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE '%@feishu'"
+# Rebuild
+npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+```
+
+- [ ] **Step 3: Verify skill file exists**
+
+```bash
+ls .claude/skills/add-feishu/SKILL.md
+```
+
+Expected: file listed.
+
+---
+
+### Task 7: Build and commit
+
+- [ ] **Step 1: Run TypeScript build**
+
+```bash
+npm run build
+```
+
+Expected: exits 0, no TypeScript errors. If errors appear, fix before proceeding.
+
+- [ ] **Step 2: Commit all changes**
+
+```bash
+git add src/channels/feishu.ts src/channels/index.ts \
+        package.json package-lock.json \
+        .env.example \
+        .claude/skills/add-feishu/SKILL.md
+
+git commit -m "$(cat <<'EOF'
+feat: add Feishu/Lark channel
+
+Ports FeishuChannel from feature/network-environment-customization.
+Uses @larksuiteoapi/node-sdk WebSocket event subscription — no public
+URL required. Supports Feishu (China) and Lark (International) via
+FEISHU_PLATFORM env var. Includes /add-feishu setup skill.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit created on `feat/feishu-channel`.
+
+- [ ] **Step 3: Verify commit**
+
+```bash
+git log --oneline -3
+```
+
+Expected: top commit shows `feat: add Feishu/Lark channel`.

--- a/docs/plans/2026-03-11-feishu-channel.md
+++ b/docs/plans/2026-03-11-feishu-channel.md
@@ -1,0 +1,222 @@
+# Feishu Channel
+
+**Date:** 2026-03-11
+**Status:** Draft
+**Branch:** `feat/feishu-channel`
+**Reference:** `feature/network-environment-customization`
+
+## Problem
+
+NanoClaw supports WhatsApp, Telegram, Slack, Discord, and Gmail, but not Feishu (飞书) / Lark — the dominant enterprise messaging platform in China. Adding Feishu enables Chinese users and teams to use NanoClaw through their primary communication tool.
+
+## Goal
+
+Add Feishu as a first-class channel, following the same patterns as Slack and Discord (built into core, activated by env vars). Support both Feishu (China, `open.feishu.cn`) and Lark (International, `open.larksuite.com`) via a single env var.
+
+## Approach
+
+**Direct port from `feature/network-environment-customization`.**
+
+The reference branch contains a complete, validated Feishu implementation (`src/channels/feishu.ts`) and a setup skill (`.claude/skills/add-feishu/SKILL.md`). The work is to port these into `main`, wire up registration, add the npm dependency, and update `.env.example`.
+
+---
+
+## Architecture
+
+### How it fits into NanoClaw
+
+Feishu follows the same channel pattern as Slack and Discord:
+
+- `src/channels/feishu.ts` exports a factory function that calls `registerChannel('feishu', factory)` at module load
+- `src/channels/index.ts` imports `'./feishu.js'` to trigger registration
+- At startup, `src/index.ts` iterates registered channels, calls each factory, and skips channels whose factory returns `null` (missing credentials)
+- Inbound messages arrive via the Feishu WebSocket SDK, are parsed into `NewMessage` objects, and handed to `opts.onMessage()`
+- Outbound messages are routed via `findChannel(channels, jid)` → `channel.sendMessage(jid, text)`
+
+### Message flow
+
+```
+INBOUND:
+  Feishu WebSocket event (im.message.receive_v1)
+    → handleMessage(): filter own messages, parse JSON text, build NewMessage
+    → opts.onMessage(chatJid, msg)           // chatJid = "<chat_id>@feishu"
+    → src/index.ts stores in SQLite
+    → main loop: trigger check → container agent
+
+OUTBOUND:
+  Agent output text
+    → src/router.ts: strip <internal> tags, prefix with assistant name
+    → findChannel(channels, jid) → FeishuChannel
+    → sendMessage(): im.v1.message.create() with JSON-encoded text
+    → Feishu chat
+```
+
+---
+
+## File Changes
+
+### New: `src/channels/feishu.ts`
+
+Full channel implementation. Key details:
+
+**Class:** `FeishuChannel implements Channel`
+
+**Fields:**
+- `name = 'feishu'`
+- `client: lark.Client` — for API calls (send messages, fetch bot info)
+- `wsClient: lark.WSClient` — for receiving events via WebSocket
+- `botOpenId: string` — fetched on connect, used to filter own messages
+- `appId`, `appSecret` — from `.env` via `readEnvFile()`
+- `platform` — `'feishu'` or `'lark'`, controls SDK domain
+
+**`connect()` sequence:**
+1. Read `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_PLATFORM` from `.env`
+2. Initialise `lark.Client({ appId, appSecret, domain })` where domain is `lark.Domain.Feishu` or `lark.Domain.Lark`
+3. Fetch `/bot/v3/info` to get own `open_id` → stored as `botOpenId`
+4. Create `lark.WSClient` and `EventDispatcher` subscribed to `im.message.receive_v1`
+5. Call `wsClient.start({ eventDispatcher })` — SDK manages reconnection
+6. Set `connected = true`
+
+**`handleMessage(data)` logic:**
+1. Extract `message` and `sender` from event payload
+2. Skip if `sender.sender_id.open_id === botOpenId` (own message)
+3. Skip if `msg.message_type !== 'text'`
+4. Parse `JSON.parse(msg.content).text` for message body
+5. Build `chatJid = msg.chat_id + '@feishu'`
+6. Call `opts.onChatMetadata(chatJid, timestamp, undefined, 'feishu', isGroup)`
+7. If `opts.registeredGroups()[chatJid]` exists → call `opts.onMessage(chatJid, newMessage)`
+
+**`sendMessage(jid, text)` logic:**
+1. Strip `@feishu` suffix to get raw `chat_id`
+2. Call `this.client.im.v1.message.create()` with:
+   - `receive_id_type: 'chat_id'`
+   - `receive_id: chatId`
+   - `msg_type: 'text'`
+   - `content: JSON.stringify({ text })`
+
+**`ownsJid(jid)`:** returns `jid.endsWith('@feishu')`
+
+**Factory:**
+```typescript
+export function createFeishuChannel(opts: ChannelOpts): Channel | null {
+  const env = readEnvFile(['FEISHU_APP_ID', 'FEISHU_APP_SECRET']);
+  if (!env.FEISHU_APP_ID || !env.FEISHU_APP_SECRET) return null;
+  return new FeishuChannel(opts);
+}
+registerChannel('feishu', createFeishuChannel);
+```
+
+---
+
+### Modified: `src/channels/index.ts`
+
+Add one import line:
+
+```typescript
+import './feishu.js';
+```
+
+---
+
+### Modified: `package.json`
+
+Add dependency:
+
+```json
+"@larksuiteoapi/node-sdk": "^1.59.0"
+```
+
+---
+
+### Modified: `.env.example`
+
+```env
+# Feishu / Lark channel
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+# FEISHU_PLATFORM=feishu   # 'feishu' (China, default) or 'lark' (International)
+```
+
+---
+
+### New: `.claude/skills/add-feishu/SKILL.md`
+
+Setup skill with 5 phases:
+
+**Phase 1 — Pre-flight**
+- Check if `FEISHU_APP_ID` already set in `.env`
+- Ask: Feishu (China, `open.feishu.cn`) or Lark (International, `open.larksuite.com`)?
+
+**Phase 2 — Create app**
+- Open developer portal:
+  - Feishu: https://open.feishu.cn/app
+  - Lark: https://open.larksuite.com/app
+- Create custom app → enable Bot feature
+- Required permissions:
+  - `im:message:read_basic` — read messages
+  - `im:message.receive_v1` — receive message events
+  - `im:message:send_basic` — send messages
+- Event subscriptions → add `im.message.receive_v1`
+- Connection mode → **WebSocket (Long Connection)** (not webhook URL)
+- Publish the app version
+
+**Phase 3 — Apply credentials**
+- Collect App ID and App Secret from app credentials page
+- Write to `.env`:
+  ```
+  FEISHU_APP_ID=cli_xxxxxxxxxxxxx
+  FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  FEISHU_PLATFORM=feishu   # or lark
+  ```
+- Run `npm install && npm run build`
+
+**Phase 4 — Register a chat**
+- Ask: group chat or direct message?
+- For group: add the bot to the group, copy the chat ID (format: `oc_xxxxxx`)
+- Construct JID: `<chat_id>@feishu`
+- Run registration (same as other channels):
+  ```
+  npx tsx src/cli.ts register --jid "oc_abc123@feishu" --name "my-group"
+  ```
+
+**Phase 5 — Verify**
+- Restart the service
+- Send a message to the chat (include trigger word if non-main group)
+- Check logs: `tail -f logs/nanoclaw.log`
+- Expected: agent response in Feishu chat within a few seconds
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FEISHU_APP_ID` | Yes | — | App ID from Feishu/Lark developer portal |
+| `FEISHU_APP_SECRET` | Yes | — | App Secret (sensitive) |
+| `FEISHU_PLATFORM` | No | `feishu` | `feishu` for China, `lark` for International |
+
+---
+
+## Feishu API Reference
+
+| Aspect | Detail |
+|---|---|
+| **Event delivery** | WebSocket (Long Connection) — no public URL needed |
+| **SDK** | `@larksuiteoapi/node-sdk` — `Client`, `WSClient`, `EventDispatcher` |
+| **Event type** | `im.message.receive_v1` |
+| **Message format** | JSON-encoded: `{ "text": "..." }` |
+| **Chat ID format** | `oc_xxxxxx` (group), `ou_xxxxxx` (DM) |
+| **User ID format** | `open_id` — per-app unique user identifier |
+| **Bot identity** | Fetched via `GET /bot/v3/info` → `bot.open_id` |
+| **Send API** | `im.v1.message.create()` with `receive_id_type: chat_id` |
+| **Domains** | Feishu: `open.feishu.cn`, Lark: `open.larksuite.com` |
+
+---
+
+## Out of Scope
+
+- Rich message types (cards, images, files) — text only for now
+- Reaction support
+- Mention/at parsing
+- Thread replies
+- Network routing (claude-code-router) — separate concern

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nanoclaw",
       "version": "1.2.12",
       "dependencies": {
+        "@larksuiteoapi/node-sdk": "^1.59.0",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
         "pino": "^9.6.0",
@@ -559,11 +560,90 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
+      "integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -961,7 +1041,6 @@
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1131,6 +1210,12 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1138,6 +1223,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -1215,6 +1311,35 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1236,6 +1361,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -1282,6 +1419,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1289,6 +1435,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/end-of-stream": {
@@ -1300,12 +1460,57 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1414,6 +1619,42 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -1435,6 +1676,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1454,6 +1741,18 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1462,6 +1761,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -1580,6 +1918,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -1625,6 +1987,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -1689,6 +2081,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -1904,6 +2308,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -1912,6 +2346,21 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -2077,6 +2526,78 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2338,7 +2859,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
@@ -2522,6 +3042,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
     "pino": "^9.6.0",

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -6,7 +6,6 @@
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
-import { ASSISTANT_NAME } from '../config.js';
 import { logger } from '../logger.js';
 import { Channel } from '../types.js';
 import { readEnvFile } from '../env.js';
@@ -16,6 +15,7 @@ export class FeishuChannel implements Channel {
   name = 'feishu';
 
   private client!: lark.Client;
+  private wsClient: lark.WSClient | undefined;
   private connected = false;
   private botOpenId: string | undefined;
   private opts: ChannelOpts;
@@ -56,7 +56,7 @@ export class FeishuChannel implements Channel {
       );
     }
 
-    const wsClient = new lark.WSClient({
+    this.wsClient = new lark.WSClient({
       appId,
       appSecret,
       domain,
@@ -69,7 +69,7 @@ export class FeishuChannel implements Channel {
       },
     });
 
-    wsClient.start({ eventDispatcher });
+    this.wsClient.start({ eventDispatcher });
     this.connected = true;
     logger.info({ domain }, 'Connected to Feishu via WebSocket');
   }
@@ -128,17 +128,16 @@ export class FeishuChannel implements Channel {
 
   async sendMessage(jid: string, text: string): Promise<void> {
     const chatId = jid.replace(/@feishu$/, '');
-    const prefixed = `${ASSISTANT_NAME}: ${text}`;
     try {
       await this.client.im.v1.message.create({
         params: { receive_id_type: 'chat_id' },
         data: {
           receive_id: chatId,
           msg_type: 'text',
-          content: JSON.stringify({ text: prefixed }),
+          content: JSON.stringify({ text }),
         },
       });
-      logger.info({ jid, length: prefixed.length }, 'Feishu message sent');
+      logger.info({ jid, length: text.length }, 'Feishu message sent');
     } catch (err) {
       logger.error({ jid, err }, 'Failed to send Feishu message');
     }
@@ -153,6 +152,7 @@ export class FeishuChannel implements Channel {
   }
 
   async disconnect(): Promise<void> {
+    this.wsClient?.close?.();
     this.connected = false;
   }
 }

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -1,0 +1,182 @@
+/**
+ * Feishu (Lark) Channel for NanoClaw
+ * Supports both Feishu (China) and Lark (International) platforms
+ *
+ * Uses official @larksuiteoapi/node-sdk for WebSocket event handling
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { ASSISTANT_NAME } from '../config.js';
+import { logger } from '../logger.js';
+import { Channel } from '../types.js';
+import { readEnvFile } from '../env.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+
+export class FeishuChannel implements Channel {
+  name = 'feishu';
+
+  private client!: lark.Client;
+  private connected = false;
+  private botOpenId: string | undefined;
+  private opts: ChannelOpts;
+  private appId: string;
+  private appSecret: string;
+  private domain: lark.Domain;
+
+  constructor(opts: ChannelOpts) {
+    this.opts = opts;
+    const env = readEnvFile([
+      'FEISHU_APP_ID',
+      'FEISHU_APP_SECRET',
+      'FEISHU_PLATFORM',
+    ]);
+    this.appId = env.FEISHU_APP_ID || '';
+    this.appSecret = env.FEISHU_APP_SECRET || '';
+    this.domain =
+      env.FEISHU_PLATFORM === 'lark' ? lark.Domain.Lark : lark.Domain.Feishu;
+  }
+
+  async connect(): Promise<void> {
+    const { appId, appSecret, domain } = this;
+
+    this.client = new lark.Client({ appId, appSecret, domain });
+
+    // Fetch bot's own open_id so we can detect our own messages
+    try {
+      const resp = await this.client.request({
+        method: 'GET',
+        url: 'https://open.feishu.cn/open-apis/bot/v3/info',
+      });
+      this.botOpenId = (resp as any)?.bot?.open_id;
+      logger.info({ botOpenId: this.botOpenId }, 'Feishu bot info fetched');
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Failed to fetch Feishu bot info, bot message detection may not work',
+      );
+    }
+
+    const wsClient = new lark.WSClient({
+      appId,
+      appSecret,
+      domain,
+      loggerLevel: lark.LoggerLevel.warn,
+    });
+
+    const eventDispatcher = new lark.EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: any) => {
+        await this.handleMessage(data);
+      },
+    });
+
+    wsClient.start({ eventDispatcher });
+    this.connected = true;
+    logger.info({ domain }, 'Connected to Feishu via WebSocket');
+  }
+
+  private async handleMessage(data: any): Promise<void> {
+    // SDK may pass data as {event: {message, sender}} or directly as {message, sender}
+    const msg = data?.message || data?.event?.message;
+    const sender = data?.sender || data?.event?.sender;
+    if (!msg) return;
+
+    // Skip bot's own messages
+    if (
+      sender?.sender_id?.open_id &&
+      sender.sender_id.open_id === this.botOpenId
+    )
+      return;
+
+    const chatId = msg.chat_id;
+    if (!chatId) return;
+
+    // Only handle text messages
+    if (msg.message_type !== 'text') return;
+
+    let content = '';
+    try {
+      const parsed = JSON.parse(msg.content || '{}');
+      content = parsed.text || '';
+    } catch {
+      return;
+    }
+    if (!content) return;
+
+    const chatJid = `${chatId}@feishu`;
+    const timestamp = new Date(Number(msg.create_time)).toISOString();
+    const senderName = sender?.sender_id?.open_id || 'unknown';
+
+    // Notify chat metadata
+    const isGroup = msg.chat_type === 'group';
+    this.opts.onChatMetadata(chatJid, timestamp, undefined, 'feishu', isGroup);
+
+    // Deliver message only if this chat is registered
+    const groups = this.opts.registeredGroups();
+    if (groups[chatJid]) {
+      this.opts.onMessage(chatJid, {
+        id: msg.message_id || '',
+        chat_jid: chatJid,
+        sender: sender?.sender_id?.open_id || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+        is_bot_message: false,
+      });
+    }
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const chatId = jid.replace(/@feishu$/, '');
+    const prefixed = `${ASSISTANT_NAME}: ${text}`;
+    try {
+      await this.client.im.v1.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'text',
+          content: JSON.stringify({ text: prefixed }),
+        },
+      });
+      logger.info({ jid, length: prefixed.length }, 'Feishu message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Feishu message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.endsWith('@feishu');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+}
+
+// Auto-register the channel if credentials are configured
+export function createFeishuChannel(opts: ChannelOpts): Channel | null {
+  const env = readEnvFile(['FEISHU_APP_ID', 'FEISHU_APP_SECRET']);
+  if (!env.FEISHU_APP_ID || !env.FEISHU_APP_SECRET) {
+    logger.warn(
+      { hasId: !!env.FEISHU_APP_ID, hasSecret: !!env.FEISHU_APP_SECRET },
+      'Feishu channel credentials missing — skipping',
+    );
+    return null;
+  }
+
+  try {
+    const channel = new FeishuChannel(opts);
+    logger.info('Feishu channel created successfully');
+    return channel;
+  } catch (error) {
+    logger.warn({ error }, 'Feishu channel not enabled (constructor error)');
+    return null;
+  }
+}
+
+// Self-register with the channel registry
+registerChannel('feishu', createFeishuChannel);

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -10,3 +10,5 @@
 // telegram
 
 // whatsapp
+
+import './feishu.js';

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,11 @@ import { readEnvFile } from './env.js';
 // Read config values from .env (falls back to process.env).
 // Secrets (API keys, tokens) are NOT read here — they are loaded only
 // by the credential proxy (credential-proxy.ts), never exposed to containers.
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'CREDENTIAL_PROXY_PORT',
+]);
 
 export const ASSISTANT_NAME =
   process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
@@ -48,7 +52,7 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
   10,
 ); // 10MB default
 export const CREDENTIAL_PROXY_PORT = parseInt(
-  process.env.CREDENTIAL_PROXY_PORT || '3001',
+  process.env.CREDENTIAL_PROXY_PORT || envConfig.CREDENTIAL_PROXY_PORT || '3001',
   10,
 );
 export const IPC_POLL_INTERVAL = 1000;


### PR DESCRIPTION
## Summary

- Adds Feishu (飞书) / Lark as a built-in channel using `@larksuiteoapi/node-sdk` WebSocket event subscription — no public URL required
- Supports both Feishu (China, `open.feishu.cn`) and Lark (International) via `FEISHU_PLATFORM` env var
- `CREDENTIAL_PROXY_PORT` is now configurable from `.env` (previously only from `process.env`), useful when another service occupies port 3001
- Switches default npm mirror from npmmirror.com to Huawei Cloud for better large-package download speed
- Includes `/add-feishu` setup skill

## Test plan

- [ ] Set `FEISHU_APP_ID` and `FEISHU_APP_SECRET` in `.env`, restart — Feishu channel connects via WebSocket
- [ ] Send a message to a registered Feishu DM or group chat — agent responds
- [ ] Set `FEISHU_PLATFORM=lark` — verify Lark (International) domain is used
- [ ] Set `CREDENTIAL_PROXY_PORT=3002` in `.env` — verify proxy starts on port 3002
- [ ] Run `/add-feishu` skill — verify setup instructions are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)