### PR TITLE
feat: add agent trace observability with web UI

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -106,6 +106,12 @@ async function readStdin(): Promise<string> {
 
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const TRACE_MARKER = '---NANOCLAW_TRACE---';
+
+/** Emit a structured trace event to the host for observability. */
+function writeTrace(event: Record<string, unknown>): void {
+  process.stdout.write(`${TRACE_MARKER}${JSON.stringify({ ...event, ts: Date.now() })}\n`);
+}
 
 function writeOutput(output: ContainerOutput): void {
   console.log(OUTPUT_START_MARKER);
@@ -366,6 +372,9 @@ async function runQuery(
   let messageCount = 0;
   let resultCount = 0;
 
+  // Trace: accumulate tool_use input JSON across deltas before emitting tool_start
+  let currentToolBlock: { id: string; name: string; isSubagent: boolean; inputBuf: string } | null = null;
+
   // Load global CLAUDE.md as additional system context (shared across all groups)
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
@@ -447,6 +456,68 @@ async function runQuery(
       log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
     }
 
+    // Trace: emit LLM and tool call events from stream_event messages
+    if (message.type === 'stream_event') {
+      const event = (message as any).event;
+      const parentToolUseId = (message as any).parent_tool_use_id;
+      const isMainAgent = parentToolUseId === null || parentToolUseId === undefined;
+
+      // Trace: LLM call start (input tokens)
+      if (event?.type === 'message_start' && isMainAgent) {
+        writeTrace({
+          type: 'llm_start',
+          input_tokens: event.message?.usage?.input_tokens ?? null,
+          model: event.message?.model ?? null,
+        });
+      }
+
+      // Trace: LLM call end (output tokens, stop reason)
+      if (event?.type === 'message_delta' && isMainAgent) {
+        writeTrace({
+          type: 'llm_end',
+          output_tokens: event.usage?.output_tokens ?? null,
+          stop_reason: event.delta?.stop_reason ?? null,
+        });
+      }
+
+      // Trace: start tracking tool_use block (input arrives via deltas)
+      if (event?.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+        currentToolBlock = { id: event.content_block.id, name: event.content_block.name, isSubagent: !isMainAgent, inputBuf: '' };
+      }
+
+      // Trace: accumulate tool_use input JSON deltas
+      if (event?.type === 'content_block_delta' && event.delta?.type === 'input_json_delta' && currentToolBlock) {
+        currentToolBlock.inputBuf += event.delta.partial_json ?? '';
+      }
+
+      // Trace: emit tool_start with full input once block is complete
+      if (event?.type === 'content_block_stop' && currentToolBlock) {
+        writeTrace({
+          type: 'tool_start',
+          tool_id: currentToolBlock.id,
+          tool_name: currentToolBlock.name,
+          is_subagent: currentToolBlock.isSubagent,
+          input_preview: currentToolBlock.inputBuf,
+        });
+        currentToolBlock = null;
+      }
+    }
+
+    // Trace: tool result (captures tool output)
+    if (message.type === 'user') {
+      const content = (message as any).message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'tool_result') {
+            const output = typeof block.content === 'string'
+              ? block.content
+              : JSON.stringify(block.content ?? '');
+            writeTrace({ type: 'tool_end', tool_id: block.tool_use_id, output });
+          }
+        }
+      }
+    }
+
     if (message.type === 'result') {
       resultCount++;
       const textResult = 'result' in message ? (message as { result?: string }).result : null;
@@ -505,6 +576,17 @@ async function main(): Promise<void> {
     prompt += '\n' + pending.join('\n');
   }
 
+  // Emit trace start
+  const traceId = `${containerInput.groupFolder}-${Date.now()}`;
+  writeTrace({
+    type: 'trace_start',
+    trace_id: traceId,
+    group: containerInput.groupFolder,
+    chat_jid: containerInput.chatJid,
+    is_scheduled: containerInput.isScheduledTask ?? false,
+    prompt_preview: containerInput.prompt.slice(0, 200),
+  });
+
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
   try {
@@ -542,9 +624,11 @@ async function main(): Promise<void> {
       log(`Got new message (${nextMessage.length} chars), starting new query`);
       prompt = nextMessage;
     }
+    writeTrace({ type: 'trace_end', trace_id: traceId, status: 'success' });
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     log(`Agent error: ${errorMessage}`);
+    writeTrace({ type: 'trace_end', trace_id: traceId, status: 'error', error: errorMessage });
     writeOutput({
       status: 'error',
       result: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "nanoclaw",
       "version": "1.2.15",
       "dependencies": {
+        "@types/express": "^5.0.6",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "express": "^5.2.1",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "yaml": "^2.8.2",
@@ -932,6 +934,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -941,6 +953,15 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -957,14 +978,73 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1109,6 +1189,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1191,6 +1284,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1215,6 +1332,44 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1237,6 +1392,46 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/cron-parser": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
@@ -1256,6 +1451,23 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1282,6 +1494,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1289,6 +1510,35 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -1300,12 +1550,42 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1349,6 +1629,12 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1357,6 +1643,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/expand-template": {
@@ -1376,6 +1671,49 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-copy": {
@@ -1414,6 +1752,45 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -1435,6 +1812,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1454,6 +1877,18 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1462,6 +1897,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -1477,6 +1936,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -1491,6 +1970,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -1524,6 +2019,21 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1627,6 +2137,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -1654,6 +2219,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1679,6 +2250,15 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
@@ -1689,6 +2269,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -1711,6 +2303,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1718,6 +2322,25 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -1904,6 +2527,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -1914,11 +2550,50 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -2022,6 +2697,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2051,6 +2742,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -2077,6 +2774,129 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2165,6 +2985,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -2288,6 +3117,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -2320,6 +3158,20 @@
         "node": "*"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2338,14 +3190,31 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@types/express": "^5.0.6",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "express": "^5.2.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "yaml": "^2.8.2",

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -32,6 +32,7 @@ import { RegisteredGroup } from './types.js';
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const TRACE_MARKER = '---NANOCLAW_TRACE---';
 
 export interface ContainerInput {
   prompt: string;
@@ -269,6 +270,7 @@ export async function runContainerAgent(
   input: ContainerInput,
   onProcess: (proc: ChildProcess, containerName: string) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
+  onTrace?: (event: Record<string, unknown>) => void,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
@@ -344,9 +346,30 @@ export async function runContainerAgent(
         }
       }
 
-      // Stream-parse for output markers
+      // Stream-parse for output and trace markers
       if (onOutput) {
         parseBuffer += chunk;
+
+        // Parse TRACE markers (observability events)
+        if (onTrace) {
+          let traceIdx: number;
+          while ((traceIdx = parseBuffer.indexOf(TRACE_MARKER)) !== -1) {
+            const lineEnd = parseBuffer.indexOf('\n', traceIdx);
+            if (lineEnd === -1) break;
+            const jsonStr = parseBuffer
+              .slice(traceIdx + TRACE_MARKER.length, lineEnd)
+              .trim();
+            parseBuffer =
+              parseBuffer.slice(0, traceIdx) + parseBuffer.slice(lineEnd + 1);
+            try {
+              const ev = JSON.parse(jsonStr);
+              onTrace(ev);
+            } catch {
+              // ignore malformed trace
+            }
+          }
+        }
+
         let startIdx: number;
         while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
           const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,16 @@ import {
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
+import {
+  initTraceDb,
+  upsertTrace,
+  finishTrace,
+  startLlmCall,
+  endLlmCall,
+  startToolCall,
+  endToolCall,
+} from './trace-db.js';
+import { startTraceServer } from './trace-server.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -310,6 +320,58 @@ async function runAgent(
       }
     : undefined;
 
+  // Build trace callback
+  let currentTraceId: string | null = null;
+  const onTrace = (ev: Record<string, unknown>) => {
+    try {
+      const type = ev.type as string;
+      if (type === 'trace_start') {
+        currentTraceId = ev.trace_id as string;
+        upsertTrace(
+          currentTraceId,
+          group.folder,
+          chatJid,
+          !!ev.is_scheduled,
+          String(ev.prompt_preview ?? ''),
+        );
+      } else if (type === 'trace_end' && currentTraceId) {
+        finishTrace(
+          currentTraceId,
+          String(ev.status ?? 'unknown'),
+          ev.error as string | undefined,
+        );
+      } else if (type === 'llm_start' && currentTraceId) {
+        startLlmCall(
+          currentTraceId,
+          (ev.input_tokens as number) ?? null,
+          (ev.model as string) ?? null,
+        );
+      } else if (type === 'llm_end' && currentTraceId) {
+        endLlmCall(
+          currentTraceId,
+          (ev.output_tokens as number) ?? null,
+          (ev.stop_reason as string) ?? null,
+        );
+      } else if (type === 'tool_start' && currentTraceId) {
+        startToolCall(
+          currentTraceId,
+          String(ev.tool_id),
+          String(ev.tool_name),
+          !!ev.is_subagent,
+          ev.input_preview ? String(ev.input_preview) : undefined,
+        );
+      } else if (type === 'tool_end' && currentTraceId) {
+        endToolCall(
+          currentTraceId,
+          String(ev.tool_id),
+          String(ev.output ?? ''),
+        );
+      }
+    } catch {
+      /* trace errors must never affect the main flow */
+    }
+  };
+
   try {
     const output = await runContainerAgent(
       group,
@@ -324,6 +386,7 @@ async function runAgent(
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
+      onTrace,
     );
 
     if (output.newSessionId) {
@@ -473,6 +536,8 @@ function ensureContainerSystemRunning(): void {
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
   initDatabase();
+  initTraceDb();
+  startTraceServer();
   logger.info('Database initialized');
   loadState();
   restoreRemoteControl();

--- a/src/trace-db.ts
+++ b/src/trace-db.ts
@@ -1,0 +1,238 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+import { STORE_DIR } from './config.js';
+
+const DB_PATH = path.join(STORE_DIR, 'traces.db');
+const RETENTION_DAYS = 90;
+
+let db: Database.Database;
+
+export function initTraceDb(): void {
+  fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+  db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS traces (
+      id TEXT PRIMARY KEY,
+      group_folder TEXT NOT NULL,
+      chat_jid TEXT NOT NULL,
+      is_scheduled INTEGER NOT NULL DEFAULT 0,
+      prompt_preview TEXT,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      status TEXT,
+      error TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_traces_started ON traces(started_at);
+    CREATE INDEX IF NOT EXISTS idx_traces_group ON traces(group_folder);
+
+    CREATE TABLE IF NOT EXISTS llm_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      input_tokens INTEGER,
+      output_tokens INTEGER,
+      model TEXT,
+      stop_reason TEXT,
+      FOREIGN KEY (trace_id) REFERENCES traces(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_llm_trace ON llm_calls(trace_id);
+
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      tool_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      is_subagent INTEGER NOT NULL DEFAULT 0,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      input_preview TEXT,
+      output_preview TEXT,
+      FOREIGN KEY (trace_id) REFERENCES traces(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_tool_trace ON tool_calls(trace_id);
+  `);
+  // Migrate existing DBs that lack input_preview column
+  try {
+    db.exec('ALTER TABLE tool_calls ADD COLUMN input_preview TEXT');
+  } catch {
+    /* already exists */
+  }
+  // On startup: close any traces that were left open by a previous crash/restart
+  db.prepare(
+    `UPDATE traces SET finished_at = ?, status = 'interrupted', error = 'Service restarted'
+     WHERE finished_at IS NULL`,
+  ).run(new Date().toISOString());
+  purgeOldTraces();
+}
+
+export function purgeOldTraces(): void {
+  const cutoff = new Date(
+    Date.now() - RETENTION_DAYS * 86400_000,
+  ).toISOString();
+  db.prepare(
+    'DELETE FROM tool_calls WHERE trace_id IN (SELECT id FROM traces WHERE started_at < ?)',
+  ).run(cutoff);
+  db.prepare(
+    'DELETE FROM llm_calls WHERE trace_id IN (SELECT id FROM traces WHERE started_at < ?)',
+  ).run(cutoff);
+  db.prepare('DELETE FROM traces WHERE started_at < ?').run(cutoff);
+}
+
+export function upsertTrace(
+  id: string,
+  group: string,
+  chatJid: string,
+  isScheduled: boolean,
+  promptPreview: string,
+): void {
+  db.prepare(
+    `
+    INSERT OR IGNORE INTO traces (id, group_folder, chat_jid, is_scheduled, prompt_preview, started_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `,
+  ).run(
+    id,
+    group,
+    chatJid,
+    isScheduled ? 1 : 0,
+    promptPreview,
+    new Date().toISOString(),
+  );
+}
+
+export function finishTrace(id: string, status: string, error?: string): void {
+  db.prepare(
+    'UPDATE traces SET finished_at = ?, status = ?, error = ? WHERE id = ?',
+  ).run(new Date().toISOString(), status, error ?? null, id);
+}
+
+// Per-trace state: current open LLM call row id and open tool_id→row id map
+const openLlmCalls = new Map<string, number>();
+const openToolCalls = new Map<string, Map<string, number>>();
+
+export function startLlmCall(
+  traceId: string,
+  inputTokens: number | null,
+  model: string | null,
+): void {
+  const result = db
+    .prepare(
+      `
+    INSERT INTO llm_calls (trace_id, started_at, input_tokens, model) VALUES (?, ?, ?, ?)
+  `,
+    )
+    .run(
+      traceId,
+      new Date().toISOString(),
+      inputTokens,
+      model,
+    ) as Database.RunResult;
+  openLlmCalls.set(traceId, result.lastInsertRowid as number);
+}
+
+export function endLlmCall(
+  traceId: string,
+  outputTokens: number | null,
+  stopReason: string | null,
+): void {
+  const rowId = openLlmCalls.get(traceId);
+  if (rowId == null) return;
+  db.prepare(
+    'UPDATE llm_calls SET finished_at = ?, output_tokens = ?, stop_reason = ? WHERE id = ?',
+  ).run(new Date().toISOString(), outputTokens, stopReason, rowId);
+  openLlmCalls.delete(traceId);
+}
+
+export function startToolCall(
+  traceId: string,
+  toolId: string,
+  toolName: string,
+  isSubagent: boolean,
+  inputPreview?: string,
+): void {
+  const result = db
+    .prepare(
+      `
+    INSERT INTO tool_calls (trace_id, tool_id, tool_name, is_subagent, started_at, input_preview)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `,
+    )
+    .run(
+      traceId,
+      toolId,
+      toolName,
+      isSubagent ? 1 : 0,
+      new Date().toISOString(),
+      inputPreview ?? null,
+    ) as Database.RunResult;
+  if (!openToolCalls.has(traceId)) openToolCalls.set(traceId, new Map());
+  openToolCalls.get(traceId)!.set(toolId, result.lastInsertRowid as number);
+}
+
+export function endToolCall(
+  traceId: string,
+  toolId: string,
+  outputPreview: string,
+): void {
+  const rowId = openToolCalls.get(traceId)?.get(toolId);
+  if (rowId == null) return;
+  db.prepare(
+    'UPDATE tool_calls SET finished_at = ?, output_preview = ? WHERE id = ?',
+  ).run(new Date().toISOString(), outputPreview, rowId);
+  openToolCalls.get(traceId)?.delete(toolId);
+}
+
+// ── Read API ──────────────────────────────────────────────────────────────────
+
+export function getTraces(limit = 50, offset = 0): unknown[] {
+  return db
+    .prepare(
+      `
+    SELECT t.*,
+      (SELECT COUNT(*) FROM llm_calls WHERE trace_id = t.id) AS llm_calls,
+      (SELECT SUM(input_tokens) FROM llm_calls WHERE trace_id = t.id) AS total_input_tokens,
+      (SELECT SUM(output_tokens) FROM llm_calls WHERE trace_id = t.id) AS total_output_tokens,
+      (SELECT COUNT(*) FROM tool_calls WHERE trace_id = t.id) AS tool_calls
+    FROM traces t
+    ORDER BY t.started_at DESC
+    LIMIT ? OFFSET ?
+  `,
+    )
+    .all(limit, offset);
+}
+
+export function getTrace(id: string): unknown {
+  return db.prepare('SELECT * FROM traces WHERE id = ?').get(id);
+}
+
+export function getLlmCalls(traceId: string): unknown[] {
+  return db
+    .prepare('SELECT * FROM llm_calls WHERE trace_id = ? ORDER BY started_at')
+    .all(traceId);
+}
+
+export function getToolCalls(traceId: string): unknown[] {
+  return db
+    .prepare('SELECT * FROM tool_calls WHERE trace_id = ? ORDER BY started_at')
+    .all(traceId);
+}
+
+export function getStats(): unknown {
+  return db
+    .prepare(
+      `
+    SELECT
+      COUNT(*) AS total_traces,
+      SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_traces,
+      (SELECT SUM(input_tokens) FROM llm_calls WHERE trace_id IN (SELECT id FROM traces WHERE started_at >= datetime('now', '-7 days'))) AS total_input_tokens,
+      (SELECT SUM(output_tokens) FROM llm_calls WHERE trace_id IN (SELECT id FROM traces WHERE started_at >= datetime('now', '-7 days'))) AS total_output_tokens,
+      (SELECT COUNT(*) FROM tool_calls WHERE trace_id IN (SELECT id FROM traces WHERE started_at >= datetime('now', '-7 days'))) AS total_tool_calls
+    FROM traces t
+    WHERE t.started_at >= datetime('now', '-7 days')
+  `,
+    )
+    .get();
+}

--- a/src/trace-server.ts
+++ b/src/trace-server.ts
@@ -1,0 +1,252 @@
+/**
+ * NanoClaw Trace UI — lightweight Express server for agent observability
+ * Shows tool calls, LLM call durations, and token usage per agent run.
+ */
+import express from 'express';
+import {
+  getTraces,
+  getTrace,
+  getLlmCalls,
+  getToolCalls,
+  getStats,
+} from './trace-db.js';
+import { logger } from './logger.js';
+
+const PORT = parseInt(process.env.TRACE_PORT || '3001', 10);
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NanoClaw Trace UI</title>
+<style>
+  :root { --bg:#0f1117; --card:#1a1d27; --border:#2a2d3e; --accent:#6c7ae0; --green:#4caf50; --red:#f44336; --yellow:#ff9800; --text:#e0e0e0; --muted:#888; }
+  * { box-sizing:border-box; margin:0; padding:0 }
+  body { background:var(--bg); color:var(--text); font:14px/1.5 "SF Mono",monospace; padding:20px }
+  h1 { color:var(--accent); margin-bottom:4px; font-size:20px }
+  .subtitle { color:var(--muted); margin-bottom:20px; font-size:12px }
+  .stats { display:flex; gap:16px; margin-bottom:20px; flex-wrap:wrap }
+  .stat { background:var(--card); border:1px solid var(--border); border-radius:8px; padding:12px 20px; text-align:center }
+  .stat .val { font-size:24px; font-weight:bold; color:var(--accent) }
+  .stat .lbl { font-size:11px; color:var(--muted); margin-top:2px }
+  table { width:100%; border-collapse:collapse; background:var(--card); border-radius:8px; overflow:hidden; margin-bottom:20px }
+  th { background:#222535; color:var(--muted); font-size:11px; text-transform:uppercase; padding:10px 12px; text-align:left; border-bottom:1px solid var(--border) }
+  td { padding:9px 12px; border-bottom:1px solid var(--border); font-size:12px; max-width:300px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+  tr:hover td { background:#1f2235; cursor:pointer }
+  .badge { display:inline-block; padding:2px 8px; border-radius:12px; font-size:11px; font-weight:bold }
+  .badge.success { background:#1a3a1a; color:var(--green) }
+  .badge.error { background:#3a1a1a; color:var(--red) }
+  .badge.running { background:#3a2a0a; color:var(--yellow) }
+  .modal { display:none; position:fixed; inset:0; background:rgba(0,0,0,.7); z-index:100; overflow:auto; padding:20px }
+  .modal.open { display:flex; align-items:flex-start; justify-content:center }
+  .modal-box { background:var(--card); border:1px solid var(--border); border-radius:10px; width:100%; max-width:900px; padding:24px; position:relative; margin-top:40px }
+  .modal-close { position:absolute; top:12px; right:16px; background:none; border:none; color:var(--muted); font-size:20px; cursor:pointer }
+  .timeline { position:relative; padding-left:24px; margin-top:16px }
+  .timeline::before { content:''; position:absolute; left:8px; top:0; bottom:0; width:2px; background:var(--border) }
+  .tl-item { position:relative; margin-bottom:12px }
+  .tl-dot { position:absolute; left:-20px; top:4px; width:10px; height:10px; border-radius:50%; border:2px solid }
+  .tl-dot.llm { border-color:var(--accent); background:#1a1d27 }
+  .tl-dot.tool { border-color:var(--green); background:#1a1d27 }
+  .tl-dot.info { border-color:var(--muted); background:#1a1d27 }
+  .tl-content { background:#12151f; border:1px solid var(--border); border-radius:6px; padding:8px 12px; font-size:12px }
+  .tl-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:4px }
+  .tl-name { font-weight:bold; color:var(--accent) }
+  .tl-name.tool { color:var(--green) }
+  .tl-dur { color:var(--muted); font-size:11px }
+  .tl-detail { color:var(--muted); font-size:11px; white-space:pre-wrap; word-break:break-word; margin-top:4px }
+  .tokens { font-size:11px; color:var(--muted) }
+  .tokens span { color:var(--text) }
+  .refresh-btn { background:var(--accent); border:none; color:#fff; padding:6px 14px; border-radius:6px; cursor:pointer; font-size:12px; margin-left:12px }
+  .search { background:var(--card); border:1px solid var(--border); color:var(--text); padding:6px 12px; border-radius:6px; font-size:12px; width:220px }
+  .toolbar { display:flex; align-items:center; gap:8px; margin-bottom:12px }
+  .auto-badge { display:inline-block; padding:1px 6px; border-radius:4px; font-size:10px; background:#2a1a3a; color:#b088f0 }
+</style>
+</head>
+<body>
+<h1>NanoClaw Trace UI</h1>
+<p class="subtitle">Agent runs · LLM calls · Tool usage · 90-day retention</p>
+<div id="stats"></div>
+<div class="toolbar">
+  <input class="search" id="search" placeholder="Filter by group or prompt…" oninput="filterRows()">
+  <button class="refresh-btn" onclick="loadAll()">↺ Refresh</button>
+  <span id="last-refresh" style="font-size:11px;color:var(--muted)"></span>
+</div>
+<table id="traces-table">
+  <thead><tr>
+    <th>Started</th><th>Group</th><th>Status</th><th>Duration</th>
+    <th>LLM calls</th><th>Tokens in/out</th><th>Tool calls</th><th>Prompt preview</th>
+  </tr></thead>
+  <tbody id="traces-body"></tbody>
+</table>
+
+<div class="modal" id="modal">
+  <div class="modal-box">
+    <button class="modal-close" onclick="closeModal()">×</button>
+    <div id="modal-content"></div>
+  </div>
+</div>
+
+<script>
+let allRows = [];
+
+function fmt(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleString('de-DE', {day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit',second:'2-digit'});
+}
+function dur(start, end) {
+  if (!start) return '—';
+  const ms = (end ? new Date(end) : new Date()) - new Date(start);
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms/1000).toFixed(1) + 's';
+  return (ms/60000).toFixed(1) + 'min';
+}
+function badge(status) {
+  const cls = status === 'success' ? 'success' : status === 'error' ? 'error' : 'running';
+  const label = status || 'running';
+  return '<span class="badge ' + cls + '">' + label + '</span>';
+}
+
+async function loadStats() {
+  const r = await fetch('/api/stats');
+  const s = await r.json();
+  document.getElementById('stats').innerHTML =
+    stat(s.total_traces, 'Traces (7d)') +
+    stat(s.error_traces, 'Errors (7d)') +
+    stat((s.total_input_tokens||0).toLocaleString(), 'Tokens in (7d)') +
+    stat((s.total_output_tokens||0).toLocaleString(), 'Tokens out (7d)') +
+    stat(s.total_tool_calls, 'Tool calls (7d)') +
+    '</div>';
+  document.getElementById('stats').outerHTML = '<div class="stats">' + document.getElementById('stats').innerHTML;
+}
+function stat(v, l) {
+  return '<div class="stat"><div class="val">'+(v??0)+'</div><div class="lbl">'+l+'</div></div>';
+}
+
+async function loadAll() {
+  const r = await fetch('/api/traces');
+  allRows = await r.json();
+  renderRows(allRows);
+  document.getElementById('last-refresh').textContent = 'Updated ' + new Date().toLocaleTimeString('de-DE');
+}
+
+function renderRows(rows) {
+  const tb = document.getElementById('traces-body');
+  tb.innerHTML = rows.map(t => {
+    const auto = t.is_scheduled ? '<span class="auto-badge">sched</span> ' : '';
+    return '<tr onclick="openTrace(\\''+t.id+'\\')">' +
+      '<td>'+fmt(t.started_at)+'</td>' +
+      '<td>'+t.group_folder+'</td>' +
+      '<td>'+badge(t.status)+'</td>' +
+      '<td>'+dur(t.started_at, t.finished_at)+'</td>' +
+      '<td style="text-align:center">'+( t.llm_calls||0)+'</td>' +
+      '<td class="tokens"><span>'+(t.total_input_tokens||0)+'</span> / <span>'+(t.total_output_tokens||0)+'</span></td>' +
+      '<td style="text-align:center">'+(t.tool_calls||0)+'</td>' +
+      '<td>'+auto+(t.prompt_preview||'').replace(/</g,'&lt;').slice(0,80)+'</td>' +
+      '</tr>';
+  }).join('');
+}
+
+function filterRows() {
+  const q = document.getElementById('search').value.toLowerCase();
+  if (!q) { renderRows(allRows); return; }
+  renderRows(allRows.filter(t =>
+    (t.group_folder||'').toLowerCase().includes(q) ||
+    (t.prompt_preview||'').toLowerCase().includes(q)
+  ));
+}
+
+async function openTrace(id) {
+  const [trace, llm, tools] = await Promise.all([
+    fetch('/api/traces/'+id).then(r=>r.json()),
+    fetch('/api/traces/'+id+'/llm').then(r=>r.json()),
+    fetch('/api/traces/'+id+'/tools').then(r=>r.json()),
+  ]);
+
+  // Merge LLM calls and tool calls into a unified timeline sorted by start
+  const events = [
+    ...llm.map(c => ({ ...c, _kind:'llm' })),
+    ...tools.map(c => ({ ...c, _kind:'tool' })),
+  ].sort((a,b) => new Date(a.started_at)-new Date(b.started_at));
+
+  let html = '<h2 style="margin-bottom:8px">Trace: '+id+'</h2>';
+  html += '<p style="color:var(--muted);font-size:12px;margin-bottom:12px">';
+  html += 'Group: <b>'+trace.group_folder+'</b> &nbsp;|&nbsp; ';
+  html += 'Started: <b>'+fmt(trace.started_at)+'</b> &nbsp;|&nbsp; ';
+  html += 'Duration: <b>'+dur(trace.started_at,trace.finished_at)+'</b> &nbsp;|&nbsp; ';
+  html += 'Status: '+badge(trace.status);
+  html += '</p>';
+  if (trace.prompt_preview) {
+    html += '<div style="background:#12151f;border:1px solid var(--border);border-radius:6px;padding:10px;font-size:12px;margin-bottom:16px;white-space:pre-wrap;word-break:break-word">';
+    html += '<b style="color:var(--muted)">Prompt preview:</b>\\n'+trace.prompt_preview.replace(/</g,'&lt;');
+    html += '</div>';
+  }
+
+  html += '<div class="timeline">';
+  for (const ev of events) {
+    if (ev._kind === 'llm') {
+      html += '<div class="tl-item"><div class="tl-dot llm"></div><div class="tl-content">';
+      html += '<div class="tl-header"><span class="tl-name">🤖 LLM call</span>';
+      html += '<span class="tl-dur">'+dur(ev.started_at,ev.finished_at)+'</span></div>';
+      if (ev.model) html += '<div class="tl-detail">model: '+ev.model+'</div>';
+      html += '<div class="tl-detail tokens">in: <span>'+(ev.input_tokens||0)+'</span> &nbsp; out: <span>'+(ev.output_tokens||0)+'</span>';
+      if (ev.stop_reason) html += ' &nbsp; stop: '+ev.stop_reason;
+      html += '</div></div></div>';
+    } else {
+      const sub = ev.is_subagent ? ' <span style="color:var(--muted);font-size:10px">(subagent)</span>' : '';
+      html += '<div class="tl-item"><div class="tl-dot tool"></div><div class="tl-content">';
+      html += '<div class="tl-header"><span class="tl-name tool">🔧 '+ev.tool_name+sub+'</span>';
+      html += '<span class="tl-dur">'+dur(ev.started_at,ev.finished_at)+'</span></div>';
+      if (ev.input_preview) {
+        html += '<div class="tl-detail" style="color:#aaa;max-height:200px;overflow-y:auto;background:#0a0c14;padding:6px 8px;border-radius:4px;margin-top:4px">▶ '+ev.input_preview.replace(/</g,'&lt;')+'</div>';
+      }
+      if (ev.output_preview) {
+        html += '<div class="tl-detail" style="max-height:200px;overflow-y:auto;background:#0a0c14;padding:6px 8px;border-radius:4px;margin-top:4px">◀ '+ev.output_preview.replace(/</g,'&lt;')+'</div>';
+      }
+      html += '</div></div>';
+    }
+  }
+  if (events.length === 0) html += '<div style="color:var(--muted);font-size:12px">No detailed events captured yet.</div>';
+  html += '</div>';
+
+  document.getElementById('modal-content').innerHTML = html;
+  document.getElementById('modal').classList.add('open');
+}
+
+function closeModal() {
+  document.getElementById('modal').classList.remove('open');
+}
+document.getElementById('modal').addEventListener('click', e => {
+  if (e.target === document.getElementById('modal')) closeModal();
+});
+
+loadStats();
+loadAll();
+setInterval(loadAll, 15000); // auto-refresh every 15s
+</script>
+</body>
+</html>`;
+
+export function startTraceServer(): void {
+  const app = express();
+
+  app.get('/', (_req, res) => res.send(HTML));
+  app.get('/api/stats', (_req, res) => res.json(getStats()));
+  app.get('/api/traces', (_req, res) => res.json(getTraces(100)));
+  app.get('/api/traces/:id', (req, res) => {
+    const t = getTrace(req.params.id);
+    if (!t) return res.status(404).json({ error: 'not found' });
+    return res.json(t);
+  });
+  app.get('/api/traces/:id/llm', (req, res) =>
+    res.json(getLlmCalls(req.params.id)),
+  );
+  app.get('/api/traces/:id/tools', (req, res) =>
+    res.json(getToolCalls(req.params.id)),
+  );
+
+  app.listen(PORT, '127.0.0.1', () => {
+    logger.info({ port: PORT }, 'Trace UI started');
+  });
+}


### PR DESCRIPTION
## Summary

- Records every agent invocation as a **trace** with start/end time, status, group, token counts, and tool call counts
- Captures **every tool call** with full input and output (no truncation)
- Lightweight **web UI on port 3001** (localhost-only) with dark-mode single-page dashboard: trace list with expandable tool call details
- Marks open traces as **interrupted** on service startup (crash recovery)
- Auto-purges traces older than 90 days
- SQLite-backed (`store/traces.db`), zero external dependencies beyond `express`

## Architecture

```
Container (agent-runner)          Host (index.ts)              Web UI
┌──────────────────┐   stdout    ┌─────────────┐   HTTP      ┌──────────┐
│ SDK message loop │ ──TRACE──►  │ trace-db.ts  │ ◄────────── │ :3001    │
│ tool_calls track │  markers    │ SQLite write │             │ traces   │
└──────────────────┘             └─────────────┘             └──────────┘
```

- Agent-runner emits `TRACE_START`, `TRACE_END`, `LLM_START`, `LLM_END` markers via stdout (same channel as `OUTPUT_MARKER`)
- Host parses markers in the existing stdout stream handler and dispatches to `trace-db.ts`
- No new IPC channels, no new ports between container and host

## Files

| File | Change |
|------|--------|
| `src/trace-db.ts` | **NEW** — SQLite schema, trace/llm/tool CRUD, auto-purge |
| `src/trace-server.ts` | **NEW** — Express server with embedded HTML/CSS dashboard |
| `src/index.ts` | Init trace DB + start server in `main()`, wire `onTrace` callback |
| `src/container-runner.ts` | Parse TRACE markers from stdout, pass to `onTrace` callback |
| `container/agent-runner/src/index.ts` | Track tool calls, emit trace markers around query lifecycle |
| `package.json` | Add `express`, `@types/express` |

## Test plan

- [ ] `npm run build` passes
- [ ] Start NanoClaw, send a message, verify trace appears at `http://localhost:3001`
- [ ] Click trace row to expand tool call details
- [ ] Restart service, verify previously-open traces show as "interrupted"
- [ ] Verify traces DB auto-purges entries > 90 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)