### PR TITLE
feat: add WeChat channel skill

### DIFF
--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: add-wechat
+description: Add WeChat as a channel. Connects via Tencent iLink Bot API with QR code authentication. Can run alongside WhatsApp, Telegram, and other channels.
+---
+
+# Add WeChat Channel
+
+This skill adds WeChat support to NanoClaw using the skills engine for deterministic code changes, then walks through interactive setup.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `wechat` is in `applied_skills`, skip to Phase 3 (Setup). The code changes are already in place.
+
+### Ask the user
+
+Use `AskUserQuestion` to confirm:
+
+AskUserQuestion: Do you want to add WeChat as a channel? WeChat will run alongside your existing channels (WhatsApp, Telegram, etc.). You'll need to scan a QR code with your WeChat account to authenticate.
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package. The package files are in this directory alongside this SKILL.md.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+Or call `initSkillsSystem()` from `skills-engine/migrate.ts`.
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-wechat
+```
+
+This deterministically:
+- Adds `src/channels/weixin.ts` (WeixinChannel class implementing Channel interface)
+- Adds `src/channels/weixin.test.ts` (basic unit tests)
+- Three-way merges WeChat support into `src/index.ts` (multi-channel support, findChannel routing)
+- Three-way merges WeChat config into `src/config.ts` (WEIXIN_ENABLED export)
+- Installs the `qrcode-terminal` npm dependency (for QR code display in terminal)
+- Updates `.env.example` with `WEIXIN_ENABLED`
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/index.ts.intent.md` — what changed and invariants for index.ts
+- `modify/src/config.ts.intent.md` — what changed for config.ts
+
+### Validate code changes
+
+```bash
+npm test
+npm run build
+```
+
+All tests must pass (including the new weixin tests) and build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Enable WeChat in .env
+
+Add to `.env`:
+```bash
+WEIXIN_ENABLED=true
+```
+
+### Start NanoClaw
+
+Restart the service to trigger QR code authentication:
+
+```bash
+# macOS:
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux:
+systemctl --user restart nanoclaw
+```
+
+Or if running in dev mode:
+```bash
+npm run dev
+```
+
+### Scan QR Code
+
+When NanoClaw starts, it will:
+1. Display a QR code in the terminal
+2. Print a URL you can open in a browser (if terminal QR doesn't work)
+3. Wait for you to scan with WeChat
+
+**Steps:**
+1. Open WeChat on your phone
+2. Tap the "+" icon → "Scan QR Code"
+3. Scan the QR code displayed in the terminal
+4. Confirm the login on your phone
+
+Once confirmed, NanoClaw will save your credentials to `data/weixin/account.json` and start receiving messages.
+
+### Register a WeChat chat
+
+WeChat uses JID format: `wx:<user_id>`
+
+To find your user ID, send a message to the bot from WeChat, then check the logs:
+
+```bash
+tail -f logs/nanoclaw.log | grep "WeChat message"
+```
+
+You'll see something like:
+```
+WeChat message stored: chatJid=wx:user123@im.wechat fromUserId=user123@im.wechat
+```
+
+Register the chat:
+
+```bash
+# Using the main group folder:
+npx tsx scripts/register-group.ts wx:user123@im.wechat main
+
+# Or create a dedicated folder:
+npx tsx scripts/register-group.ts wx:user123@im.wechat my-wechat-chat
+```
+
+### Test the connection
+
+Send a message to your WeChat bot:
+```
+@Andy hello
+```
+
+(Replace `@Andy` with your `ASSISTANT_NAME` from `.env`)
+
+The agent should respond. Check logs if it doesn't:
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Architecture
+
+### How it works
+
+- **Authentication**: QR code scan via Tencent iLink Bot API
+- **Message receiving**: Long-polling (`/ilink/bot/getupdates`) with sync buffer persistence
+- **Message sending**: POST to `/ilink/bot/sendmessage` with automatic chunking for long messages
+- **Session management**: Automatic pause on session expiry, retry with exponential backoff
+- **Credentials**: Stored in `data/weixin/account.json` (token, baseUrl, accountId)
+- **Sync state**: Stored in `data/weixin/sync.json` (get_updates_buf for resuming)
+
+### JID format
+
+WeChat JIDs use the `wx:` prefix:
+- Format: `wx:<user_id>`
+- Example: `wx:user123@im.wechat`
+
+### Message types supported
+
+- **Text messages**: Full support with quote/reference detection
+- **Voice messages**: Transcribed text is extracted if available
+- **Images/Videos/Files**: Shown as `[图片]`, `[视频]`, `[文件: filename]`
+
+### Limitations
+
+- **No group chat support**: WeChat iLink Bot API only supports 1-on-1 conversations
+- **No typing indicators**: Requires additional API calls with typing_ticket (not implemented)
+- **Session expiry**: If session expires, the bot pauses for 1 hour before retrying
+- **Message length**: Long messages are automatically split at 4000 characters
+
+## Troubleshooting
+
+### QR code doesn't appear
+
+If the terminal doesn't show the QR code:
+1. Check the logs for the QR code URL: `tail -f logs/nanoclaw.log | grep "扫码链接"`
+2. Open the URL in a browser and scan from there
+
+### "Session expired" errors
+
+The WeChat session can expire if:
+- The bot is inactive for too long
+- WeChat servers reset the session
+- Network connectivity issues
+
+When this happens, NanoClaw automatically pauses for 1 hour, then retries. To force a new login:
+
+```bash
+rm data/weixin/account.json
+# Restart NanoClaw to trigger new QR code
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+systemctl --user restart nanoclaw  # Linux
+```
+
+### Messages not being received
+
+Check:
+1. Is the chat registered? `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'wx:%'"`
+2. Is WeChat connected? `tail -f logs/nanoclaw.log | grep "WeChat"`
+3. Is the poll loop running? Look for "WeChat poll loop started" in logs
+
+### Cannot send messages
+
+Check:
+1. Is the account connected? `cat data/weixin/account.json`
+2. Check for API errors in logs: `tail -f logs/nanoclaw.log | grep "Failed to send WeChat"`
+3. Verify the JID format is correct: must start with `wx:`
+
+## After Setup
+
+If running `npm run dev` while the service is active:
+```bash
+# macOS:
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+npm run dev
+# When done testing:
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+
+# Linux:
+systemctl --user stop nanoclaw
+npm run dev
+systemctl --user start nanoclaw
+```
+
+## Removal
+
+To remove WeChat integration:
+
+1. Set `WEIXIN_ENABLED=false` in `.env` or remove the line entirely
+2. Restart NanoClaw
+3. (Optional) Remove WeChat registrations from SQLite: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE 'wx:%'"`
+4. (Optional) Remove credentials: `rm -rf data/weixin/`
+5. (Optional) Uninstall dependency: `npm uninstall qrcode-terminal` (only if not used elsewhere)
+
+To fully remove the code (not recommended unless you're sure):
+1. Delete `src/channels/weixin.ts`
+2. Remove `WeixinChannel` import and creation from `src/index.ts`
+3. Remove WeChat config (`WEIXIN_ENABLED`) from `src/config.ts`
+4. Rebuild: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `npm run build && systemctl --user restart nanoclaw` (Linux)

--- a/.claude/skills/add-wechat/add/src/channels/weixin.test.ts
+++ b/.claude/skills/add-wechat/add/src/channels/weixin.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WeixinChannel } from './weixin.js';
+
+describe('WeixinChannel', () => {
+  let channel: WeixinChannel;
+  const mockOnMessage = vi.fn();
+  const mockOnChatMetadata = vi.fn();
+  const mockRegisteredGroups = vi.fn(() => ({}));
+
+  beforeEach(() => {
+    channel = new WeixinChannel({
+      onMessage: mockOnMessage,
+      onChatMetadata: mockOnChatMetadata,
+      registeredGroups: mockRegisteredGroups,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ownsJid', () => {
+    it('should return true for wx: prefixed JIDs', () => {
+      expect(channel.ownsJid('wx:user123@im.wechat')).toBe(true);
+      expect(channel.ownsJid('wx:test')).toBe(true);
+    });
+
+    it('should return false for non-wx JIDs', () => {
+      expect(channel.ownsJid('tg:123456')).toBe(false);
+      expect(channel.ownsJid('123456@g.us')).toBe(false);
+      expect(channel.ownsJid('user@example.com')).toBe(false);
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should return false when not connected', () => {
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('name', () => {
+    it('should return weixin as channel name', () => {
+      expect(channel.name).toBe('weixin');
+    });
+  });
+});

--- a/.claude/skills/add-wechat/add/src/channels/weixin.ts
+++ b/.claude/skills/add-wechat/add/src/channels/weixin.ts
@@ -1,0 +1,616 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ASSISTANT_NAME, DATA_DIR, TRIGGER_PATTERN } from '../config.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WeixinMessage {
+  seq?: number;
+  message_id?: number;
+  from_user_id?: string;
+  to_user_id?: string;
+  client_id?: string;
+  create_time_ms?: number;
+  item_list?: MessageItem[];
+  context_token?: string;
+  message_type?: number;
+  message_state?: number;
+}
+
+interface MessageItem {
+  type?: number;
+  text_item?: { text?: string };
+  image_item?: unknown;
+  voice_item?: { text?: string };
+  file_item?: { file_name?: string };
+  ref_msg?: { title?: string; message_item?: MessageItem };
+}
+
+const MessageItemType = { TEXT: 1, IMAGE: 2, VOICE: 3, FILE: 4, VIDEO: 5 } as const;
+const MessageType = { BOT: 2 } as const;
+const MessageState = { FINISH: 2 } as const;
+
+interface GetUpdatesResp {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  msgs?: WeixinMessage[];
+  get_updates_buf?: string;
+  longpolling_timeout_ms?: number;
+}
+
+interface AccountData {
+  token: string;
+  baseUrl: string;
+  accountId: string;
+  userId?: string;
+  savedAt: string;
+}
+
+export interface WeixinChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BASE_URL = 'https://ilinkai.weixin.qq.com';
+const CHANNEL_VERSION = '1.0.0';
+const ILINK_APP_ID = 'bot';
+const ILINK_APP_CLIENT_VERSION = (1 << 16) | (0 << 8) | 0; // 1.0.0
+const LONG_POLL_TIMEOUT_MS = 35_000;
+const SESSION_EXPIRED_ERRCODE = -14;
+const SESSION_PAUSE_MS = 60 * 60 * 1000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+const BACKOFF_DELAY_MS = 30_000;
+const RETRY_DELAY_MS = 2_000;
+const MAX_MSG_LENGTH = 4000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function weixinStateDir(): string {
+  return path.join(DATA_DIR, 'weixin');
+}
+
+function randomWechatUin(): string {
+  const uint32 = crypto.randomBytes(4).readUInt32BE(0);
+  return Buffer.from(String(uint32), 'utf-8').toString('base64');
+}
+
+function generateClientId(): string {
+  return `nanoclaw-wx-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function buildCommonHeaders(): Record<string, string> {
+  return {
+    'iLink-App-Id': ILINK_APP_ID,
+    'iLink-App-ClientVersion': String(ILINK_APP_CLIENT_VERSION),
+  };
+}
+
+function buildPostHeaders(token?: string, body?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    AuthorizationType: 'ilink_bot_token',
+    'X-WECHAT-UIN': randomWechatUin(),
+    ...buildCommonHeaders(),
+  };
+  if (body) headers['Content-Length'] = String(Buffer.byteLength(body, 'utf-8'));
+  if (token?.trim()) headers.Authorization = `Bearer ${token.trim()}`;
+  return headers;
+}
+
+function extractTextBody(itemList?: MessageItem[]): string {
+  if (!itemList?.length) return '';
+  for (const item of itemList) {
+    if (item.type === MessageItemType.TEXT && item.text_item?.text != null) {
+      const text = String(item.text_item.text);
+      const ref = item.ref_msg;
+      if (!ref) return text;
+      const parts: string[] = [];
+      if (ref.title) parts.push(ref.title);
+      if (!parts.length) return text;
+      return `[引用: ${parts.join(' | ')}]\n${text}`;
+    }
+    if (item.type === MessageItemType.VOICE && item.voice_item?.text) {
+      return item.voice_item.text;
+    }
+  }
+  return '';
+}
+
+function describeNonTextItem(item: MessageItem): string | null {
+  switch (item.type) {
+    case MessageItemType.IMAGE: return '[图片]';
+    case MessageItemType.VOICE: return item.voice_item?.text || '[语音]';
+    case MessageItemType.FILE: return `[文件: ${item.file_item?.file_name || 'unknown'}]`;
+    case MessageItemType.VIDEO: return '[视频]';
+    default: return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Account persistence
+// ---------------------------------------------------------------------------
+
+function loadAccount(): AccountData | null {
+  const filePath = path.join(weixinStateDir(), 'account.json');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as AccountData;
+  } catch {
+    return null;
+  }
+}
+
+function saveAccount(data: AccountData): void {
+  const dir = weixinStateDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'account.json');
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  try { fs.chmodSync(filePath, 0o600); } catch { /* best-effort */ }
+}
+
+function loadSyncBuf(): string {
+  const filePath = path.join(weixinStateDir(), 'sync.json');
+  try {
+    if (!fs.existsSync(filePath)) return '';
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { get_updates_buf?: string };
+    return data.get_updates_buf || '';
+  } catch {
+    return '';
+  }
+}
+
+function saveSyncBuf(buf: string): void {
+  const dir = weixinStateDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'sync.json'),
+    JSON.stringify({ get_updates_buf: buf }, null, 0),
+    'utf-8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
+
+async function apiGet(baseUrl: string, endpoint: string, timeoutMs: number): Promise<string> {
+  const url = new URL(endpoint, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: buildCommonHeaders(),
+      signal: controller.signal,
+    });
+    clearTimeout(t);
+    const text = await res.text();
+    if (!res.ok) throw new Error(`GET ${endpoint} ${res.status}: ${text}`);
+    return text;
+  } catch (err) {
+    clearTimeout(t);
+    throw err;
+  }
+}
+
+async function apiPost(
+  baseUrl: string,
+  endpoint: string,
+  body: object,
+  token?: string,
+  timeoutMs = 15_000,
+): Promise<string> {
+  const url = new URL(endpoint, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  const bodyStr = JSON.stringify(body);
+  const headers = buildPostHeaders(token, bodyStr);
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body: bodyStr,
+      signal: controller.signal,
+    });
+    clearTimeout(t);
+    const text = await res.text();
+    if (!res.ok) throw new Error(`POST ${endpoint} ${res.status}: ${text}`);
+    return text;
+  } catch (err) {
+    clearTimeout(t);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// QR Login
+// ---------------------------------------------------------------------------
+
+async function loginWithQr(baseUrl: string): Promise<AccountData> {
+  logger.info('Starting WeChat QR login...');
+  console.log('\n  微信扫码登录...\n');
+
+  // 1. Fetch QR code
+  const qrRaw = await apiGet(baseUrl, 'ilink/bot/get_bot_qrcode?bot_type=3', 10_000);
+  const qrResp = JSON.parse(qrRaw) as { qrcode: string; qrcode_img_content: string };
+
+  if (!qrResp.qrcode_img_content) {
+    throw new Error('Failed to get QR code from WeChat API');
+  }
+
+  // Print QR code to terminal
+  try {
+    const qrterm = await import('qrcode-terminal');
+    qrterm.default.generate(qrResp.qrcode_img_content, { small: true }, (qr: string) => {
+      console.log(qr);
+    });
+  } catch {
+    // qrcode-terminal not available
+  }
+  console.log(`  扫码链接: ${qrResp.qrcode_img_content}\n`);
+  console.log('  请使用微信扫描上方二维码...\n');
+
+  // 2. Poll for scan result
+  const deadline = Date.now() + 5 * 60_000;
+  let currentBaseUrl = baseUrl;
+
+  while (Date.now() < deadline) {
+    try {
+      const statusRaw = await apiGet(
+        currentBaseUrl,
+        `ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrResp.qrcode)}`,
+        35_000,
+      );
+      const status = JSON.parse(statusRaw) as {
+        status: string;
+        bot_token?: string;
+        ilink_bot_id?: string;
+        baseurl?: string;
+        ilink_user_id?: string;
+        redirect_host?: string;
+      };
+
+      switch (status.status) {
+        case 'wait':
+          break;
+        case 'scaned':
+          console.log('  👀 已扫码，请在微信上确认...');
+          break;
+        case 'scaned_but_redirect':
+          if (status.redirect_host) {
+            currentBaseUrl = `https://${status.redirect_host}`;
+            logger.info({ redirectHost: status.redirect_host }, 'WeChat IDC redirect');
+          }
+          break;
+        case 'confirmed': {
+          if (!status.ilink_bot_id || !status.bot_token) {
+            throw new Error('Login confirmed but missing bot_token or ilink_bot_id');
+          }
+          const account: AccountData = {
+            token: status.bot_token,
+            baseUrl: status.baseurl || currentBaseUrl,
+            accountId: status.ilink_bot_id,
+            userId: status.ilink_user_id,
+            savedAt: new Date().toISOString(),
+          };
+          saveAccount(account);
+          console.log('\n  ✅ 微信连接成功!\n');
+          logger.info({ accountId: account.accountId }, 'WeChat login successful');
+          return account;
+        }
+        case 'expired':
+          throw new Error('QR code expired, please restart NanoClaw to retry');
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        // Long-poll timeout, normal
+        continue;
+      }
+      throw err;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error('WeChat login timed out');
+}
+
+// ---------------------------------------------------------------------------
+// Channel class
+// ---------------------------------------------------------------------------
+
+export class WeixinChannel implements Channel {
+  name = 'weixin';
+
+  private opts: WeixinChannelOpts;
+  private account: AccountData | null = null;
+  private running = false;
+  private abortController: AbortController | null = null;
+  private contextTokens = new Map<string, string>();
+  private pausedUntil = 0;
+
+  constructor(opts: WeixinChannelOpts) {
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    // Load or create account
+    this.account = loadAccount();
+    if (!this.account) {
+      this.account = await loginWithQr(BASE_URL);
+    } else {
+      logger.info({ accountId: this.account.accountId }, 'WeChat account loaded from disk');
+      console.log(`\n  微信已连接 (account: ${this.account.accountId})\n`);
+    }
+
+    this.running = true;
+    this.abortController = new AbortController();
+
+    // Start long-poll in background
+    this.pollLoop().catch((err) => {
+      if (!this.abortController?.signal.aborted) {
+        logger.error({ err }, 'WeChat poll loop crashed');
+      }
+    });
+  }
+
+  private async pollLoop(): Promise<void> {
+    let getUpdatesBuf = loadSyncBuf();
+    let consecutiveFailures = 0;
+    let nextTimeoutMs = LONG_POLL_TIMEOUT_MS;
+
+    logger.info('WeChat poll loop started');
+
+    while (this.running && !this.abortController?.signal.aborted) {
+      // Session pause check
+      if (Date.now() < this.pausedUntil) {
+        const waitMs = this.pausedUntil - Date.now();
+        logger.debug({ waitMs }, 'WeChat session paused, waiting');
+        await this.sleep(Math.min(waitMs, 10_000));
+        continue;
+      }
+
+      try {
+        const resp = await this.getUpdates(getUpdatesBuf, nextTimeoutMs);
+
+        if (resp.longpolling_timeout_ms && resp.longpolling_timeout_ms > 0) {
+          nextTimeoutMs = resp.longpolling_timeout_ms;
+        }
+
+        // Check for API errors
+        const isError =
+          (resp.ret !== undefined && resp.ret !== 0) ||
+          (resp.errcode !== undefined && resp.errcode !== 0);
+
+        if (isError) {
+          if (resp.errcode === SESSION_EXPIRED_ERRCODE || resp.ret === SESSION_EXPIRED_ERRCODE) {
+            this.pausedUntil = Date.now() + SESSION_PAUSE_MS;
+            logger.error('WeChat session expired, pausing for 1 hour');
+            consecutiveFailures = 0;
+            continue;
+          }
+          consecutiveFailures++;
+          logger.error(
+            { ret: resp.ret, errcode: resp.errcode, errmsg: resp.errmsg, failures: consecutiveFailures },
+            'WeChat getUpdates failed',
+          );
+          if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            consecutiveFailures = 0;
+            await this.sleep(BACKOFF_DELAY_MS);
+          } else {
+            await this.sleep(RETRY_DELAY_MS);
+          }
+          continue;
+        }
+
+        consecutiveFailures = 0;
+
+        // Save sync buf
+        if (resp.get_updates_buf) {
+          saveSyncBuf(resp.get_updates_buf);
+          getUpdatesBuf = resp.get_updates_buf;
+        }
+
+        // Process messages
+        for (const msg of resp.msgs ?? []) {
+          this.handleInboundMessage(msg);
+        }
+      } catch (err) {
+        if (this.abortController?.signal.aborted) return;
+        if (err instanceof Error && err.name === 'AbortError') {
+          // Long-poll timeout, normal
+          continue;
+        }
+        consecutiveFailures++;
+        logger.error({ err, failures: consecutiveFailures }, 'WeChat getUpdates error');
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          consecutiveFailures = 0;
+          await this.sleep(BACKOFF_DELAY_MS);
+        } else {
+          await this.sleep(RETRY_DELAY_MS);
+        }
+      }
+    }
+    logger.info('WeChat poll loop ended');
+  }
+
+  private async getUpdates(buf: string, timeoutMs: number): Promise<GetUpdatesResp> {
+    if (!this.account) throw new Error('WeChat not connected');
+    try {
+      const raw = await apiPost(
+        this.account.baseUrl,
+        'ilink/bot/getupdates',
+        { get_updates_buf: buf, base_info: { channel_version: CHANNEL_VERSION } },
+        this.account.token,
+        timeoutMs,
+      );
+      return JSON.parse(raw) as GetUpdatesResp;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return { ret: 0, msgs: [], get_updates_buf: buf };
+      }
+      throw err;
+    }
+  }
+
+  private handleInboundMessage(msg: WeixinMessage): void {
+    const fromUserId = msg.from_user_id ?? '';
+    if (!fromUserId) return;
+
+    // Skip bot's own messages
+    if (msg.message_type === MessageType.BOT) return;
+
+    const chatJid = `wx:${fromUserId}`;
+    const timestamp = msg.create_time_ms
+      ? new Date(msg.create_time_ms).toISOString()
+      : new Date().toISOString();
+
+    // Store context token
+    if (msg.context_token) {
+      this.contextTokens.set(fromUserId, msg.context_token);
+    }
+
+    // Extract text content
+    let content = extractTextBody(msg.item_list);
+
+    // If no text, describe non-text items
+    if (!content && msg.item_list?.length) {
+      const descriptions = msg.item_list
+        .map(describeNonTextItem)
+        .filter(Boolean);
+      content = descriptions.join(' ') || '[未知消息类型]';
+    }
+
+    if (!content) return;
+
+    // Store chat metadata
+    this.opts.onChatMetadata(chatJid, timestamp, fromUserId, 'weixin', false);
+
+    // Check if registered
+    const group = this.opts.registeredGroups()[chatJid];
+    if (!group) {
+      logger.debug({ chatJid }, 'Message from unregistered WeChat user');
+      return;
+    }
+
+    // Deliver message
+    this.opts.onMessage(chatJid, {
+      id: String(msg.message_id ?? msg.seq ?? Date.now()),
+      chat_jid: chatJid,
+      sender: fromUserId,
+      sender_name: fromUserId,
+      content,
+      timestamp,
+      is_from_me: false,
+    });
+
+    logger.info({ chatJid, fromUserId }, 'WeChat message stored');
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.account) {
+      logger.warn('WeChat not connected, cannot send message');
+      return;
+    }
+
+    const userId = jid.replace(/^wx:/, '');
+    const contextToken = this.contextTokens.get(userId);
+
+    try {
+      // Split long messages
+      const chunks = text.length <= MAX_MSG_LENGTH
+        ? [text]
+        : this.splitText(text, MAX_MSG_LENGTH);
+
+      for (const chunk of chunks) {
+        const clientId = generateClientId();
+        await apiPost(
+          this.account.baseUrl,
+          'ilink/bot/sendmessage',
+          {
+            msg: {
+              from_user_id: '',
+              to_user_id: userId,
+              client_id: clientId,
+              message_type: MessageType.BOT,
+              message_state: MessageState.FINISH,
+              item_list: [{ type: MessageItemType.TEXT, text_item: { text: chunk } }],
+              context_token: contextToken,
+            },
+            base_info: { channel_version: CHANNEL_VERSION },
+          },
+          this.account.token,
+        );
+      }
+      logger.info({ jid, length: text.length }, 'WeChat message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send WeChat message');
+    }
+  }
+
+  private splitText(text: string, limit: number): string[] {
+    const chunks: string[] = [];
+    let remaining = text;
+    while (remaining.length > 0) {
+      if (remaining.length <= limit) {
+        chunks.push(remaining);
+        break;
+      }
+      let splitAt = remaining.lastIndexOf('\n', limit);
+      if (splitAt <= 0 || splitAt < limit * 0.5) splitAt = remaining.lastIndexOf(' ', limit);
+      if (splitAt <= 0 || splitAt < limit * 0.5) splitAt = limit;
+      chunks.push(remaining.slice(0, splitAt));
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+    return chunks;
+  }
+
+  isConnected(): boolean {
+    return this.running && this.account !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('wx:');
+  }
+
+  async disconnect(): Promise<void> {
+    this.running = false;
+    this.abortController?.abort();
+    this.abortController = null;
+    this.account = null;
+    logger.info('WeChat channel disconnected');
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.account || !isTyping) return;
+    // Typing requires a typing_ticket from getConfig — skip for now
+    // as it adds complexity with minimal benefit
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      const t = setTimeout(resolve, ms);
+      this.abortController?.signal.addEventListener('abort', () => {
+        clearTimeout(t);
+        resolve();
+      }, { once: true });
+    });
+  }
+}

--- a/.claude/skills/add-wechat/manifest.yaml
+++ b/.claude/skills/add-wechat/manifest.yaml
@@ -1,0 +1,18 @@
+skill: wechat
+version: 1.0.0
+description: "WeChat integration via Tencent iLink Bot API"
+core_version: 0.1.0
+adds:
+  - src/channels/weixin.ts
+  - src/channels/weixin.test.ts
+modifies:
+  - src/index.ts
+  - src/config.ts
+structured:
+  npm_dependencies:
+    qrcode-terminal: "^0.12.0"
+  env_additions:
+    - WEIXIN_ENABLED
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/weixin.test.ts"

--- a/.claude/skills/add-wechat/modify/src/config.ts
+++ b/.claude/skills/add-wechat/modify/src/config.ts
@@ -1,0 +1,3 @@
+// WeChat configuration
+export const WEIXIN_ENABLED =
+  (process.env.WEIXIN_ENABLED || envConfig.WEIXIN_ENABLED) === 'true';

--- a/.claude/skills/add-wechat/modify/src/config.ts.intent.md
+++ b/.claude/skills/add-wechat/modify/src/config.ts.intent.md
@@ -1,0 +1,21 @@
+# Intent: src/config.ts modifications
+
+## What changed
+Added one new configuration export for WeChat channel support.
+
+## Key sections
+- **readEnvFile call**: Must include `WEIXIN_ENABLED` in the keys array. NanoClaw does NOT load `.env` into `process.env` — all `.env` values must be explicitly requested via `readEnvFile()`.
+- **WEIXIN_ENABLED**: Boolean flag from `process.env` or `envConfig`, when `true` enables WeChat channel creation
+
+## Invariants
+- All existing config exports remain unchanged
+- New WeChat key is added to the `readEnvFile` call alongside existing keys
+- New export is appended at the end of the file (before proxy section)
+- No existing behavior is modified — WeChat config is additive only
+- Both `process.env` and `envConfig` are checked (same pattern as `TELEGRAM_ONLY`)
+
+## Must-keep
+- All existing exports (`ASSISTANT_NAME`, `POLL_INTERVAL`, `TRIGGER_PATTERN`, etc.)
+- The `readEnvFile` pattern — ALL config read from `.env` must go through this function
+- The `escapeRegex` helper and `TRIGGER_PATTERN` construction
+- The proxy injection logic at the end

--- a/.claude/skills/add-wechat/modify/src/index.ts
+++ b/.claude/skills/add-wechat/modify/src/index.ts
@@ -1,0 +1,13 @@
+import { WeixinChannel } from './channels/weixin.js';
+import { WEIXIN_ENABLED } from './config.js';
+
+// In main() function, after QQBot initialization:
+  if (WEIXIN_ENABLED) {
+    const weixin = new WeixinChannel(channelOpts);
+    channels.push(weixin);
+    try {
+      await weixin.connect();
+    } catch (err) {
+      logger.warn({ err }, 'WeChat channel failed to connect, continuing without it');
+    }
+  }

--- a/.claude/skills/add-wechat/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-wechat/modify/src/index.ts.intent.md
@@ -1,0 +1,31 @@
+# Intent: src/index.ts modifications
+
+## What changed
+Added WeChat channel support to the multi-channel architecture using the `Channel` interface.
+
+## Key sections
+
+### Imports (top of file)
+- Added: `WeixinChannel` from `./channels/weixin.js`
+- Added: `WEIXIN_ENABLED` from `./config.js`
+
+### main()
+- Added: conditional WeChat creation (`if (WEIXIN_ENABLED)`)
+- Pattern: Same as QQBot - try/catch with warning on failure, continues without it
+- Location: After QQBot initialization, before WhatsApp initialization
+
+## Invariants
+- All existing message processing logic (triggers, cursors, idle timers) is preserved
+- The `runAgent` function is completely unchanged
+- State management (loadState/saveState) is unchanged
+- Recovery logic is unchanged
+- Container runtime check is unchanged (ensureContainerRuntimeRunning)
+- Other channel initialization code is unchanged
+
+## Must-keep
+- The `escapeXml` and `formatMessages` re-exports
+- The `_setRegisteredGroups` test helper
+- The `isDirectRun` guard at bottom
+- All error handling and cursor rollback logic in processGroupMessages
+- The channel initialization order and error handling patterns
+- The `channels` array and `findChannel` usage throughout


### PR DESCRIPTION
Add /add-wechat skill for integrating WeChat via Tencent iLink Bot API.

Features:
- QR code authentication flow
- Long-polling message receiving with sync buffer persistence
- Automatic message chunking for long messages
- Session management with auto-retry on expiry
- Support for text, voice transcription, and media descriptions
- JID format: wx:<user_id>

The skill includes:
- Complete WeixinChannel implementation (616 lines)
- Unit tests for basic functionality
- Intent files for three-way merging into config.ts and index.ts
- Comprehensive setup guide with troubleshooting section

<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
