### PR TITLE
Add Room API proxy for music-gen and facebook services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,14 @@
 
+# ─── Room Platform API (optional) ────────────────────────────────────────────
+# Shared secret for authenticating to Room's self-hosted services (music-gen, facebook-page-manager).
+# This is the same SELF_HOSTED_API_SECRET used in your Room Cloudflare Worker environment.
+# SELF_HOSTED_API_SECRET=
+
+# Room Worker API base URL (default: https://room1.attyzen.com)
+# ROOM_API_URL=https://room1.attyzen.com
+
+# Music Gen service URL (default: https://music-gen-container.attyzen.com)
+# MUSIC_GEN_SERVICE_URL=https://music-gen-container.attyzen.com
+
+# Facebook Page Manager service URL (default: https://facebook-page-manager-container.attyzen.com)
+# FACEBOOK_SERVICE_URL=https://facebook-page-manager-container.attyzen.com

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -20,6 +20,48 @@ const chatJid = process.env.NANOCLAW_CHAT_JID!;
 const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
 const isMain = process.env.NANOCLAW_IS_MAIN === '1';
 
+// Room API proxy URL (optional — set by container-runner when SELF_HOSTED_API_SECRET configured)
+const roomApiUrl = process.env.ROOM_API_URL || '';
+
+// ─── Room API HTTP helper ───────────────────────────────────────────────────
+
+async function roomApiFetch(
+  path: string,
+  options: { method?: string; body?: string } = {},
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  if (!roomApiUrl) {
+    return { ok: false, status: 503, data: { error: 'Room API not configured. Set SELF_HOSTED_API_SECRET in .env on the host.' } };
+  }
+
+  const url = `${roomApiUrl}${path}`;
+  const method = options.method || 'GET';
+
+  try {
+    const resp = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: options.body,
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    let data: unknown;
+    const contentType = resp.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      data = await resp.json();
+    } else if (contentType.includes('audio') || contentType.includes('octet-stream')) {
+      // Binary response — return size info, actual download handled by music_download
+      data = { type: 'binary', contentType, size: resp.headers.get('content-length') };
+    } else {
+      data = { raw: await resp.text() };
+    }
+
+    return { ok: resp.ok, status: resp.status, data };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 0, data: { error: `Request failed: ${message}` } };
+  }
+}
+
 function writeIpcFile(dir: string, data: object): string {
   fs.mkdirSync(dir, { recursive: true });
 
@@ -329,6 +371,211 @@ Use available_groups.json to find the JID for a group. The folder name must be c
 
     return {
       content: [{ type: 'text' as const, text: `Group "${args.name}" registered. It will start receiving messages immediately.` }],
+    };
+  },
+);
+
+// ─── Room Music Gen Tools ───────────────────────────────────────────────────
+
+server.tool(
+  'music_generate',
+  `Generate an AI music track using Room's Music Gen service (ACE-Step).
+Submit a job and get back a job_id to poll for completion.
+Returns the job_id immediately — generation takes 30s-5min depending on duration.
+
+Common genres: pop, rock, electronic, hip-hop, jazz, classical, lo-fi, ambient, synthwave, cinematic, chiptune
+Moods: happy, sad, energetic, calm, dark, uplifting, melancholic, epic, dreamy, mysterious
+Vocal types: "male vocal", "female vocal", "duet", "no vocal", "a cappella"
+Tempos: very-slow, slow, moderate, fast, very-fast
+
+For lyrics, use structure tags: [Verse 1], [Chorus], [Bridge], [Instrumental], [Intro], [Outro].
+Use "[inst]" for purely instrumental tracks. Keep 6-10 syllables per line.`,
+  {
+    title: z.string().optional().describe('Track title'),
+    genre: z.string().describe('Music genre (e.g. "lo-fi", "cinematic", "pop")'),
+    mood: z.string().optional().describe('Emotional mood (e.g. "calm", "epic", "melancholic")'),
+    vocal_type: z.string().optional().describe('Vocal style: "male vocal", "female vocal", "no vocal", etc.'),
+    tempo: z.string().optional().describe('Speed: very-slow, slow, moderate, fast, very-fast'),
+    bpm: z.number().optional().describe('Exact BPM (60-220)'),
+    key: z.string().optional().describe('Musical key (e.g. "C major", "A minor")'),
+    duration: z.number().default(60).describe('Length in seconds (30, 60, 90, 120, 180)'),
+    instruments: z.array(z.string()).optional().describe('Instruments to use (e.g. ["piano", "guitar", "strings"])'),
+    texture: z.array(z.string()).optional().describe('Production feel: warm, crisp, bright, dark, airy, punchy, lush, vintage'),
+    lyrics: z.string().optional().describe('Song lyrics with structure tags [Verse], [Chorus], etc. Use "[inst]" for instrumental.'),
+    prompt: z.string().optional().describe('Free-text description of desired music'),
+  },
+  async (args) => {
+    const result = await roomApiFetch('/music-gen/jobs', {
+      method: 'POST',
+      body: JSON.stringify(args),
+    });
+
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Music generation failed (${result.status}): ${JSON.stringify(result.data)}` }],
+        isError: true,
+      };
+    }
+
+    const data = result.data as { job_id?: string };
+    return {
+      content: [{ type: 'text' as const, text: `Music generation job submitted!\nJob ID: ${data.job_id}\n\nUse music_status to check progress, then music_download when completed.` }],
+    };
+  },
+);
+
+server.tool(
+  'music_status',
+  'Check the status of a music generation job. Returns: queued, processing, completed, or failed.',
+  {
+    job_id: z.string().describe('The job ID returned by music_generate'),
+  },
+  async (args) => {
+    const result = await roomApiFetch(`/music-gen/jobs/${args.job_id}`);
+
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Failed to get status (${result.status}): ${JSON.stringify(result.data)}` }],
+        isError: true,
+      };
+    }
+
+    const data = result.data as { status?: string; queue_position?: number; progress?: number };
+    const parts = [`Status: ${data.status}`];
+    if (data.queue_position !== undefined) parts.push(`Queue position: ${data.queue_position}`);
+    if (data.progress !== undefined) parts.push(`Progress: ${data.progress}%`);
+
+    return { content: [{ type: 'text' as const, text: parts.join('\n') }] };
+  },
+);
+
+server.tool(
+  'music_download',
+  'Download the generated audio file (MP3) for a completed music job. Saves to the group workspace.',
+  {
+    job_id: z.string().describe('The job ID of a completed music generation job'),
+    filename: z.string().optional().describe('Output filename (default: {job_id}.mp3). Saved to /workspace/group/'),
+  },
+  async (args) => {
+    if (!roomApiUrl) {
+      return {
+        content: [{ type: 'text' as const, text: 'Room API not configured.' }],
+        isError: true,
+      };
+    }
+
+    const url = `${roomApiUrl}/music-gen/jobs/${args.job_id}/audio?format=mp3`;
+
+    try {
+      const resp = await fetch(url, {
+        headers: { 'Content-Type': 'application/json', 'Accept': 'audio/mpeg' },
+        signal: AbortSignal.timeout(120_000),
+      });
+
+      if (!resp.ok) {
+        return {
+          content: [{ type: 'text' as const, text: `Download failed (${resp.status}). Job may still be processing — check music_status first.` }],
+          isError: true,
+        };
+      }
+
+      const buffer = Buffer.from(await resp.arrayBuffer());
+      const outName = args.filename || `${args.job_id}.mp3`;
+      const outPath = path.join('/workspace/group', outName);
+      fs.writeFileSync(outPath, buffer);
+
+      const sizeMb = (buffer.length / (1024 * 1024)).toFixed(2);
+      return {
+        content: [{ type: 'text' as const, text: `Audio saved: ${outPath} (${sizeMb} MB)\nYou can share this file with the user via send_message.` }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: `Download error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ─── Room Facebook Page Manager Tools ───────────────────────────────────────
+
+server.tool(
+  'facebook_list_pages',
+  'List all Facebook pages managed by the Room Facebook Page Manager service.',
+  {},
+  async () => {
+    const result = await roomApiFetch('/facebook/pages');
+
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Failed to list pages (${result.status}): ${JSON.stringify(result.data)}` }],
+        isError: true,
+      };
+    }
+
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result.data, null, 2) }] };
+  },
+);
+
+server.tool(
+  'facebook_approval_queue',
+  'View the Facebook content approval queue. Shows posts/comments/messages waiting for human review before publishing.',
+  {
+    status: z.enum(['pending', 'approved', 'rejected']).default('pending').describe('Filter by approval status'),
+  },
+  async (args) => {
+    const result = await roomApiFetch(`/facebook/approval?status=${args.status}`);
+
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Failed to get approval queue (${result.status}): ${JSON.stringify(result.data)}` }],
+        isError: true,
+      };
+    }
+
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result.data, null, 2) }] };
+  },
+);
+
+server.tool(
+  'facebook_approval_action',
+  'Approve, reject, or regenerate a Facebook content item in the approval queue.',
+  {
+    item_id: z.string().describe('The approval item ID'),
+    action: z.enum(['approve', 'reject', 'regenerate']).describe('Action to take'),
+    reason: z.string().optional().describe('Reason for rejection, or instructions for regeneration'),
+  },
+  async (args) => {
+    const body = args.reason ? JSON.stringify({ reason: args.reason, instructions: args.reason }) : '{}';
+
+    const result = await roomApiFetch(`/facebook/approval/${args.item_id}/${args.action}`, {
+      method: 'POST',
+      body,
+    });
+
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Action failed (${result.status}): ${JSON.stringify(result.data)}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: `${args.action} action completed for item ${args.item_id}.\n${JSON.stringify(result.data, null, 2)}` }],
+    };
+  },
+);
+
+server.tool(
+  'facebook_health',
+  'Check the health and status of the Facebook Page Manager service.',
+  {},
+  async () => {
+    const result = await roomApiFetch('/facebook/health');
+    return {
+      content: [{ type: 'text' as const, text: result.ok
+        ? `Facebook service healthy: ${JSON.stringify(result.data, null, 2)}`
+        : `Facebook service unreachable (${result.status}): ${JSON.stringify(result.data)}` }],
     };
   },
 );

--- a/container/skills/room-facebook/SKILL.md
+++ b/container/skills/room-facebook/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: room-facebook
+description: Manage Facebook Pages via the Room Facebook Page Manager service. View pages, check post approval queue, approve/reject posts, sync configs, and monitor service health. Use when users ask about Facebook page management, social media posting, or content approval.
+allowed-tools: Bash(curl:*), Bash(cat:*), WebFetch
+---
+
+# Facebook Page Manager via Room API
+
+Manage Facebook Pages through the Room Facebook Page Manager service.
+All requests go through `$ROOM_API_URL/facebook/` — the proxy handles authentication (HMAC signatures).
+
+## Prerequisites
+
+The `ROOM_API_URL` environment variable must be set (injected automatically by NanoClaw).
+Check with: `echo $ROOM_API_URL`
+
+## Check Service Health
+
+```bash
+curl -s "$ROOM_API_URL/facebook/health"
+```
+
+## List Managed Pages
+
+```bash
+curl -s "$ROOM_API_URL/facebook/pages"
+```
+
+**Response:**
+```json
+{
+  "pages": [
+    {
+      "pageId": "123456",
+      "name": "My Business Page",
+      "category": "Business",
+      "status": "active"
+    }
+  ]
+}
+```
+
+## View Approval Queue
+
+List pending posts waiting for approval:
+
+```bash
+# Pending items (default)
+curl -s "$ROOM_API_URL/facebook/approval?status=pending"
+
+# Approved items
+curl -s "$ROOM_API_URL/facebook/approval?status=approved"
+
+# Rejected items
+curl -s "$ROOM_API_URL/facebook/approval?status=rejected"
+```
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "id": "appr_123",
+      "pageId": "123456",
+      "pageName": "My Business Page",
+      "content": "Check out our new product launch!",
+      "mediaUrls": [],
+      "scheduledFor": "2026-03-29T10:00:00Z",
+      "status": "pending",
+      "createdAt": "2026-03-28T15:00:00Z"
+    }
+  ]
+}
+```
+
+## Approve a Post
+
+```bash
+curl -s -X POST "$ROOM_API_URL/facebook/approval/{id}/approve" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+## Reject a Post
+
+```bash
+curl -s -X POST "$ROOM_API_URL/facebook/approval/{id}/reject" \
+  -H "Content-Type: application/json" \
+  -d '{"reason": "Content needs revision"}'
+```
+
+## Regenerate Post Content
+
+```bash
+curl -s -X POST "$ROOM_API_URL/facebook/approval/{id}/regenerate" \
+  -H "Content-Type: application/json" \
+  -d '{"instructions": "Make it more engaging and add a call-to-action"}'
+```
+
+## Get Service Configuration
+
+```bash
+curl -s "$ROOM_API_URL/facebook/config"
+```
+
+## Sync Page Tokens
+
+Sync page access tokens from the Room database to the Facebook service:
+
+```bash
+curl -s -X POST "$ROOM_API_URL/api/admin/facebook/sync-pages" \
+  -H "Content-Type: application/json"
+```
+
+## Sync Configuration
+
+Push all `facebook.*` configs from Room DB to the service:
+
+```bash
+curl -s -X POST "$ROOM_API_URL/api/admin/facebook/sync-config" \
+  -H "Content-Type: application/json"
+```
+
+## Get Full Service Status (via Room Worker)
+
+For a comprehensive status check including health + config + secrets status:
+
+```bash
+curl -s "$ROOM_API_URL/api/admin/facebook/status"
+```
+
+## Example: Review and Approve Pending Posts
+
+```bash
+# 1. Check pending approvals
+PENDING=$(curl -s "$ROOM_API_URL/facebook/approval?status=pending")
+echo "$PENDING" | python3 -m json.tool 2>/dev/null || echo "$PENDING"
+
+# 2. Approve a specific post
+curl -s -X POST "$ROOM_API_URL/facebook/approval/appr_123/approve" \
+  -H "Content-Type: application/json" -d '{}'
+
+# 3. Notify user
+# Use send_message tool: "Approved post appr_123 for publishing."
+```
+
+## Example: Monitor Service Health
+
+```bash
+# Check health
+HEALTH=$(curl -s "$ROOM_API_URL/facebook/health")
+echo "Service health: $HEALTH"
+
+# Check managed pages
+PAGES=$(curl -s "$ROOM_API_URL/facebook/pages")
+echo "Managed pages: $PAGES"
+
+# Check pending items count
+PENDING=$(curl -s "$ROOM_API_URL/facebook/approval?status=pending")
+COUNT=$(echo "$PENDING" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('items',[])))" 2>/dev/null || echo "?")
+echo "Pending approvals: $COUNT"
+```
+
+## Tips
+
+- Always check service health before performing operations
+- Use `send_message` to notify users about approval decisions
+- The Facebook service handles rate limiting automatically
+- Post scheduling is managed by the service — just approve/reject in the queue
+- For content generation, combine with Claude's writing capabilities before submitting

--- a/container/skills/room-music/SKILL.md
+++ b/container/skills/room-music/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: room-music
+description: Generate music tracks using the Room Music Gen AI service. Submit generation jobs with genre, mood, lyrics, instruments, and get back audio files. Use when users ask for music creation, song generation, or audio production.
+allowed-tools: Bash(curl:*), Bash(cat:*), WebFetch
+---
+
+# Music Generation via Room API
+
+Generate AI music tracks using the Room Music Gen service (ACE-Step).
+All requests go through `$ROOM_API_URL/music-gen/` — the proxy handles authentication.
+
+## Prerequisites
+
+The `ROOM_API_URL` environment variable must be set (injected automatically by NanoClaw).
+Check with: `echo $ROOM_API_URL`
+
+## Submit a Generation Job
+
+```bash
+curl -s -X POST "$ROOM_API_URL/music-gen/jobs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Sunset Vibes",
+    "genre": "lo-fi",
+    "mood": "calm",
+    "vocal_type": "no vocal",
+    "tempo": "slow",
+    "bpm": 80,
+    "duration": 60,
+    "instruments": ["piano", "soft drums", "vinyl crackle"],
+    "texture": ["warm", "vintage", "lo-fi"],
+    "prompt": "relaxing lo-fi beat for studying, warm piano chords"
+  }'
+```
+
+**Response:** `{"job_id": "abc123"}`
+
+## Check Job Status
+
+```bash
+curl -s "$ROOM_API_URL/music-gen/jobs/{job_id}"
+```
+
+**Response:** `{"status": "completed", "progress": 100}` or `{"status": "processing", "queue_position": 2}`
+
+Possible statuses: `queued`, `processing`, `completed`, `failed`
+
+## Download Audio
+
+```bash
+curl -s "$ROOM_API_URL/music-gen/jobs/{job_id}/audio?format=mp3" \
+  -H "Accept: audio/mpeg" \
+  -o /workspace/group/music-output.mp3
+```
+
+## Job Parameters Reference
+
+| Parameter | Type | Description | Examples |
+|-----------|------|-------------|----------|
+| `title` | string | Track title | "Midnight Rain" |
+| `genre` | string | Music genre | pop, rock, electronic, hip-hop, jazz, classical, lo-fi, ambient, synthwave, cinematic, chiptune |
+| `mood` | string | Emotional mood | happy, sad, energetic, calm, dark, uplifting, melancholic, epic, dreamy, mysterious |
+| `vocal_type` | string | Vocal style | "male vocal", "female vocal", "duet", "no vocal", "a cappella" |
+| `tempo` | string | Speed | very-slow, slow, moderate, fast, very-fast |
+| `bpm` | number | Exact BPM (60-220) | 120 |
+| `key` | string | Musical key | "C major", "A minor", "G major" |
+| `duration` | number | Length in seconds | 30, 60, 90, 120, 180 |
+| `instruments` | string[] | Instruments to use | ["piano", "guitar", "strings", "synth pad"] |
+| `texture` | string[] | Production feel | warm, crisp, bright, dark, airy, punchy, lush, raw, polished, vintage |
+| `lyrics` | string | Song lyrics with structure tags | See lyrics format below |
+| `prompt` | string | Free-text description | "epic orchestral battle theme" |
+
+## Lyrics Format (ACE-Step)
+
+Use structure tags for best results:
+
+```
+[Intro - Solo piano, gentle]
+
+[Verse 1]
+Walking through the empty streets at night
+City lights reflecting in the rain
+
+[Chorus - Building emotion]
+We were infinite we were gold
+Now I'm standing in the cold
+
+[Instrumental - Strings swell]
+
+[Chorus - Full power]
+We were infinite we were gold
+
+[Outro - Piano only, fading]
+```
+
+- Use `[inst]` for purely instrumental tracks
+- Keep 6-10 syllables per line for natural pacing
+- ACE-Step sings ~2-3 words/second
+
+## Example: Full Workflow
+
+```bash
+# 1. Submit job
+JOB=$(curl -s -X POST "$ROOM_API_URL/music-gen/jobs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Battle Theme",
+    "genre": "cinematic",
+    "mood": "epic",
+    "vocal_type": "no vocal",
+    "bpm": 140,
+    "duration": 90,
+    "instruments": ["orchestra", "drums", "brass", "choir"],
+    "texture": ["bright", "punchy"],
+    "prompt": "epic orchestral battle theme, intense and heroic"
+  }')
+echo "$JOB"
+
+# 2. Extract job_id
+JOB_ID=$(echo "$JOB" | grep -o '"job_id":"[^"]*"' | cut -d'"' -f4)
+
+# 3. Poll status until completed
+while true; do
+  STATUS=$(curl -s "$ROOM_API_URL/music-gen/jobs/$JOB_ID")
+  echo "$STATUS"
+  echo "$STATUS" | grep -q '"completed"' && break
+  echo "$STATUS" | grep -q '"failed"' && { echo "Job failed"; break; }
+  sleep 5
+done
+
+# 4. Download audio
+curl -s "$ROOM_API_URL/music-gen/jobs/$JOB_ID/audio?format=mp3" \
+  -o /workspace/group/battle-theme.mp3
+echo "Saved to /workspace/group/battle-theme.mp3"
+```
+
+## Tips
+
+- Duration affects cost: 30s is fast, 180s takes longer
+- For vocal tracks, always provide lyrics with structure tags
+- Use `send_message` tool to notify the user while waiting for generation
+- Generated audio files can be shared via `send_message` or saved to the group workspace

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,3 +71,7 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// Room API proxy port (shares the credential proxy port — path-based routing)
+// Containers access Room APIs via: http://host.docker.internal:{CREDENTIAL_PROXY_PORT}/room-api/
+export const ROOM_API_PROXY_PORT = CREDENTIAL_PROXY_PORT;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -25,7 +25,7 @@ import {
   readonlyMountArgs,
   stopContainer,
 } from './container-runtime.js';
-import { detectAuthMode } from './credential-proxy.js';
+import { detectAuthMode, isRoomApiConfigured } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
@@ -236,6 +236,15 @@ function buildContainerArgs(
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
   } else {
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
+  }
+
+  // Room API proxy: containers call /room-api/* on the same credential proxy
+  // to access music-gen and facebook-page-manager services securely.
+  if (isRoomApiConfigured()) {
+    args.push(
+      '-e',
+      `ROOM_API_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}/room-api`,
+    );
   }
 
   // Runtime-specific args for host gateway resolution

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -43,10 +43,7 @@ function signFacebookRequest(
   body: string,
 ): string {
   const payload = `${method}\n${path}\n${timestamp}\n${body}`;
-  return crypto
-    .createHmac('sha256', secret)
-    .update(payload)
-    .digest('base64');
+  return crypto.createHmac('sha256', secret).update(payload).digest('base64');
 }
 
 /** Route a Room API request to the correct upstream service with auth. */
@@ -211,14 +208,12 @@ export function startCredentialProxy(
         }
 
         // ── Anthropic API proxy (default) ────────────────────────────
-        const headers: Record<
-          string,
-          string | number | string[] | undefined
-        > = {
-          ...(req.headers as Record<string, string>),
-          host: upstreamUrl.host,
-          'content-length': body.length,
-        };
+        const headers: Record<string, string | number | string[] | undefined> =
+          {
+            ...(req.headers as Record<string, string>),
+            host: upstreamUrl.host,
+            'content-length': body.length,
+          };
 
         // Strip hop-by-hop headers that must not be forwarded by proxies
         delete headers['connection'];

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -9,10 +9,17 @@
  *             API key via /api/oauth/claude_cli/create_api_key.
  *             Proxy injects real OAuth token on that exchange request;
  *             subsequent requests carry the temp key which is valid as-is.
+ *
+ * Room API proxy:
+ *   Requests with path prefix /room-api/ are forwarded to the Room platform
+ *   API (e.g. room1.attyzen.com). The proxy injects SELF_HOSTED_API_SECRET
+ *   as X-Api-Secret header for music-gen, and generates HMAC signatures for
+ *   facebook-page-manager requests. Containers never see these secrets.
  */
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
+import crypto from 'crypto';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
@@ -23,6 +30,114 @@ export interface ProxyConfig {
   authMode: AuthMode;
 }
 
+// ─── Room API proxy helpers ─────────────────────────────────────────────────
+
+const ROOM_API_PREFIX = '/room-api/';
+
+/** Generate HMAC-SHA256 signature for facebook-page-manager server-to-server auth. */
+function signFacebookRequest(
+  secret: string,
+  method: string,
+  path: string,
+  timestamp: string,
+  body: string,
+): string {
+  const payload = `${method}\n${path}\n${timestamp}\n${body}`;
+  return crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('base64');
+}
+
+/** Route a Room API request to the correct upstream service with auth. */
+function handleRoomApiRequest(
+  req: { url?: string; method?: string },
+  res: import('http').ServerResponse,
+  body: Buffer,
+  roomSecrets: {
+    roomApiUrl: string;
+    selfHostedApiSecret: string;
+    musicGenServiceUrl: string;
+    facebookServiceUrl: string;
+  },
+): void {
+  const reqPath = (req.url || '').slice(ROOM_API_PREFIX.length - 1); // keep leading /
+  const method = (req.method || 'GET').toUpperCase();
+  const bodyStr = body.toString();
+
+  let targetUrl: URL;
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'content-length': String(body.length),
+  };
+
+  if (reqPath.startsWith('/music-gen/')) {
+    // Music-gen service: strip /music-gen prefix, add X-Api-Secret
+    const servicePath = reqPath.slice('/music-gen'.length);
+    targetUrl = new URL(servicePath, roomSecrets.musicGenServiceUrl);
+    if (roomSecrets.selfHostedApiSecret) {
+      headers['x-api-secret'] = roomSecrets.selfHostedApiSecret;
+    }
+  } else if (reqPath.startsWith('/facebook/')) {
+    // Facebook page manager: strip /facebook prefix, add Bearer + HMAC
+    const servicePath = reqPath.slice('/facebook'.length);
+    targetUrl = new URL(servicePath, roomSecrets.facebookServiceUrl);
+    if (roomSecrets.selfHostedApiSecret) {
+      const timestamp = Date.now().toString();
+      const signature = signFacebookRequest(
+        roomSecrets.selfHostedApiSecret,
+        method,
+        servicePath,
+        timestamp,
+        bodyStr,
+      );
+      headers['authorization'] = `Bearer ${roomSecrets.selfHostedApiSecret}`;
+      headers['x-request-timestamp'] = timestamp;
+      headers['x-request-signature'] = signature;
+    }
+  } else if (reqPath.startsWith('/api/')) {
+    // Room Worker API (room1.attyzen.com/api/...): pass through with auth cookie/header
+    targetUrl = new URL(reqPath, roomSecrets.roomApiUrl);
+    if (roomSecrets.selfHostedApiSecret) {
+      headers['x-api-secret'] = roomSecrets.selfHostedApiSecret;
+    }
+  } else {
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: `Unknown Room API route: ${reqPath}` }));
+    return;
+  }
+
+  const isHttps = targetUrl.protocol === 'https:';
+  const makeReq = isHttps ? httpsRequest : httpRequest;
+
+  const upstream = makeReq(
+    {
+      hostname: targetUrl.hostname,
+      port: targetUrl.port || (isHttps ? 443 : 80),
+      path: targetUrl.pathname + targetUrl.search,
+      method,
+      headers,
+    } as RequestOptions,
+    (upRes) => {
+      res.writeHead(upRes.statusCode!, upRes.headers);
+      upRes.pipe(res);
+    },
+  );
+
+  upstream.on('error', (err) => {
+    logger.error({ err, url: targetUrl.href }, 'Room API proxy upstream error');
+    if (!res.headersSent) {
+      res.writeHead(502);
+      res.end(JSON.stringify({ error: 'Room API upstream error' }));
+    }
+  });
+
+  upstream.write(body);
+  upstream.end();
+}
+
+// ─── Main proxy ─────────────────────────────────────────────────────────────
+
 export function startCredentialProxy(
   port: number,
   host = '127.0.0.1',
@@ -32,6 +147,10 @@ export function startCredentialProxy(
     'CLAUDE_CODE_OAUTH_TOKEN',
     'ANTHROPIC_AUTH_TOKEN',
     'ANTHROPIC_BASE_URL',
+    'ROOM_API_URL',
+    'SELF_HOSTED_API_SECRET',
+    'MUSIC_GEN_SERVICE_URL',
+    'FACEBOOK_SERVICE_URL',
   ]);
 
   const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
@@ -44,18 +163,62 @@ export function startCredentialProxy(
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
+  // Room API configuration (optional — only available when configured)
+  const roomSecrets = {
+    roomApiUrl: secrets.ROOM_API_URL || 'https://room1.attyzen.com',
+    selfHostedApiSecret: secrets.SELF_HOSTED_API_SECRET || '',
+    musicGenServiceUrl:
+      secrets.MUSIC_GEN_SERVICE_URL ||
+      'https://music-gen-container.attyzen.com',
+    facebookServiceUrl:
+      secrets.FACEBOOK_SERVICE_URL ||
+      'https://facebook-page-manager-container.attyzen.com',
+  };
+
+  const roomApiConfigured = !!roomSecrets.selfHostedApiSecret;
+  if (roomApiConfigured) {
+    logger.info(
+      {
+        roomApiUrl: roomSecrets.roomApiUrl,
+        musicGen: roomSecrets.musicGenServiceUrl,
+        facebook: roomSecrets.facebookServiceUrl,
+      },
+      'Room API proxy enabled',
+    );
+  }
+
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
         const body = Buffer.concat(chunks);
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
+
+        // ── Room API proxy: /room-api/* ──────────────────────────────
+        if (req.url?.startsWith(ROOM_API_PREFIX)) {
+          if (!roomApiConfigured) {
+            res.writeHead(503);
+            res.end(
+              JSON.stringify({
+                error:
+                  'Room API not configured. Set SELF_HOSTED_API_SECRET in .env',
+              }),
+            );
+            return;
+          }
+          handleRoomApiRequest(req, res, body, roomSecrets);
+          return;
+        }
+
+        // ── Anthropic API proxy (default) ────────────────────────────
+        const headers: Record<
+          string,
+          string | number | string[] | undefined
+        > = {
+          ...(req.headers as Record<string, string>),
+          host: upstreamUrl.host,
+          'content-length': body.length,
+        };
 
         // Strip hop-by-hop headers that must not be forwarded by proxies
         delete headers['connection'];
@@ -110,7 +273,10 @@ export function startCredentialProxy(
     });
 
     server.listen(port, host, () => {
-      logger.info({ port, host, authMode }, 'Credential proxy started');
+      logger.info(
+        { port, host, authMode, roomApi: roomApiConfigured },
+        'Credential proxy started',
+      );
       resolve(server);
     });
 
@@ -122,4 +288,10 @@ export function startCredentialProxy(
 export function detectAuthMode(): AuthMode {
   const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
   return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+}
+
+/** Check if Room API credentials are configured. */
+export function isRoomApiConfigured(): boolean {
+  const secrets = readEnvFile(['SELF_HOSTED_API_SECRET']);
+  return !!secrets.SELF_HOSTED_API_SECRET;
 }


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

## Description

Adds a Room API proxy layer to the credential proxy that securely routes requests to Room's self-hosted services (music-gen and facebook-page-manager). This enables containers to access these services without exposing secrets.

### Key Changes

**Source Code:**
- Extended `credential-proxy.ts` with Room API routing logic:
  - New `handleRoomApiRequest()` function routes `/room-api/*` requests to appropriate upstream services
  - `signFacebookRequest()` generates HMAC-SHA256 signatures for facebook-page-manager server-to-server authentication
  - Injects `X-Api-Secret` header for music-gen requests
  - Injects Bearer token + HMAC signature headers for facebook requests
  - Supports three service paths: `/music-gen/`, `/facebook/`, and `/api/` (Room Worker API)
- Added `isRoomApiConfigured()` export to check if Room API credentials are available
- Updated `container-runner.ts` to inject `ROOM_API_URL` environment variable when Room API is configured
- Added Room API configuration to `.env.example` with sensible defaults

**Skills:**
- `room-music/SKILL.md`: Complete guide for music generation via Room API, including job submission, status polling, audio download, and parameter reference
- `room-facebook/SKILL.md`: Complete guide for Facebook page management, including health checks, approval queue management, post approval/rejection, and configuration sync

### How It Works

1. Containers make requests to `http://host.docker.internal:CREDENTIAL_PROXY_PORT/room-api/*`
2. The credential proxy intercepts these requests and routes them based on the path prefix
3. For music-gen: strips `/music-gen` prefix and adds `X-Api-Secret` header
4. For facebook: strips `/facebook` prefix and adds Bearer token + HMAC signature headers
5. For Room Worker API: passes through `/api/*` requests with `X-Api-Secret` header
6. Secrets are never exposed to containers; all authentication happens in the proxy

### Configuration

Optional environment variables (all have sensible defaults):
- `SELF_HOSTED_API_SECRET`: Shared secret for Room services (required to enable Room API proxy)
- `ROOM_API_URL`: Room Worker API base URL (default: https://room1.attyzen.com)
- `MUSIC_GEN_SERVICE_URL`: Music Gen service URL (default: https://music-gen-container.attyzen.com)
- `FACEBOOK_SERVICE_URL`: Facebook Page Manager service URL (default: https://facebook-page-manager-container.attyzen.com)

## For Skills

- [x] SKILL.md contains instructions, not inline code
- [x] SKILL.md files are under 500 lines (room-music: 142 lines, room-facebook: 170 lines)
- [x] Skills tested with example workflows included in documentation

https://claude.ai/code/session_019iCxs9QPJe1Ld2YryG2JSV