### PR TITLE
fix(oauth): fix token refresh locking and add in-memory cache

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -16,6 +16,7 @@ import { request as httpRequest, RequestOptions } from 'http';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
+import { getFreshOAuthToken } from './oauth-token.js';
 
 export type AuthMode = 'api-key' | 'oauth';
 
@@ -45,10 +46,10 @@ export function startCredentialProxy(
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
   return new Promise((resolve, reject) => {
-    const server = createServer((req, res) => {
+    const server = createServer(async (req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
-      req.on('end', () => {
+      req.on('end', async () => {
         const body = Buffer.concat(chunks);
         const headers: Record<string, string | number | string[] | undefined> =
           {
@@ -67,14 +68,13 @@ export function startCredentialProxy(
           delete headers['x-api-key'];
           headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
         } else {
-          // OAuth mode: replace placeholder Bearer token with the real one
-          // only when the container actually sends an Authorization header
-          // (exchange request + auth probes). Post-exchange requests use
-          // x-api-key only, so they pass through without token injection.
+          // OAuth mode: replace placeholder Bearer token with fresh token
+          // Fetch from credentials file on each request (auto-refreshes if expired)
           if (headers['authorization']) {
+            const freshToken = await getFreshOAuthToken();
             delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
+            if (freshToken) {
+              headers['authorization'] = `Bearer ${freshToken}`;
             }
           }
         }

--- a/src/oauth-token.ts
+++ b/src/oauth-token.ts
@@ -1,0 +1,164 @@
+/**
+ * OAuth token management for Claude Code credentials.
+ *
+ * Reads OAuth tokens from ~/.claude/.credentials.json and automatically
+ * refreshes them when expired.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { request as httpsRequest } from 'https';
+
+import { logger } from './logger.js';
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    scopes: string[];
+    subscriptionType: string | null;
+  };
+}
+
+const CREDENTIALS_FILE = path.join(os.homedir(), '.claude', '.credentials.json');
+const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+
+/**
+ * Get a fresh OAuth access token, refreshing if necessary.
+ *
+ * Reads from ~/.claude/.credentials.json:
+ * - If token is expired (> 5 min buffer), refresh using refresh_token
+ * - If refresh fails, falls back to .env value
+ * - If API key mode (ANTHROPIC_API_KEY set), returns null
+ *
+ * @returns Fresh OAuth access token, or null if using API key mode
+ */
+export async function getFreshOAuthToken(): Promise<string | null> {
+  // If using API key mode, skip OAuth entirely
+  if (process.env.ANTHROPIC_API_KEY) {
+    return null;
+  }
+
+  // Try to read from credentials file
+  let credentials: ClaudeCredentials;
+  try {
+    const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+    credentials = JSON.parse(content);
+  } catch (err) {
+    logger.debug({ err }, 'Credentials file not readable, falling back to .env');
+    return getEnvToken();
+  }
+
+  const oauth = credentials.claudeAiOauth;
+  if (!oauth) {
+    logger.debug('No OAuth credentials found in credentials file');
+    return getEnvToken();
+  }
+
+  // Check if token is expired (with 5 minute buffer)
+  const now = Date.now();
+  const expiresAt = oauth.expiresAt;
+  const buffer = 5 * 60 * 1000; // 5 minutes
+
+  if (expiresAt > now + buffer) {
+    // Token is still valid
+    return oauth.accessToken;
+  }
+
+  // Token is expired, refresh it
+  logger.info('OAuth token expired, refreshing...');
+  try {
+    const newToken = await refreshOAuthToken(oauth.refreshToken);
+
+    // Update credentials file with new token
+    credentials.claudeAiOauth = {
+      ...oauth,
+      accessToken: newToken.accessToken,
+      expiresAt: newToken.expiresAt,
+    };
+
+    fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(credentials, null, 2));
+    logger.info('OAuth token refreshed successfully');
+
+    return newToken.accessToken;
+  } catch (err) {
+    logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
+    return getEnvToken();
+  }
+}
+
+interface RefreshResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  expires_at?: number;
+}
+
+/**
+ * Refresh OAuth token using the refresh token.
+ */
+async function refreshOAuthToken(refreshToken: string): Promise<{
+  accessToken: string;
+  expiresAt: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const postData = JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+
+    const options = {
+      hostname: 'platform.claude.com',
+      port: 443,
+      path: '/v1/oauth/token',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(postData),
+      },
+    };
+
+    const req = httpsRequest(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`OAuth refresh failed: ${res.statusCode} ${data}`));
+          return;
+        }
+
+        try {
+          const response: RefreshResponse = JSON.parse(data);
+          resolve({
+            accessToken: response.access_token,
+            expiresAt: response.expires_at || Date.now() + response.expires_in * 1000,
+          });
+        } catch (err) {
+          reject(new Error(`Failed to parse OAuth response: ${err}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+/**
+ * Fallback to .env token if credentials file is unavailable.
+ */
+function getEnvToken(): string | null {
+  // Fall back to .env value (this is the current behavior)
+  const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN;
+  if (envToken) {
+    logger.debug('Using OAuth token from .env (may be expired)');
+    return envToken;
+  }
+  return null;
+}

--- a/src/oauth-token.ts
+++ b/src/oauth-token.ts
@@ -4,8 +4,8 @@
  * Reads OAuth tokens from ~/.claude/.credentials.json and automatically
  * refreshes them when expired.
  *
- * Thread-safety: Uses in-memory locking to prevent concurrent refreshes.
- * File writes are atomic (write temp + rename) to prevent corruption.
+ * Thread-safety: All calls are serialized through a promise chain so only
+ * one refresh can run at a time. File writes are atomic (write temp + rename).
  */
 import fs from 'fs';
 import os from 'os';
@@ -25,32 +25,36 @@ interface ClaudeCredentials {
 }
 
 const CREDENTIALS_FILE = path.join(os.homedir(), '.claude', '.credentials.json');
-const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const BUFFER = 5 * 60 * 1000; // 5 minutes
 
-// In-memory lock to prevent concurrent refresh operations
-let refreshLock: Promise<unknown> = Promise.resolve();
+// All calls chain onto this promise — serializes concurrent refresh operations.
+let refreshLock: Promise<string | null> = Promise.resolve(null);
 
 /**
  * Get a fresh OAuth access token, refreshing if necessary.
  *
  * Reads from ~/.claude/.credentials.json:
- * - If token is expired (> 5 min buffer), refresh using refresh_token
- * - If refresh fails, falls back to .env value
+ * - If token is valid (> 5 min remaining), return it
+ * - If token is expired, refresh using refresh_token
+ * - If refresh fails or file is missing, falls back to .env value
  * - If API key mode (ANTHROPIC_API_KEY set), returns null
  *
- * Thread-safe: Multiple concurrent calls will wait for an in-progress
- * refresh rather than triggering multiple refresh operations.
+ * Thread-safe: All concurrent calls are serialized so only one refresh
+ * can run at a time.
  *
  * @returns Fresh OAuth access token, or null if using API key mode
  */
-export async function getFreshOAuthToken(): Promise<string | null> {
+export function getFreshOAuthToken(): Promise<string | null> {
+  // Always chain — guarantees only one _doGetToken runs at a time
+  refreshLock = refreshLock.then(_doGetToken);
+  return refreshLock;
+}
+
+async function _doGetToken(): Promise<string | null> {
   // If using API key mode, skip OAuth entirely
   if (process.env.ANTHROPIC_API_KEY) {
     return null;
   }
-
-  // Wait for any in-progress refresh, then start our own lock
-  await refreshLock;
 
   // Try to read from credentials file
   let credentials: ClaudeCredentials;
@@ -68,53 +72,40 @@ export async function getFreshOAuthToken(): Promise<string | null> {
     return getEnvToken();
   }
 
-  // Check if token is expired (with 5 minute buffer)
-  const now = Date.now();
-  const expiresAt = oauth.expiresAt;
-  const buffer = 5 * 60 * 1000; // 5 minutes
-
-  if (expiresAt > now + buffer) {
-    // Token is still valid
+  // Token is still valid
+  if (oauth.expiresAt > Date.now() + BUFFER) {
     return oauth.accessToken;
   }
 
-  // Token is expired, refresh it with locking
+  // Token is expired — refresh it
   logger.info('OAuth token expired, refreshing...');
+  try {
+    const newToken = await refreshOAuthToken(oauth.refreshToken);
 
-  // Create a new lock for this refresh operation
-  refreshLock = (async () => {
+    // Re-read credentials file before writing to handle external updates
+    let updatedCredentials: ClaudeCredentials;
     try {
-      const newToken = await refreshOAuthToken(oauth.refreshToken);
-
-      // Re-read credentials file in case another process updated it
-      let updatedCredentials: ClaudeCredentials;
-      try {
-        const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
-        updatedCredentials = JSON.parse(content);
-      } catch {
-        // If read fails, use in-memory credentials
-        updatedCredentials = credentials;
-      }
-
-      // Update with new token
-      updatedCredentials.claudeAiOauth = {
-        ...updatedCredentials.claudeAiOauth!,
-        accessToken: newToken.accessToken,
-        expiresAt: newToken.expiresAt,
-      };
-
-      // Atomic write: write to temp file, then rename
-      writeCredentialsAtomic(updatedCredentials);
-      logger.info('OAuth token refreshed successfully');
-
-      return newToken.accessToken;
-    } catch (err) {
-      logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
-      return getEnvToken();
+      const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+      updatedCredentials = JSON.parse(content);
+    } catch {
+      updatedCredentials = credentials;
     }
-  })();
 
-  return refreshLock as Promise<string | null>;
+    updatedCredentials.claudeAiOauth = {
+      ...updatedCredentials.claudeAiOauth!,
+      accessToken: newToken.accessToken,
+      expiresAt: newToken.expiresAt,
+      // Persist rotated refresh token if the server returned one
+      ...(newToken.refreshToken && { refreshToken: newToken.refreshToken }),
+    };
+
+    writeCredentialsAtomic(updatedCredentials);
+    logger.info('OAuth token refreshed successfully');
+    return newToken.accessToken;
+  } catch (err) {
+    logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
+    return getEnvToken();
+  }
 }
 
 interface RefreshResponse {
@@ -129,6 +120,7 @@ interface RefreshResponse {
  */
 async function refreshOAuthToken(refreshToken: string): Promise<{
   accessToken: string;
+  refreshToken?: string;
   expiresAt: number;
 }> {
   return new Promise((resolve, reject) => {
@@ -137,41 +129,38 @@ async function refreshOAuthToken(refreshToken: string): Promise<{
       refresh_token: refreshToken,
     });
 
-    const options = {
-      hostname: 'platform.claude.com',
-      port: 443,
-      path: '/v1/oauth/token',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(postData),
+    const req = httpsRequest(
+      {
+        hostname: 'platform.claude.com',
+        port: 443,
+        path: '/v1/oauth/token',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(postData),
+        },
       },
-    };
-
-    const req = httpsRequest(options, (res) => {
-      let data = '';
-
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
-
-      res.on('end', () => {
-        if (res.statusCode !== 200) {
-          reject(new Error(`OAuth refresh failed: ${res.statusCode} ${data}`));
-          return;
-        }
-
-        try {
-          const response: RefreshResponse = JSON.parse(data);
-          resolve({
-            accessToken: response.access_token,
-            expiresAt: response.expires_at || Date.now() + response.expires_in * 1000,
-          });
-        } catch (err) {
-          reject(new Error(`Failed to parse OAuth response: ${err}`));
-        }
-      });
-    });
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`OAuth refresh failed: ${res.statusCode} ${data}`));
+            return;
+          }
+          try {
+            const response: RefreshResponse = JSON.parse(data);
+            resolve({
+              accessToken: response.access_token,
+              refreshToken: response.refresh_token,
+              expiresAt: response.expires_at ?? Date.now() + response.expires_in * 1000,
+            });
+          } catch (err) {
+            reject(new Error(`Failed to parse OAuth response: ${err}`));
+          }
+        });
+      },
+    );
 
     req.on('error', reject);
     req.write(postData);
@@ -181,26 +170,16 @@ async function refreshOAuthToken(refreshToken: string): Promise<{
 
 /**
  * Write credentials file atomically to prevent corruption.
- *
- * Writes to a temporary file, then renames over the target.
- * On POSIX systems, rename is atomic.
+ * Writes to a temp file then renames — atomic on POSIX systems.
  */
 function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
-  const tempFile = CREDENTIALS_FILE + '.tmp.' + Date.now();
+  const tempFile = `${CREDENTIALS_FILE}.tmp.${Date.now()}`;
   const content = JSON.stringify(credentials, null, 2);
-
   try {
-    // Write to temp file
     fs.writeFileSync(tempFile, content, 'utf-8');
-    // Atomic rename
     fs.renameSync(tempFile, CREDENTIALS_FILE);
   } catch (err) {
-    // Clean up temp file on error
-    try {
-      if (fs.existsSync(tempFile)) {
-        fs.unlinkSync(tempFile);
-      }
-    } catch {}
+    try { fs.unlinkSync(tempFile); } catch {}
     throw err;
   }
 }
@@ -209,7 +188,6 @@ function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
  * Fallback to .env token if credentials file is unavailable.
  */
 function getEnvToken(): string | null {
-  // Fall back to .env value (this is the current behavior)
   const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN;
   if (envToken) {
     logger.debug('Using OAuth token from .env (may be expired)');

--- a/src/oauth-token.ts
+++ b/src/oauth-token.ts
@@ -3,6 +3,9 @@
  *
  * Reads OAuth tokens from ~/.claude/.credentials.json and automatically
  * refreshes them when expired.
+ *
+ * Thread-safety: Uses in-memory locking to prevent concurrent refreshes.
+ * File writes are atomic (write temp + rename) to prevent corruption.
  */
 import fs from 'fs';
 import os from 'os';
@@ -24,6 +27,9 @@ interface ClaudeCredentials {
 const CREDENTIALS_FILE = path.join(os.homedir(), '.claude', '.credentials.json');
 const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 
+// In-memory lock to prevent concurrent refresh operations
+let refreshLock: Promise<unknown> = Promise.resolve();
+
 /**
  * Get a fresh OAuth access token, refreshing if necessary.
  *
@@ -32,6 +38,9 @@ const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
  * - If refresh fails, falls back to .env value
  * - If API key mode (ANTHROPIC_API_KEY set), returns null
  *
+ * Thread-safe: Multiple concurrent calls will wait for an in-progress
+ * refresh rather than triggering multiple refresh operations.
+ *
  * @returns Fresh OAuth access token, or null if using API key mode
  */
 export async function getFreshOAuthToken(): Promise<string | null> {
@@ -39,6 +48,9 @@ export async function getFreshOAuthToken(): Promise<string | null> {
   if (process.env.ANTHROPIC_API_KEY) {
     return null;
   }
+
+  // Wait for any in-progress refresh, then start our own lock
+  await refreshLock;
 
   // Try to read from credentials file
   let credentials: ClaudeCredentials;
@@ -66,26 +78,43 @@ export async function getFreshOAuthToken(): Promise<string | null> {
     return oauth.accessToken;
   }
 
-  // Token is expired, refresh it
+  // Token is expired, refresh it with locking
   logger.info('OAuth token expired, refreshing...');
-  try {
-    const newToken = await refreshOAuthToken(oauth.refreshToken);
 
-    // Update credentials file with new token
-    credentials.claudeAiOauth = {
-      ...oauth,
-      accessToken: newToken.accessToken,
-      expiresAt: newToken.expiresAt,
-    };
+  // Create a new lock for this refresh operation
+  refreshLock = (async () => {
+    try {
+      const newToken = await refreshOAuthToken(oauth.refreshToken);
 
-    fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(credentials, null, 2));
-    logger.info('OAuth token refreshed successfully');
+      // Re-read credentials file in case another process updated it
+      let updatedCredentials: ClaudeCredentials;
+      try {
+        const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+        updatedCredentials = JSON.parse(content);
+      } catch {
+        // If read fails, use in-memory credentials
+        updatedCredentials = credentials;
+      }
 
-    return newToken.accessToken;
-  } catch (err) {
-    logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
-    return getEnvToken();
-  }
+      // Update with new token
+      updatedCredentials.claudeAiOauth = {
+        ...updatedCredentials.claudeAiOauth!,
+        accessToken: newToken.accessToken,
+        expiresAt: newToken.expiresAt,
+      };
+
+      // Atomic write: write to temp file, then rename
+      writeCredentialsAtomic(updatedCredentials);
+      logger.info('OAuth token refreshed successfully');
+
+      return newToken.accessToken;
+    } catch (err) {
+      logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
+      return getEnvToken();
+    }
+  })();
+
+  return refreshLock as Promise<string | null>;
 }
 
 interface RefreshResponse {
@@ -148,6 +177,32 @@ async function refreshOAuthToken(refreshToken: string): Promise<{
     req.write(postData);
     req.end();
   });
+}
+
+/**
+ * Write credentials file atomically to prevent corruption.
+ *
+ * Writes to a temporary file, then renames over the target.
+ * On POSIX systems, rename is atomic.
+ */
+function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
+  const tempFile = CREDENTIALS_FILE + '.tmp.' + Date.now();
+  const content = JSON.stringify(credentials, null, 2);
+
+  try {
+    // Write to temp file
+    fs.writeFileSync(tempFile, content, 'utf-8');
+    // Atomic rename
+    fs.renameSync(tempFile, CREDENTIALS_FILE);
+  } catch (err) {
+    // Clean up temp file on error
+    try {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    } catch {}
+    throw err;
+  }
 }
 
 /**

--- a/src/oauth-token.ts
+++ b/src/oauth-token.ts
@@ -24,8 +24,17 @@ interface ClaudeCredentials {
   };
 }
 
-const CREDENTIALS_FILE = path.join(os.homedir(), '.claude', '.credentials.json');
+const CREDENTIALS_FILE = path.join(
+  os.homedir(),
+  '.claude',
+  '.credentials.json',
+);
 const BUFFER = 5 * 60 * 1000; // 5 minutes
+
+// In-memory cache — avoids reading the file on every proxy request.
+// Populated after each successful token read or refresh.
+// Cleared when the cached token approaches expiry so the file is re-read.
+let tokenCache: { token: string; expiresAt: number } | null = null;
 
 // All calls chain onto this promise — serializes concurrent refresh operations.
 let refreshLock: Promise<string | null> = Promise.resolve(null);
@@ -56,13 +65,21 @@ async function _doGetToken(): Promise<string | null> {
     return null;
   }
 
-  // Try to read from credentials file
+  // Return cached token if still valid
+  if (tokenCache && tokenCache.expiresAt > Date.now() + BUFFER) {
+    return tokenCache.token;
+  }
+
+  // Cache is stale — read from credentials file
   let credentials: ClaudeCredentials;
   try {
     const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
     credentials = JSON.parse(content);
   } catch (err) {
-    logger.debug({ err }, 'Credentials file not readable, falling back to .env');
+    logger.debug(
+      { err },
+      'Credentials file not readable, falling back to .env',
+    );
     return getEnvToken();
   }
 
@@ -72,8 +89,9 @@ async function _doGetToken(): Promise<string | null> {
     return getEnvToken();
   }
 
-  // Token is still valid
+  // Token is still valid — cache and return
   if (oauth.expiresAt > Date.now() + BUFFER) {
+    tokenCache = { token: oauth.accessToken, expiresAt: oauth.expiresAt };
     return oauth.accessToken;
   }
 
@@ -100,10 +118,14 @@ async function _doGetToken(): Promise<string | null> {
     };
 
     writeCredentialsAtomic(updatedCredentials);
+    tokenCache = { token: newToken.accessToken, expiresAt: newToken.expiresAt };
     logger.info('OAuth token refreshed successfully');
     return newToken.accessToken;
   } catch (err) {
-    logger.error({ err }, 'Failed to refresh OAuth token, falling back to .env');
+    logger.error(
+      { err },
+      'Failed to refresh OAuth token, falling back to .env',
+    );
     return getEnvToken();
   }
 }
@@ -142,10 +164,14 @@ async function refreshOAuthToken(refreshToken: string): Promise<{
       },
       (res) => {
         let data = '';
-        res.on('data', (chunk) => { data += chunk; });
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
         res.on('end', () => {
           if (res.statusCode !== 200) {
-            reject(new Error(`OAuth refresh failed: ${res.statusCode} ${data}`));
+            reject(
+              new Error(`OAuth refresh failed: ${res.statusCode} ${data}`),
+            );
             return;
           }
           try {
@@ -153,7 +179,8 @@ async function refreshOAuthToken(refreshToken: string): Promise<{
             resolve({
               accessToken: response.access_token,
               refreshToken: response.refresh_token,
-              expiresAt: response.expires_at ?? Date.now() + response.expires_in * 1000,
+              expiresAt:
+                response.expires_at ?? Date.now() + response.expires_in * 1000,
             });
           } catch (err) {
             reject(new Error(`Failed to parse OAuth response: ${err}`));
@@ -179,7 +206,9 @@ function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
     fs.writeFileSync(tempFile, content, 'utf-8');
     fs.renameSync(tempFile, CREDENTIALS_FILE);
   } catch (err) {
-    try { fs.unlinkSync(tempFile); } catch {}
+    try {
+      fs.unlinkSync(tempFile);
+    } catch {}
     throw err;
   }
 }
@@ -188,7 +217,8 @@ function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
  * Fallback to .env token if credentials file is unavailable.
  */
 function getEnvToken(): string | null {
-  const envToken = process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN;
+  const envToken =
+    process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN;
   if (envToken) {
     logger.debug('Using OAuth token from .env (may be expired)');
     return envToken;


### PR DESCRIPTION
## Summary

Builds on #930 (cherry-picked) with two additional fixes found during local testing.

## Changes on top of #930

**Fix 1: Correct the locking pattern**

The original lock used `await refreshLock` then reassigned `refreshLock` inside the expiry branch. Two concurrent callers could both pass the `await`, both see an expired token, and both attempt to use the same (single-use) refresh token.

Fix: always chain onto the lock so all calls are fully serialized:
```ts
// Before — broken: concurrent callers both pass the await, both refresh
let refreshLock: Promise<unknown> = Promise.resolve();
await refreshLock;
// ... check expiry, maybe reassign refreshLock ...

// After — correct: every call queues behind the previous one
let refreshLock: Promise<string | null> = Promise.resolve(null);
refreshLock = refreshLock.then(_doGetToken);
return refreshLock;
```

Also persists a rotated `refresh_token` from the server response if one is returned (some OAuth servers rotate on each use).

**Fix 2: In-memory token cache**

The original reads `~/.claude/.credentials.json` on every proxy request (one per API call). With the lock fix in place, those reads are now serialized, so high-concurrency bursts would queue unnecessarily.

Fix: cache `{ token, expiresAt }` in memory after each successful read or refresh. The file is only read again once the cached token is within 5 minutes of expiry — same buffer as before.

## Tested

Verified locally: NanoClaw picks up a fresh token from `~/.claude/.credentials.json` on startup, serves from cache on subsequent requests, and the 401 errors on token expiry are resolved.

Closes #730