### PR TITLE
feat: add send_file MCP tool for delivering files to chat

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -68,6 +68,59 @@ server.tool(
 );
 
 server.tool(
+  'send_file',
+  `Send a file (photo, document, PDF, etc.) to the user. The file must exist on disk at the given path.
+
+Use this when you need to deliver downloaded images, generated documents, analysis results, or any other file
+to the user. Photos (.jpg, .jpeg, .png, .webp) are sent as inline images; other files as document attachments.
+
+The optional caption supports Markdown formatting (*bold*, _italic_, \`code\`).`,
+  {
+    file_path: z
+      .string()
+      .describe(
+        'Absolute path to the file inside the container (e.g. /workspace/group/screenshots/page.png)',
+      ),
+    caption: z
+      .string()
+      .max(1024)
+      .optional()
+      .describe('Optional caption for the file (Markdown supported, max 1024 chars).'),
+  },
+  async (args) => {
+    if (!fs.existsSync(args.file_path)) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `File not found: ${args.file_path}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'send_file',
+      chatJid,
+      filePath: args.file_path,
+      caption: args.caption || undefined,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `File queued for delivery: ${path.basename(args.file_path)}`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
   'schedule_task',
   `Schedule a recurring or one-time task. The task will run as a full agent with access to all tools. Returns the task ID for future reference. To modify an existing task, use update_task instead.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -746,6 +746,21 @@ async function main(): Promise<void> {
         writeTasksSnapshot(group.folder, group.isMain === true, taskRows);
       }
     },
+    sendFile: async (jid, filePath, caption) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn({ jid }, 'sendFile: no channel owns JID');
+        return;
+      }
+      if (!channel.sendFile) {
+        logger.warn(
+          { jid, channel: channel.name },
+          'sendFile: channel does not support file sending, dropping',
+        );
+        return;
+      }
+      await channel.sendFile(jid, filePath, caption);
+    },
   });
   startSessionCleanup();
   queue.setProcessMessagesFn(processGroupMessages);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -6,7 +6,7 @@ import { CronExpressionParser } from 'cron-parser';
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
-import { isValidGroupFolder } from './group-folder.js';
+import { isValidGroupFolder, resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
@@ -23,6 +23,13 @@ export interface IpcDeps {
     registeredJids: Set<string>,
   ) => void;
   onTasksChanged: () => void;
+  // Optional: send a file (photo, document) to a chat. Only populated when
+  // a connected channel implements Channel.sendFile.
+  sendFile?: (
+    jid: string,
+    filePath: string,
+    caption?: string,
+  ) => Promise<void>;
 }
 
 let ipcWatcherRunning = false;
@@ -91,6 +98,53 @@ export function startIpcWatcher(deps: IpcDeps): void {
                     { chatJid: data.chatJid, sourceGroup },
                     'Unauthorized IPC message attempt blocked',
                   );
+                }
+              } else if (
+                data.type === 'send_file' &&
+                data.chatJid &&
+                data.filePath
+              ) {
+                const targetGroup = registeredGroups[data.chatJid];
+                const authorized =
+                  isMain || (targetGroup && targetGroup.folder === sourceGroup);
+                if (!authorized) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC send_file attempt blocked',
+                  );
+                } else if (!deps.sendFile) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'IPC send_file dropped — channel does not support file sending',
+                  );
+                } else {
+                  // Translate container path to host path
+                  // /workspace/group/ inside container = groups/<folder>/ on host
+                  const containerPrefix = '/workspace/group/';
+                  let hostPath = data.filePath;
+                  if (data.filePath.startsWith(containerPrefix)) {
+                    const relativePath = data.filePath.slice(containerPrefix.length);
+                    hostPath = path.join(
+                      resolveGroupFolderPath(sourceGroup),
+                      relativePath,
+                    );
+                  }
+                  if (!fs.existsSync(hostPath)) {
+                    logger.warn(
+                      { chatJid: data.chatJid, hostPath, originalPath: data.filePath },
+                      'IPC send_file — file not found on host',
+                    );
+                  } else {
+                    await deps.sendFile(
+                      data.chatJid,
+                      hostPath,
+                      data.caption || undefined,
+                    );
+                    logger.info(
+                      { chatJid: data.chatJid, sourceGroup, filePath: hostPath },
+                      'IPC file sent',
+                    );
+                  }
                 }
               }
               fs.unlinkSync(filePath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,14 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send a file (photo, document) to a chat. Used by the
+  // `send_file` MCP tool so the agent can deliver downloaded images,
+  // analysis results, etc. The filePath is an absolute host path.
+  sendFile?(
+    jid: string,
+    filePath: string,
+    caption?: string,
+  ): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

- New `send_file` MCP tool for the container agent to send files (photos, documents) back to the user
- Photos (.jpg, .jpeg, .png, .webp) sent as inline images; other types as document attachments
- Container path `/workspace/group/...` automatically translated to host path via `resolveGroupFolderPath`
- Channel-agnostic: channels implement optional `sendFile()` method in the Channel interface

## Changes

- `src/types.ts` — add `sendFile?()` to Channel interface
- `src/ipc.ts` — add `send_file` IPC handler with path translation + authorization
- `src/index.ts` — wire `sendFile` into IPC deps
- `container/agent-runner/src/ipc-mcp-stdio.ts` — add `send_file` MCP tool definition

## Use cases

- Instagram analyzer sends collected photos to user
- Website analyzer sends screenshots
- Any agent skill that downloads/generates files and needs to deliver them

## Test plan

- [x] Build passes
- [x] Tested with Telegram channel (sendPhoto/sendDocument) — files delivered correctly
- [x] Path translation verified: `/workspace/group/` → `groups/<folder>/` via `resolveGroupFolderPath`
- [x] Authorization: only owning group or main can send files
- [x] Missing file: warns in log, doesn't crash
- [ ] Channels without `sendFile` implementation: silently dropped with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)