### PR TITLE
fix(cleanup-sessions): hard-fail when sqlite3 is missing or the query errors

### DIFF
--- a/scripts/cleanup-sessions.sh
+++ b/scripts/cleanup-sessions.sh
@@ -54,12 +54,22 @@ remove() {
 
 # --- Collect active session IDs from the database ---
 
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  log "ERROR: sqlite3 CLI not found — refusing to run so we don't wipe the active session."
+  log "       Install sqlite3 (e.g. 'apt install sqlite3' or 'brew install sqlite') and re-run."
+  exit 1
+fi
+
 if [ ! -f "$STORE_DB" ]; then
   log "ERROR: database not found at $STORE_DB"
   exit 1
 fi
 
-ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>/dev/null || true)
+if ! ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>&1); then
+  log "ERROR: sqlite3 query failed: $ACTIVE_IDS"
+  log "       Refusing to run so we don't wipe the active session."
+  exit 1
+fi
 
 is_active() {
   echo "$ACTIVE_IDS" | grep -qF "$1"


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Addresses the silent-data-loss half of #1825.

The cleanup script treats sqlite3 failures as "no active sessions":

```sh
ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>/dev/null || true)
```

This swallows every sqlite3 error — missing binary, malformed DB, locked DB, permissions. `ACTIVE_IDS` ends up empty, `is_active()` returns false for everything, and the rest of the script goes on to delete:

- Session JSONLs + tool-results dirs older than 7 days
- Debug logs older than 3 days
- Todo files older than 3 days
- Telemetry files older than 7 days

…**including the currently-active session** if any of its files happen to be past the retention window.

### The fix

Refuse to run when we can't reliably enumerate active sessions:

1. `command -v sqlite3` up front — if absent, print an install hint and exit 1.
2. Capture sqlite3 output with `ACTIVE_IDS=$(sqlite3 …)` directly instead of piping through `|| true`, and exit 1 if the query itself fails.

### What this PR does NOT do

The issue also requested env-var fallbacks (`NANOCLAW_STORE_DIR` / `NANOCLAW_DATA_DIR` / `NANOCLAW_GROUPS_DIR`). After auditing `src/config.ts`, those env vars are **not currently supported** by NanoClaw itself — `STORE_DIR` / `DATA_DIR` / `GROUPS_DIR` are hardcoded via `path.resolve(PROJECT_ROOT, ...)`. So adding fallbacks to the script alone would just hide a mismatch rather than fix one. If the project wants to adopt those env vars, the right sequence is (1) add them to `src/config.ts`, (2) mirror them here — happy to file that as a follow-up PR if maintainers want it.

### Diff

```diff
-if [ ! -f "$STORE_DB" ]; then
-  log "ERROR: database not found at $STORE_DB"
-  exit 1
-fi
-
-ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>/dev/null || true)
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  log "ERROR: sqlite3 CLI not found — refusing to run so we don't wipe the active session."
+  log "       Install sqlite3 (e.g. 'apt install sqlite3' or 'brew install sqlite') and re-run."
+  exit 1
+fi
+
+if [ ! -f "$STORE_DB" ]; then
+  log "ERROR: database not found at $STORE_DB"
+  exit 1
+fi
+
+if ! ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>&1); then
+  log "ERROR: sqlite3 query failed: $ACTIVE_IDS"
+  log "       Refusing to run so we don't wipe the active session."
+  exit 1
+fi
```

1 file changed, +11, −1.

## Verification

- `bash -n scripts/cleanup-sessions.sh` → clean.
- Manually tested:
  - Run with `sqlite3` missing from `PATH` → logs the install hint and exits 1 before any `remove` call.
  - Run with a bogus path to `STORE_DB` → existing "database not found" branch still wins, exits 1.
  - Run against a valid DB → same behavior as before, no regression.
- Behavior on healthy machines is unchanged — sqlite3 is a practical hard dep of NanoClaw already (it is the message store).

## For Skills

N/A — no skills changed.
