### PR TITLE
feat: add /add-backup utility skill for automated state backup

### DIFF
--- a/.claude/skills/add-backup/README.md
+++ b/.claude/skills/add-backup/README.md
@@ -1,0 +1,47 @@
+# add-backup
+
+Automated backup and restore for NanoClaw state data.
+
+## What's Backed Up
+
+| Path | Contents |
+|------|----------|
+| `store/messages.db` | SQLite: chats, messages, scheduled tasks |
+| `groups/` | Per-group memories, logs (secrets excluded) |
+| `data/sessions/` | Claude session data, projects |
+| `data/ipc/` | Task state, group metadata |
+
+Secrets (`.env`, `.secrets/`, `*.keys.json`, etc.) are always excluded.
+
+## Files
+
+```
+add-backup/
+├── SKILL.md              # Setup wizard (4 phases), usage, troubleshooting
+├── README.md             # This file
+├── scripts/
+│   └── backup.sh         # Backup script (copied to ~/backup-nanoclaw during setup)
+└── docs/
+    └── guide-backup-restore.md  # Step-by-step restore guide
+```
+
+## Features
+
+- **Safe SQLite backups** — uses `sqlite3` backup API, no corruption from concurrent writes
+- **Log rotation** — auto-truncates to 1000 lines
+- **Integrity verification** — SHA-256 checksums generated after each backup
+- **Multiple auth methods** — SSH deploy key, GitHub PAT, or local-only (no remote)
+- **Secret protection** — `.gitignore`, pre-commit hook, and rsync exclusion patterns
+- **Channel-agnostic** — works with any NanoClaw channel configuration
+- **Configurable** — custom backup directory, branch, and cron schedule
+
+## Usage
+
+Set up via the `/add-backup` skill, then run manually or via cron:
+
+```bash
+~/backup-nanoclaw/backup.sh          # Run backup
+~/backup-nanoclaw/backup.sh --dry-run  # Preview only
+```
+
+See `SKILL.md` for the full setup wizard.

--- a/.claude/skills/add-backup/SKILL.md
+++ b/.claude/skills/add-backup/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: add-backup
+description: Add automated backup/restore for NanoClaw state data. Backs up messages.db, groups, sessions, and IPC state to a local git repo with optional remote push. Secrets are always excluded.
+---
+
+# Add Backup
+
+Set up automated backups for NanoClaw state data (messages, groups, sessions, IPC). Backups are stored in a separate local git repo with optional push to a private remote.
+
+## What Gets Backed Up
+
+| Path | Contents |
+|------|----------|
+| `store/messages.db` | SQLite: chats, messages, scheduled tasks |
+| `groups/` | Per-group memories, logs (secrets excluded) |
+| `data/sessions/` | Claude session data, projects |
+| `data/ipc/` | Task state, group metadata |
+
+**Always excluded:** `.env`, `.secrets/`, `*.keys.json`, `*recovery*.txt`, `*password*.txt`
+
+## Phase 1: Pre-flight
+
+### Check for existing setup
+
+```bash
+test -d ~/backup-nanoclaw && echo "EXISTS" || echo "NOT_FOUND"
+test -f ~/backup-nanoclaw/backup.sh && echo "SCRIPT_EXISTS" || echo "NO_SCRIPT"
+crontab -l 2>/dev/null | grep -q "backup.sh" && echo "CRON_EXISTS" || echo "NO_CRON"
+```
+
+If all three exist, backup is already configured. Ask the user: "Backup is already set up at `~/backup-nanoclaw`. Would you like to reconfigure?" If no, skip to Phase 4 (Verify) to run a dry-run.
+
+### Detect authentication
+
+Check in order:
+
+1. **SSH**: `ssh -T git@github.com 2>&1` — if output contains "successfully authenticated", SSH works
+2. **Token**: `test -n "$GITHUB_TOKEN"` or `test -n "$GH_TOKEN"`
+3. **Backup config**: If `~/backup-nanoclaw/.env` exists, source it and check for `GITHUB_TOKEN`
+4. **None detected** — will ask user in Phase 2
+
+### Check for sqlite3
+
+```bash
+command -v sqlite3 && echo "OK" || echo "MISSING"
+```
+
+If missing, install it:
+```bash
+# Linux
+sudo apt-get install -y sqlite3
+# macOS
+brew install sqlite3
+```
+
+## Phase 2: Setup
+
+### Ask user for configuration
+
+Ask these questions (with sensible defaults):
+
+1. **Backup directory** — default `~/backup-nanoclaw`
+2. **Remote repository URL** — optional, e.g. `git@github.com:user/nanoclaw-backup.git` (leave blank for local-only)
+3. **Branch name** — default `main`
+4. **Backup schedule** — default daily at midnight
+
+### Ask about authentication (only if none detected in Phase 1)
+
+Offer three options:
+
+1. **SSH deploy key** — generate a dedicated key, user adds it to GitHub as a deploy key with write access
+2. **GitHub PAT** — user generates a token at `https://github.com/settings/tokens` with `repo` scope
+3. **Local only** — no remote push, backups stay on disk
+
+### Copy backup script
+
+```bash
+mkdir -p ~/backup-nanoclaw
+cp "${CLAUDE_SKILL_DIR}/scripts/backup.sh" ~/backup-nanoclaw/backup.sh
+chmod +x ~/backup-nanoclaw/backup.sh
+```
+
+### Initialize git repo
+
+```bash
+cd ~/backup-nanoclaw
+git init -q
+```
+
+### Configure remote (if user provided URL)
+
+```bash
+cd ~/backup-nanoclaw
+git remote add origin <user-provided-url>
+```
+
+### If SSH deploy key needed
+
+Generate a dedicated key for backup push:
+
+```bash
+ssh-keygen -t ed25519 -C "nanoclaw-backup" -f ~/backup-nanoclaw/.ssh/deploy_key -N ""
+```
+
+Display the public key and instruct the user to add it as a deploy key with write access on their GitHub repo: **Settings → Deploy keys → Add deploy key → paste public key → check "Allow write access"**.
+
+Configure SSH to use the deploy key by adding to `~/.ssh/config`:
+
+```
+Host github-backup
+  HostName github.com
+  IdentityFile ~/backup-nanoclaw/.ssh/deploy_key
+  IdentitiesOnly yes
+```
+
+If using a custom SSH config host, set the remote URL accordingly: `git remote set-url origin git@github-backup:user/repo.git`
+
+### Write config file
+
+Create `~/backup-nanoclaw/.env`:
+
+```bash
+NANOCLAW_DIR=$HOME/nanoclaw
+BRANCH=main
+```
+
+If using token auth, also add:
+```bash
+GITHUB_TOKEN=ghp_...
+```
+
+If using SSH deploy key, no token is needed (SSH config handles auth).
+
+### Install pre-commit hook
+
+The script installs this automatically on first run. It blocks secret files from being committed.
+
+## Phase 3: Configure
+
+### Set up cron job
+
+Add to crontab (replacing any existing backup entry to prevent duplicates):
+
+```bash
+(crontab -l 2>/dev/null | grep -v "backup.sh"; echo "0 0 * * * $HOME/backup-nanoclaw/backup.sh >> $HOME/backup-nanoclaw/backup.log 2>&1") | crontab -
+```
+
+Default: daily at midnight. Adjust the cron expression if user chose a different schedule:
+- Every 6 hours: `0 */6 * * *`
+- Every 12 hours: `0 */12 * * *`
+- Weekly: `0 0 * * 0`
+
+### Verify cron
+
+```bash
+crontab -l | grep "backup.sh"
+```
+
+## Phase 4: Verify
+
+### Dry-run
+
+```bash
+~/backup-nanoclaw/backup.sh --dry-run
+```
+
+Expected: `[WOULD]` entries for each data path, no files copied.
+
+### Full run
+
+```bash
+~/backup-nanoclaw/backup.sh
+```
+
+Expected: files copied, git commit created, checksums generated.
+
+### Verify no secrets leaked
+
+```bash
+grep -r "ANTHROPIC_API_KEY\|CLAUDE_CODE_OAUTH_TOKEN\|TELEGRAM_BOT_TOKEN\|SLACK_BOT_TOKEN" ~/backup-nanoclaw/ --include="*.md" --include="*.json" --include="*.ts" || echo "CLEAN"
+```
+
+### Verify backup contents
+
+```bash
+ls ~/backup-nanoclaw/store/
+ls ~/backup-nanoclaw/groups/
+ls ~/backup-nanoclaw/data/
+```
+
+### Test push (if remote configured)
+
+```bash
+cd ~/backup-nanoclaw && git push -u origin main
+```
+
+## Usage
+
+```bash
+# Run backup manually
+~/backup-nanoclaw/backup.sh
+
+# Dry-run (preview only)
+~/backup-nanoclaw/backup.sh --dry-run
+
+# Custom backup directory
+~/backup-nanoclaw/backup.sh /tmp/test-backup
+
+# Check backup size
+du -sh ~/backup-nanoclaw/
+
+# Verify integrity against checksums
+cd ~/backup-nanoclaw && sha256sum -c .checksums | tail -1
+
+# View backup history
+cd ~/backup-nanoclaw && git log --oneline
+```
+
+## Restore
+
+See `${CLAUDE_SKILL_DIR}/docs/guide-backup-restore.md` for the full restore procedure.
+
+Quick restore:
+```bash
+cp ~/backup-nanoclaw/store/messages.db ~/nanoclaw/store/
+rsync -a ~/backup-nanoclaw/groups/ ~/nanoclaw/groups/
+rsync -a ~/backup-nanoclaw/data/sessions/ ~/nanoclaw/data/sessions/
+rsync -a ~/backup-nanoclaw/data/ipc/ ~/nanoclaw/data/ipc/
+# Then recreate .env from secrets manager and restart
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `sqlite3 not installed` | `sudo apt-get install -y sqlite3` (Linux) or `brew install sqlite3` (macOS) |
+| `Permission denied` on backup.sh | `chmod +x ~/backup-nanoclaw/backup.sh` |
+| Push fails with auth error | Check token (`GITHUB_TOKEN` in `.env`) or SSH key (`ssh -T git@github.com`) |
+| Push fails with 403 | Token needs `repo` scope — regenerate at GitHub settings |
+| `No changes to commit` | Normal — state hasn't changed since last backup |
+| Database locked during backup | The `sqlite3` backup API handles concurrent access. If it still fails, stop NanoClaw first |
+| Backup too large | Check for accidental large files in `groups/*/` (attachments) |
+| Cron not running | Check `crontab -l`, verify systemd cron is active (`systemctl status cron`) |
+| Log file too large | Script auto-rotates to 1000 lines. Manual reset: `> ~/backup-nanoclaw/backup.log` |
+
+## Removal
+
+To stop automated backups, remove the cron job:
+
+```bash
+(crontab -l 2>/dev/null | grep -v "backup.sh") | crontab -
+```
+
+The backup directory (`~/backup-nanoclaw`) is not removed automatically. To delete it, run manually:
+
+```bash
+rm -rf ~/backup-nanoclaw
+```
+```

--- a/.claude/skills/add-backup/docs/guide-backup-restore.md
+++ b/.claude/skills/add-backup/docs/guide-backup-restore.md
@@ -1,0 +1,121 @@
+# NanoClaw State Backup & Restore Guide
+
+Guide for backing up and restoring NanoClaw state data while keeping secrets secure.
+
+## Overview
+
+NanoClaw state consists of:
+- **Database** — Messages, chats, scheduled tasks
+- **Groups** — Per-group memories, attachments, conversation logs
+- **Sessions** — Claude session data and projects
+- **IPC State** — Current task state
+
+**Important:** Secrets (API keys, tokens) are NOT backed up. Store them separately in a secrets manager.
+
+## What to Backup
+
+### Include (State Data)
+
+| Path | Contents |
+|------|----------|
+| `store/messages.db` | SQLite: chats, messages, scheduled tasks |
+| `groups/` | Per-group CLAUDE.md memories, attachments, logs |
+| `data/sessions/` | Claude session data, projects, subagents |
+| `data/ipc/` | Current task state, group metadata |
+
+### Exclude (Secrets & Sensitive)
+
+| Pattern | Why |
+|---------|-----|
+| `.env` | Contains API keys, tokens |
+| `.secrets/` | Secret directories |
+| `*.keys.json` | Key files |
+| `*recovery*.txt` | Recovery codes |
+| `*password*.txt` | Password files |
+
+### Exclude (Rebuildable)
+
+| Path | Why |
+|------|-----|
+| `node_modules/` | Rebuilt from package.json |
+| `dist/` | Rebuilt from source |
+
+## Restore Procedure
+
+### 1. Verify Backup Integrity
+
+```bash
+cd $BACKUP_DIR
+sha256sum -c .checksums
+```
+
+### 2. Fresh NanoClaw Installation
+
+```bash
+git clone https://github.com/qwibitai/nanoclaw.git
+cd nanoclaw
+npm install
+npm run build
+```
+
+### 3. Restore State Data
+
+```bash
+NANOCLAW_DIR="$HOME/nanoclaw"
+BACKUP_DIR="$HOME/backup-nanoclaw"
+
+# Restore database
+cp "$BACKUP_DIR/store/messages.db" "$NANOCLAW_DIR/store/"
+
+# Restore groups
+rsync -a "$BACKUP_DIR/groups/" "$NANOCLAW_DIR/groups/"
+
+# Restore sessions
+rsync -a "$BACKUP_DIR/data/sessions/" "$NANOCLAW_DIR/data/sessions/"
+
+# Restore IPC state
+rsync -a "$BACKUP_DIR/data/ipc/" "$NANOCLAW_DIR/data/ipc/"
+```
+
+### 4. Recreate Secrets
+
+Create `.env` file with your credentials:
+
+```bash
+cp .env.example .env
+# Edit .env with your secrets manager values
+```
+
+Required values:
+- `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
+- `ANTHROPIC_BASE_URL` (if using custom endpoint)
+- Channel tokens (`TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, etc.)
+
+### 5. Sync env to data
+
+```bash
+cp .env data/env/env
+```
+
+### 6. Restart Service
+
+```bash
+# Linux
+systemctl --user restart nanoclaw
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Checklist
+
+### After Backup
+- [ ] Verify backup size is reasonable
+- [ ] Check `git log` for commit
+- [ ] Confirm no secrets in backup (`grep -r "API_KEY\|TOKEN"`)
+
+### After Restore
+- [ ] `.env` recreated with correct values
+- [ ] `data/env/env` synced from `.env`
+- [ ] Service starts successfully
+- [ ] Groups and history accessible

--- a/.claude/skills/add-backup/scripts/backup.sh
+++ b/.claude/skills/add-backup/scripts/backup.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# NanoClaw State Backup Script
+# Usage: ./backup.sh [--dry-run] [backup-dir]
+#
+# Backs up messages.db, groups, sessions, and IPC state.
+# Secrets are always excluded. Supports SSH, token, and local-only push.
+#
+# See: docs/guide-backup-restore.md
+
+set -e
+
+# Parse arguments
+DRY_RUN=false
+BACKUP_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run|-n)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            BACKUP_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
+# Defaults (can be overridden by .env)
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backup-nanoclaw}"
+NANOCLAW_DIR="${NANOCLAW_DIR:-$HOME/nanoclaw}"
+BRANCH="${BRANCH:-main}"
+DATE=$(date +%Y%m%d-%H%M%S)
+LOG_FILE="$BACKUP_DIR/backup.log"
+LOG_MAX_LINES=1000
+CHECKSUM_FILE="$BACKUP_DIR/.checksums"
+
+# Rotate log if it exceeds max lines
+if [ -f "$LOG_FILE" ] && [ "$(wc -l < "$LOG_FILE")" -gt "$LOG_MAX_LINES" ]; then
+    tail -n "$LOG_MAX_LINES" "$LOG_FILE" > "$LOG_FILE.tmp"
+    mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi
+
+# Load environment variables from backup dir
+if [ -f "$BACKUP_DIR/.env" ]; then
+    source "$BACKUP_DIR/.env"
+fi
+
+# Re-apply defaults for values not in .env
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backup-nanoclaw}"
+NANOCLAW_DIR="${NANOCLAW_DIR:-$HOME/nanoclaw}"
+BRANCH="${BRANCH:-main}"
+
+echo "=== NanoClaw Backup ==="
+if [ "$DRY_RUN" = true ]; then
+    echo "*** DRY RUN - No changes will be made ***"
+fi
+echo "Source: $NANOCLAW_DIR"
+echo "Backup: $BACKUP_DIR"
+echo ""
+
+# Initialize backup directory
+if [ "$DRY_RUN" = false ]; then
+    mkdir -p "$BACKUP_DIR"
+    cd "$BACKUP_DIR"
+else
+    mkdir -p "$BACKUP_DIR"
+    cd "$BACKUP_DIR" 2>/dev/null || { echo "Backup dir doesn't exist yet (would create)"; }
+fi
+
+# Initialize git if needed
+if [ ! -d ".git" ] && [ "$DRY_RUN" = false ]; then
+    git init -q
+    echo "Initialized git repository in $BACKUP_DIR"
+fi
+
+# Create .gitignore only if it doesn't exist (don't overwrite user customizations)
+if [ ! -f ".gitignore" ] && [ "$DRY_RUN" = false ]; then
+    cat > .gitignore << 'EOF'
+# These should never be committed even to backup repo
+.env
+env
+*.keys.json
+*recovery*.txt
+*password*.txt
+.checksums
+backup.log
+EOF
+fi
+
+# Install pre-commit hook to block accidental secret commits
+if [ ! -f ".git/hooks/pre-commit" ] && [ "$DRY_RUN" = false ]; then
+    mkdir -p .git/hooks
+    cat > .git/hooks/pre-commit << 'HOOK'
+#!/bin/bash
+# Block secret files from being committed
+if git diff --cached --name-only | grep -qE '\.env$|\.keys\.json$|recovery.*\.txt$|password.*\.txt$'; then
+    echo "BLOCKED: Attempting to commit secret files. Use .gitignore instead."
+    exit 1
+fi
+HOOK
+    chmod +x .git/hooks/pre-commit
+fi
+
+# Backup functions
+backup_dir() {
+    local src="$1"
+    local dest="$2"
+    if [ -d "$src" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            echo "  [WOULD] $dest ($(du -sh "$src" | cut -f1))"
+        else
+            mkdir -p "$dest"
+            rsync -a --delete "$src/" "$dest/"
+            echo "  ✓ $dest"
+        fi
+    else
+        echo "  ⊘ $dest (not found)"
+    fi
+}
+
+# Exclude sensitive files from groups
+backup_groups() {
+    local src="$NANOCLAW_DIR/groups"
+    local dest="$BACKUP_DIR/groups"
+
+    if [ -d "$src" ]; then
+        if [ "$DRY_RUN" = true ]; then
+            local size=$(du -sh "$src" | cut -f1)
+            echo "  [WOULD] groups/ ($size, excluding sensitive files)"
+        else
+            mkdir -p "$dest"
+            rsync -a --delete \
+                --exclude '*.keys.json' \
+                --exclude '*recovery*.txt' \
+                --exclude '*password*.txt' \
+                --exclude '*.env' \
+                --exclude '.secrets/' \
+                "$src/" "$dest/"
+            echo "  ✓ groups/ (excluded secrets & sensitive files)"
+        fi
+    else
+        echo "  ⊘ groups/ (not found)"
+    fi
+}
+
+echo "Backing up state..."
+
+# Backup store (database) — use sqlite3 backup API for safe concurrent copy
+if command -v sqlite3 &>/dev/null && [ -f "$NANOCLAW_DIR/store/messages.db" ]; then
+    if [ "$DRY_RUN" = true ]; then
+        echo "  [WOULD] store/messages.db (sqlite3 backup)"
+    else
+        mkdir -p "$BACKUP_DIR/store"
+        if sqlite3 "$NANOCLAW_DIR/store/messages.db" ".backup '$BACKUP_DIR/store/messages.db'"; then
+            echo "  ✓ store/messages.db (sqlite3 backup)"
+        else
+            echo "  ✗ store/messages.db (sqlite3 backup failed)"
+        fi
+    fi
+else
+    if command -v sqlite3 &>/dev/null; then
+        echo "  ⊘ store/messages.db (not found)"
+    else
+        echo "  ⊘ store/messages.db (sqlite3 not installed — install for safe backups)"
+    fi
+fi
+
+# Backup groups (exclude sensitive)
+backup_groups
+
+# Backup sessions
+backup_dir "$NANOCLAW_DIR/data/sessions" "data/sessions"
+
+# Backup IPC state
+backup_dir "$NANOCLAW_DIR/data/ipc" "data/ipc"
+
+# Git commit
+echo ""
+if [ "$DRY_RUN" = true ]; then
+    echo "[WOULD] Commit changes to backup repository"
+else
+    echo "Committing to backup repository..."
+    git add -A
+    if git diff --cached --quiet; then
+        echo "No changes to commit."
+    else
+        git commit -m "Backup $DATE"
+    fi
+fi
+
+# Git push
+echo ""
+REMOTE_URL=$(git -C "$BACKUP_DIR" config --get remote.origin.url 2>/dev/null || true)
+
+if [ "$DRY_RUN" = true ]; then
+    if [ -n "$REMOTE_URL" ]; then
+        echo "[WOULD] Push to $REMOTE_URL ($BRANCH)"
+    else
+        echo "[WOULD] No remote configured, skipping push"
+    fi
+elif [ -z "$REMOTE_URL" ]; then
+    echo "Skipping push (no remote configured)"
+else
+    AUTH_TOKEN="${GITHUB_TOKEN:-$GH_TOKEN}"
+    if [ -n "$AUTH_TOKEN" ] && [[ "$REMOTE_URL" == https://* ]]; then
+        # HTTPS remote with token — inject token into URL
+        PUSH_URL=$(echo "$REMOTE_URL" | sed -E 's|https://[^@]+@|https://'"$AUTH_TOKEN"'@|')
+        [[ "$PUSH_URL" == "$REMOTE_URL" ]] && PUSH_URL="https://${AUTH_TOKEN}@${REMOTE_URL#https://}"
+        echo "Pushing to $REMOTE_URL ($BRANCH)..."
+        if git push "$PUSH_URL" "$BRANCH" 2>&1; then
+            echo "  ✓ Pushed to remote"
+        else
+            echo "  ! Push failed. Run manually: cd $BACKUP_DIR && git push origin $BRANCH"
+        fi
+    else
+        # SSH remote or no token needed
+        echo "Pushing to $REMOTE_URL ($BRANCH)..."
+        if git push "$BRANCH" 2>&1; then
+            echo "  ✓ Pushed to remote"
+        else
+            echo "  ! Push failed. Run manually: cd $BACKUP_DIR && git push origin $BRANCH"
+        fi
+    fi
+fi
+
+# Integrity verification — checksum critical files
+echo ""
+echo "Verifying backup integrity..."
+if [ "$DRY_RUN" = true ]; then
+    echo "[WOULD] Generate checksums for backup files"
+else
+    find "$BACKUP_DIR/store" "$BACKUP_DIR/groups" "$BACKUP_DIR/data" \
+        -type f -exec sha256sum {} \; > "$CHECKSUM_FILE"
+    CHECKSUM_COUNT=$(wc -l < "$CHECKSUM_FILE")
+    echo "  ✓ $CHECKSUM_COUNT files checksummed ($CHECKSUM_FILE)"
+fi
+
+echo ""
+echo "=== Backup Complete ==="
+if [ "$DRY_RUN" = true ]; then
+    echo "*** This was a DRY RUN - no changes were made ***"
+else
+    echo "Total size: $(du -sh "$BACKUP_DIR" | cut -f1)"
+fi
+echo ""
+echo "Remember: Secrets (.env) were NOT backed up."
+echo "Store them separately in a secrets manager."


### PR DESCRIPTION
## What

Adds `/add-backup` — a utility skill that sets up automated, channel-agnostic backups of NanoClaw state data (messages.db, groups, sessions, IPC) to a local git repo with optional remote push.

## Why

NanoClaw has no built-in backup solution. Self-hosted users have no way to protect against data loss from disk failures, accidental deletions, or host migration. This fills a gap that existing upstream discussions ([#1180](https://github.com/qwibitai/nanoclaw/issues/1180), [#524](https://github.com/qwibitai/nanoclaw/pull/524), [#744](https://github.com/qwibitai/nanoclaw/pull/744), [#795](https://github.com/qwibitai/nanoclaw/pull/795)) don't cover: simple, local-first, automated git-based backup with full history.

## How it works

The SKILL.md is a 4-phase setup wizard (pre-flight → setup → configure → verify) that:
1. Checks for existing setup, detects auth (SSH/token/local), verifies sqlite3
2. Copies `scripts/backup.sh` to `~/backup-nanoclaw/`, inits git repo, optionally configures remote
3. Writes config, sets up cron job (default: daily at midnight)
4. Runs dry-run and full backup, verifies no secrets leaked

The backup script uses the sqlite3 backup API for safe concurrent copies, generates SHA-256 checksums, rotates logs, and supports SSH/token/local-only push.

Secrets (`.env`, `.secrets/`, `*.keys.json`, recovery/password files) are always excluded via `.gitignore`, pre-commit hook, and rsync patterns.

## Usage

```bash
# After /add-backup installs the script:
~/backup-nanoclaw/backup.sh          # Run backup
~/backup-nanoclaw/backup.sh --dry-run  # Preview only
```

## How it was tested

- `backup.sh --dry-run` shows `[WOULD]` entries, no files copied
- `backup.sh` copies files, creates git commit, generates checksums
- `grep -r "TOKEN\|API_KEY" $BACKUP_DIR/` finds no secrets
- Tested on fresh clone from upstream/main
- Pre-flight checks: All CONTRIBUTING.md requirements and maintainer quality standards pass — see [tracking issue](https://github.com/shrwnsan/nanoclaw/issues/4) for the full checklist.

## Files

| File | Purpose |
|------|---------|
| `.claude/skills/add-backup/SKILL.md` | Setup wizard (4 phases), usage, troubleshooting |
| `.claude/skills/add-backup/README.md` | Overview and feature list |
| `.claude/skills/add-backup/scripts/backup.sh` | Backup script |
| `.claude/skills/add-backup/docs/guide-backup-restore.md` | Restore guide |

---


🤖 Generated with [Claude Code](https://claude.com/claude-code)