### PR TITLE
fix: retry container runtime startup on boot to prevent crash loop

### DIFF
--- a/launchd/com.nanoclaw.plist
+++ b/launchd/com.nanoclaw.plist
@@ -15,6 +15,8 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -98,6 +98,8 @@ function setupLaunchd(
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -59,43 +59,62 @@ export function stopContainer(name: string): string {
   return `${CONTAINER_RUNTIME_BIN} stop ${name}`;
 }
 
-/** Ensure the container runtime is running, starting it if needed. */
+/** Ensure the container runtime is running, starting it if needed. Retries on boot. */
 export function ensureContainerRuntimeRunning(): void {
-  try {
-    execSync(`${CONTAINER_RUNTIME_BIN} system status`, { stdio: 'pipe' });
-    logger.debug('Container runtime already running');
-  } catch {
-    logger.info('Starting container runtime...');
+  const MAX_RETRIES = 10;
+  const RETRY_DELAY_MS = 5000;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
-      execSync(`${CONTAINER_RUNTIME_BIN} system start`, { stdio: 'pipe', timeout: 30000 });
-      logger.info('Container runtime started');
-    } catch (err) {
-      logger.error({ err }, 'Failed to start container runtime');
-      console.error(
-        '\n╔════════════════════════════════════════════════════════════════╗',
-      );
-      console.error(
-        '║  FATAL: Container runtime failed to start                      ║',
-      );
-      console.error(
-        '║                                                                ║',
-      );
-      console.error(
-        '║  Agents cannot run without a container runtime. To fix:        ║',
-      );
-      console.error(
-        '║  1. Ensure Apple Container is installed                        ║',
-      );
-      console.error(
-        '║  2. Run: container system start                                ║',
-      );
-      console.error(
-        '║  3. Restart NanoClaw                                           ║',
-      );
-      console.error(
-        '╚════════════════════════════════════════════════════════════════╝\n',
-      );
-      throw new Error('Container runtime is required but failed to start');
+      execSync(`${CONTAINER_RUNTIME_BIN} system status`, {
+        stdio: 'pipe',
+        timeout: 10000,
+      });
+      logger.debug('Container runtime already running');
+      return;
+    } catch {
+      logger.info({ attempt, maxRetries: MAX_RETRIES }, 'Container runtime not ready, attempting to start...');
+      try {
+        execSync(`${CONTAINER_RUNTIME_BIN} system start`, { stdio: 'pipe', timeout: 30000 });
+        logger.info('Container runtime started');
+        return;
+      } catch (err) {
+        if (attempt < MAX_RETRIES) {
+          logger.warn(
+            { err, attempt, nextRetryMs: RETRY_DELAY_MS },
+            'Container runtime not yet available, retrying...',
+          );
+          // Blocking sleep — acceptable at startup before the event loop is needed
+          execSync(`sleep ${RETRY_DELAY_MS / 1000}`);
+        } else {
+          logger.error({ err }, 'Failed to start container runtime after all retries');
+          console.error(
+            '\n╔════════════════════════════════════════════════════════════════╗',
+          );
+          console.error(
+            '║  FATAL: Container runtime failed to start                      ║',
+          );
+          console.error(
+            '║                                                                ║',
+          );
+          console.error(
+            '║  Agents cannot run without a container runtime. To fix:        ║',
+          );
+          console.error(
+            '║  1. Ensure Apple Container is installed                        ║',
+          );
+          console.error(
+            '║  2. Run: container system start                                ║',
+          );
+          console.error(
+            '║  3. Restart NanoClaw                                           ║',
+          );
+          console.error(
+            '╚════════════════════════════════════════════════════════════════╝\n',
+          );
+          throw new Error('Container runtime is required but failed to start');
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add retry loop (10 attempts, 5s apart) to `ensureContainerRuntimeRunning()` so NanoClaw waits for Apple Container services to become available after reboot
- Add `ThrottleInterval` (30s) to the launchd plist template and generator to prevent OOM from rapid crash-restart loops

Closes #1067

## Context

When NanoClaw auto-starts via launchd on reboot, Apple Container runtime services (`com.apple.container.apiserver`, etc.) aren't ready yet. The single-attempt `container system start` fails, NanoClaw throws a fatal error, `KeepAlive` restarts it immediately, and this crash loop eventually causes a JavaScript heap OOM kill.

## Test plan

- [ ] Reboot macOS with NanoClaw configured as a launchd service
- [ ] Verify NanoClaw logs show retry attempts and eventual successful startup
- [ ] Verify no OOM crash in error log after reboot
- [ ] Verify `ThrottleInterval` is present in newly generated plists via `/setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)