### PR TITLE
fix(diagnostics): honor DO_NOT_TRACK and skip ph_event when curl missing

### DIFF
--- a/setup/lib/diagnostics.sh
+++ b/setup/lib/diagnostics.sh
@@ -33,8 +33,18 @@ ph_install_id() {
 # Emit a PostHog event. First arg is the event name; remaining args are
 # `key=value` pairs merged into properties. Values are JSON-escaped for
 # quotes and backslashes; keep them short and alphanumeric-ish.
+#
+# Honors three opt-out signals, in priority order:
+#   - NANOCLAW_NO_DIAGNOSTICS=1 (project-specific)
+#   - DO_NOT_TRACK=1           (widely-used cross-project convention
+#                               from consoledonottrack.com)
+# Also returns quietly if curl isn't on PATH so minimal systems without
+# curl don't spill "command not found" before the background ampersand
+# takes effect in some shells.
 ph_event() {
   [ "${NANOCLAW_NO_DIAGNOSTICS:-}" = "1" ] && return 0
+  [ "${DO_NOT_TRACK:-}" = "1" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
   local event=$1
   shift
   local id


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug fix

## Description

`setup/lib/diagnostics.sh::ph_event` posts an anonymous PostHog event on every bash-side setup step. Two small gaps:

1. **Opt-out surface is project-specific only.** It honors `NANOCLAW_NO_DIAGNOSTICS=1`, but users who've already set the widely-used `DO_NOT_TRACK=1` (from [consoledonottrack.com](https://consoledonottrack.com/), respected by Homebrew, npm, and many others) have to add a second, nanoclaw-specific variable to silence it. This PR honors both.

2. **No `curl` guard.** On minimal systems without `curl` on PATH (Alpine, stripped containers), the current code runs `curl ... >/dev/null 2>&1 &`. The background ampersand swallows most output, but in some shells (dash, older Bash configurations) the shell still emits `command not found` to the terminal *before* the ampersand takes effect. This PR short-circuits with `command -v curl` first.

Both checks are cheap — two parameter expansions and one `command -v` before the existing code path.

### Diff summary

```diff
 ph_event() {
   [ "${NANOCLAW_NO_DIAGNOSTICS:-}" = "1" ] && return 0
+  [ "${DO_NOT_TRACK:-}" = "1" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
   local event=$1
```

### Verified locally

```console
$ bash -n setup/lib/diagnostics.sh           # syntax
$ DO_NOT_TRACK=1 ph_event test_event k=v      # returns 0, no network call
$ NANOCLAW_NO_DIAGNOSTICS=1 ph_event ...      # returns 0, no network call
$ PATH="/dev/null" ph_event ...               # returns 0, no 'command not found'
```

Common case (telemetry on, curl present) is unchanged: one extra conditional before the existing code path.

## For Skills

N/A — not a skill change.
