### PR TITLE
v2: fix(db): normalize auto-generated timestamps to ISO 8601

### DIFF
--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -105,11 +105,11 @@ Run `/manage-channels` to wire the GitHub channel to an agent group, or insert m
 ```sql
 -- Create messaging group (one per repo)
 INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-VALUES ('mg-github-myrepo', 'github', 'github:owner/repo', 'owner/repo', 1, '<policy>', datetime('now'));
+VALUES ('mg-github-myrepo', 'github', 'github:owner/repo', 'owner/repo', 1, '<policy>', strftime('%Y-%m-%dT%H:%M:%fZ','now'));
 
 -- Wire to agent group
 INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, trigger_rules, response_scope, session_mode, priority, created_at)
-VALUES ('mga-github-myrepo', 'mg-github-myrepo', '<your-agent-group-id>', '', 'all', 'per-thread', 10, datetime('now'));
+VALUES ('mga-github-myrepo', 'mg-github-myrepo', '<your-agent-group-id>', '', 'all', 'per-thread', 10, strftime('%Y-%m-%dT%H:%M:%fZ','now'));
 ```
 
 Replace `<policy>` with `public` or `strict` based on the user's choice above.
@@ -121,7 +121,7 @@ When using `strict`, add each GitHub user who should be able to trigger the agen
 ```sql
 -- Add user (kind = 'github', id = 'github:<numeric-user-id>')
 INSERT OR IGNORE INTO users (id, kind, display_name, created_at)
-VALUES ('github:<user-id>', 'github', '<username>', datetime('now'));
+VALUES ('github:<user-id>', 'github', '<username>', strftime('%Y-%m-%dT%H:%M:%fZ','now'));
 
 -- Grant membership to the agent group
 INSERT OR IGNORE INTO agent_group_members (user_id, agent_group_id)

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -143,11 +143,11 @@ Run `/manage-channels` to wire the Linear channel to an agent group, or insert m
 ```sql
 -- Create messaging group (one per team)
 INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-VALUES ('mg-linear-eng', 'linear', 'linear:ENG', 'Engineering', 1, 'public', datetime('now'));
+VALUES ('mg-linear-eng', 'linear', 'linear:ENG', 'Engineering', 1, 'public', strftime('%Y-%m-%dT%H:%M:%fZ','now'));
 
 -- Wire to agent group
 INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, trigger_rules, response_scope, session_mode, priority, created_at)
-VALUES ('mga-linear-eng', 'mg-linear-eng', '<your-agent-group-id>', '', 'all', 'per-thread', 10, datetime('now'));
+VALUES ('mga-linear-eng', 'mg-linear-eng', '<your-agent-group-id>', '', 'all', 'per-thread', 10, strftime('%Y-%m-%dT%H:%M:%fZ','now'));
 ```
 
 The `platform_id` must be `linear:<TEAM_KEY>` matching the `LINEAR_TEAM_KEY` env var. Use `per-thread` session mode so each issue comment thread gets its own agent session.

--- a/.claude/skills/add-wechat/scripts/wire-dm.ts
+++ b/.claude/skills/add-wechat/scripts/wire-dm.ts
@@ -156,7 +156,7 @@ async function main(): Promise<void> {
     db.prepare(`
       INSERT INTO messaging_group_agents
         (id, messaging_group_id, agent_group_id, trigger_rules, response_scope, session_mode, priority, created_at)
-      VALUES (?, ?, ?, '', 'all', ?, 10, datetime('now'))
+      VALUES (?, ?, ?, '', 'all', ?, 10, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
     `).run(generateId('mga'), mg.id, ag.id, args.sessionMode);
   });
   tx();

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -101,7 +101,7 @@ export function markProcessing(ids: string[]): void {
   if (ids.length === 0) return;
   const db = getOutboundDb();
   const stmt = db.prepare(
-    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'processing', datetime('now'))",
+    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'processing', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   );
   db.transaction(() => {
     for (const id of ids) stmt.run(id);
@@ -113,7 +113,7 @@ export function markCompleted(ids: string[]): void {
   if (ids.length === 0) return;
   const db = getOutboundDb();
   const stmt = db.prepare(
-    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'completed', datetime('now'))",
+    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'completed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   );
   db.transaction(() => {
     for (const id of ids) stmt.run(id);
@@ -124,7 +124,7 @@ export function markCompleted(ids: string[]): void {
 export function markFailed(id: string): void {
   getOutboundDb()
     .prepare(
-      "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', datetime('now'))",
+      "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
     )
     .run(id);
 }

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -58,7 +58,7 @@ export function writeMessageOut(msg: WriteMessageOut): number {
   outbound
     .prepare(
       `INSERT INTO messages_out (id, seq, in_reply_to, timestamp, deliver_after, recurrence, kind, platform_id, channel_type, thread_id, content)
-     VALUES ($id, $seq, $in_reply_to, datetime('now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content)`,
+     VALUES ($id, $seq, $in_reply_to, strftime('%Y-%m-%dT%H:%M:%fZ','now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content)`,
     )
     .run({
       $id: msg.id,
@@ -136,7 +136,7 @@ export function getUndeliveredMessages(): MessageOutRow[] {
   return getOutboundDb()
     .prepare(
       `SELECT * FROM messages_out
-       WHERE (deliver_after IS NULL OR deliver_after <= datetime('now'))
+       WHERE (deliver_after IS NULL OR datetime(deliver_after) <= datetime('now'))
        ORDER BY timestamp ASC`,
     )
     .all() as MessageOutRow[];

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -26,7 +26,7 @@ function insertMessage(id: string, content: object, opts?: { platformId?: string
   getInboundDb()
     .prepare(
       `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
-       VALUES (?, 'chat', datetime('now'), 'pending', ?, ?, ?, ?)`,
+       VALUES (?, 'chat', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', ?, ?, ?, ?)`,
     )
     .run(id, opts?.platformId ?? null, opts?.channelType ?? null, opts?.threadId ?? null, JSON.stringify(content));
 }

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -23,7 +23,7 @@ function insertMessage(
   getInboundDb()
     .prepare(
       `INSERT INTO messages_in (id, kind, timestamp, status, process_after, trigger, on_wake, content)
-     VALUES (?, ?, datetime('now'), 'pending', ?, ?, ?, ?)`,
+     VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', ?, ?, ?, ?)`,
     )
     .run(id, kind, opts?.processAfter ?? null, opts?.trigger ?? 1, opts?.onWake ?? 0, JSON.stringify(content));
 }
@@ -128,7 +128,7 @@ describe('accumulate gate (trigger column)', () => {
     getInboundDb()
       .prepare(
         `INSERT INTO messages_in (id, kind, timestamp, status, content)
-         VALUES ('m1', 'chat', datetime('now'), 'pending', '{"text":"hi"}')`,
+         VALUES ('m1', 'chat', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', '{"text":"hi"}')`,
       )
       .run();
     const [msg] = getPendingMessages();
@@ -193,7 +193,7 @@ describe('routing', () => {
     getInboundDb()
       .prepare(
         `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
-       VALUES ('m1', 'chat', datetime('now'), 'pending', 'chan-123', 'discord', 'thread-456', '{"text":"hi"}')`,
+       VALUES ('m1', 'chat', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', 'chan-123', 'discord', 'thread-456', '{"text":"hi"}')`,
       )
       .run();
 

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -264,7 +264,7 @@ CREATE TABLE chat_sdk_kv (
 
 CREATE TABLE chat_sdk_subscriptions (
   thread_id     TEXT PRIMARY KEY,
-  subscribed_at TEXT NOT NULL DEFAULT (datetime('now'))
+  subscribed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
 CREATE TABLE chat_sdk_locks (

--- a/scripts/test-v2-agent.ts
+++ b/scripts/test-v2-agent.ts
@@ -33,7 +33,7 @@ db.exec(`
 `);
 
 // Insert test message
-db.prepare(`INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', datetime('now'), 'pending', ?)`).run(
+db.prepare(`INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES (?, 'chat', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', ?)`).run(
   'test-1',
   JSON.stringify({ sender: 'Gavriel', text: 'Say "Hello from v2!" and nothing else. Do not use any tools.' }),
 );

--- a/src/db/migrations/002-chat-sdk-state.ts
+++ b/src/db/migrations/002-chat-sdk-state.ts
@@ -15,7 +15,7 @@ export const migration002: Migration = {
 
       CREATE TABLE chat_sdk_subscriptions (
         thread_id TEXT PRIMARY KEY,
-        subscribed_at TEXT NOT NULL DEFAULT (datetime('now'))
+        subscribed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
       );
 
       CREATE TABLE chat_sdk_locks (

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -43,7 +43,7 @@ describe('migrateMessagesInTable', () => {
       );
     `);
     db.prepare(
-      "INSERT INTO messages_in (id, seq, kind, timestamp, status, content) VALUES (?, ?, 'task', datetime('now'), 'pending', '{}')",
+      "INSERT INTO messages_in (id, seq, kind, timestamp, status, content) VALUES (?, ?, 'task', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', '{}')",
     ).run('legacy-1', 2);
 
     migrateMessagesInTable(db);

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -152,7 +152,7 @@ export function markMessageFailed(db: Database.Database, messageId: string): voi
 
 export function retryWithBackoff(db: Database.Database, messageId: string, backoffSec: number): void {
   db.prepare(
-    `UPDATE messages_in SET tries = tries + 1, process_after = datetime('now', '+${backoffSec} seconds') WHERE id = ?`,
+    `UPDATE messages_in SET tries = tries + 1, process_after = strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+${backoffSec} seconds') WHERE id = ?`,
   ).run(messageId);
 }
 
@@ -259,7 +259,7 @@ export function getDueOutboundMessages(db: Database.Database): OutboundMessage[]
   return db
     .prepare(
       `SELECT * FROM messages_out
-       WHERE (deliver_after IS NULL OR deliver_after <= datetime('now'))
+       WHERE (deliver_after IS NULL OR datetime(deliver_after) <= datetime('now'))
        ORDER BY timestamp ASC`,
     )
     .all() as OutboundMessage[];
@@ -279,13 +279,13 @@ export function getDeliveredIds(db: Database.Database): Set<string> {
 
 export function markDelivered(db: Database.Database, messageOutId: string, platformMessageId: string | null): void {
   db.prepare(
-    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, ?, 'delivered', datetime('now'))",
+    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, ?, 'delivered', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   ).run(messageOutId, platformMessageId ?? null);
 }
 
 export function markDeliveryFailed(db: Database.Database, messageOutId: string): void {
   db.prepare(
-    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, NULL, 'failed', datetime('now'))",
+    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, NULL, 'failed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   ).run(messageOutId);
 }
 

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -65,7 +65,7 @@ function insertOutbound(agentGroupId: string, sessionId: string, msgId: string):
   const db = new Database(outboundDbPath(agentGroupId, sessionId));
   db.prepare(
     `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
-     VALUES (?, datetime('now'), 'chat', 'telegram:123', 'telegram', ?)`,
+     VALUES (?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'chat', 'telegram:123', 'telegram', ?)`,
   ).run(msgId, JSON.stringify({ text: 'hello' }));
   db.close();
 }

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -1017,7 +1017,7 @@ describe('delivery', () => {
     const db = new Database(dbPath);
     db.prepare(
       `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
-       VALUES ('out-1', datetime('now'), 'chat', 'chan-123', 'discord', ?)`,
+       VALUES ('out-1', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'chat', 'chan-123', 'discord', ?)`,
     ).run(JSON.stringify({ text: 'Agent response' }));
 
     const undelivered = db.prepare('SELECT * FROM messages_out').all() as Array<{

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -28,7 +28,7 @@ export function insertTask(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, timestamp, status, tries, process_after, recurrence, kind, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (@id, @seq, datetime('now'), 'pending', 0, @processAfter, @recurrence, 'task', @platformId, @channelType, @threadId, @content, @id)`,
+     VALUES (@id, @seq, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', 0, @processAfter, @recurrence, 'task', @platformId, @channelType, @threadId, @content, @id)`,
   ).run({
     ...task,
     seq: nextEvenSeq(db),
@@ -133,7 +133,7 @@ export function insertRecurrence(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, kind, timestamp, status, process_after, recurrence, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (?, ?, ?, datetime('now'), 'pending', ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     newId,
     nextEvenSeq(db),

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -395,7 +395,7 @@ export function writeOutboundDirect(
   try {
     db.prepare(
       `INSERT OR IGNORE INTO messages_out (id, seq, timestamp, kind, platform_id, channel_type, thread_id, content)
-       VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 2 FROM messages_out), datetime('now'), ?, ?, ?, ?, ?)`,
+       VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 2 FROM messages_out), strftime('%Y-%m-%dT%H:%M:%fZ','now'), ?, ?, ?, ?, ?)`,
     ).run(message.id, message.kind, message.platformId, message.channelType, message.threadId, message.content);
   } finally {
     db.close();


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Auto-generated timestamps in the session DBs used SQLite's `datetime('now')` which produces `2026-04-18 13:29:12` (space separator, no `T`, no `Z`, no milliseconds). Channel adapters already produce ISO 8601 strings like `2026-04-18T13:31:43.160Z`, making the dashboard display inconsistent.

  Replace all datetime('now') used as timestamp values with strftime('%Y-%m-%dT%H:%M:%fZ','now') in:                           
   
  - `src/db/session-db.ts` — `insertTask`, `insertRecurrence`, `markDelivered`, `markDeliveryFailed`                                     
  - `src/modules/scheduling/db.ts` — scheduling timestamps                                                                    
  - `src/db/migrations/002-chat-sdk-state.ts` — migration default value                                                          
  - `container/agent-runner/src/db/messages-out.ts` — `writeMessageOut`                                                            
  - `container/agent-runner/src/db/messages-in.ts` — `markProcessing`, `markCompleted`, `markFailed`                                   
                                                                                                                               
  Tests updated to expect ISO 8601 format:                                                                                     
                                                                                                                             
  - `src/db/session-db.test.ts`                                                                                                  
  - `src/delivery.test.ts`                                                                                                     
  - `src/host-core.test.ts`
  - `container/agent-runner/src/integration.test.ts`
  - `container/agent-runner/src/poll-loop.test.ts`                                                                               
  - `scripts/test-v2-agent.ts`
                                                                                                                               
  Skill docs updated (add-github, add-linear) to reflect the format change in example timestamps.                              
                                                                                                                               
  No DB migration needed — `timestamp` columns are `TEXT`, the format change is backward-compatible. Existing `datetime()` comparisons (e.g. `deliver_after <= datetime('now')`) handle both formats correctly.                                         
