### PR TITLE
fix: break for-await loop on result to prevent IPC message loss

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -534,6 +534,10 @@ async function runQuery(
         result: textResult || null,
         newSessionId,
       });
+      // Break so control returns to the outer while(true) loop where
+      // waitForIpcMessage() handles follow-ups. Without this, the
+      // for-await iterator hangs and IPC messages are silently lost.
+      break;
     }
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #233 — follow-up IPC messages are silently dropped when piped to an active container after the SDK query has yielded a result.

**Root cause:** The `for await` loop in `runQuery()` continues waiting for SDK messages after the result is yielded. The SDK has finished its turn and won't consume new stream pushes, so the iterator hangs indefinitely. Follow-up messages written to the IPC input directory are picked up by `pollIpcDuringQuery` and pushed to the stream, but sit unconsumed until the idle timeout kills the container.

**Fix:** Add `break` after processing a `result` message. This returns control to the outer `while(true)` loop where `waitForIpcMessage()` correctly handles follow-ups by starting new queries.

**Impact:** One line change (`break`), 3 lines of comment. No behavioral change for the first query — only affects follow-up messages arriving after the agent responds.

**Tested by:** Running a NanoClaw instance with a trusted Telegram group. Before: messages sent 1+ minute after agent response were lost (confirmed via DB and logs). After: the outer loop picks them up and starts a new query.

## AI Disclosure

This fix was developed with Claude Code (Opus). The root cause was diagnosed by tracing orchestrator logs and reading the agent-runner source. The fix (a single `break` statement) was identified from the issue's own analysis. Human-reviewed and tested on a live NanoClaw deployment.