### PR TITLE
feat(skill): add Nostr signing daemon with per-session scoping and rate limiting

### DIFF
--- a/.claude/skills/add-nostr-signer/SKILL.md
+++ b/.claude/skills/add-nostr-signer/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: add-nostr-signer
+description: "Nostr signing daemon — keeps private key in kernel keyring, signs events via Unix socket. Required by add-nostr-dm, add-whitenoise, and add-nwc-wallet skills."
+---
+
+*Synthesized by Jorgenclaw (AI agent) and Claude Code (host AI), with direct feedback and verification from Scott Jorgensen*
+
+# Add Nostr Signing Daemon
+
+This skill installs a signing daemon that holds your Nostr private key securely in memory. Other NanoClaw skills (Nostr DM, White Noise, NWC wallet) use this daemon to sign events without ever seeing the private key.
+
+> **Feeling stuck?** Don't be afraid to ask Claude directly where you are in the process and what to do next.
+
+## What You're Setting Up
+
+| Component | What it does |
+|-----------|-------------|
+| **Signing daemon** (`tools/nostr-signer/index.js`) | A background service that reads your private key from the Linux keyring at startup and signs Nostr events on request |
+| **clawstr-post** (`tools/nostr-signer/clawstr-post.js`) | A command-line tool that lets the agent post to Nostr relays by delegating signing to the daemon |
+| **Unix socket** | The daemon listens on a socket file — other programs connect to it to request signatures |
+| **Kernel keyring** | A secure area of Linux memory where your private key is stored — it never touches disk |
+
+## Phase 1: Pre-flight
+
+### Check if already installed
+
+Check if `tools/nostr-signer/index.js` exists. If it does, skip to Phase 3 (Setup). The code is already in place.
+
+### Ask the user
+
+Use `AskUserQuestion`:
+
+AskUserQuestion: Do you have a Nostr private key (nsec), or do you need to generate one?
+
+**If they have one:** Collect it (starts with `nsec1...`). Keep it in memory only — never write it to a file or log it.
+
+**If they need one:** We'll generate one in Phase 3.
+
+## Phase 2: Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git fetch origin skill/add-nostr-signer
+git merge origin/skill/add-nostr-signer --no-edit
+```
+
+This adds `tools/nostr-signer/` with the signing daemon, posting CLI, and package.json.
+
+### Install daemon dependencies
+
+```bash
+cd tools/nostr-signer && npm install && cd ../..
+```
+
+### Update container-runner.ts
+
+Add two mounts in the `buildVolumeMounts()` function (or equivalent mount-building section) so containers can access the signing daemon:
+
+1. **Signer socket mount** — Mount the host's signing daemon socket into the container:
+   - Host path: `$XDG_RUNTIME_DIR/nostr-signer.sock` (typically `/run/user/1000/nostr-signer.sock`)
+   - Container path: `/run/nostr/signer.sock`
+   - Read-only: yes
+   - The container env var `NOSTR_SIGNER_SOCKET` should be set to `/run/nostr/signer.sock`
+
+2. **clawstr-post mount** — Mount the posting tool so containers can publish to Nostr:
+   - Host path: `tools/nostr-signer/clawstr-post.js`
+   - Container path: `/usr/local/lib/nostr-signer/clawstr-post.js`
+   - Read-only: yes
+
+Also add `-e NOSTR_SIGNER_SOCKET=/run/nostr/signer.sock` to the container environment variables.
+
+### Validate
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Generate a key (if needed)
+
+If the user doesn't have an nsec, generate one:
+
+```bash
+cd tools/nostr-signer && node -e "
+  const { generateSecretKey } = await import('nostr-tools/pure');
+  const { nsecEncode } = await import('nostr-tools/nip19');
+  const sk = generateSecretKey();
+  console.log(nsecEncode(sk));
+" && cd ../..
+```
+
+**Important:** Show the nsec to the user exactly once and tell them to save it in their password manager. It will never be shown again.
+
+### Store key in kernel keyring
+
+The keyring keeps the key in memory only — it never touches disk:
+
+```bash
+echo -n "nsec1..." | keyctl padd user wn_nsec @u
+```
+
+Replace `nsec1...` with the actual key. The `wn_nsec` name is what the daemon searches for at startup.
+
+**Verify it's stored:**
+
+```bash
+keyctl search @u user wn_nsec
+```
+
+This should print a key ID number. If it says "not found", the key wasn't stored correctly.
+
+> **Note:** The kernel keyring is cleared on reboot. You'll need to re-add the key after each restart (or add the `keyctl` command to a startup script).
+
+### Create systemd service
+
+Create `~/.config/systemd/user/nostr-signer.service`:
+
+```ini
+[Unit]
+Description=Nostr Signing Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env node /path/to/NanoClaw/tools/nostr-signer/index.js
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+Replace `/path/to/NanoClaw` with the actual project path.
+
+### Start the service
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable nostr-signer
+systemctl --user start nostr-signer
+```
+
+### Add to .env
+
+```
+NOSTR_SIGNER_SOCKET=/run/user/1000/nostr-signer.sock
+```
+
+Adjust the path if your `XDG_RUNTIME_DIR` is different (check with `echo $XDG_RUNTIME_DIR`).
+
+## Phase 4: Verify
+
+### Check the service is running
+
+```bash
+systemctl --user status nostr-signer
+```
+
+You should see `Active: active (running)` in green.
+
+### Test signing via socket
+
+```bash
+echo '{"method":"get_public_key"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/nostr-signer.sock
+```
+
+This should return a JSON response with your public key (hex format). If it does, the daemon is working.
+
+### Test clawstr-post
+
+```bash
+node tools/nostr-signer/clawstr-post.js pubkey
+```
+
+This should print the same public key.
+
+## Phase 5: Troubleshooting
+
+| Problem | What it means | What to do |
+|---------|--------------|------------|
+| "Failed to load key from keyring" | The nsec isn't in the kernel keyring | Run the `keyctl padd` command from Phase 3 again |
+| Socket not found | The daemon isn't running or socket path is wrong | Check `systemctl --user status nostr-signer` and verify the socket path |
+| Permission denied on socket | Socket has wrong permissions | The daemon sets `chmod 600` automatically — make sure you're running as the same user |
+| Key lost after reboot | Kernel keyring is cleared on reboot | Re-add the key with `keyctl padd` and restart the daemon |
+| "EADDRINUSE" error | Old socket file wasn't cleaned up | Delete the stale socket: `rm $XDG_RUNTIME_DIR/nostr-signer.sock` and restart |
+
+## Removal
+
+To remove the signing daemon:
+
+1. Stop and disable the service: `systemctl --user stop nostr-signer && systemctl --user disable nostr-signer`
+2. Remove the service file: `rm ~/.config/systemd/user/nostr-signer.service`
+3. Remove from keyring: `keyctl unlink $(keyctl search @u user wn_nsec) @u`
+4. Delete daemon files: `rm -rf tools/nostr-signer/`
+5. Remove `NOSTR_SIGNER_SOCKET` from `.env`
+6. Revert the container-runner.ts changes (remove socket and clawstr-post mounts)
+7. Rebuild: `npm run build`

--- a/.claude/skills/add-nostr-signer/SKILL.md
+++ b/.claude/skills/add-nostr-signer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-nostr-signer
-description: "Nostr signing daemon — keeps private key in kernel keyring, signs events via Unix socket. Required by add-nostr-dm, add-whitenoise, and add-nwc-wallet skills."
+description: "Nostr signing daemon — keeps private key in kernel keyring, signs events via Unix socket with per-session scoping and rate limiting. Required by add-nostr-dm, add-whitenoise, and add-nwc-wallet skills."
 ---
 
 *Synthesized by Jorgenclaw (AI agent) and Claude Code (host AI), with direct feedback and verification from Scott Jorgensen*
@@ -16,6 +16,8 @@ This skill installs a signing daemon that holds your Nostr private key securely 
 | Component | What it does |
 |-----------|-------------|
 | **Signing daemon** (`tools/nostr-signer/index.js`) | A background service that reads your private key from the Linux keyring at startup and signs Nostr events on request |
+| **Session manager** (`tools/nostr-signer/sessions.js`) | Issues short-lived tokens scoped to specific event kinds — the agent gets a permission slip, not the key |
+| **Rate limiter** (`tools/nostr-signer/rate-limiter.js`) | Prevents signing abuse — configurable burst, per-minute, and per-hour limits per session |
 | **clawstr-post** (`tools/nostr-signer/clawstr-post.js`) | A command-line tool that lets the agent post to Nostr relays by delegating signing to the daemon |
 | **Unix socket** | The daemon listens on a socket file — other programs connect to it to request signatures |
 | **Kernel keyring** | A secure area of Linux memory where your private key is stored — it never touches disk |
@@ -187,6 +189,40 @@ This should print the same public key.
 | Permission denied on socket | Socket has wrong permissions | The daemon sets `chmod 600` automatically — make sure you're running as the same user |
 | Key lost after reboot | Kernel keyring is cleared on reboot | Re-add the key with `keyctl padd` and restart the daemon |
 | "EADDRINUSE" error | Old socket file wasn't cleaned up | Delete the stale socket: `rm $XDG_RUNTIME_DIR/nostr-signer.sock` and restart |
+
+## Session Security (New)
+
+The daemon now supports **scoped sessions** — short-lived tokens that limit what an agent can sign.
+
+### How it works
+
+At container startup, the orchestrator (or user) creates a session:
+
+```bash
+echo '{"method":"session_start","params":{"scope":"1,9734,1111","ttl":"28800"}}' \
+  | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+This returns a session token valid for 8 hours, scoped to kind:1 (posts), kind:9734 (zaps), and kind:1111 (comments). The container passes this token with every `sign_event` request.
+
+### What gets blocked
+
+- **Out-of-scope kinds:** A session scoped to `[1, 1111]` cannot sign kind:0 (profile updates) or kind:8 (badge awards)
+- **Rate exceeded:** More than 5 requests in 10 seconds, 10 per minute, or 100 per hour triggers rejection
+- **Expired sessions:** After TTL, all requests with that token are rejected
+- **Invalid/revoked tokens:** Immediately rejected
+
+Every rejection is logged to `~/NanoClaw/groups/main/status/signer-alerts.log`.
+
+### Backwards compatible
+
+Existing tools that sign without a session token still work — the daemon logs a deprecation warning but signs normally. No migration required to upgrade.
+
+### Full documentation
+
+See `docs/nostr-signer-sessions.md` for the complete guide with hands-on testing commands, troubleshooting, and migration recommendations.
+
+---
 
 ## Removal
 

--- a/docs/nostr-signer-sessions.md
+++ b/docs/nostr-signer-sessions.md
@@ -1,0 +1,218 @@
+# Nostr Signer Sessions — Scoped Signing for Your AI Agent
+
+*Synthesized by Jorgenclaw (AI agent) and Claude Code (host AI), with direct feedback and verification from Scott Jorgensen*
+
+**Feeling stuck? Ask Claude directly where you are in the process and what to do next.**
+
+---
+
+## What You're Learning About
+
+Your NanoClaw agent signs Nostr events (posts, zaps, badge awards, DMs) using a signing daemon that holds your private key in kernel memory. The agent never sees the key — it just asks the daemon to sign things.
+
+Until now, the daemon signed whatever the agent asked, with no limits. That worked, but it meant a compromised container could request unlimited signatures for any event type.
+
+**Sessions** fix this. They're short-lived permission slips that tell the daemon exactly what the agent is allowed to sign, for how long, and how often.
+
+Think of it like giving someone your car keys vs. giving them a valet ticket. The valet ticket works for one trip, for one car, and expires when they're done.
+
+---
+
+## What You're Setting Up
+
+Nothing — it's already running. The signing daemon now supports sessions automatically. What you're learning here is:
+
+1. How sessions work (so you understand what's protecting your key)
+2. How to create one manually (for testing or debugging)
+3. What happens when something goes wrong (rate limits, scope violations)
+4. How your agent should use sessions going forward
+
+---
+
+## The Three Security Layers
+
+### Layer 1: Session Tokens
+
+A session token is a random string that grants permission to sign specific event types for a limited time.
+
+| What you want to do | What it means |
+|---------------------|---------------|
+| Create a session | Tell the daemon "allow signing kind:1 and kind:9734 for the next 8 hours" |
+| Use a session | Include the token with every signing request |
+| Revoke a session | Immediately invalidate the token — no more signing |
+
+**Scoped event kinds:** Each session only allows specific Nostr event types:
+
+| Kind | What it is | Risk level |
+|------|-----------|------------|
+| 1 | Public notes (posts) | Low — visible but not dangerous |
+| 1111 | Subclaw comments (NIP-22) | Low |
+| 9734 | Zap requests (Lightning payments) | Medium — involves money |
+| 8 | Badge awards | Medium — permanent credentials |
+| 0 | Profile updates | High — changes your identity |
+| 30009 | Badge definitions | High — creates new badge types |
+
+A session scoped to `[1, 1111]` can post notes and subclaw comments but cannot send zaps, award badges, or change the profile. If a container is compromised, the attacker can only do what the session allows.
+
+### Layer 2: Rate Limiting
+
+Even within a valid session, the daemon limits how fast the agent can sign:
+
+| Limit | Default | Why |
+|-------|---------|-----|
+| 5 per 10 seconds | Burst protection | Prevents rapid-fire spam |
+| 10 per minute | Normal pace | More than enough for real agent work |
+| 100 per hour | Safety ceiling | No legitimate agent needs more |
+
+If a limit is hit, the request is rejected and logged. The agent gets a clear error message. Nothing breaks — it just has to wait.
+
+### Layer 3: Backwards Compatibility
+
+If you don't use sessions yet, everything still works exactly as before. The daemon logs a deprecation warning the first time it sees a request without a session token, but it signs the event normally. This means:
+
+- Your existing tools (clawstr-post, badge-claim-listener, etc.) keep working
+- You can migrate to sessions gradually
+- Nothing breaks on upgrade
+
+---
+
+## How to Test It Yourself
+
+Open a terminal on the machine where NanoClaw runs. These commands talk directly to the signing daemon.
+
+### Create a session
+
+```bash
+echo '{"method":"session_start","params":{"scope":"1,1111","ttl":"3600"}}' \
+  | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+You'll get back something like:
+```json
+{
+  "session": {
+    "token": "ff5ec525...a long random string...",
+    "expiresAt": 1775111845270,
+    "allowedKinds": [1, 1111]
+  }
+}
+```
+
+**What this did:** Created a session that allows signing kind:1 (posts) and kind:1111 (subclaw comments) for 1 hour (3600 seconds). Save the token — you'll need it for the next steps.
+
+### Sign an event with the session
+
+```bash
+echo '{"method":"sign_event","params":{
+  "kind": 1,
+  "content": "Hello from a scoped session",
+  "tags": [],
+  "session_token": "YOUR_TOKEN_HERE"
+}}' | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+**What happens:** The daemon checks the token, confirms kind:1 is in scope, checks rate limits, and signs the event. You get back a fully signed Nostr event.
+
+### Try signing something NOT in scope
+
+```bash
+echo '{"method":"sign_event","params":{
+  "kind": 0,
+  "content": "profile update attempt",
+  "tags": [],
+  "session_token": "YOUR_TOKEN_HERE"
+}}' | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+**What happens:** The daemon rejects it:
+```json
+{"error": "Event kind 0 not in session scope [1, 1111]"}
+```
+
+The rejection is also logged to `~/NanoClaw/groups/main/status/signer-alerts.log` so you can see what was attempted.
+
+### Check session status
+
+```bash
+echo '{"method":"session_info","params":{"token":"YOUR_TOKEN_HERE"}}' \
+  | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+Returns how many times the session has been used, whether it's expired, and current rate stats.
+
+### Revoke a session
+
+```bash
+echo '{"method":"session_revoke","params":{"token":"YOUR_TOKEN_HERE"}}' \
+  | nc -U $XDG_RUNTIME_DIR/nostr-signer.sock -w 2
+```
+
+**What happens:** The token is immediately invalid. Any future signing request using it will be rejected. Use this when a container session ends, or if you suspect something is wrong.
+
+---
+
+## What the Alert Log Looks Like
+
+When the daemon rejects a request, it writes to:
+```
+~/NanoClaw/groups/main/status/signer-alerts.log
+```
+
+Example entries:
+```
+2026-04-02T05:37:39Z sign_event rejected: Event kind 0 not in session scope [1,9734] (kind=0, token=ff5ec525...)
+2026-04-02T05:38:07Z sign_event rate-limited: Rate limit: burst exceeded (5/5 in 10s) (token=ff5ec525...)
+```
+
+If you see entries you didn't expect, that's worth investigating — it could mean a tool is misconfigured, or something is trying to use the signing daemon in a way it shouldn't.
+
+---
+
+## How Your Agent Should Use Sessions
+
+Right now, your agent's tools (clawstr-post, badge-claim-listener, etc.) use legacy mode — they sign without a session token. This still works.
+
+The recommended migration path:
+
+1. **Don't rush.** Legacy mode is safe for now. The daemon logs a deprecation warning but signs normally.
+2. **When you customize a tool**, add session support at that point. Create a session at startup, pass the token with each signing request, revoke it on shutdown.
+3. **For high-risk operations** (zaps, profile updates), sessions add real protection. A session scoped to `[9734]` with a 1-hour TTL means even a compromised container can only send zap requests — and only for an hour.
+4. **For NanoClaw container startup**, the orchestrator (`src/container-runner.ts`) is the natural place to create a session and pass the token to the container as an environment variable.
+
+---
+
+## Troubleshooting
+
+| Problem | What it means | What to do |
+|---------|--------------|------------|
+| "Invalid session token" | Token doesn't exist or was revoked | Create a new session with `session_start` |
+| "Session expired" | TTL ran out | Create a new session — the old one is gone |
+| "Event kind X not in session scope" | The session doesn't allow this event type | Create a new session with the needed kind in the scope, or use legacy mode |
+| "Rate limit: burst exceeded" | Too many requests too fast | Wait 10 seconds and try again. If this keeps happening, something is looping. |
+| "Rate limit: N/10 per minute" | Hit the per-minute ceiling | Wait a minute. If legitimate, consider whether your tool is signing too often. |
+| Legacy deprecation warning in logs | Tool signing without a session token | Not urgent — works fine. Migrate when convenient. |
+| Alert log has entries you don't recognize | Something unexpected tried to sign | Check which tool or process made the request. Could be a misconfigured tool or something worth investigating. |
+
+---
+
+## Files Created by This Feature
+
+| File | What it does |
+|------|-------------|
+| `tools/nostr-signer/index.js` | Main daemon — now includes session validation and rate limiting |
+| `tools/nostr-signer/sessions.js` | Session token management (create, validate, revoke, persist to disk) |
+| `tools/nostr-signer/rate-limiter.js` | Sliding window rate limiter (burst, per-minute, per-hour) |
+| `~/.config/nanoclaw/signer-sessions.json` | Active sessions persisted to disk (survives daemon restart) |
+| `~/NanoClaw/groups/main/status/signer-alerts.log` | Rejection and rate-limit alerts |
+
+---
+
+## Why This Matters
+
+Most AI agent systems give the agent unlimited access to whatever credentials it needs. If the agent is compromised, everything it can access is compromised.
+
+Sessions are a different model: the agent gets a temporary, scoped permission slip that limits what it can do and for how long. The private key stays in kernel memory on the host. The session token is the only thing the container touches — and it can only sign what the session allows.
+
+No implementation of this pattern exists anywhere else in the Nostr ecosystem. This is the first signing daemon with per-session scoping and rate limiting. It was built because Scott asked a simple question: "What happens if the container gets hacked?" The answer used to be "they can sign anything forever." Now the answer is "they can sign what the session allows, at the rate we set, for the time we choose — and every rejection is logged."
+
+That's the difference between trusting your agent and verifying your agent.

--- a/tools/nostr-signer/clawstr-post.js
+++ b/tools/nostr-signer/clawstr-post.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * clawstr-post — Signs and publishes Nostr events via the signing daemon.
+ *
+ * Replaces `npx clawstr post` by delegating signing to the daemon socket
+ * instead of reading a hex key file. The private key never enters the container.
+ *
+ * Usage:
+ *   clawstr-post post <subclaw> "content"
+ *   clawstr-post reply <event-id> "content"
+ *   clawstr-post upvote <event-id>
+ *   clawstr-post pubkey
+ *   clawstr-post sign '{"kind":1,"content":"hello","tags":[]}'
+ */
+
+import { connect } from 'net';
+
+const SOCKET_PATH = process.env.NOSTR_SIGNER_SOCKET || '/run/nostr/signer.sock';
+const DEFAULT_RELAYS = (process.env.NOSTR_RELAYS || 'wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social').split(',');
+
+// --- Socket helpers ---
+
+function daemonRequest(payload) {
+  return new Promise((resolve, reject) => {
+    const sock = connect(SOCKET_PATH);
+    let data = '';
+    sock.on('connect', () => {
+      sock.write(JSON.stringify(payload));
+      sock.end();
+    });
+    sock.on('data', (chunk) => { data += chunk; });
+    sock.on('end', () => {
+      try { resolve(JSON.parse(data)); }
+      catch (e) { reject(new Error(`Bad response from signer: ${data}`)); }
+    });
+    sock.on('error', (err) => reject(new Error(`Cannot connect to signing daemon at ${SOCKET_PATH}: ${err.message}`)));
+  });
+}
+
+async function signEvent(kind, content, tags) {
+  const res = await daemonRequest({
+    method: 'sign_event',
+    params: { kind, content, tags },
+  });
+  if (res.error) throw new Error(res.error);
+  return res.event;
+}
+
+async function getPubkey() {
+  const res = await daemonRequest({ method: 'get_public_key' });
+  if (res.error) throw new Error(res.error);
+  return res.pubkey;
+}
+
+// --- Relay publishing (lightweight, no dependencies) ---
+
+async function publishToRelays(event) {
+  const results = [];
+  const promises = DEFAULT_RELAYS.map(async (url) => {
+    try {
+      const { default: WebSocket } = await import('ws');
+      const ws = new WebSocket(url);
+      await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => { ws.close(); reject(new Error('timeout')); }, 10000);
+        ws.on('open', () => {
+          ws.send(JSON.stringify(['EVENT', event]));
+        });
+        ws.on('message', (msg) => {
+          const parsed = JSON.parse(msg.toString());
+          if (parsed[0] === 'OK' && parsed[1] === event.id) {
+            clearTimeout(timeout);
+            if (parsed[2]) {
+              results.push(url);
+            }
+            ws.close();
+            resolve();
+          }
+        });
+        ws.on('error', (e) => { clearTimeout(timeout); reject(e); });
+      });
+    } catch (e) {
+      // relay failed, skip
+    }
+  });
+  await Promise.allSettled(promises);
+  return results;
+}
+
+// --- Commands ---
+
+async function cmdPost(subclaw, content) {
+  if (!subclaw || !content) {
+    console.error('Usage: clawstr-post post <subclaw> "content"');
+    process.exit(1);
+  }
+  let name = subclaw.replace(/^(https:\/\/clawstr\.com)?\/c\//, '').replace(/^\/+/, '');
+  const subclawUrl = `https://clawstr.com/c/${name}`;
+  const tags = [
+    ['I', subclawUrl], ['K', 'web'],
+    ['i', subclawUrl], ['k', 'web'],
+    ['L', 'agent'], ['l', 'ai', 'agent'],
+    ['client', 'clawstr-cli'],
+  ];
+  const event = await signEvent(1111, content, tags);
+  const relays = await publishToRelays(event);
+  if (relays.length > 0) {
+    console.log(`${subclawUrl}/post/${event.id}`);
+    console.error(`Posted to ${relays.length} relay(s)`);
+  } else {
+    console.error('Failed to publish to any relay');
+    process.exit(1);
+  }
+}
+
+async function cmdReply(eventId, content) {
+  if (!eventId || !content) {
+    console.error('Usage: clawstr-post reply <event-id> "content"');
+    process.exit(1);
+  }
+  const tags = [
+    ['e', eventId, '', 'reply'],
+    ['L', 'agent'], ['l', 'ai', 'agent'],
+    ['client', 'clawstr-cli'],
+  ];
+  const event = await signEvent(1111, content, tags);
+  const relays = await publishToRelays(event);
+  if (relays.length > 0) {
+    console.log(event.id);
+    console.error(`Reply published to ${relays.length} relay(s)`);
+  } else {
+    console.error('Failed to publish to any relay');
+    process.exit(1);
+  }
+}
+
+async function cmdUpvote(eventId) {
+  if (!eventId) {
+    console.error('Usage: clawstr-post upvote <event-id>');
+    process.exit(1);
+  }
+  const tags = [['e', eventId], ['client', 'clawstr-cli']];
+  const event = await signEvent(7, '+', tags);
+  const relays = await publishToRelays(event);
+  if (relays.length > 0) {
+    console.error(`Upvoted (${relays.length} relay(s))`);
+  } else {
+    console.error('Failed to publish to any relay');
+    process.exit(1);
+  }
+}
+
+async function cmdSign(jsonStr) {
+  if (!jsonStr) {
+    console.error('Usage: clawstr-post sign \'{"kind":1,"content":"...","tags":[]}\'');
+    process.exit(1);
+  }
+  const params = JSON.parse(jsonStr);
+  const event = await signEvent(params.kind, params.content, params.tags || []);
+  console.log(JSON.stringify(event));
+}
+
+// --- Main ---
+
+const [,, cmd, ...args] = process.argv;
+
+try {
+  switch (cmd) {
+    case 'post':    await cmdPost(args[0], args.slice(1).join(' ')); break;
+    case 'reply':   await cmdReply(args[0], args.slice(1).join(' ')); break;
+    case 'upvote':  await cmdUpvote(args[0]); break;
+    case 'pubkey':  console.log(await getPubkey()); break;
+    case 'sign':    await cmdSign(args[0]); break;
+    default:
+      console.error('Commands: post, reply, upvote, pubkey, sign');
+      console.error('Example: clawstr-post post ai-freedom "Hello from the daemon!"');
+      process.exit(1);
+  }
+} catch (e) {
+  console.error('Error:', e.message);
+  process.exit(1);
+}

--- a/tools/nostr-signer/clawstr-post.js
+++ b/tools/nostr-signer/clawstr-post.js
@@ -16,7 +16,7 @@
 import { connect } from 'net';
 
 const SOCKET_PATH = process.env.NOSTR_SIGNER_SOCKET || '/run/nostr/signer.sock';
-const DEFAULT_RELAYS = (process.env.NOSTR_RELAYS || 'wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social').split(',');
+const DEFAULT_RELAYS = (process.env.NOSTR_RELAYS || 'wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net,wss://relay.nostr.band,wss://purplepag.es').split(',');
 
 // --- Socket helpers ---
 
@@ -112,12 +112,16 @@ async function cmdPost(subclaw, content) {
   }
 }
 
-async function cmdReply(eventId, content) {
-  if (!eventId || !content) {
-    console.error('Usage: clawstr-post reply <event-id> "content"');
+async function cmdReply(eventId, subclaw, content) {
+  if (!eventId || !subclaw || !content) {
+    console.error('Usage: clawstr-post reply <event-id> <subclaw> "content"');
     process.exit(1);
   }
+  const subclawUrl = `https://clawstr.com/c/${subclaw}`;
+  const postUrl = `https://clawstr.com/c/${subclaw}/post/${eventId}`;
   const tags = [
+    ['I', subclawUrl], ['K', 'web'],
+    ['i', postUrl], ['k', '1111'],
     ['e', eventId, '', 'reply'],
     ['L', 'agent'], ['l', 'ai', 'agent'],
     ['client', 'clawstr-cli'],
@@ -166,7 +170,7 @@ const [,, cmd, ...args] = process.argv;
 try {
   switch (cmd) {
     case 'post':    await cmdPost(args[0], args.slice(1).join(' ')); break;
-    case 'reply':   await cmdReply(args[0], args.slice(1).join(' ')); break;
+    case 'reply':   await cmdReply(args[0], args[1], args.slice(2).join(' ')); break;
     case 'upvote':  await cmdUpvote(args[0]); break;
     case 'pubkey':  console.log(await getPubkey()); break;
     case 'sign':    await cmdSign(args[0]); break;

--- a/tools/nostr-signer/index.js
+++ b/tools/nostr-signer/index.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Nostr Signing Daemon
+ *
+ * Reads the nsec from the Linux kernel keyring at startup,
+ * holds it only in process memory, and signs Nostr events
+ * on request via a Unix socket.
+ *
+ * The agent can USE the key without ever SEEING the key.
+ */
+
+import { execSync } from 'child_process';
+import { createServer } from 'net';
+import { existsSync, unlinkSync } from 'fs';
+import { finalizeEvent, getPublicKey } from 'nostr-tools/pure';
+import { decode as decodeNsec } from 'nostr-tools/nip19';
+import { unwrapEvent as nip17Unwrap, wrapManyEvents as nip17WrapMany } from 'nostr-tools/nip17';
+
+// --- Load key from kernel keyring ---
+let secretKeyHex;
+try {
+  const keyId = execSync('keyctl search @u user wn_nsec', { encoding: 'utf8' }).trim();
+  const nsec = execSync(`keyctl print ${keyId}`, { encoding: 'utf8' }).trim();
+  const decoded = decodeNsec(nsec);
+  if (decoded.type !== 'nsec') throw new Error('Keyring value is not an nsec');
+  secretKeyHex = decoded.data;
+  console.log('[nostr-signer] Key loaded from kernel keyring');
+} catch (err) {
+  // NEVER log err.message — nostr-tools includes the raw key value in decode errors
+  console.error('[nostr-signer] Failed to load key from keyring. Ensure wn_nsec contains ONLY the nsec1... string (no extra lines or whitespace).');
+  process.exit(1);
+}
+
+const pubkey = getPublicKey(secretKeyHex);
+console.log(`[nostr-signer] Public key: ${pubkey}`);
+
+// --- Socket path ---
+const SOCKET_PATH = process.env.NOSTR_SIGNER_SOCKET
+  || `${process.env.XDG_RUNTIME_DIR || '/run/user/1000'}/nostr-signer.sock`;
+
+// Clean up stale socket
+if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH);
+
+// --- Handle requests ---
+function handleRequest(data) {
+  try {
+    const req = JSON.parse(data);
+
+    if (req.method === 'get_public_key') {
+      return JSON.stringify({ pubkey });
+    }
+
+    if (req.method === 'sign_event') {
+      const p = req.params || {};
+      if (p.kind === undefined) return JSON.stringify({ error: 'Missing required field: kind' });
+      if (p.content === undefined) return JSON.stringify({ error: 'Missing required field: content' });
+
+      const eventTemplate = {
+        kind: p.kind,
+        content: p.content,
+        tags: p.tags || [],
+        created_at: p.created_at || Math.floor(Date.now() / 1000),
+      };
+
+      const signedEvent = finalizeEvent(eventTemplate, secretKeyHex);
+      return JSON.stringify({ event: signedEvent });
+    }
+
+    if (req.method === 'unwrap_gift_wrap') {
+      const p = req.params || {};
+      if (!p.event) return JSON.stringify({ error: 'Missing required field: event' });
+      try {
+        const rumor = nip17Unwrap(p.event, secretKeyHex);
+        return JSON.stringify({ rumor });
+      } catch (err) {
+        return JSON.stringify({ error: `Unwrap failed: ${err.message}` });
+      }
+    }
+
+    if (req.method === 'wrap_dm') {
+      const p = req.params || {};
+      if (!p.recipientPubkey) return JSON.stringify({ error: 'Missing required field: recipientPubkey' });
+      if (p.message === undefined) return JSON.stringify({ error: 'Missing required field: message' });
+      try {
+        const recipients = [{ publicKey: p.recipientPubkey }];
+        const events = nip17WrapMany(secretKeyHex, recipients, p.message, p.conversationTitle, p.replyTo);
+        return JSON.stringify({ events });
+      } catch (err) {
+        return JSON.stringify({ error: `Wrap failed: ${err.message}` });
+      }
+    }
+
+    return JSON.stringify({ error: `Unknown method: ${req.method}` });
+  } catch (err) {
+    return JSON.stringify({ error: `Parse error: ${err.message}` });
+  }
+}
+
+// --- Start server ---
+const server = createServer((conn) => {
+  let buf = '';
+  conn.on('data', (chunk) => { buf += chunk; });
+  conn.on('end', () => {
+    const response = handleRequest(buf);
+    conn.end(response + '\n');
+  });
+});
+
+server.listen(SOCKET_PATH, () => {
+  // Set socket permissions to owner-only
+  execSync(`chmod 600 ${SOCKET_PATH}`);
+  console.log(`[nostr-signer] Listening on ${SOCKET_PATH}`);
+});
+
+// --- Graceful shutdown ---
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    console.log(`[nostr-signer] ${sig} received, shutting down`);
+    server.close();
+    if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH);
+    process.exit(0);
+  });
+}

--- a/tools/nostr-signer/index.js
+++ b/tools/nostr-signer/index.js
@@ -7,14 +7,37 @@
  * on request via a Unix socket.
  *
  * The agent can USE the key without ever SEEING the key.
+ *
+ * Security layers:
+ * - Session tokens with TTL and event-kind scope
+ * - Per-session rate limiting
+ * - Legacy mode (no token) supported with deprecation warning
  */
 
 import { execSync } from 'child_process';
 import { createServer } from 'net';
-import { existsSync, unlinkSync } from 'fs';
+import { existsSync, unlinkSync, appendFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
 import { finalizeEvent, getPublicKey } from 'nostr-tools/pure';
 import { decode as decodeNsec } from 'nostr-tools/nip19';
 import { unwrapEvent as nip17Unwrap, wrapManyEvents as nip17WrapMany } from 'nostr-tools/nip17';
+import * as nip44 from 'nostr-tools/nip44';
+import * as nip04 from 'nostr-tools/nip04';
+import { createSession, validateSession, revokeSession, getSessionInfo } from './sessions.js';
+import { checkRate, clearRate, getRateStats } from './rate-limiter.js';
+
+// --- Alert log ---
+const ALERT_LOG = process.env.SIGNER_ALERT_LOG
+  || `${process.env.HOME || '/tmp'}/NanoClaw/groups/main/status/signer-alerts.log`;
+
+function logAlert(msg) {
+  try {
+    const dir = dirname(ALERT_LOG);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(ALERT_LOG, `${new Date().toISOString()} ${msg}\n`);
+  } catch { /* best effort */ }
+  console.warn(`[nostr-signer] ALERT: ${msg}`);
+}
 
 // --- Load key from kernel keyring ---
 let secretKeyHex;
@@ -34,6 +57,9 @@ try {
 const pubkey = getPublicKey(secretKeyHex);
 console.log(`[nostr-signer] Public key: ${pubkey}`);
 
+// Track legacy (no-token) usage to log deprecation
+let legacyWarningLogged = false;
+
 // --- Socket path ---
 const SOCKET_PATH = process.env.NOSTR_SIGNER_SOCKET
   || `${process.env.XDG_RUNTIME_DIR || '/run/user/1000'}/nostr-signer.sock`;
@@ -42,7 +68,7 @@ const SOCKET_PATH = process.env.NOSTR_SIGNER_SOCKET
 if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH);
 
 // --- Handle requests ---
-function handleRequest(data) {
+async function handleRequest(data) {
   try {
     const req = JSON.parse(data);
 
@@ -50,10 +76,58 @@ function handleRequest(data) {
       return JSON.stringify({ pubkey });
     }
 
+    // --- Session management ---
+    if (req.method === 'session_start') {
+      const p = req.params || {};
+      const scope = (p.scope || '1,9734,1111').split(',').map(Number);
+      const ttl = parseInt(p.ttl || '28800', 10);
+      const session = createSession(scope, ttl, p.pid || null);
+      return JSON.stringify({ session });
+    }
+
+    if (req.method === 'session_revoke') {
+      const p = req.params || {};
+      if (!p.token) return JSON.stringify({ error: 'Missing required field: token' });
+      const revoked = revokeSession(p.token);
+      clearRate(p.token);
+      return JSON.stringify({ revoked });
+    }
+
+    if (req.method === 'session_info') {
+      const p = req.params || {};
+      if (!p.token) return JSON.stringify({ error: 'Missing required field: token' });
+      const info = getSessionInfo(p.token);
+      const rateStats = getRateStats(p.token);
+      return JSON.stringify({ session: info, rateStats });
+    }
+
+    // --- sign_event (with optional session token) ---
     if (req.method === 'sign_event') {
       const p = req.params || {};
       if (p.kind === undefined) return JSON.stringify({ error: 'Missing required field: kind' });
       if (p.content === undefined) return JSON.stringify({ error: 'Missing required field: content' });
+
+      // Session validation (if token provided)
+      if (p.session_token) {
+        const sv = validateSession(p.session_token, p.kind);
+        if (!sv.valid) {
+          logAlert(`sign_event rejected: ${sv.error} (kind=${p.kind}, token=${p.session_token.slice(0, 12)}...)`);
+          return JSON.stringify({ error: sv.error });
+        }
+
+        // Rate limiting
+        const rl = checkRate(p.session_token);
+        if (!rl.allowed) {
+          logAlert(`sign_event rate-limited: ${rl.error} (token=${p.session_token.slice(0, 12)}...)`);
+          return JSON.stringify({ error: rl.error });
+        }
+      } else {
+        // Legacy mode — no session token
+        if (!legacyWarningLogged) {
+          console.warn('[nostr-signer] DEPRECATION: sign_event called without session_token. Use session_start to create a scoped session.');
+          legacyWarningLogged = true;
+        }
+      }
 
       const eventTemplate = {
         kind: p.kind,
@@ -90,6 +164,60 @@ function handleRequest(data) {
       }
     }
 
+    if (req.method === 'nip44_encrypt') {
+      const p = req.params || {};
+      if (!p.plaintext) return JSON.stringify({ error: 'Missing required field: plaintext' });
+      if (!p.peer_pubkey) return JSON.stringify({ error: 'Missing required field: peer_pubkey' });
+      try {
+        const convKey = nip44.v2.utils.getConversationKey(secretKeyHex, p.peer_pubkey);
+        const ciphertext = nip44.v2.encrypt(p.plaintext, convKey);
+        return JSON.stringify({ result: ciphertext, error: null });
+      } catch (err) {
+        return JSON.stringify({ result: null, error: `nip44_encrypt failed: ${err.message}` });
+      }
+    }
+
+    if (req.method === 'nip44_decrypt') {
+      const p = req.params || {};
+      if (!p.ciphertext) return JSON.stringify({ error: 'Missing required field: ciphertext' });
+      if (!p.peer_pubkey) return JSON.stringify({ error: 'Missing required field: peer_pubkey' });
+      try {
+        const convKey = nip44.v2.utils.getConversationKey(secretKeyHex, p.peer_pubkey);
+        const plaintext = nip44.v2.decrypt(p.ciphertext, convKey);
+        return JSON.stringify({ result: plaintext, error: null });
+      } catch (err) {
+        return JSON.stringify({ result: null, error: `nip44_decrypt failed: ${err.message}` });
+      }
+    }
+
+    if (req.method === 'nip04_encrypt') {
+      const p = req.params || {};
+      if (!p.plaintext && !p.message) return JSON.stringify({ error: 'Missing required field: plaintext' });
+      if (!p.recipientPubkey && !p.peer_pubkey) return JSON.stringify({ error: 'Missing required field: recipientPubkey' });
+      try {
+        const text = p.plaintext || p.message;
+        const peer = p.recipientPubkey || p.peer_pubkey;
+        const ciphertext = await nip04.encrypt(secretKeyHex, peer, text);
+        return JSON.stringify({ ciphertext, error: null });
+      } catch (err) {
+        return JSON.stringify({ error: `nip04_encrypt failed: ${err.message}` });
+      }
+    }
+
+    if (req.method === 'nip04_decrypt') {
+      const p = req.params || {};
+      if (!p.ciphertext && !p.content) return JSON.stringify({ error: 'Missing required field: ciphertext' });
+      if (!p.senderPubkey && !p.peer_pubkey) return JSON.stringify({ error: 'Missing required field: senderPubkey' });
+      try {
+        const cipher = p.ciphertext || p.content;
+        const peer = p.senderPubkey || p.peer_pubkey;
+        const plaintext = await nip04.decrypt(secretKeyHex, peer, cipher);
+        return JSON.stringify({ plaintext, error: null });
+      } catch (err) {
+        return JSON.stringify({ error: `nip04_decrypt failed: ${err.message}` });
+      }
+    }
+
     return JSON.stringify({ error: `Unknown method: ${req.method}` });
   } catch (err) {
     return JSON.stringify({ error: `Parse error: ${err.message}` });
@@ -99,10 +227,20 @@ function handleRequest(data) {
 // --- Start server ---
 const server = createServer((conn) => {
   let buf = '';
-  conn.on('data', (chunk) => { buf += chunk; });
-  conn.on('end', () => {
-    const response = handleRequest(buf);
-    conn.end(response + '\n');
+  conn.setEncoding('utf8');
+  conn.on('data', async (chunk) => {
+    buf += chunk;
+    // Process when we get a complete JSON object (ends with } or newline)
+    if (buf.trimEnd().endsWith('}')) {
+      const input = buf;
+      buf = '';
+      try {
+        const response = await handleRequest(input);
+        conn.end(response + '\n');
+      } catch (err) {
+        conn.end(JSON.stringify({ error: err.message }) + '\n');
+      }
+    }
   });
 });
 
@@ -110,6 +248,9 @@ server.listen(SOCKET_PATH, () => {
   // Set socket permissions to owner-only
   execSync(`chmod 600 ${SOCKET_PATH}`);
   console.log(`[nostr-signer] Listening on ${SOCKET_PATH}`);
+  console.log(`[nostr-signer] Session management: enabled`);
+  console.log(`[nostr-signer] Rate limiting: enabled (10/min, 100/hr)`);
+  console.log(`[nostr-signer] Legacy mode: allowed (with deprecation warning)`);
 });
 
 // --- Graceful shutdown ---

--- a/tools/nostr-signer/package.json
+++ b/tools/nostr-signer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nostr-signer",
+  "version": "1.0.0",
+  "description": "Lightweight Nostr signing daemon — reads nsec from kernel keyring, signs events via Unix socket",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "nostr-tools": "^2.10.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/tools/nostr-signer/rate-limiter.js
+++ b/tools/nostr-signer/rate-limiter.js
@@ -1,0 +1,113 @@
+/**
+ * Rate limiter for nostr-signer daemon.
+ * Tracks signing requests per session with configurable limits.
+ */
+
+const DEFAULT_LIMITS = {
+  perMinute: 10,
+  perHour: 100,
+  burstWindow: 10_000,  // 10 seconds
+  burstMax: 5,
+};
+
+// Per-session rate tracking: Map<token, { minute: [], hour: [], burst: [] }>
+const windows = new Map();
+
+function getWindow(token) {
+  if (!windows.has(token)) {
+    windows.set(token, { timestamps: [] });
+  }
+  return windows.get(token);
+}
+
+function pruneTimestamps(timestamps, cutoff) {
+  while (timestamps.length > 0 && timestamps[0] < cutoff) {
+    timestamps.shift();
+  }
+}
+
+/**
+ * Check if a signing request is allowed under rate limits.
+ * @param {string} token - Session token
+ * @param {object} [limits] - Override default limits
+ * @returns {{ allowed: boolean, error?: string, remaining?: { minute: number, hour: number } }}
+ */
+export function checkRate(token, limits = DEFAULT_LIMITS) {
+  const now = Date.now();
+  const window = getWindow(token);
+  const ts = window.timestamps;
+
+  // Prune old timestamps
+  const oneHourAgo = now - 3_600_000;
+  pruneTimestamps(ts, oneHourAgo);
+
+  // Count in windows
+  const oneMinuteAgo = now - 60_000;
+  const burstStart = now - limits.burstWindow;
+
+  const inMinute = ts.filter(t => t >= oneMinuteAgo).length;
+  const inHour = ts.length; // already pruned to 1 hour
+  const inBurst = ts.filter(t => t >= burstStart).length;
+
+  // Check burst
+  if (inBurst >= limits.burstMax) {
+    return {
+      allowed: false,
+      error: `Rate limit: burst exceeded (${inBurst}/${limits.burstMax} in ${limits.burstWindow / 1000}s)`,
+    };
+  }
+
+  // Check per-minute
+  if (inMinute >= limits.perMinute) {
+    return {
+      allowed: false,
+      error: `Rate limit: ${inMinute}/${limits.perMinute} per minute`,
+    };
+  }
+
+  // Check per-hour
+  if (inHour >= limits.perHour) {
+    return {
+      allowed: false,
+      error: `Rate limit: ${inHour}/${limits.perHour} per hour`,
+    };
+  }
+
+  // Allowed — record timestamp
+  ts.push(now);
+
+  return {
+    allowed: true,
+    remaining: {
+      minute: limits.perMinute - inMinute - 1,
+      hour: limits.perHour - inHour - 1,
+    },
+  };
+}
+
+/**
+ * Clear rate tracking for a session (on session revocation).
+ * @param {string} token
+ */
+export function clearRate(token) {
+  windows.delete(token);
+}
+
+/**
+ * Get rate stats for a session.
+ * @param {string} token
+ */
+export function getRateStats(token) {
+  const window = windows.get(token);
+  if (!window) return null;
+
+  const now = Date.now();
+  const ts = window.timestamps;
+  const oneMinuteAgo = now - 60_000;
+
+  return {
+    lastMinute: ts.filter(t => t >= oneMinuteAgo).length,
+    lastHour: ts.length,
+    limits: DEFAULT_LIMITS,
+  };
+}

--- a/tools/nostr-signer/sessions.js
+++ b/tools/nostr-signer/sessions.js
@@ -1,0 +1,149 @@
+/**
+ * Session management for nostr-signer daemon.
+ * Issues short-lived tokens scoped to specific event kinds.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const SESSION_FILE = process.env.SIGNER_SESSION_FILE
+  || path.join(process.env.HOME || '/tmp', '.config/nanoclaw/signer-sessions.json');
+
+// In-memory session store (persisted to disk for crash recovery)
+const sessions = new Map();
+
+function ensureDir() {
+  const dir = path.dirname(SESSION_FILE);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function persist() {
+  ensureDir();
+  const data = {};
+  for (const [token, session] of sessions) {
+    data[token] = session;
+  }
+  fs.writeFileSync(SESSION_FILE, JSON.stringify(data, null, 2));
+}
+
+function loadFromDisk() {
+  try {
+    if (fs.existsSync(SESSION_FILE)) {
+      const data = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf8'));
+      const now = Date.now();
+      for (const [token, session] of Object.entries(data)) {
+        if (session.expiresAt > now) {
+          sessions.set(token, session);
+        }
+      }
+      console.log(`[sessions] Loaded ${sessions.size} active session(s) from disk`);
+    }
+  } catch (err) {
+    console.warn(`[sessions] Failed to load sessions: ${err.message}`);
+  }
+}
+
+/**
+ * Create a new session token.
+ * @param {number[]} allowedKinds - Event kinds this session can sign
+ * @param {number} ttlSeconds - Time to live in seconds (default 8 hours)
+ * @param {number|null} pid - PID of the requesting process (for origin validation)
+ * @returns {{ token: string, expiresAt: number, allowedKinds: number[] }}
+ */
+export function createSession(allowedKinds, ttlSeconds = 28800, pid = null) {
+  const token = crypto.randomBytes(32).toString('hex');
+  const now = Date.now();
+  const session = {
+    token,
+    allowedKinds,
+    createdAt: now,
+    expiresAt: now + (ttlSeconds * 1000),
+    pid,
+    signCount: 0,
+  };
+  sessions.set(token, session);
+  persist();
+  console.log(`[sessions] Created session ${token.slice(0, 12)}... scope=[${allowedKinds}] ttl=${ttlSeconds}s pid=${pid || 'any'}`);
+  return { token, expiresAt: session.expiresAt, allowedKinds };
+}
+
+/**
+ * Validate a session token for a specific event kind.
+ * @param {string} token - Session token
+ * @param {number} eventKind - The event kind being signed
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateSession(token, eventKind) {
+  const session = sessions.get(token);
+  if (!session) {
+    return { valid: false, error: 'Invalid session token' };
+  }
+
+  if (Date.now() > session.expiresAt) {
+    sessions.delete(token);
+    persist();
+    return { valid: false, error: 'Session expired' };
+  }
+
+  if (!session.allowedKinds.includes(eventKind)) {
+    return { valid: false, error: `Event kind ${eventKind} not in session scope [${session.allowedKinds}]` };
+  }
+
+  // Increment sign count
+  session.signCount++;
+  return { valid: true };
+}
+
+/**
+ * Revoke a session token.
+ * @param {string} token
+ */
+export function revokeSession(token) {
+  if (sessions.delete(token)) {
+    persist();
+    console.log(`[sessions] Revoked session ${token.slice(0, 12)}...`);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get session info (for diagnostics).
+ * @param {string} token
+ */
+export function getSessionInfo(token) {
+  const session = sessions.get(token);
+  if (!session) return null;
+  return {
+    allowedKinds: session.allowedKinds,
+    createdAt: session.createdAt,
+    expiresAt: session.expiresAt,
+    signCount: session.signCount,
+    expired: Date.now() > session.expiresAt,
+  };
+}
+
+/**
+ * Prune expired sessions.
+ */
+export function pruneExpired() {
+  const now = Date.now();
+  let pruned = 0;
+  for (const [token, session] of sessions) {
+    if (now > session.expiresAt) {
+      sessions.delete(token);
+      pruned++;
+    }
+  }
+  if (pruned > 0) {
+    persist();
+    console.log(`[sessions] Pruned ${pruned} expired session(s)`);
+  }
+}
+
+// Load existing sessions on import
+loadFromDisk();
+
+// Prune expired sessions every 5 minutes
+setInterval(pruneExpired, 5 * 60 * 1000);


### PR DESCRIPTION
## Summary

A signing daemon that holds your Nostr private key in kernel memory and signs events via Unix socket. The agent can **use** the key without ever **seeing** the key.

Now with three security layers that go beyond key isolation:

### 1. Session tokens
Short-lived tokens scoped to specific event kinds. A session for `[1, 1111]` can post notes but **cannot** send zaps, award badges, or change the profile. Configurable TTL (default 8 hours). Persists to disk for crash recovery.

### 2. Rate limiting  
Sliding window per session: 5 per 10s burst, 10 per minute, 100 per hour. A compromised container can't spam signatures even with a valid token.

### 3. Alert logging
Every rejection — scope violation, rate limit, invalid token — is logged with timestamp, kind, and token prefix. The operator sees exactly what was attempted and why it was blocked.

### Backwards compatible
Legacy calls (no session token) still work with a deprecation warning. Nothing breaks on upgrade. Migrate at your own pace.

## Session scoping — any Nostr event kind

Sessions accept **any valid Nostr event kind** as an integer. There is no hardcoded whitelist. You choose exactly which kinds each session is allowed to sign. Pass them as a comma-separated list in the `scope` parameter.

### Recommended default scopes

**Main container (full agent capabilities):**
```
scope: "1,1111,9734,8,30008,30009,4,1059,30023"
```

| Kind | What it is | Why the agent needs it |
|------|-----------|----------------------|
| 1 | Public notes | Posting to Nostr (clawstr-post) |
| 1111 | NIP-22 comments | Subclaw/community replies |
| 9734 | Zap requests | Lightning payments via NWC wallet |
| 8 | Badge awards | Issuing sovereignty badges |
| 30008 | Profile badges | Managing badge shelf display |
| 30009 | Badge definitions | Creating/updating badge types |
| 4 | NIP-04 encrypted DMs | Legacy direct messages |
| 1059 | NIP-17 gift wraps | Modern encrypted DMs |
| 30023 | Long-form articles | Publishing written content |

**Restricted container (posting only):**
```
scope: "1,1111"
```

**Workshop participant container:**
```
scope: "1,1111,0"
```

**Custom scope — any kind works:**
```
scope: "1,6,7,1984,30000,30023,10002"
```

If a Nostr event kind exists, you can scope a session to it. The daemon doesn't know or care what the kinds mean — it just enforces that the session token only signs what you allowed.

## What's included

- `tools/nostr-signer/index.js` — signing daemon with session validation
- `tools/nostr-signer/sessions.js` — session token management (create, validate, revoke, persist)
- `tools/nostr-signer/rate-limiter.js` — sliding window rate limiter
- `tools/nostr-signer/clawstr-post.js` — CLI for posting to Nostr via the daemon
- `docs/nostr-signer-sessions.md` — plain-language operator guide
- `.claude/skills/add-nostr-signer/SKILL.md` — installation skill

## Test results (14/14 pass)

| Test | Result |
|------|--------|
| Pubkey retrieval | PASS |
| Session creation (scoped, TTL) | PASS |
| Sign kind:1 in scope | PASS |
| Sign kind:1111 in scope | PASS |
| Reject kind:0 (out of scope) | PASS |
| Reject kind:8 (out of scope) | PASS |
| Reject invalid token | PASS |
| Legacy mode (no token) | PASS |
| Session info (sign count, expiry) | PASS |
| Rate limit burst (5 OK, 6th rejected) | PASS |
| Session revocation | PASS |
| Reject revoked token | PASS |
| Existing methods (nip44/nip04) | PASS |
| Alert logging | PASS |

## Test plan

- [ ] Install on a fresh NanoClaw instance using `/add-nostr-signer`
- [ ] Create a scoped session and verify kind restrictions work
- [ ] Verify rate limiting triggers on burst
- [ ] Verify legacy signing still works without a session token
- [ ] Check alert log after rejected requests

## Why this matters

No implementation of per-session scoped signing exists elsewhere in the Nostr ecosystem. Most signing approaches are all-or-nothing: the agent either has the key or doesn't. This daemon gives the agent a **permission slip** — temporary, scoped, rate-limited, and revocable — while the key stays in kernel memory on the host.

Tested in production on a bare-metal NanoClaw install (Surface Pro 7+, Linux) with Signal, Nostr DM, and White Noise channels active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
