### PR TITLE
feat: add Home Assistant MCP integration skill

### DIFF
--- a/.claude/skills/add-homeassistant/SKILL.md
+++ b/.claude/skills/add-homeassistant/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: add-homeassistant
+description: Add Home Assistant integration to NanoClaw. Lets the container agent query entity states, call services, list automations, and retrieve state history via the Home Assistant REST API. Requires a Long-Lived Access Token.
+---
+
+# Add Home Assistant Integration
+
+This skill adds a stdio-based MCP server that exposes the Home Assistant REST API as tools for the container agent.
+
+Tools added:
+- `ha_get_states` — list all entity states, optionally filtered by domain (light, switch, climate, sensor, etc.)
+- `ha_get_state` — get the current state of a specific entity by entity_id
+- `ha_call_service` — call any HA service (turn on lights, set thermostat, trigger scripts, etc.)
+- `ha_list_automations` — list all automations with friendly name, state (on/off), and last triggered time
+- `ha_get_history` — get state history for an entity over the last N hours
+
+All tool calls from the agent use the MCP prefix: `mcp__homeassistant__ha_<tool>`
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `container/agent-runner/src/homeassistant-mcp-stdio.ts` already exists. If it does, skip to Phase 3 (Configure).
+
+### Collect credentials
+
+Use `AskUserQuestion` to collect the Home Assistant URL and token:
+
+> What is your Home Assistant URL?
+>
+> - If NanoClaw and Home Assistant are on the **same Docker network**, use the container name: `http://homeassistant:8123`
+> - If Home Assistant runs in **host network mode** or on a different host, use the host IP or hostname: `http://192.168.1.x:8123`
+>
+> Default: `http://homeassistant:8123`
+
+Then:
+
+> Please provide a Long-Lived Access Token for Home Assistant.
+>
+> To create one:
+> 1. Open Home Assistant in your browser
+> 2. Click your profile icon (bottom-left)
+> 3. Scroll to **Long-Lived Access Tokens**
+> 4. Click **Create Token**, give it a name (e.g. "NanoClaw"), and copy the token
+
+### Test API connectivity
+
+```bash
+curl -s -H "Authorization: Bearer <HA_TOKEN>" \
+  "<HA_URL>/api/" | head -c 200
+```
+
+The response should be JSON with a `message` field like `"API running."`. If the request fails (401/403/connection refused), stop and tell the user to check the URL and token before proceeding.
+
+## Phase 2: Apply Code Changes
+
+### Write the MCP server
+
+Create `container/agent-runner/src/homeassistant-mcp-stdio.ts` with exactly the following content (taken from the skill's base directory at `container/agent-runner/src/homeassistant-mcp-stdio.ts` if it already exists there, otherwise write it fresh).
+
+The file is already present in this repo at `container/agent-runner/src/homeassistant-mcp-stdio.ts` — verify it exists and is non-empty before proceeding.
+
+### Wire into agent-runner index.ts
+
+Open `container/agent-runner/src/index.ts` and make five edits:
+
+**1. Add path variable** — immediately after the `tailscaleMcpServerPath` line, add:
+
+```typescript
+const homeassistantMcpServerPath = path.join(__dirname, 'homeassistant-mcp-stdio.js');
+```
+
+**2. Add to `runQuery` function signature** — in the `runQuery` function parameters, after `tailscaleMcpServerPath: string`, add:
+
+```typescript
+homeassistantMcpServerPath: string,
+```
+
+**3. Add to `allowedTools`** — in the `allowedTools` array, after `'mcp__tailscale__*'`, add:
+
+```typescript
+'mcp__homeassistant__*',
+```
+
+**4. Add to `mcpServers`** — inside the `mcpServers` object, after the closing brace of the `tailscale` entry, add:
+
+```typescript
+homeassistant: {
+  command: 'node',
+  args: [homeassistantMcpServerPath],
+  env: {
+    HA_URL: sdkEnv.HA_URL ?? '',
+    HA_TOKEN: sdkEnv.HA_TOKEN ?? '',
+  },
+},
+```
+
+**5. Update the `runQuery` call site** — find the call to `runQuery(...)` in `main()` and add `homeassistantMcpServerPath` after `tailscaleMcpServerPath`:
+
+```typescript
+// Before:
+const queryResult = await runQuery(prompt, sessionId, mcpServerPath, unraidclawMcpServerPath, tailscaleMcpServerPath, containerInput, sdkEnv, resumeAt);
+// After:
+const queryResult = await runQuery(prompt, sessionId, mcpServerPath, unraidclawMcpServerPath, tailscaleMcpServerPath, homeassistantMcpServerPath, containerInput, sdkEnv, resumeAt);
+```
+
+### Copy to per-group agent-runner
+
+Existing groups have a cached copy of the agent-runner source. Update them:
+
+```bash
+for dir in data/sessions/*/agent-runner-src; do
+  cp container/agent-runner/src/homeassistant-mcp-stdio.ts "$dir/"
+  cp container/agent-runner/src/index.ts "$dir/"
+done
+```
+
+### Build
+
+```bash
+npm run build
+./container/build.sh
+```
+
+Build must be clean before proceeding. If there are TypeScript errors, read and fix them before continuing.
+
+## Phase 2b: Update container-runner.ts
+
+### Update container-runner.ts
+
+The main NanoClaw process passes environment variables to agent containers explicitly. Open `src/container-runner.ts` and add the following two blocks immediately after the `TAILSCALE_TAILNET` block:
+
+```typescript
+  if (process.env.HA_URL) {
+    args.push('-e', `HA_URL=${process.env.HA_URL}`);
+  }
+  if (process.env.HA_TOKEN) {
+    args.push('-e', `HA_TOKEN=${process.env.HA_TOKEN}`);
+  }
+```
+
+Without this step the Home Assistant MCP server will start but will have no credentials and all tool calls will fail.
+
+## Phase 3: Configure
+
+### Configure environment variables
+
+On Unraid/Docker deployments: add the variables directly to the NanoClaw container template via the Unraid Docker UI (edit container → add variables). The credential proxy passes them to child containers automatically.
+
+Variables to add:
+
+```
+HA_URL=http://homeassistant:8123
+HA_TOKEN=<long-lived-access-token>
+```
+
+**URL note:** Use the container name (`homeassistant`) if HA is on the same Docker bridge network as NanoClaw. Use the host IP (e.g. `http://192.168.1.x:8123`) if HA runs in host network mode or on a separate machine.
+
+On standard Linux/macOS deployments: append to `.env` and sync:
+
+```bash
+HA_URL=http://homeassistant:8123
+HA_TOKEN=<long-lived-access-token>
+```
+
+Then sync:
+```bash
+cp .env data/env/env
+```
+
+Also add placeholder entries to `.env.example` if not already present:
+
+```bash
+HA_URL=
+HA_TOKEN=
+```
+
+### Restart the service
+
+On Unraid/Docker deployments, restart via SSH:
+```bash
+docker restart NanoClaw
+```
+On standard Linux: `systemctl --user restart nanoclaw`
+On macOS: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
+
+## Phase 4: Verify
+
+### Test the tools
+
+Tell the user:
+
+> Send a message like: "what lights are on in Home Assistant?"
+>
+> The agent should call `mcp__homeassistant__ha_get_states` (with domain filter `light`) and return the light entity states.
+>
+> To test service calls: "turn off all the lights"
+> The agent will call `mcp__homeassistant__ha_call_service` with the `light.turn_off` service.
+>
+> To test history: "has the front door been open today?"
+> The agent will call `mcp__homeassistant__ha_get_history` for the relevant sensor.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log | grep -i homeassistant
+```
+
+Look for tool calls like `mcp__homeassistant__ha_get_states` appearing in agent output.
+
+## Troubleshooting
+
+### "HA_URL and HA_TOKEN must be set"
+
+The env vars are not reaching the container agent. Check:
+1. The vars are set in the NanoClaw container environment (Unraid Docker UI) or in `.env` AND synced to `data/env/env`
+2. The `homeassistant` entry in `mcpServers` passes both env vars
+3. The service was restarted after adding the variables
+
+### 401 Unauthorized
+
+The token is invalid or expired. To create a new one:
+1. Open Home Assistant → Profile (bottom-left) → **Long-Lived Access Tokens**
+2. Delete the old token if present, create a new one
+3. Update `HA_TOKEN` in the NanoClaw container environment and restart
+
+### Connection refused / timeout
+
+The `HA_URL` is wrong or unreachable from inside the agent container. Check:
+1. If HA and NanoClaw are on the same Docker network, use the container name: `http://homeassistant:8123`
+2. If HA is in host network mode, use the host's IP from inside the container: `http://172.17.0.1:8123` (default Docker bridge gateway) or the LAN IP
+3. Test reachability: `docker exec NanoClaw curl -s http://homeassistant:8123/api/` (adjust container name as needed)
+
+### Agent doesn't use Home Assistant tools
+
+1. Check `container/agent-runner/src/index.ts` has `'mcp__homeassistant__*'` in `allowedTools`
+2. Check the `homeassistant` entry is in `mcpServers` with both env vars
+3. Verify the per-group source was updated (see Phase 2)
+4. Confirm the container image was rebuilt with `./container/build.sh`
+5. Try being explicit: "use the ha_get_states tool to list all lights"
+
+### Home Assistant tools return "credentials not set" but env vars are configured
+
+`HA_URL` and `HA_TOKEN` are set in the NanoClaw container but not being forwarded to agent containers. Verify `src/container-runner.ts` has the two HA passthrough blocks from Phase 2b. If missing, add them and rebuild: `npm run build` then rebuild and push the main NanoClaw image.
+
+### Agent runner won't start after changes
+
+Check for TypeScript errors:
+
+```bash
+cd container/agent-runner && npx tsc --noEmit
+```
+
+Common cause: `homeassistantMcpServerPath` parameter added to signature but not to the call site (or vice versa).
+
+### ha_get_history returns empty results
+
+Home Assistant's history recorder may not be tracking the entity. Check:
+1. The entity_id is correct (use `ha_get_states` to confirm)
+2. The `recorder` integration is enabled in HA (it is by default)
+3. The requested hours value isn't too large — HA's default history retention is 10 days
+
+## Removal
+
+To remove the Home Assistant integration:
+
+1. Delete `container/agent-runner/src/homeassistant-mcp-stdio.ts`
+2. Remove the `homeassistantMcpServerPath` variable, `homeassistantMcpServerPath` parameter, `'mcp__homeassistant__*'` from `allowedTools`, and the `homeassistant` entry from `mcpServers` in `container/agent-runner/src/index.ts`
+3. Remove `HA_URL` and `HA_TOKEN` from `.env` and sync: `cp .env data/env/env`
+4. Remove placeholder lines from `.env.example`
+5. Rebuild: `npm run build && ./container/build.sh`
+6. Restart:
+```bash
+docker restart NanoClaw  # Unraid/Docker
+# macOS: launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux: systemctl --user restart nanoclaw
+```

--- a/container/agent-runner/src/homeassistant-mcp-stdio.ts
+++ b/container/agent-runner/src/homeassistant-mcp-stdio.ts
@@ -1,0 +1,140 @@
+/**
+ * Stdio MCP Server for Home Assistant
+ * Exposes the Home Assistant REST API as tools for the container agent.
+ *
+ * Auth:
+ *   HA_URL=http://<host>:8123   (no trailing slash)
+ *   HA_TOKEN=<long-lived access token>
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const BASE = (process.env.HA_URL ?? '').replace(/\/$/, '');
+
+async function apiGet(path: string): Promise<unknown> {
+  const token = process.env.HA_TOKEN;
+  if (!BASE || !token) throw new Error('HA_URL and HA_TOKEN must be set');
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function apiPost(path: string, body: unknown): Promise<unknown> {
+  const token = process.env.HA_TOKEN;
+  if (!BASE || !token) throw new Error('HA_URL and HA_TOKEN must be set');
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+function ok(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function err(e: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+    isError: true as const,
+  };
+}
+
+// --- MCP Server ---
+
+const mcpServer = new McpServer({ name: 'homeassistant', version: '1.0.0' });
+
+mcpServer.tool(
+  'ha_get_states',
+  'List all entity states in Home Assistant. Optionally filter by domain (e.g. "light", "switch", "climate", "sensor"). Returns entity_id, state, attributes, and last_changed for each entity.',
+  {
+    domain: z.string().optional().describe('Filter by domain, e.g. "light", "switch", "climate", "sensor". Omit to return all entities.'),
+  },
+  async (args) => {
+    try {
+      const states = await apiGet('/api/states') as Array<{ entity_id: string }>;
+      const filtered = args.domain
+        ? states.filter(s => s.entity_id.startsWith(`${args.domain}.`))
+        : states;
+      return ok(filtered);
+    } catch (e) { return err(e); }
+  },
+);
+
+mcpServer.tool(
+  'ha_get_state',
+  'Get the current state of a specific Home Assistant entity by entity_id (e.g. "light.living_room", "climate.bedroom"). Returns state value, all attributes, and last_changed timestamp.',
+  {
+    entity_id: z.string().describe('Full entity ID, e.g. "light.living_room" or "sensor.temperature"'),
+  },
+  async (args) => {
+    try { return ok(await apiGet(`/api/states/${args.entity_id}`)); } catch (e) { return err(e); }
+  },
+);
+
+mcpServer.tool(
+  'ha_call_service',
+  'Call any Home Assistant service (e.g. turn on a light, set thermostat temperature, trigger a script). Returns the resulting state(s) of affected entities.',
+  {
+    domain: z.string().describe('Service domain, e.g. "light", "switch", "climate", "script"'),
+    service: z.string().describe('Service name, e.g. "turn_on", "turn_off", "set_temperature"'),
+    entity_id: z.string().optional().describe('Target entity ID, e.g. "light.living_room". Omit if the service does not target a specific entity.'),
+    data: z.record(z.string(), z.unknown()).optional().describe('Additional service data as a JSON object, e.g. {"brightness": 128} or {"temperature": 21.5}'),
+  },
+  async (args) => {
+    try {
+      const body: Record<string, unknown> = { ...args.data };
+      if (args.entity_id) body.entity_id = args.entity_id;
+      return ok(await apiPost(`/api/services/${args.domain}/${args.service}`, body));
+    } catch (e) { return err(e); }
+  },
+);
+
+mcpServer.tool(
+  'ha_list_automations',
+  'List all automations in Home Assistant with their friendly name, current state (on/off), and last triggered timestamp.',
+  {},
+  async () => {
+    try {
+      const states = await apiGet('/api/states') as Array<{
+        entity_id: string;
+        state: string;
+        attributes: Record<string, unknown>;
+      }>;
+      const automations = states
+        .filter(s => s.entity_id.startsWith('automation.'))
+        .map(s => ({
+          entity_id: s.entity_id,
+          friendly_name: s.attributes.friendly_name ?? s.entity_id,
+          state: s.state,
+          last_triggered: s.attributes.last_triggered ?? null,
+        }));
+      return ok(automations);
+    } catch (e) { return err(e); }
+  },
+);
+
+mcpServer.tool(
+  'ha_get_history',
+  'Get the state history for a specific entity over the last N hours. Useful for understanding recent changes, checking if a device was on/off at a particular time, or tracking sensor readings.',
+  {
+    entity_id: z.string().describe('Full entity ID to retrieve history for, e.g. "sensor.temperature"'),
+    hours: z.number().int().min(1).max(168).default(24).describe('How many hours of history to retrieve (1–168, default 24)'),
+  },
+  async (args) => {
+    try {
+      const start = new Date(Date.now() - args.hours * 60 * 60 * 1000).toISOString();
+      const url = `/api/history/period/${start}?filter_entity_id=${encodeURIComponent(args.entity_id)}&minimal_response=true`;
+      return ok(await apiGet(url));
+    } catch (e) { return err(e); }
+  },
+);
+
+const transport = new StdioServerTransport();
+await mcpServer.connect(transport);

--- a/container/agent-runner/src/homeassistant-mcp-stdio.ts
+++ b/container/agent-runner/src/homeassistant-mcp-stdio.ts
@@ -2,9 +2,9 @@
  * Stdio MCP Server for Home Assistant
  * Exposes the Home Assistant REST API as tools for the container agent.
  *
- * Auth:
- *   HA_URL=http://<host>:8123   (no trailing slash)
- *   HA_TOKEN=<long-lived access token>
+ * Auth (one of two paths, detected at startup):
+ *   OneCLI  — ONECLI_URL is set and reachable; HA_URL + HA_TOKEN are injected by OneCLI
+ *   Env var — HA_URL + HA_TOKEN read directly from process.env / .env file
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -44,6 +44,46 @@ function err(e: unknown) {
     content: [{ type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
     isError: true as const,
   };
+}
+
+// --- Credential path detection ---
+
+async function detectCredentialPath(): Promise<void> {
+  const onecliUrl = process.env.ONECLI_URL;
+  let source: 'onecli' | 'env' = 'env';
+
+  if (onecliUrl) {
+    try {
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(), 2000);
+      const res = await fetch(`${onecliUrl}/health`, { signal: ac.signal });
+      clearTimeout(timer);
+      if (res.ok) {
+        source = 'onecli';
+        console.error('[homeassistant] credential path: OneCLI (HA_URL + HA_TOKEN injected by vault)');
+      } else {
+        console.error(`[homeassistant] OneCLI responded HTTP ${res.status} — falling back to process.env`);
+      }
+    } catch {
+      console.error('[homeassistant] OneCLI unreachable (ONECLI_URL set but probe timed out or failed) — falling back to process.env');
+    }
+  } else {
+    console.error('[homeassistant] credential path: process.env (ONECLI_URL not set)');
+  }
+
+  const haUrl = process.env.HA_URL;
+  const haToken = process.env.HA_TOKEN;
+  const missing = [!haUrl && 'HA_URL', !haToken && 'HA_TOKEN'].filter(Boolean).join(', ');
+
+  if (missing) {
+    const hint = source === 'onecli'
+      ? `OneCLI is reachable but did not inject ${missing} — check your vault configuration.`
+      : `Set ${missing} in your .env file.`;
+    console.error(`[homeassistant] missing required credentials: ${missing}\n  ${hint}`);
+    process.exit(1);
+  }
+
+  console.error(`[homeassistant] credentials verified (source: ${source === 'onecli' ? 'OneCLI' : 'process.env'})`);
 }
 
 // --- MCP Server ---
@@ -135,6 +175,8 @@ mcpServer.tool(
     } catch (e) { return err(e); }
   },
 );
+
+await detectCredentialPath();
 
 const transport = new StdioServerTransport();
 await mcpServer.connect(transport);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -375,6 +375,7 @@ async function runQuery(
   prompt: string,
   sessionId: string | undefined,
   mcpServerPath: string,
+  homeassistantMcpServerPath: string,
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
@@ -469,6 +470,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__homeassistant__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -482,6 +484,14 @@ async function runQuery(
             NANOCLAW_CHAT_JID: containerInput.chatJid,
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        homeassistant: {
+          command: 'node',
+          args: [homeassistantMcpServerPath],
+          env: {
+            HA_URL: sdkEnv.HA_URL ?? '',
+            HA_TOKEN: sdkEnv.HA_TOKEN ?? '',
           },
         },
       },
@@ -630,6 +640,10 @@ async function main(): Promise<void> {
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const homeassistantMcpServerPath = path.join(
+    __dirname,
+    'homeassistant-mcp-stdio.js',
+  );
 
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
@@ -686,6 +700,7 @@ async function main(): Promise<void> {
         prompt,
         sessionId,
         mcpServerPath,
+        homeassistantMcpServerPath,
         containerInput,
         sdkEnv,
         resumeAt,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -268,6 +268,13 @@ async function buildContainerArgs(
     );
   }
 
+  if (process.env.HA_URL) {
+    args.push('-e', `HA_URL=${process.env.HA_URL}`);
+  }
+  if (process.env.HA_TOKEN) {
+    args.push('-e', `HA_TOKEN=${process.env.HA_TOKEN}`);
+  }
+
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -268,13 +268,6 @@ async function buildContainerArgs(
     );
   }
 
-  if (process.env.HA_URL) {
-    args.push('-e', `HA_URL=${process.env.HA_URL}`);
-  }
-  if (process.env.HA_TOKEN) {
-    args.push('-e', `HA_TOKEN=${process.env.HA_TOKEN}`);
-  }
-
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 


### PR DESCRIPTION
## Summary

Adds a Home Assistant REST API integration so the container agent can query and control a Home Assistant instance:

- **`homeassistant-mcp-stdio.ts`** — stdio MCP server wrapping the HA REST API, authenticated via a Long-Lived Access Token (`HA_URL` + `HA_TOKEN`)
- **`container/agent-runner/src/index.ts`** — registers the `homeassistant` MCP server and adds `mcp__homeassistant__*` to `allowedTools`
- **`.claude/skills/add-homeassistant/SKILL.md`** — `/add-homeassistant` skill guiding users through token creation, URL configuration, wiring, and verification

## Env var forwarding

The `HA_URL` / `HA_TOKEN` `-e` forwarding hunks that were originally part of this PR have been removed in a follow-up commit. Centralised MCP skill env forwarding now lives on `feat/matrix-channel` (#1624) via a `MCP_SKILL_ENV_KEYS` loop in `buildContainerArgs()`, which covers `HA_URL` and `HA_TOKEN` along with the rest of the MCP skill credentials. Once #1624 lands, those vars are forwarded automatically and this PR no longer needs to touch `container-runner.ts`.

## Tools exposed

| Tool | Description |
|------|-------------|
| `ha_get_states` | List all entity states, optionally filtered by domain (light, switch, climate, sensor, etc.) |
| `ha_get_state` | Get current state and attributes for a specific entity by entity_id |
| `ha_call_service` | Call any HA service — turn on lights, set thermostat, trigger automations/scripts |
| `ha_list_automations` | List all automations with friendly name, on/off state, and last triggered timestamp |
| `ha_get_history` | Get state history for an entity over the last N hours |

## Auth

Long-Lived Access Token created at **Profile → Long-Lived Access Tokens** in the HA UI. Token is passed as `HA_TOKEN`; `HA_URL` is the base URL of the HA instance (supports container name for same-network deployments, or host IP for host-network/remote).

## Prerequisites

- `HA_URL` and `HA_TOKEN` must be present in the NanoClaw container environment
- Forwarding into agent containers is provided by #1624's `MCP_SKILL_ENV_KEYS` loop — no longer carried in this PR

## Test plan

- [ ] Set `HA_URL` and `HA_TOKEN` in the environment
- [ ] Send "what lights are currently on?" — agent should call `mcp__homeassistant__ha_get_states` with domain `light`
- [ ] Send "turn off the living room light" — agent should call `mcp__homeassistant__ha_call_service`
- [ ] Send "has the front door sensor changed state today?" — agent should call `mcp__homeassistant__ha_get_history`
- [ ] Verify containers without `HA_*` vars get a clear error rather than silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)