### PR TITLE
fix(container): check all agent-runner source files for cache staleness

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -212,13 +212,25 @@ function buildVolumeMounts(
     'agent-runner-src',
   );
   if (fs.existsSync(agentRunnerSrc)) {
-    const srcIndex = path.join(agentRunnerSrc, 'index.ts');
-    const cachedIndex = path.join(groupAgentRunnerDir, 'index.ts');
-    const needsCopy =
-      !fs.existsSync(groupAgentRunnerDir) ||
-      !fs.existsSync(cachedIndex) ||
-      (fs.existsSync(srcIndex) &&
-        fs.statSync(srcIndex).mtimeMs > fs.statSync(cachedIndex).mtimeMs);
+    // Check if ANY source file is newer than its cached copy (not just index.ts)
+    let needsCopy = !fs.existsSync(groupAgentRunnerDir);
+    if (!needsCopy) {
+      try {
+        const srcFiles = fs
+          .readdirSync(agentRunnerSrc)
+          .filter((f) => f.endsWith('.ts'));
+        needsCopy = srcFiles.some((f) => {
+          const srcPath = path.join(agentRunnerSrc, f);
+          const cachedPath = path.join(groupAgentRunnerDir, f);
+          return (
+            !fs.existsSync(cachedPath) ||
+            fs.statSync(srcPath).mtimeMs > fs.statSync(cachedPath).mtimeMs
+          );
+        });
+      } catch {
+        needsCopy = true;
+      }
+    }
     if (needsCopy) {
       fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary
- Agent-runner source cache only compared `index.ts` mtime when deciding
  whether to refresh the per-group copy. Changes to other files (e.g.
  `ipc-mcp-stdio.ts`) were silently ignored — containers launched with
  stale code until manual cache clear.
- Now checks all `.ts` files in the source directory.

## Test plan
- [ ] Modify only `ipc-mcp-stdio.ts` (not `index.ts`), restart NanoClaw,
      verify next container spawn picks up the change
- [ ] Verify `data/sessions/<group>/agent-runner-src/` gets refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)