### PR TITLE
chore: add /setup-dev for local development

### DIFF
--- a/.claude/skills/setup-dev/SKILL.md
+++ b/.claude/skills/setup-dev/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: setup-dev
+description: Merge everything under dev-agents/ into .claude/ so dev skills and other assets become available. Use when the user runs /setup-dev.
+---
+
+# Setup Dev Skills
+
+Run the installer script:
+
+```bash
+bash .claude/skills/setup-dev/setup-dev.sh
+```
+
+Then confirm to the user which skills were installed and that they are now available.

--- a/.claude/skills/setup-dev/setup-dev.sh
+++ b/.claude/skills/setup-dev/setup-dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+src="$repo_root/dev-agents"
+dst="$repo_root/.claude"
+
+for category_dir in "$src"/*/; do
+  category=$(basename "$category_dir")
+  mkdir -p "$dst/$category"
+  for item_dir in "$category_dir"*/; do
+    [ -e "$item_dir" ] || continue
+    item=$(basename "$item_dir")
+    cp -r "$item_dir" "$dst/$category/$item"
+    echo "Installed: $category/$item"
+  done
+done

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ groups/global/*
 # Skills system (local per-installation state)
 .nanoclaw/
 
+# Dev assets (installed locally via /setup-dev, source lives in dev-agents/)
+.claude/*/dev-*/
+
 agents-sdk-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,18 @@ Every user should have clean and minimal code that does exactly what they need. 
 ### Testing
 
 Test your skill by running it on a fresh clone before submitting.
+
+### Local development assets
+
+`dev-agents/` mirrors the `.claude/` structure and is the place to add assets for developing `nanoclaw` itself:
+
+| `dev-agents/` path           | Installed to              |
+| ---------------------------- | ------------------------- |
+| `dev-agents/skills/dev-*/`   | `.claude/skills/dev-*/`   |
+| `dev-agents/commands/dev-*/` | `.claude/commands/dev-*/` |
+
+**Convention:** all items in `dev-agents/` must use the `dev-` prefix (e.g. `dev-my-skill`, `dev-my-command`).
+This prefix is how the gitignore rule `.claude/*/dev-*/` identifies installed-but-not-committed assets across all categories.
+
+Run `/setup-dev` to merge `dev-agents/` into `.claude/`.
+Then they will be available to use in the current repo.

--- a/dev-agents/skills/dev-hello/SKILL.md
+++ b/dev-agents/skills/dev-hello/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: dev-hello
+description: Responds with a friendly greeting. Use when the user says "hello", "hi", or asks for a greeting.
+---
+
+# Hello World Skill
+
+A minimal skill that demonstrates the skill format. When applied, respond with a warm, brief greeting.
+
+## Behavior
+
+1. Greet the user warmly and concisely.
+2. Optionally mention you're using the hello skill if context makes it helpful.
+3. Keep the response short—one or two sentences.
+
+## Example
+
+User: "Hey!"
+
+Response: "Hello! How can I help you today?"


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code

## Description

Add a `/setup-dev` skill to copy skills or other agentic tools from `./dev-agents` to `.claude`.

This allow additional skills, commands, and other assets to be added to the repo without polluting the skills available to `nanoclaw`.

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone

The skill has a "pre-built" bash to copy the files so that no tokens are wasted to do that trivial task.

## Alternative

Using `npx skills add ...` to add skills specific for nanoclaw development. But that requires @qwibitai to create that repo first.