### PR TITLE
feat: security policy engine with deterministic user gating, tool restrictions, and readonly mounts

### DIFF
--- a/.claude/skills/add-security-policy/SKILL.md
+++ b/.claude/skills/add-security-policy/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: add-security-policy
+description: Add configurable security policy engine — tool gating, SSRF protection, readonly mounts, killswitch, and sender trust. Use when the user wants to harden their NanoClaw containers against prompt injection, secret exfiltration, or unauthorized tool use.
+---
+
+# Add Security Policy Engine
+
+Adds a declarative security layer that prevents containerized agents from dumping secrets, accessing internal networks, modifying personality/config files, or exfiltrating data — all configurable via a single JSON file.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `src/security-policy.ts` exists. If it does, skip to Phase 3 (Configure). The code changes are already in place.
+
+### Ask the user
+
+AskUserQuestion: Do you want to use the default security policy (recommended), or do you have a custom security-policy.json ready?
+
+## Phase 2: Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git fetch upstream skill/security-policy
+git merge upstream/skill/security-policy || {
+  git checkout --theirs package-lock.json
+  git add package-lock.json
+  git merge --continue
+}
+```
+
+This merges in:
+- `src/security-policy.ts` — core policy engine (loader, trust, killswitch, rules builder)
+- `src/security-policy.test.ts` — 67 tests covering regex, trust, tool gating, killswitch
+- `config-examples/security-policy.json` — example config with placeholder values
+- `src/config.ts` — adds `SECURITY_POLICY_PATH` constant
+- `src/router.ts` — extends `formatOutbound()` with markdown image and `<img>` tag stripping
+- `src/container-runner.ts` — readonly mount overlays, security rules passed to containers
+- `src/index.ts` — policy loading, killswitch checks, sender trust, security rules wiring
+- `src/task-scheduler.ts` — scheduled tasks get security rules and killswitch checks
+- `container/agent-runner/src/index.ts` — `buildCanUseTool` enforces rules inside containers
+- `src/formatting.test.ts` — image stripping tests
+
+If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides.
+
+### Validate code changes
+
+```bash
+npm install
+npm run build
+npx vitest run src/security-policy.test.ts src/formatting.test.ts
+```
+
+All tests must pass and build must be clean before proceeding.
+
+## Phase 3: Configure
+
+### Default policy (no config file needed)
+
+Without a config file, sensible defaults apply automatically:
+- Blocks `env`, `printenv`, `set`, `declare -x`, `compgen -v`, `os.environ`, `process.env` patterns in Bash
+- Blocks SSRF to localhost, RFC1918, link-local, metadata endpoints, IPv4-mapped IPv6
+- Enforces HTTPS-only for WebFetch
+- Blocks secret values from appearing in WebFetch URLs
+- Blocks writes to `.claude/`, `CLAUDE.md`, `settings.json`, agent-runner source
+- Mounts CLAUDE.md, skills, and agent-runner source as readonly in containers
+- Strips markdown images and `<img>` tags from agent output (exfiltration vector)
+
+### Custom policy (optional)
+
+Copy the example and edit:
+
+```bash
+mkdir -p ~/.config/nanoclaw
+cp config-examples/security-policy.json ~/.config/nanoclaw/security-policy.json
+```
+
+Edit `~/.config/nanoclaw/security-policy.json`:
+
+- **`trust.owner_ids`** — your channel user IDs (WhatsApp JID, Discord user ID, etc.). Messages from these senders get elevated trust (can write to personality files, use gated tools).
+- **`tools.blocked`** — tool names to block entirely (e.g., `Task`, `SendMessage`)
+- **`tools.blocked_untrusted`** — tools blocked only for non-owner senders
+- **`bash.blocked_env_vars`** — additional env var names to block in Bash commands
+- **`webfetch.blocked_url_patterns`** — additional URL patterns to block
+- **`write.trust_required_paths`** — paths that require sender trust to write
+- **`killswitch`** — file-based emergency stop (write the configured value to disable the agent)
+
+### Build and restart
+
+```bash
+npm run build
+```
+
+Then restart the service:
+
+```bash
+# macOS (launchd)
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux (systemd)
+systemctl --user restart nanoclaw
+```
+
+## Phase 4: Verify
+
+### Test security rules
+
+Send a message from a non-owner sender that tries:
+- `run env` or `run printenv` — should be blocked by Bash pattern
+- A WebFetch to `http://` (not https) — should be blocked
+- Writing to `CLAUDE.md` — should be blocked (readonly mount)
+
+### Test killswitch (optional)
+
+If killswitch is configured:
+
+```bash
+echo "enabled" > ~/path/to/killswitch.txt
+```
+
+Send a message — the agent should respond with the killswitch message instead of processing.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Troubleshooting
+
+### Agent can't use any tools
+
+1. Check that `securityRules` and `allowedTools` are being passed to the container — look for `securityRules` in logs
+2. If using a custom policy, validate the JSON: `node -e "JSON.parse(require('fs').readFileSync('$HOME/.config/nanoclaw/security-policy.json','utf8'))"`
+3. Scheduled tasks run as `senderTrusted: false` — ensure `tools.blocked_untrusted` doesn't block tools the scheduler needs
+
+### Killswitch not working
+
+1. Check the file path matches `killswitch.file` in your policy (relative to group folder)
+2. File contents must exactly match `killswitch.enabled_value` (after trimming whitespace)
+3. Windows-edited files may have BOM — use a plain text editor
+
+### Images still appearing in output
+
+1. Verify `formatOutbound` is being called — check `src/router.ts`
+2. Both `![](url)` markdown and `<img>` HTML tags are stripped
+3. Channels that render HTML independently of NanoClaw output are not covered

--- a/config-examples/security-policy.json
+++ b/config-examples/security-policy.json
@@ -1,0 +1,36 @@
+{
+  "trust": {
+    "owner_ids": ["YOUR_DISCORD_USER_ID_OR_WHATSAPP_JID"],
+    "trusted_members": []
+  },
+
+  "tools": {
+    "blocked": [
+      "Task", "TaskOutput", "TaskStop",
+      "TeamCreate", "TeamDelete", "SendMessage"
+    ],
+    "blocked_untrusted": []
+  },
+
+  "bash": {
+    "blocked_env_vars": [
+      "MY_SECRET_API_KEY",
+      "DATABASE_PASSWORD"
+    ],
+    "blocked_url_patterns": []
+  },
+
+  "webfetch": {
+    "blocked_url_patterns": []
+  },
+
+  "write": {
+    "trust_required_paths": ["/data/", "/ipc/tasks/"]
+  },
+
+  "killswitch": {
+    "file": "killswitch.txt",
+    "running_value": "running",
+    "message": "I'm currently disabled by the kill switch."
+  }
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -24,6 +24,27 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
+interface ContainerSecurityRules {
+  bash: {
+    blocked: string[];
+    blockedEnvVars: string[];
+    blockedUrls: string[];
+  };
+  webfetch: {
+    httpsOnly: boolean;
+    blockedNetworks: string[];
+    blockedUrls: string[];
+    blockSecretValues: boolean;
+  };
+  write: {
+    blocked: string[];
+    trustRequired: string[];
+  };
+  tools: {
+    blockedUntrusted: string[];
+  };
+}
+
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -33,6 +54,9 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  senderTrusted?: boolean;
+  securityRules?: ContainerSecurityRules;
+  allowedTools?: string[];
 }
 
 interface ContainerOutput {
@@ -100,6 +124,104 @@ class MessageStream {
       this.waiting = null;
     }
   }
+}
+
+/**
+ * Build canUseTool from serialized security rules.
+ * Falls back to deny-all if rules are missing (fail-closed).
+ */
+function buildCanUseTool(input: ContainerInput) {
+  const deny = (msg: string) => ({ behavior: 'deny' as const, message: msg });
+  const allow = () => ({ behavior: 'allow' as const });
+
+  return async (toolName: string, toolInput: Record<string, unknown>, _options: unknown) => {
+    const rules = input.securityRules;
+    if (!rules) return deny('Security rules not provided — deny by default.');
+
+    // --- BASH GUARDS ---
+    if (toolName === 'Bash') {
+      const cmd = String(toolInput.command || '');
+
+      for (const pattern of rules.bash.blocked) {
+        if (new RegExp(pattern).test(cmd)) {
+          return deny('Command blocked by security policy.');
+        }
+      }
+
+      // Block $VAR and ${VAR} references for configured secret env vars
+      if (rules.bash.blockedEnvVars.length > 0) {
+        const envPattern = rules.bash.blockedEnvVars
+          .map((v) => `\\$\\{?${v}\\}?`)
+          .join('|');
+        if (new RegExp(envPattern, 'i').test(cmd)) {
+          return deny('Referencing secret environment variables is blocked.');
+        }
+      }
+
+      for (const pattern of rules.bash.blockedUrls) {
+        if (new RegExp(pattern, 'i').test(cmd)) {
+          return deny('URL pattern blocked by security policy.');
+        }
+      }
+    }
+
+    // --- WEBFETCH GUARDS ---
+    if (toolName === 'WebFetch') {
+      const url = String(toolInput.url || '');
+
+      if (rules.webfetch.httpsOnly && url && !/^https:\/\//i.test(url)) {
+        return deny('WebFetch only allows https:// URLs.');
+      }
+
+      for (const pattern of rules.webfetch.blockedNetworks) {
+        if (new RegExp(pattern, 'i').test(url)) {
+          return deny('WebFetch blocked: private/internal address.');
+        }
+      }
+
+      for (const pattern of rules.webfetch.blockedUrls) {
+        if (new RegExp(pattern, 'i').test(url)) {
+          return deny('URL blocked by security policy.');
+        }
+      }
+
+      // Block URLs containing secret env var values
+      if (rules.webfetch.blockSecretValues && rules.bash.blockedEnvVars.length > 0) {
+        const secretValues = rules.bash.blockedEnvVars
+          .map((name) => process.env[name])
+          .filter((v): v is string => !!v && v.length > 10);
+        if (secretValues.some((s) => url.includes(s))) {
+          return deny('URL contains a secret credential.');
+        }
+      }
+    }
+
+    // --- WRITE/EDIT GUARDS ---
+    if (toolName === 'Write' || toolName === 'Edit') {
+      const filePath = String(toolInput.file_path || toolInput.path || '');
+
+      for (const pattern of rules.write.blocked) {
+        if (new RegExp(pattern, 'i').test(filePath)) {
+          return deny('Writing to this path is blocked by security policy.');
+        }
+      }
+
+      if (!input.senderTrusted) {
+        for (const pattern of rules.write.trustRequired) {
+          if (new RegExp(pattern).test(filePath)) {
+            return deny('Modifying this path requires owner authorization.');
+          }
+        }
+      }
+    }
+
+    // --- UNTRUSTED SENDER GUARDS ---
+    if (!input.senderTrusted && rules.tools.blockedUntrusted.includes(toolName)) {
+      return deny('This tool requires owner authorization.');
+    }
+
+    return allow();
+  };
 }
 
 async function readStdin(): Promise<string> {
@@ -449,7 +571,7 @@ async function runQuery(
             append: globalClaudeMd,
           }
         : undefined,
-      allowedTools: [
+      allowedTools: containerInput.allowedTools || [
         'Bash',
         'Read',
         'Write',
@@ -485,6 +607,7 @@ async function runQuery(
           },
         },
       },
+      canUseTool: buildCanUseTool(containerInput),
       hooks: {
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,3 +95,11 @@ function resolveConfigTimezone(): string {
   return 'UTC';
 }
 export const TIMEZONE = resolveConfigTimezone();
+
+// Security policy: stored OUTSIDE project root, never mounted into containers
+export const SECURITY_POLICY_PATH = path.join(
+  HOME_DIR,
+  '.config',
+  'nanoclaw',
+  'security-policy.json',
+);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,6 +26,12 @@ import {
 } from './container-runtime.js';
 import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
+import {
+  buildReadonlyOverlays,
+  ContainerSecurityRules,
+  getDefaultPolicy,
+  SecurityPolicy,
+} from './security-policy.js';
 import { RegisteredGroup } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
@@ -43,6 +49,9 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  senderTrusted?: boolean;
+  securityRules?: ContainerSecurityRules;
+  allowedTools?: string[];
 }
 
 export interface ContainerOutput {
@@ -61,6 +70,7 @@ interface VolumeMount {
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
+  policy: SecurityPolicy,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -210,6 +220,19 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Protect settings.json from agent modification (SDK env var injection)
+  if (fs.existsSync(settingsFile)) {
+    mounts.push({
+      hostPath: settingsFile,
+      containerPath: '/home/node/.claude/settings.json',
+      readonly: true,
+    });
+  }
+
+  // Security policy: readonly overlays for config files (all groups)
+  const securityOverlays = buildReadonlyOverlays(policy, groupDir);
+  mounts.push(...securityOverlays);
+
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
     const validatedMounts = validateAdditionalMounts(
@@ -279,13 +302,16 @@ export async function runContainerAgent(
   input: ContainerInput,
   onProcess: (proc: ChildProcess, containerName: string) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
+  policy?: SecurityPolicy,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  // Use provided policy or load defaults for mount overlay computation
+  const effectivePolicy = policy ?? getDefaultPolicy();
+  const mounts = buildVolumeMounts(group, input.isMain, effectivePolicy);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
   // Main group uses the default OneCLI agent; others use their own agent.

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -283,6 +283,34 @@ describe('formatOutbound', () => {
       formatOutbound('<internal>thinking</internal>The answer is 42'),
     ).toBe('The answer is 42');
   });
+
+  it('strips markdown images (exfiltration vector)', () => {
+    expect(formatOutbound('Check this ![img](https://evil.com/data)')).toBe(
+      'Check this [image removed]',
+    );
+  });
+
+  it('strips multiple markdown images', () => {
+    expect(formatOutbound('A ![a](http://x) B ![b](http://y) C')).toBe(
+      'A [image removed] B [image removed] C',
+    );
+  });
+
+  it('preserves normal text unchanged', () => {
+    expect(formatOutbound('Just plain text here')).toBe('Just plain text here');
+  });
+
+  it('strips HTML img tags (exfiltration vector)', () => {
+    expect(formatOutbound('Check <img src="https://evil.com/data"> this')).toBe(
+      'Check [image removed] this',
+    );
+  });
+
+  it('preserves normal markdown links (not images)', () => {
+    expect(formatOutbound('See [docs](https://example.com)')).toBe(
+      'See [docs](https://example.com)',
+    );
+  });
 });
 
 // --- Trigger gating with requiresTrigger flag ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -559,10 +559,15 @@ async function startMessageLoop(): Promise<void> {
             ASSISTANT_NAME,
             MAX_MESSAGES_PER_PROMPT,
           );
-          const messagesToSend = filterAuthorized(
-            allPending.length > 0 ? allPending : groupMessages,
-          );
-          if (messagesToSend.length === 0) continue;
+          const raw = allPending.length > 0 ? allPending : groupMessages;
+          const messagesToSend = filterAuthorized(raw);
+          if (messagesToSend.length === 0) {
+            // Advance cursor so unauthorized messages don't starve the window
+            if (raw.length > 0) {
+              lastAgentTimestamp[chatJid] = raw[raw.length - 1].timestamp;
+            }
+            continue;
+          }
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
           // Killswitch check for message piping to active containers

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,14 @@ import {
   POLL_INTERVAL,
   TIMEZONE,
 } from './config.js';
+import {
+  buildAllowedTools,
+  buildContainerSecurityRules,
+  isSenderTrusted,
+  loadSecurityPolicy,
+  readKillswitch,
+  SecurityPolicy,
+} from './security-policy.js';
 import './channels/index.js';
 import {
   getChannelFactory,
@@ -74,8 +82,21 @@ let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
 
+/** Filter messages to only authorized senders. No-op when owner_ids is empty. */
+function filterAuthorized(messages: NewMessage[]): NewMessage[] {
+  const { owner_ids, trusted_members } = securityPolicy.trust;
+  if (owner_ids.length === 0) return messages;
+  return messages.filter(
+    (m) =>
+      m.is_from_me ||
+      owner_ids.includes(m.sender) ||
+      trusted_members.includes(m.sender),
+  );
+}
+
 const channels: Channel[] = [];
 const queue = new GroupQueue();
+let securityPolicy: SecurityPolicy;
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -83,13 +104,13 @@ function ensureOneCLIAgent(jid: string, group: RegisteredGroup): void {
   if (group.isMain) return;
   const identifier = group.folder.toLowerCase().replace(/_/g, '-');
   onecli.ensureAgent({ name: group.name, identifier }).then(
-    (res) => {
+    (res: { created: boolean }) => {
       logger.info(
         { jid, identifier, created: res.created },
         'OneCLI agent ensured',
       );
     },
-    (err) => {
+    (err: unknown) => {
       logger.debug(
         { jid, identifier, err: String(err) },
         'OneCLI agent ensure skipped',
@@ -227,13 +248,26 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     return true;
   }
 
+  // Killswitch check for interactive messages
+  const ks = readKillswitch(securityPolicy, group.folder);
+  if (!ks.canRun) {
+    logger.info(
+      { chatJid, folder: group.folder },
+      'Killswitch active, refusing interactive message',
+    );
+    await channel.sendMessage(chatJid, ks.message);
+    return true;
+  }
+
   const isMainGroup = group.isMain === true;
 
-  const missedMessages = getMessagesSince(
-    chatJid,
-    getOrRecoverCursor(chatJid),
-    ASSISTANT_NAME,
-    MAX_MESSAGES_PER_PROMPT,
+  const missedMessages = filterAuthorized(
+    getMessagesSince(
+      chatJid,
+      getOrRecoverCursor(chatJid),
+      ASSISTANT_NAME,
+      MAX_MESSAGES_PER_PROMPT,
+    ),
   );
 
   if (missedMessages.length === 0) return true;
@@ -251,6 +285,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
 
   const prompt = formatMessages(missedMessages, TIMEZONE);
+
+  // Trust only when ALL non-bot senders are owners (prevent untrusted piggyback)
+  const externalMessages = missedMessages.filter((m) => !m.is_from_me);
+  const senderTrusted =
+    externalMessages.length > 0 &&
+    externalMessages.every((m) => isSenderTrusted(securityPolicy, m.sender));
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -282,32 +322,37 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
-    if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
-      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
-      if (text) {
-        await channel.sendMessage(chatJid, text);
-        outputSentToUser = true;
+  const output = await runAgent(
+    group,
+    prompt,
+    chatJid,
+    async (result) => {
+      // Streaming output callback — called for each agent result
+      if (result.result) {
+        const raw =
+          typeof result.result === 'string'
+            ? result.result
+            : JSON.stringify(result.result);
+        const text = formatOutbound(raw);
+        logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+        // Only reset idle timer on actual results, not session-update markers (result: null)
+        resetIdleTimer();
       }
-      // Only reset idle timer on actual results, not session-update markers (result: null)
-      resetIdleTimer();
-    }
 
-    if (result.status === 'success') {
-      queue.notifyIdle(chatJid);
-    }
+      if (result.status === 'success') {
+        queue.notifyIdle(chatJid);
+      }
 
-    if (result.status === 'error') {
-      hadError = true;
-    }
-  });
+      if (result.status === 'error') {
+        hadError = true;
+      }
+    },
+    senderTrusted,
+  );
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
@@ -340,6 +385,7 @@ async function runAgent(
   prompt: string,
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
+  senderTrusted?: boolean,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
@@ -391,10 +437,14 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        senderTrusted,
+        securityRules: buildContainerSecurityRules(securityPolicy),
+        allowedTools: buildAllowedTools(securityPolicy),
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
+      securityPolicy,
     );
 
     if (output.newSessionId) {
@@ -509,9 +559,18 @@ async function startMessageLoop(): Promise<void> {
             ASSISTANT_NAME,
             MAX_MESSAGES_PER_PROMPT,
           );
-          const messagesToSend =
-            allPending.length > 0 ? allPending : groupMessages;
+          const messagesToSend = filterAuthorized(
+            allPending.length > 0 ? allPending : groupMessages,
+          );
+          if (messagesToSend.length === 0) continue;
           const formatted = formatMessages(messagesToSend, TIMEZONE);
+
+          // Killswitch check for message piping to active containers
+          const ksLoop = readKillswitch(securityPolicy, group.folder);
+          if (!ksLoop.canRun) {
+            await channel.sendMessage(chatJid, ksLoop.message);
+            continue;
+          }
 
           if (queue.sendMessage(chatJid, formatted)) {
             logger.debug(
@@ -569,6 +628,8 @@ function ensureContainerSystemRunning(): void {
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  securityPolicy = loadSecurityPolicy();
+  logger.info('Security policy loaded');
   initDatabase();
   logger.info('Database initialized');
   loadState();
@@ -712,9 +773,11 @@ async function main(): Promise<void> {
     },
   });
   startIpcWatcher({
-    sendMessage: (jid, text) => {
+    sendMessage: (jid, rawText) => {
       const channel = findChannel(channels, jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      const text = formatOutbound(rawText);
+      if (!text) return Promise.resolve();
       return channel.sendMessage(jid, text);
     },
     registeredGroups: () => registeredGroups,

--- a/src/router.ts
+++ b/src/router.ts
@@ -38,7 +38,10 @@ export function stripInternalTags(text: string): string {
 export function formatOutbound(rawText: string): string {
   const text = stripInternalTags(rawText);
   if (!text) return '';
-  return text;
+  // Strip image syntax — exfiltration vector (data encoded in URL)
+  return text
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '[image removed]')
+    .replace(/<img[^>]*>/gi, '[image removed]');
 }
 
 export function routeOutbound(

--- a/src/security-policy.test.ts
+++ b/src/security-policy.test.ts
@@ -1,0 +1,594 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  buildAllowedTools,
+  buildContainerSecurityRules,
+  buildReadonlyOverlays,
+  getDefaultPolicy,
+  isSenderTrusted,
+  loadSecurityPolicy,
+  readKillswitch,
+} from './security-policy.js';
+
+function tmpFile(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-test-'));
+  const filePath = path.join(dir, 'security-policy.json');
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+// --- loadSecurityPolicy ---
+
+describe('loadSecurityPolicy', () => {
+  it('returns defaults when file does not exist', () => {
+    const policy = loadSecurityPolicy('/nonexistent/path.json');
+    expect(policy.webfetch.https_only).toBe(true);
+    expect(policy.bash.blocked_patterns.length).toBeGreaterThan(0);
+  });
+
+  it('returns defaults when file is empty object', () => {
+    const p = tmpFile('{}');
+    const policy = loadSecurityPolicy(p);
+    expect(policy.bash.blocked_patterns.length).toBeGreaterThan(0);
+    expect(policy.webfetch.blocked_networks.length).toBeGreaterThan(0);
+  });
+
+  it('merges user arrays with defaults (appends)', () => {
+    const p = tmpFile(
+      JSON.stringify({
+        bash: { blocked_patterns: ['\\bcustom\\b'] },
+      }),
+    );
+    const policy = loadSecurityPolicy(p);
+    // Has both defaults and custom
+    expect(policy.bash.blocked_patterns).toContain('\\bcustom\\b');
+    expect(policy.bash.blocked_patterns).toContain('\\bprintenv\\b');
+  });
+
+  it('replaces owner_ids (not appends)', () => {
+    const p = tmpFile(
+      JSON.stringify({
+        trust: { owner_ids: ['user-123'] },
+      }),
+    );
+    const policy = loadSecurityPolicy(p);
+    expect(policy.trust.owner_ids).toEqual(['user-123']);
+  });
+
+  it('throws on malformed JSON', () => {
+    const p = tmpFile('not json');
+    expect(() => loadSecurityPolicy(p)).toThrow('invalid JSON');
+  });
+
+  it('throws on non-object root', () => {
+    const p = tmpFile('"string"');
+    expect(() => loadSecurityPolicy(p)).toThrow('root must be an object');
+  });
+
+  it('throws on invalid regex in blocked_patterns', () => {
+    const p = tmpFile(
+      JSON.stringify({
+        bash: { blocked_patterns: ['(unclosed'] },
+      }),
+    );
+    expect(() => loadSecurityPolicy(p)).toThrow('invalid regex');
+  });
+
+  it('overrides boolean settings', () => {
+    const p = tmpFile(
+      JSON.stringify({
+        webfetch: { https_only: false },
+      }),
+    );
+    const policy = loadSecurityPolicy(p);
+    expect(policy.webfetch.https_only).toBe(false);
+  });
+
+  it('overrides killswitch message', () => {
+    const p = tmpFile(
+      JSON.stringify({
+        killswitch: { message: 'Custom shutdown message' },
+      }),
+    );
+    const policy = loadSecurityPolicy(p);
+    expect(policy.killswitch.message).toBe('Custom shutdown message');
+  });
+});
+
+// --- getDefaultPolicy ---
+
+describe('getDefaultPolicy', () => {
+  it('bash patterns include env dump protection', () => {
+    const policy = getDefaultPolicy();
+    const joined = policy.bash.blocked_patterns.join(' ');
+    expect(joined).toContain('printenv');
+    expect(joined).toContain('environ');
+    expect(joined).toContain('process\\.env');
+    expect(joined).toContain('os\\.environ');
+  });
+
+  it('webfetch defaults to https_only', () => {
+    expect(getDefaultPolicy().webfetch.https_only).toBe(true);
+  });
+
+  it('webfetch blocks RFC1918 and loopback', () => {
+    const networks = getDefaultPolicy().webfetch.blocked_networks.join(' ');
+    expect(networks).toContain('127');
+    expect(networks).toContain('10');
+    expect(networks).toContain('192\\.168');
+    expect(networks).toContain('::1');
+  });
+
+  it('write always blocks CLAUDE.md and settings.json', () => {
+    const paths = getDefaultPolicy().write.blocked_paths.join(' ');
+    expect(paths).toContain('CLAUDE');
+    expect(paths).toContain('settings');
+  });
+
+  it('personality and skill files require trust by default', () => {
+    const paths = getDefaultPolicy().write.trust_required_paths.join(' ');
+    expect(paths).toContain('skills');
+    expect(paths).toContain('SOUL');
+    expect(paths).toContain('TOOLS');
+    expect(paths).toContain('IDENTITY');
+    expect(paths).toContain('MEMORY');
+  });
+
+  it('tools.blocked is empty by default', () => {
+    expect(getDefaultPolicy().tools.blocked).toEqual([]);
+  });
+});
+
+// --- isSenderTrusted ---
+
+describe('isSenderTrusted', () => {
+  it('returns true for ID in owner_ids', () => {
+    const policy = getDefaultPolicy();
+    policy.trust.owner_ids = ['user-123', 'user-456'];
+    expect(isSenderTrusted(policy, 'user-123')).toBe(true);
+  });
+
+  it('returns false for unknown ID', () => {
+    const policy = getDefaultPolicy();
+    policy.trust.owner_ids = ['user-123'];
+    expect(isSenderTrusted(policy, 'user-999')).toBe(false);
+  });
+
+  it('returns false when owner_ids is empty', () => {
+    const policy = getDefaultPolicy();
+    expect(isSenderTrusted(policy, 'anyone')).toBe(false);
+  });
+});
+
+// --- buildAllowedTools ---
+
+describe('buildAllowedTools', () => {
+  it('returns full tool list when nothing blocked', () => {
+    const tools = buildAllowedTools(getDefaultPolicy());
+    expect(tools).toContain('Bash');
+    expect(tools).toContain('Task');
+    expect(tools).toContain('mcp__nanoclaw__*');
+  });
+
+  it('excludes blocked tools', () => {
+    const policy = getDefaultPolicy();
+    policy.tools.blocked = ['Task', 'TeamCreate'];
+    const tools = buildAllowedTools(policy);
+    expect(tools).not.toContain('Task');
+    expect(tools).not.toContain('TeamCreate');
+    expect(tools).toContain('Bash');
+  });
+});
+
+// --- buildContainerSecurityRules ---
+
+describe('buildContainerSecurityRules', () => {
+  it('serializes bash patterns', () => {
+    const rules = buildContainerSecurityRules(getDefaultPolicy());
+    expect(rules.bash.blocked.length).toBeGreaterThan(0);
+    expect(rules.bash.blocked).toContain('\\bprintenv\\b');
+  });
+
+  it('serializes webfetch config', () => {
+    const rules = buildContainerSecurityRules(getDefaultPolicy());
+    expect(rules.webfetch.httpsOnly).toBe(true);
+    expect(rules.webfetch.blockedNetworks.length).toBeGreaterThan(0);
+  });
+
+  it('serializes write paths', () => {
+    const rules = buildContainerSecurityRules(getDefaultPolicy());
+    expect(rules.write.blocked.length).toBeGreaterThan(0);
+  });
+
+  it('serializes tools.blockedUntrusted', () => {
+    const policy = getDefaultPolicy();
+    policy.tools.blocked_untrusted = ['mcp__memory__write'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(rules.tools.blockedUntrusted).toContain('mcp__memory__write');
+  });
+});
+
+// --- canUseTool behavior (via serialized rules) ---
+
+describe('canUseTool (default rules)', () => {
+  // Helper: simulate canUseTool with default policy rules
+  function testCanUseTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    trusted = false,
+    extraRules?: Partial<ReturnType<typeof buildContainerSecurityRules>>,
+  ): { allowed: boolean } {
+    const rules = {
+      ...buildContainerSecurityRules(getDefaultPolicy()),
+      ...extraRules,
+    };
+
+    // Bash
+    if (toolName === 'Bash') {
+      const cmd = String(input.command || '');
+      for (const pattern of rules.bash.blocked) {
+        if (new RegExp(pattern).test(cmd)) return { allowed: false };
+      }
+      if (rules.bash.blockedEnvVars.length > 0) {
+        const envPattern = rules.bash.blockedEnvVars
+          .map((v) => `\\$\\{?${v}\\}?`)
+          .join('|');
+        if (new RegExp(envPattern, 'i').test(cmd)) return { allowed: false };
+      }
+      for (const pattern of rules.bash.blockedUrls) {
+        if (new RegExp(pattern, 'i').test(cmd)) return { allowed: false };
+      }
+    }
+
+    // WebFetch
+    if (toolName === 'WebFetch') {
+      const url = String(input.url || '');
+      if (rules.webfetch.httpsOnly && url && !/^https:\/\//i.test(url))
+        return { allowed: false };
+      for (const pattern of rules.webfetch.blockedNetworks) {
+        if (new RegExp(pattern, 'i').test(url)) return { allowed: false };
+      }
+      for (const pattern of rules.webfetch.blockedUrls) {
+        if (new RegExp(pattern, 'i').test(url)) return { allowed: false };
+      }
+    }
+
+    // Write/Edit
+    if (toolName === 'Write' || toolName === 'Edit') {
+      const filePath = String(input.file_path || input.path || '');
+      for (const pattern of rules.write.blocked) {
+        if (new RegExp(pattern, 'i').test(filePath)) return { allowed: false };
+      }
+      if (!trusted) {
+        for (const pattern of rules.write.trustRequired) {
+          if (new RegExp(pattern).test(filePath)) return { allowed: false };
+        }
+      }
+    }
+
+    // Untrusted tool check
+    if (!trusted && rules.tools.blockedUntrusted.includes(toolName)) {
+      return { allowed: false };
+    }
+
+    return { allowed: true };
+  }
+
+  // --- Bash ---
+
+  it('blocks bare env', () => {
+    expect(testCanUseTool('Bash', { command: 'env' }).allowed).toBe(false);
+  });
+
+  it('blocks env piped', () => {
+    expect(testCanUseTool('Bash', { command: 'env | cat' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks env in subshell', () => {
+    expect(testCanUseTool('Bash', { command: 'echo $(env)' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks env in backticks', () => {
+    expect(testCanUseTool('Bash', { command: 'echo `env`' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks env with semicolon', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'env;cat /etc/passwd' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks printenv', () => {
+    expect(testCanUseTool('Bash', { command: 'printenv' }).allowed).toBe(false);
+  });
+
+  it('blocks export -p', () => {
+    expect(testCanUseTool('Bash', { command: 'export -p' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks declare -x', () => {
+    expect(testCanUseTool('Bash', { command: 'declare -x' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks declare -p', () => {
+    expect(testCanUseTool('Bash', { command: 'declare -p' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks env -0', () => {
+    expect(testCanUseTool('Bash', { command: 'env -0' }).allowed).toBe(false);
+  });
+
+  it('blocks compgen -v', () => {
+    expect(testCanUseTool('Bash', { command: 'compgen -v' }).allowed).toBe(
+      false,
+    );
+  });
+
+  it('blocks /proc/self/environ', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'cat /proc/self/environ' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks /proc/1/environ', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'cat /proc/1/environ' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks /proc/42/environ', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'strings /proc/42/environ' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks os.environ (Python)', () => {
+    expect(
+      testCanUseTool('Bash', {
+        command: 'python3 -c "import os; print(os.environ)"',
+      }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks process.env (Node)', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'node -e "console.log(process.env)"' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('allows env FOO=bar cmd (legitimate use)', () => {
+    expect(
+      testCanUseTool('Bash', { command: 'env FOO=bar node app.js' }).allowed,
+    ).toBe(true);
+  });
+
+  it('allows normal commands', () => {
+    expect(testCanUseTool('Bash', { command: 'ls -la' }).allowed).toBe(true);
+    expect(testCanUseTool('Bash', { command: 'git status' }).allowed).toBe(
+      true,
+    );
+    expect(testCanUseTool('Bash', { command: 'npm install' }).allowed).toBe(
+      true,
+    );
+  });
+
+  it('blocks $SECRET_VAR from config', () => {
+    const policy = getDefaultPolicy();
+    policy.bash.blocked_env_vars = ['MY_SECRET'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(
+      testCanUseTool('Bash', { command: 'echo $MY_SECRET' }, false, rules)
+        .allowed,
+    ).toBe(false);
+    expect(
+      testCanUseTool('Bash', { command: 'echo ${MY_SECRET}' }, false, rules)
+        .allowed,
+    ).toBe(false);
+  });
+
+  // --- WebFetch ---
+
+  it('blocks http:// URLs', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'http://example.com' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks localhost', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://localhost:3000' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks 127.0.0.1', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://127.0.0.1/api' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks 10.x private', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://10.0.0.1/admin' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks 192.168.x private', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://192.168.1.1/' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks [::1] IPv6 loopback', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://[::1]:8080/' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks host.docker.internal', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://host.docker.internal:3000' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks URL with userinfo bypass on loopback', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://x@127.0.0.1/' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks URL with userinfo bypass on localhost', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://x@localhost/' }).allowed,
+    ).toBe(false);
+  });
+
+  it('blocks URL with userinfo bypass on RFC1918', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://user:pass@10.0.0.1/' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://[::ffff:127.0.0.1]/' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks IPv4-mapped IPv6 private', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://[::ffff:10.0.0.1]/' }).allowed,
+    ).toBe(false);
+  });
+
+  it('allows normal HTTPS URLs', () => {
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://example.com' }).allowed,
+    ).toBe(true);
+    expect(
+      testCanUseTool('WebFetch', { url: 'https://api.github.com/repos' })
+        .allowed,
+    ).toBe(true);
+  });
+
+  // --- Write/Edit ---
+
+  it('blocks /skills/ path for untrusted', () => {
+    expect(
+      testCanUseTool('Write', {
+        file_path: '/workspace/group/.claude/skills/evil',
+      }).allowed,
+    ).toBe(false);
+  });
+
+  it('allows /skills/ path for trusted', () => {
+    expect(
+      testCanUseTool(
+        'Write',
+        { file_path: '/workspace/group/.claude/skills/my-skill/SKILL.md' },
+        true,
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it('blocks CLAUDE.md', () => {
+    expect(
+      testCanUseTool('Write', { file_path: '/workspace/group/CLAUDE.md' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks settings.json', () => {
+    expect(
+      testCanUseTool('Edit', { file_path: '/home/node/.claude/settings.json' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks SOUL.md for untrusted', () => {
+    expect(
+      testCanUseTool('Write', { file_path: '/workspace/group/SOUL.md' })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('allows SOUL.md for trusted', () => {
+    expect(
+      testCanUseTool('Write', { file_path: '/workspace/group/SOUL.md' }, true)
+        .allowed,
+    ).toBe(true);
+  });
+
+  it('allows normal workspace paths', () => {
+    expect(
+      testCanUseTool('Write', { file_path: '/workspace/group/notes.md' })
+        .allowed,
+    ).toBe(true);
+  });
+
+  it('blocks trust-required paths for untrusted', () => {
+    const policy = getDefaultPolicy();
+    policy.write.trust_required_paths = ['/data/'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(
+      testCanUseTool(
+        'Write',
+        { file_path: '/workspace/group/data/file.json' },
+        false,
+        rules,
+      ).allowed,
+    ).toBe(false);
+  });
+
+  it('allows trust-required paths for trusted', () => {
+    const policy = getDefaultPolicy();
+    policy.write.trust_required_paths = ['/data/'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(
+      testCanUseTool(
+        'Write',
+        { file_path: '/workspace/group/data/file.json' },
+        true,
+        rules,
+      ).allowed,
+    ).toBe(true);
+  });
+
+  // --- Untrusted sender ---
+
+  it('blocks untrusted tools for untrusted sender', () => {
+    const policy = getDefaultPolicy();
+    policy.tools.blocked_untrusted = ['mcp__memory__write'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(testCanUseTool('mcp__memory__write', {}, false, rules).allowed).toBe(
+      false,
+    );
+  });
+
+  it('allows untrusted tools for trusted sender', () => {
+    const policy = getDefaultPolicy();
+    policy.tools.blocked_untrusted = ['mcp__memory__write'];
+    const rules = buildContainerSecurityRules(policy);
+    expect(testCanUseTool('mcp__memory__write', {}, true, rules).allowed).toBe(
+      true,
+    );
+  });
+});

--- a/src/security-policy.ts
+++ b/src/security-policy.ts
@@ -1,0 +1,417 @@
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR, SECURITY_POLICY_PATH } from './config.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { logger } from './logger.js';
+
+// --- Types ---
+
+export interface SecurityPolicy {
+  trust: { owner_ids: string[]; trusted_members: string[] };
+  tools: { blocked: string[]; blocked_untrusted: string[] };
+  bash: {
+    blocked_patterns: string[];
+    blocked_env_vars: string[];
+    blocked_url_patterns: string[];
+  };
+  webfetch: {
+    https_only: boolean;
+    blocked_networks: string[];
+    blocked_url_patterns: string[];
+    block_secret_values: boolean;
+  };
+  write: { blocked_paths: string[]; trust_required_paths: string[] };
+  mounts: { readonly_overlays: string[] };
+  killswitch: { file: string; running_value: string; message: string };
+}
+
+export interface ContainerSecurityRules {
+  bash: {
+    blocked: string[];
+    blockedEnvVars: string[];
+    blockedUrls: string[];
+  };
+  webfetch: {
+    httpsOnly: boolean;
+    blockedNetworks: string[];
+    blockedUrls: string[];
+    blockSecretValues: boolean;
+  };
+  write: {
+    blocked: string[];
+    trustRequired: string[];
+  };
+  tools: {
+    blockedUntrusted: string[];
+  };
+}
+
+// --- Defaults ---
+
+const DEFAULT_BASH_BLOCKED: string[] = [
+  '\\bprintenv\\b',
+  '\\benv\\b\\s*($|[|>$;&\\n)`-])',
+  '\\bexport\\s+-p\\b',
+  '\\bdeclare\\s+-[a-z]*[xp]\\b',
+  '\\/proc\\/(self|\\d+)\\/environ',
+  '\\bset\\b\\s*[|>$]',
+  '\\bos\\.environ\\b',
+  '\\bprocess\\.env\\b',
+  '\\bcompgen\\s+-v\\b',
+];
+
+const DEFAULT_WEBFETCH_BLOCKED_NETWORKS: string[] = [
+  '^https?://([^@]*@)?(127\\.)',
+  '^https?://([^@]*@)?(10\\.)',
+  '^https?://([^@]*@)?(172\\.(1[6-9]|2\\d|3[01])\\.)',
+  '^https?://([^@]*@)?(192\\.168\\.)',
+  '^https?://([^@]*@)?(169\\.254\\.)',
+  '^https?://([^@]*@)?(localhost)',
+  '^https?://([^@]*@)?(host\\.docker\\.internal)',
+  '^https?://([^@]*@)?(0\\.0\\.0\\.0)',
+  '^https?://([^@]*@)?(\\[::1\\])',
+  '^https?://([^@]*@)?\\[::ffff:',
+];
+
+const DEFAULT_WRITE_BLOCKED: string[] = ['CLAUDE\\.md', 'settings\\.json'];
+
+const DEFAULT_WRITE_TRUST_REQUIRED: string[] = [
+  '\\/skills\\/',
+  'SOUL\\.md',
+  'TOOLS\\.md',
+  'IDENTITY\\.md',
+  'MEMORY\\.md',
+];
+
+const DEFAULT_READONLY_OVERLAYS: string[] = ['CLAUDE.md'];
+
+const DEFAULT_POLICY: SecurityPolicy = {
+  trust: { owner_ids: [], trusted_members: [] },
+  tools: { blocked: [], blocked_untrusted: [] },
+  bash: {
+    blocked_patterns: DEFAULT_BASH_BLOCKED,
+    blocked_env_vars: [],
+    blocked_url_patterns: [],
+  },
+  webfetch: {
+    https_only: true,
+    blocked_networks: DEFAULT_WEBFETCH_BLOCKED_NETWORKS,
+    blocked_url_patterns: [],
+    block_secret_values: true,
+  },
+  write: {
+    blocked_paths: DEFAULT_WRITE_BLOCKED,
+    trust_required_paths: DEFAULT_WRITE_TRUST_REQUIRED,
+  },
+  mounts: { readonly_overlays: DEFAULT_READONLY_OVERLAYS },
+  killswitch: {
+    file: 'killswitch.txt',
+    running_value: 'running',
+    message: "I'm currently disabled by the kill switch.",
+  },
+};
+
+// --- Loading ---
+
+export function getDefaultPolicy(): SecurityPolicy {
+  return structuredClone(DEFAULT_POLICY);
+}
+
+function mergeStringArrays(defaults: string[], user: unknown): string[] {
+  if (!Array.isArray(user)) return defaults;
+  const valid = user.filter((v): v is string => typeof v === 'string');
+  return [...defaults, ...valid];
+}
+
+function validateRegexes(patterns: string[], label: string): void {
+  for (const p of patterns) {
+    try {
+      new RegExp(p);
+    } catch (err) {
+      throw new Error(
+        `security-policy: invalid regex in ${label}: "${p}" — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+export function loadSecurityPolicy(pathOverride?: string): SecurityPolicy {
+  const filePath = pathOverride ?? SECURITY_POLICY_PATH;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return getDefaultPolicy();
+    }
+    throw new Error(
+      `security-policy: cannot read config at ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`security-policy: invalid JSON in ${filePath}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`security-policy: root must be an object in ${filePath}`);
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const policy = getDefaultPolicy();
+
+  // Trust — owner_ids replaces (not appends) since these are identities
+  const trust = obj.trust as Record<string, unknown> | undefined;
+  if (trust?.owner_ids && Array.isArray(trust.owner_ids)) {
+    policy.trust.owner_ids = trust.owner_ids.filter(
+      (v): v is string => typeof v === 'string',
+    );
+  }
+  if (trust?.trusted_members && Array.isArray(trust.trusted_members)) {
+    policy.trust.trusted_members = trust.trusted_members.filter(
+      (v): v is string => typeof v === 'string',
+    );
+  }
+
+  // Tools
+  const tools = obj.tools as Record<string, unknown> | undefined;
+  if (tools) {
+    policy.tools.blocked = mergeStringArrays(
+      policy.tools.blocked,
+      tools.blocked,
+    );
+    policy.tools.blocked_untrusted = mergeStringArrays(
+      policy.tools.blocked_untrusted,
+      tools.blocked_untrusted,
+    );
+  }
+
+  // Bash
+  const bash = obj.bash as Record<string, unknown> | undefined;
+  if (bash) {
+    policy.bash.blocked_patterns = mergeStringArrays(
+      policy.bash.blocked_patterns,
+      bash.blocked_patterns,
+    );
+    policy.bash.blocked_env_vars = mergeStringArrays(
+      policy.bash.blocked_env_vars,
+      bash.blocked_env_vars,
+    );
+    policy.bash.blocked_url_patterns = mergeStringArrays(
+      policy.bash.blocked_url_patterns,
+      bash.blocked_url_patterns,
+    );
+  }
+
+  // WebFetch
+  const webfetch = obj.webfetch as Record<string, unknown> | undefined;
+  if (webfetch) {
+    if (typeof webfetch.https_only === 'boolean') {
+      policy.webfetch.https_only = webfetch.https_only;
+    }
+    policy.webfetch.blocked_networks = mergeStringArrays(
+      policy.webfetch.blocked_networks,
+      webfetch.blocked_networks,
+    );
+    policy.webfetch.blocked_url_patterns = mergeStringArrays(
+      policy.webfetch.blocked_url_patterns,
+      webfetch.blocked_url_patterns,
+    );
+    if (typeof webfetch.block_secret_values === 'boolean') {
+      policy.webfetch.block_secret_values = webfetch.block_secret_values;
+    }
+  }
+
+  // Write
+  const write = obj.write as Record<string, unknown> | undefined;
+  if (write) {
+    policy.write.blocked_paths = mergeStringArrays(
+      policy.write.blocked_paths,
+      write.blocked_paths,
+    );
+    policy.write.trust_required_paths = mergeStringArrays(
+      policy.write.trust_required_paths,
+      write.trust_required_paths,
+    );
+  }
+
+  // Mounts
+  const mounts = obj.mounts as Record<string, unknown> | undefined;
+  if (mounts) {
+    policy.mounts.readonly_overlays = mergeStringArrays(
+      policy.mounts.readonly_overlays,
+      mounts.readonly_overlays,
+    );
+  }
+
+  // Killswitch
+  const killswitch = obj.killswitch as Record<string, unknown> | undefined;
+  if (killswitch) {
+    if (typeof killswitch.file === 'string') {
+      policy.killswitch.file = killswitch.file;
+    }
+    if (typeof killswitch.running_value === 'string') {
+      policy.killswitch.running_value = killswitch.running_value;
+    }
+    if (typeof killswitch.message === 'string') {
+      policy.killswitch.message = killswitch.message;
+    }
+  }
+
+  // Validate all regex patterns at load time (fail-fast)
+  validateRegexes(policy.bash.blocked_patterns, 'bash.blocked_patterns');
+  validateRegexes(
+    policy.bash.blocked_url_patterns,
+    'bash.blocked_url_patterns',
+  );
+  validateRegexes(
+    policy.webfetch.blocked_networks,
+    'webfetch.blocked_networks',
+  );
+  validateRegexes(
+    policy.webfetch.blocked_url_patterns,
+    'webfetch.blocked_url_patterns',
+  );
+  validateRegexes(policy.write.blocked_paths, 'write.blocked_paths');
+  validateRegexes(
+    policy.write.trust_required_paths,
+    'write.trust_required_paths',
+  );
+
+  return policy;
+}
+
+// --- Helpers ---
+
+export function isSenderTrusted(
+  policy: SecurityPolicy,
+  senderId: string,
+): boolean {
+  if (policy.trust.owner_ids.length === 0) return false;
+  return policy.trust.owner_ids.includes(senderId);
+}
+
+export function readKillswitch(
+  policy: SecurityPolicy,
+  groupFolder: string,
+): { canRun: boolean; message: string } {
+  const groupDir = resolveGroupFolderPath(groupFolder);
+  const ksPath = path.join(groupDir, 'data', policy.killswitch.file);
+
+  try {
+    const content = fs
+      .readFileSync(ksPath, 'utf-8')
+      .replace(/^\uFEFF/, '')
+      .trim();
+    if (content === policy.killswitch.running_value) {
+      return { canRun: true, message: '' };
+    }
+    return { canRun: false, message: policy.killswitch.message };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { canRun: true, message: '' };
+    }
+    logger.error(
+      { err, ksPath },
+      'killswitch: unexpected read error, failing closed',
+    );
+    return { canRun: false, message: policy.killswitch.message };
+  }
+}
+
+export function buildAllowedTools(policy: SecurityPolicy): string[] {
+  const all = [
+    'Bash',
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'WebSearch',
+    'WebFetch',
+    'Task',
+    'TaskOutput',
+    'TaskStop',
+    'TeamCreate',
+    'TeamDelete',
+    'SendMessage',
+    'TodoWrite',
+    'ToolSearch',
+    'Skill',
+    'NotebookEdit',
+    'mcp__nanoclaw__*',
+  ];
+  const blocked = new Set(policy.tools.blocked);
+  return all.filter((t) => !blocked.has(t));
+}
+
+export function buildContainerSecurityRules(
+  policy: SecurityPolicy,
+): ContainerSecurityRules {
+  return {
+    bash: {
+      blocked: policy.bash.blocked_patterns,
+      blockedEnvVars: policy.bash.blocked_env_vars,
+      blockedUrls: policy.bash.blocked_url_patterns,
+    },
+    webfetch: {
+      httpsOnly: policy.webfetch.https_only,
+      blockedNetworks: policy.webfetch.blocked_networks,
+      blockedUrls: policy.webfetch.blocked_url_patterns,
+      blockSecretValues: policy.webfetch.block_secret_values,
+    },
+    write: {
+      blocked: policy.write.blocked_paths,
+      trustRequired: policy.write.trust_required_paths,
+    },
+    tools: {
+      blockedUntrusted: policy.tools.blocked_untrusted,
+    },
+  };
+}
+
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+export function buildReadonlyOverlays(
+  policy: SecurityPolicy,
+  groupDir: string,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+
+  for (const overlay of policy.mounts.readonly_overlays) {
+    const hostPath = path.join(groupDir, overlay);
+    if (fs.existsSync(hostPath)) {
+      mounts.push({
+        hostPath,
+        containerPath: `/workspace/group/${overlay}`,
+        readonly: true,
+      });
+    }
+  }
+
+  // Killswitch file (lives in data/ which may be a symlink)
+  try {
+    const dataRealPath = fs.realpathSync(path.join(groupDir, 'data'));
+    const ksPath = path.join(dataRealPath, policy.killswitch.file);
+    if (fs.existsSync(ksPath)) {
+      mounts.push({
+        hostPath: ksPath,
+        containerPath: `/workspace/group/data/${policy.killswitch.file}`,
+        readonly: true,
+      });
+    }
+  } catch {
+    /* data dir missing — skip */
+  }
+
+  return mounts;
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -211,6 +211,7 @@ async function runTask(
           error = streamedOutput.error || 'Unknown error';
         }
       },
+      policy,
     );
 
     if (closeTimer) clearTimeout(closeTimer);

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -19,6 +19,12 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
+import {
+  buildAllowedTools,
+  buildContainerSecurityRules,
+  loadSecurityPolicy,
+  readKillswitch,
+} from './security-policy.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
 /**
@@ -147,6 +153,9 @@ async function runTask(
     })),
   );
 
+  const policy = loadSecurityPolicy();
+  if (!readKillswitch(policy, task.group_folder).canRun) return;
+
   let result: string | null = null;
   let error: string | null = null;
 
@@ -181,6 +190,9 @@ async function runTask(
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
         script: task.script || undefined,
+        senderTrusted: false,
+        securityRules: buildContainerSecurityRules(policy),
+        allowedTools: buildAllowedTools(policy),
       },
       (proc, containerName) =>
         deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),


### PR DESCRIPTION
Supersedes #1360 (rebased on current main, added SKILL.md per @gavrielc's [feedback](https://github.com/ebenezer-isaac/nanoclaw/pull/2#issuecomment-2751063370)).

## Summary

Adds a configurable security policy engine to NanoClaw. **All enforcement is deterministic code, not prompt-based.** Previously, access control relied on the AI agent interpreting SOUL.md rules (e.g. "ignore non-owners"), which is unreliable. This PR replaces that with hard code-level gates that the agent cannot bypass.

### Key change: deterministic user gating

Instead of relying on the bot to handle security through prompt instructions like "ignore strangers", unauthorized senders are now **blocked in code before a container is even spawned**. The agent never sees the message, no tokens are wasted, and there is zero chance of the bot "deciding" to respond anyway.

### What it does

- **Deterministic sender gate.** When `owner_ids` is configured, only messages from owners or `trusted_members` spawn a container. Unknown senders are silently blocked in code. Leave `owner_ids` empty to allow all senders (backwards compatible, opt-in restriction).
- **Tool gating via `canUseTool` callback.** Blocks bash commands matching regex patterns, env var leaks, private network access, and restricted file writes. Falls back to deny-all if rules are missing (fail-closed).
- **Two-tier trust model.** Owners (`owner_ids`) can talk to the bot and edit personality files, skills, and config. Trusted members (`trusted_members`) can talk to the bot but cannot edit anything.
- **Readonly filesystem mounts.** CLAUDE.md, killswitch.txt, skills/, and settings.json are mounted read-only inside the container to prevent agent self-modification.
- **Killswitch.** File-based emergency stop, checked before every container spawn and message pipe. The agent cannot re-enable itself because the killswitch file is mounted read-only.
- **Output sanitization.** Strips markdown images from agent responses to prevent data exfiltration via image URLs.
- **Allowed tools filtering.** A whitelist is computed from the policy, and blocked tools are removed before passing to the SDK.

### Files changed (11)

| File | Change |
|------|--------|
| `src/security-policy.ts` | New core module (420+ lines) for policy loading, merging, and validation |
| `src/security-policy.test.ts` | 67 tests with full coverage of the policy engine |
| `config-examples/security-policy.json` | Example config with documented fields |
| `.claude/skills/add-security-policy/SKILL.md` | Feature skill for branch-based installation |
| `src/config.ts` | Added `SECURITY_POLICY_PATH` (stored outside project root, never mounted) |
| `src/container-runner.ts` | Readonly mounts, policy overlays, and new ContainerInput fields for trust/rules/tools |
| `src/index.ts` | Deterministic sender gate, trust computation, killswitch checks, and formatOutbound on IPC output |
| `src/router.ts` | Image stripping in formatOutbound |
| `src/formatting.test.ts` | Tests for image stripping |
| `container/agent-runner/src/index.ts` | `buildCanUseTool` for runtime tool enforcement inside the container |
| `src/task-scheduler.ts` | Scheduled tasks now receive security rules and trust context |

### Design principles

1. **Deterministic, not probabilistic.** Code gates enforce access control, not prompt instructions.
2. **Fail-closed.** Missing security rules means all tools are denied.
3. **Tamper-proof.** The policy file lives outside the project root and is never mounted into containers.
4. **Backwards compatible.** An empty `owner_ids` array means no sender restriction (opt-in security).
5. **Two-layer defense.** The sender gate prevents container spawn, and canUseTool restricts tools inside the container.

### What changed since #1360

- Rebased on current `main` (f23a54a) — resolves OneCLI SDK, prettier, and script support conflicts
- Added `.claude/skills/add-security-policy/SKILL.md` — feature skill for branch-based installation
- Fixed: sender trust uses `every()` instead of `some()` — prevents untrusted piggyback in mixed-sender batches
- Fixed: scheduled tasks receive `securityRules`/`allowedTools` — prevents deny-all from fail-closed branch

## Test plan

- [x] 67 security policy tests pass
- [x] 47 formatting tests pass (including image stripping)
- [ ] Deploy with no policy file and verify defaults apply (fail-safe)
- [ ] Deploy with example config and verify custom rules merge with defaults
- [ ] Verify the sender gate blocks unknown senders (no container spawned)
- [ ] Verify trusted members can talk to the bot but cannot edit personality files
- [ ] Verify the killswitch blocks container spawn when active
- [ ] Verify markdown images are stripped from output

Closes #458