### PR TITLE
fix: add SELinux :z label to Docker volume mounts

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -241,6 +241,24 @@ async function buildContainerArgs(
   });
   if (onecliApplied) {
     logger.info({ containerName }, 'OneCLI gateway config applied');
+    // On SELinux-enforcing systems, files written by OneCLI to /tmp get the
+    // default tmp_t context which Docker cannot read. Relabel any .pem files
+    // that OneCLI just mounted so the container can access them. chcon is a
+    // no-op on non-SELinux systems and we ignore failures silently.
+    const pemPaths = args
+      .filter((_, i) => args[i - 1] === '-v')
+      .map((v) => v.split(':')[0])
+      .filter((p) => p.endsWith('.pem'));
+    if (pemPaths.length > 0) {
+      try {
+        const { execFileSync } = await import('child_process');
+        execFileSync('chcon', ['-t', 'container_file_t', ...pemPaths], {
+          stdio: 'ignore',
+        });
+      } catch {
+        // chcon not available or SELinux not enforcing — safe to ignore
+      }
+    }
   } else {
     logger.warn(
       { containerName },
@@ -265,7 +283,7 @@ async function buildContainerArgs(
     if (mount.readonly) {
       args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
     } else {
-      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}:z`);
     }
   }
 

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -32,9 +32,9 @@ beforeEach(() => {
 // --- Pure functions ---
 
 describe('readonlyMountArgs', () => {
-  it('returns -v flag with :ro suffix', () => {
+  it('returns -v flag with :ro,z suffix (SELinux label)', () => {
     const args = readonlyMountArgs('/host/path', '/container/path');
-    expect(args).toEqual(['-v', '/host/path:/container/path:ro']);
+    expect(args).toEqual(['-v', '/host/path:/container/path:ro,z']);
   });
 });
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -24,7 +24,7 @@ export function readonlyMountArgs(
   hostPath: string,
   containerPath: string,
 ): string[] {
-  return ['-v', `${hostPath}:${containerPath}:ro`];
+  return ['-v', `${hostPath}:${containerPath}:ro,z`];
 }
 
 /** Stop a container by name. Uses execFileSync to avoid shell injection. */


### PR DESCRIPTION
Docker volume mounts on SELinux-enforcing systems (e.g. Fedora, RHEL) fail with permission denied unless the :z relabelling option is set. Add :z to both read-write and read-only mounts so NanoClaw works out of the box on SELinux hosts. The option is a no-op on non-SELinux systems so this is safe for all platforms.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
