### PR TITLE
fix: sync agent-runner source to existing session directories

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -190,8 +190,20 @@ function buildVolumeMounts(
     group.folder,
     'agent-runner-src',
   );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
-    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  if (fs.existsSync(agentRunnerSrc)) {
+    if (!fs.existsSync(groupAgentRunnerDir)) {
+      fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+    } else {
+      // Sync source files so skill-branch updates propagate to existing sessions
+      // while preserving any agent-created files in the group directory.
+      for (const entry of fs.readdirSync(agentRunnerSrc)) {
+        fs.cpSync(
+          path.join(agentRunnerSrc, entry),
+          path.join(groupAgentRunnerDir, entry),
+          { recursive: true },
+        );
+      }
+    }
   }
   mounts.push({
     hostPath: groupAgentRunnerDir,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -56,6 +56,31 @@ interface VolumeMount {
   readonly: boolean;
 }
 
+/**
+ * Sync agent-runner source files into a per-group directory.
+ * On first run (dest doesn't exist), copies the entire directory.
+ * On subsequent runs, copies each entry individually to pick up changes.
+ * No-op if the source directory doesn't exist.
+ */
+export function syncAgentRunnerSource(
+  srcDir: string,
+  destDir: string,
+): void {
+  if (!fs.existsSync(srcDir)) return;
+
+  if (!fs.existsSync(destDir)) {
+    fs.cpSync(srcDir, destDir, { recursive: true });
+  } else {
+    for (const entry of fs.readdirSync(srcDir)) {
+      fs.cpSync(
+        path.join(srcDir, entry),
+        path.join(destDir, entry),
+        { recursive: true },
+      );
+    }
+  }
+}
+
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
@@ -190,21 +215,7 @@ function buildVolumeMounts(
     group.folder,
     'agent-runner-src',
   );
-  if (fs.existsSync(agentRunnerSrc)) {
-    if (!fs.existsSync(groupAgentRunnerDir)) {
-      fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
-    } else {
-      // Sync source files so skill-branch updates propagate to existing sessions
-      // while preserving any agent-created files in the group directory.
-      for (const entry of fs.readdirSync(agentRunnerSrc)) {
-        fs.cpSync(
-          path.join(agentRunnerSrc, entry),
-          path.join(groupAgentRunnerDir, entry),
-          { recursive: true },
-        );
-      }
-    }
-  }
+  syncAgentRunnerSource(agentRunnerSrc, groupAgentRunnerDir);
   mounts.push({
     hostPath: groupAgentRunnerDir,
     containerPath: '/app/src',

--- a/src/sync-agent-runner.test.ts
+++ b/src/sync-agent-runner.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Mock config (required by container-runner.ts import)
+vi.mock('./config.js', () => ({
+  CONTAINER_IMAGE: 'nanoclaw-agent:latest',
+  CONTAINER_MAX_OUTPUT_SIZE: 10485760,
+  CONTAINER_TIMEOUT: 1800000,
+  CREDENTIAL_PROXY_PORT: 3001,
+  DATA_DIR: '/tmp/nanoclaw-test-data',
+  GROUPS_DIR: '/tmp/nanoclaw-test-groups',
+  IDLE_TIMEOUT: 1800000,
+  TIMEZONE: 'America/Los_Angeles',
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('./mount-security.js', () => ({
+  validateAdditionalMounts: vi.fn(() => []),
+}));
+
+import { syncAgentRunnerSource } from './container-runner.js';
+
+describe('syncAgentRunnerSource', () => {
+  let tmpDir: string;
+  let srcDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-test-'));
+    srcDir = path.join(tmpDir, 'src');
+    destDir = path.join(tmpDir, 'dest');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copies entire directory when dest does not exist', () => {
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'index.ts'), 'original');
+    fs.writeFileSync(path.join(srcDir, 'utils.ts'), 'helper');
+
+    syncAgentRunnerSource(srcDir, destDir);
+
+    expect(fs.existsSync(destDir)).toBe(true);
+    expect(fs.readFileSync(path.join(destDir, 'index.ts'), 'utf-8')).toBe(
+      'original',
+    );
+    expect(fs.readFileSync(path.join(destDir, 'utils.ts'), 'utf-8')).toBe(
+      'helper',
+    );
+  });
+
+  it('syncs individual files when dest already exists (picks up changes)', () => {
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.mkdirSync(destDir, { recursive: true });
+    // Stale file in dest
+    fs.writeFileSync(path.join(destDir, 'index.ts'), 'old');
+    // Updated + new files in source
+    fs.writeFileSync(path.join(srcDir, 'index.ts'), 'updated');
+    fs.writeFileSync(path.join(srcDir, 'new-file.ts'), 'brand new');
+
+    syncAgentRunnerSource(srcDir, destDir);
+
+    expect(fs.readFileSync(path.join(destDir, 'index.ts'), 'utf-8')).toBe(
+      'updated',
+    );
+    expect(fs.readFileSync(path.join(destDir, 'new-file.ts'), 'utf-8')).toBe(
+      'brand new',
+    );
+  });
+
+  it('does nothing when source directory does not exist', () => {
+    syncAgentRunnerSource(path.join(tmpDir, 'nonexistent'), destDir);
+
+    expect(fs.existsSync(destDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Agent-runner source files are now synced to per-group session directories on every container launch, not just on first creation
- Preserves agent-created files in the group directory while updating source files from `container/agent-runner/src/`

Fixes #905

## Problem

When a skill branch adds new files to `container/agent-runner/src/` (e.g. a new MCP server config), existing session directories never pick up the changes because the copy only happens when the directory doesn't exist. Users must manually delete `data/sessions/*/agent-runner-src/` after every skill merge.

## Change

Replace the existence check with a sync that copies source files into existing directories:

- **New sessions:** full recursive copy (unchanged behavior)
- **Existing sessions:** overwrite each source entry while preserving agent-created files

## Test plan

- [x] All 201 existing tests pass
- [x] Verified manually: merged a skill branch, restarted service, new files appeared in session directory without manual deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)