### PR TITLE
fix: OAuth credential proxy — auto-refresh tokens + beta header

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -11,6 +11,13 @@ vi.mock('./logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
+// Mock getFreshOAuthToken — returns the env value or null
+vi.mock('./oauth-token.js', () => ({
+  getFreshOAuthToken: vi.fn(
+    async () => mockEnv.CLAUDE_CODE_OAUTH_TOKEN || null,
+  ),
+}));
+
 import { startCredentialProxy } from './credential-proxy.js';
 
 function makeRequest(
@@ -49,6 +56,7 @@ describe('credential-proxy', () => {
   let proxyPort: number;
   let upstreamPort: number;
   let lastUpstreamHeaders: http.IncomingHttpHeaders;
+  const originalEnv = { ...process.env };
 
   beforeEach(async () => {
     lastUpstreamHeaders = {};
@@ -68,15 +76,28 @@ describe('credential-proxy', () => {
     await new Promise<void>((r) => proxyServer?.close(() => r()));
     await new Promise<void>((r) => upstreamServer?.close(() => r()));
     for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+    // Restore process.env
+    process.env = { ...originalEnv };
   });
 
   async function startProxy(env: Record<string, string>): Promise<number> {
-    Object.assign(mockEnv, env, {
-      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
-    });
+    Object.assign(mockEnv, env);
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
     proxyServer = await startCredentialProxy(0);
     return (proxyServer.address() as AddressInfo).port;
   }
+
+  it('health endpoint returns 200', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    const res = await makeRequest(proxyPort, {
+      method: 'GET',
+      path: '/health',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+  });
 
   it('API-key mode injects x-api-key and strips placeholder', async () => {
     proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
@@ -97,7 +118,28 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['x-api-key']).toBe('sk-ant-real-key');
   });
 
-  it('OAuth mode replaces Authorization when container sends one', async () => {
+  it('API-key mode strips any Authorization header from container', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+          authorization: 'Bearer should-be-stripped',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['x-api-key']).toBe('sk-ant-real-key');
+    expect(lastUpstreamHeaders['authorization']).toBeUndefined();
+  });
+
+  it('OAuth mode injects Bearer unconditionally and adds beta header', async () => {
     proxyPort = await startProxy({
       CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
     });
@@ -106,10 +148,10 @@ describe('credential-proxy', () => {
       proxyPort,
       {
         method: 'POST',
-        path: '/api/oauth/claude_cli/create_api_key',
+        path: '/v1/messages',
         headers: {
           'content-type': 'application/json',
-          authorization: 'Bearer placeholder',
+          'x-api-key': 'placeholder',
         },
       },
       '{}',
@@ -118,29 +160,9 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['authorization']).toBe(
       'Bearer real-oauth-token',
     );
-  });
-
-  it('OAuth mode does not inject Authorization when container omits it', async () => {
-    proxyPort = await startProxy({
-      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
-    });
-
-    // Post-exchange: container uses x-api-key only, no Authorization header
-    await makeRequest(
-      proxyPort,
-      {
-        method: 'POST',
-        path: '/v1/messages',
-        headers: {
-          'content-type': 'application/json',
-          'x-api-key': 'temp-key-from-exchange',
-        },
-      },
-      '{}',
-    );
-
-    expect(lastUpstreamHeaders['x-api-key']).toBe('temp-key-from-exchange');
-    expect(lastUpstreamHeaders['authorization']).toBeUndefined();
+    expect(lastUpstreamHeaders['anthropic-beta']).toBe('oauth-2025-04-20');
+    // x-api-key must be stripped in OAuth mode
+    expect(lastUpstreamHeaders['x-api-key']).toBeUndefined();
   });
 
   it('strips hop-by-hop headers', async () => {
@@ -162,17 +184,16 @@ describe('credential-proxy', () => {
     );
 
     // Proxy strips client hop-by-hop headers. Node's HTTP client may re-add
-    // its own Connection header (standard HTTP/1.1 behavior), but the client's
-    // custom keep-alive and transfer-encoding must not be forwarded.
+    // its own transfer-encoding when piping (standard HTTP/1.1 behavior),
+    // but the client's custom keep-alive must not be forwarded.
     expect(lastUpstreamHeaders['keep-alive']).toBeUndefined();
-    expect(lastUpstreamHeaders['transfer-encoding']).toBeUndefined();
   });
 
-  it('returns 502 when upstream is unreachable', async () => {
+  it('returns JSON 502 when upstream is unreachable', async () => {
     Object.assign(mockEnv, {
       ANTHROPIC_API_KEY: 'sk-ant-real-key',
-      ANTHROPIC_BASE_URL: 'http://127.0.0.1:59999',
     });
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:59999';
     proxyServer = await startCredentialProxy(0);
     proxyPort = (proxyServer.address() as AddressInfo).port;
 
@@ -187,6 +208,28 @@ describe('credential-proxy', () => {
     );
 
     expect(res.statusCode).toBe(502);
-    expect(res.body).toBe('Bad Gateway');
+    const body = JSON.parse(res.body);
+    expect(body.error).toMatch(/Proxy error/);
+  });
+
+  it('returns 503 when no credentials are configured', async () => {
+    // No API key, no OAuth token
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(503);
+    const body = JSON.parse(res.body);
+    expect(body.error).toMatch(/No credentials/);
   });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -3,80 +3,106 @@
  * Containers connect here instead of directly to the Anthropic API.
  * The proxy injects real credentials so containers never see them.
  *
- * Two auth modes:
- *   API key:  Proxy injects x-api-key on every request.
- *   OAuth:    Container CLI exchanges its placeholder token for a temp
- *             API key via /api/oauth/claude_cli/create_api_key.
- *             Proxy injects real OAuth token on that exchange request;
- *             subsequent requests carry the temp key which is valid as-is.
+ * Data flow:
+ *   Container (ANTHROPIC_BASE_URL=http://host.docker.internal:<port>)
+ *     → This proxy (replaces auth headers)
+ *       → api.anthropic.com (real credentials)
+ *         → SSE streams back through proxy to container
+ *
+ * Security model (OAuth):
+ *   The SDK's normal OAuth flow calls /api/oauth/claude_cli/create_api_key to
+ *   exchange an OAuth token for a temporary API key, then uses that key for
+ *   subsequent requests. In our setup the container is untrusted — if we allowed
+ *   the exchange, the response body would deliver a working temp API key into
+ *   the container, defeating credential isolation entirely.
+ *
+ *   Instead, we inject the real credential on every outbound request. The SDK
+ *   inside the container only ever has a placeholder key, which is worthless
+ *   outside this proxy. No credential ever enters the container.
  */
-import { createServer, Server } from 'http';
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
+import { getFreshOAuthToken } from './oauth-token.js';
 
-export type AuthMode = 'api-key' | 'oauth';
-
-export interface ProxyConfig {
-  authMode: AuthMode;
-}
+const REQUEST_TIMEOUT = 600_000; // 10 minutes for long agent conversations
 
 export function startCredentialProxy(
   port: number,
   host = '127.0.0.1',
 ): Promise<Server> {
-  const secrets = readEnvFile([
-    'ANTHROPIC_API_KEY',
-    'CLAUDE_CODE_OAUTH_TOKEN',
-    'ANTHROPIC_AUTH_TOKEN',
-    'ANTHROPIC_BASE_URL',
-  ]);
-
-  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
-  const oauthToken =
-    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
-
   const upstreamUrl = new URL(
-    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
+    process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
   );
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
   return new Promise((resolve, reject) => {
-    const server = createServer((req, res) => {
-      const chunks: Buffer[] = [];
-      req.on('data', (c) => chunks.push(c));
-      req.on('end', () => {
-        const body = Buffer.concat(chunks);
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
+    const server = createServer(
+      async (req: IncomingMessage, res: ServerResponse) => {
+        const start = Date.now();
 
-        // Strip hop-by-hop headers that must not be forwarded by proxies
-        delete headers['connection'];
+        // Health check
+        if (req.method === 'GET' && req.url === '/health') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+          return;
+        }
+
+        // Read API key from .env on each request (rotated keys take effect
+        // immediately). OAuth tokens are handled by getFreshOAuthToken() which
+        // reads from ~/.claude/.credentials.json with auto-refresh.
+        const creds = readEnvFile([
+          'ANTHROPIC_API_KEY',
+          'CLAUDE_CODE_OAUTH_TOKEN',
+          'ANTHROPIC_AUTH_TOKEN',
+        ]);
+        const apiKey = creds.ANTHROPIC_API_KEY;
+        const oauthToken = apiKey ? null : await getFreshOAuthToken();
+
+        if (!apiKey && !oauthToken) {
+          res.writeHead(503, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify({ error: 'No credentials configured on host' }),
+          );
+          return;
+        }
+
+        // Build forwarded headers — replace auth
+        const headers: Record<string, string | string[] | undefined> = {
+          ...req.headers,
+        };
+        // Strip hop-by-hop headers that must not be forwarded (RFC 2616 §13.5.1).
+        // transfer-encoding is critical: we stream via req.pipe(), so forwarding
+        // the client's chunked framing header while the upstream negotiates its
+        // own would cause mismatches.
+        delete headers.host;
+        delete headers.connection;
         delete headers['keep-alive'];
         delete headers['transfer-encoding'];
 
-        if (authMode === 'api-key') {
-          // API key mode: inject x-api-key on every request
+        // Credential injection — always unconditional, never exchange-based.
+        //
+        // See module docstring for security rationale. We inject the real
+        // credential on every request. The container SDK only has a placeholder,
+        // so the OAuth exchange endpoint is never called — no temp API key ever
+        // enters the container.
+        if (apiKey) {
+          headers['x-api-key'] = apiKey;
+          delete headers['authorization'];
+        } else if (oauthToken) {
+          headers['authorization'] = `Bearer ${oauthToken}`;
+          // OAuth on the Messages API requires this beta feature flag.
+          // Without it, api.anthropic.com returns 401 "OAuth authentication is
+          // currently not supported." The SDK normally sends this itself, but
+          // since we bypass the exchange flow (the SDK thinks it has an API key
+          // via the placeholder), it won't. We must inject it.
+          // If Anthropic graduates OAuth out of beta, this becomes a no-op.
+          headers['anthropic-beta'] = 'oauth-2025-04-20';
           delete headers['x-api-key'];
-          headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
-        } else {
-          // OAuth mode: replace placeholder Bearer token with the real one
-          // only when the container actually sends an Authorization header
-          // (exchange request + auth probes). Post-exchange requests use
-          // x-api-key only, so they pass through without token injection.
-          if (headers['authorization']) {
-            delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
-            }
-          }
         }
 
         const upstream = makeRequest(
@@ -89,28 +115,46 @@ export function startCredentialProxy(
           } as RequestOptions,
           (upRes) => {
             res.writeHead(upRes.statusCode!, upRes.headers);
-            upRes.pipe(res);
+            upRes.pipe(res); // Stream SSE without buffering
           },
         );
 
+        upstream.setTimeout(REQUEST_TIMEOUT, () => {
+          logger.warn({ path: req.url }, 'Proxy request timed out');
+          upstream.destroy();
+        });
+
         upstream.on('error', (err) => {
+          const duration = Date.now() - start;
           logger.error(
-            { err, url: req.url },
+            { err, path: req.url, duration },
             'Credential proxy upstream error',
           );
           if (!res.headersSent) {
-            res.writeHead(502);
-            res.end('Bad Gateway');
+            res.writeHead(502, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: `Proxy error: ${err.message}` }));
           }
         });
 
-        upstream.write(body);
-        upstream.end();
-      });
-    });
+        req.pipe(upstream); // Stream request body (handles large base64 images)
+
+        res.on('finish', () => {
+          const duration = Date.now() - start;
+          logger.debug(
+            {
+              method: req.method,
+              path: req.url,
+              status: res.statusCode,
+              duration,
+            },
+            'Proxied API request',
+          );
+        });
+      },
+    );
 
     server.listen(port, host, () => {
-      logger.info({ port, host, authMode }, 'Credential proxy started');
+      logger.info({ port, host }, 'Credential proxy started');
       resolve(server);
     });
 
@@ -119,7 +163,7 @@ export function startCredentialProxy(
 }
 
 /** Detect which auth mode the host is configured for. */
-export function detectAuthMode(): AuthMode {
+export function detectAuthMode(): 'api-key' | 'oauth' {
   const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
   return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
 }

--- a/src/oauth-token.ts
+++ b/src/oauth-token.ts
@@ -1,0 +1,227 @@
+/**
+ * OAuth token management for Claude Code credentials.
+ *
+ * Reads OAuth tokens from ~/.claude/.credentials.json and automatically
+ * refreshes them when expired.
+ *
+ * Thread-safety: All calls are serialized through a promise chain so only
+ * one refresh can run at a time. File writes are atomic (write temp + rename).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { request as httpsRequest } from 'https';
+
+import { logger } from './logger.js';
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    scopes: string[];
+    subscriptionType: string | null;
+  };
+}
+
+const CREDENTIALS_FILE = path.join(
+  os.homedir(),
+  '.claude',
+  '.credentials.json',
+);
+const BUFFER = 5 * 60 * 1000; // 5 minutes
+
+// In-memory cache — avoids reading the file on every proxy request.
+// Populated after each successful token read or refresh.
+// Cleared when the cached token approaches expiry so the file is re-read.
+let tokenCache: { token: string; expiresAt: number } | null = null;
+
+// All calls chain onto this promise — serializes concurrent refresh operations.
+let refreshLock: Promise<string | null> = Promise.resolve(null);
+
+/**
+ * Get a fresh OAuth access token, refreshing if necessary.
+ *
+ * Reads from ~/.claude/.credentials.json:
+ * - If token is valid (> 5 min remaining), return it
+ * - If token is expired, refresh using refresh_token
+ * - If refresh fails or file is missing, falls back to .env value
+ * - If API key mode (ANTHROPIC_API_KEY set), returns null
+ *
+ * Thread-safe: All concurrent calls are serialized so only one refresh
+ * can run at a time.
+ *
+ * @returns Fresh OAuth access token, or null if using API key mode
+ */
+export function getFreshOAuthToken(): Promise<string | null> {
+  // Always chain — guarantees only one _doGetToken runs at a time
+  refreshLock = refreshLock.then(_doGetToken);
+  return refreshLock;
+}
+
+async function _doGetToken(): Promise<string | null> {
+  // If using API key mode, skip OAuth entirely
+  if (process.env.ANTHROPIC_API_KEY) {
+    return null;
+  }
+
+  // Return cached token if still valid
+  if (tokenCache && tokenCache.expiresAt > Date.now() + BUFFER) {
+    return tokenCache.token;
+  }
+
+  // Cache is stale — read from credentials file
+  let credentials: ClaudeCredentials;
+  try {
+    const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+    credentials = JSON.parse(content);
+  } catch (err) {
+    logger.debug(
+      { err },
+      'Credentials file not readable, falling back to .env',
+    );
+    return getEnvToken();
+  }
+
+  const oauth = credentials.claudeAiOauth;
+  if (!oauth) {
+    logger.debug('No OAuth credentials found in credentials file');
+    return getEnvToken();
+  }
+
+  // Token is still valid — cache and return
+  if (oauth.expiresAt > Date.now() + BUFFER) {
+    tokenCache = { token: oauth.accessToken, expiresAt: oauth.expiresAt };
+    return oauth.accessToken;
+  }
+
+  // Token is expired — refresh it
+  logger.info('OAuth token expired, refreshing...');
+  try {
+    const newToken = await refreshOAuthToken(oauth.refreshToken);
+
+    // Re-read credentials file before writing to handle external updates
+    let updatedCredentials: ClaudeCredentials;
+    try {
+      const content = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+      updatedCredentials = JSON.parse(content);
+    } catch {
+      updatedCredentials = credentials;
+    }
+
+    updatedCredentials.claudeAiOauth = {
+      ...updatedCredentials.claudeAiOauth!,
+      accessToken: newToken.accessToken,
+      expiresAt: newToken.expiresAt,
+      // Persist rotated refresh token if the server returned one
+      ...(newToken.refreshToken && { refreshToken: newToken.refreshToken }),
+    };
+
+    writeCredentialsAtomic(updatedCredentials);
+    tokenCache = { token: newToken.accessToken, expiresAt: newToken.expiresAt };
+    logger.info('OAuth token refreshed successfully');
+    return newToken.accessToken;
+  } catch (err) {
+    logger.error(
+      { err },
+      'Failed to refresh OAuth token, falling back to .env',
+    );
+    return getEnvToken();
+  }
+}
+
+interface RefreshResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  expires_at?: number;
+}
+
+/**
+ * Refresh OAuth token using the refresh token.
+ */
+async function refreshOAuthToken(refreshToken: string): Promise<{
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const postData = JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    });
+
+    const req = httpsRequest(
+      {
+        hostname: 'platform.claude.com',
+        port: 443,
+        path: '/v1/oauth/token',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(postData),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(
+              new Error(`OAuth refresh failed: ${res.statusCode} ${data}`),
+            );
+            return;
+          }
+          try {
+            const response: RefreshResponse = JSON.parse(data);
+            resolve({
+              accessToken: response.access_token,
+              refreshToken: response.refresh_token,
+              expiresAt:
+                response.expires_at ?? Date.now() + response.expires_in * 1000,
+            });
+          } catch (err) {
+            reject(new Error(`Failed to parse OAuth response: ${err}`));
+          }
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+/**
+ * Write credentials file atomically to prevent corruption.
+ * Writes to a temp file then renames — atomic on POSIX systems.
+ */
+function writeCredentialsAtomic(credentials: ClaudeCredentials): void {
+  const tempFile = `${CREDENTIALS_FILE}.tmp.${Date.now()}`;
+  const content = JSON.stringify(credentials, null, 2);
+  try {
+    fs.writeFileSync(tempFile, content, 'utf-8');
+    fs.renameSync(tempFile, CREDENTIALS_FILE);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tempFile);
+    } catch {}
+    throw err;
+  }
+}
+
+/**
+ * Fallback to .env token if credentials file is unavailable.
+ */
+function getEnvToken(): string | null {
+  const envToken =
+    process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_AUTH_TOKEN;
+  if (envToken) {
+    logger.debug('Using OAuth token from .env (may be expired)');
+    return envToken;
+  }
+  return null;
+}

--- a/src/remote-control.test.ts
+++ b/src/remote-control.test.ts
@@ -45,14 +45,20 @@ describe('remote-control', () => {
     stdoutFileContent = '';
 
     // Default fs mocks
-    mkdirSyncSpy = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
-    writeFileSyncSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    mkdirSyncSpy = vi
+      .spyOn(fs, 'mkdirSync')
+      .mockImplementation(() => undefined as any);
+    writeFileSyncSpy = vi
+      .spyOn(fs, 'writeFileSync')
+      .mockImplementation(() => {});
     unlinkSyncSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
     openSyncSpy = vi.spyOn(fs, 'openSync').mockReturnValue(42 as any);
     closeSyncSpy = vi.spyOn(fs, 'closeSync').mockImplementation(() => {});
 
     // readFileSync: return stdoutFileContent for the stdout file, state file, etc.
-    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: string) => {
+    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((
+      p: string,
+    ) => {
       if (p.endsWith('remote-control.stdout')) return stdoutFileContent;
       if (p.endsWith('remote-control.json')) {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -74,7 +80,8 @@ describe('remote-control', () => {
       spawnMock.mockReturnValue(proc);
 
       // Simulate URL appearing in stdout file on first poll
-      stdoutFileContent = 'Session URL: https://claude.ai/code?bridge=env_abc123\n';
+      stdoutFileContent =
+        'Session URL: https://claude.ai/code?bridge=env_abc123\n';
       vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
 
       const result = await startRemoteControl('user1', 'tg:123', '/project');
@@ -157,7 +164,9 @@ describe('remote-control', () => {
       spawnMock.mockReturnValueOnce(proc1).mockReturnValueOnce(proc2);
 
       // First start: process alive, URL found
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
       stdoutFileContent = 'https://claude.ai/code?bridge=env_first\n';
       await startRemoteControl('user1', 'tg:123', '/project');
 
@@ -239,7 +248,9 @@ describe('remote-control', () => {
       const proc = createMockProcess(55555);
       spawnMock.mockReturnValue(proc);
       stdoutFileContent = 'https://claude.ai/code?bridge=env_stop\n';
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
 
       await startRemoteControl('user1', 'tg:123', '/project');
 
@@ -337,7 +348,9 @@ describe('remote-control', () => {
         if (p.endsWith('remote-control.json')) return JSON.stringify(session);
         return '';
       }) as any);
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
 
       restoreRemoteControl();
       expect(getActiveSession()).not.toBeNull();
@@ -365,13 +378,15 @@ describe('remote-control', () => {
 
       restoreRemoteControl();
 
-      return startRemoteControl('user2', 'tg:456', '/project').then((result) => {
-        expect(result).toEqual({
-          ok: true,
-          url: 'https://claude.ai/code?bridge=env_restored',
-        });
-        expect(spawnMock).not.toHaveBeenCalled();
-      });
+      return startRemoteControl('user2', 'tg:456', '/project').then(
+        (result) => {
+          expect(result).toEqual({
+            ok: true,
+            url: 'https://claude.ai/code?bridge=env_restored',
+          });
+          expect(spawnMock).not.toHaveBeenCalled();
+        },
+      );
     });
   });
 });

--- a/src/remote-control.ts
+++ b/src/remote-control.ts
@@ -196,9 +196,11 @@ export async function startRemoteControl(
   });
 }
 
-export function stopRemoteControl(): {
-  ok: true;
-} | { ok: false; error: string } {
+export function stopRemoteControl():
+  | {
+      ok: true;
+    }
+  | { ok: false; error: string } {
   if (!activeSession) {
     return { ok: false, error: 'No active Remote Control session' };
   }


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

OAuth users are hitting 401 "OAuth authentication is currently not supported" because the credential proxy doesn't send the required `anthropic-beta: oauth-2025-04-20` header. Additionally, OAuth tokens stored in `.env` expire after ~4 hours with no automatic refresh, causing silent auth failures.

This PR fixes both issues:

**1. Beta header injection** (`credential-proxy.ts`):
- Injects `anthropic-beta: oauth-2025-04-20` on all OAuth-proxied requests
- Unconditional credential injection — the proxy always replaces auth headers, regardless of what the container sends. This prevents the SDK's OAuth exchange flow from delivering a working temp API key into the untrusted container.
- `req.pipe()` streaming for large request bodies (base64 images)
- `/health` endpoint, JSON error responses (502/503), 10-min timeout

**2. Token auto-refresh** (new `oauth-token.ts`):
- Reads `~/.claude/.credentials.json` (same file the `claude` CLI maintains)
- In-memory cache with 5-minute expiry buffer
- Auto-refreshes expired tokens via `platform.claude.com/v1/oauth/token`
- Promise-chain serialization (only one refresh runs at a time)
- Atomic file writes (write temp + rename) to prevent credential corruption
- Falls back to `.env` token if credentials file is unavailable

Based on work by @calebfaruki (#871) and @kianwoon (#930, #969). Supersedes both PRs with a combined, tested implementation.

Related issues: #730 (OAuth tokens expire)