### PR TITLE
fix: prepend ANTHROPIC_BASE_URL pathname to proxy requests and pass ANTHROPIC_MODEL to container

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -28,6 +28,7 @@ import {
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
+import { readEnvFile } from './env.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -238,6 +239,10 @@ function buildContainerArgs(
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
   }
 
+  const envModel = readEnvFile(['ANTHROPIC_MODEL']);
+  if (envModel.ANTHROPIC_MODEL) {
+    args.push('-e', `ANTHROPIC_MODEL=${envModel.ANTHROPIC_MODEL}`);
+  }
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -83,7 +83,7 @@ export function startCredentialProxy(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: upstreamUrl.pathname.replace(/\/+$/, '') + req.url,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Enable compatibility with third-party Claude-compatible API providers like MiniMax:
```
ANTHROPIC_BASE_URL="https://api.minimaxi.com/anthropic"
ANTHROPIC_MODEL="MiniMax-M2.5"
```
Previously the proxy stripped the /anthropic prefix, causing requests to hit the wrong endpoint. The model env var was also not forwarded to containers.

Fix #685 

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
