### PR TITLE
fix: prepend base path from ANTHROPIC_BASE_URL in credential proxy

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -79,11 +79,13 @@ export function startCredentialProxy(
           }
         }
 
+        // Prepend the upstream base path (e.g. /api/anthropic) to the request path
+        const basePath = upstreamUrl.pathname.replace(/\/+$/, '');
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: basePath + req.url,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
The credential proxy was only using the hostname from ANTHROPIC_BASE_URL, dropping any path prefix (e.g. /api/anthropic). This caused 404 errors when using proxy services with non-root base paths.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
