### PR TITLE
fix: preserve ANTHROPIC_BASE_URL path prefix in credential proxy

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -43,6 +43,9 @@ export function startCredentialProxy(
   );
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
+  // Preserve path prefix from ANTHROPIC_BASE_URL (e.g. /api/claudecode)
+  const upstreamPathPrefix =
+    upstreamUrl.pathname === '/' ? '' : upstreamUrl.pathname.replace(/\/$/, '');
 
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
@@ -83,7 +86,7 @@ export function startCredentialProxy(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: upstreamPathPrefix + req.url,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Summary

- Credential proxy now preserves the path prefix from `ANTHROPIC_BASE_URL`
- Previously, if `ANTHROPIC_BASE_URL=https://proxy.example.com/api/claude`, requests to `/v1/messages` would be forwarded to `https://proxy.example.com/v1/messages`, losing the `/api/claude` prefix
- After this fix, requests correctly go to `https://proxy.example.com/api/claude/v1/messages`
- No behavior change when `ANTHROPIC_BASE_URL` has no path (the default `https://api.anthropic.com` case)

## Use cases

- Users behind reverse proxies with path-based routing
- Users accessing Anthropic-compatible APIs (e.g. providers that expose Claude-compatible endpoints under a subpath)
- Corporate API gateways that namespace services under path prefixes

## Test plan

- [x] Existing `credential-proxy.test.ts` tests pass
- [x] Verified with path-prefixed `ANTHROPIC_BASE_URL`: requests correctly include the prefix
- [x] Verified with default `ANTHROPIC_BASE_URL` (`https://api.anthropic.com`): no behavior change

?? Generated with [Claude Code](https://claude.com/claude-code)