### PR TITLE
fix: add pre-flight credential validation to docker-entrypoint.sh

### DIFF
--- a/Dockerfile.unraid
+++ b/Dockerfile.unraid
@@ -1,0 +1,46 @@
+FROM node:22-slim
+
+# Build tools for native modules (better-sqlite3)
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    curl \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker CLI (not daemon — uses host socket)
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+    https://download.docker.com/linux/debian bookworm stable" \
+    > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source and build
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Copy runtime assets
+COPY container/ ./container/
+COPY groups/ ./groups/
+COPY .claude/ ./.claude/
+COPY setup/ ./setup/
+
+# Startup script — builds agent image if missing, then starts NanoClaw
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+# Persistent data volumes
+VOLUME ["/app/data", "/app/groups", "/app/logs", "/app/store"]
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+echo "=== NanoClaw startup ==="
+
+# Pre-flight: validate required credentials before touching any state.
+# Exit early so the container can be corrected without leaving behind
+# a partially-initialised data directory that corrupts future starts.
+
+_preflight_ok=1
+
+# Claude API key (required — without this nothing works)
+if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    echo ""
+    echo "ERROR: No Claude API key found."
+    echo "  Please set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN."
+    _preflight_ok=0
+fi
+
+# At least one channel credential (required — no channel = nothing to respond to)
+if [ -z "$TELEGRAM_BOT_TOKEN" ] && \
+   [ -z "$WHATSAPP_TOKEN" ] && \
+   [ -z "$SLACK_BOT_TOKEN" ] && \
+   [ -z "$DISCORD_BOT_TOKEN" ]; then
+    echo ""
+    echo "ERROR: No channel credentials found."
+    echo "  Please set at least one of the following before starting NanoClaw:"
+    echo "    TELEGRAM_BOT_TOKEN"
+    echo "    WHATSAPP_TOKEN"
+    echo "    SLACK_BOT_TOKEN"
+    echo "    DISCORD_BOT_TOKEN"
+    _preflight_ok=0
+fi
+
+if [ "$_preflight_ok" = "0" ]; then
+    echo ""
+    echo "NanoClaw will not start until the above credentials are configured."
+    echo "Fix the missing variables and restart the container."
+    exit 1
+fi
+
+# Build agent image if not present on host
+if ! docker image inspect nanoclaw-agent:latest > /dev/null 2>&1; then
+    echo "Building nanoclaw-agent image..."
+    cd /app/container && sh build.sh
+    cd /app
+else
+    echo "nanoclaw-agent image found, skipping build."
+fi
+
+# Pre-create persistent data directory structure so volume mounts
+# don't start empty and cause runtime errors on first boot
+mkdir -p \
+    /app/data/sessions \
+    /app/data/env \
+    /app/data/ipc \
+    /app/logs \
+    /app/store
+
+chown -R 1000:1000 /app/data/sessions
+
+# Seed a minimal .claude.json for each existing group session directory
+# so claude-code considers itself logged in without needing the host's real token file.
+for session_dir in /app/data/sessions/*/; do
+    [ -d "$session_dir" ] || continue
+    claude_json="$session_dir.claude.json"
+    if [ ! -f "$claude_json" ]; then
+        cat > "$claude_json" <<'EOF'
+{
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "2.1.76",
+  "oauthAccount": {
+    "accountUuid": "00000000-0000-0000-0000-000000000000",
+    "emailAddress": "agent@nanoclaw.local",
+    "organizationUuid": "00000000-0000-0000-0000-000000000000",
+    "displayName": "NanoClaw Agent",
+    "organizationRole": "admin",
+    "organizationName": "NanoClaw"
+  }
+}
+EOF
+        chown 1000:1000 "$claude_json"
+        echo "Seeded .claude.json for $session_dir"
+    fi
+done
+
+echo "Starting NanoClaw..."
+exec node dist/index.js


### PR DESCRIPTION
Fixes #1289

## Problem

Starting NanoClaw without credentials configured does not fail fast. The process initialises the database, creates session directories, and leaves partially-constructed state in the data volume. When credentials are later added and the container restarted, that stale state causes further failures — recovery requires a full data wipe.

This was discovered during first-time setup on Unraid, where it's easy to start the container before finishing credential configuration.

## Solution

Two pre-flight checks at the top of `docker-entrypoint.sh`, before any filesystem writes or `node` is exec'd:

1. **Claude API key** — requires `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
2. **Channel credential** — requires at least one of `TELEGRAM_BOT_TOKEN`, `WHATSAPP_TOKEN`, `SLACK_BOT_TOKEN`, `DISCORD_BOT_TOKEN`

If either check fails, an actionable error message is printed and the entrypoint exits with code 1 — before `mkdir`, before the DB is opened, before any session directory is created. The data volume stays clean and the container can be corrected and restarted without any manual cleanup.

Example output when no credentials are set:
```
=== NanoClaw startup ===

ERROR: No Claude API key found.
  Please set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN.

ERROR: No channel credentials found.
  Please set at least one of the following before starting NanoClaw:
    TELEGRAM_BOT_TOKEN
    WHATSAPP_TOKEN
    SLACK_BOT_TOKEN
    DISCORD_BOT_TOKEN

NanoClaw will not start until the above credentials are configured.
Fix the missing variables and restart the container.
```

## Notes

- Both checks are collected before exiting so all errors are shown in a single run
- The check is permissive: any single recognised credential passes; multi-channel setups are unaffected
- Also introduces `Dockerfile.unraid` — the Dockerfile used to build the Unraid/Docker image that references this entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)