### PR TITLE
fix: prepend base URL pathname to request path in credential-proxy

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -205,6 +205,43 @@ describe('credential-proxy', () => {
     expect(receivedPath).toBe('/api/anthropic/v1/messages');
   });
 
+  it('passes through request path when base URL has no pathname', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    let receivedPath = '';
+    upstreamServer = http.createServer((req, res) => {
+      receivedPath = req.url!;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(0, '127.0.0.1', resolve),
+    );
+    upstreamPort = (upstreamServer.address() as AddressInfo).port;
+
+    Object.assign(mockEnv, {
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages?beta=true',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(receivedPath).toBe('/v1/messages?beta=true');
+  });
+
   it('returns 502 when upstream is unreachable', async () => {
     Object.assign(mockEnv, {
       ANTHROPIC_API_KEY: 'sk-ant-real-key',

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -168,6 +168,43 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['transfer-encoding']).toBeUndefined();
   });
 
+  it('prepends base URL pathname to request path', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    let receivedPath = '';
+    upstreamServer = http.createServer((req, res) => {
+      receivedPath = req.url!;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(0, '127.0.0.1', resolve),
+    );
+    upstreamPort = (upstreamServer.address() as AddressInfo).port;
+
+    Object.assign(mockEnv, {
+      ANTHROPIC_API_KEY: 'sk-ant-real-key',
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}/api/anthropic`,
+    });
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(receivedPath).toBe('/api/anthropic/v1/messages');
+  });
+
   it('returns 502 when upstream is unreachable', async () => {
     Object.assign(mockEnv, {
       ANTHROPIC_API_KEY: 'sk-ant-real-key',

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -81,8 +81,8 @@ export function startCredentialProxy(
 
         const upstreamPath =
           upstreamUrl.pathname === '/'
-            ? req.url
-            : upstreamUrl.pathname + req.url;
+            ? (req.url ?? '/')
+            : upstreamUrl.pathname.replace(/\/$/, '') + req.url;
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -79,11 +79,15 @@ export function startCredentialProxy(
           }
         }
 
+        const upstreamPath =
+          upstreamUrl.pathname === '/'
+            ? req.url
+            : upstreamUrl.pathname + req.url;
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: upstreamPath,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Summary
- Fix credential-proxy to prepend `ANTHROPIC_BASE_URL` pathname to the request path
- Previously, if `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, requests to `/v1/messages?beta=true` would be forwarded as-is instead of `/api/anthropic/v1/messages?beta=true`

## Fix
- Added path concatenation logic: `upstreamUrl.pathname + req.url` when base URL has a non-root pathname
- Added unit test verifying the path prefix is correctly prepended

## Testing
- All 6 credential-proxy tests pass
- TypeScript build succeeds