### PR TITLE
Feature create new session

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -686,9 +686,17 @@ async function main(): Promise<void> {
   let resumeAt: string | undefined;
   try {
     while (true) {
-      log(
-        `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
-      );
+      // Apply any pending session reset before starting the next query.
+      // This ensures /new-session takes effect even when the container is
+      // idle-waiting or was mid-query when the reset message arrived.
+      if (pendingReset) {
+        log('Applying pending reset: clearing sessionId and resumeAt for new session');
+        sessionId = undefined;
+        resumeAt = undefined;
+        pendingReset = false;
+      }
+
+      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
       const queryResult = await runQuery(
         prompt,
@@ -723,16 +731,6 @@ async function main(): Promise<void> {
       if (nextMessage === null) {
         log('Close sentinel received, exiting');
         break;
-      }
-
-      // Apply any pending session reset before starting the next query.
-      // This ensures /new-session takes effect even when the container is
-      // idle-waiting or was mid-query when the reset message arrived.
-      if (pendingReset) {
-        log('Applying pending reset: clearing sessionId and resumeAt for new session');
-        sessionId = undefined;
-        resumeAt = undefined;
-        pendingReset = false;
       }
 
       log(`Got new message (${nextMessage.length} chars), starting new query`);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -6,6 +6,7 @@
  *   Stdin: Full ContainerInput JSON (read until EOF, like before)
  *   IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
  *          Files: {type:"message", text:"..."}.json — polled and consumed
+ *                 {type:"reset"}.json — clear sessionId/resumeAt before next query
  *          Sentinel: /workspace/ipc/input/_close — signals session end
  *
  * Stdout protocol:
@@ -289,6 +290,10 @@ function formatTranscriptMarkdown(
   return lines.join('\n');
 }
 
+// Set to true when a {type:"reset"} IPC message is received.
+// Applied by the main loop before the next runQuery call.
+let pendingReset = false;
+
 /**
  * Check for _close sentinel.
  */
@@ -324,6 +329,9 @@ function drainIpcInput(): string[] {
         fs.unlinkSync(filePath);
         if (data.type === 'message' && data.text) {
           messages.push(data.text);
+        } else if (data.type === 'reset') {
+          log('Reset control message received — will clear sessionId/resumeAt before next query');
+          pendingReset = true;
         }
       } catch (err) {
         log(
@@ -715,6 +723,16 @@ async function main(): Promise<void> {
       if (nextMessage === null) {
         log('Close sentinel received, exiting');
         break;
+      }
+
+      // Apply any pending session reset before starting the next query.
+      // This ensures /new-session takes effect even when the container is
+      // idle-waiting or was mid-query when the reset message arrived.
+      if (pendingReset) {
+        log('Applying pending reset: clearing sessionId and resumeAt for new session');
+        sessionId = undefined;
+        resumeAt = undefined;
+        pendingReset = false;
       }
 
       log(`Got new message (${nextMessage.length} chars), starting new query`);

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -2,6 +2,13 @@
 
 You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
+## Chat Commands
+
+These commands are handled by the host before reaching you — you never see them as messages. Tell users about them when relevant:
+
+- `/new-session` — Clears the current conversation session. The next message starts fresh with no prior history. (Non-main groups: device owner only. Main group: any sender; `/new-session <folder>` clears another group's session.)
+- `/remote-control` / `/remote-control-end` — Opens/closes a VS Code remote control session. (Main group only.)
+
 ## What You Can Do
 
 - Answer questions and have conversations

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -3,14 +3,17 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   _initTestDatabase,
   createTask,
+  deleteSession,
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
   getLastBotMessageTimestamp,
   getMessagesSince,
   getNewMessages,
+  getSession,
   getTaskById,
   setRegisteredGroup,
+  setSession,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -618,6 +621,27 @@ describe('message query LIMIT', () => {
 });
 
 // --- RegisteredGroup isMain round-trip ---
+
+describe('deleteSession', () => {
+  it('removes a stored session', () => {
+    setSession('main', 'abc-123');
+    expect(getSession('main')).toBe('abc-123');
+    deleteSession('main');
+    expect(getSession('main')).toBeUndefined();
+  });
+
+  it('does not throw when deleting a non-existent session', () => {
+    expect(() => deleteSession('no-such-folder')).not.toThrow();
+  });
+
+  it('only removes the targeted group session', () => {
+    setSession('group-a', 'session-a');
+    setSession('group-b', 'session-b');
+    deleteSession('group-a');
+    expect(getSession('group-a')).toBeUndefined();
+    expect(getSession('group-b')).toBe('session-b');
+  });
+});
 
 describe('registered group isMain', () => {
   it('persists isMain=true through set/get round-trip', () => {

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -178,6 +178,33 @@ export class GroupQueue {
   }
 
   /**
+   * Send a session reset control message to the active container identified by
+   * its group folder. The container will clear its in-memory sessionId and
+   * resumeAt before starting the next query, ensuring /new-session takes effect
+   * even while the container is idle-waiting or mid-query.
+   * Returns true if the message was written, false if no matching active container.
+   */
+  sendResetByFolder(groupFolder: string): boolean {
+    for (const [, state] of this.groups) {
+      if (state.active && !state.isTaskContainer && state.groupFolder === groupFolder) {
+        const inputDir = path.join(DATA_DIR, 'ipc', groupFolder, 'input');
+        try {
+          fs.mkdirSync(inputDir, { recursive: true });
+          const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
+          const filepath = path.join(inputDir, filename);
+          const tempPath = `${filepath}.tmp`;
+          fs.writeFileSync(tempPath, JSON.stringify({ type: 'reset' }));
+          fs.renameSync(tempPath, filepath);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Signal the active container to wind down by writing a close sentinel.
    */
   closeStdin(groupJid: string): void {

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -186,7 +186,11 @@ export class GroupQueue {
    */
   sendResetByFolder(groupFolder: string): boolean {
     for (const [, state] of this.groups) {
-      if (state.active && !state.isTaskContainer && state.groupFolder === groupFolder) {
+      if (
+        state.active &&
+        !state.isTaskContainer &&
+        state.groupFolder === groupFolder
+      ) {
         const inputDir = path.join(DATA_DIR, 'ipc', groupFolder, 'input');
         try {
           fs.mkdirSync(inputDir, { recursive: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,8 +640,14 @@ async function main(): Promise<void> {
 
     deleteSession(targetFolder);
     delete sessions[targetFolder];
+
+    // If a container is currently running for this group, send it a reset
+    // control message so it clears its in-memory sessionId/resumeAt before
+    // the next query. Without this the container would continue the old
+    // Claude session even though the host has already discarded it.
+    const resetSent = queue.sendResetByFolder(targetFolder);
     logger.info(
-      { targetFolder, sender: msg.sender },
+      { targetFolder, sender: msg.sender, containerReset: resetSent },
       'Session cleared via /new-session command',
     );
     await channel.sendMessage(chatJid, 'Session cleared. Starting fresh.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
 import {
+  deleteSession,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -592,6 +593,60 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
+  // Handle /new-session command — clears the current session for a group
+  async function handleNewSession(
+    command: string,
+    chatJid: string,
+    msg: NewMessage,
+  ): Promise<void> {
+    const channel = findChannel(channels, chatJid);
+    if (!channel) return;
+
+    const group = registeredGroups[chatJid];
+    if (!group) return;
+
+    const isMain = group.isMain === true;
+
+    // Non-main groups: device owner only
+    if (!isMain && !msg.is_from_me) {
+      await channel.sendMessage(
+        chatJid,
+        'Session commands require owner access.',
+      );
+      return;
+    }
+
+    // Resolve target folder
+    let targetFolder = group.folder;
+    if (isMain && command.startsWith('/new-session ')) {
+      const requestedFolder = command.slice('/new-session '.length).trim();
+      const match = Object.values(registeredGroups).find(
+        (g) => g.folder === requestedFolder,
+      );
+      if (!match) {
+        await channel.sendMessage(
+          chatJid,
+          `Unknown group folder: ${requestedFolder}`,
+        );
+        return;
+      }
+      targetFolder = match.folder;
+    }
+
+    if (!sessions[targetFolder]) {
+      await channel.sendMessage(chatJid, 'No active session to clear.');
+      return;
+    }
+
+    deleteSession(targetFolder);
+    delete sessions[targetFolder];
+    logger.info(
+      { targetFolder, sender: msg.sender },
+      'Session cleared via /new-session command',
+    );
+    await channel.sendMessage(chatJid, 'Session cleared. Starting fresh.');
+  }
+
   // Handle /remote-control and /remote-control-end commands
   async function handleRemoteControl(
     command: string,
@@ -642,6 +697,14 @@ async function main(): Promise<void> {
       if (trimmed === '/remote-control' || trimmed === '/remote-control-end') {
         handleRemoteControl(trimmed, chatJid, msg).catch((err) =>
           logger.error({ err, chatJid }, 'Remote control command error'),
+        );
+        return;
+      }
+
+      // New session command — clears the current session
+      if (trimmed === '/new-session' || trimmed.startsWith('/new-session ')) {
+        handleNewSession(trimmed, chatJid, msg).catch((err) =>
+          logger.error({ err, chatJid }, 'New session command error'),
         );
         return;
       }


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

We add a `/new-session` chat command that lets users clear the current Claude SDK session for a group, forcing the next message to start with a clean conversation history. The command is handled entirely by the host process before routing to the agent, so the agent never sees it. We used the `/remote-control` feature for reference.

In non-main groups it is restricted to the device owner (is_from_me); in the main group any sender can use it, and a `/new-session <folder>` variant allows clearing another group's session by folder name.

Also added an IPC command to reset the current sessionId inside running containers.

The global CLAUDE.md is updated to document `/new-session` alongside `/remote-control` so the agent can inform users about available commands.

solves #1211

- [x] tested on local and new installation
