### PR TITLE
feat: add web channel — browser portal for NanoClaw

### DIFF
--- a/.claude/skills/add-web-channel/SKILL.md
+++ b/.claude/skills/add-web-channel/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-web-channel
-description: Add a browser-based web channel. Serves a mobile-friendly chat UI directly from NanoClaw — no Redis, no separate app. Acts as a portal into your existing main group conversation, sharing its CLAUDE.md and memory. Works as a fallback when other channels (e.g. WhatsApp) are unavailable.
+description: Add a browser-based web channel. Serves a mobile-friendly chat UI directly from NanoClaw — no Redis, no separate app. The index page lists all registered conversations; each opens as a full-screen portal sharing history and memory with its source channel (WhatsApp, Telegram, etc).
 ---
 
 # Add Web Channel
 
 This skill adds a browser-based chat interface to NanoClaw. The web UI is served directly by NanoClaw on a configurable port, requires no external services, and is installable as a PWA on iOS and Android.
 
-**Design:** The web channel is a portal — it shares the same CLAUDE.md, mnemon memory, and conversation history as your main group. Open it on any device via Tailscale (or your LAN) and you see the same assistant, the same context, the full history from all channels.
+**Design:** The web channel is a multi-conversation portal. The index page at `/` lists every registered group. Tapping a conversation opens `/c/<folder>` — a full-screen chat that shares the same CLAUDE.md, mnemon memory, and message history as the source channel. Open it on any device via Tailscale (or your LAN) and you see the same assistant, the same context, the full history from all channels.
 
 ## Phase 1: Pre-flight
 
@@ -68,28 +68,44 @@ tail -20 logs/nanoclaw.log | grep "Web channel"
 # Expected: Web channel listening  {"port": 3080}
 ```
 
-Open in browser: `http://<your-pi-ip>:3080` (or `http://<tailscale-hostname>:3080`)
+Open in browser: `http://<your-pi-ip>:3080`
 
-If you set a token: `http://<host>:3080/?token=<your-token>`
+If you set a token, add it once as a query parameter — the server sets a session cookie so you don't need it again:
 
-Bookmark that URL. On iPhone/iPad: tap Share → Add to Home Screen for a full-screen PWA.
+```
+http://<host>:3080/?token=<your-token>
+```
 
-## How it works
+You should see the conversation index. Tap any group to open its chat.
 
-- `GET /` — chat UI (vanilla HTML/JS, no build step, no CDN dependencies)
-- `GET /history` — loads recent messages from `messages.db`, including messages from all channels (WhatsApp, Telegram, etc.) that share the same group folder
-- `GET /events` — Server-Sent Events stream; pushes new messages in real time
-- `POST /send` — sends a message into the agent pipeline
-- `GET /manifest.json` — PWA manifest for home screen installation
+Bookmark individual conversation URLs for quick access. On iPhone/iPad: tap Share → Add to Home Screen for a full-screen PWA.
 
-The web channel symlinks `groups/web/` to the main group's folder, so it shares CLAUDE.md, mnemon memory, and agent behaviour. It has its own session context (conversation history in the active agent window) but full access to long-term mnemon memory.
+## URL structure
+
+```
+GET /                      — conversation index (list of registered groups)
+GET /c/<folder>            — chat UI for a specific group
+GET /c/<folder>/history    — message history API (?since=<ISO timestamp>)
+POST /c/<folder>/send      — send a message into the agent pipeline
+GET /manifest.json         — PWA manifest
+```
+
+Messages sent from the web UI are routed through the group's real channel JID (e.g. the WhatsApp main JID), so the agent responds in its native context. Bot responses appear in both the web UI and the source channel.
+
+## Trigger behaviour for non-main groups
+
+Non-main groups with `requires_trigger = true` (the default) still require the trigger word (e.g. `@vbotpi`) in web messages. Main groups and groups with `requires_trigger = false` respond to all messages without a trigger.
 
 ## Troubleshooting
 
 **Port already in use:** Change `WEB_CHANNEL_PORT` in `.env` and restart.
 
-**401 Unauthorized:** Your token in the URL doesn't match `WEB_CHANNEL_TOKEN`. Re-check `.env` and the bookmarked URL.
+**401 Unauthorized:** Pass `?token=<token>` once in the URL — the cookie is then set for the session.
 
-**Messages not appearing in real time:** The SSE connection may have dropped. Reload the page — history loads on every open, so you won't miss anything.
+**Conversation not found (404):** The folder name in the URL must match a registered group's `folder` field in the DB. Check with:
 
-**WhatsApp messages not showing in web UI:** The history query pulls messages for all JIDs that share the main group's folder. Confirm the main group is registered in the DB with `is_main = 1`.
+```bash
+sqlite3 store/messages.db "SELECT folder, name FROM registered_groups;"
+```
+
+**Messages from other channels not showing:** The history query pulls all messages for JIDs matching the group's folder. Confirm the group is registered with the correct folder name.

--- a/.claude/skills/add-web-channel/SKILL.md
+++ b/.claude/skills/add-web-channel/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: add-web-channel
+description: Add a browser-based web channel. Serves a mobile-friendly chat UI directly from NanoClaw — no Redis, no separate app. Acts as a portal into your existing main group conversation, sharing its CLAUDE.md and memory. Works as a fallback when other channels (e.g. WhatsApp) are unavailable.
+---
+
+# Add Web Channel
+
+This skill adds a browser-based chat interface to NanoClaw. The web UI is served directly by NanoClaw on a configurable port, requires no external services, and is installable as a PWA on iOS and Android.
+
+**Design:** The web channel is a portal — it shares the same CLAUDE.md, mnemon memory, and conversation history as your main group. Open it on any device via Tailscale (or your LAN) and you see the same assistant, the same context, the full history from all channels.
+
+## Phase 1: Pre-flight
+
+Check if the channel is already installed:
+
+```bash
+test -f src/channels/web.ts && echo "already installed"
+```
+
+If already installed, skip to Phase 3 (Configure).
+
+## Phase 2: Merge the skill branch
+
+```bash
+git fetch upstream
+git merge upstream/skill/add-web-channel --no-edit
+npm install
+npm run build
+```
+
+Resolve any conflicts (unlikely — web.ts is a new file). If `src/channels/index.ts` conflicts, keep both the existing channel imports AND the new `import './web.js'` line.
+
+## Phase 3: Configure
+
+Add to `.env`:
+
+```
+WEB_CHANNEL_PORT=3080
+WEB_CHANNEL_TOKEN=
+```
+
+**Port:** Choose any open port. 3080 is the default. If you're exposing via Tailscale, pick something you'll remember.
+
+**Token:** Generate a random token for authentication:
+
+```bash
+openssl rand -hex 16
+```
+
+Paste the output as `WEB_CHANNEL_TOKEN`. If left empty, the web UI is accessible to anyone who can reach the port — fine for Tailscale-only setups, not recommended for public exposure.
+
+## Phase 4: Restart
+
+```bash
+# Linux (systemd)
+systemctl --user restart nanoclaw
+
+# macOS (launchd)
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 5: Verify
+
+Check logs for the startup message:
+
+```bash
+tail -20 logs/nanoclaw.log | grep "Web channel"
+# Expected: Web channel listening  {"port": 3080}
+```
+
+Open in browser: `http://<your-pi-ip>:3080` (or `http://<tailscale-hostname>:3080`)
+
+If you set a token: `http://<host>:3080/?token=<your-token>`
+
+Bookmark that URL. On iPhone/iPad: tap Share → Add to Home Screen for a full-screen PWA.
+
+## How it works
+
+- `GET /` — chat UI (vanilla HTML/JS, no build step, no CDN dependencies)
+- `GET /history` — loads recent messages from `messages.db`, including messages from all channels (WhatsApp, Telegram, etc.) that share the same group folder
+- `GET /events` — Server-Sent Events stream; pushes new messages in real time
+- `POST /send` — sends a message into the agent pipeline
+- `GET /manifest.json` — PWA manifest for home screen installation
+
+The web channel symlinks `groups/web/` to the main group's folder, so it shares CLAUDE.md, mnemon memory, and agent behaviour. It has its own session context (conversation history in the active agent window) but full access to long-term mnemon memory.
+
+## Troubleshooting
+
+**Port already in use:** Change `WEB_CHANNEL_PORT` in `.env` and restart.
+
+**401 Unauthorized:** Your token in the URL doesn't match `WEB_CHANNEL_TOKEN`. Re-check `.env` and the bookmarked URL.
+
+**Messages not appearing in real time:** The SSE connection may have dropped. Reload the page — history loads on every open, so you won't miss anything.
+
+**WhatsApp messages not showing in web UI:** The history query pulls messages for all JIDs that share the main group's folder. Confirm the main group is registered in the DB with `is_main = 1`.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Web channel (optional — remove to disable)
+WEB_CHANNEL_PORT=3080
+WEB_CHANNEL_TOKEN=

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -10,3 +10,6 @@
 // telegram
 
 // whatsapp
+
+// web
+import './web.js';

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -376,7 +376,7 @@ function addMsg(isBot,content,ts,id){
   if(id&&seen.has(id))return;if(id)seen.add(id);
   const w=document.createElement('div');w.className='m '+(isBot?'a':'u');
   const b=document.createElement('div');b.className='b';
-  if(isBot){try{b.innerHTML=typeof marked!=='undefined'?marked.parse(content||'',{gfm:true}):(content||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');}catch(e){b.textContent=content||'';}}else b.textContent=content||'';
+  if(isBot){try{b.innerHTML=typeof marked!=='undefined'?marked.parse(content||'',{gfm:true}):(content||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\\n/g,'<br>');}catch(e){b.textContent=content||'';}}else b.textContent=content||'';
   const t=document.createElement('div');t.className='ts';t.textContent=fmt(ts);
   w.appendChild(b);w.appendChild(t);msgs.appendChild(w);msgs.scrollTop=msgs.scrollHeight;
 }

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1,57 +1,51 @@
-import fs from 'fs';
 import http from 'http';
-import path from 'path';
 
-import { ASSISTANT_NAME, GROUPS_DIR } from '../config.js';
-import {
-  DisplayMessage,
-  getAllRegisteredGroups,
-  getMessagesForDisplay,
-  setRegisteredGroup,
-} from '../db.js';
+import { ASSISTANT_NAME } from '../config.js';
+import { getAllRegisteredGroups, getMessagesForDisplay } from '../db.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
-import { Channel, RegisteredGroup } from '../types.js';
+import { Channel } from '../types.js';
 import { ChannelOpts, registerChannel } from './registry.js';
 
-const WEB_JID = 'web:main';
-const POLL_MS = 2000;
 const HISTORY_LIMIT = 100;
 
 export class WebChannel implements Channel {
   name = 'web';
   private server: http.Server | null = null;
-  private sseClients = new Set<http.ServerResponse>();
-  private pollTimer: NodeJS.Timeout | null = null;
-  private lastPollAt: string;
 
   constructor(
     private port: number,
     private token: string | null,
     private opts: ChannelOpts,
-  ) {
-    this.lastPollAt = new Date().toISOString();
-  }
+  ) {}
 
   async connect(): Promise<void> {
-    this.ensureGroupRegistered();
-    this.ensureSymlink();
-
     this.server = http.createServer((req, res) => {
       if (!this.checkAuth(req, res)) return;
 
-      const url = new URL(req.url ?? '/', `http://localhost`);
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      const parts = url.pathname.split('/').filter(Boolean);
+      // GET /                        → conversation index
+      // GET /c/<folder>              → chat UI
+      // GET /c/<folder>/history      → history API
+      // POST /c/<folder>/send        → send API
+      // GET /manifest.json           → PWA manifest
 
       if (req.method === 'GET' && url.pathname === '/') {
-        this.serveUI(res);
+        this.serveIndex(res);
       } else if (req.method === 'GET' && url.pathname === '/manifest.json') {
         this.serveManifest(res);
-      } else if (req.method === 'GET' && url.pathname === '/history') {
-        this.serveHistory(req, res);
-      } else if (req.method === 'GET' && url.pathname === '/events') {
-        this.handleSSE(req, res);
-      } else if (req.method === 'POST' && url.pathname === '/send') {
-        this.handleSend(req, res);
+      } else if (parts[0] === 'c' && parts[1]) {
+        const folder = parts[1];
+        if (req.method === 'GET' && parts.length === 2) {
+          this.serveChat(res, folder);
+        } else if (req.method === 'GET' && parts[2] === 'history') {
+          this.serveHistory(req, res, folder);
+        } else if (req.method === 'POST' && parts[2] === 'send') {
+          this.handleSend(req, res, folder);
+        } else {
+          res.writeHead(404).end('Not found');
+        }
       } else {
         res.writeHead(404).end('Not found');
       }
@@ -64,23 +58,9 @@ export class WebChannel implements Channel {
       });
       this.server!.once('error', reject);
     });
-
-    this.pollTimer = setInterval(() => this.pollMessages(), POLL_MS);
   }
 
   async disconnect(): Promise<void> {
-    if (this.pollTimer) {
-      clearInterval(this.pollTimer);
-      this.pollTimer = null;
-    }
-    for (const client of this.sseClients) {
-      try {
-        client.end();
-      } catch {
-        /* ignore */
-      }
-    }
-    this.sseClients.clear();
     if (this.server) {
       await new Promise<void>((resolve) => this.server!.close(() => resolve()));
       this.server = null;
@@ -88,70 +68,39 @@ export class WebChannel implements Channel {
     logger.info('Web channel stopped');
   }
 
-  async sendMessage(_jid: string, _text: string): Promise<void> {
-    // Web messages are injected into the main channel's JID, so the owning
-    // channel (e.g. WhatsApp) handles sending and storage. Nothing to do here.
-  }
+  async sendMessage(_jid: string, _text: string): Promise<void> {}
 
   isConnected(): boolean {
     return this.server?.listening ?? false;
   }
 
   ownsJid(jid: string): boolean {
-    return jid === WEB_JID;
+    return jid.startsWith('web:');
   }
 
   // --- Private ---
 
-  private allJidsForTarget(): string[] {
-    const targetFolder = this.targetFolder();
+  private conversations(): Array<{ folder: string; name: string }> {
     const groups = getAllRegisteredGroups();
-    const jids = Object.entries(groups)
-      .filter(([, g]) => g.folder === targetFolder)
-      .map(([jid]) => jid);
-    // Always include web:main (may not be registered yet on first call)
-    if (!jids.includes(WEB_JID)) jids.push(WEB_JID);
-    return jids;
+    return Object.entries(groups)
+      .filter(([jid]) => !jid.startsWith('web:'))
+      .map(([, g]) => ({ folder: g.folder, name: g.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  private targetFolder(): string {
-    const groups = this.opts.registeredGroups();
-    const main = Object.values(groups).find(
-      (g) => g.isMain && g.folder !== 'web',
-    );
-    return main?.folder ?? 'main';
-  }
-
-  // The real channel JID to route messages through (e.g. the WhatsApp main JID).
-  // Web messages injected here so the owning channel (WhatsApp) handles delivery,
-  // making the response appear in both WhatsApp and web history.
-  private targetJid(): string {
+  private targetJid(folder: string): string | null {
     const groups = this.opts.registeredGroups();
     const entry = Object.entries(groups).find(
-      ([jid, g]) => g.isMain && jid !== WEB_JID,
+      ([jid, g]) => g.folder === folder && !jid.startsWith('web:'),
     );
-    return entry?.[0] ?? WEB_JID;
+    return entry?.[0] ?? null;
   }
 
-  private pollMessages(): void {
-    const since = this.lastPollAt;
-    this.lastPollAt = new Date().toISOString();
-    const jids = this.allJidsForTarget();
-    const msgs = getMessagesForDisplay(jids, since);
-    for (const msg of msgs) {
-      this.pushSSE(msg);
-    }
-  }
-
-  private pushSSE(msg: DisplayMessage): void {
-    const payload = `data: ${JSON.stringify(msg)}\n\n`;
-    for (const client of [...this.sseClients]) {
-      try {
-        client.write(payload);
-      } catch {
-        this.sseClients.delete(client);
-      }
-    }
+  private jidsForFolder(folder: string): string[] {
+    const groups = getAllRegisteredGroups();
+    return Object.entries(groups)
+      .filter(([jid, g]) => g.folder === folder && !jid.startsWith('web:'))
+      .map(([jid]) => jid);
   }
 
   private checkAuth(
@@ -159,13 +108,11 @@ export class WebChannel implements Channel {
     res: http.ServerResponse,
   ): boolean {
     if (!this.token) return true;
-    const url = new URL(req.url ?? '/', `http://localhost`);
-    const queryToken = url.searchParams.get('token');
-    const authHeader = req.headers['authorization'] ?? '';
+    const url = new URL(req.url ?? '/', 'http://localhost');
     const cookie = this.parseCookie(req.headers['cookie'] ?? '');
     if (
-      queryToken === this.token ||
-      authHeader === `Bearer ${this.token}` ||
+      url.searchParams.get('token') === this.token ||
+      (req.headers['authorization'] ?? '') === `Bearer ${this.token}` ||
       cookie['nc_token'] === this.token
     ) {
       return true;
@@ -184,64 +131,74 @@ export class WebChannel implements Channel {
     );
   }
 
-  private serveUI(res: http.ServerResponse): void {
+  private cookieHeader(): Record<string, string> {
+    return this.token
+      ? {
+          'Set-Cookie': `nc_token=${this.token}; Path=/; HttpOnly; SameSite=Strict`,
+        }
+      : {};
+  }
+
+  private serveIndex(res: http.ServerResponse): void {
     res.writeHead(200, {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
-      ...(this.token
-        ? {
-            'Set-Cookie': `nc_token=${this.token}; Path=/; HttpOnly; SameSite=Strict`,
-          }
-        : {}),
+      ...this.cookieHeader(),
     });
-    res.end(buildUI(ASSISTANT_NAME));
+    res.end(buildIndex(ASSISTANT_NAME, this.conversations()));
+  }
+
+  private serveChat(res: http.ServerResponse, folder: string): void {
+    const groups = getAllRegisteredGroups();
+    const entry = Object.entries(groups).find(
+      ([jid, g]) => g.folder === folder && !jid.startsWith('web:'),
+    );
+    if (!entry) {
+      res.writeHead(404).end('Conversation not found');
+      return;
+    }
+    const [, g] = entry;
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...this.cookieHeader(),
+    });
+    res.end(buildChat(ASSISTANT_NAME, folder, g.name));
   }
 
   private serveManifest(res: http.ServerResponse): void {
-    const manifest = {
-      name: ASSISTANT_NAME,
-      short_name: ASSISTANT_NAME,
-      start_url: '/',
-      display: 'standalone',
-      background_color: '#0f172a',
-      theme_color: '#0f172a',
-      icons: [],
-    };
-    res
-      .writeHead(200, { 'Content-Type': 'application/manifest+json' })
-      .end(JSON.stringify(manifest));
+    res.writeHead(200, { 'Content-Type': 'application/manifest+json' }).end(
+      JSON.stringify({
+        name: ASSISTANT_NAME,
+        short_name: ASSISTANT_NAME,
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#0f172a',
+        theme_color: '#0f172a',
+        icons: [],
+      }),
+    );
   }
 
   private serveHistory(
     req: http.IncomingMessage,
     res: http.ServerResponse,
+    folder: string,
   ): void {
     const url = new URL(req.url ?? '/', 'http://localhost');
     const since = url.searchParams.get('since') ?? new Date(0).toISOString();
     const limit = since === new Date(0).toISOString() ? HISTORY_LIMIT : 50;
-    const jids = this.allJidsForTarget();
+    const jids = this.jidsForFolder(folder);
     const msgs = getMessagesForDisplay(jids, since, limit);
     res
       .writeHead(200, { 'Content-Type': 'application/json' })
       .end(JSON.stringify(msgs));
   }
 
-  private handleSSE(req: http.IncomingMessage, res: http.ServerResponse): void {
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    });
-    res.write(':\n\n');
-    this.sseClients.add(res);
-    req.on('close', () => this.sseClients.delete(res));
-    req.on('error', () => this.sseClients.delete(res));
-  }
-
   private handleSend(
     req: http.IncomingMessage,
     res: http.ServerResponse,
+    folder: string,
   ): void {
     let body = '';
     req.on('data', (chunk) => (body += chunk));
@@ -253,9 +210,16 @@ export class WebChannel implements Channel {
           return;
         }
 
+        const routeJid = this.targetJid(folder);
+        if (!routeJid) {
+          res
+            .writeHead(404)
+            .end(JSON.stringify({ error: 'conversation not found' }));
+          return;
+        }
+
         const timestamp = new Date().toISOString();
         const msgId = `web-${Date.now()}`;
-        const routeJid = this.targetJid();
 
         this.opts.onChatMetadata(routeJid, timestamp, 'Web', 'web', false);
         this.opts.onMessage(routeJid, {
@@ -278,63 +242,65 @@ export class WebChannel implements Channel {
       }
     });
   }
-
-  private ensureGroupRegistered(): void {
-    const groups = this.opts.registeredGroups();
-    if (groups[WEB_JID]) return;
-
-    const newGroup: RegisteredGroup = {
-      name: 'Web',
-      folder: 'web',
-      trigger: '',
-      added_at: new Date().toISOString(),
-      requiresTrigger: false,
-      isMain: true,
-    };
-
-    try {
-      setRegisteredGroup(WEB_JID, newGroup);
-      groups[WEB_JID] = newGroup;
-      logger.info('Web group auto-registered');
-    } catch (err) {
-      logger.error({ err }, 'Web channel: failed to auto-register group');
-    }
-  }
-
-  private ensureSymlink(): void {
-    const webDir = path.join(GROUPS_DIR, 'web');
-    const targetFolder = this.targetFolder();
-    const targetDir = path.join(GROUPS_DIR, targetFolder);
-
-    try {
-      const stat = fs.lstatSync(webDir);
-      if (stat.isSymbolicLink()) return;
-      logger.debug(
-        { webDir },
-        'Web groups/web dir already exists as a directory — leaving it',
-      );
-      return;
-    } catch {
-      // Does not exist — create symlink
-    }
-
-    if (!fs.existsSync(targetDir)) {
-      fs.mkdirSync(targetDir, { recursive: true });
-    }
-
-    try {
-      fs.symlinkSync(targetDir, webDir);
-      logger.info(
-        { target: targetDir },
-        'Web channel: created groups/web symlink',
-      );
-    } catch (err) {
-      logger.error({ err }, 'Web channel: failed to create groups/web symlink');
-    }
-  }
 }
 
-function buildUI(assistantName: string): string {
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function buildIndex(
+  assistantName: string,
+  convs: Array<{ folder: string; name: string }>,
+): string {
+  const items = convs
+    .map(
+      (c) =>
+        `<a href="/c/${esc(c.folder)}" class="conv"><span class="cname">${esc(c.name)}</span><span class="cfolder">${esc(c.folder)}</span></a>`,
+    )
+    .join('');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<link rel="manifest" href="/manifest.json">
+<title>${esc(assistantName)}</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{--bg:#0f172a;--surface:#1e293b;--text:#f1f5f9;--muted:#64748b;--border:#334155;--accent:#2563eb}
+html,body{min-height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
+#app{max-width:480px;margin:0 auto;padding:32px 16px}
+h1{font-size:22px;font-weight:700;margin-bottom:8px}
+.sub{color:var(--muted);font-size:14px;margin-bottom:28px}
+.conv{display:flex;flex-direction:column;padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:12px;text-decoration:none;color:var(--text);margin-bottom:10px;gap:3px;transition:border-color .15s}
+.conv:hover,.conv:focus{border-color:var(--accent);outline:none}
+.cname{font-weight:600}
+.cfolder{font-size:12px;color:var(--muted);font-family:'SF Mono','Fira Code',monospace}
+.empty{color:var(--muted);font-size:14px}
+</style>
+</head>
+<body>
+<div id="app">
+  <h1>${esc(assistantName)}</h1>
+  <p class="sub">Choose a conversation</p>
+  ${items || '<p class="empty">No conversations registered yet.</p>'}
+</div>
+</body>
+</html>`;
+}
+
+function buildChat(
+  assistantName: string,
+  folder: string,
+  groupName: string,
+): string {
+  const histUrl = `/c/${esc(folder)}/history`;
+  const sendUrl = `/c/${esc(folder)}/send`;
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -342,16 +308,21 @@ function buildUI(assistantName: string): string {
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,interactive-widget=resizes-content">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="${assistantName}">
+<meta name="apple-mobile-web-app-title" content="${esc(assistantName)}">
 <link rel="manifest" href="/manifest.json">
-<title>${assistantName}</title>
+<title>${esc(groupName)} — ${esc(assistantName)}</title>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
-:root{--bg:#0f172a;--surface:#1e293b;--user:#2563eb;--bot:#1e293b;--text:#f1f5f9;--muted:#64748b;--border:#334155}
+:root{--bg:#0f172a;--surface:#1e293b;--user:#2563eb;--text:#f1f5f9;--muted:#64748b;--border:#334155}
 html,body{height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
 #app{display:flex;flex-direction:column;height:100dvh;max-width:680px;margin:0 auto}
-#hdr{padding:12px max(16px,env(safe-area-inset-right)) 12px max(16px,env(safe-area-inset-left));background:var(--surface);border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:8px}
-#dot{width:8px;height:8px;border-radius:50%;background:#22c55e;flex-shrink:0;transition:background .3s}
+#hdr{padding:12px max(16px,env(safe-area-inset-right)) 12px max(16px,env(safe-area-inset-left));background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px}
+#back{color:var(--muted);text-decoration:none;font-size:22px;line-height:1;flex-shrink:0;padding:0 4px}
+#back:hover{color:var(--text)}
+#hdr-info{display:flex;flex-direction:column;flex:1;min-width:0}
+#hdr-name{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#hdr-sub{display:flex;align-items:center;gap:5px;font-size:12px;color:var(--muted)}
+#dot{width:7px;height:7px;border-radius:50%;background:#22c55e;flex-shrink:0;transition:background .3s}
 #dot.off{background:var(--muted)}
 #msgs{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px}
 .m{max-width:82%;display:flex;flex-direction:column;gap:3px}
@@ -376,93 +347,61 @@ html,body{height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -ap
 </head>
 <body>
 <div id="app">
-  <div id="hdr"><div id="dot" class="off"></div>${assistantName}</div>
+  <div id="hdr">
+    <a id="back" href="/" title="All conversations">‹</a>
+    <div id="hdr-info">
+      <div id="hdr-name">${esc(groupName)}</div>
+      <div id="hdr-sub"><div id="dot" class="off"></div><span id="st">connecting…</span></div>
+    </div>
+  </div>
   <div id="msgs"></div>
   <form id="frm"><div id="ftr"><textarea id="inp" placeholder="Message…" rows="1"></textarea><button type="submit" id="btn" class="dim">↑</button></div></form>
 </div>
 <script>
-// Minimal markdown renderer — no external dependencies
-// Uses \\x60 (hex for backtick) in regexes to avoid template-literal conflicts in the host .ts file
-function md(src) {
-  const esc = s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  const blocks = [];
-  // Code blocks: match triple-backtick fences
-  src = src.replace(/\x60\x60\x60([\s\S]*?)\x60\x60\x60/g, (_,c) => {
-    blocks.push('<pre><code>'+esc(c.replace(/^[a-z]+\\n/,''))+'</code></pre>');
-    return '\x01'+(blocks.length-1)+'\x01';
-  });
-  const inline = s => s
-    .replace(/\x60([^\x60]+)\x60/g, (_,c) => '<code>'+esc(c)+'</code>')
-    .replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>')
-    .replace(/\*(.+?)\*/g,'<em>$1</em>');
-  const lines = src.split('\\n');
-  const out = []; let listBuf = [], listType = null;
-  const flushList = () => { if(listBuf.length){out.push('<'+listType+'>'+listBuf.map(x=>'<li>'+x+'</li>').join('')+'</'+listType+'>'); listBuf=[]; listType=null;} };
-  for (const raw of lines) {
-    const bm = raw.match(/^([-*\u2022]) (.+)/); const om = raw.match(/^\d+\. (.+)/);
-    if (bm) { if(listType&&listType!=='ul') flushList(); listType='ul'; listBuf.push(inline(bm[2])); continue; }
-    if (om) { if(listType&&listType!=='ol') flushList(); listType='ol'; listBuf.push(inline(om[1])); continue; }
-    flushList();
-    const t = raw.trim();
-    if (!t) { out.push(''); continue; }
-    if (/^#{1,3} /.test(t)) { const [,...rest]=t.split(' '); out.push('<strong>'+inline(rest.join(' '))+'</strong>'); continue; }
+const HIST='${histUrl}',SEND='${sendUrl}';
+function md(src){
+  const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  const blocks=[];
+  src=src.replace(/\x60\x60\x60([\s\S]*?)\x60\x60\x60/g,(_,c)=>{blocks.push('<pre><code>'+esc(c.replace(/^[a-z]+\\n/,''))+'</code></pre>');return '\x01'+(blocks.length-1)+'\x01';});
+  const inline=s=>s.replace(/\x60([^\x60]+)\x60/g,(_,c)=>'<code>'+esc(c)+'</code>').replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>').replace(/\*(.+?)\*/g,'<em>$1</em>');
+  const lines=src.split('\\n'),out=[];let lb=[],lt=null;
+  const fl=()=>{if(lb.length){out.push('<'+lt+'>'+lb.map(x=>'<li>'+x+'</li>').join('')+'</'+lt+'>');lb=[];lt=null;}};
+  for(const raw of lines){
+    const bm=raw.match(/^([-*\u2022]) (.+)/),om=raw.match(/^\d+\. (.+)/);
+    if(bm){if(lt&&lt!=='ul')fl();lt='ul';lb.push(inline(bm[2]));continue;}
+    if(om){if(lt&&lt!=='ol')fl();lt='ol';lb.push(inline(om[1]));continue;}
+    fl();const t=raw.trim();if(!t){out.push('');continue;}
+    if(/^#{1,3} /.test(t)){const[,...r]=t.split(' ');out.push('<strong>'+inline(r.join(' '))+'</strong>');continue;}
     out.push(inline(t));
   }
-  flushList();
-  let html = out.join('\\n').replace(/\x01(\d+)\x01/g, (_,i)=>blocks[+i]);
-  html = html.replace(/([^\\n<][^\\n]+)/g, s => s.startsWith('<') ? s : '<p>'+s+'</p>');
+  fl();let html=out.join('\\n').replace(/\x01(\d+)\x01/g,(_,i)=>blocks[+i]);
+  html=html.replace(/([^\\n<][^\\n]+)/g,s=>s.startsWith('<')?s:'<p>'+s+'</p>');
   return html.replace(/\\n/g,'');
 }
-
-const msgs = document.getElementById('msgs');
-const inp = document.getElementById('inp');
-const btn = document.getElementById('btn');
-const dot = document.getElementById('dot');
-const seen = new Set();
-
-function fmt(ts){ try { return new Date(ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}); } catch(e){ return ''; } }
-
-function addMsg(isBot, content, ts, id) {
-  if(id && seen.has(id)) return; if(id) seen.add(id);
-  const wrap = document.createElement('div'); wrap.className = 'm '+(isBot?'a':'u');
-  const b = document.createElement('div'); b.className = 'b';
-  if(isBot) { try { b.innerHTML = md(content||''); } catch(e) { b.textContent = content||''; } } else b.textContent = content||'';
-  const t = document.createElement('div'); t.className = 'ts'; t.textContent = fmt(ts);
-  wrap.appendChild(b); wrap.appendChild(t); msgs.appendChild(wrap);
-  msgs.scrollTop = msgs.scrollHeight;
+const msgs=document.getElementById('msgs'),inp=document.getElementById('inp'),btn=document.getElementById('btn'),dot=document.getElementById('dot'),st=document.getElementById('st'),seen=new Set();
+function fmt(ts){try{return new Date(ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});}catch(e){return '';}}
+function addMsg(isBot,content,ts,id){
+  if(id&&seen.has(id))return;if(id)seen.add(id);
+  const w=document.createElement('div');w.className='m '+(isBot?'a':'u');
+  const b=document.createElement('div');b.className='b';
+  if(isBot){try{b.innerHTML=md(content||'');}catch(e){b.textContent=content||'';}}else b.textContent=content||'';
+  const t=document.createElement('div');t.className='ts';t.textContent=fmt(ts);
+  w.appendChild(b);w.appendChild(t);msgs.appendChild(w);msgs.scrollTop=msgs.scrollHeight;
 }
-
-// Load history then poll for new messages every 2s
-let lastTs = '1970-01-01T00:00:00.000Z';
-
-function poll() {
-  fetch('/history?since='+encodeURIComponent(lastTs))
-    .then(r => { dot.classList.toggle('off', !r.ok); return r.json(); })
-    .then(ms => {
-      for(const m of ms) {
-        if(m.timestamp > lastTs) lastTs = m.timestamp;
-        try { addMsg(!!m.is_bot_message, m.content, m.timestamp, m.id); } catch(e) {}
-      }
-    })
-    .catch(() => dot.classList.add('off'));
+let lastTs='1970-01-01T00:00:00.000Z';
+function poll(){
+  fetch(HIST+'?since='+encodeURIComponent(lastTs))
+    .then(r=>{const ok=r.ok;dot.classList.toggle('off',!ok);st.textContent=ok?'connected':'reconnecting…';return r.json();})
+    .then(ms=>{for(const m of ms){if(m.timestamp>lastTs)lastTs=m.timestamp;try{addMsg(!!m.is_bot_message,m.content,m.timestamp,m.id);}catch(e){}}})
+    .catch(()=>{dot.classList.add('off');st.textContent='offline';});
 }
-
-poll();
-setInterval(poll, 2000);
-
-// Input auto-resize and button state
-function updateBtn(){ btn.classList.toggle('dim', !inp.value.trim()); }
-inp.addEventListener('input', () => { inp.style.height='auto'; inp.style.height=Math.min(inp.scrollHeight,160)+'px'; updateBtn(); });
-inp.addEventListener('keyup', updateBtn);
-inp.addEventListener('change', updateBtn);
-inp.addEventListener('keydown', e => { if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();} });
-document.getElementById('frm').addEventListener('submit', e => { e.preventDefault(); send(); });
-
-function send() {
-  const text=inp.value.trim(); if(!text) return;
-  inp.value=''; inp.style.height='auto'; btn.classList.add('dim');
-  fetch('/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text})}).catch(()=>{});
-}
+poll();setInterval(poll,2000);
+function upd(){btn.classList.toggle('dim',!inp.value.trim());}
+inp.addEventListener('input',()=>{inp.style.height='auto';inp.style.height=Math.min(inp.scrollHeight,160)+'px';upd();});
+inp.addEventListener('keyup',upd);inp.addEventListener('change',upd);
+inp.addEventListener('keydown',e=>{if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();}});
+document.getElementById('frm').addEventListener('submit',e=>{e.preventDefault();send();});
+function send(){const text=inp.value.trim();if(!text)return;inp.value='';inp.style.height='auto';btn.classList.add('dim');fetch(SEND,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text})}).catch(()=>{});}
 </script>
 </body>
 </html>`;

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1,0 +1,479 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+
+import { ASSISTANT_NAME, GROUPS_DIR } from '../config.js';
+import {
+  DisplayMessage,
+  getAllRegisteredGroups,
+  getMessagesForDisplay,
+  setRegisteredGroup,
+} from '../db.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { Channel, RegisteredGroup } from '../types.js';
+import { ChannelOpts, registerChannel } from './registry.js';
+
+const WEB_JID = 'web:main';
+const POLL_MS = 2000;
+const HISTORY_LIMIT = 100;
+
+export class WebChannel implements Channel {
+  name = 'web';
+  private server: http.Server | null = null;
+  private sseClients = new Set<http.ServerResponse>();
+  private pollTimer: NodeJS.Timeout | null = null;
+  private lastPollAt: string;
+
+  constructor(
+    private port: number,
+    private token: string | null,
+    private opts: ChannelOpts,
+  ) {
+    this.lastPollAt = new Date().toISOString();
+  }
+
+  async connect(): Promise<void> {
+    this.ensureGroupRegistered();
+    this.ensureSymlink();
+
+    this.server = http.createServer((req, res) => {
+      if (!this.checkAuth(req, res)) return;
+
+      const url = new URL(req.url ?? '/', `http://localhost`);
+
+      if (req.method === 'GET' && url.pathname === '/') {
+        this.serveUI(res);
+      } else if (req.method === 'GET' && url.pathname === '/manifest.json') {
+        this.serveManifest(res);
+      } else if (req.method === 'GET' && url.pathname === '/history') {
+        this.serveHistory(req, res);
+      } else if (req.method === 'GET' && url.pathname === '/events') {
+        this.handleSSE(req, res);
+      } else if (req.method === 'POST' && url.pathname === '/send') {
+        this.handleSend(req, res);
+      } else {
+        res.writeHead(404).end('Not found');
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.listen(this.port, '0.0.0.0', () => {
+        logger.info({ port: this.port }, 'Web channel listening');
+        resolve();
+      });
+      this.server!.once('error', reject);
+    });
+
+    this.pollTimer = setInterval(() => this.pollMessages(), POLL_MS);
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    for (const client of this.sseClients) {
+      try {
+        client.end();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.sseClients.clear();
+    if (this.server) {
+      await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+      this.server = null;
+    }
+    logger.info('Web channel stopped');
+  }
+
+  async sendMessage(_jid: string, _text: string): Promise<void> {
+    // Web messages are injected into the main channel's JID, so the owning
+    // channel (e.g. WhatsApp) handles sending and storage. Nothing to do here.
+  }
+
+  isConnected(): boolean {
+    return this.server?.listening ?? false;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid === WEB_JID;
+  }
+
+  // --- Private ---
+
+  private allJidsForTarget(): string[] {
+    const targetFolder = this.targetFolder();
+    const groups = getAllRegisteredGroups();
+    const jids = Object.entries(groups)
+      .filter(([, g]) => g.folder === targetFolder)
+      .map(([jid]) => jid);
+    // Always include web:main (may not be registered yet on first call)
+    if (!jids.includes(WEB_JID)) jids.push(WEB_JID);
+    return jids;
+  }
+
+  private targetFolder(): string {
+    const groups = this.opts.registeredGroups();
+    const main = Object.values(groups).find(
+      (g) => g.isMain && g.folder !== 'web',
+    );
+    return main?.folder ?? 'main';
+  }
+
+  // The real channel JID to route messages through (e.g. the WhatsApp main JID).
+  // Web messages injected here so the owning channel (WhatsApp) handles delivery,
+  // making the response appear in both WhatsApp and web history.
+  private targetJid(): string {
+    const groups = this.opts.registeredGroups();
+    const entry = Object.entries(groups).find(
+      ([jid, g]) => g.isMain && jid !== WEB_JID,
+    );
+    return entry?.[0] ?? WEB_JID;
+  }
+
+  private pollMessages(): void {
+    const since = this.lastPollAt;
+    this.lastPollAt = new Date().toISOString();
+    const jids = this.allJidsForTarget();
+    const msgs = getMessagesForDisplay(jids, since);
+    for (const msg of msgs) {
+      this.pushSSE(msg);
+    }
+  }
+
+  private pushSSE(msg: DisplayMessage): void {
+    const payload = `data: ${JSON.stringify(msg)}\n\n`;
+    for (const client of [...this.sseClients]) {
+      try {
+        client.write(payload);
+      } catch {
+        this.sseClients.delete(client);
+      }
+    }
+  }
+
+  private checkAuth(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): boolean {
+    if (!this.token) return true;
+    const url = new URL(req.url ?? '/', `http://localhost`);
+    const queryToken = url.searchParams.get('token');
+    const authHeader = req.headers['authorization'] ?? '';
+    const cookie = this.parseCookie(req.headers['cookie'] ?? '');
+    if (
+      queryToken === this.token ||
+      authHeader === `Bearer ${this.token}` ||
+      cookie['nc_token'] === this.token
+    ) {
+      return true;
+    }
+    res.writeHead(401, { 'Content-Type': 'text/plain' }).end('Unauthorized');
+    return false;
+  }
+
+  private parseCookie(header: string): Record<string, string> {
+    return Object.fromEntries(
+      header
+        .split(';')
+        .map((p) => p.trim().split('='))
+        .filter((p) => p.length === 2)
+        .map(([k, v]) => [k.trim(), v.trim()]),
+    );
+  }
+
+  private serveUI(res: http.ServerResponse): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...(this.token
+        ? {
+            'Set-Cookie': `nc_token=${this.token}; Path=/; HttpOnly; SameSite=Strict`,
+          }
+        : {}),
+    });
+    res.end(buildUI(ASSISTANT_NAME));
+  }
+
+  private serveManifest(res: http.ServerResponse): void {
+    const manifest = {
+      name: ASSISTANT_NAME,
+      short_name: ASSISTANT_NAME,
+      start_url: '/',
+      display: 'standalone',
+      background_color: '#0f172a',
+      theme_color: '#0f172a',
+      icons: [],
+    };
+    res
+      .writeHead(200, { 'Content-Type': 'application/manifest+json' })
+      .end(JSON.stringify(manifest));
+  }
+
+  private serveHistory(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): void {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const since = url.searchParams.get('since') ?? new Date(0).toISOString();
+    const limit = since === new Date(0).toISOString() ? HISTORY_LIMIT : 50;
+    const jids = this.allJidsForTarget();
+    const msgs = getMessagesForDisplay(jids, since, limit);
+    res
+      .writeHead(200, { 'Content-Type': 'application/json' })
+      .end(JSON.stringify(msgs));
+  }
+
+  private handleSSE(req: http.IncomingMessage, res: http.ServerResponse): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    res.write(':\n\n');
+    this.sseClients.add(res);
+    req.on('close', () => this.sseClients.delete(res));
+    req.on('error', () => this.sseClients.delete(res));
+  }
+
+  private handleSend(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): void {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      try {
+        const { text } = JSON.parse(body) as { text?: string };
+        if (!text?.trim()) {
+          res.writeHead(400).end(JSON.stringify({ error: 'text required' }));
+          return;
+        }
+
+        const timestamp = new Date().toISOString();
+        const msgId = `web-${Date.now()}`;
+        const routeJid = this.targetJid();
+
+        this.opts.onChatMetadata(routeJid, timestamp, 'Web', 'web', false);
+        this.opts.onMessage(routeJid, {
+          id: msgId,
+          chat_jid: routeJid,
+          sender: 'web',
+          sender_name: 'You',
+          content: text,
+          timestamp,
+          is_from_me: false,
+        });
+
+        res
+          .writeHead(200, { 'Content-Type': 'application/json' })
+          .end(JSON.stringify({ ok: true, id: msgId }));
+
+        logger.info({ length: text.length }, 'Web channel: message received');
+      } catch {
+        res.writeHead(400).end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
+  }
+
+  private ensureGroupRegistered(): void {
+    const groups = this.opts.registeredGroups();
+    if (groups[WEB_JID]) return;
+
+    const newGroup: RegisteredGroup = {
+      name: 'Web',
+      folder: 'web',
+      trigger: '',
+      added_at: new Date().toISOString(),
+      requiresTrigger: false,
+      isMain: true,
+    };
+
+    try {
+      setRegisteredGroup(WEB_JID, newGroup);
+      groups[WEB_JID] = newGroup;
+      logger.info('Web group auto-registered');
+    } catch (err) {
+      logger.error({ err }, 'Web channel: failed to auto-register group');
+    }
+  }
+
+  private ensureSymlink(): void {
+    const webDir = path.join(GROUPS_DIR, 'web');
+    const targetFolder = this.targetFolder();
+    const targetDir = path.join(GROUPS_DIR, targetFolder);
+
+    try {
+      const stat = fs.lstatSync(webDir);
+      if (stat.isSymbolicLink()) return;
+      logger.debug(
+        { webDir },
+        'Web groups/web dir already exists as a directory — leaving it',
+      );
+      return;
+    } catch {
+      // Does not exist — create symlink
+    }
+
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir, { recursive: true });
+    }
+
+    try {
+      fs.symlinkSync(targetDir, webDir);
+      logger.info(
+        { target: targetDir },
+        'Web channel: created groups/web symlink',
+      );
+    } catch (err) {
+      logger.error({ err }, 'Web channel: failed to create groups/web symlink');
+    }
+  }
+}
+
+function buildUI(assistantName: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,interactive-widget=resizes-content">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="${assistantName}">
+<link rel="manifest" href="/manifest.json">
+<title>${assistantName}</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{--bg:#0f172a;--surface:#1e293b;--user:#2563eb;--bot:#1e293b;--text:#f1f5f9;--muted:#64748b;--border:#334155}
+html,body{height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
+#app{display:flex;flex-direction:column;height:100dvh;max-width:680px;margin:0 auto}
+#hdr{padding:12px max(16px,env(safe-area-inset-right)) 12px max(16px,env(safe-area-inset-left));background:var(--surface);border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:8px}
+#dot{width:8px;height:8px;border-radius:50%;background:#22c55e;flex-shrink:0;transition:background .3s}
+#dot.off{background:var(--muted)}
+#msgs{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px}
+.m{max-width:82%;display:flex;flex-direction:column;gap:3px}
+.m.u{align-self:flex-end;align-items:flex-end}
+.m.a{align-self:flex-start;align-items:flex-start}
+.b{padding:10px 14px;border-radius:18px;word-break:break-word;line-height:1.5}
+.m.u .b{background:var(--user);border-bottom-right-radius:4px}
+.m.a .b{background:var(--surface);border:1px solid var(--border);border-bottom-left-radius:4px}
+.ts{font-size:11px;color:var(--muted);padding:0 4px}
+.b pre{background:#0f172a;border:1px solid var(--border);border-radius:6px;padding:10px;overflow-x:auto;margin:8px 0;font-size:13px}
+.b code{font-family:'SF Mono','Fira Code',monospace;font-size:13px;background:#0f172a;padding:1px 4px;border-radius:4px}
+.b pre code{background:none;padding:0}
+.b p{margin:4px 0}.b p:first-child{margin-top:0}.b p:last-child{margin-bottom:0}
+.b ul,.b ol{padding-left:20px;margin:4px 0}
+.b strong{font-weight:600}
+#ftr{padding:12px max(16px,env(safe-area-inset-right)) max(12px,env(safe-area-inset-bottom)) max(16px,env(safe-area-inset-left));background:var(--surface);border-top:1px solid var(--border);display:flex;gap:8px;align-items:flex-end}
+#inp{flex:1;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:20px;padding:10px 16px;font-size:15px;resize:none;min-height:42px;max-height:160px;outline:none;line-height:1.4;font-family:inherit}
+#inp:focus{border-color:var(--user)}
+#btn{width:42px;height:42px;border-radius:50%;background:var(--user);color:#fff;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:18px;transition:opacity .15s}
+#btn.dim{opacity:.35}
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="hdr"><div id="dot" class="off"></div>${assistantName}</div>
+  <div id="msgs"></div>
+  <form id="frm"><div id="ftr"><textarea id="inp" placeholder="Message…" rows="1"></textarea><button type="submit" id="btn" class="dim">↑</button></div></form>
+</div>
+<script>
+// Minimal markdown renderer — no external dependencies
+// Uses \\x60 (hex for backtick) in regexes to avoid template-literal conflicts in the host .ts file
+function md(src) {
+  const esc = s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  const blocks = [];
+  // Code blocks: match triple-backtick fences
+  src = src.replace(/\x60\x60\x60([\s\S]*?)\x60\x60\x60/g, (_,c) => {
+    blocks.push('<pre><code>'+esc(c.replace(/^[a-z]+\\n/,''))+'</code></pre>');
+    return '\x01'+(blocks.length-1)+'\x01';
+  });
+  const inline = s => s
+    .replace(/\x60([^\x60]+)\x60/g, (_,c) => '<code>'+esc(c)+'</code>')
+    .replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g,'<em>$1</em>');
+  const lines = src.split('\\n');
+  const out = []; let listBuf = [], listType = null;
+  const flushList = () => { if(listBuf.length){out.push('<'+listType+'>'+listBuf.map(x=>'<li>'+x+'</li>').join('')+'</'+listType+'>'); listBuf=[]; listType=null;} };
+  for (const raw of lines) {
+    const bm = raw.match(/^([-*\u2022]) (.+)/); const om = raw.match(/^\d+\. (.+)/);
+    if (bm) { if(listType&&listType!=='ul') flushList(); listType='ul'; listBuf.push(inline(bm[2])); continue; }
+    if (om) { if(listType&&listType!=='ol') flushList(); listType='ol'; listBuf.push(inline(om[1])); continue; }
+    flushList();
+    const t = raw.trim();
+    if (!t) { out.push(''); continue; }
+    if (/^#{1,3} /.test(t)) { const [,...rest]=t.split(' '); out.push('<strong>'+inline(rest.join(' '))+'</strong>'); continue; }
+    out.push(inline(t));
+  }
+  flushList();
+  let html = out.join('\\n').replace(/\x01(\d+)\x01/g, (_,i)=>blocks[+i]);
+  html = html.replace(/([^\\n<][^\\n]+)/g, s => s.startsWith('<') ? s : '<p>'+s+'</p>');
+  return html.replace(/\\n/g,'');
+}
+
+const msgs = document.getElementById('msgs');
+const inp = document.getElementById('inp');
+const btn = document.getElementById('btn');
+const dot = document.getElementById('dot');
+const seen = new Set();
+
+function fmt(ts){ try { return new Date(ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}); } catch(e){ return ''; } }
+
+function addMsg(isBot, content, ts, id) {
+  if(id && seen.has(id)) return; if(id) seen.add(id);
+  const wrap = document.createElement('div'); wrap.className = 'm '+(isBot?'a':'u');
+  const b = document.createElement('div'); b.className = 'b';
+  if(isBot) { try { b.innerHTML = md(content||''); } catch(e) { b.textContent = content||''; } } else b.textContent = content||'';
+  const t = document.createElement('div'); t.className = 'ts'; t.textContent = fmt(ts);
+  wrap.appendChild(b); wrap.appendChild(t); msgs.appendChild(wrap);
+  msgs.scrollTop = msgs.scrollHeight;
+}
+
+// Load history then poll for new messages every 2s
+let lastTs = '1970-01-01T00:00:00.000Z';
+
+function poll() {
+  fetch('/history?since='+encodeURIComponent(lastTs))
+    .then(r => { dot.classList.toggle('off', !r.ok); return r.json(); })
+    .then(ms => {
+      for(const m of ms) {
+        if(m.timestamp > lastTs) lastTs = m.timestamp;
+        try { addMsg(!!m.is_bot_message, m.content, m.timestamp, m.id); } catch(e) {}
+      }
+    })
+    .catch(() => dot.classList.add('off'));
+}
+
+poll();
+setInterval(poll, 2000);
+
+// Input auto-resize and button state
+function updateBtn(){ btn.classList.toggle('dim', !inp.value.trim()); }
+inp.addEventListener('input', () => { inp.style.height='auto'; inp.style.height=Math.min(inp.scrollHeight,160)+'px'; updateBtn(); });
+inp.addEventListener('keyup', updateBtn);
+inp.addEventListener('change', updateBtn);
+inp.addEventListener('keydown', e => { if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();} });
+document.getElementById('frm').addEventListener('submit', e => { e.preventDefault(); send(); });
+
+function send() {
+  const text=inp.value.trim(); if(!text) return;
+  inp.value=''; inp.style.height='auto'; btn.classList.add('dim');
+  fetch('/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text})}).catch(()=>{});
+}
+</script>
+</body>
+</html>`;
+}
+
+registerChannel('web', (opts: ChannelOpts) => {
+  const env = readEnvFile(['WEB_CHANNEL_PORT', 'WEB_CHANNEL_TOKEN']);
+  const port = parseInt(
+    process.env.WEB_CHANNEL_PORT || env.WEB_CHANNEL_PORT || '3080',
+    10,
+  );
+  const token = process.env.WEB_CHANNEL_TOKEN || env.WEB_CHANNEL_TOKEN || null;
+  return new WebChannel(port, token, opts);
+});

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -226,7 +226,7 @@ export class WebChannel implements Channel {
           id: msgId,
           chat_jid: routeJid,
           sender: 'web',
-          sender_name: 'You',
+          sender_name: 'Web User',
           content: text,
           timestamp,
           is_from_me: false,
@@ -335,9 +335,19 @@ html,body{height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -ap
 .b pre{background:#0f172a;border:1px solid var(--border);border-radius:6px;padding:10px;overflow-x:auto;margin:8px 0;font-size:13px}
 .b code{font-family:'SF Mono','Fira Code',monospace;font-size:13px;background:#0f172a;padding:1px 4px;border-radius:4px}
 .b pre code{background:none;padding:0}
-.b p{margin:4px 0}.b p:first-child{margin-top:0}.b p:last-child{margin-bottom:0}
+.b p{margin:6px 0}.b p:first-child{margin-top:0}.b p:last-child{margin-bottom:0}
 .b ul,.b ol{padding-left:20px;margin:4px 0}
 .b strong{font-weight:600}
+.b h1,.b h2,.b h3{font-weight:700;margin:10px 0 4px;line-height:1.3}
+.b h1{font-size:1.2em}.b h2{font-size:1.1em}.b h3{font-size:1em}
+.b table{border-collapse:collapse;width:100%;margin:8px 0;font-size:13px}
+.b th,.b td{border:1px solid var(--border);padding:6px 10px;text-align:left;vertical-align:top}
+.b th{background:rgba(255,255,255,.06);font-weight:600}
+.b blockquote{border-left:3px solid var(--muted);margin:6px 0;padding:2px 12px;opacity:.8}
+.b blockquote p{margin:2px 0}
+.b hr{border:none;border-top:1px solid var(--border);margin:8px 0}
+.b a{color:#60a5fa;text-decoration:underline}
+.b img{max-width:100%;border-radius:6px;margin:4px 0}
 #ftr{padding:12px max(16px,env(safe-area-inset-right)) max(12px,env(safe-area-inset-bottom)) max(16px,env(safe-area-inset-left));background:var(--surface);border-top:1px solid var(--border);display:flex;gap:8px;align-items:flex-end}
 #inp{flex:1;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:20px;padding:10px 16px;font-size:15px;resize:none;min-height:42px;max-height:160px;outline:none;line-height:1.4;font-family:inherit}
 #inp:focus{border-color:var(--user)}
@@ -357,34 +367,16 @@ html,body{height:100dvh;background:var(--bg);color:var(--text);font:15px/1.5 -ap
   <div id="msgs"></div>
   <form id="frm"><div id="ftr"><textarea id="inp" placeholder="Message…" rows="1"></textarea><button type="submit" id="btn" class="dim">↑</button></div></form>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
 const HIST='${histUrl}',SEND='${sendUrl}';
-function md(src){
-  const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  const blocks=[];
-  src=src.replace(/\x60\x60\x60([\s\S]*?)\x60\x60\x60/g,(_,c)=>{blocks.push('<pre><code>'+esc(c.replace(/^[a-z]+\\n/,''))+'</code></pre>');return '\x01'+(blocks.length-1)+'\x01';});
-  const inline=s=>s.replace(/\x60([^\x60]+)\x60/g,(_,c)=>'<code>'+esc(c)+'</code>').replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>').replace(/\*(.+?)\*/g,'<em>$1</em>');
-  const lines=src.split('\\n'),out=[];let lb=[],lt=null;
-  const fl=()=>{if(lb.length){out.push('<'+lt+'>'+lb.map(x=>'<li>'+x+'</li>').join('')+'</'+lt+'>');lb=[];lt=null;}};
-  for(const raw of lines){
-    const bm=raw.match(/^([-*\u2022]) (.+)/),om=raw.match(/^\d+\. (.+)/);
-    if(bm){if(lt&&lt!=='ul')fl();lt='ul';lb.push(inline(bm[2]));continue;}
-    if(om){if(lt&&lt!=='ol')fl();lt='ol';lb.push(inline(om[1]));continue;}
-    fl();const t=raw.trim();if(!t){out.push('');continue;}
-    if(/^#{1,3} /.test(t)){const[,...r]=t.split(' ');out.push('<strong>'+inline(r.join(' '))+'</strong>');continue;}
-    out.push(inline(t));
-  }
-  fl();let html=out.join('\\n').replace(/\x01(\d+)\x01/g,(_,i)=>blocks[+i]);
-  html=html.replace(/([^\\n<][^\\n]+)/g,s=>s.startsWith('<')?s:'<p>'+s+'</p>');
-  return html.replace(/\\n/g,'');
-}
 const msgs=document.getElementById('msgs'),inp=document.getElementById('inp'),btn=document.getElementById('btn'),dot=document.getElementById('dot'),st=document.getElementById('st'),seen=new Set();
 function fmt(ts){try{return new Date(ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});}catch(e){return '';}}
 function addMsg(isBot,content,ts,id){
   if(id&&seen.has(id))return;if(id)seen.add(id);
   const w=document.createElement('div');w.className='m '+(isBot?'a':'u');
   const b=document.createElement('div');b.className='b';
-  if(isBot){try{b.innerHTML=md(content||'');}catch(e){b.textContent=content||'';}}else b.textContent=content||'';
+  if(isBot){try{b.innerHTML=typeof marked!=='undefined'?marked.parse(content||'',{gfm:true}):(content||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');}catch(e){b.textContent=content||'';}}else b.textContent=content||'';
   const t=document.createElement('div');t.className='ts';t.textContent=fmt(ts);
   w.appendChild(b);w.appendChild(t);msgs.appendChild(w);msgs.scrollTop=msgs.scrollHeight;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -404,6 +404,37 @@ export function getLastBotMessageTimestamp(
   return row?.ts ?? undefined;
 }
 
+export interface DisplayMessage {
+  id: string;
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  content: string;
+  timestamp: string;
+  is_from_me: number;
+  is_bot_message: number;
+}
+
+export function getMessagesForDisplay(
+  jids: string[],
+  since: string,
+  limit: number = 100,
+): DisplayMessage[] {
+  if (jids.length === 0) return [];
+  const placeholders = jids.map(() => '?').join(',');
+  const sql = `
+    SELECT * FROM (
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message
+      FROM messages
+      WHERE chat_jid IN (${placeholders}) AND timestamp > ?
+        AND content != '' AND content IS NOT NULL
+      ORDER BY timestamp DESC
+      LIMIT ?
+    ) ORDER BY timestamp
+  `;
+  return db.prepare(sql).all(...jids, since, limit) as DisplayMessage[];
+}
+
 export function createTask(
   task: Omit<ScheduledTask, 'last_run' | 'last_result'>,
 ): void {


### PR DESCRIPTION
## Summary

Adds a browser-based chat UI served directly by NanoClaw — no Redis, no separate app, no external dependencies.

- **`src/channels/web.ts`** — `WebChannel` class, self-registers on startup, serves the UI and a `/history` polling endpoint
- **`src/db.ts`** — adds `getMessagesForDisplay()` for unified chat history (user + bot messages)
- **`src/channels/index.ts`** — adds `import './web.js'` stub
- **`.env.example`** — documents `WEB_CHANNEL_PORT` (default 3080) and optional `WEB_CHANNEL_TOKEN`
- **`.claude/skills/add-web-channel/SKILL.md`** — install, configure, verify instructions

## Design

The web channel acts as a **portal into the main conversation**: web messages are routed through the primary registered group JID (e.g. WhatsApp main), so the agent's context and responses are shared across both channels. Bot replies appear in both the web UI and WhatsApp without any echo or duplication.

The UI uses 2-second HTTP polling (chosen over SSE for iOS Safari reliability). The form uses native `<form>` submit for reliable mobile keyboard handling.

## Install

```bash
# In .env
WEB_CHANNEL_PORT=3080
WEB_CHANNEL_TOKEN=          # leave empty for LAN-only, no auth
```

Open `http://<host>:3080` in a browser.

## Test plan

- [ ] Send a message from the web UI — bot responds and reply appears in the web UI
- [ ] If WhatsApp is configured, bot response also appears in WhatsApp
- [ ] Token auth: set `WEB_CHANNEL_TOKEN`, confirm `/` returns 401 without the token
- [ ] iOS Safari: message sends on tap, no stale page served

🤖 Generated with [Claude Code](https://claude.com/claude-code)