### PR TITLE
fix(apple-container): wire credential proxy, fix env loading, fix launchd PATH

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -101,7 +101,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 
+import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 
 /** The container runtime binary name. */
@@ -37,12 +38,15 @@ function detectHostGateway(): string {
  * but the proxy must start before any container.
  * The /convert-to-apple-container skill sets this during setup.
  */
-export const PROXY_BIND_HOST = process.env.CREDENTIAL_PROXY_HOST;
-if (!PROXY_BIND_HOST) {
+const proxyBindHostRaw =
+  process.env.CREDENTIAL_PROXY_HOST ||
+  readEnvFile(['CREDENTIAL_PROXY_HOST']).CREDENTIAL_PROXY_HOST;
+if (!proxyBindHostRaw) {
   throw new Error(
     'CREDENTIAL_PROXY_HOST is not set in .env. Run /convert-to-apple-container to configure.',
   );
 }
+export const PROXY_BIND_HOST: string = proxyBindHostRaw;
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { OneCLI } from '@onecli-sh/sdk';
 
 import {
   ASSISTANT_NAME,
+  CREDENTIAL_PROXY_PORT,
   DEFAULT_TRIGGER,
   getTriggerPattern,
   GROUPS_DIR,
@@ -14,6 +15,7 @@ import {
   POLL_INTERVAL,
   TIMEZONE,
 } from './config.js';
+import { startCredentialProxy } from './credential-proxy.js';
 import './channels/index.js';
 import {
   getChannelFactory,
@@ -28,6 +30,7 @@ import {
 import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
+  PROXY_BIND_HOST,
 } from './container-runtime.js';
 import {
   getAllChats,
@@ -548,6 +551,11 @@ function ensureContainerSystemRunning(): void {
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  await startCredentialProxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST);
+  logger.info(
+    { port: CREDENTIAL_PROXY_PORT, host: PROXY_BIND_HOST },
+    'Credential proxy listening',
+  );
   initDatabase();
   logger.info('Database initialized');
   loadState();


### PR DESCRIPTION
## Summary

Three bugs in the `skill/apple-container` branch prevent a fresh setup from working end-to-end on macOS. After fixing all three, a clean Apple Container install via `/setup` → `/convert-to-apple-container` runs and Telegram messages reach the agent successfully.

### 1. Credential proxy is never started

`src/credential-proxy.ts` defines and tests `startCredentialProxy()`, but no production code path calls it. Containers attempt to reach `host.docker.internal:3001` and get connection refused, surfacing as `API Error: Unable to connect to API` in the chat.

**Fix:** wire `startCredentialProxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST)` into `main()` in `src/index.ts`, immediately after `ensureContainerSystemRunning()`.

### 2. `CREDENTIAL_PROXY_HOST` is read from `process.env`, not from `.env`

The project pattern (`src/env.ts`) deliberately keeps secrets out of `process.env` and exposes them via `readEnvFile()`. `src/container-runtime.ts` read `CREDENTIAL_PROXY_HOST` directly from `process.env`, so it was always `undefined` under both vitest and the launchd-managed service. The module-level throw fired on every startup.

**Fix:** fall back to `readEnvFile(['CREDENTIAL_PROXY_HOST']).CREDENTIAL_PROXY_HOST`. Also narrow the export to `string` since the throw guarantees it.

### 3. launchd plist's PATH is missing `/opt/homebrew/bin`

The `/convert-to-apple-container` skill instructs users to install Apple Container via `brew install container`, which on Apple Silicon places the binary at `/opt/homebrew/bin/container`. The generated plist had `PATH=/usr/local/bin:/usr/bin:/bin:~/.local/bin`, so the service crashed on every startup with `container: command not found`.

**Fix:** prepend `/opt/homebrew/bin` to the plist PATH in `setup/service.ts`.

## Reproduction (without these fixes)

On a fresh clone, macOS 26 / Apple Silicon:

```
brew install container
container system start
container system kernel set --recommended
git fetch upstream skill/apple-container && git merge upstream/skill/apple-container
bash setup.sh
npx tsx setup/index.ts --step container -- --runtime container
npx tsx setup/index.ts --step service
launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
```

Symptom chain:
1. Service crashes immediately: `container: command not found` → `Container runtime is required but failed to start` (bug 3).
2. After patching plist PATH manually: service crashes with `CREDENTIAL_PROXY_HOST is not set in .env` (bug 2 — `.env` has the value, but `process.env` does not).
3. After patching env loading: service starts, Telegram bot connects, but every container request fails with `API Error: Unable to connect to API` because the credential proxy was never started (bug 1).

With this PR, all three are resolved.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — all 245 tests pass (no test changes; existing `credential-proxy.test.ts` still passes)
- [x] Fresh service start under launchd: credential proxy listens on `0.0.0.0:3001`, log line `Credential proxy listening` appears, Telegram bot connects, real Telegram messages reach the agent and Claude responds successfully through the proxy in OAuth mode

## Notes

This is my first PR to NanoClaw — happy to adjust commit structure, message wording, or scope if anything is off. Tested live on macOS 26.3.1, Apple Container 0.11.0 (installed via Homebrew), Node 22.22.0.