### PR TITLE
fix: reset idle timer when IPC message piped to active container

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -481,4 +481,104 @@ describe('GroupQueue', () => {
     resolveProcess!();
     await vi.advanceTimersByTimeAsync(10);
   });
+
+  // --- Idle timer resetter ---
+
+  it('sendMessage invokes registered idle timer resetter', async () => {
+    let resolveProcess: () => void;
+
+    const processMessages = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveProcess = resolve;
+      });
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    queue.registerProcess(
+      'group1@g.us',
+      {} as any,
+      'container-1',
+      'test-group',
+    );
+
+    const resetter = vi.fn();
+    queue.registerIdleTimerResetter('group1@g.us', resetter);
+
+    queue.sendMessage('group1@g.us', 'hello');
+    expect(resetter).toHaveBeenCalledTimes(1);
+
+    // Second message should invoke it again
+    queue.sendMessage('group1@g.us', 'world');
+    expect(resetter).toHaveBeenCalledTimes(2);
+
+    resolveProcess!();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+
+  it('sendMessage does not throw when no resetter is registered', async () => {
+    let resolveProcess: () => void;
+
+    const processMessages = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveProcess = resolve;
+      });
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    queue.registerProcess(
+      'group1@g.us',
+      {} as any,
+      'container-1',
+      'test-group',
+    );
+
+    // No resetter registered — sendMessage should still succeed
+    expect(() => queue.sendMessage('group1@g.us', 'hello')).not.toThrow();
+    expect(queue.sendMessage('group1@g.us', 'hello')).toBe(true);
+
+    resolveProcess!();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+
+  it('unregisterIdleTimerResetter stops callback invocation', async () => {
+    let resolveProcess: () => void;
+
+    const processMessages = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveProcess = resolve;
+      });
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+    queue.enqueueMessageCheck('group1@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+    queue.registerProcess(
+      'group1@g.us',
+      {} as any,
+      'container-1',
+      'test-group',
+    );
+
+    const resetter = vi.fn();
+    queue.registerIdleTimerResetter('group1@g.us', resetter);
+
+    queue.sendMessage('group1@g.us', 'hello');
+    expect(resetter).toHaveBeenCalledTimes(1);
+
+    // Unregister, then send another message
+    queue.unregisterIdleTimerResetter('group1@g.us');
+
+    queue.sendMessage('group1@g.us', 'world');
+    expect(resetter).toHaveBeenCalledTimes(1); // not called again
+
+    resolveProcess!();
+    await vi.advanceTimersByTimeAsync(10);
+  });
 });

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -34,6 +34,15 @@ export class GroupQueue {
   private processMessagesFn: ((groupJid: string) => Promise<boolean>) | null =
     null;
   private shuttingDown = false;
+  private idleTimerResetters = new Map<string, () => void>();
+
+  registerIdleTimerResetter(groupJid: string, resetter: () => void): void {
+    this.idleTimerResetters.set(groupJid, resetter);
+  }
+
+  unregisterIdleTimerResetter(groupJid: string): void {
+    this.idleTimerResetters.delete(groupJid);
+  }
 
   private getGroup(groupJid: string): GroupState {
     let state = this.groups.get(groupJid);
@@ -171,6 +180,7 @@ export class GroupQueue {
       const tempPath = `${filepath}.tmp`;
       fs.writeFileSync(tempPath, JSON.stringify({ type: 'message', text }));
       fs.renameSync(tempPath, filepath);
+      this.idleTimerResetters.get(groupJid)?.();
       return true;
     } catch {
       return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     }, IDLE_TIMEOUT);
   };
 
+  queue.registerIdleTimerResetter(chatJid, resetIdleTimer);
+
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
@@ -235,6 +237,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   });
 
   await channel.setTyping?.(chatJid, false);
+  queue.unregisterIdleTimerResetter(chatJid);
   if (idleTimer) clearTimeout(idleTimer);
 
   if (output === 'error' || hadError) {


### PR DESCRIPTION
## Summary
- When a message is piped to an active container via `sendMessage()`, the idle timer was not reset. With short `IDLE_TIMEOUT` values (e.g. 2 minutes), this causes the container to be killed immediately after accepting a piped message.
- Registers `resetIdleTimer` as a callback on `GroupQueue` so `sendMessage()` can invoke it after a successful IPC file write.
- Adds `registerIdleTimerResetter`/`unregisterIdleTimerResetter` to `GroupQueue` and hooks them in `processGroupMessages()`.

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 201 existing tests pass
- [ ] Manual: set `IDLE_TIMEOUT` to 2 minutes, send a message near the end of the idle window, verify the container is not killed prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)