### PR TITLE
feat: add outbound file attachment support for container agents

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -41,24 +41,63 @@ const server = new McpServer({
 
 server.tool(
   'send_message',
-  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times.",
+  "Send a message to the user or group immediately while you're still running. Use this for progress updates, to send multiple messages, or to send file attachments (screenshots, generated files, etc.). You can call this multiple times.",
   {
-    text: z.string().describe('The message text to send'),
+    text: z.string().optional().describe('The message text to send (optional when sending files)'),
     sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
+    files: z.array(z.string()).optional().describe('File paths to send as attachments (e.g. ["/workspace/group/attachments/screenshot.png"]). Paths must be under /workspace/group/ or /workspace/extra/.'),
   },
   async (args) => {
-    const data: Record<string, string | undefined> = {
+    if (!args.text && (!args.files || args.files.length === 0)) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: must provide text or files (or both).' }],
+        isError: true,
+      };
+    }
+
+    // Validate and convert file paths to workspace-relative
+    let validFiles: string[] | undefined;
+    if (args.files && args.files.length > 0) {
+      const errors: string[] = [];
+      validFiles = [];
+      for (const filePath of args.files) {
+        if (!filePath.startsWith('/workspace/group/') && !filePath.startsWith('/workspace/extra/')) {
+          errors.push(`${filePath}: must be under /workspace/group/ or /workspace/extra/`);
+          continue;
+        }
+        if (!fs.existsSync(filePath)) {
+          errors.push(`${filePath}: file not found`);
+          continue;
+        }
+        // Convert to workspace-relative: strip /workspace/ prefix
+        validFiles.push(filePath.slice('/workspace/'.length));
+      }
+      if (errors.length > 0 && validFiles.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: `File errors:\n${errors.join('\n')}` }],
+          isError: true,
+        };
+      }
+    }
+
+    const data: Record<string, unknown> = {
       type: 'message',
       chatJid,
-      text: args.text,
+      text: args.text || undefined,
       sender: args.sender || undefined,
       groupFolder,
       timestamp: new Date().toISOString(),
     };
+    if (validFiles && validFiles.length > 0) {
+      data.files = validFiles;
+    }
 
     writeIpcFile(MESSAGES_DIR, data);
 
-    return { content: [{ type: 'text' as const, text: 'Message sent.' }] };
+    const parts: string[] = [];
+    if (args.text) parts.push('Message sent.');
+    if (validFiles && validFiles.length > 0) parts.push(`${validFiles.length} file(s) attached.`);
+    return { content: [{ type: 'text' as const, text: parts.join(' ') }] };
   },
 );
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -18,6 +18,16 @@ Your output is sent to the user or group.
 
 You also have `mcp__nanoclaw__send_message` which sends a message immediately while you're still working. This is useful when you want to acknowledge a request before starting longer work.
 
+### Sending files
+
+To send files (screenshots, generated code, PDFs, etc.) as actual attachments, use `mcp__nanoclaw__send_message` with the `files` parameter:
+
+```
+mcp__nanoclaw__send_message({ text: "Here's the screenshot", files: ["/workspace/group/attachments/screenshot.png"] })
+```
+
+Files must be under `/workspace/group/` or `/workspace/extra/`. When you take a screenshot or generate a file that the user should see, always send it with `files` — don't just describe it in text.
+
 ### Internal thoughts
 
 If part of your output is internal reasoning rather than something for the user, wrap it in `<internal>` tags:

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -18,6 +18,16 @@ Your output is sent to the user or group.
 
 You also have `mcp__nanoclaw__send_message` which sends a message immediately while you're still working. This is useful when you want to acknowledge a request before starting longer work.
 
+### Sending files
+
+To send files (screenshots, generated code, PDFs, etc.) as actual attachments, use `mcp__nanoclaw__send_message` with the `files` parameter:
+
+```
+mcp__nanoclaw__send_message({ text: "Here's the screenshot", files: ["/workspace/group/attachments/screenshot.png"] })
+```
+
+Files must be under `/workspace/group/` or `/workspace/extra/`. When you take a screenshot or generate a file that the user should see, always send it with `files` — don't just describe it in text.
+
 ### Internal thoughts
 
 If part of your output is internal reasoning rather than something for the user, wrap it in `<internal>` tags:

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,6 +563,14 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
+    sendFile: (jid, text, filePaths) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      if (channel.sendFile) return channel.sendFile(jid, text, filePaths);
+      // Fallback: channels without sendFile get text-only
+      logger.warn({ jid, channel: channel.name }, 'Channel does not support file sending');
+      return channel.sendMessage(jid, text || 'File attachment not supported by this channel.');
+    },
     registeredGroups: () => registeredGroups,
     registerGroup,
     syncGroups: async (force: boolean) => {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -53,6 +53,7 @@ beforeEach(() => {
 
   deps = {
     sendMessage: async () => {},
+    sendFile: async () => {},
     registeredGroups: () => groups,
     registerGroup: (jid, group) => {
       groups[jid] = group;

--- a/src/ipc-files.test.ts
+++ b/src/ipc-files.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { RegisteredGroup } from './types.js';
+
+const tmpGroups = path.join(os.tmpdir(), 'nanoclaw-test-ipc-files');
+
+vi.mock('./config.js', async () => {
+  const path = await import('path');
+  const os = await import('os');
+  return {
+    DATA_DIR: '/tmp/nanoclaw-test-data',
+    GROUPS_DIR: path.join(os.tmpdir(), 'nanoclaw-test-ipc-files'),
+    IPC_POLL_INTERVAL: 1000,
+    TIMEZONE: 'UTC',
+  };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Import after mocks are set up
+import { resolveIpcFilePaths } from './ipc.js';
+
+function makeGroups(): Record<string, RegisteredGroup> {
+  return {
+    'dc:123': {
+      name: 'Test Discord',
+      folder: 'discord_test',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+    },
+    'dc:456': {
+      name: 'With Mounts',
+      folder: 'discord_mounts',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      containerConfig: {
+        additionalMounts: [
+          { hostPath: path.join(tmpGroups, '_extra_projects'), containerPath: 'projects' },
+        ],
+      },
+    },
+  };
+}
+
+describe('resolveIpcFilePaths', () => {
+  let GROUPS: Record<string, RegisteredGroup>;
+
+  beforeEach(() => {
+    GROUPS = makeGroups();
+
+    // Create test group directory with a file
+    const groupDir = path.join(tmpGroups, 'discord_test');
+    fs.mkdirSync(path.join(groupDir, 'attachments'), { recursive: true });
+    fs.writeFileSync(path.join(groupDir, 'attachments', 'img.png'), 'fake-image');
+    fs.writeFileSync(path.join(groupDir, 'output.txt'), 'hello');
+
+    // Create extra mount directory with a file
+    const extraDir = path.join(tmpGroups, '_extra_projects');
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(path.join(extraDir, 'code.js'), 'console.log("hi")');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpGroups, { recursive: true, force: true });
+  });
+
+  it('resolves group/attachments/img.png to host path', () => {
+    const result = resolveIpcFilePaths(
+      ['group/attachments/img.png'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('discord_test');
+    expect(result[0]).toContain('attachments/img.png');
+  });
+
+  it('resolves multiple group files', () => {
+    const result = resolveIpcFilePaths(
+      ['group/attachments/img.png', 'group/output.txt'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it('rejects traversal attempts', () => {
+    const result = resolveIpcFilePaths(
+      ['group/../../../etc/passwd'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects absolute paths', () => {
+    const result = resolveIpcFilePaths(
+      ['/etc/passwd'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips files that do not exist on host', () => {
+    const result = resolveIpcFilePaths(
+      ['group/nonexistent.png'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects paths not starting with group/ or extra/', () => {
+    const result = resolveIpcFilePaths(
+      ['something/file.txt'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles extra/ paths when additionalMounts are configured', () => {
+    const result = resolveIpcFilePaths(
+      ['extra/projects/code.js'],
+      'discord_mounts',
+      GROUPS,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('code.js');
+  });
+
+  it('rejects extra/ paths with no matching mount', () => {
+    const result = resolveIpcFilePaths(
+      ['extra/unknown/file.txt'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('filters valid from invalid in mixed input', () => {
+    const result = resolveIpcFilePaths(
+      ['group/attachments/img.png', '/etc/passwd', 'group/nonexistent.png'],
+      'discord_test',
+      GROUPS,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('img.png');
+  });
+
+  it('rejects .. in extra/ paths', () => {
+    const result = resolveIpcFilePaths(
+      ['extra/projects/../../../etc/passwd'],
+      'discord_mounts',
+      GROUPS,
+    );
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -3,15 +3,16 @@ import path from 'path';
 
 import { CronExpressionParser } from 'cron-parser';
 
-import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
+import { DATA_DIR, GROUPS_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
-import { isValidGroupFolder } from './group-folder.js';
+import { resolveGroupFolderPath, isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
   sendMessage: (jid: string, text: string) => Promise<void>;
+  sendFile: (jid: string, text: string, filePaths: string[]) => Promise<void>;
   registeredGroups: () => Record<string, RegisteredGroup>;
   registerGroup: (jid: string, group: RegisteredGroup) => void;
   syncGroups: (force: boolean) => Promise<void>;
@@ -22,6 +23,106 @@ export interface IpcDeps {
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
+}
+
+/**
+ * Resolve workspace-relative file paths from IPC to host-absolute paths.
+ * Security: rejects traversal, absolute paths, and non-existent files.
+ */
+export function resolveIpcFilePaths(
+  workspaceRelativePaths: string[],
+  sourceGroup: string,
+  registeredGroups: Record<string, RegisteredGroup>,
+): string[] {
+  const resolved: string[] = [];
+
+  for (const relPath of workspaceRelativePaths) {
+    // Reject absolute paths
+    if (path.isAbsolute(relPath)) {
+      logger.warn({ relPath }, 'IPC file: rejecting absolute path');
+      continue;
+    }
+    // Reject traversal
+    if (relPath.includes('..')) {
+      logger.warn({ relPath }, 'IPC file: rejecting path with traversal');
+      continue;
+    }
+
+    let hostPath: string | null = null;
+
+    if (relPath.startsWith('group/')) {
+      // group/attachments/img.png → {GROUPS_DIR}/{folder}/attachments/img.png
+      const rest = relPath.slice('group/'.length);
+      try {
+        const groupDir = resolveGroupFolderPath(sourceGroup);
+        hostPath = path.resolve(groupDir, rest);
+        // Ensure resolved path stays within group dir
+        const realBase = fs.realpathSync(groupDir);
+        if (!fs.existsSync(hostPath)) {
+          logger.warn({ relPath, hostPath }, 'IPC file: file not found on host');
+          continue;
+        }
+        const realPath = fs.realpathSync(hostPath);
+        if (!realPath.startsWith(realBase + path.sep) && realPath !== realBase) {
+          logger.warn({ relPath, hostPath }, 'IPC file: path escapes group directory');
+          continue;
+        }
+        hostPath = realPath;
+      } catch (err) {
+        logger.warn({ relPath, err }, 'IPC file: failed to resolve group path');
+        continue;
+      }
+    } else if (relPath.startsWith('extra/')) {
+      // extra/{mountName}/file.txt → resolve via additionalMounts
+      const rest = relPath.slice('extra/'.length);
+      const slashIndex = rest.indexOf('/');
+      if (slashIndex === -1) {
+        logger.warn({ relPath }, 'IPC file: extra path missing file component');
+        continue;
+      }
+      const mountName = rest.slice(0, slashIndex);
+      const filePart = rest.slice(slashIndex + 1);
+
+      // Find the group's additionalMounts
+      const group = Object.values(registeredGroups).find(
+        (g) => g.folder === sourceGroup,
+      );
+      const mount = group?.containerConfig?.additionalMounts?.find((m) => {
+        const cPath = m.containerPath || path.basename(m.hostPath);
+        return cPath === mountName;
+      });
+      if (!mount) {
+        logger.warn({ relPath, mountName }, 'IPC file: no matching mount for extra path');
+        continue;
+      }
+
+      const expandedHost = mount.hostPath.replace(/^~/, process.env.HOME || '');
+      hostPath = path.resolve(expandedHost, filePart);
+      if (!fs.existsSync(hostPath)) {
+        logger.warn({ relPath, hostPath }, 'IPC file: extra file not found on host');
+        continue;
+      }
+      try {
+        const realHost = fs.realpathSync(hostPath);
+        const realBase = fs.realpathSync(expandedHost);
+        if (!realHost.startsWith(realBase + path.sep) && realHost !== realBase) {
+          logger.warn({ relPath, hostPath }, 'IPC file: extra path escapes mount directory');
+          continue;
+        }
+        hostPath = realHost;
+      } catch {
+        logger.warn({ relPath, hostPath }, 'IPC file: failed to resolve extra path');
+        continue;
+      }
+    } else {
+      logger.warn({ relPath }, 'IPC file: path must start with group/ or extra/');
+      continue;
+    }
+
+    resolved.push(hostPath);
+  }
+
+  return resolved;
 }
 
 let ipcWatcherRunning = false;
@@ -73,18 +174,39 @@ export function startIpcWatcher(deps: IpcDeps): void {
             const filePath = path.join(messagesDir, file);
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-              if (data.type === 'message' && data.chatJid && data.text) {
+              if (data.type === 'message' && data.chatJid && (data.text || data.files)) {
                 // Authorization: verify this group can send to this chatJid
                 const targetGroup = registeredGroups[data.chatJid];
                 if (
                   isMain ||
                   (targetGroup && targetGroup.folder === sourceGroup)
                 ) {
-                  await deps.sendMessage(data.chatJid, data.text);
-                  logger.info(
-                    { chatJid: data.chatJid, sourceGroup },
-                    'IPC message sent',
-                  );
+                  const text = data.text || '';
+                  const files = Array.isArray(data.files) ? data.files as string[] : undefined;
+
+                  if (files && files.length > 0) {
+                    const hostPaths = resolveIpcFilePaths(files, sourceGroup, registeredGroups);
+                    if (hostPaths.length > 0) {
+                      await deps.sendFile(data.chatJid, text, hostPaths);
+                      logger.info(
+                        { chatJid: data.chatJid, sourceGroup, fileCount: hostPaths.length },
+                        'IPC file message sent',
+                      );
+                    } else if (text) {
+                      // All files failed resolution — fall back to text-only
+                      await deps.sendMessage(data.chatJid, text);
+                      logger.warn(
+                        { chatJid: data.chatJid, sourceGroup },
+                        'All IPC files failed resolution, sent text-only',
+                      );
+                    }
+                  } else {
+                    await deps.sendMessage(data.chatJid, text);
+                    logger.info(
+                      { chatJid: data.chatJid, sourceGroup },
+                      'IPC message sent',
+                    );
+                  }
                 } else {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,8 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send file attachments. Channels that support it implement it.
+  sendFile?(jid: string, text: string, filePaths: string[]): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

- Adds `files` parameter to the `send_message` MCP tool so container agents can send file attachments (screenshots, PDFs, generated files) alongside text messages
- Validates file paths at three layers: container MCP tool, host IPC resolution, and channel implementation
- Adds optional `sendFile` method to the `Channel` interface; channels without it get a graceful fallback warning
- 10 new test cases for file path resolution + updated existing IPC auth tests

## Design

File paths flow through three validation checkpoints:

1. **Container** — MCP tool rejects paths not under `/workspace/group/` or `/workspace/extra/`, verifies file exists
2. **Host IPC** — `resolveIpcFilePaths()` rejects absolute paths and `..` traversal, confirms resolved path is within the group directory
3. **Channel** — each channel's `sendFile` can apply its own constraints (e.g., file size limits)

Channels that don't implement `sendFile` log a warning and send a text message indicating file attachment isn't supported.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npx vitest run src/ipc-files.test.ts` — 10 tests pass (path resolution, traversal rejection, absolute path rejection)
- [x] `npx vitest run src/ipc-auth.test.ts` — 33 tests pass (existing tests with `sendFile` stub added)