### PR TITLE
feat: session size rotation and pre-death memory flush

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,11 @@ export const CREDENTIAL_PROXY_PORT = parseInt(
 );
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const SESSION_MAX_SIZE_BYTES = parseInt(
+  process.env.SESSION_MAX_SIZE_BYTES || '10485760',
+  10,
+); // 10MB default — rotate session when JSONL exceeds this
+export const FLUSH_TIMEOUT = parseInt(process.env.FLUSH_TIMEOUT || '20000', 10); // 20s — time window for pre-death memory flush
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
   _initTestDatabase,
+  clearSession,
   createTask,
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
+  getAllSessions,
   getMessagesSince,
   getNewMessages,
+  getSession,
   getTaskById,
   setRegisteredGroup,
+  setSession,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -480,5 +484,45 @@ describe('registered group isMain', () => {
     const group = groups['group@g.us'];
     expect(group).toBeDefined();
     expect(group.isMain).toBeUndefined();
+  });
+});
+
+// --- Session CRUD ---
+
+describe('session management', () => {
+  it('stores and retrieves a session', () => {
+    setSession('telegram_main', 'session-abc-123');
+    expect(getSession('telegram_main')).toBe('session-abc-123');
+  });
+
+  it('returns undefined for unknown group', () => {
+    expect(getSession('nonexistent')).toBeUndefined();
+  });
+
+  it('overwrites session on repeated set', () => {
+    setSession('telegram_main', 'session-1');
+    setSession('telegram_main', 'session-2');
+    expect(getSession('telegram_main')).toBe('session-2');
+  });
+
+  it('getAllSessions returns all stored sessions', () => {
+    setSession('group_a', 'sess-a');
+    setSession('group_b', 'sess-b');
+    const all = getAllSessions();
+    expect(all).toEqual({ group_a: 'sess-a', group_b: 'sess-b' });
+  });
+
+  it('clearSession removes only the target group', () => {
+    setSession('group_a', 'sess-a');
+    setSession('group_b', 'sess-b');
+    clearSession('group_a');
+    expect(getSession('group_a')).toBeUndefined();
+    expect(getSession('group_b')).toBe('sess-b');
+  });
+
+  it('clearSession is a no-op for unknown group', () => {
+    setSession('group_a', 'sess-a');
+    clearSession('nonexistent');
+    expect(getSession('group_a')).toBe('sess-a');
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -526,6 +526,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function clearSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,11 @@ import path from 'path';
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
+  DATA_DIR,
+  FLUSH_TIMEOUT,
   IDLE_TIMEOUT,
   POLL_INTERVAL,
+  SESSION_MAX_SIZE_BYTES,
   TIMEZONE,
   TRIGGER_PATTERN,
 } from './config.js';
@@ -27,6 +30,7 @@ import {
   PROXY_BIND_HOST,
 } from './container-runtime.js';
 import {
+  clearSession,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -58,6 +62,23 @@ import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
+
+function getDirectorySize(dirPath: string): number {
+  let total = 0;
+  try {
+    for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirectorySize(fullPath);
+      } else {
+        total += fs.statSync(fullPath).size;
+      }
+    }
+  } catch {
+    /* directory doesn't exist */
+  }
+  return total;
+}
 
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
@@ -191,15 +212,41 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   // Track idle timer for closing stdin when agent is idle
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let flushing = false;
+
+  const FLUSH_INSTRUCTION =
+    '[SESSION ENDING — MEMORY FLUSH]\n' +
+    "Your session is about to end. You have ~15 seconds. Quickly persist anything important you haven't already saved:\n" +
+    '1. New facts, corrections, or decisions → update the relevant memory files\n' +
+    '2. In-progress work status → write a note so you can resume next session\n' +
+    "3. Anything the user asked you to remember → ensure it's in your memory files\n" +
+    'If everything important is already saved, respond with just "<internal>Nothing to flush.</internal>".';
 
   const resetIdleTimer = () => {
+    if (flushing) return; // Don't reset during flush
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
-      logger.debug(
-        { group: group.name },
-        'Idle timeout, closing container stdin',
-      );
-      queue.closeStdin(chatJid);
+      flushing = true;
+      const sent = queue.sendMessage(chatJid, FLUSH_INSTRUCTION);
+      if (sent) {
+        logger.debug(
+          { group: group.name },
+          'Idle timeout, sending memory flush before close',
+        );
+        setTimeout(() => {
+          logger.debug(
+            { group: group.name },
+            'Flush window expired, closing container',
+          );
+          queue.closeStdin(chatJid);
+        }, FLUSH_TIMEOUT);
+      } else {
+        logger.debug(
+          { group: group.name },
+          'Idle timeout, closing container stdin',
+        );
+        queue.closeStdin(chatJid);
+      }
     }, IDLE_TIMEOUT);
   };
 
@@ -267,7 +314,34 @@ async function runAgent(
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
-  const sessionId = sessions[group.folder];
+  let sessionId: string | undefined = sessions[group.folder];
+
+  // Check session size — rotate if over threshold
+  if (sessionId) {
+    const sessionDir = path.join(DATA_DIR, 'sessions', group.folder, '.claude');
+    const size = getDirectorySize(sessionDir);
+    if (size > SESSION_MAX_SIZE_BYTES) {
+      const sizeMB = (size / 1024 / 1024).toFixed(1);
+      logger.info(
+        { group: group.name, sessionId, sizeMB },
+        'Session exceeds size limit, rotating to fresh session',
+      );
+      // Archive old session directory
+      const archiveName = `${group.folder}-${Date.now()}`;
+      const archiveDir = path.join(DATA_DIR, 'sessions', archiveName);
+      try {
+        fs.renameSync(
+          path.join(DATA_DIR, 'sessions', group.folder),
+          archiveDir,
+        );
+      } catch {
+        /* best-effort archive */
+      }
+      clearSession(group.folder);
+      delete sessions[group.folder];
+      sessionId = undefined;
+    }
+  }
 
   // Update tasks snapshot for container to read (filtered by group)
   const tasks = getAllTasks();


### PR DESCRIPTION
## Problem

Long-running NanoClaw instances accumulate large session transcripts in `.claude/`. Once the transcript grows past what the SDK can resume (observed at 55MB/16K lines), it silently falls back to creating a new session — the agent loses all conversation context and containers exit in ~25s instead of maintaining the IPC loop.

## Changes

**Session size rotation** — Before each agent run, checks `.claude/` directory size. If it exceeds `SESSION_MAX_SIZE_BYTES` (default 10MB), archives the old session and starts fresh. The agent loses history but regains the ability to function.

**Pre-death memory flush** — On idle timeout, instead of immediately closing the container, sends the agent a flush instruction with a `FLUSH_TIMEOUT` (default 20s) grace period to persist important state to memory files. Falls back to immediate close if the IPC message can't be delivered. Only fires on idle timeout, not hard timeout.

**New env vars**: `SESSION_MAX_SIZE_BYTES` (default `10485760`), `FLUSH_TIMEOUT` (default `20000`).

## Validated in production

Tested on a Telegram-based NanoClaw instance:
- Old session had grown to **218MB** in `.claude/` — every container was starting a new session (25s runs, no context)
- After deploying: old session archived to `{group}-{timestamp}`, fresh session created (2.5MB)
- Next container resumed successfully: 77s run with session ID, context restored

## Test plan

- [x] 6 new tests for session DB operations (`clearSession` + existing CRUD coverage)
- [x] All 207 tests pass
- [x] Production validated on real instance