### PR TITLE
feat: support multiple instances on the same machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npm run build        # Compile TypeScript
 ./container/build.sh # Rebuild agent container
 ```
 
-Service management:
+Service management (replace `nanoclaw` with `nanoclaw-<instance>` for named instances):
 ```bash
 # macOS (launchd)
 launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
@@ -53,6 +53,20 @@ launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # restart
 systemctl --user start nanoclaw
 systemctl --user stop nanoclaw
 systemctl --user restart nanoclaw
+```
+
+## Multi-Instance
+
+Set `NANOCLAW_INSTANCE` in `.env` to run multiple instances on one machine. Each instance needs its own project directory and unique instance name. The instance name scopes service names, container prefixes, and orphan cleanup.
+
+```bash
+# Instance A (.env)
+NANOCLAW_INSTANCE=work
+CREDENTIAL_PROXY_PORT=3001
+
+# Instance B (.env)
+NANOCLAW_INSTANCE=personal
+CREDENTIAL_PROXY_PORT=3002
 ```
 
 ## Troubleshooting

--- a/launchd/com.nanoclaw.plist
+++ b/launchd/com.nanoclaw.plist
@@ -2,6 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- For named instances, label becomes com.nanoclaw-{instance} -->
     <key>Label</key>
     <string>com.nanoclaw</string>
     <key>ProgramArguments</key>

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { INSTANCE_NAME } from '../src/config.js';
 import { logger } from '../src/logger.js';
 import {
   getPlatform,
@@ -19,6 +20,14 @@ import {
   isWSL,
 } from './platform.js';
 import { emitStatus } from './status.js';
+
+// Service and file names scoped by instance to allow multi-instance deployments
+const SERVICE_LABEL = INSTANCE_NAME
+  ? `com.nanoclaw-${INSTANCE_NAME}`
+  : 'com.nanoclaw';
+const SYSTEMD_SERVICE_NAME = INSTANCE_NAME
+  ? `nanoclaw-${INSTANCE_NAME}`
+  : 'nanoclaw';
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -77,7 +86,7 @@ function setupLaunchd(
     homeDir,
     'Library',
     'LaunchAgents',
-    'com.nanoclaw.plist',
+    `${SERVICE_LABEL}.plist`,
   );
   fs.mkdirSync(path.dirname(plistPath), { recursive: true });
 
@@ -86,7 +95,7 @@ function setupLaunchd(
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.nanoclaw</string>
+    <string>${SERVICE_LABEL}</string>
     <key>ProgramArguments</key>
     <array>
         <string>${nodePath}</string>
@@ -103,12 +112,14 @@ function setupLaunchd(
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
-        <string>${homeDir}</string>
+        <string>${homeDir}</string>${INSTANCE_NAME ? `
+        <key>NANOCLAW_INSTANCE</key>
+        <string>${INSTANCE_NAME}</string>` : ''}
     </dict>
     <key>StandardOutPath</key>
-    <string>${projectRoot}/logs/nanoclaw.log</string>
+    <string>${projectRoot}/logs/${SERVICE_LABEL.replace('com.', '')}.log</string>
     <key>StandardErrorPath</key>
-    <string>${projectRoot}/logs/nanoclaw.error.log</string>
+    <string>${projectRoot}/logs/${SERVICE_LABEL.replace('com.', '')}.error.log</string>
 </dict>
 </plist>`;
 
@@ -128,7 +139,7 @@ function setupLaunchd(
   let serviceLoaded = false;
   try {
     const output = execSync('launchctl list', { encoding: 'utf-8' });
-    serviceLoaded = output.includes('com.nanoclaw');
+    serviceLoaded = output.includes(SERVICE_LABEL);
   } catch {
     // launchctl list failed
   }
@@ -213,7 +224,7 @@ function setupSystemd(
   let systemctlPrefix: string;
 
   if (runningAsRoot) {
-    unitPath = '/etc/systemd/system/nanoclaw.service';
+    unitPath = `/etc/systemd/system/${SYSTEMD_SERVICE_NAME}.service`;
     systemctlPrefix = 'systemctl';
     logger.info('Running as root — installing system-level systemd unit');
   } else {
@@ -229,12 +240,12 @@ function setupSystemd(
     }
     const unitDir = path.join(homeDir, '.config', 'systemd', 'user');
     fs.mkdirSync(unitDir, { recursive: true });
-    unitPath = path.join(unitDir, 'nanoclaw.service');
+    unitPath = path.join(unitDir, `${SYSTEMD_SERVICE_NAME}.service`);
     systemctlPrefix = 'systemctl --user';
   }
 
   const unit = `[Unit]
-Description=NanoClaw Personal Assistant
+Description=NanoClaw Personal Assistant${INSTANCE_NAME ? ` (${INSTANCE_NAME})` : ''}
 After=network.target
 
 [Service]
@@ -244,9 +255,9 @@ WorkingDirectory=${projectRoot}
 Restart=always
 RestartSec=5
 Environment=HOME=${homeDir}
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
-StandardOutput=append:${projectRoot}/logs/nanoclaw.log
-StandardError=append:${projectRoot}/logs/nanoclaw.error.log
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin${INSTANCE_NAME ? `\nEnvironment=NANOCLAW_INSTANCE=${INSTANCE_NAME}` : ''}
+StandardOutput=append:${projectRoot}/logs/${SYSTEMD_SERVICE_NAME}.log
+StandardError=append:${projectRoot}/logs/${SYSTEMD_SERVICE_NAME}.error.log
 
 [Install]
 WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
@@ -273,13 +284,13 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   }
 
   try {
-    execSync(`${systemctlPrefix} enable nanoclaw`, { stdio: 'ignore' });
+    execSync(`${systemctlPrefix} enable ${SYSTEMD_SERVICE_NAME}`, { stdio: 'ignore' });
   } catch (err) {
     logger.error({ err }, 'systemctl enable failed');
   }
 
   try {
-    execSync(`${systemctlPrefix} start nanoclaw`, { stdio: 'ignore' });
+    execSync(`${systemctlPrefix} start ${SYSTEMD_SERVICE_NAME}`, { stdio: 'ignore' });
   } catch (err) {
     logger.error({ err }, 'systemctl start failed');
   }
@@ -287,7 +298,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   // Verify
   let serviceLoaded = false;
   try {
-    execSync(`${systemctlPrefix} is-active nanoclaw`, { stdio: 'ignore' });
+    execSync(`${systemctlPrefix} is-active ${SYSTEMD_SERVICE_NAME}`, { stdio: 'ignore' });
     serviceLoaded = true;
   } catch {
     // Not active
@@ -312,17 +323,29 @@ function setupNohupFallback(
 ): void {
   logger.warn('No systemd detected — generating nohup wrapper script');
 
-  const wrapperPath = path.join(projectRoot, 'start-nanoclaw.sh');
-  const pidFile = path.join(projectRoot, 'nanoclaw.pid');
+  const scriptName = INSTANCE_NAME
+    ? `start-nanoclaw-${INSTANCE_NAME}.sh`
+    : 'start-nanoclaw.sh';
+  const wrapperPath = path.join(projectRoot, scriptName);
+  const pidName = INSTANCE_NAME
+    ? `nanoclaw-${INSTANCE_NAME}.pid`
+    : 'nanoclaw.pid';
+  const pidFile = path.join(projectRoot, pidName);
+  const logBase = INSTANCE_NAME ? `nanoclaw-${INSTANCE_NAME}` : 'nanoclaw';
+
+  const envLine = INSTANCE_NAME
+    ? `export NANOCLAW_INSTANCE=${JSON.stringify(INSTANCE_NAME)}`
+    : '';
 
   const lines = [
     '#!/bin/bash',
-    '# start-nanoclaw.sh — Start NanoClaw without systemd',
+    `# ${scriptName} — Start NanoClaw without systemd`,
     `# To stop: kill \\$(cat ${pidFile})`,
     '',
     'set -euo pipefail',
     '',
     `cd ${JSON.stringify(projectRoot)}`,
+    ...(envLine ? [envLine] : []),
     '',
     '# Stop existing instance if running',
     `if [ -f ${JSON.stringify(pidFile)} ]; then`,
@@ -336,12 +359,12 @@ function setupNohupFallback(
     '',
     'echo "Starting NanoClaw..."',
     `nohup ${JSON.stringify(nodePath)} ${JSON.stringify(projectRoot + '/dist/index.js')} \\`,
-    `  >> ${JSON.stringify(projectRoot + '/logs/nanoclaw.log')} \\`,
-    `  2>> ${JSON.stringify(projectRoot + '/logs/nanoclaw.error.log')} &`,
+    `  >> ${JSON.stringify(projectRoot + '/logs/' + logBase + '.log')} \\`,
+    `  2>> ${JSON.stringify(projectRoot + '/logs/' + logBase + '.error.log')} &`,
     '',
     `echo $! > ${JSON.stringify(pidFile)}`,
     'echo "NanoClaw started (PID $!)"',
-    `echo "Logs: tail -f ${projectRoot}/logs/nanoclaw.log"`,
+    `echo "Logs: tail -f ${projectRoot}/logs/${logBase}.log"`,
   ];
   const wrapper = lines.join('\n') + '\n';
 

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -14,13 +14,6 @@ import Database from 'better-sqlite3';
 import { INSTANCE_NAME, STORE_DIR } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { logger } from '../src/logger.js';
-
-const SERVICE_LABEL = INSTANCE_NAME
-  ? `com.nanoclaw-${INSTANCE_NAME}`
-  : 'com.nanoclaw';
-const SYSTEMD_SERVICE_NAME = INSTANCE_NAME
-  ? `nanoclaw-${INSTANCE_NAME}`
-  : 'nanoclaw';
 import {
   getPlatform,
   getServiceManager,
@@ -28,6 +21,13 @@ import {
   isRoot,
 } from './platform.js';
 import { emitStatus } from './status.js';
+
+const SERVICE_LABEL = INSTANCE_NAME
+  ? `com.nanoclaw-${INSTANCE_NAME}`
+  : 'com.nanoclaw';
+const SYSTEMD_SERVICE_NAME = INSTANCE_NAME
+  ? `nanoclaw-${INSTANCE_NAME}`
+  : 'nanoclaw';
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -11,9 +11,16 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { STORE_DIR } from '../src/config.js';
+import { INSTANCE_NAME, STORE_DIR } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { logger } from '../src/logger.js';
+
+const SERVICE_LABEL = INSTANCE_NAME
+  ? `com.nanoclaw-${INSTANCE_NAME}`
+  : 'com.nanoclaw';
+const SYSTEMD_SERVICE_NAME = INSTANCE_NAME
+  ? `nanoclaw-${INSTANCE_NAME}`
+  : 'nanoclaw';
 import {
   getPlatform,
   getServiceManager,
@@ -36,9 +43,9 @@ export async function run(_args: string[]): Promise<void> {
   if (mgr === 'launchd') {
     try {
       const output = execSync('launchctl list', { encoding: 'utf-8' });
-      if (output.includes('com.nanoclaw')) {
+      if (output.includes(SERVICE_LABEL)) {
         // Check if it has a PID (actually running)
-        const line = output.split('\n').find((l) => l.includes('com.nanoclaw'));
+        const line = output.split('\n').find((l) => l.includes(SERVICE_LABEL));
         if (line) {
           const pidField = line.trim().split(/\s+/)[0];
           service = pidField !== '-' && pidField ? 'running' : 'stopped';
@@ -50,14 +57,14 @@ export async function run(_args: string[]): Promise<void> {
   } else if (mgr === 'systemd') {
     const prefix = isRoot() ? 'systemctl' : 'systemctl --user';
     try {
-      execSync(`${prefix} is-active nanoclaw`, { stdio: 'ignore' });
+      execSync(`${prefix} is-active ${SYSTEMD_SERVICE_NAME}`, { stdio: 'ignore' });
       service = 'running';
     } catch {
       try {
         const output = execSync(`${prefix} list-unit-files`, {
           encoding: 'utf-8',
         });
-        if (output.includes('nanoclaw')) {
+        if (output.includes(SYSTEMD_SERVICE_NAME)) {
           service = 'stopped';
         }
       } catch {
@@ -66,7 +73,10 @@ export async function run(_args: string[]): Promise<void> {
     }
   } else {
     // Check for nohup PID file
-    const pidFile = path.join(projectRoot, 'nanoclaw.pid');
+    const pidName = INSTANCE_NAME
+      ? `nanoclaw-${INSTANCE_NAME}.pid`
+      : 'nanoclaw.pid';
+    const pidFile = path.join(projectRoot, pidName);
     if (fs.existsSync(pidFile)) {
       try {
         const raw = fs.readFileSync(pidFile, 'utf-8').trim();

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,23 @@ import { readEnvFile } from './env.js';
 // Read config values from .env (falls back to process.env).
 // Secrets (API keys, tokens) are NOT read here — they are loaded only
 // by the credential proxy (credential-proxy.ts), never exposed to containers.
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'NANOCLAW_INSTANCE',
+]);
+
+// Instance name for multi-instance support. When set, namespaces service names,
+// container prefixes, and credential proxy port to avoid conflicts.
+// Leave unset for single-instance deployments (backward compatible).
+const rawInstance =
+  process.env.NANOCLAW_INSTANCE || envConfig.NANOCLAW_INSTANCE || '';
+if (rawInstance && !/^[a-zA-Z0-9-]+$/.test(rawInstance)) {
+  throw new Error(
+    `NANOCLAW_INSTANCE must contain only alphanumeric characters and hyphens, got: "${rawInstance}"`,
+  );
+}
+export const INSTANCE_NAME = rawInstance;
 
 export const ASSISTANT_NAME =
   process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -14,6 +14,7 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   IDLE_TIMEOUT,
+  INSTANCE_NAME,
   TIMEZONE,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
@@ -277,7 +278,8 @@ export async function runContainerAgent(
 
   const mounts = buildVolumeMounts(group, input.isMain);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
-  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const prefix = INSTANCE_NAME ? `nanoclaw-${INSTANCE_NAME}` : 'nanoclaw';
+  const containerName = `${prefix}-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(mounts, containerName);
 
   logger.debug(

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 
+import { INSTANCE_NAME } from './config.js';
 import { logger } from './logger.js';
 
 /** The container runtime binary name. */
@@ -103,8 +104,11 @@ export function ensureContainerRuntimeRunning(): void {
 /** Kill orphaned NanoClaw containers from previous runs. */
 export function cleanupOrphans(): void {
   try {
+    const filterPrefix = INSTANCE_NAME
+      ? `nanoclaw-${INSTANCE_NAME}-`
+      : 'nanoclaw-';
     const output = execSync(
-      `${CONTAINER_RUNTIME_BIN} ps --filter name=nanoclaw- --format '{{.Names}}'`,
+      `${CONTAINER_RUNTIME_BIN} ps --filter name=${filterPrefix} --format '{{.Names}}'`,
       { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
     );
     const orphans = output.trim().split('\n').filter(Boolean);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
   IDLE_TIMEOUT,
+  INSTANCE_NAME,
   POLL_INTERVAL,
   TIMEZONE,
   TRIGGER_PATTERN,
@@ -466,6 +467,9 @@ function ensureContainerSystemRunning(): void {
 }
 
 async function main(): Promise<void> {
+  if (INSTANCE_NAME) {
+    logger.info({ instance: INSTANCE_NAME }, 'Starting NanoClaw instance');
+  }
   ensureContainerSystemRunning();
   initDatabase();
   logger.info('Database initialized');


### PR DESCRIPTION
## Summary

- Adds `NANOCLAW_INSTANCE` env var to namespace all shared resources, enabling multiple NanoClaw instances to coexist on the same machine
- Scopes container name prefixes, orphan cleanup, service names (launchd/systemd/nohup), log files, and PID files per instance
- Validates instance names (alphanumeric + hyphens only) and passes the env var through all service definitions
- Fully backward compatible — omitting `NANOCLAW_INSTANCE` produces identical behavior to before

## Test plan

- [ ] Verify single-instance deployment works unchanged (no `NANOCLAW_INSTANCE` set)
- [ ] Set `NANOCLAW_INSTANCE=work` + `CREDENTIAL_PROXY_PORT=3001` in one project dir, `NANOCLAW_INSTANCE=personal` + `CREDENTIAL_PROXY_PORT=3002` in another — confirm both start without conflict
- [ ] Confirm orphan cleanup only stops containers belonging to the same instance
- [ ] Confirm `setup/verify.ts` correctly detects the named instance's service
- [ ] Test invalid instance name (e.g. spaces, slashes) throws at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)