### PR TITLE
improve(agent-runner): set the claude model explicitly in the code

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -392,6 +392,7 @@ async function runQuery(
   for await (const message of query({
     prompt: stream,
     options: {
+      model: 'claude-opus-4-6',
       cwd: '/workspace/group',
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,


### PR DESCRIPTION
## Type of Change

- [x] **Simplification** - reduces or simplifies source code

## Description
Being explicit about which model is to be used is better. It's hard to find out which model is being used. `data/sessions/${session-id}/.claude/projects/-workspace-group/foo.jsonl` took some searching even with AI. 

Sonnet is a decent model, but Opus is so much better at agentic things. If people want to downgrade to Sonnet later, then by all means. But at least this way, they get the best experience first and can easily find where to downgrade later. 



