### PR TITLE
feat: add IMAP/SMTP email integration

### DIFF
--- a/.claude/skills/add-imap/SKILL.md
+++ b/.claude/skills/add-imap/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: add-imap
+description: Add IMAP/SMTP email integration to NanoClaw. Connects a Hetzner (or any IMAP) mailbox directly — no Gmail forwarding needed. Supports channel mode (emails trigger the agent) or tool-only mode (agent has email tools).
+---
+
+# Add IMAP Integration
+
+This skill adds IMAP email support to NanoClaw using imapflow and nodemailer — either as a full channel (inbox polling) or as a tool-only integration (agent can read/send/reply/archive/search emails on demand).
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `src/channels/imap.ts` exists:
+
+```bash
+ls src/channels/imap.ts 2>/dev/null && echo EXISTS || echo NOT_FOUND
+```
+
+**If it exists** — IMAP is already installed. Ask the user with `AskUserQuestion`:
+
+> IMAP is already set up. What would you like to do?
+>
+> - **Add a global account** — accessible to all channels (e.g. a shared inbox)
+> - **Add a local account** — scoped to one group/user only
+> - **Troubleshoot** — something isn't working
+
+For "add global account" or "add local account": skip directly to [Add an Account](#add-an-account) below.
+For "troubleshoot": skip to the Troubleshooting section.
+
+**If it doesn't exist** — continue with Phase 2 (fresh install).
+
+### Ask the user (fresh install only)
+
+Use `AskUserQuestion`:
+
+> Should incoming emails trigger the agent automatically?
+>
+> - **Yes** — Channel mode: NanoClaw polls the inbox every 60s and delivers new emails as messages
+> - **No** — Tool-only: The agent gets full email tools (read, send, reply, archive, search) but won't monitor the inbox
+
+## Phase 2: Apply Code Changes
+
+The code files are already part of the NanoClaw codebase. Verify they are present:
+
+```bash
+ls src/channels/imap.ts container/agent-runner/src/imap-mcp-stdio.ts
+```
+
+### Verify channel registration (channel mode only)
+
+Check `src/channels/index.ts` — it should contain `import './imap.js'`. If not, add it after the `// imap` comment:
+
+```typescript
+// imap
+import './imap.js';
+```
+
+### Add email handling instructions (channel mode only)
+
+Append to `groups/main/CLAUDE.md`:
+
+```markdown
+## Email Notifications
+
+When you receive an email notification (messages starting with `[Email from ...`), inform the user about it but do NOT reply to the email unless specifically asked. You have IMAP tools available — use them only when the user explicitly asks you to take action on an email.
+```
+
+### Install dependencies
+
+```bash
+npm install
+cd container/agent-runner && npm install && cd ../..
+```
+
+### Build
+
+```bash
+npm run build
+```
+
+Build must succeed with no TypeScript errors before proceeding.
+
+## Phase 3: Credentials Setup
+
+### Account types
+
+NanoClaw supports two types of IMAP accounts:
+
+- **Global** (`~/.imap-mcp/config.json`) — mounted into every container. Use for shared inboxes. In channel mode, global accounts are polled for inbound messages.
+- **Local** (`~/.imap-mcp-{group-folder}/config.json`) — mounted only into that group's container. Use for personal or per-channel accounts. Local accounts are tool-only (not polled).
+
+Both use the same format: `{ "accounts": { "<name>": { imap, smtp, from } } }`. The MCP server merges global + local so the agent sees all accounts.
+
+### Check for existing config
+
+```bash
+ls -la ~/.imap-mcp/config.json 2>/dev/null && echo "EXISTS" || echo "NOT FOUND"
+```
+
+If it exists and the user wants to keep it, skip to Phase 4.
+
+### Gather credentials
+
+Ask the user with `AskUserQuestion`:
+
+> Please provide your IMAP/SMTP credentials:
+>
+> 1. **Account name** — a short identifier (e.g. `work`, `personal`)
+> 2. **IMAP host and port** (usually port `993` with SSL)
+> 3. **SMTP host and port** (usually port `465` with SSL or `587` with STARTTLS)
+> 4. **Email address and password**
+> 5. **Display name** for outgoing emails (e.g. `Alice <alice@example.com>`)
+> 6. **Global or local?** — shared inbox accessible to all channels, or scoped to one group?
+
+### Write config
+
+For a **global** account:
+
+```bash
+mkdir -p ~/.imap-mcp
+```
+
+`~/.imap-mcp/config.json`:
+
+```json
+{
+  "accounts": {
+    "work": {
+      "imap": { "host": "imap.example.com", "port": 993, "secure": true, "auth": { "user": "you@example.com", "pass": "secret" } },
+      "smtp": { "host": "smtp.example.com", "port": 465, "secure": true, "auth": { "user": "you@example.com", "pass": "secret" } },
+      "from": "You <you@example.com>",
+      "archiveFolder": "Archive",
+      "pollFolders": ["INBOX"]
+    }
+  }
+}
+```
+
+```bash
+chmod 600 ~/.imap-mcp/config.json
+```
+
+For a **local** account scoped to one group, use the same format at `~/.imap-mcp-{group-folder}/config.json`.
+
+### Test the connection
+
+```bash
+node --input-type=module << 'EOF'
+import { ImapFlow } from 'imapflow';
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+const cfg = JSON.parse(readFileSync(homedir() + '/.imap-mcp/config.json', 'utf-8'));
+const account = Object.values(cfg.accounts)[0];
+const client = new ImapFlow({ ...account.imap, logger: false });
+await client.connect();
+const status = await client.status('INBOX', { messages: true, unseen: true });
+console.log('Connected! messages:', status.messages, 'unseen:', status.unseen);
+await client.logout();
+EOF
+```
+
+## Phase 4: Build & Restart
+
+### Clear stale agent-runner copies
+
+```bash
+rm -r data/sessions/*/agent-runner-src 2>/dev/null || true
+```
+
+### Rebuild container
+
+```bash
+cd container && ./build.sh && cd ..
+```
+
+### Compile and restart
+
+```bash
+npm run build
+```
+
+```bash
+# Linux
+systemctl --user restart nanoclaw
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 5: Verify
+
+Tell the user:
+
+> IMAP is connected! Try asking in your main channel:
+>
+> `list my recent emails` — the agent should use `mcp__imap__list_emails`
+
+### Channel mode
+
+In channel mode, the IMAP channel uses JID `imap:{accountName}` (e.g. `imap:work`). Register it with `mcp__nanoclaw__register_group`:
+- `jid`: `imap:work`
+- `name`: `Email Inbox`
+- `folder`: `imap_work`
+- `trigger`: your trigger word
+
+Ask the user to send a test email. It should be picked up within 60 seconds. Monitor:
+
+```bash
+tail -f logs/nanoclaw.log | grep -iE "(imap|email)"
+```
+
+## Add an Account
+
+Use this when IMAP is already installed and you want to add another account (e.g. a new user's personal inbox, or a second shared mailbox).
+
+### Gather details
+
+Ask with `AskUserQuestion`:
+
+> Is this a **global** account (shared across all channels) or a **local** account (scoped to one group)?
+>
+> For a local account: which group folder should it belong to? (Check `groups/` or `data/sessions/` for folder names.)
+>
+> Then provide:
+> 1. **Account name** — short identifier (e.g. `work`, `alice`)
+> 2. **IMAP host and port**
+> 3. **SMTP host and port**
+> 4. **Email address and password**
+> 5. **Display name** (e.g. `Alice <alice@example.com>`)
+
+### Update the config file
+
+Read the existing config, merge in the new account, and write it back.
+
+For **global**: `~/.imap-mcp/config.json`
+For **local**: `~/.imap-mcp-{group-folder}/config.json` (create dir if needed)
+
+Add the new account under `accounts`:
+
+```json
+{
+  "accounts": {
+    "existing-account": { "...": "..." },
+    "new-account-name": {
+      "imap": { "host": "imap.example.com", "port": 993, "secure": true, "auth": { "user": "user@example.com", "pass": "secret" } },
+      "smtp": { "host": "smtp.example.com", "port": 465, "secure": true, "auth": { "user": "user@example.com", "pass": "secret" } },
+      "from": "Name <user@example.com>",
+      "archiveFolder": "Archive"
+    }
+  }
+}
+```
+
+```bash
+chmod 600 ~/.imap-mcp/config.json  # or the local path
+```
+
+### Restart (global accounts only)
+
+Local accounts are picked up automatically on the next container spawn — no restart needed.
+
+For global accounts in channel mode, restart to start polling the new inbox:
+
+```bash
+systemctl --user restart nanoclaw   # Linux
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+```
+
+---
+
+## Troubleshooting
+
+### Connection refused / auth failure
+
+- Verify host, port, and credentials in the config file
+- For port 587 (STARTTLS), set `"secure": false`
+- Check that IMAP access is enabled in your mailbox settings
+
+### Container can't access email
+
+- Verify the config directory is mounted: check `src/container-runner.ts` for the `.imap-mcp` mount
+- Check container logs: `cat groups/main/logs/container-*.log | tail -100`
+
+### Emails not being detected (channel mode)
+
+- Check logs: `tail -50 logs/nanoclaw.log | grep -i imap`
+- Verify the IMAP group is registered: check the `groups/` directory
+- The channel only delivers to registered groups
+
+## Removal
+
+1. Remove `import './imap.js'` from `src/channels/index.ts`
+2. Remove the `.imap-mcp` mounts from `src/container-runner.ts`
+3. Remove the `imap` MCP server block from `container/agent-runner/src/index.ts`
+4. Remove `mcp__imap__*` from the `allowedTools` array in `container/agent-runner/src/index.ts`
+5. Delete `src/channels/imap.ts` and `container/agent-runner/src/imap-mcp-stdio.ts`
+6. Uninstall deps: `npm uninstall imapflow nodemailer && cd container/agent-runner && npm uninstall imapflow nodemailer && cd ../..`
+7. Clear stale agent-runner copies: `rm -r data/sessions/*/agent-runner-src 2>/dev/null || true`
+8. Rebuild: `cd container && ./build.sh && cd .. && npm run build`
+9. Restart the service

--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -11,10 +11,13 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.76",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "cron-parser": "^5.0.0",
+        "imapflow": "^1.0.0",
+        "nodemailer": "^6.9.0",
         "zod": "^4.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.7",
+        "@types/nodemailer": "^6.4.0",
         "typescript": "^5.7.3"
       }
     },
@@ -397,6 +400,12 @@
         }
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
@@ -405,6 +414,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/accepts": {
@@ -451,6 +481,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -651,6 +690,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/es-define-property": {
@@ -968,6 +1016,32 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/imapflow": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.2.15.tgz",
+      "integrity": "sha512-sYpvo7P6TRjjv1sr9Q+ObQH3TKmMwaTIuRx0VQNZ7gwRybB3HRlM+JupeBVp1WKi3Ag8VrKbXFpAUO9v1MrwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1",
+        "nodemailer": "8.0.2",
+        "pino": "10.3.1",
+        "socks": "2.8.7"
+      }
+    },
+    "node_modules/imapflow/node_modules/nodemailer": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
+      "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1024,6 +1098,42 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
     },
     "node_modules/luxon": {
       "version": "3.7.2",
@@ -1104,6 +1214,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1123,6 +1242,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -1174,6 +1302,43 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1182,6 +1347,22 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1211,6 +1392,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1233,6 +1420,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-from-string": {
@@ -1258,6 +1454,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -1410,6 +1615,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1417,6 +1664,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/toidentifier": {

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -12,10 +12,13 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
+    "imapflow": "^1.0.0",
+    "nodemailer": "^6.9.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",
+    "@types/nodemailer": "^6.4.0",
     "typescript": "^5.7.3"
   }
 }

--- a/container/agent-runner/src/imap-mcp-stdio.ts
+++ b/container/agent-runner/src/imap-mcp-stdio.ts
@@ -1,0 +1,430 @@
+/**
+ * IMAP MCP Server for NanoClaw — multi-account
+ *
+ * Loads accounts from two config files (merged):
+ *   /home/node/.imap-mcp-global/config.json   — shared accounts (info@, etc.)
+ *   /home/node/.imap-mcp-local/config.json    — local (per-channel) accounts
+ *
+ * Config format:
+ *   { "accounts": { "<name>": { imap, smtp, from, archiveFolder? } } }
+ *
+ * All tools accept an optional "account" parameter.
+ * Use list_accounts to discover available account names.
+ *
+ * Tools:
+ *   list_accounts  — discover configured accounts
+ *   list_emails    — list or search emails (search params optional)
+ *   get_email      — fetch full email by UID
+ *   compose_email  — compose new, reply, or forward — saves draft by default
+ *   move_email     — move to any folder; use 'Trash' to delete, 'Archive' to archive
+ *   list_folders   — list all IMAP folders
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import fs from 'fs';
+import { ImapFlow } from 'imapflow';
+import nodemailer from 'nodemailer';
+// @ts-ignore — nodemailer internal, no type declarations
+import MailComposer from 'nodemailer/lib/mail-composer/index.js';
+
+const GLOBAL_CONFIG_PATH = '/home/node/.imap-mcp-global/config.json';
+const LOCAL_CONFIG_PATH = '/home/node/.imap-mcp-local/config.json';
+
+interface AccountConfig {
+  imap: { host: string; port: number; secure: boolean; auth: { user: string; pass: string } };
+  smtp: { host: string; port: number; secure: boolean; auth: { user: string; pass: string } };
+  from: string;
+  archiveFolder?: string; // override if server special-use detection is wrong
+}
+
+// Cache of special-use folder paths per account (user → { '\trash': path, '\drafts': path, ... })
+const specialFolderCache = new Map<string, Record<string, string>>();
+
+async function resolveSpecialFolders(cfg: AccountConfig): Promise<Record<string, string>> {
+  const key = cfg.imap.auth.user;
+  if (specialFolderCache.has(key)) return specialFolderCache.get(key)!;
+  const client = makeClient(cfg);
+  const map: Record<string, string> = {};
+  try {
+    await client.connect();
+    const list = await client.list();
+    for (const f of list) {
+      if (f.specialUse) map[f.specialUse.toLowerCase()] = f.path;
+    }
+  } finally {
+    await client.logout().catch(() => {});
+  }
+  specialFolderCache.set(key, map);
+  return map;
+}
+
+// Resolve a logical folder name ('Trash', 'Archive', 'Drafts', 'Sent', 'Junk')
+// to the actual server path using RFC 6154 special-use attributes.
+async function resolveFolder(cfg: AccountConfig, logical: string, override?: string): Promise<string> {
+  if (override) return override;
+  const special = await resolveSpecialFolders(cfg);
+  const logicalLower = logical.toLowerCase();
+  // RFC 6154 special-use names map
+  const rfcKey: Record<string, string> = {
+    trash: '\\trash', archive: '\\archive', drafts: '\\drafts',
+    sent: '\\sent', junk: '\\junk', spam: '\\junk',
+  };
+  const key = rfcKey[logicalLower];
+  if (key && special[key]) return special[key];
+  // Fall back to the literal name the caller passed
+  return logical;
+}
+
+function loadAccounts(): Record<string, AccountConfig> {
+  const accounts: Record<string, AccountConfig> = {};
+  for (const configPath of [GLOBAL_CONFIG_PATH, LOCAL_CONFIG_PATH]) {
+    if (!fs.existsSync(configPath)) continue;
+    try {
+      const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { accounts: Record<string, AccountConfig> };
+      Object.assign(accounts, cfg.accounts ?? {});
+    } catch { /* ignore malformed files */ }
+  }
+  return accounts;
+}
+
+function getAccount(accounts: Record<string, AccountConfig>, name?: string): [string, AccountConfig] {
+  if (name) {
+    if (!accounts[name]) throw new Error(`Account "${name}" not found. Use list_accounts to see available accounts.`);
+    return [name, accounts[name]];
+  }
+  const first = Object.entries(accounts)[0];
+  if (!first) throw new Error('No IMAP accounts configured.');
+  return first;
+}
+
+function makeClient(cfg: AccountConfig): ImapFlow {
+  return new ImapFlow({
+    host: cfg.imap.host,
+    port: cfg.imap.port,
+    secure: cfg.imap.secure,
+    auth: cfg.imap.auth,
+    logger: false,
+  });
+}
+
+function makeTransport(cfg: AccountConfig) {
+  return nodemailer.createTransport({
+    host: cfg.smtp.host,
+    port: cfg.smtp.port,
+    secure: cfg.smtp.secure,
+    auth: cfg.smtp.auth,
+  });
+}
+
+const ACCOUNT_PARAM = z.string().optional().describe(
+  'Account name to use. Call list_accounts to see available accounts. Defaults to first account.',
+);
+
+const server = new McpServer({ name: 'imap', version: '2.0.0' });
+
+// ─── list_accounts ────────────────────────────────────────────────────────────
+
+server.tool(
+  'list_accounts',
+  'List all configured email accounts available to you.',
+  {},
+  async () => {
+    const accounts = loadAccounts();
+    const entries = Object.entries(accounts);
+    if (entries.length === 0) {
+      return { content: [{ type: 'text' as const, text: 'No email accounts configured.' }] };
+    }
+    const lines = entries.map(([name, cfg]) => `${name}: ${cfg.from}`);
+    return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+  },
+);
+
+// ─── list_emails ──────────────────────────────────────────────────────────────
+
+server.tool(
+  'list_emails',
+  'List or search emails. Omit search params to list recent emails. Add from/subject/body/since/before to filter.',
+  {
+    account: ACCOUNT_PARAM,
+    folder: z.string().default('INBOX').describe('Folder to list/search (default: INBOX)'),
+    limit: z.number().int().min(1).max(100).default(20).describe('Max emails to return (default: 20)'),
+    offset: z.number().int().min(0).default(0).describe('Skip this many emails for pagination (default: 0)'),
+    unseen_only: z.boolean().default(false).describe('Only return unread emails'),
+    from: z.string().optional().describe('Filter by sender address or name'),
+    subject: z.string().optional().describe('Filter by subject text'),
+    body: z.string().optional().describe('Filter by body text'),
+    since: z.string().optional().describe('ISO date — only emails on or after this date'),
+    before: z.string().optional().describe('ISO date — only emails before this date'),
+  },
+  async (args) => {
+    const [accountName, cfg] = getAccount(loadAccounts(), args.account);
+    const client = makeClient(cfg);
+    try {
+      await client.connect();
+      const lock = await client.getMailboxLock(args.folder);
+      try {
+        // Build search criteria — empty object returns all messages
+        const criteria: Record<string, unknown> = {};
+        if (args.unseen_only) criteria['seen'] = false;
+        if (args.from) criteria['from'] = args.from;
+        if (args.subject) criteria['subject'] = args.subject;
+        if (args.body) criteria['body'] = args.body;
+        if (args.since) criteria['since'] = new Date(args.since);
+        if (args.before) criteria['before'] = new Date(args.before);
+
+        const allUids = await client.search(criteria, { uid: true });
+        if (!allUids || allUids.length === 0) {
+          return { content: [{ type: 'text' as const, text: `No emails found in ${args.folder} (${accountName}).` }] };
+        }
+        allUids.sort((a, b) => b - a);
+        const total = allUids.length;
+        const pageUids = allUids.slice(args.offset, args.offset + args.limit);
+        if (pageUids.length === 0) {
+          return { content: [{ type: 'text' as const, text: `No more emails (total: ${total}, offset: ${args.offset}).` }] };
+        }
+        const results: string[] = [];
+        for await (const msg of client.fetch(pageUids, { uid: true, envelope: true, flags: true }, { uid: true })) {
+          const envelope = msg.envelope;
+          const from = envelope?.from?.[0]
+            ? `${envelope.from[0].name ?? ''} <${envelope.from[0].address ?? ''}>`.trim()
+            : 'Unknown';
+          const subject = envelope?.subject ?? '(no subject)';
+          const date = envelope?.date?.toISOString().split('T')[0] ?? '';
+          const seen = (msg.flags ?? new Set<string>()).has('\\Seen');
+          results.push(`UID ${msg.uid} | ${seen ? 'READ' : 'UNREAD'} | ${date} | From: ${from} | Subject: ${subject}`);
+        }
+        const header = `[${accountName}] Showing ${args.offset + 1}–${args.offset + results.length} of ${total} in ${args.folder}:`;
+        return { content: [{ type: 'text' as const, text: `${header}\n${results.join('\n')}` }] };
+      } finally {
+        lock.release();
+      }
+    } finally {
+      await client.logout().catch(() => {});
+    }
+  },
+);
+
+// ─── get_email ────────────────────────────────────────────────────────────────
+
+server.tool(
+  'get_email',
+  'Get full email by UID — returns headers and body.',
+  {
+    account: ACCOUNT_PARAM,
+    uid: z.number().int().describe('UID of the email to fetch'),
+    folder: z.string().default('INBOX').describe('Folder containing the email (default: INBOX)'),
+  },
+  async (args) => {
+    const [, cfg] = getAccount(loadAccounts(), args.account);
+    const client = makeClient(cfg);
+    try {
+      await client.connect();
+      const lock = await client.getMailboxLock(args.folder);
+      try {
+        const msg = await client.fetchOne(
+          String(args.uid),
+          { uid: true, envelope: true, flags: true, bodyStructure: true, source: true },
+          { uid: true },
+        );
+        if (!msg) return { content: [{ type: 'text' as const, text: `Email UID ${args.uid} not found.` }] };
+        const envelope = msg.envelope;
+        const from = envelope?.from?.map((a) => `${a.name ?? ''} <${a.address ?? ''}>`.trim()).join(', ') ?? '';
+        const to = envelope?.to?.map((a) => `${a.name ?? ''} <${a.address ?? ''}>`.trim()).join(', ') ?? '';
+        const subject = envelope?.subject ?? '(no subject)';
+        const date = envelope?.date?.toISOString() ?? '';
+        const messageId = envelope?.messageId ?? '';
+        let bodyText = '';
+        if (msg.source) {
+          const raw = Buffer.isBuffer(msg.source) ? msg.source.toString('utf-8') : String(msg.source);
+          const bodyStart = raw.indexOf('\r\n\r\n');
+          bodyText = bodyStart !== -1 ? raw.slice(bodyStart + 4) : raw;
+          if (bodyText.length > 8000) bodyText = bodyText.slice(0, 8000) + '\n... (truncated)';
+        }
+        return {
+          content: [{ type: 'text' as const, text: [
+            `UID: ${args.uid}`, `Message-ID: ${messageId}`, `Date: ${date}`,
+            `From: ${from}`, `To: ${to}`, `Subject: ${subject}`, '', bodyText,
+          ].join('\n') }],
+        };
+      } finally {
+        lock.release();
+      }
+    } finally {
+      await client.logout().catch(() => {});
+    }
+  },
+);
+
+// ─── compose_email ────────────────────────────────────────────────────────────
+
+server.tool(
+  'compose_email',
+  [
+    'Compose a new email, reply, or forward. Saves as draft by default (send: false) — set send: true to send immediately.',
+    'For replies: set reply_to_uid to auto-fill recipient, subject (Re: ...), and threading headers.',
+    'For forwards: set forward_uid to fetch and append the original email body.',
+  ].join(' '),
+  {
+    account: ACCOUNT_PARAM,
+    to: z.string().describe('Recipient(s), comma-separated. Auto-filled when reply_to_uid is set.'),
+    subject: z.string().optional().describe('Subject. Auto-filled for replies (Re: ...) and forwards (Fwd: ...).'),
+    body: z.string().describe('Plain-text body'),
+    cc: z.string().optional().describe('CC address(es), comma-separated'),
+    bcc: z.string().optional().describe('BCC address(es), comma-separated'),
+    html: z.string().optional().describe('Optional HTML body'),
+    send: z.boolean().default(false).describe('If false (default), saves as draft. If true, sends immediately.'),
+    reply_to_uid: z.number().int().optional().describe('UID of email to reply to — sets threading headers and auto-fills recipient/subject'),
+    forward_uid: z.number().int().optional().describe('UID of email to forward — appends original message body'),
+    source_folder: z.string().default('INBOX').describe('Folder for reply_to_uid/forward_uid lookup (default: INBOX)'),
+    drafts_folder: z.string().optional().describe('Folder to save draft in (auto-detected via IMAP special-use)'),
+    reply_all: z.boolean().default(false).describe('When replying, also include original To/CC recipients'),
+  },
+  async (args) => {
+    const [accountName, cfg] = getAccount(loadAccounts(), args.account);
+
+    let to = args.to;
+    let subject = args.subject ?? '';
+    let inReplyTo = '';
+    let references = '';
+    let prependBody = '';
+
+    // Fetch original email for reply or forward
+    const refUid = args.reply_to_uid ?? args.forward_uid;
+    if (refUid !== undefined) {
+      const client = makeClient(cfg);
+      try {
+        await client.connect();
+        const lock = await client.getMailboxLock(args.source_folder);
+        try {
+          const msg = await client.fetchOne(String(refUid), { uid: true, envelope: true, source: true }, { uid: true });
+          if (!msg) throw new Error(`Email UID ${refUid} not found`);
+          const envelope = msg.envelope;
+
+          if (args.reply_to_uid !== undefined) {
+            // Reply: set threading headers, auto-fill recipient and subject
+            inReplyTo = envelope?.messageId ?? '';
+            references = inReplyTo;
+            if (!args.subject) {
+              const orig = envelope?.subject ?? '';
+              subject = orig.startsWith('Re:') ? orig : `Re: ${orig}`;
+            }
+            const replyAddr = envelope?.replyTo?.[0]?.address ?? envelope?.from?.[0]?.address ?? '';
+            to = to || replyAddr;
+            if (args.reply_all) {
+              const extras = [...(envelope?.to ?? []), ...(envelope?.cc ?? [])]
+                .map((a) => a.address ?? '')
+                .filter((a) => a && a !== cfg.smtp.auth.user)
+                .join(', ');
+              to = [to, extras].filter(Boolean).join(', ');
+            }
+          } else {
+            // Forward: prepend original message info
+            const origFrom = envelope?.from?.[0]?.address ?? '';
+            const origDate = envelope?.date?.toISOString() ?? '';
+            const origSubject = envelope?.subject ?? '(no subject)';
+            if (!args.subject) subject = `Fwd: ${origSubject}`;
+            let origBody = '';
+            if (msg.source) {
+              const raw = Buffer.isBuffer(msg.source) ? msg.source.toString('utf-8') : String(msg.source);
+              const bodyStart = raw.indexOf('\r\n\r\n');
+              origBody = bodyStart !== -1 ? raw.slice(bodyStart + 4) : raw;
+              if (origBody.length > 8000) origBody = origBody.slice(0, 8000);
+            }
+            prependBody = [
+              '---------- Forwarded message ----------',
+              `From: ${origFrom}`, `Date: ${origDate}`, `Subject: ${origSubject}`, '',
+              origBody, '',
+            ].join('\n');
+          }
+        } finally {
+          lock.release();
+        }
+      } finally {
+        await client.logout().catch(() => {});
+      }
+    }
+
+    const fullBody = prependBody ? `${args.body}\n\n${prependBody}` : args.body;
+    const mailOptions = {
+      from: cfg.from, to, cc: args.cc, bcc: args.bcc,
+      subject, text: fullBody, html: args.html,
+      ...(inReplyTo ? { inReplyTo, references } : {}),
+    };
+
+    if (args.send) {
+      const transport = makeTransport(cfg);
+      await transport.sendMail(mailOptions);
+      return { content: [{ type: 'text' as const, text: `Email sent from ${accountName} (${cfg.from}) to ${to}.` }] };
+    } else {
+      // Save as draft
+      const raw = await new Promise<Buffer>((resolve, reject) => {
+        const composer = new MailComposer(mailOptions);
+        composer.compile().build((err: Error | null, msg: Buffer) => {
+          if (err) reject(err); else resolve(msg);
+        });
+      });
+      const client = makeClient(cfg);
+      try {
+        const draftsFolder = await resolveFolder(cfg, 'Drafts', args.drafts_folder);
+        await client.connect();
+        await client.append(draftsFolder, raw, ['\\Draft', '\\Seen']);
+        return { content: [{ type: 'text' as const, text: `Draft saved to ${draftsFolder} (${accountName}).` }] };
+      } finally {
+        await client.logout().catch(() => {});
+      }
+    }
+  },
+);
+
+// ─── move_email ───────────────────────────────────────────────────────────────
+
+server.tool(
+  'move_email',
+  'Move an email to any folder. Use "Trash" to delete, "Archive" to archive — actual paths are auto-detected.',
+  {
+    account: ACCOUNT_PARAM,
+    uid: z.number().int().describe('UID of the email to move'),
+    from_folder: z.string().default('INBOX').describe('Source folder (default: INBOX)'),
+    to_folder: z.string().describe('Destination folder — use "Trash", "Archive", "Sent", "Junk", or an exact path'),
+  },
+  async (args) => {
+    const [, cfg] = getAccount(loadAccounts(), args.account);
+    const archiveOverride = args.to_folder === 'Archive' ? cfg.archiveFolder : undefined;
+    const dest = await resolveFolder(cfg, args.to_folder, archiveOverride);
+    const client = makeClient(cfg);
+    try {
+      await client.connect();
+      const lock = await client.getMailboxLock(args.from_folder);
+      try {
+        await client.messageMove(String(args.uid), dest, { uid: true });
+        return { content: [{ type: 'text' as const, text: `UID ${args.uid} moved to ${dest}.` }] };
+      } finally { lock.release(); }
+    } finally { await client.logout().catch(() => {}); }
+  },
+);
+
+// ─── list_folders ─────────────────────────────────────────────────────────────
+
+server.tool(
+  'list_folders',
+  'List all IMAP folders/mailboxes for an account.',
+  { account: ACCOUNT_PARAM },
+  async (args) => {
+    const [, cfg] = getAccount(loadAccounts(), args.account);
+    const client = makeClient(cfg);
+    try {
+      await client.connect();
+      const list = await client.list();
+      const folders = list.map((f) => f.path);
+      return {
+        content: [{ type: 'text' as const, text: folders.length === 0 ? 'No folders found.' : folders.join('\n') }],
+      };
+    } finally { await client.logout().catch(() => {}); }
+  },
+);
+
+// Start the stdio transport
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -407,23 +407,33 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
+        'mcp__imap__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+      mcpServers: (() => {
+        const servers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {
+          nanoclaw: {
+            command: 'node',
+            args: [mcpServerPath],
+            env: {
+              NANOCLAW_CHAT_JID: containerInput.chatJid,
+              NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+              NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+            },
           },
-        },
-      },
+        };
+        const imapSrv = path.join(path.dirname(fileURLToPath(import.meta.url)), 'imap-mcp-stdio.js');
+        const imapGlobal = '/home/node/.imap-mcp-global/config.json';
+        const imapPersonal = '/home/node/.imap-mcp-personal/config.json';
+        if (fs.existsSync(imapSrv) && (fs.existsSync(imapGlobal) || fs.existsSync(imapPersonal))) {
+          servers.imap = { command: 'node', args: [imapSrv], env: {} };
+        }
+        return servers;
+      })(),
       hooks: {
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "imapflow": "^1.0.0",
+        "nodemailer": "^6.9.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "yaml": "^2.8.2",
@@ -18,6 +20,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
+        "@types/nodemailer": "^6.4.23",
         "@vitest/coverage-v8": "^4.0.18",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
@@ -967,6 +970,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
@@ -1107,6 +1120,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/assertion-error": {
@@ -1289,6 +1313,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -1493,6 +1526,22 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1513,6 +1562,75 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/imapflow": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.2.15.tgz",
+      "integrity": "sha512-sYpvo7P6TRjjv1sr9Q+ObQH3TKmMwaTIuRx0VQNZ7gwRybB3HRlM+JupeBVp1WKi3Ag8VrKbXFpAUO9v1MrwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1",
+        "nodemailer": "8.0.2",
+        "pino": "10.3.1",
+        "socks": "2.8.7"
+      }
+    },
+    "node_modules/imapflow/node_modules/nodemailer": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
+      "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/imapflow/node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/imapflow/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/imapflow/node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1524,6 +1642,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1578,6 +1705,42 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
       "license": "MIT"
     },
     "node_modules/luxon": {
@@ -1689,6 +1852,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/obug": {
@@ -2051,6 +2223,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -2129,6 +2307,30 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/sonic-boom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "dependencies": {
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "imapflow": "^1.0.0",
+    "nodemailer": "^6.9.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "yaml": "^2.8.2",
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
+    "@types/nodemailer": "^6.4.23",
     "@vitest/coverage-v8": "^4.0.18",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",

--- a/src/channels/imap.ts
+++ b/src/channels/imap.ts
@@ -1,0 +1,302 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import nodemailer from 'nodemailer';
+import { ImapFlow } from 'imapflow';
+
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+const POLL_INTERVAL_MS = 60_000;
+
+interface AccountConfig {
+  imap: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth: { user: string; pass: string };
+  };
+  smtp: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth: { user: string; pass: string };
+  };
+  from: string;
+  archiveFolder?: string;
+  pollFolders?: string[];
+}
+
+interface AccountsConfig {
+  accounts: Record<string, AccountConfig>;
+}
+
+function loadConfigFrom(
+  configPath: string,
+): Record<string, AccountConfig> | null {
+  try {
+    if (!fs.existsSync(configPath)) return null;
+    const raw = JSON.parse(
+      fs.readFileSync(configPath, 'utf-8'),
+    ) as AccountsConfig;
+    if (!raw.accounts || typeof raw.accounts !== 'object') {
+      logger.warn(
+        { configPath },
+        'IMAP: config missing "accounts" key — skipping',
+      );
+      return null;
+    }
+    return raw.accounts;
+  } catch (err) {
+    logger.warn({ err, configPath }, 'IMAP: failed to load config');
+    return null;
+  }
+}
+
+// Discover global IMAP accounts from ~/.imap-mcp/config.json.
+// Per-channel local accounts (~/.imap-mcp-{folder}/) are tool-only — not polled.
+function discoverImapConfigs(): Array<{
+  accountName: string;
+  account: AccountConfig;
+}> {
+  const globalPath = path.join(os.homedir(), '.imap-mcp', 'config.json');
+  const accounts = loadConfigFrom(globalPath);
+  if (!accounts) return [];
+  return Object.entries(accounts).map(([accountName, account]) => ({
+    accountName,
+    account,
+  }));
+}
+
+export class ImapChannel implements Channel {
+  name: string;
+
+  private jid: string;
+  private opts: ChannelOpts;
+  private config: AccountConfig;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private lastSeen: Map<string, number> = new Map(); // folder → last seen UID
+  private connected = false;
+
+  constructor(jid: string, config: AccountConfig, opts: ChannelOpts) {
+    this.name = `imap:${jid}`;
+    this.jid = jid;
+    this.config = config;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.connected = true;
+    logger.info({ host: this.config.imap.host }, 'IMAP channel connected');
+    console.log(`\n  IMAP channel: ${this.config.imap.auth.user}`);
+    console.log(`  Polling inbox every ${POLL_INTERVAL_MS / 1000}s\n`);
+
+    // Initial poll
+    await this.poll();
+
+    this.pollTimer = setInterval(() => {
+      this.poll().catch((err) => logger.error({ err }, 'IMAP poll error'));
+    }, POLL_INTERVAL_MS);
+  }
+
+  private async poll(): Promise<void> {
+    const folders = this.config.pollFolders ?? ['INBOX'];
+
+    for (const folder of folders) {
+      await this.pollFolder(folder);
+    }
+  }
+
+  private async pollFolder(folder: string): Promise<void> {
+    const client = new ImapFlow({
+      host: this.config.imap.host,
+      port: this.config.imap.port,
+      secure: this.config.imap.secure,
+      auth: this.config.imap.auth,
+      logger: false,
+    });
+
+    try {
+      await client.connect();
+      const lock = await client.getMailboxLock(folder);
+
+      try {
+        const lastUid = this.lastSeen.get(folder) ?? 0;
+
+        const messages: Array<{
+          uid: number;
+          from: string;
+          subject: string;
+          body: string;
+          date: string;
+        }> = [];
+
+        for await (const msg of client.fetch(
+          { seen: false },
+          { uid: true, envelope: true },
+        )) {
+          const uid = msg.uid ?? 0;
+          if (uid <= lastUid) continue;
+
+          const envelope = msg.envelope;
+          const from = envelope?.from?.[0]
+            ? `${envelope.from[0].name ?? ''} <${envelope.from[0].address ?? ''}>`.trim()
+            : 'Unknown';
+          const subject = envelope?.subject ?? '(no subject)';
+          const date =
+            envelope?.date?.toISOString() ?? new Date().toISOString();
+
+          // Fetch the full message source for body text
+          let body = '';
+          try {
+            const fullMsg = await client.fetchOne(
+              String(uid),
+              { source: true },
+              { uid: true },
+            );
+            if (fullMsg && fullMsg.source) {
+              const raw = Buffer.isBuffer(fullMsg.source)
+                ? fullMsg.source.toString('utf-8')
+                : String(fullMsg.source);
+              const bodyStart = raw.indexOf('\r\n\r\n');
+              body = bodyStart !== -1 ? raw.slice(bodyStart + 4) : raw;
+            }
+          } catch {
+            body = '(body unavailable)';
+          }
+
+          messages.push({
+            uid,
+            from,
+            subject,
+            body: body.slice(0, 4000),
+            date,
+          });
+        }
+
+        if (messages.length === 0) {
+          lock.release();
+          return;
+        }
+
+        // Update lastSeen
+        const maxUid = Math.max(...messages.map((m) => m.uid));
+        this.lastSeen.set(folder, maxUid);
+
+        // Deliver each email as a message
+        for (const msg of messages) {
+          const content = `[Email from ${msg.from}] ${msg.subject}\n\n${msg.body}`;
+          const timestamp = msg.date;
+
+          this.opts.onChatMetadata(
+            this.jid,
+            timestamp,
+            'IMAP Inbox',
+            'imap',
+            false,
+          );
+
+          const group = this.opts.registeredGroups()[this.jid];
+          if (!group) {
+            logger.debug(
+              { uid: msg.uid, subject: msg.subject },
+              'IMAP: no registered group for imap:inbox',
+            );
+            lock.release();
+            return;
+          }
+
+          this.opts.onMessage(this.jid, {
+            id: `imap-${msg.uid}`,
+            chat_jid: this.jid,
+            sender: msg.from,
+            sender_name: msg.from,
+            content,
+            timestamp,
+            is_from_me: false,
+          });
+
+          logger.info(
+            { uid: msg.uid, subject: msg.subject, from: msg.from },
+            'IMAP message delivered',
+          );
+        }
+      } finally {
+        lock.release();
+      }
+    } catch (err) {
+      logger.error({ err, folder }, 'IMAP poll failed');
+    } finally {
+      try {
+        await client.logout();
+      } catch {
+        // ignore logout errors
+      }
+    }
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (jid !== this.jid) return;
+
+    try {
+      const transport = nodemailer.createTransport({
+        host: this.config.smtp.host,
+        port: this.config.smtp.port,
+        secure: this.config.smtp.secure,
+        auth: this.config.smtp.auth,
+      });
+
+      // Determine recipient from registered group config (fallback to smtp user)
+      const groups = this.opts.registeredGroups();
+      const group = groups[jid];
+      const to = (group as any)?.imapReplyTo ?? this.config.smtp.auth.user;
+
+      await transport.sendMail({
+        from: this.config.from,
+        to,
+        subject: 'NanoClaw reply',
+        text,
+      });
+
+      logger.info({ jid, to }, 'IMAP: sent reply via SMTP');
+    } catch (err) {
+      logger.error({ jid, err }, 'IMAP: failed to send message via SMTP');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid === this.jid;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.connected = false;
+    logger.info('IMAP channel disconnected');
+  }
+
+  async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
+    // IMAP does not support typing indicators
+  }
+}
+
+// Register one channel instance per account in the global config.
+for (const { accountName, account } of discoverImapConfigs()) {
+  const jid = `imap:${accountName}`;
+  registerChannel(
+    jid,
+    (opts: ChannelOpts) => new ImapChannel(jid, account, opts),
+  );
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -5,6 +5,8 @@
 
 // gmail
 
+// imap
+
 // slack
 
 // telegram

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, exec, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -198,6 +199,27 @@ function buildVolumeMounts(
     containerPath: '/app/src',
     readonly: false,
   });
+
+  // Mount IMAP accounts.
+  // Global shared accounts (~/.imap-mcp/) → /home/node/.imap-mcp-global/
+  // Local per-channel accounts (~/.imap-mcp-{folder}/) → /home/node/.imap-mcp-local/
+  // The MCP server merges both so the agent sees all available accounts.
+  const globalImapDir = path.join(os.homedir(), '.imap-mcp');
+  if (fs.existsSync(globalImapDir)) {
+    mounts.push({
+      hostPath: globalImapDir,
+      containerPath: '/home/node/.imap-mcp-global',
+      readonly: true,
+    });
+  }
+  const perGroupImapDir = path.join(os.homedir(), `.imap-mcp-${group.folder}`);
+  if (fs.existsSync(perGroupImapDir)) {
+    mounts.push({
+      hostPath: perGroupImapDir,
+      containerPath: '/home/node/.imap-mcp-local',
+      readonly: true,
+    });
+  }
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {


### PR DESCRIPTION
## Summary

- Adds IMAP email as an optional **channel** (inbox polling → agent messages) and **toolset** (agent reads/composes/manages email on demand)
- 6 MCP tools exposed via `imap-mcp-stdio` subprocess: `list_accounts`, `list_emails`, `get_email`, `compose_email`, `move_email`, `list_folders`
- `compose_email` saves as draft by default — opt-in to send with `send: true`
- Folder paths (`Trash`, `Drafts`, `Archive`) auto-resolved using **RFC 6154 special-use attributes**, so it works correctly across providers (Hetzner, Gmail, Outlook, iCloud) with no user config
- Multi-account: merges global (`~/.imap-mcp/`) and per-channel (`~/.imap-mcp-{group}/`) configs
- Includes `/add-imap` skill for guided setup (channel or tool-only mode)

## Changed files

| File | Purpose |
|------|---------|
| `src/channels/imap.ts` | Channel — polls inbox, delivers emails as messages, sends replies via SMTP |
| `container/agent-runner/src/imap-mcp-stdio.ts` | MCP server — 6 tools for agent email access |
| `container/agent-runner/src/index.ts` | Wire IMAP MCP server when config exists |
| `src/container-runner.ts` | Mount IMAP config dirs into container |
| `src/channels/index.ts` | Add `// imap` placeholder (import added by skill) |
| `package.json` / `container/agent-runner/package.json` | Add imapflow + nodemailer deps |
| `.claude/skills/add-imap/SKILL.md` | Guided setup skill |

