### PR TITLE
fix: prevent duplicate task runs, clean up orphaned tasks, and harden IPC

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -4,6 +4,9 @@ import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
+
+const MAX_IPC_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+const MAX_OUTBOUND_MESSAGE_LENGTH = 50_000;
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
@@ -73,15 +76,29 @@ export function startIpcWatcher(deps: IpcDeps): void {
           for (const file of messageFiles) {
             const filePath = path.join(messagesDir, file);
             try {
+              const stat = fs.statSync(filePath);
+              if (stat.size > MAX_IPC_FILE_SIZE) {
+                const errorDir = path.join(ipcBaseDir, 'errors');
+                fs.mkdirSync(errorDir, { recursive: true });
+                fs.renameSync(filePath, path.join(errorDir, `${sourceGroup}-${file}`));
+                logger.warn({ filePath, size: stat.size }, 'IPC file exceeds size limit, moved to errors');
+                continue;
+              }
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               if (data.type === 'message' && data.chatJid && data.text) {
+                // Truncate oversized outbound messages
+                let text = data.text as string;
+                if (text.length > MAX_OUTBOUND_MESSAGE_LENGTH) {
+                  logger.warn({ length: text.length, chatJid: data.chatJid }, 'Truncating outbound IPC message');
+                  text = text.slice(0, MAX_OUTBOUND_MESSAGE_LENGTH) + '\n[truncated]';
+                }
                 // Authorization: verify this group can send to this chatJid
                 const targetGroup = registeredGroups[data.chatJid];
                 if (
                   isMain ||
                   (targetGroup && targetGroup.folder === sourceGroup)
                 ) {
-                  await deps.sendMessage(data.chatJid, data.text);
+                  await deps.sendMessage(data.chatJid, text);
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup },
                     'IPC message sent',
@@ -124,6 +141,14 @@ export function startIpcWatcher(deps: IpcDeps): void {
           for (const file of taskFiles) {
             const filePath = path.join(tasksDir, file);
             try {
+              const stat = fs.statSync(filePath);
+              if (stat.size > MAX_IPC_FILE_SIZE) {
+                const errorDir = path.join(ipcBaseDir, 'errors');
+                fs.mkdirSync(errorDir, { recursive: true });
+                fs.renameSync(filePath, path.join(errorDir, `${sourceGroup}-${file}`));
+                logger.warn({ filePath, size: stat.size }, 'IPC file exceeds size limit, moved to errors');
+                continue;
+              }
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               // Pass source group identity to processTaskIpc for authorization
               await processTaskIpc(data, sourceGroup, isMain, deps);

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -250,6 +250,15 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
   schedulerRunning = true;
   logger.info('Scheduler loop started');
 
+  // Clean up orphaned once tasks: if active with null next_run, was mid-execution during crash
+  const allTasks = getAllTasks();
+  for (const task of allTasks) {
+    if (task.schedule_type === 'once' && task.status === 'active' && !task.next_run) {
+      updateTaskAfterRun(task.id, null, 'Cleaned up: orphaned after crash');
+      logger.info({ taskId: task.id }, 'Cleaned up orphaned once task');
+    }
+  }
+
   const loop = async () => {
     try {
       const dueTasks = getDueTasks();
@@ -262,6 +271,15 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
         const currentTask = getTaskById(task.id);
         if (!currentTask || currentTask.status !== 'active') {
           continue;
+        }
+
+        // Pre-advance next_run so the task won't be re-picked on the next poll
+        // if execution takes longer than the scheduler interval.
+        if (currentTask.schedule_type !== 'once') {
+          const advancedNextRun = computeNextRun(currentTask);
+          if (advancedNextRun) {
+            updateTask(currentTask.id, { next_run: advancedNextRun });
+          }
         }
 
         deps.queue.enqueueTask(currentTask.chat_jid, currentTask.id, () =>


### PR DESCRIPTION
## Summary

- **Task scheduler duplicate run prevention:** Pre-advance `next_run` before enqueueing recurring tasks, so slow-running tasks (>60s) aren't picked up again on the next scheduler poll
- **Orphaned `once` task cleanup:** On scheduler startup, mark `once` tasks that are `active` with `null` next_run as completed — these were mid-execution when the process crashed
- **IPC file size limit (1MB):** Oversized IPC files are moved to `data/ipc/errors/` instead of being processed, preventing memory issues from malformed or excessively large container output
- **IPC message truncation (50k chars):** Outbound messages exceeding 50,000 characters are truncated with a `[truncated]` suffix

## Test plan

- [ ] Verify existing scheduler tests still pass
- [ ] Verify a recurring task with >60s execution doesn't run twice
- [ ] Verify a `once` task orphaned by a crash is cleaned up on restart
- [ ] Verify an IPC file >1MB is moved to errors directory
- [ ] Verify an outbound message >50k chars is truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)