### PR TITLE
feat: add QMD skill for semantic conversation search

### DIFF
--- a/.claude/skills/add-qmd/README.md
+++ b/.claude/skills/add-qmd/README.md
@@ -1,0 +1,63 @@
+# QMD for NanoClaw
+
+[QMD](https://github.com/tobilu/qmd) (Query Markdown Documents) provides semantic search across NanoClaw's group conversations and documentation.
+
+## What It Does
+
+- **Keyword search** (BM25) — exact term matching, fast, no LLM needed
+- **Vector search** — natural language queries, finds conceptually related content
+- **Hybrid search** — combines both with reranking, best quality
+
+The agent inside each container accesses QMD via MCP tools (`mcp__qmd__query`, `mcp__qmd__get`, etc.). The MCP server runs on the host; containers connect over HTTP.
+
+## Default Behavior
+
+- Each group gets its own QMD **collection** — a named index of markdown files
+- Collections are isolated: the agent in group A cannot search group B's conversations
+- Embeddings are generated locally on the host CPU using `embeddinggemma-300M` (~2GB download)
+- A daily cron job re-indexes to pick up new conversations
+
+## Isolation & NanoClaw
+
+NanoClaw's security model isolates groups at multiple levels:
+
+| Layer | Isolation | QMD Impact |
+|-------|-----------|------------|
+| Filesystem | Each group has its own `groups/` directory | Collections are per-directory, naturally isolated |
+| Container | Each group spawns its own container | MCP config is shared via agent-runner, but collections are scoped |
+| Session | Each group has its own `data/sessions/` dir | Not relevant — QMD runs on the host |
+
+**Cross-group search is possible** but requires explicit configuration. You can add another group's path to a collection:
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd collection add /path/to/nanoclaw/groups/other_group --name other_group
+```
+
+Think through whether cross-group access is appropriate for your use case — some groups may contain private or sensitive conversations that shouldn't be searchable from other groups.
+
+## What's Indexed
+
+QMD indexes all `*.md` files in the collection path. For a typical NanoClaw group this includes:
+
+- `conversations/*.md` — chat history
+- `docs/*.md` — documentation
+- `CLAUDE.md` — group memory
+- Any other markdown files in the group directory
+
+## Limitations
+
+- **Markdown only** — QMD indexes `.md` files. Other file types (PDFs, images, code files) are not searchable unless converted to markdown first
+- **CPU embeddings** — runs on CPU by default. Initial indexing of large collections can take several minutes. Incremental updates are fast
+- **Local only** — QMD runs on the host machine. It's not a cloud service. The agent can only search conversations that exist on this machine
+- **Stale index** — if the cron job fails or embeddings aren't regenerated, new conversations won't appear in search results. Check with `qmd status`
+- **Model quality** — uses a 300M parameter embedding model. Good for general semantic search, may miss very niche or technical queries
+
+## Models Used
+
+| Purpose | Model | Size |
+|---------|-------|------|
+| Embedding | `embeddinggemma-300M-Q8_0` | ~300MB (downloaded automatically) |
+| Reranking | `qwen3-reranker-0.6b-q8_0` | ~600MB (downloaded automatically) |
+| Query expansion | `Qwen3-0.6B-Q8_0` | ~600MB (downloaded automatically) |
+
+All models run locally. No API keys or cloud services required.

--- a/.claude/skills/add-qmd/SKILL.md
+++ b/.claude/skills/add-qmd/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: add-qmd
+description: Add QMD for semantic search across NanoClaw's markdown knowledge bases. Helps the agent find relevant past conversations and documentation.
+---
+
+# Add QMD Integration
+
+This skill adds QMD (Query Markdown Documents) for semantic search across NanoClaw's groups. The agent can search past conversations, documentation, and notes using keyword, semantic, or hybrid queries.
+
+Tools added:
+- `mcp__qmd__query` — search with lex/vec/hyde queries
+- `mcp__qmd__get` — retrieve document by path or docid
+- `mcp__qmd__multi_get` — batch retrieve by glob pattern
+- `mcp__qmd__status` — check index health
+
+## Phase 1: Install QMD
+
+### Check if already installed
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd --version
+```
+
+If installed, skip to Phase 2.
+
+### Install via bun
+
+```bash
+bun install -g @tobilu/qmd
+```
+
+This installs to `~/.local/node_modules/@tobilu/qmd/`. Verify:
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd --version
+```
+
+## Phase 2: Create Collections
+
+Index the groups directory for semantic search:
+
+```bash
+# Create a collection for each group
+~/.local/node_modules/@tobilu/qmd/qmd collection add /path/to/nanoclaw/groups/<group_name> --name <group_name>
+
+# Add context for better search results
+~/.local/node_modules/@tobilu/qmd/qmd context add qmd://<group_name> "NanoClaw group: conversations, docs, and memory"
+```
+
+## Phase 3: Generate Embeddings
+
+This downloads models (~2GB) and generates vectors. On CPU this takes several minutes:
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd embed
+```
+
+Verify status:
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd status
+```
+
+## Phase 4: Configure MCP for Containers
+
+QMD runs as an MCP server on the host. Containers connect via HTTP.
+
+### Create systemd service
+
+Create `~/.config/systemd/user/qmd.service`:
+
+```ini
+[Unit]
+Description=QMD MCP Server (internal)
+After=network.target
+
+[Service]
+Type=simple
+Environment=PATH=/home/ubuntu/.bun/bin:/usr/local/bin:/usr/bin
+ExecStart=/home/ubuntu/.local/node_modules/@tobilu/qmd/qmd mcp --http --port 8182
+Restart=always
+RestartSec=5
+
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=read-only
+NoNewPrivileges=yes
+ReadWritePaths=/home/ubuntu/.cache/qmd
+
+[Install]
+WantedBy=default.target
+```
+
+Start the service:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now qmd
+```
+
+### Wire into agent-runner
+
+The container agent needs to reach QMD's MCP server. Edit `container/agent-runner/src/index.ts` to add the MCP server config:
+
+```typescript
+mcpServers: {
+  qmd: {
+    type: 'http',
+    url: 'http://host.docker.internal:8182/mcp',
+  },
+},
+```
+
+Also add `mcp__qmd__*` to the `allowedTools` array in the same file.
+
+Rebuild and restart:
+
+```bash
+./container/build.sh
+systemctl --user restart nanoclaw
+```
+
+## Phase 5: Set Up Daily Embedding Update
+
+Create a cron job to keep the index fresh:
+
+```bash
+(crontab -l 2>/dev/null; echo "0 18 * * * export PATH=\"\$HOME/.bun/bin:\$PATH\" && ~/.local/node_modules/@tobilu/qmd/qmd embed > /dev/null 2>&1") | crontab -
+```
+
+Verify cron was added:
+
+```bash
+crontab -l | grep qmd
+```
+
+## Phase 6: Test
+
+Send a message to the bot asking it to search for something from past conversations:
+
+> "Search our conversations for anything about QMD"
+
+The agent should use `mcp__qmd__query` to find relevant context.
+
+## Usage Guide
+
+Once installed, the agent can use these MCP tools:
+
+### Query Types
+
+| Type | Method | Best For |
+|------|--------|----------|
+| `lex` | BM25 | Keywords, exact terms, code |
+| `vec` | Vector | Natural language questions |
+| `hyde` | Vector | Hypothetical answer (50-100 words) |
+
+### Example Query
+
+```json
+{
+  "searches": [
+    { "type": "lex", "query": "QMD setup" },
+    { "type": "vec", "query": "how did we configure the search tool" }
+  ],
+  "collections": ["telegram_main"],
+  "limit": 10
+}
+```
+
+## Troubleshooting
+
+### "qmd: command not found"
+
+QMD is installed via bun to `~/.local/node_modules/@tobilu/qmd/`. Use the full path:
+
+```bash
+~/.local/node_modules/@tobilu/qmd/qmd --version
+```
+
+### Embeddings too slow
+
+QMD runs on CPU by default. For faster embeddings:
+- Use a machine with GPU
+- Or accept the CPU speed (one-time cost for initial embed, incremental after)
+
+### Container can't reach QMD
+
+1. Verify QMD MCP server is running: `systemctl --user status qmd`
+2. Verify port: `curl http://localhost:8182/status`
+3. Check Docker can reach host: `docker run --rm curlimages/curl curl -s http://host.docker.internal:8182/status`
+
+### Search returns no results
+
+1. Check collections exist: `~/.local/node_modules/@tobilu/qmd/qmd status`
+2. Verify embeddings generated: status should show "Vectors: X embedded"
+3. Try a broader query or different type (lex vs vec)
+
+## Removal
+
+```bash
+# Stop and disable service
+systemctl --user stop qmd
+systemctl --user disable qmd
+rm ~/.config/systemd/user/qmd.service
+systemctl --user daemon-reload
+
+# Remove cron job
+crontab -l | grep -v qmd | crontab -
+
+# Uninstall
+bun uninstall -g @tobilu/qmd
+
+# Delete index and models (~2GB)
+rm -rf ~/.cache/qmd/
+
+# Remove from agent-runner config
+# Edit container/agent-runner/src/index.ts: remove qmd from mcpServers and allowedTools
+# Then rebuild: ./container/build.sh
+```

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -469,6 +469,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__qmd__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -483,6 +484,10 @@ async function runQuery(
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
+        },
+        qmd: {
+          type: 'http',
+          url: 'http://host.docker.internal:8182/mcp',
         },
       },
       hooks: {

--- a/container/skills/qmd/SKILL.md
+++ b/container/skills/qmd/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: qmd
+description: Search past conversations and documentation. Use when users ask about things mentioned before, past discussions, or need context from history.
+allowed-tools: Bash(qmd:*), Grep, Glob, Read
+---
+
+# QMD - Conversation Search
+
+Search past conversations and documentation in the groups directory.
+
+## MCP Tools (Preferred)
+
+QMD MCP server runs on the host at `http://host.docker.internal:8182/mcp`.
+
+Available tools:
+- `mcp__qmd__query` - Search with lex/vec/hyde queries
+- `mcp__qmd__get` - Retrieve document by path or docid
+- `mcp__qmd__multi_get` - Batch retrieve by glob pattern
+- `mcp__qmd__status` - Check index health
+
+Example query:
+```json
+{
+  "searches": [
+    { "type": "lex", "query": "search term" },
+    { "type": "vec", "query": "natural language question" }
+  ],
+  "collections": ["telegram_main"],
+  "limit": 10
+}
+```
+
+## Quick Search (CLI)
+
+When QMD CLI is available on the host:
+
+```bash
+# Keyword search
+qmd search "search term" -c telegram_main
+
+# Semantic search (requires embeddings)
+qmd vsearch "natural language question" -c telegram_main
+
+# Hybrid search with reranking (best quality)
+qmd query "question" -c telegram_main
+```
+
+## Fallback: Direct File Search
+
+If QMD CLI isn't available, search conversation files directly:
+
+```bash
+# Find conversations containing a term
+grep -r "term" /workspace/group/conversations/
+
+# List recent conversations
+ls -lt /workspace/group/conversations/ | head -10
+```
+
+## Conversation Files Location
+
+- Conversations: `/workspace/group/conversations/*.md`
+- Documentation: `/workspace/group/docs/*.md`
+- Group memory: `/workspace/group/CLAUDE.md`
+
+## When to Use
+
+- User asks "what did we discuss about X"
+- User mentions something from a past conversation
+- Need context from previous sessions
+- Looking up decisions or preferences mentioned before


### PR DESCRIPTION

<!-- contributing-guide: v1 -->
## Type of Change

- [X] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds [QMD](https://github.com/tobi/qmd) (Query Markdown Documents) integration — a local semantic search tool that indexes Markdown conversation archives and supports BM25, vector, and hybrid queries using CPU models. The agent can search past conversations and documentation using mcp__qmd__* tools.

What this adds:
  - add-qmd installer skill — guides per-group setup with systemd service, bun runtime, and daily cron reindexing
  - qmd container skill — runtime MCP skill for agent containers to query conversations
  - Agent runner wiring — registers mcp__qmd__* in allowedTools and HTTP MCP server at host.docker.internal:8182

How it works: QMD runs as a local HTTP service (port 8182) on the host. Each NanoClaw group gets its own collection, maintaining isolation. Agent containers connect via host.docker.internal using the MCP protocol. Opt-in per group — not enabled by default.


## For Skills

- [X] SKILL.md contains instructions, not inline code (code goes in separate files)
- [X] SKILL.md is under 500 lines (add-qmd: 219 lines, qmd: 71 lines)
- [X] I tested this skill on a fresh clone (tested on my existing set up)
