### PR TITLE
fix: use portable shebang in build.sh

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build the NanoClaw agent container image
 
 set -e


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`container/build.sh` uses `#!/bin/bash`, which doesn't exist on NixOS and other distros that don't symlink bash into `/bin`. Changed to `#!/usr/bin/env bash` for portability.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)