### PR TITLE
skill/sentry: add Sentry IPC integration

### DIFF
--- a/.claude/skills/add-sentry/SKILL.md
+++ b/.claude/skills/add-sentry/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: add-sentry
+description: Add Sentry integration (issue lookup, event search, project management) via IPC bridge. Gives agents tools to list projects, search/resolve/ignore/assign issues, and inspect events.
+---
+
+# Add Sentry Integration
+
+This skill adds Sentry issue management to NanoClaw via the IPC bridge pattern.
+
+## What It Provides
+
+- **list_projects** -- List all Sentry projects in the organization
+- **list_issues** -- Search and filter issues by project, query, sort, and limit
+- **get_issue** -- Get full details for a single issue
+- **get_events** -- Get latest event occurrences for an issue
+- **resolve_issue** -- Mark an issue as resolved
+- **ignore_issue** -- Ignore an issue
+- **assign_issue** -- Assign an issue to a user
+
+## Credentials
+
+The Sentry auth token is resolved in this order:
+
+1. **Environment variable**: `SENTRY_AUTH_TOKEN`
+2. **macOS Keychain**: service `nanoclaw`, account `sentry-auth-token`
+
+To store the token in Keychain:
+
+```bash
+security add-generic-password -s nanoclaw -a sentry-auth-token -w "<your-token>"
+```
+
+## Configuration
+
+The wrapper reads `org` and `baseUrl` from `config/private.yaml` (loaded by `scripts/load_private_config.py`):
+
+```yaml
+sentry:
+  org: your-org-slug
+  baseUrl: https://sentry.io
+```
+
+## Architecture
+
+- `scripts/sentry_wrapper.py` -- Host-side Python wrapper that calls the Sentry API
+- `src/sentry-ipc.ts` -- Host-side IPC handler that bridges container requests to the wrapper
+- `container/agent-runner/src/sentry-mcp-stdio.ts` -- Container-side MCP server exposing tools to agents
+- IPC directories: `{group}/sentry/requests/` and `{group}/sentry/responses/`
+
+## Skill Type
+
+Feature skill -- merged from the `skill/sentry` branch.

--- a/.claude/skills/add-sentry/SKILL.md
+++ b/.claude/skills/add-sentry/SKILL.md
@@ -1,52 +1,139 @@
 ---
 name: add-sentry
-description: Add Sentry integration (issue lookup, event search, project management) via IPC bridge. Gives agents tools to list projects, search/resolve/ignore/assign issues, and inspect events.
+description: Add Sentry integration (issue lookup, event search, project management) via IPC bridge. Gives agents tools to list projects, search/resolve/ignore/assign issues, and inspect events. Host-side Python wrapper shells out to the Sentry API; container agents reach it through an MCP server over the IPC bridge.
 ---
 
 # Add Sentry Integration
 
-This skill adds Sentry issue management to NanoClaw via the IPC bridge pattern.
+This skill adds Sentry issue management to NanoClaw via the host-side IPC bridge pattern. The container agent never sees the Sentry auth token — the host wrapper resolves credentials locally and only returns the API response.
+
+**Skill type:** Feature skill (branch-based). Code lives on the `skill/sentry` branch; this SKILL.md merges it in and walks through setup.
 
 ## What It Provides
 
-- **list_projects** -- List all Sentry projects in the organization
-- **list_issues** -- Search and filter issues by project, query, sort, and limit
-- **get_issue** -- Get full details for a single issue
-- **get_events** -- Get latest event occurrences for an issue
-- **resolve_issue** -- Mark an issue as resolved
-- **ignore_issue** -- Ignore an issue
-- **assign_issue** -- Assign an issue to a user
+- **list_projects** — List Sentry projects in the organization
+- **list_issues** — Search and filter issues (project, query, sort, limit)
+- **get_issue** — Full details for a single issue
+- **get_events** — Latest event occurrences for an issue
+- **resolve_issue** — Mark an issue resolved
+- **ignore_issue** — Ignore an issue
+- **assign_issue** — Assign an issue to a user
 
-## Credentials
+No delete operations are exposed.
 
-The Sentry auth token is resolved in this order:
+## Phase 1: Pre-flight
 
-1. **Environment variable**: `SENTRY_AUTH_TOKEN`
-2. **macOS Keychain**: service `nanoclaw`, account `sentry-auth-token`
+Check if the skill is already applied:
 
-To store the token in Keychain:
+```bash
+test -f src/sentry-ipc.ts && echo "Already applied" || echo "Not applied"
+```
+
+If already applied, skip to Phase 3 (Setup / Verify).
+
+## Phase 2: Apply Code Changes
+
+Merge the skill branch:
+
+```bash
+git fetch upstream skill/sentry
+git merge upstream/skill/sentry
+```
+
+> **Note:** `upstream` is the remote pointing to `qwibitai/nanoclaw`. If your remote uses a different name, substitute accordingly.
+
+This adds:
+- `scripts/sentry_wrapper.py` — host-side Python wrapper that calls the Sentry API
+- `src/sentry-ipc.ts` — host-side IPC handler bridging container requests to the wrapper
+- `container/agent-runner/src/sentry-mcp-stdio.ts` — container-side MCP server exposing tools to agents
+- IPC wiring in `src/ipc.ts` (registers `processSentryIpc`)
+- IPC directory creation in `src/container-runner.ts` (`{group}/sentry/requests/`, `{group}/sentry/responses/`)
+- MCP server registration and `mcp__sentry__*` allowed tool in `container/agent-runner/src/index.ts`
+
+### Validate
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+### Rebuild container
+
+```bash
+./container/build.sh
+```
+
+### Restart service
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 3: Setup
+
+### Store the Sentry auth token
+
+The wrapper resolves the token in this order:
+
+1. `SENTRY_AUTH_TOKEN` environment variable
+2. macOS Keychain: service `nanoclaw`, account `sentry-auth-token`
+
+On macOS, store it in Keychain so it survives reboots and isn't written to disk:
 
 ```bash
 security add-generic-password -s nanoclaw -a sentry-auth-token -w "<your-token>"
 ```
 
-## Configuration
+On Linux, export `SENTRY_AUTH_TOKEN` in the environment NanoClaw runs under (e.g. the systemd unit's `Environment=` directive or `.env`).
 
-The wrapper reads `org` and `baseUrl` from `config/private.yaml` (loaded by `scripts/load_private_config.py`):
+Create a token at `https://<your-org>.sentry.io/settings/account/api/auth-tokens/` with scopes `event:read`, `org:read`, `project:read`, and `event:admin` (only if you want resolve/ignore/assign).
 
-```yaml
-sentry:
-  org: your-org-slug
-  baseUrl: https://sentry.io
+### Configure org and base URL
+
+The wrapper reads these from the environment:
+
+- `SENTRY_ORG` — **required**. Your Sentry organization slug.
+- `SENTRY_BASE_URL` — optional. Defaults to `https://sentry.io`. Override for self-hosted Sentry.
+
+Export them in whatever environment NanoClaw runs under:
+
+```bash
+# .env or equivalent
+SENTRY_ORG=your-org-slug
+SENTRY_BASE_URL=https://sentry.io
 ```
 
-## Architecture
+If `SENTRY_ORG` is missing, the wrapper returns `{"error": "SENTRY_ORG env var is required"}` and exits 1 — every Sentry tool call will surface that error to the agent.
 
-- `scripts/sentry_wrapper.py` -- Host-side Python wrapper that calls the Sentry API
-- `src/sentry-ipc.ts` -- Host-side IPC handler that bridges container requests to the wrapper
-- `container/agent-runner/src/sentry-mcp-stdio.ts` -- Container-side MCP server exposing tools to agents
-- IPC directories: `{group}/sentry/requests/` and `{group}/sentry/responses/`
+### Verify end-to-end
 
-## Skill Type
+From your main group, send a prompt that exercises the sentry tools, e.g.:
 
-Feature skill -- merged from the `skill/sentry` branch.
+> "List the last 5 unresolved issues for project `<your-project-slug>`"
+
+Expected:
+- The agent invokes `mcp__sentry__list_issues` with `project=<slug>`, `query=is:unresolved`, `limit=5`.
+- A request file appears briefly under `{group}/sentry/requests/`, then a matching response under `{group}/sentry/responses/`.
+- The agent replies with issue titles and IDs.
+
+If nothing happens, check the host process logs for `Error processing sentry IPC` and run the wrapper manually to isolate:
+
+```bash
+SENTRY_ORG=<slug> python3 scripts/sentry_wrapper.py projects
+```
+
+## Security Constraints
+
+- **Token never enters the container.** The host wrapper reads it from Keychain or env, shells out to Sentry, and returns only the JSON response. The container side only sees the MCP tool interface.
+- **No destructive Sentry operations.** The wrapper exposes resolve / ignore / assign but no delete. Any new tool that mutates Sentry state should go through explicit review.
+- **Per-group IPC isolation.** Requests and responses are scoped to `{group}/sentry/`, so one group cannot read another's results.
+- **Main-group or trusted-sender only** is the intended policy for destructive Sentry operations (resolve / ignore / assign). Enforcing that policy at the IPC layer is follow-up work; until then, treat those tools as available to any group with the skill enabled.
+
+## Troubleshooting
+
+- **`{"error": "SENTRY_ORG env var is required"}`** — export `SENTRY_ORG` in NanoClaw's environment and restart the service.
+- **`401 Unauthorized` from Sentry** — the token is missing or has insufficient scopes. Re-create with `event:read`, `org:read`, `project:read` at minimum.
+- **Wrapper runs manually but tools fail from the container** — the host service's environment is stale. Restart NanoClaw so it re-reads `.env` (or the Keychain token).
+- **Tool calls hang** — check that `src/ipc.ts` contains the `processSentryIpc` call inside `processIpcFiles` and that the host polling loop is running (`logs/nanoclaw.log`).

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -375,6 +375,7 @@ async function runQuery(
   prompt: string,
   sessionId: string | undefined,
   mcpServerPath: string,
+  sentryMcpPath: string,
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
@@ -469,6 +470,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__sentry__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -483,6 +485,11 @@ async function runQuery(
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
+        },
+        sentry: {
+          command: 'node',
+          args: [sentryMcpPath],
+          env: {},
         },
       },
       hooks: {
@@ -627,6 +634,7 @@ async function main(): Promise<void> {
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const sentryMcpPath = path.join(__dirname, 'sentry-mcp-stdio.js');
 
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
@@ -683,6 +691,7 @@ async function main(): Promise<void> {
         prompt,
         sessionId,
         mcpServerPath,
+        sentryMcpPath,
         containerInput,
         sdkEnv,
         resumeAt,

--- a/container/agent-runner/src/sentry-mcp-stdio.ts
+++ b/container/agent-runner/src/sentry-mcp-stdio.ts
@@ -1,0 +1,136 @@
+/**
+ * Sentry MCP Server (container-side proxy)
+ *
+ * Exposes Sentry tools to the agent via IPC bridge.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import fs from 'fs';
+import path from 'path';
+
+const IPC_DIR = '/workspace/ipc';
+const REQUESTS_DIR = path.join(IPC_DIR, 'sentry', 'requests');
+const RESPONSES_DIR = path.join(IPC_DIR, 'sentry', 'responses');
+const POLL_INTERVAL_MS = 100;
+const TIMEOUT_MS = 30_000;
+
+function generateRequestId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function ipcRequest(
+  tool: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const requestId = generateRequestId();
+  const requestFile = path.join(REQUESTS_DIR, `${requestId}.json`);
+  const responseFile = path.join(RESPONSES_DIR, `${requestId}.json`);
+  fs.mkdirSync(REQUESTS_DIR, { recursive: true });
+  const tempFile = `${requestFile}.tmp`;
+  fs.writeFileSync(tempFile, JSON.stringify({ id: requestId, tool, args }));
+  fs.renameSync(tempFile, requestFile);
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(responseFile)) {
+      const raw = fs.readFileSync(responseFile, 'utf-8');
+      fs.unlinkSync(responseFile);
+      const response = JSON.parse(raw);
+      if (response.error) throw new Error(response.error);
+      return response.result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `Sentry IPC timeout after ${TIMEOUT_MS}ms for tool "${tool}"`,
+  );
+}
+
+function textResult(data: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+const server = new McpServer({ name: 'sentry', version: '1.0.0' });
+
+server.tool(
+  'list_projects',
+  'List all Sentry projects in the organization',
+  {},
+  async () => textResult(await ipcRequest('list_projects', {})),
+);
+
+server.tool(
+  'list_issues',
+  'List Sentry issues for a project',
+  {
+    project: z.string().describe('Sentry project slug'),
+    query: z
+      .string()
+      .optional()
+      .describe('Sentry search query (e.g. "is:unresolved")'),
+    sort: z
+      .enum(['date', 'freq', 'new', 'priority'])
+      .optional()
+      .describe('Sort order'),
+    limit: z.number().optional().describe('Maximum number of issues'),
+  },
+  async (args) => textResult(await ipcRequest('list_issues', args)),
+);
+
+server.tool(
+  'get_issue',
+  'Get details for a single Sentry issue',
+  {
+    issue_id: z.string().describe('Sentry issue ID'),
+    project: z.string().describe('Sentry project slug'),
+  },
+  async (args) => textResult(await ipcRequest('get_issue', args)),
+);
+
+server.tool(
+  'get_events',
+  'Get latest events/occurrences for a Sentry issue',
+  {
+    issue_id: z.string().describe('Sentry issue ID'),
+    project: z.string().describe('Sentry project slug'),
+    limit: z.number().optional().describe('Maximum number of events'),
+  },
+  async (args) => textResult(await ipcRequest('get_events', args)),
+);
+
+server.tool(
+  'resolve_issue',
+  'Mark a Sentry issue as resolved',
+  {
+    issue_id: z.string().describe('Sentry issue ID'),
+    project: z.string().describe('Sentry project slug'),
+  },
+  async (args) => textResult(await ipcRequest('resolve_issue', args)),
+);
+
+server.tool(
+  'ignore_issue',
+  'Ignore a Sentry issue',
+  {
+    issue_id: z.string().describe('Sentry issue ID'),
+    project: z.string().describe('Sentry project slug'),
+  },
+  async (args) => textResult(await ipcRequest('ignore_issue', args)),
+);
+
+server.tool(
+  'assign_issue',
+  'Assign a Sentry issue to a user',
+  {
+    issue_id: z.string().describe('Sentry issue ID'),
+    project: z.string().describe('Sentry project slug'),
+    assignee: z.string().describe('Email or username to assign to'),
+  },
+  async (args) => textResult(await ipcRequest('assign_issue', args)),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/scripts/sentry_wrapper.py
+++ b/scripts/sentry_wrapper.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Minimal Sentry API wrapper.
+
+Capabilities:
+- list projects
+- list issues (with query/sort/limit)
+- get issue details
+- get issue events (latest occurrences)
+- update issue (resolve, ignore, assign)
+
+No delete operations on purpose.
+
+Auth: SENTRY_AUTH_TOKEN env var, falls back to macOS Keychain
+(service=nanoclaw, account=sentry-auth-token).
+
+Config: Reads org and baseUrl from config/private.yaml via load_private_config.
+
+Examples:
+  python3 scripts/sentry_wrapper.py projects
+  python3 scripts/sentry_wrapper.py issues --project krobar-api
+  python3 scripts/sentry_wrapper.py issues --project krobar-api --query 'is:unresolved' --sort freq --limit 10
+  python3 scripts/sentry_wrapper.py issue --id 12345 --project krobar-api
+  python3 scripts/sentry_wrapper.py events --id 12345 --project krobar-api
+  python3 scripts/sentry_wrapper.py resolve --id 12345 --project krobar-api
+  python3 scripts/sentry_wrapper.py ignore --id 12345 --project krobar-api
+  python3 scripts/sentry_wrapper.py assign --id 12345 --project krobar-api --assignee user@example.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+# Load config — try private config loader first, fall back to env vars
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from load_private_config import load_private_config
+    _PRIVATE = load_private_config()
+    SENTRY_BASE_URL = _PRIVATE["sentry"]["baseUrl"].rstrip("/")
+    SENTRY_ORG = _PRIVATE["sentry"]["org"]
+except (ImportError, KeyError):
+    SENTRY_BASE_URL = os.environ.get("SENTRY_BASE_URL", "https://sentry.io").rstrip("/")
+    SENTRY_ORG = os.environ.get("SENTRY_ORG", "")
+    if not SENTRY_ORG:
+        print(json.dumps({"error": "SENTRY_ORG env var is required when load_private_config is unavailable"}))
+        sys.exit(1)
+
+
+def die(message: str, code: int = 1) -> int:
+    print(json.dumps({"error": message}), file=sys.stdout)
+    return code
+
+
+def resolve_token() -> str:
+    """Resolve SENTRY_AUTH_TOKEN from env, falling back to macOS Keychain."""
+    token = os.environ.get("SENTRY_AUTH_TOKEN", "")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            [
+                "security", "find-generic-password",
+                "-s", "nanoclaw",
+                "-a", "sentry-auth-token", "-w",
+            ],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+TOKEN = resolve_token()
+
+
+def api_request(
+    method: str, path: str, data: dict | None = None, params: dict | None = None
+) -> dict | list:
+    """Make an authenticated Sentry API request."""
+    if not TOKEN:
+        raise RuntimeError("No Sentry auth token available")
+
+    url = f"{SENTRY_BASE_URL}{path}"
+    if params:
+        url += "?" + urlencode(params)
+
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = Request(url, data=body, method=method)
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("Accept", "application/json")
+    if body:
+        req.add_header("Content-Type", "application/json")
+
+    with urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw.strip() else {}
+
+
+def cmd_projects(_args: argparse.Namespace) -> int:
+    """List all projects in the org."""
+    try:
+        result = api_request("GET", f"/api/0/organizations/{SENTRY_ORG}/projects/")
+        projects = [
+            {
+                "slug": p.get("slug"),
+                "name": p.get("name"),
+                "platform": p.get("platform"),
+                "dateCreated": p.get("dateCreated"),
+            }
+            for p in result
+        ] if isinstance(result, list) else result
+        print(json.dumps(projects, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_issues(args: argparse.Namespace) -> int:
+    """List issues for a project."""
+    try:
+        params: dict[str, str] = {}
+        if args.query:
+            params["query"] = args.query
+        if args.sort:
+            params["sort"] = args.sort
+        if args.limit:
+            params["limit"] = str(args.limit)
+
+        result = api_request(
+            "GET",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/",
+            params=params,
+        )
+        issues = [
+            {
+                "id": i.get("id"),
+                "title": i.get("title"),
+                "culprit": i.get("culprit"),
+                "level": i.get("level"),
+                "status": i.get("status"),
+                "count": i.get("count"),
+                "userCount": i.get("userCount"),
+                "firstSeen": i.get("firstSeen"),
+                "lastSeen": i.get("lastSeen"),
+                "permalink": i.get("permalink"),
+                "assignedTo": i.get("assignedTo"),
+            }
+            for i in result
+        ] if isinstance(result, list) else result
+        print(json.dumps(issues, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_issue(args: argparse.Namespace) -> int:
+    """Get details for a single issue."""
+    try:
+        result = api_request(
+            "GET",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/{args.id}/",
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_events(args: argparse.Namespace) -> int:
+    """Get latest events for an issue."""
+    try:
+        result = api_request(
+            "GET",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/{args.id}/events/",
+            params={"limit": str(args.limit or 10)},
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_resolve(args: argparse.Namespace) -> int:
+    """Resolve an issue."""
+    try:
+        result = api_request(
+            "PUT",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/{args.id}/",
+            data={"status": "resolved"},
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_ignore(args: argparse.Namespace) -> int:
+    """Ignore an issue."""
+    try:
+        result = api_request(
+            "PUT",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/{args.id}/",
+            data={"status": "ignored"},
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def cmd_assign(args: argparse.Namespace) -> int:
+    """Assign an issue."""
+    try:
+        result = api_request(
+            "PUT",
+            f"/api/0/projects/{SENTRY_ORG}/{args.project}/issues/{args.id}/",
+            data={"assignedTo": args.assignee},
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+    except (HTTPError, URLError, RuntimeError) as err:
+        return die(str(err))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Minimal Sentry API wrapper")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("projects")
+
+    p_issues = sub.add_parser("issues")
+    p_issues.add_argument("--project", required=True)
+    p_issues.add_argument("--query")
+    p_issues.add_argument("--sort", choices=["date", "freq", "new", "priority"])
+    p_issues.add_argument("--limit", type=int, default=25)
+
+    p_issue = sub.add_parser("issue")
+    p_issue.add_argument("--id", required=True)
+    p_issue.add_argument("--project", required=True)
+
+    p_events = sub.add_parser("events")
+    p_events.add_argument("--id", required=True)
+    p_events.add_argument("--project", required=True)
+    p_events.add_argument("--limit", type=int, default=10)
+
+    p_resolve = sub.add_parser("resolve")
+    p_resolve.add_argument("--id", required=True)
+    p_resolve.add_argument("--project", required=True)
+
+    p_ignore = sub.add_parser("ignore")
+    p_ignore.add_argument("--id", required=True)
+    p_ignore.add_argument("--project", required=True)
+
+    p_assign = sub.add_parser("assign")
+    p_assign.add_argument("--id", required=True)
+    p_assign.add_argument("--project", required=True)
+    p_assign.add_argument("--assignee", required=True)
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    dispatch = {
+        "projects": cmd_projects,
+        "issues": cmd_issues,
+        "issue": cmd_issue,
+        "events": cmd_events,
+        "resolve": cmd_resolve,
+        "ignore": cmd_ignore,
+        "assign": cmd_assign,
+    }
+    return dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentry_wrapper.py
+++ b/scripts/sentry_wrapper.py
@@ -13,7 +13,9 @@ No delete operations on purpose.
 Auth: SENTRY_AUTH_TOKEN env var, falls back to macOS Keychain
 (service=nanoclaw, account=sentry-auth-token).
 
-Config: Reads org and baseUrl from config/private.yaml via load_private_config.
+Config: reads `SENTRY_ORG` (required) and `SENTRY_BASE_URL` (optional, defaults
+to https://sentry.io) from the environment. Installers are responsible for
+exporting these before invoking the wrapper — see `.claude/skills/add-sentry/SKILL.md`.
 
 Examples:
   python3 scripts/sentry_wrapper.py projects
@@ -33,24 +35,15 @@ import json
 import os
 import subprocess
 import sys
-from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-# Load config — try private config loader first, fall back to env vars
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-try:
-    from load_private_config import load_private_config
-    _PRIVATE = load_private_config()
-    SENTRY_BASE_URL = _PRIVATE["sentry"]["baseUrl"].rstrip("/")
-    SENTRY_ORG = _PRIVATE["sentry"]["org"]
-except (ImportError, KeyError):
-    SENTRY_BASE_URL = os.environ.get("SENTRY_BASE_URL", "https://sentry.io").rstrip("/")
-    SENTRY_ORG = os.environ.get("SENTRY_ORG", "")
-    if not SENTRY_ORG:
-        print(json.dumps({"error": "SENTRY_ORG env var is required when load_private_config is unavailable"}))
-        sys.exit(1)
+SENTRY_BASE_URL = os.environ.get("SENTRY_BASE_URL", "https://sentry.io").rstrip("/")
+SENTRY_ORG = os.environ.get("SENTRY_ORG", "")
+if not SENTRY_ORG:
+    print(json.dumps({"error": "SENTRY_ORG env var is required"}))
+    sys.exit(1)
 
 
 def die(message: str, code: int = 1) -> int:

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -180,6 +180,12 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'sentry', 'requests'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(groupIpcDir, 'sentry', 'responses'), {
+    recursive: true,
+  });
   mounts.push({
     hostPath: groupIpcDir,
     containerPath: '/workspace/ipc',

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -8,6 +8,7 @@ import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
+import { processSentryIpc } from './sentry-ipc.js';
 import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
@@ -144,6 +145,13 @@ export function startIpcWatcher(deps: IpcDeps): void {
         }
       } catch (err) {
         logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
+      }
+
+      // Process Sentry IPC requests (request-response bridge)
+      try {
+        processSentryIpc(path.join(ipcBaseDir, sourceGroup));
+      } catch (err) {
+        logger.error({ err, sourceGroup }, 'Error processing sentry IPC');
       }
     }
 

--- a/src/sentry-ipc.ts
+++ b/src/sentry-ipc.ts
@@ -1,0 +1,212 @@
+/**
+ * Host-side Sentry IPC handler.
+ *
+ * Watches for request files from containers in {group}/sentry/requests/,
+ * executes the sentry_wrapper.py script, and writes responses to
+ * {group}/sentry/responses/.
+ *
+ * Auth token resolved by the wrapper from env or macOS Keychain.
+ */
+
+import { execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+const SCRIPTS_DIR = path.join(process.cwd(), 'scripts');
+const SENTRY_WRAPPER = path.join(SCRIPTS_DIR, 'sentry_wrapper.py');
+
+interface SentryRequest {
+  id: string;
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Run the sentry wrapper script and return parsed JSON output.
+ */
+function runSentryCmd(args: string[]): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'python3',
+      [SENTRY_WRAPPER, ...args],
+      { maxBuffer: 10 * 1024 * 1024, timeout: 30000 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`sentry wrapper error: ${stderr || error.message}`));
+          return;
+        }
+        const trimmed = stdout.trim();
+        if (!trimmed) {
+          resolve(null);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(trimmed);
+          // The wrapper outputs {"error": "..."} on failure
+          if (
+            parsed &&
+            typeof parsed === 'object' &&
+            'error' in parsed &&
+            Object.keys(parsed).length === 1
+          ) {
+            reject(new Error(parsed.error));
+            return;
+          }
+          resolve(parsed);
+        } catch {
+          resolve(trimmed);
+        }
+      },
+    );
+  });
+}
+
+// --- Tool dispatcher ---
+
+async function handleRequest(req: SentryRequest): Promise<unknown> {
+  const { tool, args } = req;
+
+  switch (tool) {
+    case 'list_projects':
+      return runSentryCmd(['projects']);
+
+    case 'list_issues': {
+      if (!args.project) throw new Error('project is required');
+      const cmdArgs = ['issues', '--project', String(args.project)];
+      if (args.query) cmdArgs.push('--query', String(args.query));
+      if (args.sort) cmdArgs.push('--sort', String(args.sort));
+      if (args.limit) cmdArgs.push('--limit', String(args.limit));
+      return runSentryCmd(cmdArgs);
+    }
+
+    case 'get_issue': {
+      if (!args.issue_id) throw new Error('issue_id is required');
+      if (!args.project) throw new Error('project is required');
+      return runSentryCmd([
+        'issue',
+        '--id',
+        String(args.issue_id),
+        '--project',
+        String(args.project),
+      ]);
+    }
+
+    case 'get_events': {
+      if (!args.issue_id) throw new Error('issue_id is required');
+      if (!args.project) throw new Error('project is required');
+      const cmdArgs = [
+        'events',
+        '--id',
+        String(args.issue_id),
+        '--project',
+        String(args.project),
+      ];
+      if (args.limit) cmdArgs.push('--limit', String(args.limit));
+      return runSentryCmd(cmdArgs);
+    }
+
+    case 'resolve_issue': {
+      if (!args.issue_id) throw new Error('issue_id is required');
+      if (!args.project) throw new Error('project is required');
+      return runSentryCmd([
+        'resolve',
+        '--id',
+        String(args.issue_id),
+        '--project',
+        String(args.project),
+      ]);
+    }
+
+    case 'ignore_issue': {
+      if (!args.issue_id) throw new Error('issue_id is required');
+      if (!args.project) throw new Error('project is required');
+      return runSentryCmd([
+        'ignore',
+        '--id',
+        String(args.issue_id),
+        '--project',
+        String(args.project),
+      ]);
+    }
+
+    case 'assign_issue': {
+      if (!args.issue_id) throw new Error('issue_id is required');
+      if (!args.project) throw new Error('project is required');
+      if (!args.assignee) throw new Error('assignee is required');
+      return runSentryCmd([
+        'assign',
+        '--id',
+        String(args.issue_id),
+        '--project',
+        String(args.project),
+        '--assignee',
+        String(args.assignee),
+      ]);
+    }
+
+    default:
+      throw new Error(`Unknown sentry tool: ${tool}`);
+  }
+}
+
+/**
+ * Process all pending Sentry IPC requests in a given group's IPC directory.
+ */
+export function processSentryIpc(groupIpcDir: string): void {
+  const requestsDir = path.join(groupIpcDir, 'sentry', 'requests');
+  const responsesDir = path.join(groupIpcDir, 'sentry', 'responses');
+
+  if (!fs.existsSync(requestsDir)) return;
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(requestsDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    const requestPath = path.join(requestsDir, file);
+
+    let req: SentryRequest;
+    try {
+      req = JSON.parse(fs.readFileSync(requestPath, 'utf-8'));
+    } catch (err) {
+      logger.error({ file, err }, 'Failed to parse sentry IPC request');
+      fs.unlinkSync(requestPath);
+      continue;
+    }
+
+    // Delete the request file immediately to avoid reprocessing
+    fs.unlinkSync(requestPath);
+
+    // Process async — write response when done
+    handleRequest(req)
+      .then((result) => {
+        writeResponse(responsesDir, req.id, { result });
+      })
+      .catch((err) => {
+        logger.error(
+          { requestId: req.id, tool: req.tool, err },
+          'Sentry IPC error',
+        );
+        writeResponse(responsesDir, req.id, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }
+}
+
+function writeResponse(
+  responsesDir: string,
+  requestId: string,
+  data: { result?: unknown; error?: string },
+): void {
+  fs.mkdirSync(responsesDir, { recursive: true });
+  const responsePath = path.join(responsesDir, `${requestId}.json`);
+  const tempPath = `${responsePath}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(data));
+  fs.renameSync(tempPath, responsePath);
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds Sentry issue management to NanoClaw via the IPC bridge pattern.

**What:** Agents get seven tools — `list_projects`, `list_issues`, `get_issue`, `get_events`, `resolve_issue`, `ignore_issue`, `assign_issue` — for managing Sentry issues directly from conversation.

**Why:** Useful for debugging and incident response workflows. Agents can look up errors, inspect events, and triage issues without leaving the chat.

**How it works:**
- `scripts/sentry_wrapper.py` — host-side Python wrapper calling the Sentry API
- `src/sentry-ipc.ts` — host-side IPC handler bridging container requests to the wrapper
- `container/agent-runner/src/sentry-mcp-stdio.ts` — container-side MCP server exposing tools to agents
- IPC directories: `{group}/sentry/requests/` and `{group}/sentry/responses/`

**Credentials:** Resolved from `SENTRY_AUTH_TOKEN` env var or macOS Keychain (service `nanoclaw`, account `sentry-auth-token`). Config (`org`, `baseUrl`) from `config/private.yaml`.

**Usage:** Run `/add-sentry` to merge the skill branch and configure credentials.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines (52 lines)
- [x] I tested this skill on a fresh clone
