### PR TITLE
feat: add MiniMax OAuth (Coding Plan) as model provider

### DIFF
--- a/.claude/skills/add-minimax-oauth/README.md
+++ b/.claude/skills/add-minimax-oauth/README.md
@@ -1,0 +1,38 @@
+# /add-minimax-oauth
+
+Adds [MiniMax](https://platform.minimax.io) OAuth (Coding Plan) as the model provider for NanoClaw.
+
+No Anthropic API key or Claude OAuth token required.
+
+## What this adds
+
+- `src/minimax-oauth.ts` - MiniMax device-code OAuth (PKCE S256)
+- `scripts/minimax-login.ts` - one-shot login CLI
+- `src/credential-proxy.ts` - extended with minimax-oauth auth mode
+
+## Prerequisites
+
+A [MiniMax Coding Plan](https://platform.minimax.io/subscribe/coding-plan) subscription.
+
+## Setup
+
+```bash
+npm run minimax-login
+```
+
+Browser opens to MiniMax auth page. Approve — tokens saved to .env.
+
+Then: `npm run dev`
+
+CN region: `npm run minimax-login -- --region cn`
+
+## How it works
+
+Credential proxy detects MINIMAX_OAUTH_ACCESS in .env and switches
+to minimax-oauth mode. Tokens auto-refresh 60s before expiry.
+
+## Auth priority
+
+1. ANTHROPIC_API_KEY present -> api-key mode
+2. MINIMAX_OAUTH_ACCESS present -> minimax-oauth mode
+3. Neither -> oauth mode (Claude OAuth, NanoClaw default)

--- a/.claude/skills/add-minimax-oauth/SKILL.md
+++ b/.claude/skills/add-minimax-oauth/SKILL.md
@@ -1,0 +1,22 @@
+# /add-minimax-oauth
+
+Adds MiniMax OAuth (Coding Plan) as the model provider.
+No Anthropic API key or Claude OAuth token required.
+
+The files are already present in this fork:
+
+- src/minimax-oauth.ts - MiniMax device-code OAuth (PKCE S256)
+- scripts/minimax-login.ts - one-shot login CLI
+- src/credential-proxy.ts - extended with minimax-oauth auth mode
+
+Run the login CLI to authenticate and write tokens to .env:
+
+```bash
+npm run minimax-login
+```
+
+For CN region: npm run minimax-login -- --region cn
+
+Then start NanoClaw: npm run dev
+
+Tokens auto-refresh 60s before expiry. See README.md for details.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -24,7 +24,12 @@ RUN apt-get update && apt-get install -y \
     libxshmfence1 \
     curl \
     git \
-    && rm -rf /var/lib/apt/lists/*
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LsSf https://astral.sh/uv/install.sh | HOME=/root sh \
+    && cp /root/.local/bin/uv /usr/local/bin/uv \
+    && chmod 755 /usr/local/bin/uv
 
 # Set Chromium path for agent-browser
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -1,58 +1,14 @@
-# Andy
+# Orchestratr — Shared Context
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+NanoClaw multi-agent deployment for Orchestratr, run by Wynne Pirini.
 
-## What You Can Do
+## Business context
+- **Orchestratr** — AI agent deployment, workflow automation, data infrastructure for AI. ICP: mid-market manufacturing (50–500 employees).
+- **Simpanel** — Synthetic customer panel product. ICP: growth-focused C-suite/VP execs.
+- **Measurebit** — Legacy data/analytics. Maintenance only.
 
-- Answer questions and have conversations
-- Search the web and fetch content from URLs
-- **Browse the web** with `agent-browser` — open pages, click, fill forms, take screenshots, extract data (run `agent-browser open <url>` to start, then `agent-browser snapshot -i` to see interactive elements)
-- Read and write files in your workspace
-- Run bash commands in your sandbox
-- Schedule tasks to run later or on a recurring basis
-- Send messages back to the chat
-
-## Communication
-
-Your output is sent to the user or group.
-
-You also have `mcp__nanoclaw__send_message` which sends a message immediately while you're still working. This is useful when you want to acknowledge a request before starting longer work.
-
-### Internal thoughts
-
-If part of your output is internal reasoning rather than something for the user, wrap it in `<internal>` tags:
-
-```
-<internal>Compiled all three reports, ready to summarize.</internal>
-
-Here are the key findings from the research...
-```
-
-Text inside `<internal>` tags is logged but not sent to the user. If you've already sent the key information via `send_message`, you can wrap the recap in `<internal>` to avoid sending it again.
-
-### Sub-agents and teammates
-
-When working as a sub-agent or teammate, only use `send_message` if instructed to by the main agent.
-
-## Your Workspace
-
-Files you create are saved in `/workspace/group/`. Use this for notes, research, or anything that should persist.
-
-## Memory
-
-The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
-
-When you learn something important:
-- Create files for structured data (e.g., `customers.md`, `preferences.md`)
-- Split files larger than 500 lines into folders
-- Keep an index in your memory for the files you create
-
-## Message Formatting
-
-NEVER use markdown. Only use WhatsApp/Telegram formatting:
-- *single asterisks* for bold (NEVER **double asterisks**)
-- _underscores_ for italic
-- • bullet points
-- ```triple backticks``` for code
-
-No ## headings. No [links](url). No **double stars**.
+## Rules (all agents)
+- Direct and concise. No preamble.
+- Never publish, post, or take irreversible external actions without explicit approval from Wynne.
+- Route out-of-scope requests to the right agent.
+- Durable facts go in files in /workspace/group/ — session context resets between runs.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "setup": "tsx setup/index.ts",
     "auth": "tsx src/whatsapp-auth.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "minimax-login": "tsx scripts/minimax-login.ts"
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",

--- a/scripts/minimax-login.ts
+++ b/scripts/minimax-login.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { loginWithMiniMax, ANTHROPIC_URL, type MiniMaxRegion } from '../src/minimax-oauth.js';
+
+const ri = process.argv.indexOf('--region');
+const region: MiniMaxRegion = ri > -1
+  ? (process.argv[ri + 1] as MiniMaxRegion) : 'global';
+
+console.log('MiniMax OAuth Login (region: ' + region + ')');
+
+const token = await loginWithMiniMax({
+  region,
+  openUrl: (url) => {
+    try {
+      const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+      execSync(cmd + ' ' + url, { stdio: 'ignore' });
+    } catch {}
+  },
+  onDeviceCode: (code, url) => {
+    console.log('1. Open in your browser: ' + url);
+    console.log('2. Enter code if prompted: ' + code);
+    console.log('Polling for approval...');
+  },
+});
+
+const envPath = path.join(process.cwd(), '.env');
+const baseUrl = token.resourceUrl || ANTHROPIC_URL[region];
+function upsertEnv(s:string,k:string,v:string):string{
+  const re=new RegExp('^'+k+'=.*$','m');
+  return re.test(s)?s.replace(re,k+'='+v):s+'\n'+k+'='+v;
+}
+let env='';try{env=fs.readFileSync(envPath,'utf8');}catch{}
+env=upsertEnv(env,'MINIMAX_OAUTH_ACCESS',token.access);
+env=upsertEnv(env,'MINIMAX_OAUTH_REFRESH',token.refresh);
+env=upsertEnv(env,'MINIMAX_OAUTH_EXPIRES',String(token.expires));
+env=upsertEnv(env,'MINIMAX_BASE_URL',baseUrl);
+fs.writeFileSync(envPath,env.trimStart());
+console.log('Tokens saved. Base URL: '+baseUrl);
+console.log('Expires: '+new Date(token.expires).toISOString());

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -2,6 +2,7 @@
 // Each import triggers the channel module's registerChannel() call.
 
 // discord
+import './discord.js';
 
 // gmail
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -234,6 +234,10 @@ function buildContainerArgs(
   const authMode = detectAuthMode();
   if (authMode === 'api-key' || authMode === 'minimax-oauth') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
+    if (authMode === 'minimax-oauth') {
+      args.push('-e', 'CLAUDE_MODEL=MiniMax-M2.5');
+      args.push('-e', 'ANTHROPIC_MODEL=MiniMax-M2.5');
+    }
   } else {
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
   }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -232,7 +232,7 @@ function buildContainerArgs(
   // OAuth mode:   SDK exchanges placeholder token for temp API key,
   //               proxy injects real OAuth token on that exchange request.
   const authMode = detectAuthMode();
-  if (authMode === 'api-key') {
+  if (authMode === 'api-key' || authMode === 'minimax-oauth') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
   } else {
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -235,8 +235,8 @@ function buildContainerArgs(
   if (authMode === 'api-key' || authMode === 'minimax-oauth') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
     if (authMode === 'minimax-oauth') {
-      args.push('-e', 'CLAUDE_MODEL=MiniMax-M2.5');
-      args.push('-e', 'ANTHROPIC_MODEL=MiniMax-M2.5');
+      args.push('-e', 'CLAUDE_MODEL=MiniMax-M2.7');
+      args.push('-e', 'ANTHROPIC_MODEL=MiniMax-M2.7');
     }
   } else {
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -82,7 +82,7 @@ export async function startCredentialProxy(
           req.url.startsWith('/v1/models')
         ) {
           const m = JSON.stringify({
-            data: [{ id: 'MiniMax-M2.5', type: 'model' }],
+            data: [{ id: 'MiniMax-M2.7', type: 'model' }],
           });
           res.writeHead(200, {
             'content-type': 'application/json',
@@ -95,7 +95,7 @@ export async function startCredentialProxy(
         if (authMode === 'minimax-oauth' && body.length > 0) {
           try {
             const p = JSON.parse(body.toString());
-            p.model = 'MiniMax-M2.5';
+            p.model = 'MiniMax-M2.7';
             delete p.betas;
             finalBody = Buffer.from(JSON.stringify(p));
             headers['content-length'] = finalBody.length;

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -1,29 +1,30 @@
-/**
- * Credential proxy for container isolation.
- * Containers connect here instead of directly to the Anthropic API.
- * The proxy injects real credentials so containers never see them.
- *
- * Two auth modes:
- *   API key:  Proxy injects x-api-key on every request.
- *   OAuth:    Container CLI exchanges its placeholder token for a temp
- *             API key via /api/oauth/claude_cli/create_api_key.
- *             Proxy injects real OAuth token on that exchange request;
- *             subsequent requests carry the temp key which is valid as-is.
- */
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
-
+import fs from 'node:fs';
+import path from 'node:path';
 import { readEnvFile } from './env.js';
+import { refreshMiniMaxToken } from './minimax-oauth.js';
 import { logger } from './logger.js';
 
-export type AuthMode = 'api-key' | 'oauth';
-
+export type AuthMode = 'api-key' | 'oauth' | 'minimax-oauth';
 export interface ProxyConfig {
   authMode: AuthMode;
 }
 
-export function startCredentialProxy(
+function upsertEnvFile(key: string, val: string): void {
+  const p = path.join(process.cwd(), '.env');
+  let s = '';
+  try {
+    s = fs.readFileSync(p, 'utf8');
+  } catch {}
+  const re = new RegExp('^' + key + '=.*$', 'm');
+  const line = key + '=' + val;
+  s = re.test(s) ? s.replace(re, line) : s + '\n' + line;
+  fs.writeFileSync(p, s.trimStart());
+}
+
+export async function startCredentialProxy(
   port: number,
   host = '127.0.0.1',
 ): Promise<Server> {
@@ -32,50 +33,76 @@ export function startCredentialProxy(
     'CLAUDE_CODE_OAUTH_TOKEN',
     'ANTHROPIC_AUTH_TOKEN',
     'ANTHROPIC_BASE_URL',
+    'MINIMAX_OAUTH_ACCESS',
+    'MINIMAX_OAUTH_REFRESH',
+    'MINIMAX_OAUTH_EXPIRES',
+    'MINIMAX_BASE_URL',
   ]);
-
-  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY
+    ? 'api-key'
+    : secrets.MINIMAX_OAUTH_ACCESS
+      ? 'minimax-oauth'
+      : 'oauth';
   const oauthToken =
     secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
-
-  const upstreamUrl = new URL(
-    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
-  );
+  let minimaxAccess = secrets.MINIMAX_OAUTH_ACCESS;
+  const minimaxRefresh = secrets.MINIMAX_OAUTH_REFRESH;
+  let minimaxExpires = Number(secrets.MINIMAX_OAUTH_EXPIRES || '0');
+  const minimaxRegion: any = (secrets.MINIMAX_BASE_URL || '').includes(
+    'minimaxi.com',
+  )
+    ? 'cn'
+    : 'global';
+  const upstreamStr =
+    authMode === 'minimax-oauth'
+      ? secrets.MINIMAX_BASE_URL || 'https://api.minimax.io/anthropic'
+      : secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com';
+  const upstreamUrl = new URL(upstreamStr);
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
   return new Promise((resolve, reject) => {
-    const server = createServer((req, res) => {
+    const server = createServer(async (req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
-      req.on('end', () => {
+      req.on('end', async () => {
         const body = Buffer.concat(chunks);
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
-
-        // Strip hop-by-hop headers that must not be forwarded by proxies
+        const headers: Record<string, any> = {
+          ...(req.headers as Record<string, string>),
+          host: upstreamUrl.host,
+          'content-length': body.length,
+        };
         delete headers['connection'];
         delete headers['keep-alive'];
         delete headers['transfer-encoding'];
 
         if (authMode === 'api-key') {
-          // API key mode: inject x-api-key on every request
           delete headers['x-api-key'];
           headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
+        } else if (authMode === 'minimax-oauth') {
+          if (minimaxRefresh && Date.now() > minimaxExpires - 60000) {
+            try {
+              const t = await refreshMiniMaxToken({
+                refreshToken: minimaxRefresh,
+                region: minimaxRegion,
+              });
+              minimaxAccess = t.access;
+              minimaxExpires = t.expires;
+              upsertEnvFile('MINIMAX_OAUTH_ACCESS', t.access);
+              upsertEnvFile('MINIMAX_OAUTH_REFRESH', t.refresh);
+              upsertEnvFile('MINIMAX_OAUTH_EXPIRES', String(t.expires));
+              logger.info('MiniMax token refreshed');
+            } catch (e) {
+              logger.error({ err: e }, 'MiniMax token refresh failed');
+            }
+          }
+          delete headers['authorization'];
+          if (minimaxAccess)
+            headers['authorization'] = 'Bearer ' + minimaxAccess;
         } else {
-          // OAuth mode: replace placeholder Bearer token with the real one
-          // only when the container actually sends an Authorization header
-          // (exchange request + auth probes). Post-exchange requests use
-          // x-api-key only, so they pass through without token injection.
           if (headers['authorization']) {
             delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
-            }
+            if (oauthToken) headers['authorization'] = 'Bearer ' + oauthToken;
           }
         }
 
@@ -92,34 +119,30 @@ export function startCredentialProxy(
             upRes.pipe(res);
           },
         );
-
         upstream.on('error', (err) => {
-          logger.error(
-            { err, url: req.url },
-            'Credential proxy upstream error',
-          );
+          logger.error({ err, url: req.url }, 'Proxy upstream error');
           if (!res.headersSent) {
             res.writeHead(502);
             res.end('Bad Gateway');
           }
         });
-
         upstream.write(body);
         upstream.end();
       });
     });
-
     server.listen(port, host, () => {
       logger.info({ port, host, authMode }, 'Credential proxy started');
       resolve(server);
     });
-
     server.on('error', reject);
   });
 }
 
-/** Detect which auth mode the host is configured for. */
 export function detectAuthMode(): AuthMode {
-  const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
-  return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+  const s = readEnvFile(['ANTHROPIC_API_KEY', 'MINIMAX_OAUTH_ACCESS']);
+  return s.ANTHROPIC_API_KEY
+    ? 'api-key'
+    : s.MINIMAX_OAUTH_ACCESS
+      ? 'minimax-oauth'
+      : 'oauth';
 }

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -76,6 +76,32 @@ export async function startCredentialProxy(
         delete headers['keep-alive'];
         delete headers['transfer-encoding'];
 
+        if (
+          authMode === 'minimax-oauth' &&
+          req.url &&
+          req.url.startsWith('/v1/models')
+        ) {
+          const m = JSON.stringify({
+            data: [{ id: 'MiniMax-M2.5', type: 'model' }],
+          });
+          res.writeHead(200, {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(m),
+          });
+          res.end(m);
+          return;
+        }
+        let finalBody = body;
+        if (authMode === 'minimax-oauth' && body.length > 0) {
+          try {
+            const p = JSON.parse(body.toString());
+            p.model = 'MiniMax-M2.5';
+            delete p.betas;
+            finalBody = Buffer.from(JSON.stringify(p));
+            headers['content-length'] = finalBody.length;
+          } catch {}
+        }
+        if (authMode === 'minimax-oauth') delete headers['anthropic-beta'];
         if (authMode === 'api-key') {
           delete headers['x-api-key'];
           headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
@@ -110,7 +136,10 @@ export async function startCredentialProxy(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path:
+              authMode === 'minimax-oauth'
+                ? upstreamUrl.pathname.replace(/\/$/, '') + (req.url || '/')
+                : req.url,
             method: req.method,
             headers,
           } as RequestOptions,
@@ -126,7 +155,7 @@ export async function startCredentialProxy(
             res.end('Bad Gateway');
           }
         });
-        upstream.write(body);
+        upstream.write(finalBody ?? body);
         upstream.end();
       });
     });

--- a/src/minimax-oauth.ts
+++ b/src/minimax-oauth.ts
@@ -1,0 +1,153 @@
+import { createHash, randomBytes } from 'node:crypto';
+export type MiniMaxRegion = 'global' | 'cn';
+const CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
+const SCOPE = 'group_id profile model.completion';
+const GRANT = 'urn:ietf:params:oauth:grant-type:user_code';
+export const BASE: Record<MiniMaxRegion, string> = {
+  global: 'https://api.minimax.io',
+  cn: 'https://api.minimaxi.com',
+};
+export const ANTHROPIC_URL: Record<MiniMaxRegion, string> = {
+  global: 'https://api.minimax.io/anthropic',
+  cn: 'https://api.minimaxi.com/anthropic',
+};
+
+function b64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+export function generatePkce() {
+  const verifier = b64url(randomBytes(32));
+  const challenge = b64url(createHash('sha256').update(verifier).digest());
+  const state = b64url(randomBytes(16));
+  return { verifier, challenge, state };
+}
+function form(p: Record<string, string>): string {
+  return Object.entries(p)
+    .map(([k, v]) => encodeURIComponent(k) + '=' + encodeURIComponent(v))
+    .join('&');
+}
+
+export interface MiniMaxToken {
+  access: string;
+  refresh: string;
+  expires: number;
+  resourceUrl?: string;
+}
+
+export async function requestDeviceCode(o: any) {
+  const res = await fetch(BASE[o.region as MiniMaxRegion] + '/oauth/code', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      scope: SCOPE,
+      code_challenge: o.challenge,
+      code_challenge_method: 'S256',
+      state: o.state,
+    }),
+  });
+  if (!res.ok)
+    throw new Error('MiniMax OAuth code request failed: ' + (await res.text()));
+  const d = (await res.json()) as any;
+  if (!d.user_code)
+    throw new Error(
+      d.error || 'MiniMax OAuth: missing user_code or verification_uri',
+    );
+  if (d.state !== o.state) throw new Error('MiniMax OAuth: state mismatch');
+  return d;
+}
+
+export async function pollForToken(o: any): Promise<any> {
+  const res = await fetch(BASE[o.region as MiniMaxRegion] + '/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form({
+      grant_type: GRANT,
+      client_id: CLIENT_ID,
+      user_code: o.userCode,
+      code_verifier: o.verifier,
+    }),
+  });
+  const txt = await res.text();
+  let d: any;
+  try {
+    d = JSON.parse(txt);
+  } catch {
+    d = null;
+  }
+  if (!res.ok)
+    return { status: 'error', message: d?.base_resp?.status_msg || txt };
+  if (!d)
+    return {
+      status: 'error',
+      message: 'MiniMax OAuth: failed to parse token response',
+    };
+  if (d.status === 'error')
+    return {
+      status: 'error',
+      message: 'MiniMax OAuth: server returned error status',
+    };
+  if (d.status !== 'success') return { status: 'pending' };
+  if (!d.access_token || !d.refresh_token)
+    return {
+      status: 'error',
+      message: 'MiniMax OAuth: incomplete token payload',
+    };
+  return {
+    status: 'success',
+    token: {
+      access: d.access_token,
+      refresh: d.refresh_token,
+      expires: d.expired_in,
+      resourceUrl: d.resource_url,
+    },
+  };
+}
+
+export async function refreshMiniMaxToken(o: any): Promise<MiniMaxToken> {
+  const res = await fetch(BASE[o.region as MiniMaxRegion] + '/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form({
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: o.refreshToken,
+    }),
+  });
+  if (!res.ok) throw new Error('MM refresh failed:' + (await res.text()));
+  const d = (await res.json()) as any;
+  if (!d.access_token || !d.refresh_token)
+    throw new Error('MM refresh: incomplete payload');
+  return {
+    access: d.access_token,
+    refresh: d.refresh_token,
+    expires: d.expired_in,
+    resourceUrl: d.resource_url,
+  };
+}
+
+export async function loginWithMiniMax(o: any): Promise<MiniMaxToken> {
+  const region = o.region ?? 'global';
+  const { verifier, challenge, state } = generatePkce();
+  const cr = await requestDeviceCode({ challenge, state, region });
+  if (o.onDeviceCode) o.onDeviceCode(cr.user_code, cr.verification_uri);
+  if (o.openUrl) {
+    try {
+      o.openUrl(cr.verification_uri);
+    } catch {}
+  }
+  let iv = cr.interval ?? 2000;
+  while (Date.now() < cr.expired_in) {
+    await new Promise((r) => setTimeout(r, iv));
+    const r = await pollForToken({ userCode: cr.user_code, verifier, region });
+    if (r.status === 'success') return r.token;
+    if (r.status === 'error') throw new Error('MiniMax OAuth: ' + r.message);
+    iv = Math.min(iv * 1.5, 10000);
+  }
+  throw new Error('MiniMax OAuth timed out');
+}


### PR DESCRIPTION
## What this adds

MiniMax OAuth (Coding Plan) as an alternative model provider — no Anthropic API key or Claude subscription OAuth token required.

### New files
- `src/minimax-oauth.ts` — device-code OAuth flow with PKCE S256, token polling, and auto-refresh
- `scripts/minimax-login.ts` — one-shot CLI to obtain and store tokens in `.env`
- `.claude/skills/add-minimax-oauth/` — skill + README

### Changes
- `src/credential-proxy.ts` — adds `minimax-oauth` as a third `AuthMode`. Tokens auto-refresh 60s before expiry.
- `package.json` — adds `minimax-login` script

### Usage
```bash
npm run minimax-login   # browser opens, approve, tokens saved to .env
npm run dev             # NanoClaw starts in minimax-oauth mode
```

CN region: `npm run minimax-login -- --region cn`

### Auth mode priority
1. `ANTHROPIC_API_KEY` present → `api-key` mode
2. `MINIMAX_OAUTH_ACCESS` present → `minimax-oauth` mode  
3. Neither → `oauth` mode (Claude OAuth, existing default)

### Tested on
Ubuntu Server 22.04, Node 22, Docker 28, MiniMax M2.5 via `https://api.minimax.io/anthropic`