### PR TITLE
fix: send only last output to prevent duplicate messages (#1020)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
+  // Track the last output to avoid sending duplicate messages when SDK returns multiple results
+  // See: https://github.com/qwibitai/nanoclaw/issues/1020
+  let lastOutput: string | null = null;
+
   const output = await runAgent(group, prompt, chatJid, async (result) => {
     // Streaming output callback — called for each agent result
     if (result.result) {
@@ -218,7 +222,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
       if (text) {
-        await channel.sendMessage(chatJid, text);
+        // Track the last output instead of sending immediately
+        lastOutput = text;
         outputSentToUser = true;
       }
       // Only reset idle timer on actual results, not session-update markers (result: null)
@@ -233,6 +238,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       hadError = true;
     }
   });
+
+  // Send only the last output to avoid duplicate messages
+  if (lastOutput) {
+    await channel.sendMessage(chatJid, lastOutput);
+  }
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);


### PR DESCRIPTION
## Summary
Fixes duplicate messages sent to users when the SDK returns multiple streaming results.

## Problem
When a user sends a message, they receive **two different replies** instead of one. This happens because `processGroupMessages` in `src/index.ts` calls `channel.sendMessage()` for each result returned by the SDK in the streaming callback.

## Solution
Track the last output during streaming and send only that after streaming completes.

## Changes
- Added `lastOutput` variable to track the final result
- Modified streaming callback to update `lastOutput` instead of sending immediately
- Added post-streaming send of only the last output

## Testing
✅ Verified with multiple test messages - each message now receives only one reply.

## References
Fixes #1020

---

**Note:** This fix affects all channels (WhatsApp, Telegram, Slack, Discord, Gmail, etc.) as the issue is in the core message processing logic.