### PR TITLE
fix: always re-copy agent-runner source to avoid stale cache

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -202,16 +202,7 @@ function buildVolumeMounts(
     'agent-runner-src',
   );
   if (fs.existsSync(agentRunnerSrc)) {
-    const srcIndex = path.join(agentRunnerSrc, 'index.ts');
-    const cachedIndex = path.join(groupAgentRunnerDir, 'index.ts');
-    const needsCopy =
-      !fs.existsSync(groupAgentRunnerDir) ||
-      !fs.existsSync(cachedIndex) ||
-      (fs.existsSync(srcIndex) &&
-        fs.statSync(srcIndex).mtimeMs > fs.statSync(cachedIndex).mtimeMs);
-    if (needsCopy) {
-      fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
-    }
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
   mounts.push({
     hostPath: groupAgentRunnerDir,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The agent-runner source sync in `container-runner.ts` only checks the mtime of `index.ts` to decide whether to re-copy the source directory into the per-group cache. The directory contains multiple files (e.g. `ipc-mcp-stdio.ts`), so edits to any file other than `index.ts` don't trigger a re-copy — the container runs stale code.

Removed the mtime check and always copy unconditionally. The directory is ~42KB (2 files), so the optimization isn't worth the correctness risk.

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)