### PR TITLE
fix(onecli): thread ONECLI_API_KEY to the host-side client in src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   GROUPS_DIR,
   IDLE_TIMEOUT,
   MAX_MESSAGES_PER_PROMPT,
+  ONECLI_API_KEY,
   ONECLI_URL,
   POLL_INTERVAL,
   TIMEZONE,
@@ -78,7 +79,7 @@ let messageLoopRunning = false;
 const channels: Channel[] = [];
 const queue = new GroupQueue();
 
-const onecli = new OneCLI({ url: ONECLI_URL });
+const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 function ensureOneCLIAgent(jid: string, group: RegisteredGroup): void {
   if (group.isMain) return;


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Fixes #1818.

`src/config.ts` exposes both `ONECLI_URL` and `ONECLI_API_KEY`, and `src/container-runner.ts` passes both into its `OneCLI` constructor:

```ts
const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
```

But the host-side client in `src/index.ts` was only getting the URL:

```ts
const onecli = new OneCLI({ url: ONECLI_URL });
```

This is the client used by `ensureOneCLIAgent()` to provision agents for non-main groups. When the OneCLI server is behind an API key, those calls fail with unauthorized even though the operator has `ONECLI_API_KEY` set.

One-line fix — thread `apiKey` through to match `container-runner.ts`. Also add `ONECLI_API_KEY` to the imports from `./config.js`.

### Diff

```diff
 import {
   MAX_MESSAGES_PER_PROMPT,
+  ONECLI_API_KEY,
   ONECLI_URL,
 } from './config.js';
-const onecli = new OneCLI({ url: ONECLI_URL });
+const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
```

1 file changed, +2, −1.

## Verification

- Confirmed the host-side client is invoked by `ensureOneCLIAgent()` (lines 82–99) for every registered group during startup recovery (line 577–580) and on new group registration (line 183–184).
- Confirmed no existing call site passes an overriding options bag that would get clobbered.
- Matches the pattern already present in `src/container-runner.ts:32`, so no new behavior shape is introduced.

## For Skills

N/A — no skills changed.
