### PR TITLE
feat: add /approve and /reject skills (approval-gated capabilities)

### DIFF
--- a/container/skills/approve/SKILL.md
+++ b/container/skills/approve/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: approve
+description: Approve a pending admin capability change by ID. Use when the user runs /approve <id>.
+---
+
+# /approve — Approve Pending Change
+
+Apply a pending admin capability change.
+
+**Main-channel check:** Only the main channel has `/workspace/project` mounted. Run:
+
+```bash
+test -d /workspace/project && echo "MAIN" || echo "NOT_MAIN"
+```
+
+If `NOT_MAIN`, respond with:
+> This command is available in your main chat only. Send `/approve <id>` there.
+
+Then stop.
+
+## Usage
+
+`/approve <id>`
+
+The `<id>` is provided by the user. Extract it from the message.
+
+If no ID is provided, respond:
+> Usage: `/approve <id>` — Use `/capabilities pending` to see pending changes.
+
+## Steps
+
+1. Read pending approvals:
+
+```bash
+cat /workspace/group/.nanoclaw/admin/pending-approvals.json 2>/dev/null || echo '[]'
+```
+
+2. Find the entry matching the given ID. If not found, respond:
+> ❌ No pending approval with ID `<id>`. Use `/capabilities pending` to see current requests.
+
+3. Read current capabilities config:
+
+```bash
+cat /workspace/group/.nanoclaw/admin/capabilities.json 2>/dev/null || echo '{"enabledAdminCommands":["capabilities","status","approve","reject"],"version":1}'
+```
+
+4. Apply the change:
+   - If action is `enable`: add `commandName` to `enabledAdminCommands` (if not already present).
+   - If action is `disable`: remove `commandName` from `enabledAdminCommands`.
+
+5. Write updated config back to `capabilities.json`.
+
+6. Remove the approved entry from `pending-approvals.json` and write back.
+
+7. Append audit entry:
+
+```bash
+echo '{"timestamp":"...","action":"approve","approvalId":"<id>","change":"<action> /<commandName>"}' >> /workspace/group/.nanoclaw/admin/audit.jsonl
+```
+
+8. Respond:
+
+```
+✅ *Approved* (`<id>`)
+Applied: <action> /<commandName>
+```

--- a/container/skills/capabilities/SKILL.md
+++ b/container/skills/capabilities/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: capabilities
-description: Show what this NanoClaw instance can do — installed skills, available tools, and system info. Read-only. Use when the user asks what the bot can do, what's installed, or runs /capabilities.
+description: Show and manage admin capabilities — installed skills, tools, system info. Supports enable/disable/pending subcommands with approval flow for sensitive changes. Use when the user runs /capabilities.
 ---
 
-# /capabilities — System Capabilities Report
+# /capabilities — System Capabilities
 
-Generate a structured read-only report of what this NanoClaw instance can do.
+Show what this NanoClaw instance can do, and manage admin command toggles.
 
 **Main-channel check:** Only the main channel has `/workspace/project` mounted. Run:
 
@@ -14,27 +14,74 @@ test -d /workspace/project && echo "MAIN" || echo "NOT_MAIN"
 ```
 
 If `NOT_MAIN`, respond with:
-> This command is available in your main chat only. Send `/capabilities` there to see what I can do.
+> This command is available in your main chat only. Send `/capabilities` there.
 
-Then stop — do not generate the report.
+Then stop.
 
-## How to gather the information
+## Subcommands
 
-Run these commands and compile the results into the report format below.
+Parse the user message to determine the subcommand:
+
+- `/capabilities` (no args) → **show report** (section below)
+- `/capabilities enable <command>` → **enable** a command
+- `/capabilities disable <command>` → **disable** a command
+- `/capabilities pending` → **list pending approvals**
+
+---
+
+## Persistent state
+
+All state lives under `/workspace/group/.nanoclaw/admin/`. Create the directory if it doesn't exist:
+
+```bash
+mkdir -p /workspace/group/.nanoclaw/admin
+```
+
+### Files
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `capabilities.json` | `{"enabledAdminCommands": [...], "version": 1}` | Which admin commands are enabled |
+| `pending-approvals.json` | `[{id, action, commandName, requestedAt, beforeState}, ...]` | Pending sensitive changes |
+| `audit.jsonl` | One JSON object per line | Audit trail of all changes |
+
+### Defaults
+
+If `capabilities.json` does not exist, the default state is:
+
+```json
+{"enabledAdminCommands": ["capabilities", "status", "approve", "reject"], "version": 1}
+```
+
+### Reading state
+
+```bash
+cat /workspace/group/.nanoclaw/admin/capabilities.json 2>/dev/null || echo '{"enabledAdminCommands":["capabilities","status","approve","reject"],"version":1}'
+```
+
+---
+
+## Constants
+
+- **Sensitive commands** (require approval to toggle): `capabilities`, `approve`, `reject`
+- **Undisableable commands** (cannot be disabled at all): `capabilities`, `approve`
+- **Admin commands** (the full set): `capabilities`, `status`, `approve`, `reject`
+
+---
+
+## Subcommand: show report (no args)
+
+Generate a structured report of what this instance can do.
 
 ### 1. Installed skills
-
-List skill directories available to you:
 
 ```bash
 ls -1 /home/node/.claude/skills/ 2>/dev/null || echo "No skills found"
 ```
 
-Each directory is an installed skill. The directory name is the skill name (e.g., `agent-browser` → `/agent-browser`).
-
 ### 2. Available tools
 
-Read the allowed tools from your SDK configuration. You always have access to:
+You always have access to:
 - **Core:** Bash, Read, Write, Edit, Glob, Grep
 - **Web:** WebSearch, WebFetch
 - **Orchestration:** Task, TaskOutput, TaskStop, TeamCreate, TeamDelete, SendMessage
@@ -55,8 +102,6 @@ The NanoClaw MCP server exposes these tools (via `mcp__nanoclaw__*` prefix):
 
 ### 4. Container skills (Bash tools)
 
-Check for executable tools in the container:
-
 ```bash
 which agent-browser 2>/dev/null && echo "agent-browser: available" || echo "agent-browser: not found"
 ```
@@ -68,9 +113,11 @@ ls /workspace/group/CLAUDE.md 2>/dev/null && echo "Group memory: yes" || echo "G
 ls /workspace/extra/ 2>/dev/null && echo "Extra mounts: $(ls /workspace/extra/ 2>/dev/null | wc -l | tr -d ' ')" || echo "Extra mounts: none"
 ```
 
-## Report format
+### 6. Admin command status
 
-Present the report as a clean, readable message. Example:
+Read `capabilities.json` (or use defaults) and show which admin commands are enabled/disabled.
+
+### Report format
 
 ```
 📋 *NanoClaw Capabilities*
@@ -93,8 +140,95 @@ Present the report as a clean, readable message. Example:
 • Group memory: yes/no
 • Extra mounts: N directories
 • Main channel: yes
+
+*Admin Commands:*
+• /capabilities: ✓ enabled (undisableable)
+• /status: ✓ enabled
+• /approve: ✓ enabled (undisableable)
+• /reject: ✓ enabled
 ```
 
-Adapt the output based on what you actually find — don't list things that aren't installed.
+Adapt the output based on what you actually find.
 
-**See also:** `/status` for a quick health check of session, workspace, and tasks.
+---
+
+## Subcommand: enable
+
+`/capabilities enable <command>`
+
+1. Strip leading `/` from the command name.
+2. Check the command is a known admin command (`capabilities`, `status`, `approve`, `reject`). If not, respond: `❌ Unknown admin command: /<name>. Known commands: capabilities, status, approve, reject.`
+3. Read current config. If already enabled, respond: `/<name> is already enabled.`
+4. **If the command is sensitive** (`capabilities`, `approve`, `reject`): create a pending approval:
+   - Generate a random 8-character hex ID: `$(head -c 4 /dev/urandom | xxd -p)`
+   - Add to `pending-approvals.json`
+   - Append audit line: `{"timestamp":"...","action":"request","change":"enable /<name>","approvalId":"<id>"}`
+   - Respond:
+     ```
+     ⏳ *Approval required*
+     Enabling `/<name>` is a sensitive change.
+     *Before:* disabled
+     *After:* enabled
+     To approve: `/approve <id>`
+     To reject: `/reject <id>`
+     ```
+5. **If not sensitive** (e.g., `status`): apply immediately.
+   - Update `capabilities.json` to add the command to `enabledAdminCommands`.
+   - Append audit line: `{"timestamp":"...","action":"apply","change":"enable /<name>"}`
+   - Respond: `✅ /<name> is now enabled.`
+
+---
+
+## Subcommand: disable
+
+`/capabilities disable <command>`
+
+1. Strip leading `/` from the command name.
+2. Check the command is a known admin command. If not, respond with error.
+3. **If undisableable** (`capabilities`, `approve`): respond: `🔒 /<name> cannot be disabled — it is required for admin recovery.` Then stop.
+4. Read current config. If already disabled, respond: `/<name> is already disabled.`
+5. **If sensitive** (`reject`): create pending approval (same flow as enable, but action is "disable").
+6. **If not sensitive** (`status`): apply immediately.
+   - Update `capabilities.json` to remove the command from `enabledAdminCommands`.
+   - Append audit line: `{"timestamp":"...","action":"apply","change":"disable /<name>"}`
+   - Respond: `✅ /<name> is now disabled.`
+
+---
+
+## Subcommand: pending
+
+`/capabilities pending`
+
+1. Read `pending-approvals.json`. If file doesn't exist or is empty array, respond: `No pending approvals.`
+2. Otherwise list each pending item:
+
+```
+📋 *Pending Approvals*
+
+• ID: `<id>` — <action> /<commandName>
+  Requested: <requestedAt>
+  `/approve <id>` · `/reject <id>`
+```
+
+---
+
+## Writing state files
+
+When updating `capabilities.json`, write the full file (read-modify-write via bash):
+
+```bash
+# Example: add "status" to enabled list
+CONFIG=$(cat /workspace/group/.nanoclaw/admin/capabilities.json 2>/dev/null || echo '{"enabledAdminCommands":["capabilities","status","approve","reject"],"version":1}')
+# Modify with jq or string manipulation, then write back
+echo "$UPDATED_CONFIG" > /workspace/group/.nanoclaw/admin/capabilities.json
+```
+
+When appending audit entries:
+
+```bash
+echo '{"timestamp":"2026-03-14T10:00:00Z","action":"apply","change":"disable /status"}' >> /workspace/group/.nanoclaw/admin/audit.jsonl
+```
+
+When updating pending approvals, read the full array, add/remove the item, write back the full file.
+
+**See also:** `/status` for a quick health check. `/approve` and `/reject` to resolve pending changes.

--- a/container/skills/reject/SKILL.md
+++ b/container/skills/reject/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: reject
+description: Reject a pending admin capability change by ID with optional reason. Use when the user runs /reject <id>.
+---
+
+# /reject — Reject Pending Change
+
+Reject and discard a pending admin capability change.
+
+**Main-channel check:** Only the main channel has `/workspace/project` mounted. Run:
+
+```bash
+test -d /workspace/project && echo "MAIN" || echo "NOT_MAIN"
+```
+
+If `NOT_MAIN`, respond with:
+> This command is available in your main chat only. Send `/reject <id>` there.
+
+Then stop.
+
+**Enabled check:** `/reject` can be disabled via `/capabilities disable reject`. Check:
+
+```bash
+cat /workspace/group/.nanoclaw/admin/capabilities.json 2>/dev/null || echo '{"enabledAdminCommands":["capabilities","status","approve","reject"],"version":1}'
+```
+
+If `reject` is NOT in the `enabledAdminCommands` array, respond with:
+> `/reject` is currently disabled. An admin can re-enable it with `/capabilities enable reject` in the main chat.
+
+Then stop.
+
+## Usage
+
+`/reject <id> [reason]`
+
+The `<id>` is required. The `reason` is optional free text after the ID.
+
+If no ID is provided, respond:
+> Usage: `/reject <id> [reason]` — Use `/capabilities pending` to see pending changes.
+
+## Steps
+
+1. Read pending approvals:
+
+```bash
+cat /workspace/group/.nanoclaw/admin/pending-approvals.json 2>/dev/null || echo '[]'
+```
+
+2. Find the entry matching the given ID. If not found, respond:
+> ❌ No pending approval with ID `<id>`. Use `/capabilities pending` to see current requests.
+
+3. Remove the rejected entry from `pending-approvals.json` and write back.
+
+4. Append audit entry:
+
+```bash
+echo '{"timestamp":"...","action":"reject","approvalId":"<id>","change":"<action> /<commandName>","reason":"<reason or empty>"}' >> /workspace/group/.nanoclaw/admin/audit.jsonl
+```
+
+5. Respond:
+
+```
+❌ *Rejected* (`<id>`)
+Change: <action> /<commandName>
+Reason: <reason or "none given">
+```
+
+No config changes are made — the capability state remains as it was before the request.

--- a/container/skills/status/SKILL.md
+++ b/container/skills/status/SKILL.md
@@ -18,6 +18,17 @@ If `NOT_MAIN`, respond with:
 
 Then stop — do not generate the report.
 
+**Enabled check:** `/status` can be disabled via `/capabilities disable status`. Check:
+
+```bash
+cat /workspace/group/.nanoclaw/admin/capabilities.json 2>/dev/null || echo '{"enabledAdminCommands":["capabilities","status","approve","reject"],"version":1}'
+```
+
+If `status` is NOT in the `enabledAdminCommands` array, respond with:
+> `/status` is currently disabled. An admin can re-enable it with `/capabilities enable status` in the main chat.
+
+Then stop — do not generate the report.
+
 ## How to gather the information
 
 Run the checks below and compile results into the report format.


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Extends PR1's read-only `/capabilities` and `/status` with mutation support:

- `/capabilities enable <cmd>` / `disable <cmd>` / `pending` — toggle admin commands with persistent state
- `/approve <id>` — apply a pending approval-gated change
- `/reject <id> [reason]` — reject a pending change with optional reason

Key design decisions:
- **Sensitive commands** (`capabilities`, `approve`, `reject`) require approval before toggling
- **Undisableable commands** (`capabilities`, `approve`) prevent self-lockout
- **Non-sensitive toggles** (e.g. `status`) apply immediately
- `/status` and `/reject` check their enabled state before executing
- Persistent state in `/workspace/group/.nanoclaw/admin/` (capabilities.json, pending-approvals.json, audit.jsonl)
- Zero `src/` changes — fully skill-first, AI-native approach

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone