### PR TITLE
`fix: rename @Andy trigger references when assistant name changes`

### DIFF
--- a/setup/register.test.ts
+++ b/setup/register.test.ts
@@ -236,6 +236,33 @@ describe('file templating', () => {
     expect(content).toContain('You are C.L.A.U.D.E.');
   });
 
+  it('replaces @Andy trigger references in CLAUDE.md content', () => {
+    let content = [
+      '# Andy',
+      '',
+      'You are Andy.',
+      '',
+      'Scheduled tasks:',
+      '```json',
+      '[',
+      '  { "trigger": "@Andy", "prompt": "daily digest" },',
+      '  { "trigger": "@Andy", "prompt": "weekly review" }',
+      ']',
+      '```',
+    ].join('\n');
+
+    content = content.replace(/^# Andy$/m, '# Ruby');
+    content = content.replace(/You are Andy/g, 'You are Ruby');
+    content = content.replace(/@Andy\b/g, '@Ruby');
+
+    expect(content).not.toContain('@Andy');
+    expect(content).toContain('@Ruby');
+    // Sanity: word boundary prevents accidentally matching longer names
+    // that happen to start with "Andy"
+    const overlap = '@Andyville'.replace(/@Andy\b/g, '@Ruby');
+    expect(overlap).toBe('@Andyville');
+  });
+
   it('updates .env ASSISTANT_NAME line', () => {
     let envContent = 'SOME_KEY=value\nASSISTANT_NAME="Andy"\nOTHER=test';
 

--- a/setup/register.test.ts
+++ b/setup/register.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the assistant-name rename pass in setup/register.ts.
+ *
+ * register.ts updates per-group CLAUDE.md files when ASSISTANT_NAME changes
+ * away from the "Andy" default. Originally it only rewrote the `# Andy`
+ * heading and `You are Andy` identity line, missing the `@Andy` trigger
+ * references that scheduled-task examples ship with (see groups/main/CLAUDE.md
+ * lines 153 and 199, which use `"trigger": "@Andy"`). That left a renamed
+ * install with two different assistant names in the same file.
+ *
+ * Tests the regex chain in isolation so we can pin the word-boundary anchor
+ * without spinning up the full register.run() flow (DB init, migrations,
+ * channel wiring, etc).
+ */
+import { describe, expect, it } from 'vitest';
+
+function applyAssistantNameRename(content: string, assistantName: string): string {
+  let result = content;
+  result = result.replace(/^# Andy$/m, `# ${assistantName}`);
+  result = result.replace(/You are Andy/g, `You are ${assistantName}`);
+  // Word-boundary anchor — see register.ts:226.
+  result = result.replace(/@Andy\b/g, `@${assistantName}`);
+  return result;
+}
+
+describe('assistant-name rename pass (#1870)', () => {
+  it('replaces @Andy trigger references alongside heading and identity rewrites', () => {
+    const source = [
+      '# Andy',
+      '',
+      'You are Andy.',
+      '',
+      'Scheduled tasks:',
+      '```json',
+      '[',
+      '  { "trigger": "@Andy", "prompt": "daily digest" },',
+      '  { "trigger": "@Andy", "prompt": "weekly review" }',
+      ']',
+      '```',
+    ].join('\n');
+
+    const renamed = applyAssistantNameRename(source, 'Ruby');
+
+    expect(renamed).toContain('# Ruby');
+    expect(renamed).toContain('You are Ruby.');
+    expect(renamed).not.toContain('@Andy');
+    expect(renamed).toContain('"trigger": "@Ruby"');
+  });
+
+  it('preserves names that happen to start with "Andy" via the word-boundary anchor', () => {
+    // Without \b, /@Andy/g would rewrite "@Andyville" to "@Rubyville" — a
+    // false positive. Pin the boundary behavior here so a future relax can't
+    // silently re-introduce that regression.
+    expect(applyAssistantNameRename('mention @Andyville here', 'Ruby')).toBe(
+      'mention @Andyville here',
+    );
+    expect(applyAssistantNameRename('mention @AndyBot here', 'Ruby')).toBe(
+      'mention @AndyBot here',
+    );
+  });
+
+  it('renames @Andy at end of line, end of string, and surrounded by punctuation', () => {
+    expect(applyAssistantNameRename('hey @Andy how are you', 'Ruby')).toBe(
+      'hey @Ruby how are you',
+    );
+    expect(applyAssistantNameRename('"@Andy"', 'Ruby')).toBe('"@Ruby"');
+    expect(applyAssistantNameRename('@Andy.', 'Ruby')).toBe('@Ruby.');
+    expect(applyAssistantNameRename('@Andy,', 'Ruby')).toBe('@Ruby,');
+    expect(applyAssistantNameRename('@Andy', 'Ruby')).toBe('@Ruby');
+  });
+
+  it('handles multi-word and punctuation-containing assistant names', () => {
+    const source = [
+      '# Andy',
+      'You are Andy.',
+      'Trigger: @Andy',
+    ].join('\n');
+
+    const renamed = applyAssistantNameRename(source, 'C.L.A.U.D.E.');
+
+    expect(renamed).toContain('# C.L.A.U.D.E.');
+    expect(renamed).toContain('You are C.L.A.U.D.E.');
+    expect(renamed).toContain('@C.L.A.U.D.E.');
+  });
+
+  it('is a no-op when no Andy references are present', () => {
+    const source = '# Ruby\nYou are Ruby.\nTrigger: @Ruby';
+    expect(applyAssistantNameRename(source, 'Ruby')).toBe(source);
+  });
+
+  it('does not touch unrelated @mentions of other users', () => {
+    expect(applyAssistantNameRename('cc @alice and @bob', 'Ruby')).toBe(
+      'cc @alice and @bob',
+    );
+  });
+});

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -162,6 +162,8 @@ export async function run(args: string[]): Promise<void> {
           /You are Andy/g,
           `You are ${parsed.assistantName}`,
         );
+        // Also rename trigger references (e.g. scheduled-task "trigger": "@Andy" entries)
+        content = content.replace(/@Andy\b/g, `@${parsed.assistantName}`);
         fs.writeFileSync(mdFile, content);
         logger.info({ file: mdFile }, 'Updated CLAUDE.md');
       }

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -223,6 +223,10 @@ export async function run(args: string[]): Promise<void> {
       let content = fs.readFileSync(mdFile, 'utf-8');
       content = content.replace(/^# Andy$/m, `# ${parsed.assistantName}`);
       content = content.replace(/You are Andy/g, `You are ${parsed.assistantName}`);
+      // Also rename trigger references (e.g. scheduled-task "trigger": "@Andy"
+      // entries in groups/<folder>/CLAUDE.md). Word-boundary anchor keeps
+      // names like "@Andyville" intact.
+      content = content.replace(/@Andy\b/g, `@${parsed.assistantName}`);
       fs.writeFileSync(mdFile, content);
       log.info('Updated CLAUDE.md', { file: mdFile });
     }


### PR DESCRIPTION
```
## What

When `ASSISTANT_NAME` is set to a non-default value, rename `@Andy` trigger references in group CLAUDE.md files along with the existing heading and identity-line replacements.

## Why

register.ts replaced `# Andy` and `You are Andy` in group CLAUDE.md files, but missed `@Andy` trigger references inside scheduled-task `"trigger"` fields in the same file. After a rename, the heading and identity line reflect the new name while scheduled tasks still trigger on `@Andy`, which is exactly the inconsistency reported in #1870.

## How it works

Adds a third replacement pass in the CLAUDE.md update loop:

    content = content.replace(/@Andy\b/g, `@${parsed.assistantName}`);

The `\b` word boundary prevents accidentally rewriting names that happen to start with `Andy` (e.g. `@Andyville`).

## How it was tested

Added a vitest case under `file templating` covering scheduled-task trigger replacement and the word-boundary behaviour.

## Scope

Fixes the register.ts side of #1870. The channel-skill forwarding part (passing `--assistant-name` through `add-telegram` et al., Bug 1 in the issue) lives on `skill/*` branches and is out of scope for this core-codebase PR.

## Checklist

- [x] Fix
```