### PR TITLE
feat(skill/proton): complete Proton suite — 36 MCP tools (Mail, Pass, Drive, Calendar, VPN)

### DIFF
--- a/.claude/skills/add-proton/SKILL.md
+++ b/.claude/skills/add-proton/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: add-proton
+description: "Add Proton suite integration to NanoClaw. 36 MCP tools across Mail (via Bridge), Pass (via pass-cli), Drive (via rclone), Calendar (via Radicale CalDAV), and VPN status. Full credential management with TOTP, encrypted backup, and calendar scheduling."
+---
+
+*Synthesized by Jorgenclaw (AI agent) and Claude Code (host AI), with direct feedback and verification from Scott Jorgensen*
+
+# Add Proton Suite Integration
+
+This skill adds the full Proton suite to NanoClaw — 36 MCP tools across five products. Your agent can read/send email, manage passwords with 2FA, back up files to encrypted cloud storage, schedule calendar events, and check VPN status.
+
+> **Feeling stuck?** Don't be afraid to ask Claude directly where you are in the process and what to do next.
+
+## What You're Setting Up
+
+| Component | What it does |
+|-----------|-------------|
+| **Proton Bridge** | Proton's official app that decrypts email locally, exposes IMAP/SMTP on localhost |
+| **pass-cli** | Proton's official CLI for Pass — credential vault, TOTP generation, password creation |
+| **rclone** | Open-source tool with official Proton Drive backend — upload, download, sync files |
+| **Radicale** | Lightweight CalDAV server — calendar events that sync to your phone |
+| **proton-mcp** (`tools/proton-mcp/`) | MCP server that wraps all of the above into agent tools |
+
+### Requirements
+
+- **Paid Proton plan** (Mail Plus, Pass Plus, or Proton Unlimited) — required for Bridge and pass-cli
+- **Docker** — agents run in containers
+- **Node.js 18+**
+
+## Pre-flight
+
+### Check if already applied
+
+Check if `tools/proton-mcp/index.js` exists. If it does, skip to Setup. The code is already in place.
+
+### Ask the user
+
+Use `AskUserQuestion`:
+
+Which Proton products do you want to set up? (You can add more later)
+
+- **Mail** — Read, send, search, forward, manage emails
+- **Pass** — Credential vault with TOTP for autonomous 2FA
+- **Drive** — Encrypted cloud backup for agent memory and files
+- **Calendar** — Schedule events, reminders, follow-ups (syncs to phone)
+- **VPN** — Check connection status
+- **All of the above** (recommended)
+
+## Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git fetch origin skill/add-proton
+git merge origin/skill/add-proton --no-edit
+```
+
+This adds `tools/proton-mcp/` with the MCP server (36 tools across Mail, Pass, Drive, Calendar, VPN).
+
+### Install dependencies
+
+```bash
+cd tools/proton-mcp && npm install && cd ../..
+```
+
+### Mount credentials in container
+
+Add these mounts to `src/container-runner.ts` in the `buildVolumeMounts()` function:
+
+- Mount `tools/proton-mcp/` read-only at `/usr/local/lib/proton-mcp` — **all groups**
+- Mount `~/.proton-mcp` (Bridge credentials) read-only at `/home/node/.proton-mcp` — **all groups**
+- Mount `pass-cli` binary and `~/.local/share/proton-pass-cli/` session data — **main group only**
+- Mount `rclone` binary and `~/.config/rclone/` config — **main group only**
+- Set `PROTON_PASS_KEY_PROVIDER=fs` env var in containers
+
+### Add Proton MCP server to agent runner
+
+In `container/agent-runner/src/index.ts`, add a `proton` entry to the `mcpServers` config:
+
+```typescript
+...(fs.existsSync('/usr/local/lib/proton-mcp/index.js') ? {
+  proton: {
+    command: 'node',
+    args: ['/usr/local/lib/proton-mcp/index.js'],
+  },
+} : {}),
+```
+
+Also add `'mcp__proton__*'` to `allowedTools`.
+
+### Add config exports
+
+Add to `src/config.ts`:
+- `PROTON_PASS_BIN` — path to pass-cli binary
+- `PROTON_PASS_VAULT` — default vault name (NanoClaw)
+
+### Validate
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+## Setup: Mail (Proton Bridge)
+
+### Install Proton Bridge
+
+1. Download from https://proton.me/mail/bridge
+2. Install: `sudo dpkg -i protonmail-bridge*.deb` (Ubuntu/Pop!_OS) or drag to Applications (macOS)
+3. Launch Bridge and sign in with your Proton account
+4. Verify IMAP and SMTP are enabled in Bridge settings
+
+### Get Bridge credentials
+
+1. In Bridge, click your account name
+2. Note the **username** (your email) and the **Bridge password** (a generated string)
+3. Note the ports — usually IMAP: `1143`, SMTP: `1025`
+
+### Docker network relay (Linux only)
+
+Proton Bridge only listens on localhost. Containers can't reach it directly. Set up a relay:
+
+```bash
+sudo apt install -y socat
+```
+
+Create `~/.config/systemd/user/proton-bridge-relay.service`:
+
+```ini
+[Unit]
+Description=Relay Proton Bridge IMAP/SMTP to Docker network
+After=proton-bridge.service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c '\
+  socat TCP-LISTEN:1143,bind=172.17.0.1,fork,reuseaddr TCP:127.0.0.1:1143 & \
+  socat TCP-LISTEN:1025,bind=172.17.0.1,fork,reuseaddr TCP:127.0.0.1:1025 & \
+  wait'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now proton-bridge-relay
+```
+
+> **macOS:** Docker Desktop handles this automatically via `host.docker.internal`. Skip this step.
+
+### Create config file
+
+```bash
+mkdir -p ~/.proton-mcp
+cat > ~/.proton-mcp/bridge.json << 'EOF'
+{
+  "imap_host": "host.docker.internal",
+  "imap_port": 1143,
+  "smtp_host": "host.docker.internal",
+  "smtp_port": 1025,
+  "username": "your-email@proton.me",
+  "password": "<bridge-generated-password>"
+}
+EOF
+```
+
+## Setup: Pass (pass-cli)
+
+### Install pass-cli
+
+```bash
+curl -fsSL https://proton.me/download/pass-cli/install.sh | bash
+```
+
+### Login and configure
+
+```bash
+PROTON_PASS_KEY_PROVIDER=fs pass-cli login
+pass-cli settings set default-vault --vault-name NanoClaw
+```
+
+Use the **filesystem key provider** (`fs`) so the session survives reboots and works inside Docker containers.
+
+### Create a vault
+
+```bash
+PROTON_PASS_KEY_PROVIDER=fs pass-cli vault create --name NanoClaw
+```
+
+## Setup: Drive (rclone)
+
+### Install rclone
+
+```bash
+curl -fsSL https://rclone.org/install.sh | sudo bash
+```
+
+The apt version is too old — use the install script to get rclone 1.62+ which includes the `protondrive` backend.
+
+### Configure
+
+```bash
+rclone config
+```
+
+Create a new remote named `protondrive`, select the `protondrive` type, enter your Proton credentials.
+
+### Test
+
+```bash
+rclone lsd protondrive:
+```
+
+## Setup: Calendar (Radicale)
+
+### Install Radicale
+
+```bash
+sudo apt install -y radicale
+```
+
+### Configure
+
+Create `~/.config/radicale/config`:
+
+```ini
+[server]
+hosts = 127.0.0.1:5232
+
+[auth]
+type = htpasswd
+htpasswd_filename = ~/.config/radicale/users
+htpasswd_encryption = plain
+
+[storage]
+filesystem_folder = ~/.var/lib/radicale/collections
+
+[rights]
+type = from_file
+file = ~/.config/radicale/rights
+```
+
+Create `~/.config/radicale/users`:
+```
+jorgenclaw:nanoclaw-cal
+yourusername:your-cal-password
+```
+
+Create `~/.config/radicale/rights`:
+```ini
+[owner]
+user = .+
+collection = {user}/.*
+permissions = RrWw
+
+[user-reads-agent]
+user = yourusername
+collection = jorgenclaw/.*
+permissions = RrWw
+
+[agent-reads-user]
+user = jorgenclaw
+collection = yourusername/.*
+permissions = Rr
+
+[root-access]
+user = .+
+collection = {user}
+permissions = RrWw
+```
+
+### Create systemd service
+
+Create `~/.config/systemd/user/radicale.service`:
+
+```ini
+[Unit]
+Description=Radicale CalDAV Server
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/radicale --config ~/.config/radicale/config
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now radicale
+```
+
+### Create calendars
+
+```bash
+curl -u jorgenclaw:nanoclaw-cal -X MKCALENDAR http://127.0.0.1:5232/jorgenclaw/calendar/
+curl -u yourusername:your-cal-password -X MKCALENDAR http://127.0.0.1:5232/yourusername/calendar/
+```
+
+### Subscribe from phone (optional)
+
+Expose Radicale via Tailscale, then:
+- **iOS:** Settings > Calendar > Accounts > Add CalDAV Account
+- **Android:** Install DAVx5, add CalDAV account
+- Server: `http://<tailscale-ip>:5232`
+
+## Rebuild and restart
+
+```bash
+npm run build
+./container/build.sh
+systemctl --user restart nanoclaw
+```
+
+## Verify
+
+### Test from chat
+
+| What to say | Expected tool |
+|---|---|
+| "Check my email" | `mail__get_unread` |
+| "Send an email to test@example.com" | `mail__send_message` |
+| "What's my GitHub password?" | `pass__get_item` |
+| "Generate a TOTP code for GitHub" | `pass__get_totp` |
+| "List my Drive files" | `drive__list` |
+| "What's on my calendar this week?" | `calendar__list_events` |
+| "Am I on VPN?" | `vpn__status` |
+
+### All 36 tools
+
+| Category | Tools |
+|---|---|
+| **Mail** (15) | get_unread, list_messages, get_message, search_messages, send_message, reply_message, forward_message, get_thread, mark_message, star_message, delete_message, move_message, list_folders, list_folder_messages, get_attachments |
+| **Pass** (9) | list_vaults, list_items, search_items, get_item, create_item, update_item, trash_item, generate_password, get_totp |
+| **Drive** (6) | list, upload, upload_folder, download, delete, mkdir |
+| **Calendar** (5) | list_events, get_event, create_event, update_event, delete_event |
+| **VPN** (1) | status |
+
+## Troubleshooting
+
+| Problem | What it means | What to do |
+|---------|--------------|------------|
+| "IMAP connection failed" | Bridge isn't running or wrong port | `systemctl --user start proton-bridge` and verify `nc -z 127.0.0.1 1143` |
+| "Authentication failed" | Wrong credentials in bridge.json | Get fresh Bridge password from Bridge GUI settings |
+| "Proton Bridge credentials not found" | Missing config file | Create `~/.proton-mcp/bridge.json` per setup instructions |
+| "Connection refused" from container | Bridge only listens on localhost | Set up the socat relay service (Linux) or use `host.docker.internal` (macOS) |
+| pass-cli "Passphrases file not found" | Key provider issue after reboot | Run `PROTON_PASS_KEY_PROVIDER=fs pass-cli login` |
+| rclone "unusual activity" | Proton flagged the login | Wait 15-30 min, or contact https://proton.me/support/appeal-abuse |
+| Calendar "400 Bad Request" | ICS formatting issue | Check Radicale logs: `journalctl --user -u radicale` |
+
+## Security Notes
+
+- **Pass and Drive tools are main-group only** — non-main groups cannot access credentials or cloud files (enforced by container mount isolation, not just policy)
+- `pass-cli` uses the **filesystem key provider** — the encryption key is stored on disk, not in the kernel keyring. This is necessary for Docker container access and reboot survival
+- `list_items` and `search_items` **never expose passwords** — only `get_item` returns credentials
+- TOTP seeds are as sensitive as passwords — never logged in error messages
+
+## Removal
+
+1. Remove `tools/proton-mcp/`
+2. Revert container-runner.ts changes (remove proton-mcp, pass-cli, rclone mounts)
+3. Revert agent-runner index.ts changes (remove proton MCP server)
+4. Remove config files: `~/.proton-mcp/`, `~/.config/radicale/`, `~/.config/rclone/`
+5. Rebuild: `npm run build && ./container/build.sh`
+6. Optionally stop services: `systemctl --user stop proton-bridge radicale`

--- a/tools/proton-mcp/calendar/calendar-client.js
+++ b/tools/proton-mcp/calendar/calendar-client.js
@@ -1,0 +1,161 @@
+/**
+ * Calendar client — wraps Radicale CalDAV server via HTTP.
+ * No external dependencies — uses Node.js built-in http module.
+ */
+
+import http from 'http';
+import crypto from 'crypto';
+
+const CAL_HOST = process.env.CALDAV_HOST || '127.0.0.1';
+const CAL_PORT = parseInt(process.env.CALDAV_PORT || '5232', 10);
+const CAL_USER = process.env.CALDAV_USER || 'jorgenclaw';
+const CAL_PASS = process.env.CALDAV_PASS || 'nanoclaw-cal';
+
+const AUTH = Buffer.from(`${CAL_USER}:${CAL_PASS}`).toString('base64');
+
+function request(method, path, body = null, contentType = 'application/xml') {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: CAL_HOST,
+      port: CAL_PORT,
+      path,
+      method,
+      headers: {
+        Authorization: `Basic ${AUTH}`,
+        ...(body ? { 'Content-Type': contentType, 'Content-Length': Buffer.byteLength(body) } : {}),
+      },
+    };
+
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+
+    req.on('error', reject);
+    req.setTimeout(10000, () => { req.destroy(); reject(new Error('Request timed out')); });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+function formatDate(d) {
+  // Accept ISO string or Date, output YYYYMMDDTHHMMSSZ
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d+/, '');
+}
+
+function parseIcsEvents(icsText) {
+  const events = [];
+  const blocks = icsText.split('BEGIN:VEVENT');
+  for (let i = 1; i < blocks.length; i++) {
+    const block = blocks[i].split('END:VEVENT')[0];
+    const get = (key) => {
+      const match = block.match(new RegExp(`^${key}[^:]*:(.*)$`, 'm'));
+      return match ? match[1].trim() : null;
+    };
+    events.push({
+      uid: get('UID'),
+      summary: get('SUMMARY'),
+      description: get('DESCRIPTION'),
+      start: get('DTSTART'),
+      end: get('DTEND'),
+      location: get('LOCATION'),
+    });
+  }
+  return events;
+}
+
+export async function listEvents(from, to, calendarUser = CAL_USER, calendarName = 'calendar') {
+  const startStr = formatDate(from);
+  const endStr = formatDate(to);
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<C:calendar-query xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:D="DAV:">
+  <D:prop>
+    <D:getetag/>
+    <C:calendar-data/>
+  </D:prop>
+  <C:filter>
+    <C:comp-filter name="VCALENDAR">
+      <C:comp-filter name="VEVENT">
+        <C:time-range start="${startStr}" end="${endStr}"/>
+      </C:comp-filter>
+    </C:comp-filter>
+  </C:filter>
+</C:calendar-query>`;
+
+  const res = await request('REPORT', `/${calendarUser}/${calendarName}/`, body);
+  if (res.status >= 400) throw new Error(`CalDAV error ${res.status}: ${res.body.slice(0, 200)}`);
+
+  return parseIcsEvents(res.body);
+}
+
+export async function getEvent(eventId, calendarUser = CAL_USER, calendarName = 'calendar') {
+  const res = await request('GET', `/${calendarUser}/${calendarName}/${eventId}.ics`, null);
+  if (res.status === 404) throw new Error(`Event "${eventId}" not found`);
+  if (res.status >= 400) throw new Error(`CalDAV error ${res.status}`);
+
+  const events = parseIcsEvents(res.body);
+  return events[0] || null;
+}
+
+export async function createEvent({ title, start, end, description, location, calendarUser = CAL_USER, calendarName = 'calendar' }) {
+  const uid = crypto.randomUUID();
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//NanoClaw//EN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTART:${formatDate(start)}`,
+    `DTEND:${formatDate(end)}`,
+    `SUMMARY:${title}`,
+  ];
+  if (description) lines.push(`DESCRIPTION:${description}`);
+  if (location) lines.push(`LOCATION:${location}`);
+  lines.push(`DTSTAMP:${formatDate(new Date())}`, 'END:VEVENT', 'END:VCALENDAR');
+  const ics = lines.join('\n');
+
+  const res = await request('PUT', `/${calendarUser}/${calendarName}/${uid}.ics`, ics, 'text/calendar');
+  if (res.status >= 400) throw new Error(`Failed to create event: ${res.status}`);
+
+  return { uid, title, start, end };
+}
+
+export async function updateEvent({ eventId, title, start, end, description, location, calendarUser = CAL_USER, calendarName = 'calendar' }) {
+  // Fetch existing event first
+  const existing = await request('GET', `/${calendarUser}/${calendarName}/${eventId}.ics`, null);
+  if (existing.status === 404) throw new Error(`Event "${eventId}" not found`);
+
+  const existingEvents = parseIcsEvents(existing.body);
+  const ev = existingEvents[0] || {};
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//NanoClaw//EN',
+    'BEGIN:VEVENT',
+    `UID:${eventId}`,
+    `DTSTART:${formatDate(start || ev.start)}`,
+    `DTEND:${formatDate(end || ev.end)}`,
+    `SUMMARY:${title || ev.summary}`,
+  ];
+  const desc = description || ev.description;
+  const loc = location || ev.location;
+  if (desc) lines.push(`DESCRIPTION:${desc}`);
+  if (loc) lines.push(`LOCATION:${loc}`);
+  lines.push(`DTSTAMP:${formatDate(new Date())}`, 'END:VEVENT', 'END:VCALENDAR');
+  const ics = lines.join('\n');
+
+  const res = await request('PUT', `/${calendarUser}/${calendarName}/${eventId}.ics`, ics, 'text/calendar');
+  if (res.status >= 400) throw new Error(`Failed to update event: ${res.status}`);
+
+  return { uid: eventId, updated: true };
+}
+
+export async function deleteEvent(eventId, calendarUser = CAL_USER, calendarName = 'calendar') {
+  const res = await request('DELETE', `/${calendarUser}/${calendarName}/${eventId}.ics`);
+  if (res.status >= 400) throw new Error(`Failed to delete event: ${res.status}`);
+  return { uid: eventId, deleted: true };
+}

--- a/tools/proton-mcp/drive/drive-client.js
+++ b/tools/proton-mcp/drive/drive-client.js
@@ -1,0 +1,58 @@
+/**
+ * Proton Drive client — wraps rclone's protondrive backend.
+ * Uses execFile (not exec) to prevent shell injection.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const RCLONE_BIN = process.env.RCLONE_BIN || 'rclone';
+const REMOTE = process.env.PROTON_DRIVE_REMOTE || 'protondrive:';
+
+async function runRclone(args, { timeout = 60000 } = {}) {
+  const { stdout } = await execFileAsync(RCLONE_BIN, args, {
+    timeout,
+    env: { ...process.env },
+  });
+  return stdout.trim();
+}
+
+export async function listFiles(remotePath = '') {
+  const fullPath = `${REMOTE}${remotePath}`;
+  const output = await runRclone(['lsjson', fullPath]);
+  if (!output) return [];
+  return JSON.parse(output);
+}
+
+export async function upload(localPath, remotePath) {
+  await runRclone(['copy', localPath, `${REMOTE}${remotePath}`], { timeout: 300000 });
+  return { success: true, remote_path: remotePath };
+}
+
+export async function uploadFolder(localPath, remotePath) {
+  await runRclone(['copy', localPath, `${REMOTE}${remotePath}`], { timeout: 300000 });
+  return { success: true, remote_path: remotePath };
+}
+
+export async function download(remotePath, localPath) {
+  await runRclone(['copy', `${REMOTE}${remotePath}`, localPath], { timeout: 300000 });
+  return { success: true, local_path: localPath };
+}
+
+export async function deleteRemote(remotePath) {
+  // Determine if path is a file or directory
+  try {
+    await runRclone(['deletefile', `${REMOTE}${remotePath}`]);
+  } catch {
+    // If deletefile fails, try purge (for directories)
+    await runRclone(['purge', `${REMOTE}${remotePath}`]);
+  }
+  return { success: true, deleted: remotePath };
+}
+
+export async function mkdir(remotePath) {
+  await runRclone(['mkdir', `${REMOTE}${remotePath}`]);
+  return { success: true, path: remotePath };
+}

--- a/tools/proton-mcp/index.js
+++ b/tools/proton-mcp/index.js
@@ -1,0 +1,726 @@
+#!/usr/bin/env node
+/**
+ * Proton MCP Server — Phase 4: Mail + Pass + Drive + VPN
+ *
+ * Mail: Connects to Proton Bridge via IMAP/SMTP and exposes mail tools.
+ * Pass: Wraps pass-cli for credential vault and TOTP operations.
+ * Drive: Wraps rclone protondrive backend for backup and file operations.
+ * VPN: Checks VPN status via external IP lookup.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+import { getUnread, listMessages, getMessage, searchMessages, getThread, markMessage, starMessage, deleteMessage, moveMessage, listFolders, listMessagesInFolder, getAttachments } from './mail/imap-client.js';
+import { sendMessage, replyMessage, forwardMessage } from './mail/smtp-client.js';
+import { listVaults, listItems, viewItem, searchItems, createItem, updateItem, trashItem, getTOTP } from './pass/pass-client.js';
+import { listFiles, upload, uploadFolder, download, deleteRemote, mkdir } from './drive/drive-client.js';
+import { getVpnStatus } from './vpn/vpn-client.js';
+import { listEvents, getEvent, createEvent, updateEvent, deleteEvent } from './calendar/calendar-client.js';
+
+// --- Config ---
+
+function loadConfig() {
+  // Try bridge.json first
+  const configPaths = [
+    path.join(process.env.HOME || '/home/node', '.proton-mcp', 'bridge.json'),
+    '/home/node/.proton-mcp/bridge.json',
+  ];
+
+  for (const p of configPaths) {
+    if (fs.existsSync(p)) {
+      try {
+        return JSON.parse(fs.readFileSync(p, 'utf-8'));
+      } catch { /* try next */ }
+    }
+  }
+
+  // Fall back to env vars
+  if (process.env.PROTON_BRIDGE_USERNAME && process.env.PROTON_BRIDGE_PASSWORD) {
+    return {
+      imap_host: process.env.PROTON_BRIDGE_IMAP_HOST || '127.0.0.1',
+      imap_port: parseInt(process.env.PROTON_BRIDGE_IMAP_PORT || '1143', 10),
+      smtp_host: process.env.PROTON_BRIDGE_SMTP_HOST || '127.0.0.1',
+      smtp_port: parseInt(process.env.PROTON_BRIDGE_SMTP_PORT || '1025', 10),
+      username: process.env.PROTON_BRIDGE_USERNAME,
+      password: process.env.PROTON_BRIDGE_PASSWORD,
+    };
+  }
+
+  throw new Error(
+    'Proton Bridge credentials not found. Create ~/.proton-mcp/bridge.json or set PROTON_BRIDGE_USERNAME and PROTON_BRIDGE_PASSWORD env vars.',
+  );
+}
+
+// --- MCP Server ---
+
+const server = new McpServer({
+  name: 'proton',
+  version: '4.0.0',
+});
+
+let config;
+try {
+  config = loadConfig();
+} catch (err) {
+  config = null;
+}
+
+function getConfig() {
+  if (!config) {
+    config = loadConfig();
+  }
+  return config;
+}
+
+function errorResult(msg) {
+  return { content: [{ type: 'text', text: JSON.stringify({ error: msg }) }], isError: true };
+}
+
+// --- Tool: get_unread ---
+server.tool(
+  'mail__get_unread',
+  'Get unread emails from Proton Mail inbox',
+  {},
+  async () => {
+    try {
+      const result = await getUnread(getConfig());
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: list_messages ---
+server.tool(
+  'mail__list_messages',
+  'List recent emails from Proton Mail inbox',
+  {
+    limit: z.number().min(1).max(50).optional().describe('Number of messages to fetch (default 10)'),
+  },
+  async (args) => {
+    try {
+      const result = await listMessages(getConfig(), args.limit || 10);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: get_message ---
+server.tool(
+  'mail__get_message',
+  'Get a single email by message ID (sequence number). Includes threading headers.',
+  {
+    message_id: z.number().describe('Message sequence number from list_messages'),
+  },
+  async (args) => {
+    try {
+      const result = await getMessage(getConfig(), args.message_id);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: search_messages ---
+server.tool(
+  'mail__search_messages',
+  'Search emails by keyword in subject and body',
+  {
+    query: z.string().describe('Search query'),
+  },
+  async (args) => {
+    try {
+      const result = await searchMessages(getConfig(), args.query);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: send_message ---
+server.tool(
+  'mail__send_message',
+  'Send an email via Proton Mail. Supports CC, BCC, HTML, and file attachments.',
+  {
+    to: z.string().describe('Recipient email address(es), comma-separated'),
+    subject: z.string().describe('Email subject'),
+    body: z.string().describe('Email body (plain text)'),
+    html: z.string().optional().describe('HTML body (if provided, plain text body becomes fallback)'),
+    cc: z.string().optional().describe('CC recipient(s), comma-separated'),
+    bcc: z.string().optional().describe('BCC recipient(s), comma-separated'),
+    attachments: z.array(z.object({
+      filename: z.string(),
+      path: z.string().optional().describe('Absolute path to file on disk'),
+      content: z.string().optional().describe('File content as base64 string'),
+      contentType: z.string().optional().describe('MIME type (optional, inferred from filename)'),
+    })).optional().describe('Files to attach'),
+  },
+  async (args) => {
+    try {
+      const result = await sendMessage(getConfig(), args);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: reply_message ---
+server.tool(
+  'mail__reply_message',
+  'Reply to an email, preserving the thread. Set reply_all=true to include all original recipients.',
+  {
+    message_id: z.number().describe('Sequence number of the message to reply to'),
+    body: z.string().describe('Reply body (plain text)'),
+    reply_all: z.boolean().optional().describe('Reply to all recipients (default: false, reply to sender only)'),
+    cc: z.string().optional().describe('Additional CC recipient(s), comma-separated'),
+    bcc: z.string().optional().describe('BCC recipient(s), comma-separated'),
+    attachments: z.array(z.object({
+      filename: z.string(),
+      path: z.string().optional(),
+      content: z.string().optional(),
+      contentType: z.string().optional(),
+    })).optional().describe('Files to attach'),
+  },
+  async (args) => {
+    try {
+      const result = await replyMessage(getConfig(), {
+        originalMessageId: args.message_id,
+        body: args.body,
+        replyAll: args.reply_all,
+        cc: args.cc,
+        bcc: args.bcc,
+        attachments: args.attachments,
+      });
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: get_thread ---
+server.tool(
+  'mail__get_thread',
+  'Fetch the full email chain (thread) for a message',
+  {
+    message_id: z.number().describe('Sequence number of any message in the thread'),
+  },
+  async (args) => {
+    try {
+      const result = await getThread(getConfig(), args.message_id);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: mark_message ---
+server.tool(
+  'mail__mark_message',
+  'Mark an email as read or unread',
+  {
+    message_id: z.number().describe('Message sequence number'),
+    read: z.boolean().describe('true = mark as read, false = mark as unread'),
+  },
+  async (args) => {
+    try {
+      const result = await markMessage(getConfig(), args.message_id, args.read);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: forward_message ---
+server.tool(
+  'mail__forward_message',
+  'Forward an email to another recipient',
+  {
+    message_id: z.number().describe('Sequence number of the message to forward'),
+    to: z.string().describe('Recipient email address'),
+    body: z.string().optional().describe('Optional message to prepend'),
+    cc: z.string().optional().describe('CC recipient(s), comma-separated'),
+    bcc: z.string().optional().describe('BCC recipient(s), comma-separated'),
+  },
+  async (args) => {
+    try {
+      const result = await forwardMessage(getConfig(), args);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    } catch (err) {
+      return errorResult(err.message);
+    }
+  },
+);
+
+// --- Tool: star_message ---
+server.tool(
+  'mail__star_message',
+  'Star or unstar an email',
+  {
+    message_id: z.number().describe('Message sequence number'),
+    star: z.boolean().describe('true = star, false = unstar'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await starMessage(getConfig(), args.message_id, args.star)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Tool: delete_message ---
+server.tool(
+  'mail__delete_message',
+  'Permanently delete an email from inbox',
+  {
+    message_id: z.number().describe('Message sequence number'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await deleteMessage(getConfig(), args.message_id)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Tool: move_message ---
+server.tool(
+  'mail__move_message',
+  'Move an email to a different folder (e.g. Trash, Archive, a label)',
+  {
+    message_id: z.number().describe('Message sequence number'),
+    folder: z.string().describe('Destination folder name (use mail__list_folders to see available folders)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await moveMessage(getConfig(), args.message_id, args.folder)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Tool: list_folders ---
+server.tool(
+  'mail__list_folders',
+  'List all mail folders and labels',
+  {},
+  async () => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await listFolders(getConfig())) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Tool: list_folder_messages ---
+server.tool(
+  'mail__list_folder_messages',
+  'List messages in a specific folder (Sent, Drafts, Trash, or any label)',
+  {
+    folder: z.string().describe('Folder name (e.g. "Sent", "Trash", "Drafts")'),
+    limit: z.number().min(1).max(50).optional().describe('Number of messages (default 10)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await listMessagesInFolder(getConfig(), args.folder, args.limit || 10)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Tool: get_attachments ---
+server.tool(
+  'mail__get_attachments',
+  'Download attachments from an email. Returns base64-encoded content.',
+  {
+    message_id: z.number().describe('Message sequence number'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await getAttachments(getConfig(), args.message_id)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Pass Tools ---
+
+// pass__list_vaults
+server.tool(
+  'pass__list_vaults',
+  'List available Proton Pass vaults',
+  {},
+  async () => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await listVaults()) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__list_items — never exposes passwords or TOTP seeds
+server.tool(
+  'pass__list_items',
+  'List credential names in a Proton Pass vault (no passwords returned)',
+  {
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const result = await listItems(args.vault);
+      const safe = (result.items || []).map((item) => ({
+        title: item.content?.title,
+        username: item.content?.content?.Login?.username || item.content?.content?.Login?.email,
+        urls: item.content?.content?.Login?.urls || [],
+        state: item.state,
+      }));
+      return { content: [{ type: 'text', text: JSON.stringify(safe) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__search_items — never exposes passwords or TOTP seeds
+server.tool(
+  'pass__search_items',
+  'Search Proton Pass items by keyword (no passwords returned)',
+  {
+    query: z.string().describe('Search keyword'),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const result = await searchItems(args.query, args.vault);
+      const safe = (result.items || []).map((item) => ({
+        title: item.content?.title,
+        username: item.content?.content?.Login?.username || item.content?.content?.Login?.email,
+        urls: item.content?.content?.Login?.urls || [],
+        state: item.state,
+      }));
+      return { content: [{ type: 'text', text: JSON.stringify(safe) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__get_item — returns full credential (username, password, URLs)
+server.tool(
+  'pass__get_item',
+  'Get a credential from Proton Pass by name. Returns username, password, and URLs.',
+  {
+    name: z.string().describe('Item title'),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const result = await viewItem(args.name, args.vault);
+      const item = result.item;
+      const login = item.content?.content?.Login || {};
+      return { content: [{ type: 'text', text: JSON.stringify({
+        title: item.content?.title,
+        username: login.username || login.email,
+        password: login.password,
+        urls: login.urls || [],
+        note: item.content?.note || '',
+        has_totp: !!(login.totp_uri),
+      }) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__create_item — store new login credential
+server.tool(
+  'pass__create_item',
+  'Store a new login credential in Proton Pass',
+  {
+    title: z.string().describe('Item title'),
+    username: z.string().optional(),
+    password: z.string().optional(),
+    url: z.string().optional(),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const result = await createItem(args);
+      return { content: [{ type: 'text', text: JSON.stringify({ success: true, result }) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__update_item — update existing credential fields
+server.tool(
+  'pass__update_item',
+  'Update an existing credential in Proton Pass',
+  {
+    name: z.string().describe('Item title to update'),
+    username: z.string().optional(),
+    password: z.string().optional(),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const { name, vault, ...updates } = args;
+      const result = await updateItem(name, updates, vault);
+      return { content: [{ type: 'text', text: JSON.stringify({ success: true, result }) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__trash_item — move item to trash
+server.tool(
+  'pass__trash_item',
+  'Move a credential to the trash in Proton Pass',
+  {
+    name: z.string().describe('Item title to trash'),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      const result = await trashItem(args.name, args.vault);
+      return { content: [{ type: 'text', text: JSON.stringify({ success: true, result }) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__generate_password — generate a random password
+server.tool(
+  'pass__generate_password',
+  'Generate a random password using Proton Pass',
+  {
+    length: z.number().optional().describe('Password length (default: 20)'),
+  },
+  async (args) => {
+    try {
+      const { execFile } = await import('child_process');
+      const { promisify } = await import('util');
+      const execFileAsync = promisify(execFile);
+      const bin = process.env.PROTON_PASS_BIN || 'pass-cli';
+      const genArgs = ['password', 'generate'];
+      if (args.length) genArgs.push(`${args.length}`);
+      const { stdout } = await execFileAsync(bin, genArgs, {
+        timeout: 10000,
+        env: { ...process.env, PROTON_PASS_KEY_PROVIDER: 'fs' },
+      });
+      return { content: [{ type: 'text', text: JSON.stringify({ password: stdout.trim() }) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// pass__get_totp — generate current TOTP code (most critical tool)
+server.tool(
+  'pass__get_totp',
+  'Generate the current TOTP authentication code for an item in Proton Pass. Use for autonomous 2FA.',
+  {
+    name: z.string().describe('Item title (must have a TOTP seed stored)'),
+    vault: z.string().optional().describe('Vault name (default: NanoClaw)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await getTOTP(args.name, args.vault)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Drive Tools ---
+
+// drive__list
+server.tool(
+  'drive__list',
+  'List files and folders at a path on Proton Drive',
+  {
+    path: z.string().optional().describe('Remote path (default: root)'),
+  },
+  async (args) => {
+    try {
+      const items = await listFiles(args.path || '');
+      const safe = items.map(({ Name, IsDir, Size, ModTime }) => ({
+        name: Name, type: IsDir ? 'folder' : 'file', size: Size, modified: ModTime,
+      }));
+      return { content: [{ type: 'text', text: JSON.stringify(safe) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// drive__upload
+server.tool(
+  'drive__upload',
+  'Upload a file to Proton Drive',
+  {
+    local_path: z.string().describe('Local file path'),
+    remote_path: z.string().describe('Remote destination path on Drive'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await upload(args.local_path, args.remote_path)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// drive__upload_folder
+server.tool(
+  'drive__upload_folder',
+  'Upload a folder to Proton Drive (copies all contents recursively)',
+  {
+    local_path: z.string().describe('Local folder path'),
+    remote_path: z.string().describe('Remote destination path on Drive'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await uploadFolder(args.local_path, args.remote_path)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// drive__download
+server.tool(
+  'drive__download',
+  'Download a file or folder from Proton Drive to local path',
+  {
+    remote_path: z.string().describe('Remote path on Drive'),
+    local_path: z.string().describe('Local destination path'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await download(args.remote_path, args.local_path)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// drive__delete
+server.tool(
+  'drive__delete',
+  'Delete a file or folder from Proton Drive',
+  {
+    remote_path: z.string().describe('Remote path to delete'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await deleteRemote(args.remote_path)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// drive__mkdir
+server.tool(
+  'drive__mkdir',
+  'Create a folder on Proton Drive',
+  {
+    remote_path: z.string().describe('Remote folder path to create'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await mkdir(args.remote_path)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Calendar Tools ---
+
+// calendar__list_events
+server.tool(
+  'calendar__list_events',
+  'List calendar events in a date range. Can read both Jorgenclaw and Scott calendars.',
+  {
+    from: z.string().describe('Start date (ISO 8601, e.g. 2026-03-21)'),
+    to: z.string().describe('End date (ISO 8601, e.g. 2026-03-28)'),
+    calendar_user: z.string().optional().describe('Calendar owner: "jorgenclaw" (default) or "scott"'),
+  },
+  async (args) => {
+    try {
+      const events = await listEvents(args.from, args.to, args.calendar_user);
+      return { content: [{ type: 'text', text: JSON.stringify(events) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// calendar__get_event
+server.tool(
+  'calendar__get_event',
+  'Get a single calendar event by its UID',
+  {
+    event_id: z.string().describe('Event UID'),
+    calendar_user: z.string().optional().describe('Calendar owner (default: jorgenclaw)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await getEvent(args.event_id, args.calendar_user)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// calendar__create_event
+server.tool(
+  'calendar__create_event',
+  'Create a calendar event. Use for reminders, follow-ups, and deadlines.',
+  {
+    title: z.string().describe('Event title'),
+    start: z.string().describe('Start time (ISO 8601)'),
+    end: z.string().describe('End time (ISO 8601)'),
+    description: z.string().optional(),
+    location: z.string().optional(),
+    calendar_user: z.string().optional().describe('Calendar owner (default: jorgenclaw)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await createEvent(args)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// calendar__update_event
+server.tool(
+  'calendar__update_event',
+  'Update an existing calendar event',
+  {
+    event_id: z.string().describe('Event UID to update'),
+    title: z.string().optional(),
+    start: z.string().optional().describe('New start time (ISO 8601)'),
+    end: z.string().optional().describe('New end time (ISO 8601)'),
+    description: z.string().optional(),
+    location: z.string().optional(),
+    calendar_user: z.string().optional().describe('Calendar owner (default: jorgenclaw)'),
+  },
+  async (args) => {
+    try {
+      const { event_id: eventId, calendar_user: calendarUser, ...updates } = args;
+      return { content: [{ type: 'text', text: JSON.stringify(await updateEvent({ eventId, calendarUser, ...updates })) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// calendar__delete_event
+server.tool(
+  'calendar__delete_event',
+  'Delete a calendar event',
+  {
+    event_id: z.string().describe('Event UID to delete'),
+    calendar_user: z.string().optional().describe('Calendar owner (default: jorgenclaw)'),
+  },
+  async (args) => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await deleteEvent(args.event_id, args.calendar_user)) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- VPN Tools ---
+
+// vpn__status
+server.tool(
+  'vpn__status',
+  'Check VPN connection status — shows current IP, location, and whether traffic is routed through ProtonVPN',
+  {},
+  async () => {
+    try {
+      return { content: [{ type: 'text', text: JSON.stringify(await getVpnStatus()) }] };
+    } catch (err) { return errorResult(err.message); }
+  },
+);
+
+// --- Start ---
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tools/proton-mcp/mail/imap-client.js
+++ b/tools/proton-mcp/mail/imap-client.js
@@ -1,0 +1,355 @@
+/**
+ * IMAP client for Proton Bridge
+ * Handles read operations: list, get, search, unread, thread, mark
+ */
+
+import Imap from 'imap';
+import { simpleParser } from 'mailparser';
+
+/**
+ * Create a short-lived IMAP connection, run `fn`, then close.
+ */
+function withImap(config, fn) {
+  return new Promise((resolve, reject) => {
+    const imap = new Imap({
+      user: config.username,
+      password: config.password,
+      host: config.imap_host || '127.0.0.1',
+      port: config.imap_port || 1143,
+      tls: false,
+      authTimeout: 10000,
+    });
+
+    imap.once('ready', () => {
+      fn(imap)
+        .then((result) => {
+          imap.end();
+          resolve(result);
+        })
+        .catch((err) => {
+          imap.end();
+          reject(err);
+        });
+    });
+
+    imap.once('error', (err) => reject(new Error(`IMAP connection failed: ${err.message}. Is Proton Bridge running?`)));
+    imap.connect();
+  });
+}
+
+/**
+ * Fetch messages by sequence numbers. Returns parsed message objects.
+ */
+function fetchMessages(imap, seqnos, bodiesOpt = '') {
+  return new Promise((resolve, reject) => {
+    if (seqnos.length === 0) { resolve([]); return; }
+
+    const messages = [];
+    const f = imap.fetch(seqnos, { bodies: bodiesOpt, struct: true });
+
+    f.on('message', (msg, seqno) => {
+      let raw = '';
+      msg.on('body', (stream) => {
+        stream.on('data', (chunk) => { raw += chunk.toString('utf8'); });
+      });
+      msg.once('end', () => {
+        messages.push({ seqno, raw });
+      });
+    });
+
+    f.once('error', reject);
+    f.once('end', async () => {
+      const parsed = [];
+      for (const m of messages) {
+        try {
+          const mail = await simpleParser(m.raw);
+          parsed.push({
+            id: m.seqno,
+            subject: mail.subject || '(no subject)',
+            from: mail.from?.text || 'unknown',
+            to: mail.to?.text || '',
+            cc: mail.cc?.text || '',
+            date: mail.date?.toISOString() || '',
+            body: mail.text || mail.html || '',
+            message_id_header: mail.messageId || null,
+            in_reply_to: mail.inReplyTo || null,
+            references: mail.references || [],
+            seen: true, // will be overridden by caller if needed
+          });
+        } catch {
+          parsed.push({ id: m.seqno, subject: '(parse error)', from: '', to: '', date: '', body: '', message_id_header: null, in_reply_to: null, references: [], seen: true });
+        }
+      }
+      resolve(parsed);
+    });
+  });
+}
+
+/**
+ * Open INBOX and return box info.
+ */
+function openInbox(imap, readOnly = true) {
+  return new Promise((resolve, reject) => {
+    imap.openBox('INBOX', readOnly, (err, box) => {
+      if (err) reject(err);
+      else resolve(box);
+    });
+  });
+}
+
+/**
+ * IMAP SEARCH wrapper.
+ */
+function imapSearch(imap, criteria) {
+  return new Promise((resolve, reject) => {
+    imap.search(criteria, (err, results) => {
+      if (err) reject(err);
+      else resolve(results || []);
+    });
+  });
+}
+
+// --- Exported operations ---
+
+export async function getUnread(config) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+    const uids = await imapSearch(imap, ['UNSEEN']);
+    if (uids.length === 0) return { count: 0, messages: [] };
+
+    const recent = uids.slice(-20);
+    const messages = await fetchMessages(imap, recent, 'HEADER');
+    return {
+      count: uids.length,
+      messages: messages.map((m) => ({
+        id: m.id,
+        subject: m.subject,
+        from: m.from,
+        date: m.date,
+      })),
+    };
+  });
+}
+
+export async function listMessages(config, limit = 10) {
+  return withImap(config, async (imap) => {
+    const box = await openInbox(imap, true);
+    const total = box.messages.total;
+    if (total === 0) return [];
+
+    const start = Math.max(1, total - limit + 1);
+    const range = `${start}:${total}`;
+
+    const messages = await fetchMessages(imap, range, 'HEADER');
+
+    // Check which are unseen
+    const unseenIds = new Set(await imapSearch(imap, ['UNSEEN']));
+    return messages
+      .map((m) => ({ ...m, seen: !unseenIds.has(m.id), body: undefined }))
+      .reverse();
+  });
+}
+
+export async function getMessage(config, messageId) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+    const messages = await fetchMessages(imap, [messageId], '');
+    if (messages.length === 0) throw new Error(`Message ${messageId} not found`);
+    return messages[0];
+  });
+}
+
+export async function searchMessages(config, query) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+    const uids = await imapSearch(imap, [['TEXT', query]]);
+    if (uids.length === 0) return [];
+
+    const recent = uids.slice(-10);
+    const messages = await fetchMessages(imap, recent, 'HEADER');
+    return messages.map((m) => ({ ...m, body: undefined }));
+  });
+}
+
+export async function getMessageHeaders(config, messageId) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+    const messages = await fetchMessages(imap, [messageId], 'HEADER');
+    if (messages.length === 0) throw new Error(`Message ${messageId} not found`);
+    return {
+      messageId: messages[0].message_id_header,
+      subject: messages[0].subject,
+      from: messages[0].from,
+      to: messages[0].to,
+      cc: messages[0].cc || null,
+      references: messages[0].references,
+      inReplyTo: messages[0].in_reply_to,
+    };
+  });
+}
+
+export async function getThread(config, messageId) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+
+    // 1. Fetch the starting message to get its threading headers
+    const startMsgs = await fetchMessages(imap, [messageId], '');
+    if (startMsgs.length === 0) throw new Error(`Message ${messageId} not found`);
+
+    // 2. Collect all Message-IDs in the thread
+    const refIds = [
+      startMsgs[0].message_id_header,
+      ...(startMsgs[0].references || []),
+      startMsgs[0].in_reply_to,
+    ].filter(Boolean);
+
+    // 3. Search INBOX for each referenced Message-ID
+    const allSeqnos = new Set([messageId]);
+    for (const id of refIds) {
+      const results = await imapSearch(imap, [['HEADER', 'Message-ID', id]]);
+      results.forEach(n => allSeqnos.add(n));
+    }
+
+    // 4. Fetch all matching messages
+    const seqnoArray = [...allSeqnos];
+    const threadMsgs = await fetchMessages(imap, seqnoArray, '');
+
+    // 5. Sort chronologically
+    return threadMsgs.sort((a, b) => new Date(a.date) - new Date(b.date));
+  });
+}
+
+export async function markMessage(config, messageId, read) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, false);
+    await new Promise((resolve, reject) => {
+      const action = read ? '+FLAGS' : '-FLAGS';
+      imap.store(messageId, action, ['\\Seen'], (err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+    return { success: true, message_id: messageId, read };
+  });
+}
+
+export async function starMessage(config, messageId, star) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, false);
+    await new Promise((resolve, reject) => {
+      const action = star ? '+FLAGS' : '-FLAGS';
+      imap.store(messageId, action, ['\\Flagged'], (err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+    return { success: true, message_id: messageId, starred: star };
+  });
+}
+
+export async function deleteMessage(config, messageId) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, false);
+    await new Promise((resolve, reject) => {
+      imap.store(messageId, '+FLAGS', ['\\Deleted'], (err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+    await new Promise((resolve, reject) => {
+      imap.expunge((err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+    return { success: true, message_id: messageId, deleted: true };
+  });
+}
+
+export async function moveMessage(config, messageId, destFolder) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, false);
+    await new Promise((resolve, reject) => {
+      imap.move(messageId, destFolder, (err) => {
+        if (err) reject(err); else resolve();
+      });
+    });
+    return { success: true, message_id: messageId, moved_to: destFolder };
+  });
+}
+
+export async function listFolders(config) {
+  return withImap(config, async (imap) => {
+    return new Promise((resolve, reject) => {
+      imap.getBoxes((err, boxes) => {
+        if (err) reject(err);
+        else {
+          const folders = [];
+          function walk(obj, prefix = '') {
+            for (const [name, box] of Object.entries(obj)) {
+              const fullName = prefix ? `${prefix}${box.delimiter}${name}` : name;
+              folders.push({ name: fullName, delimiter: box.delimiter });
+              if (box.children) walk(box.children, fullName);
+            }
+          }
+          walk(boxes);
+          resolve(folders);
+        }
+      });
+    });
+  });
+}
+
+function openBox(imap, folder, readOnly = true) {
+  return new Promise((resolve, reject) => {
+    imap.openBox(folder, readOnly, (err, box) => {
+      if (err) reject(err);
+      else resolve(box);
+    });
+  });
+}
+
+export async function listMessagesInFolder(config, folder, limit = 10) {
+  return withImap(config, async (imap) => {
+    const box = await openBox(imap, folder, true);
+    const total = box.messages.total;
+    if (total === 0) return [];
+
+    const start = Math.max(1, total - limit + 1);
+    const range = `${start}:${total}`;
+
+    const messages = await fetchMessages(imap, range, 'HEADER');
+    return messages
+      .map((m) => ({ ...m, body: undefined }))
+      .reverse();
+  });
+}
+
+export async function getAttachments(config, messageId) {
+  return withImap(config, async (imap) => {
+    await openInbox(imap, true);
+
+    return new Promise((resolve, reject) => {
+      const f = imap.fetch([messageId], { bodies: '', struct: true });
+      let raw = '';
+
+      f.on('message', (msg) => {
+        msg.on('body', (stream) => {
+          stream.on('data', (chunk) => { raw += chunk.toString('utf8'); });
+        });
+      });
+
+      f.once('error', reject);
+      f.once('end', async () => {
+        try {
+          const mail = await simpleParser(raw);
+          const attachments = (mail.attachments || []).map((a) => ({
+            filename: a.filename,
+            contentType: a.contentType,
+            size: a.size,
+            content: a.content.toString('base64'),
+          }));
+          resolve(attachments);
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  });
+}

--- a/tools/proton-mcp/mail/smtp-client.js
+++ b/tools/proton-mcp/mail/smtp-client.js
@@ -1,0 +1,105 @@
+/**
+ * SMTP client for Proton Bridge
+ * Handles send and reply operations via nodemailer
+ */
+
+import nodemailer from 'nodemailer';
+import { getMessageHeaders, getMessage as getFullMessage } from './imap-client.js';
+
+function createTransporter(config) {
+  return nodemailer.createTransport({
+    host: config.smtp_host || '127.0.0.1',
+    port: config.smtp_port || 1025,
+    secure: false,
+    auth: {
+      user: config.username,
+      pass: config.password,
+    },
+    tls: { rejectUnauthorized: false },
+  });
+}
+
+export async function sendMessage(config, { to, subject, body, html, cc, bcc, attachments }) {
+  const transporter = createTransporter(config);
+
+  const mailOpts = {
+    from: config.username,
+    to,
+    cc,
+    bcc,
+    subject,
+    attachments,
+  };
+  if (html) {
+    mailOpts.html = html;
+    if (body) mailOpts.text = body; // plain text fallback
+  } else {
+    mailOpts.text = body;
+  }
+
+  const info = await transporter.sendMail(mailOpts);
+  return { success: true, message_id: info.messageId };
+}
+
+export async function forwardMessage(config, { originalMessageId, to, body, cc, bcc }) {
+  const original = await getFullMessage(config, originalMessageId);
+
+  const fwdSubject = original.subject.startsWith('Fwd:')
+    ? original.subject
+    : `Fwd: ${original.subject}`;
+
+  const fwdBody = `${body || ''}\n\n---------- Forwarded message ----------\nFrom: ${original.from}\nDate: ${original.date}\nSubject: ${original.subject}\nTo: ${original.to}\n\n${original.body}`;
+
+  const transporter = createTransporter(config);
+
+  const info = await transporter.sendMail({
+    from: config.username,
+    to,
+    cc,
+    bcc,
+    subject: fwdSubject,
+    text: fwdBody,
+  });
+
+  return { success: true, message_id: info.messageId };
+}
+
+export async function replyMessage(config, { originalMessageId, body, cc, bcc, replyAll, attachments }) {
+  const headers = await getMessageHeaders(config, originalMessageId);
+
+  const replySubject = headers.subject.startsWith('Re:')
+    ? headers.subject
+    : `Re: ${headers.subject}`;
+
+  // Build References chain: existing refs + original Message-ID
+  const refsList = [...(headers.references || []), headers.messageId].filter(Boolean);
+  const referencesStr = refsList.join(' ');
+
+  // Reply-all: include original To and CC recipients (excluding ourselves)
+  let to = headers.from;
+  if (replyAll) {
+    const allRecipients = [headers.from, headers.to, headers.cc].filter(Boolean).join(', ');
+    // Remove our own address to avoid sending to ourselves
+    const ownAddr = config.username.toLowerCase();
+    to = allRecipients
+      .split(/,\s*/)
+      .filter((addr) => !addr.toLowerCase().includes(ownAddr))
+      .join(', ') || headers.from;
+  }
+
+  const transporter = createTransporter(config);
+
+  const info = await transporter.sendMail({
+    from: config.username,
+    to,
+    cc,
+    bcc,
+    subject: replySubject,
+    text: body,
+    inReplyTo: headers.messageId,
+    references: referencesStr,
+    attachments,
+  });
+
+  return { success: true, message_id: info.messageId };
+}

--- a/tools/proton-mcp/package.json
+++ b/tools/proton-mcp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proton-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for Proton suite — Mail via Bridge (IMAP/SMTP) + Pass via CLI",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "imap": "^0.8.19",
+    "mailparser": "^3.6.0",
+    "nodemailer": "^6.9.0",
+    "@modelcontextprotocol/sdk": "latest"
+  }
+}

--- a/tools/proton-mcp/pass/pass-client.js
+++ b/tools/proton-mcp/pass/pass-client.js
@@ -1,0 +1,84 @@
+/**
+ * Proton Pass client — wraps pass-cli for vault/item/TOTP operations.
+ * Uses execFile (not exec) to prevent shell injection.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const PASS_BIN = process.env.PROTON_PASS_BIN || 'pass-cli';
+const DEFAULT_VAULT = process.env.PROTON_PASS_VAULT || 'NanoClaw';
+
+const PASS_ENV = { ...process.env, PROTON_PASS_KEY_PROVIDER: 'fs' };
+
+async function runPass(args, { timeout = 15000 } = {}) {
+  const { stdout } = await execFileAsync(PASS_BIN, [...args, '--output', 'json'], {
+    timeout,
+    env: PASS_ENV,
+  });
+  return JSON.parse(stdout);
+}
+
+async function runPassRaw(args, { timeout = 15000 } = {}) {
+  const { stdout } = await execFileAsync(PASS_BIN, args, {
+    timeout,
+    env: PASS_ENV,
+  });
+  return stdout.trim();
+}
+
+export async function listVaults() {
+  return runPass(['vault', 'list']);
+}
+
+export async function listItems(vault = DEFAULT_VAULT) {
+  // item list takes vault name as a positional argument
+  return runPass(['item', 'list', vault]);
+}
+
+export async function viewItem(title, vault = DEFAULT_VAULT) {
+  return runPass(['item', 'view', '--item-title', title, '--vault-name', vault]);
+}
+
+export async function searchItems(query, vault = DEFAULT_VAULT) {
+  // pass-cli has no search command — filter item list client-side
+  const result = await listItems(vault);
+  const q = query.toLowerCase();
+  const matched = (result.items || []).filter((item) => {
+    const t = item.content?.title?.toLowerCase() || '';
+    const u = item.content?.content?.Login?.username?.toLowerCase() || '';
+    const urls = (item.content?.content?.Login?.urls || []).join(' ').toLowerCase();
+    return t.includes(q) || u.includes(q) || urls.includes(q);
+  });
+  return { items: matched };
+}
+
+export async function createItem({ title, username, password, url, notes, vault = DEFAULT_VAULT }) {
+  const args = ['item', 'create', 'login',
+    '--vault-name', vault,
+    '--title', title,
+  ];
+  if (username) args.push('--username', username);
+  if (password) args.push('--password', password);
+  if (url) args.push('--url', url);
+  // pass-cli create doesn't support --note; notes not available on create
+  return runPassRaw(args);
+}
+
+export async function updateItem(title, updates, vault = DEFAULT_VAULT) {
+  const args = ['item', 'update', '--item-title', title, '--vault-name', vault];
+  for (const [key, value] of Object.entries(updates)) {
+    if (value) args.push('--field', `${key}=${value}`);
+  }
+  return runPassRaw(args);
+}
+
+export async function trashItem(title, vault = DEFAULT_VAULT) {
+  return runPassRaw(['item', 'trash', '--item-title', title, '--vault-name', vault]);
+}
+
+export async function getTOTP(title, vault = DEFAULT_VAULT) {
+  return runPass(['item', 'totp', '--item-title', title, '--vault-name', vault]);
+}

--- a/tools/proton-mcp/vpn/vpn-client.js
+++ b/tools/proton-mcp/vpn/vpn-client.js
@@ -1,0 +1,39 @@
+/**
+ * VPN status client — checks current VPN state via external IP lookup.
+ * Works regardless of how the VPN is configured (router-level, ProtonVPN app, etc.)
+ */
+
+import https from 'https';
+
+function fetchJson(url, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Request timed out')), timeout);
+    https.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        clearTimeout(timer);
+        try { resolve(JSON.parse(data)); }
+        catch { reject(new Error(`Bad response: ${data.slice(0, 200)}`)); }
+      });
+    }).on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+export async function getVpnStatus() {
+  const info = await fetchJson('https://ipinfo.io/json');
+  // Proton VPN typically exits via Datacamp Limited or similar providers
+  const isVpn = /datacamp|protonvpn|m247|datapacket/i.test(info.org || '');
+  return {
+    connected: isVpn,
+    ip: info.ip,
+    city: info.city,
+    region: info.region,
+    country: info.country,
+    org: info.org,
+    timezone: info.timezone,
+  };
+}


### PR DESCRIPTION
## Summary

  Expands the Proton skill from 8 mail-only tools (Phase 1.5) to a complete **36-tool suite**:

  - **Mail (15)**: read, send, reply-all, forward, star, delete, move between folders, HTML email, attachments, search, threads
  - **Pass (9)**: credential vault CRUD, TOTP generation for autonomous 2FA, password generator
  - **Drive (6)**: upload, download, list, delete, mkdir via rclone's official protondrive backend
  - **Calendar (5)**: create, list, update, delete events via Radicale CalDAV server
  - **VPN (1)**: status check (IP, location, VPN detection)

  ### Security
  - Pass and Drive are **main-group only** (container mount isolation)
  - `pass-cli` uses filesystem key provider (Docker + reboot safe)
  - `list_items`/`search_items` never expose passwords

  ### Dependencies
  - `pass-cli` (official Proton CLI, paid plan required)
  - `rclone` 1.62+ (official protondrive backend)
  - `radicale` (lightweight CalDAV server)

  ## Test plan
  - [ ] Mail: send, reply-all, forward, attachments, folders
  - [ ] Pass: list, get, create, TOTP, password generation
  - [ ] Drive: upload, list, download
  - [ ] Calendar: create event, list events, delete
  - [ ] VPN: status returns IP and location

  🤖 Generated with [Claude Code](https://claude.com/claude-code)