### PR TITLE
feat: add /add-model-config skill — per-invocation model, effort, and thinking config

### DIFF
--- a/.claude/skills/add-model-config/SKILL.md
+++ b/.claude/skills/add-model-config/SKILL.md
@@ -5,7 +5,7 @@ description: Enable per-invocation model, effort, and thinking configuration for
 
 # Add Model Configuration
 
-This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` so each container invocation can specify the Claude model and reasoning mode to use. Omitting them leaves SDK defaults unchanged.
+This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` so each container invocation can specify the Claude model and reasoning mode. Omitting them leaves SDK defaults unchanged — existing behaviour is fully preserved.
 
 ## Phase 1: Pre-flight
 
@@ -17,58 +17,64 @@ grep -q "model\?:" src/container-runner.ts && echo "already applied" || echo "no
 
 If already applied, stop here.
 
-## Phase 2: Apply Code Changes
+## Phase 2: Edit source files
 
-### Ensure upstream remote
+### 1. `src/container-runner.ts` — add ThinkingConfig type and three fields to ContainerInput
 
-```bash
-git remote -v
+Find the `ContainerInput` interface (search for `export interface ContainerInput`). Directly above it, add the `ThinkingConfig` type:
+
+```typescript
+export type ThinkingConfig =
+  | { type: 'adaptive' }
+  | { type: 'enabled'; budgetTokens?: number }
+  | { type: 'disabled' };
 ```
 
-If `upstream` is missing, add it:
+Then, inside `ContainerInput`, add three optional fields after `script?`:
 
-```bash
-git remote add upstream https://github.com/qwibitai/nanoclaw.git
+```typescript
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  thinking?: ThinkingConfig;
 ```
 
-### Merge the skill branch
+### 2. `container/agent-runner/src/index.ts` — import ThinkingConfig and extend ContainerInput
 
-```bash
-git fetch upstream
-git merge upstream/skill/model-mode-passthrough
+At the top of the file, add `ThinkingConfig` to the existing SDK import:
+
+```typescript
+import { query, HookCallback, PreCompactHookInput, ThinkingConfig } from '@anthropic-ai/claude-agent-sdk';
 ```
 
-If the merge reports conflicts in `package-lock.json`, resolve by taking theirs:
+Inside the local `ContainerInput` interface, add three optional fields after `script?`:
 
-```bash
-git checkout --theirs package-lock.json
-git add package-lock.json
-git merge --continue
+```typescript
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  thinking?: ThinkingConfig;
 ```
 
-For other conflicts, read both sides and resolve by intent.
+In `runQuery()`, find the `query()` call. Add the three fields to its options, just before the `env:` line:
 
-This merges:
-- `src/container-runner.ts` — adds `ThinkingConfig` type export and `model?`, `effort?`, `thinking?` fields to `ContainerInput`
-- `container/agent-runner/src/index.ts` — imports `ThinkingConfig` from the SDK, adds the three fields to its local `ContainerInput`, and forwards them to `query()`
+```typescript
+      model: containerInput.model,
+      effort: containerInput.effort,
+      thinking: containerInput.thinking,
+```
 
-### Validate
+## Phase 3: Validate and rebuild
 
 ```bash
 npm run build
 ```
 
-Build must be clean before proceeding.
-
-## Phase 3: Rebuild Container
-
-The agent runner inside the container has changed, so the container image must be rebuilt:
+Build must be clean. Then rebuild the container image (the agent runner inside has changed):
 
 ```bash
 ./container/build.sh
 ```
 
-Then restart the service:
+Restart the service:
 
 ```bash
 # macOS:
@@ -87,14 +93,8 @@ Container invocations now accept three optional fields on `ContainerInput`:
 | `effort` | `'low' \| 'medium' \| 'high' \| 'max'` | Reasoning effort level |
 | `thinking` | `ThinkingConfig` | `{ type: 'adaptive' }`, `{ type: 'enabled', budgetTokens?: number }`, or `{ type: 'disabled' }` |
 
-All three are optional. Omitting them leaves the SDK defaults unchanged (existing behaviour is preserved).
-
 ## Removal
 
-To remove:
-
-1. Remove `ThinkingConfig` export and the three fields from `ContainerInput` in `src/container-runner.ts`
-2. Remove the three fields from `ContainerInput` and the `query()` options in `container/agent-runner/src/index.ts`
-3. Remove the `ThinkingConfig` import in `container/agent-runner/src/index.ts`
-4. Rebuild: `npm run build && ./container/build.sh`
-5. Restart the service
+1. Remove `ThinkingConfig` and the three fields from `ContainerInput` in `src/container-runner.ts`
+2. Remove `ThinkingConfig` from the import, the three fields from `ContainerInput`, and the three lines from `query()` options in `container/agent-runner/src/index.ts`
+3. `npm run build && ./container/build.sh` and restart

--- a/.claude/skills/add-model-config/SKILL.md
+++ b/.claude/skills/add-model-config/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: add-model-config
-description: Enable per-invocation model, effort, and thinking configuration for container agents. Required before roles or groups can specify which Claude model to use.
+description: Enable per-group model, effort, and thinking configuration for container agents. Reads a model-config.json from each group's folder and passes it to the agent SDK on every invocation.
 ---
 
 # Add Model Configuration
 
-This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` so each container invocation can specify the Claude model and reasoning mode. Omitting them leaves SDK defaults unchanged — existing behaviour is fully preserved.
+This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` and wires up the host to read per-group config from `groups/<name>/model-config.json`. Omitting the config file leaves SDK defaults unchanged — existing behaviour is fully preserved.
+
+Use `/configure-group` after this skill to set the model config for individual groups.
 
 ## Phase 1: Pre-flight
 
 ### Check if already applied
 
 ```bash
-grep -q "model\?:" src/container-runner.ts && echo "already applied" || echo "not applied"
+grep -q "model-config.json" src/index.ts && echo "already applied" || echo "not applied"
 ```
 
 If already applied, stop here.
@@ -30,7 +32,7 @@ export type ThinkingConfig =
   | { type: 'disabled' };
 ```
 
-Then, inside `ContainerInput`, add three optional fields after `script?`:
+Inside `ContainerInput`, add three optional fields after `script?`:
 
 ```typescript
   model?: string;
@@ -40,7 +42,7 @@ Then, inside `ContainerInput`, add three optional fields after `script?`:
 
 ### 2. `container/agent-runner/src/index.ts` — import ThinkingConfig and extend ContainerInput
 
-At the top of the file, add `ThinkingConfig` to the existing SDK import:
+Add `ThinkingConfig` to the existing SDK import line:
 
 ```typescript
 import { query, HookCallback, PreCompactHookInput, ThinkingConfig } from '@anthropic-ai/claude-agent-sdk';
@@ -54,12 +56,80 @@ Inside the local `ContainerInput` interface, add three optional fields after `sc
   thinking?: ThinkingConfig;
 ```
 
-In `runQuery()`, find the `query()` call. Add the three fields to its options, just before the `env:` line:
+In `runQuery()`, find the `query()` call and add the three fields to its options just before the `env:` line:
 
 ```typescript
       model: containerInput.model,
       effort: containerInput.effort,
       thinking: containerInput.thinking,
+```
+
+### 3. `src/index.ts` — read model config and pass it to runContainerAgent
+
+Add a helper function after the imports, before the first function definition:
+
+```typescript
+function readGroupModelConfig(folder: string): { model?: string; effort?: 'low' | 'medium' | 'high' | 'max'; thinking?: import('./container-runner.js').ThinkingConfig } {
+  try {
+    const configPath = path.join(resolveGroupFolderPath(folder), 'model-config.json');
+    if (fs.existsSync(configPath)) {
+      return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    }
+  } catch {
+    // ignore malformed config
+  }
+  return {};
+}
+```
+
+Find the `runContainerAgent` call in the message handler (search for `groupFolder: group.folder,`). Spread the model config into the `ContainerInput`:
+
+```typescript
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        assistantName: ASSISTANT_NAME,
+        ...readGroupModelConfig(group.folder),
+      },
+```
+
+### 4. `src/task-scheduler.ts` — same for scheduled tasks
+
+Add the same helper function after the imports in `task-scheduler.ts`:
+
+```typescript
+function readGroupModelConfig(folder: string): { model?: string; effort?: 'low' | 'medium' | 'high' | 'max'; thinking?: import('./container-runner.js').ThinkingConfig } {
+  try {
+    const configPath = path.join(resolveGroupFolderPath(folder), 'model-config.json');
+    if (fs.existsSync(configPath)) {
+      return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    }
+  } catch {
+    // ignore malformed config
+  }
+  return {};
+}
+```
+
+Find the `runContainerAgent` call (search for `isScheduledTask: true,`). Spread the model config into the `ContainerInput`:
+
+```typescript
+      {
+        prompt: task.prompt,
+        sessionId,
+        groupFolder: task.group_folder,
+        chatJid: task.chat_jid,
+        isMain,
+        isScheduledTask: true,
+        assistantName: ASSISTANT_NAME,
+        script: task.script || undefined,
+        ...readGroupModelConfig(task.group_folder),
+      },
 ```
 
 ## Phase 3: Validate and rebuild
@@ -85,16 +155,29 @@ systemctl --user restart nanoclaw
 
 ## After Installation
 
-Container invocations now accept three optional fields on `ContainerInput`:
+Create `groups/<name>/model-config.json` to set the model for a group, or run `/configure-group` to do it interactively.
 
-| Field | Type | Description |
-|---|---|---|
-| `model` | `string` | Claude model ID (e.g. `claude-haiku-4-5-20251001`) |
-| `effort` | `'low' \| 'medium' \| 'high' \| 'max'` | Reasoning effort level |
-| `thinking` | `ThinkingConfig` | `{ type: 'adaptive' }`, `{ type: 'enabled', budgetTokens?: number }`, or `{ type: 'disabled' }` |
+Example config file:
+
+```json
+{
+  "model": "claude-haiku-4-5-20251001",
+  "effort": "low"
+}
+```
+
+```json
+{
+  "model": "claude-opus-4-6",
+  "thinking": { "type": "adaptive" }
+}
+```
+
+All three fields are optional. An empty or missing config file leaves SDK defaults unchanged.
 
 ## Removal
 
 1. Remove `ThinkingConfig` and the three fields from `ContainerInput` in `src/container-runner.ts`
 2. Remove `ThinkingConfig` from the import, the three fields from `ContainerInput`, and the three lines from `query()` options in `container/agent-runner/src/index.ts`
-3. `npm run build && ./container/build.sh` and restart
+3. Remove `readGroupModelConfig` and the `...readGroupModelConfig(...)` spreads from `src/index.ts` and `src/task-scheduler.ts`
+4. `npm run build && ./container/build.sh` and restart

--- a/.claude/skills/add-model-config/SKILL.md
+++ b/.claude/skills/add-model-config/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: add-model-config
+description: Enable per-invocation model, effort, and thinking configuration for container agents. Required before roles or groups can specify which Claude model to use.
+---
+
+# Add Model Configuration
+
+This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` so each container invocation can specify the Claude model and reasoning mode to use. Omitting them leaves SDK defaults unchanged.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+```bash
+grep -q "model\?:" src/container-runner.ts && echo "already applied" || echo "not applied"
+```
+
+If already applied, stop here.
+
+## Phase 2: Apply Code Changes
+
+### Ensure upstream remote
+
+```bash
+git remote -v
+```
+
+If `upstream` is missing, add it:
+
+```bash
+git remote add upstream https://github.com/qwibitai/nanoclaw.git
+```
+
+### Merge the skill branch
+
+```bash
+git fetch upstream
+git merge upstream/skill/model-mode-passthrough
+```
+
+If the merge reports conflicts in `package-lock.json`, resolve by taking theirs:
+
+```bash
+git checkout --theirs package-lock.json
+git add package-lock.json
+git merge --continue
+```
+
+For other conflicts, read both sides and resolve by intent.
+
+This merges:
+- `src/container-runner.ts` — adds `ThinkingConfig` type export and `model?`, `effort?`, `thinking?` fields to `ContainerInput`
+- `container/agent-runner/src/index.ts` — imports `ThinkingConfig` from the SDK, adds the three fields to its local `ContainerInput`, and forwards them to `query()`
+
+### Validate
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+## Phase 3: Rebuild Container
+
+The agent runner inside the container has changed, so the container image must be rebuilt:
+
+```bash
+./container/build.sh
+```
+
+Then restart the service:
+
+```bash
+# macOS:
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux:
+systemctl --user restart nanoclaw
+```
+
+## After Installation
+
+Container invocations now accept three optional fields on `ContainerInput`:
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | `string` | Claude model ID (e.g. `claude-haiku-4-5-20251001`) |
+| `effort` | `'low' \| 'medium' \| 'high' \| 'max'` | Reasoning effort level |
+| `thinking` | `ThinkingConfig` | `{ type: 'adaptive' }`, `{ type: 'enabled', budgetTokens?: number }`, or `{ type: 'disabled' }` |
+
+All three are optional. Omitting them leaves the SDK defaults unchanged (existing behaviour is preserved).
+
+## Removal
+
+To remove:
+
+1. Remove `ThinkingConfig` export and the three fields from `ContainerInput` in `src/container-runner.ts`
+2. Remove the three fields from `ContainerInput` and the `query()` options in `container/agent-runner/src/index.ts`
+3. Remove the `ThinkingConfig` import in `container/agent-runner/src/index.ts`
+4. Rebuild: `npm run build && ./container/build.sh`
+5. Restart the service

--- a/.claude/skills/add-model-config/SKILL.md
+++ b/.claude/skills/add-model-config/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-model-config
-description: Enable per-group model, effort, and thinking configuration for container agents. Reads a model-config.json from each group's folder and passes it to the agent SDK on every invocation.
+description: Enable per-group model, effort, and thinking configuration for container agents. Stores config in the group's containerConfig in the database and passes it to the agent SDK on every invocation.
 ---
 
 # Add Model Configuration
 
-This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` and wires up the host to read per-group config from `groups/<name>/model-config.json`. Omitting the config file leaves SDK defaults unchanged — existing behaviour is fully preserved.
+This skill adds optional `model`, `effort`, and `thinking` fields to `ContainerInput` and wires up the host to read them from the group's `containerConfig` in the database. Omitting config leaves SDK defaults unchanged — existing behaviour is fully preserved.
 
 Use `/configure-group` after this skill to set the model config for individual groups.
 
@@ -14,16 +14,16 @@ Use `/configure-group` after this skill to set the model config for individual g
 ### Check if already applied
 
 ```bash
-grep -q "model-config.json" src/index.ts && echo "already applied" || echo "not applied"
+grep -q "ThinkingConfig" src/types.ts && echo "already applied" || echo "not applied"
 ```
 
 If already applied, stop here.
 
 ## Phase 2: Edit source files
 
-### 1. `src/container-runner.ts` — add ThinkingConfig type and three fields to ContainerInput
+### 1. `src/types.ts` — add ThinkingConfig and three fields to ContainerConfig
 
-Find the `ContainerInput` interface (search for `export interface ContainerInput`). Directly above it, add the `ThinkingConfig` type:
+Add the `ThinkingConfig` exported type directly above the `ContainerConfig` interface:
 
 ```typescript
 export type ThinkingConfig =
@@ -32,7 +32,7 @@ export type ThinkingConfig =
   | { type: 'disabled' };
 ```
 
-Inside `ContainerInput`, add three optional fields after `script?`:
+Inside `ContainerConfig`, add three optional fields after `timeout?`:
 
 ```typescript
   model?: string;
@@ -40,12 +40,27 @@ Inside `ContainerInput`, add three optional fields after `script?`:
   thinking?: ThinkingConfig;
 ```
 
-### 2. `container/agent-runner/src/index.ts` — import ThinkingConfig and extend ContainerInput
+### 2. `src/container-runner.ts` — add three fields to ContainerInput
 
-Add `ThinkingConfig` to the existing SDK import line:
+Inside the `ContainerInput` interface, add three optional fields after `script?`:
 
 ```typescript
-import { query, HookCallback, PreCompactHookInput, ThinkingConfig } from '@anthropic-ai/claude-agent-sdk';
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  thinking?: import('./types.js').ThinkingConfig;
+```
+
+### 3. `container/agent-runner/src/index.ts` — import ThinkingConfig and extend ContainerInput
+
+Add `ThinkingConfig` to the existing SDK import:
+
+```typescript
+import {
+  query,
+  HookCallback,
+  PreCompactHookInput,
+  ThinkingConfig,
+} from '@anthropic-ai/claude-agent-sdk';
 ```
 
 Inside the local `ContainerInput` interface, add three optional fields after `script?`:
@@ -56,7 +71,7 @@ Inside the local `ContainerInput` interface, add three optional fields after `sc
   thinking?: ThinkingConfig;
 ```
 
-In `runQuery()`, find the `query()` call and add the three fields to its options just before the `env:` line:
+In `runQuery()`, find the `query()` call and add the three fields just before the `env:` line:
 
 ```typescript
       model: containerInput.model,
@@ -64,25 +79,9 @@ In `runQuery()`, find the `query()` call and add the three fields to its options
       thinking: containerInput.thinking,
 ```
 
-### 3. `src/index.ts` — read model config and pass it to runContainerAgent
+### 4. `src/index.ts` — pass model config from group.containerConfig
 
-Add a helper function after the imports, before the first function definition:
-
-```typescript
-function readGroupModelConfig(folder: string): { model?: string; effort?: 'low' | 'medium' | 'high' | 'max'; thinking?: import('./container-runner.js').ThinkingConfig } {
-  try {
-    const configPath = path.join(resolveGroupFolderPath(folder), 'model-config.json');
-    if (fs.existsSync(configPath)) {
-      return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    }
-  } catch {
-    // ignore malformed config
-  }
-  return {};
-}
-```
-
-Find the `runContainerAgent` call in the message handler (search for `groupFolder: group.folder,`). Spread the model config into the `ContainerInput`:
+Find the `runContainerAgent` call in the message handler (search for `groupFolder: group.folder,`). Pass the model fields from `containerConfig`:
 
 ```typescript
     const output = await runContainerAgent(
@@ -94,29 +93,15 @@ Find the `runContainerAgent` call in the message handler (search for `groupFolde
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
-        ...readGroupModelConfig(group.folder),
+        model: group.containerConfig?.model,
+        effort: group.containerConfig?.effort,
+        thinking: group.containerConfig?.thinking,
       },
 ```
 
-### 4. `src/task-scheduler.ts` — same for scheduled tasks
+### 5. `src/task-scheduler.ts` — same for scheduled tasks
 
-Add the same helper function after the imports in `task-scheduler.ts`:
-
-```typescript
-function readGroupModelConfig(folder: string): { model?: string; effort?: 'low' | 'medium' | 'high' | 'max'; thinking?: import('./container-runner.js').ThinkingConfig } {
-  try {
-    const configPath = path.join(resolveGroupFolderPath(folder), 'model-config.json');
-    if (fs.existsSync(configPath)) {
-      return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    }
-  } catch {
-    // ignore malformed config
-  }
-  return {};
-}
-```
-
-Find the `runContainerAgent` call (search for `isScheduledTask: true,`). Spread the model config into the `ContainerInput`:
+The task scheduler already looks up the full group object. Find the `runContainerAgent` call (search for `isScheduledTask: true,`) and pass the model fields from `group.containerConfig`:
 
 ```typescript
       {
@@ -128,7 +113,9 @@ Find the `runContainerAgent` call (search for `isScheduledTask: true,`). Spread 
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
         script: task.script || undefined,
-        ...readGroupModelConfig(task.group_folder),
+        model: group.containerConfig?.model,
+        effort: group.containerConfig?.effort,
+        thinking: group.containerConfig?.thinking,
       },
 ```
 
@@ -155,29 +142,22 @@ systemctl --user restart nanoclaw
 
 ## After Installation
 
-Create `groups/<name>/model-config.json` to set the model for a group, or run `/configure-group` to do it interactively.
+Use `/configure-group` to set the model config for individual groups interactively. Config is stored in the database alongside other group settings — no restart needed after changes.
 
-Example config file:
+Model shorthands supported by the SDK:
 
-```json
-{
-  "model": "haiku",
-  "effort": "low"
-}
-```
+| Shorthand | Model |
+|-----------|-------|
+| `haiku`   | claude-haiku-4-5 |
+| `sonnet`  | claude-sonnet-4-6 |
+| `opus`    | claude-opus-4-6 |
 
-```json
-{
-  "model": "opus",
-  "thinking": { "type": "adaptive" }
-}
-```
-
-All three fields are optional. An empty or missing config file leaves SDK defaults unchanged.
+All three fields are optional. Groups without config use SDK defaults.
 
 ## Removal
 
-1. Remove `ThinkingConfig` and the three fields from `ContainerInput` in `src/container-runner.ts`
-2. Remove `ThinkingConfig` from the import, the three fields from `ContainerInput`, and the three lines from `query()` options in `container/agent-runner/src/index.ts`
-3. Remove `readGroupModelConfig` and the `...readGroupModelConfig(...)` spreads from `src/index.ts` and `src/task-scheduler.ts`
-4. `npm run build && ./container/build.sh` and restart
+1. Remove `ThinkingConfig` type and the three fields from `ContainerConfig` in `src/types.ts`
+2. Remove the three fields from `ContainerInput` in `src/container-runner.ts`
+3. Remove `ThinkingConfig` from the import, the three fields from local `ContainerInput`, and the three lines from `query()` options in `container/agent-runner/src/index.ts`
+4. Remove the `model/effort/thinking` lines from the `runContainerAgent` calls in `src/index.ts` and `src/task-scheduler.ts`
+5. `npm run build && ./container/build.sh` and restart

--- a/.claude/skills/add-model-config/SKILL.md
+++ b/.claude/skills/add-model-config/SKILL.md
@@ -161,14 +161,14 @@ Example config file:
 
 ```json
 {
-  "model": "claude-haiku-4-5-20251001",
+  "model": "haiku",
   "effort": "low"
 }
 ```
 
 ```json
 {
-  "model": "claude-opus-4-6",
+  "model": "opus",
   "thinking": { "type": "adaptive" }
 }
 ```

--- a/.claude/skills/configure-group/SKILL.md
+++ b/.claude/skills/configure-group/SKILL.md
@@ -73,14 +73,14 @@ Examples:
 Haiku, no thinking config (most groups):
 ```json
 {
-  "model": "claude-haiku-4-5-20251001"
+  "model": "haiku"
 }
 ```
 
 Opus with adaptive thinking (research/planning groups):
 ```json
 {
-  "model": "claude-opus-4-6",
+  "model": "opus",
   "thinking": { "type": "adaptive" }
 }
 ```

--- a/.claude/skills/configure-group/SKILL.md
+++ b/.claude/skills/configure-group/SKILL.md
@@ -41,9 +41,9 @@ Based on what the group does, recommend the right model and explain your reasoni
 
 | Use case | Recommended | Reasoning |
 |---|---|---|
-| General chat, reminders, simple tasks | `claude-haiku-4-5-20251001` | Fast and cheap; haiku handles most day-to-day assistant work well |
-| Structured tasks, coding, analysis | `claude-sonnet-4-6` | Better reasoning without the cost of opus |
-| Deep research, complex planning | `claude-opus-4-6` with `thinking: { "type": "adaptive" }` | Opus with adaptive thinking for tasks that benefit from extended reasoning |
+| General chat, reminders, simple tasks | `haiku` | Fast and cheap; haiku handles most day-to-day assistant work well |
+| Structured tasks, coding, analysis | `sonnet` | Better reasoning without the cost of opus |
+| Deep research, complex planning | `opus` with `thinking: { "type": "adaptive" }` | Opus with adaptive thinking for tasks that benefit from extended reasoning |
 
 For `effort`:
 - Omit it for most cases (let the model decide)

--- a/.claude/skills/configure-group/SKILL.md
+++ b/.claude/skills/configure-group/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: configure-group
+description: Set the Claude model, effort level, and thinking mode for a group. Writes groups/<name>/model-config.json. Requires /add-model-config to be installed first.
+---
+
+# Configure Group Model
+
+Set which Claude model a group uses. Writes `groups/<name>/model-config.json`, which the host reads on every invocation.
+
+Requires `/add-model-config` to be installed. If it isn't, run that first.
+
+## Step 1: List available groups
+
+```bash
+ls groups/
+```
+
+Show the user the list of group folders.
+
+## Step 2: Ask which group to configure
+
+Use `AskUserQuestion` to ask which group they want to configure. If the user has already told you, skip this.
+
+## Step 3: Read the group's current config and CLAUDE.md
+
+Check for an existing config:
+
+```bash
+cat groups/<name>/model-config.json 2>/dev/null || echo "(no config — using SDK defaults)"
+```
+
+Read the group's CLAUDE.md to understand its purpose:
+
+```bash
+cat groups/<name>/CLAUDE.md
+```
+
+## Step 4: Recommend a model
+
+Based on what the group does, recommend the right model and explain your reasoning. Use this as a guide:
+
+| Use case | Recommended | Reasoning |
+|---|---|---|
+| General chat, reminders, simple tasks | `claude-haiku-4-5-20251001` | Fast and cheap; haiku handles most day-to-day assistant work well |
+| Structured tasks, coding, analysis | `claude-sonnet-4-6` | Better reasoning without the cost of opus |
+| Deep research, complex planning | `claude-opus-4-6` with `thinking: { "type": "adaptive" }` | Opus with adaptive thinking for tasks that benefit from extended reasoning |
+
+For `effort`:
+- Omit it for most cases (let the model decide)
+- `"low"` for high-frequency lightweight tasks where speed matters
+- `"max"` only for opus on tasks that need maximum reasoning depth
+
+## Step 5: Confirm with the user
+
+Present your recommendation with a short explanation. Ask if they want to use it or adjust.
+
+## Step 6: Write the config
+
+Write `groups/<name>/model-config.json`:
+
+```json
+{
+  "model": "<model-id>",
+  "effort": "<level>",
+  "thinking": { "type": "adaptive" }
+}
+```
+
+Only include fields the user wants to set. Omit `effort` and `thinking` unless explicitly needed — the SDK defaults are sensible.
+
+Examples:
+
+Haiku, no thinking config (most groups):
+```json
+{
+  "model": "claude-haiku-4-5-20251001"
+}
+```
+
+Opus with adaptive thinking (research/planning groups):
+```json
+{
+  "model": "claude-opus-4-6",
+  "thinking": { "type": "adaptive" }
+}
+```
+
+## Step 7: Confirm
+
+Show the user the written config and confirm the group will use it on the next invocation. No restart is needed — the config is read fresh on each message.

--- a/.claude/skills/configure-group/SKILL.md
+++ b/.claude/skills/configure-group/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: configure-group
-description: Set the Claude model, effort level, and thinking mode for a group. Writes groups/<name>/model-config.json. Requires /add-model-config to be installed first.
+description: Set the Claude model, effort level, and thinking mode for a group. Updates the group's containerConfig in the database. Requires /add-model-config to be installed first.
 ---
 
 # Configure Group Model
 
-Set which Claude model a group uses. Writes `groups/<name>/model-config.json`, which the host reads on every invocation.
+Set which Claude model a group uses. Updates the group's `containerConfig` in the database, which the host reads on every invocation.
 
 Requires `/add-model-config` to be installed. If it isn't, run that first.
 
 ## Step 1: List available groups
 
 ```bash
-ls groups/
+sqlite3 store/messages.db "SELECT folder, name, container_config FROM registered_groups ORDER BY added_at"
 ```
 
-Show the user the list of group folders.
+Show the user the list of groups with their current model config (parsed from `container_config` JSON).
 
 ## Step 2: Ask which group to configure
 
@@ -23,10 +23,10 @@ Use `AskUserQuestion` to ask which group they want to configure. If the user has
 
 ## Step 3: Read the group's current config and CLAUDE.md
 
-Check for an existing config:
+Read the current `containerConfig` for the group:
 
 ```bash
-cat groups/<name>/model-config.json 2>/dev/null || echo "(no config — using SDK defaults)"
+sqlite3 store/messages.db "SELECT container_config FROM registered_groups WHERE folder='<name>'"
 ```
 
 Read the group's CLAUDE.md to understand its purpose:
@@ -37,16 +37,16 @@ cat groups/<name>/CLAUDE.md
 
 ## Step 4: Recommend a model
 
-Based on what the group does, recommend the right model and explain your reasoning. Use this as a guide:
+Based on what the group does, recommend the right model and explain your reasoning:
 
 | Use case | Recommended | Reasoning |
 |---|---|---|
-| General chat, reminders, simple tasks | `haiku` | Fast and cheap; haiku handles most day-to-day assistant work well |
+| General chat, reminders, simple tasks | `haiku` | Fast and cheap; handles most day-to-day work well |
 | Structured tasks, coding, analysis | `sonnet` | Better reasoning without the cost of opus |
-| Deep research, complex planning | `opus` with `thinking: { "type": "adaptive" }` | Opus with adaptive thinking for tasks that benefit from extended reasoning |
+| Deep research, complex planning | `opus` + `thinking: adaptive` | Extended reasoning for tasks that benefit from it |
 
 For `effort`:
-- Omit it for most cases (let the model decide)
+- Omit for most cases (let the model decide)
 - `"low"` for high-frequency lightweight tasks where speed matters
 - `"max"` only for opus on tasks that need maximum reasoning depth
 
@@ -54,37 +54,48 @@ For `effort`:
 
 Present your recommendation with a short explanation. Ask if they want to use it or adjust.
 
-## Step 6: Write the config
+## Step 6: Update the database
 
-Write `groups/<name>/model-config.json`:
+Read the group's full record, merge the model config into `containerConfig`, and write it back using `npx tsx`:
 
-```json
-{
-  "model": "<model-id>",
-  "effort": "<level>",
-  "thinking": { "type": "adaptive" }
-}
+```bash
+npx tsx -e "
+import { getAllRegisteredGroups, setRegisteredGroup } from './src/db.js';
+const groups = getAllRegisteredGroups();
+const entry = Object.entries(groups).find(([, g]) => g.folder === '<name>');
+if (!entry) { console.error('Group not found'); process.exit(1); }
+const [jid, group] = entry;
+group.containerConfig = {
+  ...group.containerConfig,
+  model: '<model>',
+  effort: '<effort>',        // omit if not needed
+  thinking: { type: 'adaptive' },  // omit if not needed
+};
+setRegisteredGroup(jid, group);
+console.log('Updated');
+"
 ```
 
-Only include fields the user wants to set. Omit `effort` and `thinking` unless explicitly needed — the SDK defaults are sensible.
+Only include the fields the user wants to set. To clear a field, set it to `undefined` (omit it from the object spread).
 
 Examples:
 
-Haiku, no thinking config (most groups):
-```json
-{
-  "model": "haiku"
-}
+Haiku with no extra config (most groups):
+```typescript
+group.containerConfig = { ...group.containerConfig, model: 'haiku' };
 ```
 
-Opus with adaptive thinking (research/planning groups):
-```json
-{
-  "model": "opus",
-  "thinking": { "type": "adaptive" }
-}
+Opus with adaptive thinking:
+```typescript
+group.containerConfig = { ...group.containerConfig, model: 'opus', thinking: { type: 'adaptive' } };
+```
+
+To clear model config entirely:
+```typescript
+const { model, effort, thinking, ...rest } = group.containerConfig ?? {};
+group.containerConfig = rest;
 ```
 
 ## Step 7: Confirm
 
-Show the user the written config and confirm the group will use it on the next invocation. No restart is needed — the config is read fresh on each message.
+Show the user the updated config and confirm the group will use it on the next invocation. No restart is needed — the config is read from the database on each message.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -21,6 +21,7 @@ import {
   query,
   HookCallback,
   PreCompactHookInput,
+  ThinkingConfig,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
@@ -33,6 +34,9 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  thinking?: ThinkingConfig;
 }
 
 interface ContainerOutput {
@@ -470,6 +474,9 @@ async function runQuery(
         'NotebookEdit',
         'mcp__nanoclaw__*',
       ],
+      model: containerInput.model,
+      effort: containerInput.effort,
+      thinking: containerInput.thinking,
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,9 +34,6 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
-  model?: string;
-  effort?: 'low' | 'medium' | 'high' | 'max';
-  thinking?: ThinkingConfig;
 }
 
 interface ContainerOutput {
@@ -474,9 +471,6 @@ async function runQuery(
         'NotebookEdit',
         'mcp__nanoclaw__*',
       ],
-      model: containerInput.model,
-      effort: containerInput.effort,
-      thinking: containerInput.thinking,
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,11 +34,6 @@ const onecli = new OneCLI({ url: ONECLI_URL });
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
-export type ThinkingConfig =
-  | { type: 'adaptive' }
-  | { type: 'enabled'; budgetTokens?: number }
-  | { type: 'disabled' };
-
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -48,9 +43,6 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
-  model?: string;
-  effort?: 'low' | 'medium' | 'high' | 'max';
-  thinking?: ThinkingConfig;
 }
 
 export interface ContainerOutput {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,6 +34,11 @@ const onecli = new OneCLI({ url: ONECLI_URL });
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
+export type ThinkingConfig =
+  | { type: 'adaptive' }
+  | { type: 'enabled'; budgetTokens?: number }
+  | { type: 'disabled' };
+
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -43,6 +48,9 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  model?: string;
+  effort?: 'low' | 'medium' | 'high' | 'max';
+  thinking?: ThinkingConfig;
 }
 
 export interface ContainerOutput {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds two operational skills with no source changes in the PR itself — Claude makes the edits at install time.

### `/add-model-config`

Gives Claude instructions to patch four files:

- `src/container-runner.ts` — exports `ThinkingConfig` type and adds `model?`, `effort?`, `thinking?` to `ContainerInput`
- `container/agent-runner/src/index.ts` — imports `ThinkingConfig` from the SDK, extends its local `ContainerInput`, forwards the three fields to `query()`
- `src/index.ts` — adds `readGroupModelConfig()` helper that reads `groups/<name>/model-config.json` and spreads the result into each `runContainerAgent` call
- `src/task-scheduler.ts` — same `readGroupModelConfig` pattern for scheduled task invocations

All fields are optional. Missing or empty config file leaves SDK defaults unchanged.

### `/configure-group`

Interactive skill (no source changes) that lists groups, reads each group's CLAUDE.md to recommend the right model, confirms with the user, and writes `groups/<name>/model-config.json`. Requires `/add-model-config` first.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone