### PR TITLE
feat: add discord-threads skill

### DIFF
--- a/.claude/skills/add-discord-threads/SKILL.md
+++ b/.claude/skills/add-discord-threads/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: add-discord-threads
+description: Add Discord thread management to NanoClaw. Agents can create and manage threads, and replies auto-route to active threads. Requires Discord channel to be set up first (use /add-discord).
+---
+
+# Add Discord Thread Management
+
+This skill adds Discord thread support: agents can create/manage threads via MCP tools, and incoming thread messages are automatically routed so replies go to the correct thread.
+
+> **Compatibility:** NanoClaw v1.0.0. Requires Discord channel already set up (`/add-discord`).
+
+## Features
+
+| Tool | Description |
+|------|-------------|
+| `discord_create_thread` | Create a new thread in the current Discord channel |
+| `discord_manage_thread` | Archive, unarchive, lock, unlock, or rename a thread |
+
+## File Structure
+
+```
+.claude/skills/add-discord-threads/
+├── SKILL.md            # This documentation
+├── container-skill.md  # Agent-readable skill doc (copied to container)
+├── mcp-tools.ts        # Container-side MCP tool registrations
+└── ipc-handlers.ts     # Host-side IPC handler functions
+```
+
+## Prerequisites
+
+1. Discord channel exists:
+   ```bash
+   test -f src/channels/discord.ts || echo "MISSING: Run /add-discord first"
+   ```
+
+2. Two-layer mount mechanism in place (required for MCP tool discovery):
+   ```bash
+   grep -q 'src-global' src/container-runner.ts || echo "MISSING: Update container-runner.ts to two-layer mount"
+   ```
+
+## Integration Points
+
+### 1. Container skill documentation
+
+Copy the fixed skill doc to the container skills directory:
+
+```bash
+mkdir -p container/skills/discord-threads
+cp .claude/skills/add-discord-threads/container-skill.md container/skills/discord-threads/SKILL.md
+```
+
+---
+
+### 2. Container MCP tools: `container/agent-runner/src/ipc-mcp-stdio.ts`
+
+Append the contents of `.claude/skills/add-discord-threads/mcp-tools.ts` to `container/agent-runner/src/ipc-mcp-stdio.ts`, **before** the `// Start the stdio transport` line.
+
+The file contains:
+- `THREAD_RESULTS_DIR` constant
+- `waitForThreadResult()` helper (polls for IPC result files)
+- `discord_create_thread` tool registration
+- `discord_manage_thread` tool registration
+
+---
+
+### 3. Host IPC handlers: `src/ipc.ts`
+
+**3a.** In the `processTaskIpc` function's `switch` statement, add two new cases **before** the `default` case:
+
+```typescript
+    case 'discord_create_thread':
+      await handleDiscordCreateThread(data, sourceGroup);
+      break;
+
+    case 'discord_manage_thread':
+      await handleDiscordManageThread(data, sourceGroup);
+      break;
+```
+
+**3b.** Append the contents of `.claude/skills/add-discord-threads/ipc-handlers.ts` to the bottom of `src/ipc.ts`.
+
+The file contains `handleDiscordCreateThread()` and `handleDiscordManageThread()` functions that use discord.js REST API directly (no Client instance needed).
+
+---
+
+### 4. Passive thread awareness: `src/channels/discord.ts`
+
+These are small inline modifications to the existing Discord channel code.
+
+**4a.** Add `ThreadChannel` to the import from `discord.js`:
+
+```typescript
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message,
+  TextChannel,
+  ThreadChannel,
+} from 'discord.js';
+```
+
+**4b.** Add an `activeThreads` map to the `DiscordChannel` class properties (after `private botToken`):
+
+```typescript
+  private activeThreads = new Map<string, string>();
+```
+
+**4c.** In the `MessageCreate` handler, **replace** the existing `const channelId` and `const chatJid` lines after `if (message.author.bot) return;` with:
+
+```typescript
+      let channelId = message.channelId;
+      let chatJid = `dc:${channelId}`;
+
+      // Thread awareness: if message is in a thread, resolve to parent channel
+      const isThread = message.channel instanceof ThreadChannel;
+      if (isThread) {
+        const threadChannel = message.channel as ThreadChannel;
+        const parentId = threadChannel.parentId;
+        if (parentId) {
+          const parentJid = `dc:${parentId}`;
+          this.activeThreads.set(parentJid, channelId);
+          channelId = parentId;
+          chatJid = parentJid;
+        }
+      }
+```
+
+**4d.** In `sendMessage`, **replace** `const channelId = jid.replace(/^dc:/, '');` with:
+
+```typescript
+      const activeThreadId = this.activeThreads.get(jid);
+      const channelId = activeThreadId || jid.replace(/^dc:/, '');
+```
+
+**4e.** In `setTyping`, **replace** `const channelId = jid.replace(/^dc:/, '');` with:
+
+```typescript
+      const activeThreadId = this.activeThreads.get(jid);
+      const channelId = activeThreadId || jid.replace(/^dc:/, '');
+```
+
+---
+
+### 5. Update test mock: `src/channels/discord.test.ts`
+
+Add `ThreadChannel` class to the discord.js mock return value:
+
+```typescript
+  class ThreadChannel {}
+
+  return {
+    Client: MockClient,
+    Events,
+    GatewayIntentBits,
+    TextChannel,
+    ThreadChannel,
+  };
+```
+
+## Validate
+
+```bash
+npm run build
+npm test
+```
+
+Both must pass with zero failures.
+
+## Deploy
+
+```bash
+# Rebuild container (picks up new container skill doc)
+./container/build.sh
+
+# Restart service
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Notes
+
+- Bot needs `MANAGE_THREADS` + `CREATE_PUBLIC_THREADS` Discord server permissions
+- discord.js is already a project dependency; REST class is used directly (no extra Client instance)
+- `DISCORD_BOT_TOKEN` is read from env / `.env`
+- Thread tools only work for Discord channels (chatJid starting with `dc:`)
+- Active thread tracking is per-parent-channel; when a user messages in a thread, subsequent agent replies route there automatically

--- a/.claude/skills/add-discord-threads/container-skill.md
+++ b/.claude/skills/add-discord-threads/container-skill.md
@@ -1,0 +1,39 @@
+---
+name: discord-threads
+description: Create and manage Discord threads in the current channel. Use when you need to organize discussions into threads, create focused conversation spaces, or manage existing threads.
+---
+
+# Discord Thread Management
+
+Create and manage threads in Discord channels using MCP tools.
+
+## Available Tools
+
+### `discord_create_thread`
+
+Create a new thread in the current Discord channel.
+
+**Parameters:**
+- `name` (required) — Thread title (max 100 characters)
+- `auto_archive_minutes` (optional) — Auto-archive after inactivity: `60`, `1440` (1 day), `4320` (3 days), or `10080` (7 days). Default: `1440`
+- `initial_message` (optional) — First message to post in the thread
+
+**Returns:** `{ threadId, threadJid }` — the new thread's Discord ID and JID for messaging.
+
+### `discord_manage_thread`
+
+Manage an existing Discord thread.
+
+**Parameters:**
+- `thread_id` (required) — The Discord thread ID
+- `action` (required) — One of: `archive`, `unarchive`, `lock`, `unlock`, `rename`
+- `name` (optional) — New name when action is `rename`
+
+**Returns:** `{ success, message }`
+
+## Usage Notes
+
+- These tools only work in Discord channels (chatJid starts with `dc:`)
+- The bot needs `MANAGE_THREADS` and `CREATE_PUBLIC_THREADS` permissions in the server
+- After creating a thread, messages sent to the thread are automatically routed there
+- When someone messages in a thread, the agent receives and replies in the same thread

--- a/.claude/skills/add-discord-threads/ipc-handlers.ts
+++ b/.claude/skills/add-discord-threads/ipc-handlers.ts
@@ -1,0 +1,178 @@
+/**
+ * Discord Thread IPC Handlers
+ * Appended to src/ipc.ts (bottom of file, after processTaskIpc)
+ *
+ * These functions handle thread operations received via IPC from container agents.
+ * They use discord.js REST API directly (no Client instance needed).
+ */
+
+async function handleDiscordCreateThread(
+  data: Record<string, unknown>,
+  sourceGroup: string,
+): Promise<void> {
+  const { REST, Routes } = await import('discord.js');
+  const { readEnvFile } = await import('./env.js');
+
+  const requestId = data.requestId as string;
+  const chatJid = data.chatJid as string;
+  const name = data.name as string;
+  const autoArchiveMinutes = (data.auto_archive_minutes as number) || 1440;
+  const initialMessage = data.initial_message as string | undefined;
+  const resultsDir = path.join(DATA_DIR, 'ipc', sourceGroup, 'thread_results');
+
+  fs.mkdirSync(resultsDir, { recursive: true });
+
+  const writeResult = (result: object) => {
+    const resultPath = path.join(resultsDir, `${requestId}.json`);
+    const tempPath = `${resultPath}.tmp`;
+    fs.writeFileSync(tempPath, JSON.stringify(result, null, 2));
+    fs.renameSync(tempPath, resultPath);
+  };
+
+  try {
+    const envVars = readEnvFile(['DISCORD_BOT_TOKEN']);
+    const token =
+      process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN;
+    if (!token) {
+      writeResult({
+        success: false,
+        message: 'DISCORD_BOT_TOKEN not configured',
+      });
+      return;
+    }
+
+    const channelId = chatJid.replace(/^dc:/, '');
+    const rest = new REST({ version: '10' }).setToken(token);
+
+    let threadId: string;
+
+    if (initialMessage) {
+      const msg = (await rest.post(Routes.channelMessages(channelId), {
+        body: { content: initialMessage },
+      })) as { id: string };
+
+      const thread = (await rest.post(
+        Routes.threads(channelId, msg.id),
+        {
+          body: {
+            name,
+            auto_archive_duration: autoArchiveMinutes,
+          },
+        },
+      )) as { id: string };
+
+      threadId = thread.id;
+    } else {
+      const thread = (await rest.post(Routes.threads(channelId), {
+        body: {
+          name,
+          auto_archive_duration: autoArchiveMinutes,
+          type: 11, // PUBLIC_THREAD
+        },
+      })) as { id: string };
+
+      threadId = thread.id;
+    }
+
+    writeResult({
+      success: true,
+      threadId,
+      threadJid: `dc:${threadId}`,
+    });
+
+    logger.info(
+      { threadId, channelId, sourceGroup },
+      'Discord thread created via IPC',
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({ err, sourceGroup }, 'Failed to create Discord thread');
+    writeResult({ success: false, message });
+  }
+}
+
+async function handleDiscordManageThread(
+  data: Record<string, unknown>,
+  sourceGroup: string,
+): Promise<void> {
+  const { REST, Routes } = await import('discord.js');
+  const { readEnvFile } = await import('./env.js');
+
+  const requestId = data.requestId as string;
+  const threadId = data.thread_id as string;
+  const action = data.action as string;
+  const newName = data.name as string | undefined;
+  const resultsDir = path.join(
+    DATA_DIR,
+    'ipc',
+    sourceGroup,
+    'thread_results',
+  );
+
+  fs.mkdirSync(resultsDir, { recursive: true });
+
+  const writeResult = (result: object) => {
+    const resultPath = path.join(resultsDir, `${requestId}.json`);
+    const tempPath = `${resultPath}.tmp`;
+    fs.writeFileSync(tempPath, JSON.stringify(result, null, 2));
+    fs.renameSync(tempPath, resultPath);
+  };
+
+  try {
+    const envVars = readEnvFile(['DISCORD_BOT_TOKEN']);
+    const token =
+      process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN;
+    if (!token) {
+      writeResult({
+        success: false,
+        message: 'DISCORD_BOT_TOKEN not configured',
+      });
+      return;
+    }
+
+    const rest = new REST({ version: '10' }).setToken(token);
+
+    let body: Record<string, unknown>;
+    switch (action) {
+      case 'archive':
+        body = { archived: true };
+        break;
+      case 'unarchive':
+        body = { archived: false };
+        break;
+      case 'lock':
+        body = { locked: true };
+        break;
+      case 'unlock':
+        body = { locked: false };
+        break;
+      case 'rename':
+        body = { name: newName };
+        break;
+      default:
+        writeResult({
+          success: false,
+          message: `Unknown action: ${action}`,
+        });
+        return;
+    }
+
+    await rest.patch(Routes.channel(threadId), { body });
+
+    writeResult({
+      success: true,
+      message: `Thread ${action} successful`,
+    });
+    logger.info(
+      { threadId, action, sourceGroup },
+      'Discord thread managed via IPC',
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      { err, action, sourceGroup },
+      'Failed to manage Discord thread',
+    );
+    writeResult({ success: false, message });
+  }
+}

--- a/.claude/skills/add-discord-threads/mcp-tools.ts
+++ b/.claude/skills/add-discord-threads/mcp-tools.ts
@@ -1,0 +1,126 @@
+/**
+ * Discord Thread MCP Tools
+ * Appended to container/agent-runner/src/ipc-mcp-stdio.ts
+ *
+ * These tools allow agents to create and manage Discord threads via IPC.
+ * The host side (src/ipc.ts) handles the actual Discord API calls.
+ */
+
+// --- Discord Thread Tools ---
+
+const THREAD_RESULTS_DIR = path.join(IPC_DIR, 'thread_results');
+
+async function waitForThreadResult(requestId: string, maxWait = 30000): Promise<Record<string, unknown>> {
+  const resultFile = path.join(THREAD_RESULTS_DIR, `${requestId}.json`);
+  const pollInterval = 500;
+  let elapsed = 0;
+
+  while (elapsed < maxWait) {
+    if (fs.existsSync(resultFile)) {
+      try {
+        const result = JSON.parse(fs.readFileSync(resultFile, 'utf-8'));
+        fs.unlinkSync(resultFile);
+        return result;
+      } catch (err) {
+        return { success: false, message: `Failed to read result: ${err}` };
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, pollInterval));
+    elapsed += pollInterval;
+  }
+
+  return { success: false, message: 'Request timed out waiting for thread operation result' };
+}
+
+server.tool(
+  'discord_create_thread',
+  `Create a new thread in the current Discord channel. Only works in Discord channels (chatJid starts with "dc:").
+Returns the thread ID and JID that can be used for messaging.`,
+  {
+    name: z.string().max(100).describe('Thread title (max 100 characters)'),
+    auto_archive_minutes: z.enum(['60', '1440', '4320', '10080']).optional()
+      .describe('Auto-archive after inactivity: 60 (1hr), 1440 (1 day), 4320 (3 days), 10080 (7 days). Default: 1440'),
+    initial_message: z.string().optional().describe('Optional first message to post in the thread'),
+  },
+  async (args) => {
+    if (!chatJid.startsWith('dc:')) {
+      return {
+        content: [{ type: 'text' as const, text: 'discord_create_thread only works in Discord channels (chatJid must start with "dc:").' }],
+        isError: true,
+      };
+    }
+
+    const requestId = `thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const data = {
+      type: 'discord_create_thread',
+      requestId,
+      chatJid,
+      name: args.name,
+      auto_archive_minutes: args.auto_archive_minutes ? parseInt(args.auto_archive_minutes, 10) : 1440,
+      initial_message: args.initial_message,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    };
+
+    writeIpcFile(TASKS_DIR, data);
+
+    const result = await waitForThreadResult(requestId);
+
+    if (result.success) {
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ threadId: result.threadId, threadJid: result.threadJid }) }],
+      };
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: `Failed to create thread: ${result.message}` }],
+      isError: true,
+    };
+  },
+);
+
+server.tool(
+  'discord_manage_thread',
+  'Manage an existing Discord thread: archive, unarchive, lock, unlock, or rename.',
+  {
+    thread_id: z.string().describe('The Discord thread ID'),
+    action: z.enum(['archive', 'unarchive', 'lock', 'unlock', 'rename']).describe('Action to perform'),
+    name: z.string().max(100).optional().describe('New thread name (required when action is "rename")'),
+  },
+  async (args) => {
+    if (args.action === 'rename' && !args.name) {
+      return {
+        content: [{ type: 'text' as const, text: 'The "name" parameter is required when action is "rename".' }],
+        isError: true,
+      };
+    }
+
+    const requestId = `thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const data: Record<string, string | undefined> = {
+      type: 'discord_manage_thread',
+      requestId,
+      thread_id: args.thread_id,
+      action: args.action,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    };
+    if (args.name) data.name = args.name;
+
+    writeIpcFile(TASKS_DIR, data);
+
+    const result = await waitForThreadResult(requestId);
+
+    if (result.success) {
+      return {
+        content: [{ type: 'text' as const, text: `Thread ${args.action} successful.` }],
+      };
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: `Failed to ${args.action} thread: ${result.message}` }],
+      isError: true,
+    };
+  },
+);


### PR DESCRIPTION
## Summary

- New skill (`/add-discord-threads`) that adds Discord thread management to NanoClaw
- Agents can create and manage threads via MCP tools (`discord_create_thread`, `discord_manage_thread`)
- Incoming thread messages are auto-routed so agent replies go to the correct thread
- Follows the fixed-code-file pattern (like x-integration): SKILL.md references standalone code files instead of inline code blocks

## File Structure

```
.claude/skills/add-discord-threads/
├── SKILL.md            # Installation instructions
├── container-skill.md  # Agent-readable skill doc (copied to container)
├── mcp-tools.ts        # Container-side MCP tool registrations
└── ipc-handlers.ts     # Host-side IPC handler functions
```

## How it works

1. **Container side**: Two MCP tools registered in `ipc-mcp-stdio.ts` — agent writes IPC task file, polls for result
2. **Host side**: IPC handler in `src/ipc.ts` receives task, calls Discord REST API to create/manage threads, writes result file
3. **Passive awareness**: `discord.ts` detects thread messages via `ThreadChannel`, tracks active threads per parent channel, auto-routes replies

## Prerequisites

- Discord channel set up (`/add-discord`)
- Two-layer mount mechanism (PR #1053)
- Bot needs `MANAGE_THREADS` + `CREATE_PUBLIC_THREADS` Discord permissions

## Test plan

- [x] Skill installs cleanly following SKILL.md instructions
- [x] `npm run build` passes after installation
- [x] `npm test` passes (271 tests)
- [x] Thread creation works end-to-end via Discord
- [x] Agent replies route to active thread automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)