### PR TITLE
fix(router): include message id in XML format for agent context

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -23,7 +23,8 @@ export function formatMessages(
       m.reply_to_message_content && m.reply_to_sender_name
         ? `\n  <quoted_message from="${escapeXml(m.reply_to_sender_name)}">${escapeXml(m.reply_to_message_content)}</quoted_message>`
         : '';
-    return `<message sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}"${replyAttr}>${replySnippet}${escapeXml(m.content)}</message>`;
+    const idAttr = m.id ? ` id="${escapeXml(m.id)}"` : '';
+    return `<message${idAttr} sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}"${replyAttr}>${replySnippet}${escapeXml(m.content)}</message>`;
   });
 
   const header = `<context timezone="${escapeXml(timezone)}" />\n`;


### PR DESCRIPTION
## Summary

- The `formatMessages()` function in `router.ts` produces XML that the container agent receives as conversation context
- The `<message>` tags were missing the `id` attribute, so the agent had no way to reference specific messages by their numeric ID
- This caused `react_to_message` MCP tool calls to fail — the agent would pass `"last"` as the `message_id` since it couldn't extract a real ID from the XML
- `Number.parseInt("last")` returns `NaN`, and the Telegram channel correctly rejects it with `"invalid chat or message id"`

**Fix:** Add the `id` attribute from `NewMessage.id` to each `<message>` tag:
```xml
<!-- Before -->
<message sender="User" time="15:00">text</message>

<!-- After -->
<message id="11750" sender="User" time="15:00">text</message>
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] Tested with Telegram channel — reactions now appear in chat
- [x] Verified in logs: `messageId` shows numeric IDs instead of `"last"`
- [ ] Verify other channels (WhatsApp, Slack) still work — `m.id` is always present in `NewMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)