### PR TITLE
feat: add Google Workspace CLI integration skill

### DIFF
--- a/.claude/skills/add-google-workspace/SKILL.md
+++ b/.claude/skills/add-google-workspace/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: add-google-workspace
+description: Add Google Workspace integration to NanoClaw. Gives agents access to Gmail, Calendar, Drive, Docs, Sheets, and more via a thin MCP wrapper around the gws CLI. Write operations require user confirmation. All calls are audit-logged.
+---
+
+# Add Google Workspace Integration
+
+This skill adds Google Workspace access to NanoClaw agents via a custom MCP server that wraps the [Google Workspace CLI](https://github.com/googleworkspace/cli) (`gws`). The MCP server exposes just 3 tools (discover, help, run) instead of gws's 200+ API methods, keeping the agent's context window clean.
+
+**Note:** gws previously shipped a built-in MCP mode (`gws mcp`) but removed it in v0.8.0 due to context bloat. This skill provides a curated alternative. If gws reintroduces a built-in MCP mode with a curated tool set, that would be preferable to this wrapper.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+```bash
+grep -q "gws-mcp-stdio" container/agent-runner/src/index.ts && echo "GWS_APPLIED=true" || echo "GWS_APPLIED=false"
+```
+
+If GWS_APPLIED=true, skip to Phase 3 (Host Setup).
+
+### Check host prerequisites
+
+```bash
+command -v gws >/dev/null 2>&1 && echo "GWS_INSTALLED=true" || echo "GWS_INSTALLED=false"
+ls ~/.config/gws/credentials.json 2>/dev/null && echo "GWS_AUTHENTICATED=true" || echo "GWS_AUTHENTICATED=false"
+```
+
+## Phase 2: Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git fetch upstream skill/google-workspace
+git merge upstream/skill/google-workspace || {
+  git checkout --theirs package-lock.json
+  git add package-lock.json
+  git merge --continue
+}
+```
+
+If `upstream` remote doesn't exist:
+
+```bash
+git remote add upstream https://github.com/qwibitai/nanoclaw.git
+git fetch upstream skill/google-workspace
+git merge upstream/skill/google-workspace
+```
+
+This merges in:
+- `container/agent-runner/src/gws-mcp-stdio.ts` — MCP server with 3 tools: gws_discover, gws_help, gws_run
+- `container/skills/google-workspace/SKILL.md` — container-side skill docs
+- `container/Dockerfile` — adds `@googleworkspace/cli` to global npm install
+- `container/agent-runner/src/index.ts` — registers the gws MCP server + allows `mcp__gws__*` tools
+- `src/container-runner.ts` — conditional read-only mount of `~/.config/gws/` into containers
+
+### Validate build
+
+```bash
+npm install
+npm run build
+```
+
+## Phase 3: Host Setup
+
+### Install Google Workspace CLI (if not installed)
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+### Authenticate (if not authenticated)
+
+Tell the user:
+
+> First, set up a Google Cloud project with OAuth:
+
+```bash
+gws auth setup
+```
+
+> Follow the prompts:
+> - Select "External" user type for personal accounts
+> - Add your email as a test user
+> - Choose "Desktop app" when creating OAuth client
+>
+> Then authenticate:
+
+```bash
+gws auth login
+```
+
+> Select the scopes you need (Gmail, Calendar, Drive, etc.).
+
+### Headless servers
+
+On headless servers, `gws auth login` won't work because it opens a browser. Two options:
+
+1. **SSH tunnel:** Authenticate on a machine with a browser using an SSH tunnel to forward the OAuth callback
+2. **Manual credentials:** Run `gws auth login` on a local machine, then copy `~/.config/gws/credentials.json` (containing client_id, client_secret, refresh_token) to the server. The MCP server handles token refresh automatically.
+
+### Verify authentication
+
+```bash
+gws auth status
+```
+
+## Phase 4: Rebuild and Restart
+
+```bash
+rm -r data/sessions/*/agent-runner-src 2>/dev/null || true
+cd container && ./build.sh && cd ..
+npm run build
+```
+
+Restart the service:
+
+```bash
+# macOS:
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux:
+systemctl --user restart nanoclaw
+```
+
+## Phase 5: Verify
+
+Ask the agent: "Check my calendar for today", "What are my recent emails?", or "Search Drive for quarterly report".
+
+## Key Features
+
+- **3-tool MCP design** — gws_discover, gws_help, gws_run. Avoids the context bloat of exposing 200+ API methods.
+- **Write guardrails** — write operations (send, create, update, delete) require nonce-based user confirmation. The agent must ask the user before executing.
+- **Audit logging** — every tool call logged to `{group}/logs/gws-audit.jsonl` with timestamps, classification, duration, and results.
+- **Auto token refresh** — the MCP server reads `credentials.json` and refreshes OAuth tokens automatically, working around gws's keyring-based credential storage that doesn't work in containers.
+
+## Troubleshooting
+
+- **"gws: command not found" in container** — rebuild the container image (`./container/build.sh`)
+- **"Authentication failed"** — run `gws auth login` on the host, or copy credentials.json for headless servers
+- **Token refresh fails** — check that `~/.config/gws/credentials.json` contains `client_id`, `client_secret`, and `refresh_token`
+- **Agent doesn't use gws tools** — verify `mcp__gws__*` is in allowedTools in `container/agent-runner/src/index.ts`
+- **Mount not appearing** — verify `~/.config/gws/` exists on the host. The mount is conditional.
+
+## Removal
+
+1. Remove gws MCP server registration and `mcp__gws__*` from allowedTools in `container/agent-runner/src/index.ts`
+2. Delete `container/agent-runner/src/gws-mcp-stdio.ts`
+3. Delete `container/skills/google-workspace/`
+4. Remove `@googleworkspace/cli` from the Dockerfile npm install line
+5. Remove the gws mount block from `src/container-runner.ts`
+6. Rebuild: `./container/build.sh && npm run build` and restart the service

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y \
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
-# Install agent-browser and claude-code globally
-RUN npm install -g agent-browser @anthropic-ai/claude-code
+# Install agent-browser, claude-code, and Google Workspace CLI globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code @googleworkspace/cli
 
 # Create app directory
 WORKDIR /app

--- a/container/agent-runner/src/gws-mcp-stdio.ts
+++ b/container/agent-runner/src/gws-mcp-stdio.ts
@@ -1,0 +1,459 @@
+/**
+ * Google Workspace MCP Server for NanoClaw
+ *
+ * Thin passthrough wrapper around the Google Workspace CLI (gws).
+ * Preserves gws's dynamic API discovery while adding:
+ * - Guardrails: write operations require user confirmation via nonce
+ * - Audit logging: every tool call logged to gws-audit.jsonl
+ *
+ * Three tools:
+ *   gws_discover  — list services or methods within a service
+ *   gws_help      — get usage/parameter docs for a command
+ *   gws_run       — execute any gws command (with guardrails)
+ *
+ * @see https://github.com/googleworkspace/cli
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+// --- Configuration ---
+
+const AUDIT_LOG_DIR = '/workspace/group/logs';
+const AUDIT_LOG_FILE = path.join(AUDIT_LOG_DIR, 'gws-audit.jsonl');
+const GWS_BIN = 'gws';
+const EXEC_TIMEOUT_MS = 120_000;
+const HELP_TIMEOUT_MS = 15_000;
+const DISCOVER_TIMEOUT_MS = 30_000;
+const NONCE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_OUTPUT_SIZE = 100 * 1024; // 100KB
+const GWS_CREDS_PATH = '/home/node/.config/gws/credentials.json';
+const GWS_CLIENT_PATH = '/home/node/.config/gws/client_secret.json';
+
+// --- Token management ---
+// gws expects encrypted credential storage which doesn't work in containers.
+// Instead, we read the mounted credentials.json (client_id + client_secret +
+// refresh_token) and inject a fresh access token via GOOGLE_WORKSPACE_CLI_TOKEN.
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getAccessToken(): Promise<string | null> {
+  // Return cached token if still valid (with 60s buffer)
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+
+  try {
+    if (!fs.existsSync(GWS_CREDS_PATH)) return null;
+    const creds = JSON.parse(fs.readFileSync(GWS_CREDS_PATH, 'utf-8'));
+
+    // If the file has client_id + refresh_token, exchange for access token
+    if (creds.client_id && creds.client_secret && creds.refresh_token) {
+      const params = new URLSearchParams({
+        client_id: creds.client_id,
+        client_secret: creds.client_secret,
+        refresh_token: creds.refresh_token,
+        grant_type: 'refresh_token',
+      });
+
+      const resp = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      });
+
+      if (!resp.ok) return null;
+      const data = await resp.json();
+      cachedToken = {
+        token: data.access_token,
+        expiresAt: Date.now() + (data.expires_in || 3600) * 1000,
+      };
+      return cachedToken.token;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// --- Nonce store for write confirmation ---
+
+const pendingNonces = new Map<string, { command: string; expiresAt: number }>();
+
+function generateNonce(command: string): string {
+  const nonce = crypto.randomBytes(16).toString('hex');
+  pendingNonces.set(nonce, {
+    command,
+    expiresAt: Date.now() + NONCE_EXPIRY_MS,
+  });
+  return nonce;
+}
+
+function consumeNonce(nonce: string, command: string): boolean {
+  const entry = pendingNonces.get(nonce);
+  if (!entry) return false;
+  pendingNonces.delete(nonce);
+  if (Date.now() > entry.expiresAt) return false;
+  // Verify the command matches what was originally requested
+  if (entry.command !== command) return false;
+  return true;
+}
+
+// Periodic cleanup of expired nonces
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of pendingNonces) {
+    if (now > entry.expiresAt) pendingNonces.delete(key);
+  }
+}, 60_000);
+
+// --- Operation classification ---
+
+const WRITE_PATTERNS = [
+  'create', 'insert', 'update', 'patch', 'delete', 'remove',
+  'trash', 'send', 'modify', 'copy', 'move', 'batchupdate',
+  'empty', 'import', 'untrash', 'archive', 'star', 'label',
+  'forward', 'reply', 'reply-all',
+  '+send', '+reply', '+reply-all', '+forward',
+];
+
+const READ_PATTERNS = [
+  'list', 'get', 'search', 'query', 'export', 'watch', 'resolve',
+  '+read', '+triage', '+watch',
+  'discover', 'help', '--help',
+];
+
+function classifyOperation(command: string): 'read' | 'write' {
+  const lower = command.toLowerCase();
+  const tokens = lower.split(/\s+/);
+
+  // Check read patterns first (more specific matches)
+  for (const token of tokens) {
+    if (READ_PATTERNS.some(p => token === p || token.endsWith(p))) {
+      return 'read';
+    }
+  }
+
+  // Check write patterns
+  for (const token of tokens) {
+    if (WRITE_PATTERNS.some(p => token === p || token.endsWith(p))) {
+      return 'write';
+    }
+  }
+
+  // Default to write (safe fallback)
+  return 'write';
+}
+
+// --- Audit logging ---
+
+interface AuditEntry {
+  timestamp: string;
+  tool: string;
+  command: string;
+  classification: 'read' | 'write' | 'discover' | 'help';
+  confirmed: boolean | null;
+  nonce?: string;
+  status: 'success' | 'error' | 'confirmation_required' | 'nonce_invalid';
+  duration_ms: number;
+  result_size: number;
+  error: string | null;
+}
+
+function writeAuditLog(entry: AuditEntry): void {
+  try {
+    fs.mkdirSync(AUDIT_LOG_DIR, { recursive: true });
+    fs.appendFileSync(AUDIT_LOG_FILE, JSON.stringify(entry) + '\n');
+  } catch {
+    // Audit logging should never break the tool
+  }
+}
+
+// --- Command execution ---
+
+async function execGws(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const token = await getAccessToken();
+  const env = { ...process.env };
+  if (token) {
+    env.GOOGLE_WORKSPACE_CLI_TOKEN = token;
+  }
+
+  return new Promise((resolve) => {
+    execFile(GWS_BIN, args, {
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+      env,
+    }, (error, stdout, stderr) => {
+      let output = stdout || '';
+      if (output.length > MAX_OUTPUT_SIZE) {
+        output = output.slice(0, MAX_OUTPUT_SIZE) + '\n... [output truncated at 100KB]';
+      }
+      resolve({
+        stdout: output,
+        stderr: stderr || '',
+        exitCode: error ? (error as NodeJS.ErrnoException & { code?: number }).code === 'ETIMEDOUT' ? 124 : 1 : 0,
+      });
+    });
+  });
+}
+
+/**
+ * Parse a command string into arguments, respecting shell quoting.
+ * Handles single quotes, double quotes, and backslash escapes.
+ */
+function parseCommand(command: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (const char of command) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && !inSingle) {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (char === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if ((char === ' ' || char === '\t') && !inSingle && !inDouble) {
+      if (current.length > 0) {
+        args.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) {
+    args.push(current);
+  }
+  return args;
+}
+
+// --- MCP Server ---
+
+const server = new McpServer({
+  name: 'gws',
+  version: '1.0.0',
+});
+
+// Tool descriptions include common examples so models have a starting point
+// without needing to call gws_discover first.
+
+server.tool(
+  'gws_discover',
+  `List available Google Workspace services, or list methods/commands within a specific service.
+Use this to find out what operations are available before calling gws_run.
+
+Examples:
+  gws_discover()                    → list all services
+  gws_discover({ service: "gmail" }) → list Gmail commands and methods
+  gws_discover({ service: "drive" }) → list Drive commands and methods
+
+Available services include: gmail, drive, sheets, calendar, slides, docs, people, chat, forms, keep, meet, admin, classroom, tasks`,
+  {
+    service: z.string().optional().describe('Service name to explore (e.g., "gmail", "drive", "calendar"). Omit to list all services.'),
+  },
+  async (args) => {
+    const start = Date.now();
+    const gwsArgs = args.service ? [args.service, '--help'] : ['--help'];
+
+    const result = await execGws(gwsArgs, DISCOVER_TIMEOUT_MS);
+
+    writeAuditLog({
+      timestamp: new Date().toISOString(),
+      tool: 'gws_discover',
+      command: args.service || '(all services)',
+      classification: 'discover',
+      confirmed: null,
+      status: result.exitCode === 0 ? 'success' : 'error',
+      duration_ms: Date.now() - start,
+      result_size: result.stdout.length,
+      error: result.exitCode !== 0 ? result.stderr : null,
+    });
+
+    const output = result.exitCode === 0
+      ? result.stdout
+      : `Error (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`;
+
+    return { content: [{ type: 'text' as const, text: output }] };
+  },
+);
+
+server.tool(
+  'gws_help',
+  `Get detailed help for a specific Google Workspace CLI command, including parameters and usage.
+
+Examples:
+  gws_help({ service: "gmail", command: "+send" })        → how to send email
+  gws_help({ service: "gmail", command: "+read" })         → how to read email
+  gws_help({ service: "calendar", command: "events list" }) → how to list events
+  gws_help({ service: "drive", command: "files list" })    → how to list files`,
+  {
+    service: z.string().describe('Service name (e.g., "gmail", "drive", "calendar")'),
+    command: z.string().optional().describe('Command or method to get help for (e.g., "+send", "files list"). Omit for service-level help.'),
+  },
+  async (args) => {
+    const start = Date.now();
+    const gwsArgs = [args.service];
+    if (args.command) {
+      gwsArgs.push(...args.command.split(/\s+/));
+    }
+    gwsArgs.push('--help');
+
+    const result = await execGws(gwsArgs, HELP_TIMEOUT_MS);
+
+    writeAuditLog({
+      timestamp: new Date().toISOString(),
+      tool: 'gws_help',
+      command: `${args.service} ${args.command || ''}`.trim(),
+      classification: 'help',
+      confirmed: null,
+      status: result.exitCode === 0 ? 'success' : 'error',
+      duration_ms: Date.now() - start,
+      result_size: result.stdout.length,
+      error: result.exitCode !== 0 ? result.stderr : null,
+    });
+
+    const output = result.exitCode === 0
+      ? result.stdout
+      : `Error (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`;
+
+    return { content: [{ type: 'text' as const, text: output }] };
+  },
+);
+
+server.tool(
+  'gws_run',
+  `Execute any Google Workspace CLI command. This is the main tool for interacting with Google Workspace services.
+
+IMPORTANT — WRITE OPERATIONS REQUIRE CONFIRMATION:
+When you call this with a write operation (send, create, update, delete, etc.), the tool will return a confirmation_required response with a nonce. You MUST then:
+1. Use send_message to ask the user for confirmation, showing them exactly what will happen
+2. Wait for the user to reply "yes" / "approve" / "go ahead" (or similar)
+3. Call gws_run again with the SAME command and the nonce to execute
+
+Read operations (list, get, search, read, triage) execute immediately.
+
+Examples:
+  gws_run({ command: "gmail +triage" })                                → list unread emails (read, immediate)
+  gws_run({ command: "gmail +read --id 18e4f2a" })                     → read an email (read, immediate)
+  gws_run({ command: "gmail +send --to user@example.com --subject 'Hello' --body 'Hi there'" }) → send email (write, needs confirmation)
+  gws_run({ command: "drive files list --q 'name contains report'" })  → list Drive files (read, immediate)
+  gws_run({ command: "calendar events list --calendarId primary" })    → list calendar events (read, immediate)
+  gws_run({ command: "sheets spreadsheets.values get --spreadsheetId ID --range A1:B10" }) → read sheet (read, immediate)`,
+  {
+    command: z.string().describe('The gws command to execute (without the "gws" prefix). E.g., "gmail +send --to user@example.com --subject Hello"'),
+    confirmed_nonce: z.string().optional().describe('Confirmation nonce returned by a previous confirmation_required response. Required for write operations.'),
+  },
+  async (args) => {
+    const start = Date.now();
+    const classification = classifyOperation(args.command);
+    const gwsArgs = parseCommand(args.command);
+
+    // Write operations require confirmation
+    if (classification === 'write') {
+      if (!args.confirmed_nonce) {
+        // First call — return confirmation request with nonce
+        const nonce = generateNonce(args.command);
+
+        writeAuditLog({
+          timestamp: new Date().toISOString(),
+          tool: 'gws_run',
+          command: args.command,
+          classification: 'write',
+          confirmed: false,
+          nonce,
+          status: 'confirmation_required',
+          duration_ms: Date.now() - start,
+          result_size: 0,
+          error: null,
+        });
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'confirmation_required',
+              operation: args.command,
+              nonce,
+              message: 'This write operation requires user confirmation. Send a message to the user describing what will happen, then call gws_run again with the same command and the confirmed_nonce parameter set to this nonce after they approve.',
+            }, null, 2),
+          }],
+        };
+      }
+
+      // Second call — verify nonce and execute
+      if (!consumeNonce(args.confirmed_nonce, args.command)) {
+        writeAuditLog({
+          timestamp: new Date().toISOString(),
+          tool: 'gws_run',
+          command: args.command,
+          classification: 'write',
+          confirmed: false,
+          nonce: args.confirmed_nonce,
+          status: 'nonce_invalid',
+          duration_ms: Date.now() - start,
+          result_size: 0,
+          error: 'Invalid, expired, or mismatched confirmation nonce',
+        });
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'Confirmation failed: invalid, expired, or mismatched nonce. Please start the confirmation flow again by calling gws_run without a nonce.',
+          }],
+          isError: true,
+        };
+      }
+    }
+
+    // Execute the command
+    const result = await execGws(gwsArgs, EXEC_TIMEOUT_MS);
+
+    writeAuditLog({
+      timestamp: new Date().toISOString(),
+      tool: 'gws_run',
+      command: args.command,
+      classification,
+      confirmed: classification === 'write' ? true : null,
+      nonce: args.confirmed_nonce || undefined,
+      status: result.exitCode === 0 ? 'success' : 'error',
+      duration_ms: Date.now() - start,
+      result_size: result.stdout.length,
+      error: result.exitCode !== 0 ? result.stderr : null,
+    });
+
+    if (result.exitCode !== 0) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Command failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`,
+        }],
+        isError: true,
+      };
+    }
+
+    return { content: [{ type: 'text' as const, text: result.stdout }] };
+  },
+);
+
+// Start the stdio transport
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -409,7 +409,8 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
+        'mcp__gws__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -423,6 +424,14 @@ async function runQuery(
             NANOCLAW_CHAT_JID: containerInput.chatJid,
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        gws: {
+          command: 'node',
+          args: [path.join(path.dirname(mcpServerPath), 'gws-mcp-stdio.js')],
+          env: {
+            NANOCLAW_CHAT_JID: containerInput.chatJid,
+            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
           },
         },
       },

--- a/container/skills/google-workspace/SKILL.md
+++ b/container/skills/google-workspace/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: google-workspace
+description: Access Google Workspace services (Gmail, Drive, Calendar, Sheets, Docs, Slides, People, Chat, Forms, Keep, Meet) via the gws CLI. Use when the user asks about email, calendar, files, spreadsheets, documents, or any Google Workspace service.
+---
+
+# Google Workspace Integration
+
+You have access to Google Workspace via three MCP tools. These tools wrap the `gws` CLI, which dynamically discovers all Google Workspace APIs.
+
+## Available Tools
+
+### `mcp__gws__gws_discover`
+List available services or explore methods within a service. Use this to find out what operations are available.
+
+### `mcp__gws__gws_help`
+Get detailed help for a specific command, including parameters and usage examples.
+
+### `mcp__gws__gws_run`
+Execute any gws command. This is the main tool for all Google Workspace operations.
+
+## Common Operations
+
+### Gmail
+```
+gws_run({ command: "gmail +triage" })                              # Unread inbox summary
+gws_run({ command: "gmail +read --id MESSAGE_ID" })                # Read a specific email
+gws_run({ command: "gmail +send --to user@example.com --subject 'Subject' --body 'Body'" })  # Send email (needs confirmation)
+gws_run({ command: "gmail +reply --id MESSAGE_ID --body 'Reply'" })  # Reply (needs confirmation)
+gws_run({ command: "gmail +forward --id MESSAGE_ID --to user@example.com" })  # Forward (needs confirmation)
+gws_run({ command: "gmail users.messages list --userId me --q 'from:someone@example.com'" })  # Search
+```
+
+### Calendar
+```
+gws_run({ command: "calendar events list --calendarId primary" })  # List upcoming events
+gws_run({ command: "calendar events insert --calendarId primary --requestBody '{...}'" })  # Create event (needs confirmation)
+```
+
+### Drive
+```
+gws_run({ command: "drive files list --q 'name contains report'" })  # Search files
+gws_run({ command: "drive files get --fileId FILE_ID" })            # Get file metadata
+```
+
+### Sheets
+```
+gws_run({ command: "sheets spreadsheets.values get --spreadsheetId ID --range 'Sheet1!A1:B10'" })  # Read cells
+gws_run({ command: "sheets spreadsheets.values update --spreadsheetId ID --range 'A1' --requestBody '{...}'" })  # Update (needs confirmation)
+```
+
+### Docs, Slides, People, Chat, Forms, Keep, Meet
+Use `gws_discover({ service: "SERVICE_NAME" })` to explore available operations for any service.
+
+## Write Operation Confirmation Flow
+
+Write operations (send, create, update, delete, etc.) require user confirmation:
+
+1. Call `gws_run` with the command → returns `confirmation_required` with a `nonce`
+2. Use `mcp__nanoclaw__send_message` to tell the user what you're about to do and ask for approval
+3. Wait for the user to approve
+4. Call `gws_run` again with the same command and `confirmed_nonce` set to the nonce
+
+**Never skip the confirmation flow for write operations.** The tool enforces this — write commands without a valid nonce will not execute.
+
+Read operations (list, get, search, read, triage) execute immediately without confirmation.
+
+## Audit Log
+
+All tool calls are logged to `/workspace/group/logs/gws-audit.jsonl` with timestamps, commands, classification, and results.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -177,6 +177,17 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Google Workspace CLI credentials (read-only)
+  // gws uses ~/.config/gws/ for OAuth tokens and client config
+  const gwsConfigDir = path.join(process.env.HOME || '/root', '.config', 'gws');
+  if (fs.existsSync(gwsConfigDir)) {
+    mounts.push({
+      hostPath: gwsConfigDir,
+      containerPath: '/home/node/.config/gws',
+      readonly: true,
+    });
+  }
+
   // Copy agent-runner source into a per-group writable location so agents
   // can customize it (add tools, change behavior) without affecting other
   // groups. Recompiled on container startup via entrypoint.sh.


### PR DESCRIPTION
● Summary

  - Custom MCP server wrapping the Google Workspace CLI (gws) with 3 tools: gws_discover, gws_help, gws_run
  - Write-operation guardrails via nonce-based confirmation (agent must ask user before sends, creates, deletes)
  - Audit logging of every tool call to gws-audit.jsonl
  - Auto token refresh for containerized environments (works around gws's keyring-based credential storage)

  Why a custom MCP wrapper?

  gws v0.8.0 removed its built-in gws mcp subcommand because exposing 200-400 API methods as individual tools caused context
  window bloat. This skill solves that with a thin wrapper that exposes just 3 tools -- the agent uses gws_discover to
  explore APIs dynamically, gws_help for parameter docs, and gws_run to execute commands.

  If gws reintroduces a built-in MCP mode with a curated tool set (rather than exposing every API method), that would be
  preferable to this wrapper.

  What's included

  ┌──────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
  │                     File                     │                          Purpose                           │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ container/agent-runner/src/gws-mcp-stdio.ts  │ MCP server (3 tools, guardrails, audit log, token refresh) │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ container/skills/google-workspace/SKILL.md   │ Container-side skill docs for the agent                    │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ .claude/skills/add-google-workspace/SKILL.md │ Host-side install instructions (/add-google-workspace)     │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ container/Dockerfile                         │ Adds @googleworkspace/cli to global npm install            │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ container/agent-runner/src/index.ts          │ Registers gws MCP server + allows mcp__gws__* tools        │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
  │ src/container-runner.ts                      │ Conditional read-only mount of ~/.config/gws/ credentials  │
  └──────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘

  How it works

  1. User runs /add-google-workspace -- merges skill branch + walks through OAuth setup
  2. Host mounts ~/.config/gws/ (credentials) into container read-only
  3. MCP server starts alongside the agent, reads credentials, auto-refreshes tokens
  4. Agent calls gws_discover/gws_help to explore APIs, gws_run to execute
  5. Read operations execute immediately; write operations return a nonce that requires user confirmation

  Type of Change

  - Feature skill - adds a channel or integration (source code changes + SKILL.md)

  Test plan

  - PII scan -- no personal info in any committed files
  - Build passes (npm run build)
  - Tested with Gmail (triage, read, send with confirmation), Calendar (list events), Drive (list files), Sheets (read cells)
  - Confirmed write guardrails block unapproved operations
  - Confirmed conditional mount skips cleanly when ~/.config/gws/ doesn't exist
  - Audit log writes correctly to {group}/logs/gws-audit.jsonl

  For Skills

  - SKILL.md contains instructions, not inline code (code goes in separate files)
  - SKILL.md is under 500 lines
  - I tested this skill on a fresh clone

  Closes #1122