### PR TITLE
fix: isolate channel connect failures so one broken channel doesn't crash startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -677,6 +677,9 @@ async function main(): Promise<void> {
   // Create and connect all registered channels.
   // Each channel self-registers via the barrel import above.
   // Factories return null when credentials are missing, so unconfigured channels are skipped.
+  // A connect() failure in one channel must not crash the whole service —
+  // e.g. expired OAuth tokens in a single channel should not take down
+  // WhatsApp/Discord/etc. that would otherwise still work.
   for (const channelName of getRegisteredChannelNames()) {
     const factory = getChannelFactory(channelName)!;
     const channel = factory(channelOpts);
@@ -687,8 +690,15 @@ async function main(): Promise<void> {
       );
       continue;
     }
-    channels.push(channel);
-    await channel.connect();
+    try {
+      await channel.connect();
+      channels.push(channel);
+    } catch (err) {
+      logger.error(
+        { channel: channelName, err },
+        'Channel connect failed — continuing without it. Re-run the channel skill or refresh credentials to restore.',
+      );
+    }
   }
   if (channels.length === 0) {
     logger.fatal('No channels connected');


### PR DESCRIPTION
## Problem

A single channel throwing in `connect()` — e.g. Gmail with an expired OAuth refresh token returning `invalid_grant` — propagates out of `main()` and kills the whole service. Every other channel (Discord, WhatsApp, Telegram, ...) becomes unreachable until the broken channel is manually fixed.

```
[INFO]  Discord bot connected  username: "Andy#2122"
[ERROR] Failed to start NanoClaw
    err: GaxiosError: invalid_grant
    at async GmailChannel.connect (dist/channels/gmail.js:51:25)
    at async main (dist/index.js:476:9)
[systemd] nanoclaw.service: Main process exited, code=exited, status=1/FAILURE
[systemd] Scheduled restart job, restart counter is at N...
```

The service ends up in a systemd crash loop until the user notices and manually repairs the broken credential.

## Fix

Wrap each `channel.connect()` in try/catch. Failed channels are logged at `ERROR` level with their credentials-recovery hint, and `main()` keeps starting with the channels that did connect. The existing `"No channels connected"` fatal guard still applies, so we don't silently run with zero connectivity.

Also move `channels.push(channel)` to **after** the successful connect, so the `channels` array never contains a half-initialized channel.

## Reproduction

1. Have a working NanoClaw install with Gmail + at least one other channel (Discord works well)
2. Revoke the Gmail OAuth refresh token on the Google side (or wait for it to expire naturally)
3. `systemctl --user restart nanoclaw.service`

**Before:** systemd crash loop, all channels unreachable.
**After:** one ERROR log line for Gmail, NanoClaw starts normally and serves Discord / the other channels. Gmail can be fixed later via `/add-gmail` re-run without downtime for anything else.

## Scope

One-thing-per-PR: only the try/catch wrapper and the push-after-connect reorder. No other behavior changes. 12 lines added, 2 lines removed in `src/index.ts`.

## Testing

- Ran `npm run build` clean on upstream 1.2.53 base
- Started service directly via `node dist/index.js` with a known-bad Gmail OAuth token: Discord connected, Gmail logged the error and was skipped, `"NanoClaw running"` reached
- Started via `systemctl --user start nanoclaw.service`: `active (running)`, no crash loop, ports 4401/4402 serving normally
- Verified a channel with missing env vars still takes the early-return factory path (no regression)

Co-authored fix-analysis with Claude Opus 4.6 (1M context).