### PR TITLE
fix: agent-runner source not updating for existing groups

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -51,11 +51,43 @@ RUN npm run build
 # Create workspace directories
 RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
 
+# Pre-create tsconfig for runtime compilation from merged source in /tmp/src.
+# Placed in /app so node_modules resolution works correctly.
+RUN echo '{"compilerOptions":{"target":"ES2022","module":"NodeNext","moduleResolution":"NodeNext","outDir":"/tmp/dist","rootDir":"/tmp/src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["/tmp/src/**/*"]}' > /app/tsconfig.build.json
+
 # Create entrypoint script
+# Source merging: /app/src-global (read-only mount) + /app/src-custom (per-group overrides)
+# are merged into /tmp/src before compilation. Custom files take priority, so per-group
+# agents can add or override tool files without blocking global updates.
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+COPY <<'ENTRY' /app/entrypoint.sh
+#!/bin/bash
+set -e
+# Two-layer source merge for clean upgrades + per-group customization:
+#   /app/src-global  (read-only mount)  — latest global agent-runner source
+#   /app/src-custom  (read-write mount) — per-group tool overrides/additions
+# Merged into /tmp/src then compiled via tsconfig.build.json (in /app for node_modules).
+mkdir -p /tmp/src
+if [ -d /app/src-global ]; then
+  cp -r /app/src-global/* /tmp/src/
+else
+  cp -r /app/src/* /tmp/src/
+fi
+if [ -d /app/src-custom ] && [ "$(ls -A /app/src-custom 2>/dev/null)" ]; then
+  cp -r /app/src-custom/* /tmp/src/
+fi
+# Symlink node_modules and package.json so module resolution works from /tmp/src
+ln -sfn /app/node_modules /tmp/node_modules
+ln -sfn /app/package.json /tmp/package.json
+cd /app && npx tsc -p tsconfig.build.json 2>&1 >&2
+ln -s /app/node_modules /tmp/dist/node_modules
+chmod -R a-w /tmp/dist
+cat > /tmp/input.json
+node /tmp/dist/index.js < /tmp/input.json
+ENTRY
+RUN chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -175,27 +175,33 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // Copy agent-runner source into a per-group writable location so agents
-  // can customize it (add tools, change behavior) without affecting other
-  // groups. Recompiled on container startup via entrypoint.sh.
+  // Agent-runner source: two-layer mount for clean upgrades + per-group customization.
+  // 1. Global source (read-only) — always reflects the latest codebase
+  // 2. Per-group custom dir (read-write) — agents can add/override tool files
+  // The entrypoint merges them at startup: global first, then custom overlay, then compile.
   const agentRunnerSrc = path.join(
     projectRoot,
     'container',
     'agent-runner',
     'src',
   );
-  const groupAgentRunnerDir = path.join(
+  if (fs.existsSync(agentRunnerSrc)) {
+    mounts.push({
+      hostPath: agentRunnerSrc,
+      containerPath: '/app/src-global',
+      readonly: true,
+    });
+  }
+  const groupCustomSrcDir = path.join(
     DATA_DIR,
     'sessions',
     group.folder,
-    'agent-runner-src',
+    'agent-runner-custom',
   );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
-    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
-  }
+  fs.mkdirSync(groupCustomSrcDir, { recursive: true });
   mounts.push({
-    hostPath: groupAgentRunnerDir,
-    containerPath: '/app/src',
+    hostPath: groupCustomSrcDir,
+    containerPath: '/app/src-custom',
     readonly: false,
   });
 


### PR DESCRIPTION
## Summary

- Agent-runner source code was cached per-group on first run and never refreshed, preventing new MCP tools or source changes from reaching existing groups
- Replaced single copy-on-first-run approach with a two-layer mount system: `src-global` (read-only, shared) + `src-custom` (read-write, per-group overrides)
- Container entrypoint now merges both layers into `/tmp/src` at startup, compiles with a pre-built `tsconfig.build.json`, and symlinks `node_modules` from `/app`

## Changes

| File | Description |
|------|-------------|
| `src/container-runner.ts` | Replace `!fs.existsSync` copy-once logic with two-layer mount (`src-global` + `src-custom`) |
| `container/Dockerfile` | Add entrypoint script for source merge, pre-create `tsconfig.build.json` targeting `/tmp/src` |

## Root cause

The original code checked `if (!fs.existsSync(groupAgentRunnerDir))` before copying source, meaning once a group's source directory existed, it was never updated. Any new MCP tools added to `container/agent-runner/src/` would only appear for newly created groups.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (271 tests)
- [x] Container builds successfully with `./container/build.sh`
- [x] Verified new MCP tools appear in existing group sessions after restart
- [x] Verified per-group custom source overrides work via `src-custom` mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)