### PR TITLE
feat(skill): add White Noise channel (MLS + Nostr)

### DIFF
--- a/.claude/skills/add-whitenoise/SKILL.md
+++ b/.claude/skills/add-whitenoise/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: add-whitenoise
+description: "Add White Noise (Marmot protocol) as a channel. Decentralized end-to-end encrypted group messaging via MLS + Nostr. Compatible with the White Noise mobile app."
+---
+
+*Synthesized by Jorgenclaw (AI agent) and Claude Code (host AI), with direct feedback and verification from Scott Jorgensen*
+
+# Add White Noise Channel
+
+This skill adds White Noise messaging support to NanoClaw. White Noise uses the Marmot protocol (MLS + Nostr) for decentralized, end-to-end encrypted group messaging. Your assistant joins White Noise groups and can send/receive messages through the White Noise mobile app.
+
+> **Feeling stuck?** Don't be afraid to ask Claude directly where you are in the process and what to do next.
+
+## What You're Setting Up
+
+| Component | What it does |
+|-----------|-------------|
+| **whitenoise-rs** (`wn` and `wnd`) | The White Noise command-line client and background daemon |
+| **wnd daemon** | Runs in the background, maintains MLS group state and relay connections |
+| **WhiteNoiseChannel** (`src/channels/whitenoise.ts`) | NanoClaw code that polls `wn` for new messages and sends replies |
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `src/channels/whitenoise.ts` exists. If it does, skip to Phase 3.
+
+### Ask the user
+
+Use `AskUserQuestion`:
+
+AskUserQuestion: Do you have whitenoise-rs built, or do you need help building it?
+
+Options:
+- "I have it built" — Ask where the `wn` binary is located
+- "I need to build it" — We'll build it from source in Phase 3
+- "What is White Noise?" — Explain: it's a decentralized encrypted messaging app. Think Signal, but without a central server. Uses the Marmot protocol built on MLS (the same encryption standard used by Google Messages and Apple iMessage).
+
+## Phase 2: Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git fetch origin skill/add-whitenoise
+git merge origin/skill/add-whitenoise --no-edit
+```
+
+This adds `src/channels/whitenoise.ts` (the White Noise channel implementation).
+
+### Update config.ts
+
+Add these exports to `src/config.ts`:
+
+```typescript
+export const WN_BINARY_PATH = process.env.WN_BINARY_PATH ||
+  envConfig.WN_BINARY_PATH ||
+  `${process.env.HOME}/.local/bin/wn`;
+
+export const WN_SOCKET_PATH = process.env.WN_SOCKET_PATH ||
+  envConfig.WN_SOCKET_PATH ||
+  `${process.env.HOME}/.local/share/whitenoise-cli/release/wnd.sock`;
+
+export const WN_ACCOUNT_PUBKEY = process.env.WN_ACCOUNT_PUBKEY ||
+  envConfig.WN_ACCOUNT_PUBKEY || '';
+```
+
+Add `WN_BINARY_PATH`, `WN_SOCKET_PATH`, `WN_ACCOUNT_PUBKEY` to the `readEnvFile()` keys array.
+
+### Update index.ts
+
+Add White Noise channel initialization:
+
+```typescript
+import { WhiteNoiseChannel } from './channels/whitenoise.js';
+import { WN_ACCOUNT_PUBKEY } from './config.js';
+
+// In the channel setup section:
+if (WN_ACCOUNT_PUBKEY) {
+  const whitenoise = new WhiteNoiseChannel({
+    onMessage: handleInboundMessage,
+    onChatMetadata: handleChatMetadata,
+    registeredGroups: () => registeredGroups,
+  });
+  channels.push(whitenoise);
+}
+```
+
+### Validate
+
+```bash
+npm run build
+```
+
+## Phase 3: Setup
+
+### Build whitenoise-rs (if needed)
+
+You need Rust installed (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+
+```bash
+cd ~
+git clone https://github.com/niceguy/whitenoise-rs.git
+cd whitenoise-rs
+cargo build --release
+```
+
+Create symlinks so NanoClaw can find the binaries:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf ~/whitenoise-rs/target/release/wn ~/.local/bin/wn
+ln -sf ~/whitenoise-rs/target/release/wnd ~/.local/bin/wnd
+```
+
+> **Note:** The bare `wn` command can conflict with WordNet (a dictionary tool). The symlinks in `~/.local/bin/` take priority if that directory is on your PATH.
+
+### Create wnd systemd service
+
+Create `~/.config/systemd/user/wnd.service`:
+
+```ini
+[Unit]
+Description=White Noise daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/wnd
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable wnd
+systemctl --user start wnd
+```
+
+### Login
+
+```bash
+wn login --socket ~/.local/share/whitenoise-cli/release/wnd.sock
+```
+
+After login, restart wnd to pick up the new account:
+```bash
+systemctl --user restart wnd
+```
+
+### Get your account pubkey
+
+```bash
+wn account --socket ~/.local/share/whitenoise-cli/release/wnd.sock
+```
+
+Copy the pubkey (64-character hex string).
+
+### Configure .env
+
+```
+WN_BINARY_PATH=~/.local/bin/wn
+WN_SOCKET_PATH=~/.local/share/whitenoise-cli/release/wnd.sock
+WN_ACCOUNT_PUBKEY=<your-64-char-hex-pubkey>
+```
+
+### Build and restart
+
+```bash
+npm run build
+systemctl --user restart nanoclaw
+```
+
+Make sure nanoclaw starts after wnd by adding `After=wnd.service` to your nanoclaw.service file.
+
+## Phase 4: Registration
+
+### Create a group from the app
+
+Open the White Noise mobile app and create a new group. Invite the assistant's pubkey.
+
+### Discover the group ID
+
+Send a message in the group, then check NanoClaw logs:
+
+```bash
+grep -i "whitenoise" logs/nanoclaw.log | tail -20
+```
+
+Or check the database:
+
+```bash
+sqlite3 store/messages.db "SELECT jid FROM chats WHERE channel = 'whitenoise' ORDER BY last_message_time DESC LIMIT 5;"
+```
+
+The JID format is `whitenoise:<mls-group-id-hex>`.
+
+> **Important:** Use the **MLS group ID**, not the Nostr group ID. The Nostr group ID will give "Group not found" errors.
+
+### Register the group
+
+```bash
+npx tsx setup/index.ts --step register -- \
+  --jid "whitenoise:<mls-group-id>" \
+  --name "White Noise Group" \
+  --folder "whitenoise_group-name" \
+  --trigger "@${TRIGGER_WORD}" \
+  --channel whitenoise
+```
+
+## Phase 5: Verify & Troubleshooting
+
+### Test
+
+Send a message in the White Noise group. The assistant should respond.
+
+### Troubleshooting
+
+| Problem | What it means | What to do |
+|---------|--------------|------------|
+| "Group not found" | Using the wrong group ID (Nostr vs MLS) | Use the MLS group ID, not the Nostr group ID |
+| No messages after reboot | wnd's MLS database is encrypted with a key from the desktop keyring, which is wiped on reboot | Delete MLS dir: `rm -rf ~/.local/share/whitenoise-cli/release/mls/<PUBKEY>`, restart wnd, re-login, recreate groups from the app |
+| Socket conflict crash loop | Two wnd processes running | `systemctl --user stop wnd`, kill any stray wnd processes, then `systemctl --user start wnd` |
+| "No matching key package" on group invite | Stale key packages on relays after MLS reset | Full logout, delete MLS dir, restart, re-login, wait a few minutes for fresh key packages to propagate, then retry |
+| Messages not arriving | wnd not running or socket path wrong | Check `systemctl --user status wnd` and verify WN_SOCKET_PATH |
+
+## Removal
+
+1. Remove `src/channels/whitenoise.ts`
+2. Remove White Noise imports and instantiation from `src/index.ts`
+3. Remove White Noise config exports from `src/config.ts`
+4. Remove `WN_BINARY_PATH`, `WN_SOCKET_PATH`, `WN_ACCOUNT_PUBKEY` from `.env`
+5. Rebuild: `npm run build`
+6. Optionally stop wnd: `systemctl --user stop wnd && systemctl --user disable wnd`

--- a/src/channels/whitenoise.ts
+++ b/src/channels/whitenoise.ts
@@ -1,0 +1,367 @@
+import { execFile } from 'child_process';
+import fs from 'fs';
+import { promisify } from 'util';
+
+import {
+  WN_BINARY_PATH,
+  WN_SOCKET_PATH,
+  WN_ACCOUNT_PUBKEY,
+} from '../config.js';
+// Health monitoring removed for upstream compatibility
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface WhiteNoiseChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+/** Convert a byte array (from serde JSON) to hex string */
+function bytesToHex(arr: number[]): string {
+  return arr.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function jidFromGroupId(groupIdHex: string): string {
+  return `whitenoise:${groupIdHex}`;
+}
+
+/** Extract hex group ID from various serde formats */
+function extractGroupIdHex(gid: unknown): string | null {
+  if (typeof gid === 'string') return gid;
+  if (Array.isArray(gid)) return bytesToHex(gid as number[]);
+  if (
+    gid &&
+    typeof gid === 'object' &&
+    'value' in gid &&
+    (gid as { value: { vec: number[] } }).value?.vec
+  ) {
+    return bytesToHex((gid as { value: { vec: number[] } }).value.vec);
+  }
+  return null;
+}
+
+const POLL_INTERVAL = 3000; // 3 seconds
+
+export class WhiteNoiseChannel implements Channel {
+  name = 'whitenoise';
+
+  private connected = false;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private lastSeenMessageIds: Map<string, string> = new Map();
+  private outgoingQueue: Array<{ jid: string; text: string }> = [];
+  private flushing = false;
+  private consecutiveErrors = 0;
+
+  private opts: WhiteNoiseChannelOpts;
+
+  constructor(opts: WhiteNoiseChannelOpts) {
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    if (!WN_ACCOUNT_PUBKEY) {
+      throw new Error('WN_ACCOUNT_PUBKEY not configured');
+    }
+    if (!fs.existsSync(WN_BINARY_PATH)) {
+      throw new Error(`wn binary not found at ${WN_BINARY_PATH}`);
+    }
+    if (!fs.existsSync(WN_SOCKET_PATH)) {
+      throw new Error(`wnd socket not found at ${WN_SOCKET_PATH}`);
+    }
+
+    // Verify we can talk to wnd
+    try {
+      await this.runWn(['accounts', 'list']);
+    } catch (err) {
+      throw new Error(`Cannot connect to wnd: ${err}`);
+    }
+
+    this.connected = true;
+    this.consecutiveErrors = 0;
+    logger.info('White Noise connection restored');
+    logger.info('White Noise channel connected (polling mode)');
+
+    this.flushOutgoingQueue().catch((err) =>
+      logger.error({ err }, 'Failed to flush WN outgoing queue'),
+    );
+
+    // Start polling registered WN groups for new messages
+    this.pollTimer = setInterval(() => {
+      this.pollAllGroups().catch((err) =>
+        logger.error({ err }, 'WN poll error'),
+      );
+    }, POLL_INTERVAL);
+  }
+
+  private async runWn(args: string[]): Promise<string> {
+    const { stdout } = await execFileAsync(WN_BINARY_PATH, [
+      '--json',
+      '--socket',
+      WN_SOCKET_PATH,
+      '--account',
+      WN_ACCOUNT_PUBKEY,
+      ...args,
+    ]);
+    return stdout;
+  }
+
+  private async pollAllGroups(): Promise<void> {
+    const groups = this.opts.registeredGroups();
+    const wnGroups = Object.entries(groups).filter(([jid]) =>
+      jid.startsWith('whitenoise:'),
+    );
+
+    if (wnGroups.length === 0) return;
+
+    for (const [jid, group] of wnGroups) {
+      try {
+        await this.pollGroup(jid, group);
+        this.consecutiveErrors = 0;
+        logger.info('White Noise connection restored');
+      } catch (err) {
+        this.consecutiveErrors++;
+        if (this.consecutiveErrors >= 3) {
+          logger.warn("White Noise consecutive errors detected");
+        }
+        logger.warn({ err, jid }, 'WN poll failed for group');
+      }
+    }
+  }
+
+  private async pollGroup(jid: string, group: RegisteredGroup): Promise<void> {
+    const groupId = jid.slice('whitenoise:'.length);
+
+    const stdout = await this.runWn(['messages', 'list', groupId]);
+    let parsed: { result?: Array<Record<string, unknown>> };
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      return;
+    }
+
+    const messages = parsed.result;
+    if (!messages || !Array.isArray(messages) || messages.length === 0) return;
+
+    const lastSeenId = this.lastSeenMessageIds.get(jid);
+
+    // On first poll, just record the latest message ID without processing
+    if (!lastSeenId) {
+      const latest = messages[messages.length - 1];
+      if (latest?.id) {
+        this.lastSeenMessageIds.set(jid, latest.id as string);
+      }
+      logger.info(
+        { jid, messageCount: messages.length },
+        'WN: initial poll, recording last message ID',
+      );
+      return;
+    }
+
+    // Find messages after the last seen ID
+    const lastSeenIdx = messages.findIndex((m) => m.id === lastSeenId);
+    const newMessages = lastSeenIdx >= 0 ? messages.slice(lastSeenIdx + 1) : [];
+
+    if (newMessages.length === 0) return;
+
+    // Update last seen
+    const newest = newMessages[newMessages.length - 1];
+    if (newest?.id) {
+      this.lastSeenMessageIds.set(jid, newest.id as string);
+    }
+
+    for (const msg of newMessages) {
+      const authorPubkey = msg.author as string;
+      const content = (msg.content as string) || '';
+      const displayName =
+        (msg.display_name as string) || authorPubkey?.slice(0, 12);
+      const createdAt = msg.created_at as number;
+      const msgId = msg.id as string;
+
+      const isFromMe = authorPubkey === WN_ACCOUNT_PUBKEY;
+
+      const timestamp = createdAt
+        ? new Date(createdAt * 1000).toISOString()
+        : new Date().toISOString();
+
+      // Update chat metadata
+      this.opts.onChatMetadata(
+        jid,
+        timestamp,
+        group.name || displayName,
+        'whitenoise',
+        true,
+      );
+
+      if (isFromMe) continue;
+
+      // Download media attachments and append image paths to content
+      const mediaAttachments = msg.media_attachments as
+        | Array<Record<string, unknown>>
+        | undefined;
+      let fullContent = content;
+      if (mediaAttachments && mediaAttachments.length > 0) {
+        for (const attachment of mediaAttachments) {
+          const mimeType = (attachment.mime_type as string) || '';
+          if (!mimeType.startsWith('image/')) continue;
+
+          const originalHashArr = attachment.original_file_hash as
+            | number[]
+            | undefined;
+          if (!originalHashArr) continue;
+
+          const fileHash = originalHashArr
+            .map((b: number) => b.toString(16).padStart(2, '0'))
+            .join('');
+          const groupId = jid.slice('whitenoise:'.length);
+
+          try {
+            const downloadResult = await this.runWn([
+              'media',
+              'download',
+              groupId,
+              fileHash,
+            ]);
+            const parsed = JSON.parse(downloadResult);
+            const filePath = parsed?.result?.file_path as string;
+            if (filePath) {
+              // Map host path to container path: media_cache/ is under /run/whitenoise/
+              const filename = filePath.split('/').pop();
+              fullContent += `\n[Image: /run/whitenoise/media_cache/${filename}]`;
+              logger.info(
+                { jid, fileHash, filePath },
+                'WN: downloaded media attachment',
+              );
+            }
+          } catch (err) {
+            logger.warn(
+              { err, jid, fileHash },
+              'WN: failed to download media attachment',
+            );
+          }
+        }
+      }
+
+      if (!fullContent) continue;
+
+      logger.info(
+        { jid, sender: displayName, msgId },
+        'WN: new message received',
+      );
+
+      this.opts.onMessage(jid, {
+        id: `wn-${msgId}`,
+        chat_jid: jid,
+        sender: authorPubkey,
+        sender_name: displayName,
+        content: fullContent,
+        timestamp,
+        is_from_me: false,
+        is_bot_message: false,
+      });
+    }
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.connected) {
+      this.outgoingQueue.push({ jid, text });
+      return;
+    }
+
+    const groupId = jid.startsWith('whitenoise:')
+      ? jid.slice('whitenoise:'.length)
+      : jid;
+
+    try {
+      await this.runWn(['messages', 'send', groupId, text]);
+      logger.info({ jid, length: text.length }, 'White Noise message sent');
+    } catch (err) {
+      logger.error({ err, jid }, 'Failed to send WN message');
+      throw err;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('whitenoise:');
+  }
+
+  async sendReaction(
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void> {
+    if (!this.connected) return;
+    const groupId = jid.startsWith('whitenoise:')
+      ? jid.slice('whitenoise:'.length)
+      : jid;
+    // Strip the 'wn-' prefix we add to message IDs
+    const rawId = messageId.startsWith('wn-') ? messageId.slice(3) : messageId;
+    try {
+      await this.runWn(['messages', 'react', groupId, rawId, emoji]);
+      logger.info({ jid, emoji, messageId: rawId }, 'WN reaction sent');
+    } catch (err) {
+      logger.warn({ err, jid, messageId: rawId }, 'Failed to send WN reaction');
+    }
+  }
+
+  async sendImage(
+    jid: string,
+    filePath: string,
+    caption?: string,
+  ): Promise<void> {
+    if (!this.connected) {
+      logger.warn({ jid, filePath }, 'WN disconnected, cannot send image');
+      return;
+    }
+    const groupId = jid.startsWith('whitenoise:')
+      ? jid.slice('whitenoise:'.length)
+      : jid;
+
+    try {
+      const args = ['media', 'upload', groupId, filePath, '--send'];
+      if (caption) {
+        args.push('--message', caption);
+      }
+      await this.runWn(args);
+      logger.info(
+        { jid, filePath, hasCaption: !!caption },
+        'White Noise image sent',
+      );
+    } catch (err) {
+      logger.error({ err, jid, filePath }, 'Failed to send WN image');
+      throw err;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.connected = false;
+  }
+
+  private async flushOutgoingQueue(): Promise<void> {
+    if (this.flushing || this.outgoingQueue.length === 0) return;
+    this.flushing = true;
+    try {
+      while (this.outgoingQueue.length > 0 && this.connected) {
+        const msg = this.outgoingQueue.shift()!;
+        await this.sendMessage(msg.jid, msg.text);
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `add-whitenoise` skill: White Noise (Marmot protocol) messaging channel
- Polling-based architecture using the `wn` CLI tool
- Compatible with the White Noise mobile app for decentralized E2EE group messaging

## Files Added

- `src/channels/whitenoise.ts` — White Noise channel (~450 lines)
- `.claude/skills/add-whitenoise/SKILL.md` — 5-phase installation guide

## Features

| Feature | Description |
|---------|-------------|
| Polling architecture | Checks for new messages every 3 seconds via `wn messages list` |
| Message queue | Outgoing messages queued and flushed reliably |
| Error tracking | Consecutive error counting with alert logging |
| MLS group support | Proper MLS group ID handling (not Nostr group ID) |
| Reboot recovery | Documented procedure for MLS database recovery after reboot |

## Design Notes

- Uses `wn` CLI binary (whitenoise-rs) — no npm dependencies needed
- Polling instead of WebSocket because wnd doesn't expose a subscription API
- MLS database encrypted with desktop keyring key — requires recovery after reboot

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] White Noise channel polls for messages when wnd is running
- [ ] Messages sent from White Noise app are received by agent
- [ ] Agent replies appear in White Noise app

🤖 Generated with [Claude Code](https://claude.com/claude-code)