### PR TITLE
fix(credential-proxy): auto-refresh OAuth token, handle keychain-only auth

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -9,13 +9,152 @@
  *             API key via /api/oauth/claude_cli/create_api_key.
  *             Proxy injects real OAuth token on that exchange request;
  *             subsequent requests carry the temp key which is valid as-is.
+ *
+ * OAuth tokens expire (~1 hour). The proxy auto-refreshes them using the
+ * stored refresh token before they expire, so agents never see 401s.
  */
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
+import { homedir } from 'os';
+import { join } from 'path';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
+
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+/** Refresh the token this many ms before it actually expires. */
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+interface OAuthCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Read the full OAuth credential object from ~/.claude/.credentials.json
+ * or fall back to the macOS keychain.
+ */
+function readFullOAuthCredentials(): OAuthCredentials | undefined {
+  // Primary: credentials file written by Claude Code CLI
+  try {
+    const credPath = join(homedir(), '.claude', '.credentials.json');
+    const data = JSON.parse(readFileSync(credPath, 'utf8'));
+    const oauth = data?.claudeAiOauth;
+    if (oauth?.accessToken) return oauth as OAuthCredentials;
+  } catch {
+    // fall through to keychain
+  }
+
+  // Fallback: macOS keychain
+  if (process.platform !== 'darwin') return undefined;
+  try {
+    const raw = execSync(
+      'security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null',
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    const data = JSON.parse(raw);
+    const oauth = data?.claudeAiOauth;
+    if (oauth?.accessToken) return oauth as OAuthCredentials;
+  } catch {
+    // not available
+  }
+
+  return undefined;
+}
+
+/**
+ * Persist refreshed OAuth credentials back to ~/.claude/.credentials.json
+ * so the next process restart picks up the new token.
+ */
+function saveOAuthCredentials(updated: OAuthCredentials): void {
+  const credPath = join(homedir(), '.claude', '.credentials.json');
+  try {
+    let root: Record<string, unknown> = {};
+    try {
+      root = JSON.parse(readFileSync(credPath, 'utf8'));
+    } catch {
+      // file missing — start fresh
+    }
+    root.claudeAiOauth = {
+      ...((root.claudeAiOauth as object) ?? {}),
+      ...updated,
+    };
+    writeFileSync(credPath, JSON.stringify(root, null, 2));
+  } catch (err) {
+    logger.warn({ err }, 'Failed to persist refreshed OAuth token');
+  }
+}
+
+/**
+ * Exchange a refresh token for a new access token.
+ * Returns the updated credentials, or undefined on failure.
+ */
+function refreshOAuthToken(
+  refreshToken: string,
+): Promise<OAuthCredentials | undefined> {
+  return new Promise((resolve) => {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: OAUTH_CLIENT_ID,
+    }).toString();
+
+    const req = httpsRequest(
+      {
+        hostname: 'platform.claude.com',
+        port: 443,
+        path: '/v1/oauth/token',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString());
+            if (data.access_token) {
+              const creds: OAuthCredentials = {
+                accessToken: data.access_token,
+                refreshToken: data.refresh_token ?? refreshToken,
+                expiresAt: data.expires_in
+                  ? Date.now() + data.expires_in * 1000
+                  : undefined,
+              };
+              logger.info('OAuth token refreshed successfully');
+              resolve(creds);
+            } else {
+              logger.error(
+                { status: res.statusCode, data },
+                'OAuth token refresh returned no access_token',
+              );
+              resolve(undefined);
+            }
+          } catch (err) {
+            logger.error({ err }, 'Failed to parse OAuth refresh response');
+            resolve(undefined);
+          }
+        });
+      },
+    );
+
+    req.on('error', (err) => {
+      logger.error({ err }, 'OAuth token refresh request failed');
+      resolve(undefined);
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
 
 export type AuthMode = 'api-key' | 'oauth';
 
@@ -35,8 +174,83 @@ export function startCredentialProxy(
   ]);
 
   const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
-  const oauthToken =
-    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+
+  // Token cache: tracks the current access token AND its real expiry time.
+  // When the token is within REFRESH_BUFFER_MS of expiry we trigger a refresh.
+  const TOKEN_CACHE_TTL_MS = 30_000; // re-read from disk every 30 s at most
+  interface TokenCache {
+    value?: string;
+    /** Wall-clock expiry of the cache entry (not the token itself). */
+    cacheExpiresAt: number;
+    /** Real expiry of the OAuth token, if known. */
+    tokenExpiresAt?: number;
+  }
+  let tokenCache: TokenCache = { cacheExpiresAt: 0 };
+  let refreshPromise: Promise<void> | null = null;
+
+  const doRefresh = (refreshToken: string, now: number): Promise<void> => {
+    refreshPromise = (async () => {
+      const updated = await refreshOAuthToken(refreshToken);
+      if (updated) {
+        saveOAuthCredentials(updated);
+        tokenCache = {
+          value: updated.accessToken,
+          cacheExpiresAt: now + TOKEN_CACHE_TTL_MS,
+          tokenExpiresAt: updated.expiresAt,
+        };
+      }
+      refreshPromise = null;
+    })();
+    return refreshPromise;
+  };
+
+  const ensureTokenFresh = async (): Promise<void> => {
+    if (refreshPromise) return refreshPromise;
+
+    const now = Date.now();
+
+    // Always read from disk so we have an up-to-date expiresAt.
+    // This is critical when the proxy falls back to the macOS keychain,
+    // which does not include expiresAt — in that case we treat the token
+    // as needing a refresh so the proxy can learn the real expiry.
+    const creds = readFullOAuthCredentials();
+    const tokenExpiry = creds?.expiresAt ?? tokenCache.tokenExpiresAt;
+
+    if (
+      creds?.refreshToken &&
+      (tokenExpiry === undefined || now >= tokenExpiry - REFRESH_BUFFER_MS)
+    ) {
+      return doRefresh(creds.refreshToken, now);
+    }
+  };
+
+  const getOauthToken = async (): Promise<string | undefined> => {
+    if (secrets.CLAUDE_CODE_OAUTH_TOKEN) return secrets.CLAUDE_CODE_OAUTH_TOKEN;
+    if (secrets.ANTHROPIC_AUTH_TOKEN) return secrets.ANTHROPIC_AUTH_TOKEN;
+
+    const now = Date.now();
+
+    // Re-read from disk if cache TTL elapsed, then refresh if needed.
+    if (now >= tokenCache.cacheExpiresAt) {
+      const creds = readFullOAuthCredentials();
+      tokenCache = {
+        value: creds?.accessToken,
+        cacheExpiresAt: now + TOKEN_CACHE_TTL_MS,
+        tokenExpiresAt: creds?.expiresAt,
+      };
+      // Refresh when expired, near-expiry, OR when expiresAt is unknown
+      // (keychain fallback — the keychain doesn't store expiresAt).
+      if (
+        creds?.refreshToken &&
+        (creds.expiresAt === undefined ||
+          now >= creds.expiresAt - REFRESH_BUFFER_MS)
+      ) {
+        await ensureTokenFresh();
+      }
+    }
+
+    return tokenCache.value;
+  };
 
   const upstreamUrl = new URL(
     secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
@@ -48,7 +262,7 @@ export function startCredentialProxy(
     const server = createServer((req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
-      req.on('end', () => {
+      req.on('end', async () => {
         const body = Buffer.concat(chunks);
         const headers: Record<string, string | number | string[] | undefined> =
           {
@@ -73,39 +287,72 @@ export function startCredentialProxy(
           // x-api-key only, so they pass through without token injection.
           if (headers['authorization']) {
             delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
+            const token = await getOauthToken();
+            if (token) {
+              headers['authorization'] = `Bearer ${token}`;
             }
           }
         }
 
-        const upstream = makeRequest(
-          {
-            hostname: upstreamUrl.hostname,
-            port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
-            method: req.method,
-            headers,
-          } as RequestOptions,
-          (upRes) => {
+        const forwardRequest = (
+          hdrs: Record<string, string | number | string[] | undefined>,
+          onResponse: (upRes: import('http').IncomingMessage) => void,
+        ) => {
+          const up = makeRequest(
+            {
+              hostname: upstreamUrl.hostname,
+              port: upstreamUrl.port || (isHttps ? 443 : 80),
+              path: req.url,
+              method: req.method,
+              headers: hdrs,
+            } as RequestOptions,
+            onResponse,
+          );
+          up.on('error', (err) => {
+            logger.error(
+              { err, url: req.url },
+              'Credential proxy upstream error',
+            );
+            if (!res.headersSent) {
+              res.writeHead(502);
+              res.end('Bad Gateway');
+            }
+          });
+          up.write(body);
+          up.end();
+          return up;
+        };
+
+        forwardRequest(headers, async (upRes) => {
+          // On 401, refresh the token and retry once (OAuth mode only).
+          if (
+            upRes.statusCode === 401 &&
+            authMode === 'oauth' &&
+            headers['authorization']
+          ) {
+            // Drain the 401 body so the socket is reusable.
+            upRes.resume();
+            logger.warn(
+              { url: req.url },
+              'Upstream 401 — refreshing OAuth token and retrying',
+            );
+            // Force-invalidate the cache so ensureTokenFresh will refresh.
+            tokenCache = { cacheExpiresAt: 0 };
+            await ensureTokenFresh();
+            const newToken = tokenCache.value;
+            const retryHeaders = { ...headers };
+            if (newToken) {
+              retryHeaders['authorization'] = `Bearer ${newToken}`;
+            }
+            forwardRequest(retryHeaders, (retryRes) => {
+              res.writeHead(retryRes.statusCode!, retryRes.headers);
+              retryRes.pipe(res);
+            });
+          } else {
             res.writeHead(upRes.statusCode!, upRes.headers);
             upRes.pipe(res);
-          },
-        );
-
-        upstream.on('error', (err) => {
-          logger.error(
-            { err, url: req.url },
-            'Credential proxy upstream error',
-          );
-          if (!res.headersSent) {
-            res.writeHead(502);
-            res.end('Bad Gateway');
           }
         });
-
-        upstream.write(body);
-        upstream.end();
       });
     });
 


### PR DESCRIPTION
## Problem

OAuth access tokens expire after ~1 hour. The credential proxy was injecting a static token read at startup and never refreshing it, so container agents started getting 401s after the first hour.

The failure was silent and permanent: once expired, the token stayed expired for the lifetime of the process (potentially days if running as a launchd/systemd service).

### Root cause: keychain-only path

On macOS, when `~/.claude/.credentials.json` is absent, the proxy falls back to the macOS keychain. The keychain entry stores only `accessToken` — no `expiresAt`. Without `expiresAt`, any expiry-based refresh guard evaluates to false and never triggers. The token silently expires.

## Changes

- **`readFullOAuthCredentials()`** — reads `~/.claude/.credentials.json` first (written by Claude Code CLI after auth), falls back to macOS keychain
- **`saveOAuthCredentials()`** — persists refreshed credentials back to the file so future process restarts pick up the latest token
- **`refreshOAuthToken()`** — exchanges a refresh token for a new access token via `platform.claude.com/v1/oauth/token`
- **Token cache** — 30s in-memory cache tracking `accessToken` + `expiresAt`; re-reads from disk on TTL miss
- **Proactive refresh** — triggers when token is expired, within 5 min of expiry, **or when `expiresAt` is unknown** (the keychain path). On the first cache miss after startup the proxy immediately refreshes and learns the real expiry, breaking the cycle.
- **Reactive 401 retry** — if upstream returns 401, the cache is invalidated, the token is force-refreshed, and the request is retried once. Safety net for any edge-case slippage.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| API key mode | ✅ works | ✅ unchanged |
| OAuth, `.credentials.json` present with `expiresAt` | ❌ no refresh | ✅ refreshes before expiry |
| OAuth, keychain only (no `expiresAt`) | ❌ never refreshes | ✅ refreshes on first request, then tracks real expiry |
| Upstream returns 401 | ❌ agent sees 401 | ✅ proxy refreshes and retries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)