### PR TITLE
feat: add NANOCLAW_EXTRA_MOUNTS for additional agent container volume mounts

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -108,6 +108,9 @@ vi.mock('child_process', async () => {
 
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
 import type { RegisteredGroup } from './types.js';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { logger } from './logger.js';
 
 const testGroup: RegisteredGroup = {
   name: 'Test Group',
@@ -226,5 +229,98 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+describe('NANOCLAW_EXTRA_MOUNTS parsing', () => {
+  const originalExtraMounts = process.env.NANOCLAW_EXTRA_MOUNTS;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(spawn).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalExtraMounts !== undefined) {
+      process.env.NANOCLAW_EXTRA_MOUNTS = originalExtraMounts;
+    } else {
+      delete process.env.NANOCLAW_EXTRA_MOUNTS;
+    }
+  });
+
+  function getSpawnArgs(): string[] {
+    const call = vi.mocked(spawn).mock.calls[0];
+    return call ? (call[1] as string[]) : [];
+  }
+
+  async function runOnce() {
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+  }
+
+  it('parses a single readonly mount correctly', async () => {
+    process.env.NANOCLAW_EXTRA_MOUNTS = '/mnt/cache/logs:/central-logs:ro';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    // readonlyMountArgs mock returns ['-v', 'host:container:ro']
+    expect(args).toContain('-v');
+    expect(args).toContainEqual('/mnt/cache/logs:/central-logs:ro');
+  });
+
+  it('parses multiple mounts with mixed modes correctly', async () => {
+    process.env.NANOCLAW_EXTRA_MOUNTS =
+      '/mnt/cache/logs:/central-logs:ro,/mnt/data:/data:rw';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    // ro mount goes through readonlyMountArgs mock → 'host:container:ro'
+    expect(args).toContainEqual('/mnt/cache/logs:/central-logs:ro');
+    // rw mount → 'host:container'
+    expect(args).toContainEqual('/mnt/data:/data');
+  });
+
+  it('adds no extra mounts when env var is not set', async () => {
+    delete process.env.NANOCLAW_EXTRA_MOUNTS;
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args.join(' ')).not.toContain('/central-logs');
+  });
+
+  it('skips malformed entries with a warning', async () => {
+    process.env.NANOCLAW_EXTRA_MOUNTS = 'bad-entry,:/also-bad,:';
+
+    await runOnce();
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: expect.any(String) }),
+      expect.stringContaining('malformed'),
+    );
+  });
+
+  it('defaults to readonly when mode is not specified', async () => {
+    process.env.NANOCLAW_EXTRA_MOUNTS = '/mnt/share:/share';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    // No mode specified → readonly → goes through readonlyMountArgs mock → ':ro'
+    expect(args).toContainEqual('/mnt/share:/share:ro');
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -240,6 +240,31 @@ function buildVolumeMounts(
     mounts.push(...validatedMounts);
   }
 
+  // NANOCLAW_EXTRA_MOUNTS: user-defined volume mounts from environment
+  // Format: "hostpath:containerpath[:mode],hostpath2:containerpath2[:mode]"
+  // Mode defaults to "ro" when omitted. Malformed entries are skipped
+  // with a warning rather than crashing the container launch.
+  const extraMountsEnv = process.env.NANOCLAW_EXTRA_MOUNTS;
+  if (extraMountsEnv) {
+    for (const entry of extraMountsEnv.split(',')) {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split(':');
+      if (parts.length < 2 || !parts[0] || !parts[1]) {
+        logger.warn(
+          { entry: trimmed },
+          'NANOCLAW_EXTRA_MOUNTS: skipping malformed entry (need hostpath:containerpath[:mode])',
+        );
+        continue;
+      }
+      const hostPath = parts[0];
+      const containerPath = parts[1];
+      const mode = parts[2]?.toLowerCase();
+      const readonly = mode !== 'rw';
+      mounts.push({ hostPath, containerPath, readonly });
+    }
+  }
+
   return mounts;
 }
 


### PR DESCRIPTION
Adds NANOCLAW_EXTRA_MOUNTS environment variable support for passing additional volume mounts into agent containers.

Format: hostpath:containerpath:mode,hostpath2:containerpath2:mode
Example: /mnt/cache/logs:/central-logs:ro

Useful for giving agents read-only access to host log directories, shared data, or other resources without modifying the core template. Mounts are validated and appended to the standard container args.

Includes tests covering: valid single and multiple mounts, read-only and read-write modes, invalid format handling, and empty/unset variable behaviour.