### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        language: system
+        entry: npx prettier --write
+        types: [ts]
+        files: ^src/
+
+      - id: eslint
+        name: eslint
+        language: system
+        entry: npx eslint --fix
+        types: [ts]
+        files: ^src/
+
+      - id: typecheck
+        name: typecheck
+        language: system
+        entry: npx tsc --noEmit
+        pass_filenames: false
+        always_run: true
+
+      - id: vitest
+        name: vitest
+        language: system
+        entry: npx vitest run
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with four local hooks:
  - **prettier** — formats staged `src/` TypeScript files
  - **eslint** — lints & auto-fixes staged `src/` TypeScript files
  - **typecheck** — full `tsc --noEmit` on every commit
  - **vitest** — full test suite on every commit

Requires `pre-commit` to be installed (`pip install pre-commit`, then `pre-commit install`).

## Test plan
- [ ] `pre-commit run --all-files` passes on a clean checkout