### PR TITLE
feat: forward MCP skill env vars and Docker network into agent containers

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -108,6 +108,9 @@ vi.mock('child_process', async () => {
 
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
 import type { RegisteredGroup } from './types.js';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { logger } from './logger.js';
 
 const testGroup: RegisteredGroup = {
   name: 'Test Group',
@@ -226,5 +229,222 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+describe('MCP skill env var forwarding', () => {
+  const ALL_KEYS = [
+    'TS_API_KEY',
+    'TS_API_CLIENT_ID',
+    'TS_API_CLIENT_SECRET',
+    'TS_API_TAILNET',
+    'HA_URL',
+    'HA_TOKEN',
+    'OLLAMA_URL',
+    'LITELLM_URL',
+    'LITELLM_MASTER_KEY',
+    'UNRAIDCLAW_SERVERS',
+    'UNRAIDCLAW_API_KEY',
+    'UNRAIDCLAW_URL',
+    'PAPERCLIP_URL',
+    'PAPERCLIP_AGENT_JWT_SECRET',
+    'PAPERCLIP_AGENT_ID',
+    'PAPERCLIP_COMPANY_ID',
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(spawn).mockClear();
+    vi.mocked(logger.debug).mockClear();
+    for (const key of ALL_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const key of ALL_KEYS) {
+      if (saved[key] !== undefined) {
+        process.env[key] = saved[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  function getSpawnArgs(): string[] {
+    const call = vi.mocked(spawn).mock.calls[0];
+    return call ? (call[1] as string[]) : [];
+  }
+
+  async function runOnce() {
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+  }
+
+  it('forwards vars that are set in process.env', async () => {
+    process.env.TS_API_KEY = 'tskey-test';
+    process.env.HA_URL = 'http://ha:8123';
+    process.env.HA_TOKEN = 'ha-token-secret';
+    process.env.OLLAMA_URL = 'http://ollama:11434';
+    process.env.UNRAIDCLAW_API_KEY = 'unraid-key';
+    process.env.PAPERCLIP_AGENT_ID = 'agent-1';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args).toContain('TS_API_KEY=tskey-test');
+    expect(args).toContain('HA_URL=http://ha:8123');
+    expect(args).toContain('HA_TOKEN=ha-token-secret');
+    expect(args).toContain('OLLAMA_URL=http://ollama:11434');
+    expect(args).toContain('UNRAIDCLAW_API_KEY=unraid-key');
+    expect(args).toContain('PAPERCLIP_AGENT_ID=agent-1');
+  });
+
+  it('does not forward vars that are unset', async () => {
+    await runOnce();
+
+    const args = getSpawnArgs();
+    const joined = args.join(' ');
+    for (const key of ALL_KEYS) {
+      expect(joined).not.toContain(`${key}=`);
+    }
+  });
+
+  it('does not forward vars that are empty strings', async () => {
+    process.env.TS_API_KEY = '';
+    process.env.HA_TOKEN = '';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args.join(' ')).not.toContain('TS_API_KEY=');
+    expect(args.join(' ')).not.toContain('HA_TOKEN=');
+  });
+
+  it('forwards only the set subset, leaving unset vars absent', async () => {
+    process.env.LITELLM_URL = 'http://litellm:4000';
+    process.env.LITELLM_MASTER_KEY = 'sk-litellm-test';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args).toContain('LITELLM_URL=http://litellm:4000');
+    expect(args).toContain('LITELLM_MASTER_KEY=sk-litellm-test');
+    expect(args.join(' ')).not.toContain('TS_API_KEY=');
+    expect(args.join(' ')).not.toContain('HA_URL=');
+    expect(args.join(' ')).not.toContain('PAPERCLIP_URL=');
+  });
+
+  it('redacts secret values in container-runner debug logs', async () => {
+    process.env.TS_API_KEY = 'tskey-supersecret';
+    process.env.HA_TOKEN = 'ha-token-supersecret';
+    process.env.LITELLM_MASTER_KEY = 'sk-litellm-supersecret';
+    process.env.UNRAIDCLAW_API_KEY = 'unraid-supersecret';
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = 'jwt-supersecret';
+    process.env.TS_API_CLIENT_SECRET = 'client-supersecret';
+    // Non-secret URL — should NOT be redacted
+    process.env.HA_URL = 'http://ha:8123';
+
+    await runOnce();
+
+    const debugCalls = vi.mocked(logger.debug).mock.calls;
+    const containerCfgCall = debugCalls.find(
+      (c) => c[1] === 'Container mount configuration',
+    );
+    expect(containerCfgCall).toBeDefined();
+    const loggedArgs = (containerCfgCall![0] as { containerArgs: string })
+      .containerArgs;
+
+    expect(loggedArgs).not.toContain('tskey-supersecret');
+    expect(loggedArgs).not.toContain('ha-token-supersecret');
+    expect(loggedArgs).not.toContain('sk-litellm-supersecret');
+    expect(loggedArgs).not.toContain('unraid-supersecret');
+    expect(loggedArgs).not.toContain('jwt-supersecret');
+    expect(loggedArgs).not.toContain('client-supersecret');
+    expect(loggedArgs).toContain('TS_API_KEY=<redacted>');
+    expect(loggedArgs).toContain('HA_TOKEN=<redacted>');
+    expect(loggedArgs).toContain('HA_URL=http://ha:8123');
+  });
+});
+
+describe('NANOCLAW_DOCKER_NETWORK', () => {
+  const original = process.env.NANOCLAW_DOCKER_NETWORK;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(spawn).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (original !== undefined) {
+      process.env.NANOCLAW_DOCKER_NETWORK = original;
+    } else {
+      delete process.env.NANOCLAW_DOCKER_NETWORK;
+    }
+  });
+
+  function getSpawnArgs(): string[] {
+    const call = vi.mocked(spawn).mock.calls[0];
+    return call ? (call[1] as string[]) : [];
+  }
+
+  async function runOnce() {
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+  }
+
+  it('passes --network when NANOCLAW_DOCKER_NETWORK is set', async () => {
+    process.env.NANOCLAW_DOCKER_NETWORK = 'ai-local';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    const idx = args.indexOf('--network');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('ai-local');
+  });
+
+  it('omits --network when NANOCLAW_DOCKER_NETWORK is unset', async () => {
+    delete process.env.NANOCLAW_DOCKER_NETWORK;
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args).not.toContain('--network');
+  });
+
+  it('omits --network when NANOCLAW_DOCKER_NETWORK is empty/whitespace', async () => {
+    process.env.NANOCLAW_DOCKER_NETWORK = '   ';
+
+    await runOnce();
+
+    const args = getSpawnArgs();
+    expect(args).not.toContain('--network');
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -35,6 +35,70 @@ const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
+// MCP skill env vars forwarded from the host into the agent container.
+// stdio MCP servers (Tailscale, Home Assistant, Ollama/LiteLLM, UnraidClaw,
+// Paperclip) read these directly from process.env inside the container.
+const MCP_SKILL_ENV_KEYS = [
+  // Tailscale
+  'TS_API_KEY',
+  'TS_API_CLIENT_ID',
+  'TS_API_CLIENT_SECRET',
+  'TS_API_TAILNET',
+  // Home Assistant
+  'HA_URL',
+  'HA_TOKEN',
+  // Ollama / LiteLLM
+  'OLLAMA_URL',
+  'LITELLM_URL',
+  'LITELLM_MASTER_KEY',
+  // UnraidClaw
+  'UNRAIDCLAW_SERVERS',
+  'UNRAIDCLAW_API_KEY',
+  'UNRAIDCLAW_URL',
+  // Paperclip
+  'PAPERCLIP_URL',
+  'PAPERCLIP_AGENT_JWT_SECRET',
+  'PAPERCLIP_AGENT_ID',
+  'PAPERCLIP_COMPANY_ID',
+];
+
+// Env keys whose values must never appear in logs.
+const SECRET_ENV_KEYS = new Set<string>([
+  'TS_API_KEY',
+  'TS_API_CLIENT_SECRET',
+  'HA_TOKEN',
+  'LITELLM_MASTER_KEY',
+  'UNRAIDCLAW_API_KEY',
+  'PAPERCLIP_AGENT_JWT_SECRET',
+]);
+
+/**
+ * Redact secret values from a container args array before logging.
+ * Detects `-e KEY=VALUE` pairs and masks the value half when KEY is in
+ * SECRET_ENV_KEYS. Non-secret -e args (like URLs and IDs) pass through
+ * unchanged for debugging.
+ */
+export function redactContainerArgs(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-e' && i + 1 < args.length) {
+      const next = args[i + 1];
+      const eqIdx = next.indexOf('=');
+      if (eqIdx > 0) {
+        const key = next.slice(0, eqIdx);
+        if (SECRET_ENV_KEYS.has(key)) {
+          out.push(arg, `${key}=<redacted>`);
+          i++;
+          continue;
+        }
+      }
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -268,6 +332,26 @@ async function buildContainerArgs(
     );
   }
 
+  // MCP skill credentials — forward host env vars into the container so
+  // stdio MCP servers (Tailscale, Home Assistant, Ollama/LiteLLM,
+  // UnraidClaw, Paperclip) can read them via process.env. Only forward
+  // vars that are non-empty on the host. Values are redacted from any
+  // logs of the args array — see redactContainerArgs().
+  for (const key of MCP_SKILL_ENV_KEYS) {
+    const val = process.env[key];
+    if (val) {
+      args.push('-e', `${key}=${val}`);
+    }
+  }
+
+  // Attach to a custom Docker network when configured (e.g. shared
+  // network with Ollama, Home Assistant, etc.). Falls back to Docker's
+  // default bridge when unset.
+  const dockerNetwork = process.env.NANOCLAW_DOCKER_NETWORK;
+  if (dockerNetwork && dockerNetwork.trim().length > 0) {
+    args.push('--network', dockerNetwork.trim());
+  }
+
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 
@@ -326,7 +410,7 @@ export async function runContainerAgent(
         (m) =>
           `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
       ),
-      containerArgs: containerArgs.join(' '),
+      containerArgs: redactContainerArgs(containerArgs).join(' '),
     },
     'Container mount configuration',
   );
@@ -556,7 +640,7 @@ export async function runContainerAgent(
         }
         logLines.push(
           `=== Container Args ===`,
-          containerArgs.join(' '),
+          redactContainerArgs(containerArgs).join(' '),
           ``,
           `=== Mounts ===`,
           mounts

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -60,6 +60,9 @@ const MCP_SKILL_ENV_KEYS = [
   'PAPERCLIP_AGENT_JWT_SECRET',
   'PAPERCLIP_AGENT_ID',
   'PAPERCLIP_COMPANY_ID',
+  // Vikunja
+  'VIKUNJA_URL',
+  'VIKUNJA_TOKEN',
 ];
 
 // Env keys whose values must never appear in logs.
@@ -70,6 +73,7 @@ const SECRET_ENV_KEYS = new Set<string>([
   'LITELLM_MASTER_KEY',
   'UNRAIDCLAW_API_KEY',
   'PAPERCLIP_AGENT_JWT_SECRET',
+  'VIKUNJA_TOKEN',
 ]);
 
 /**


### PR DESCRIPTION
MCP skill stdio binaries run inside agent containers and read credentials directly from process.env. Previously no skill vars were forwarded into containers, causing all MCP integrations (Ollama, Home Assistant, Tailscale, UnraidClaw, Paperclip, LiteLLM) to silently fail to get credentials.

This PR adds:
- MCP_SKILL_ENV_KEYS constant listing all 16 skill credential vars forwarded via -e into agent containers (only when non-empty)
- SECRET_ENV_KEYS set + redactContainerArgs() helper — secret values are redacted in all log output
- NANOCLAW_DOCKER_NETWORK support — agent containers join the specified network via --network, enabling hostname resolution to Ollama, LiteLLM, Paperclip etc. on user-defined networks

Forwarded vars by skill:
Tailscale: TS_API_KEY, TS_API_CLIENT_ID, TS_API_CLIENT_SECRET, TS_API_TAILNET
Home Assistant: HA_URL, HA_TOKEN
Ollama/LiteLLM: OLLAMA_URL, LITELLM_URL, LITELLM_MASTER_KEY
UnraidClaw: UNRAIDCLAW_SERVERS, UNRAIDCLAW_API_KEY, UNRAIDCLAW_URL
Paperclip: PAPERCLIP_URL, PAPERCLIP_AGENT_JWT_SECRET, PAPERCLIP_AGENT_ID, PAPERCLIP_COMPANY_ID

Note: for correct credential proxy routing on user-defined Docker networks, see companion PR #1727.