### PR TITLE
fix: guard numeric config env vars against NaN and non-positive values

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * Reload src/config.js with a freshly-mutated process.env.
+ *
+ * Each test stubs env vars before calling, then restores the originals.
+ * Uses dynamic import + vi-free module cache reset so config.ts is re-evaluated
+ * with the new environment rather than returning a cached copy from a prior test.
+ */
+async function loadConfigWithEnv(
+  env: Record<string, string | undefined>,
+): Promise<typeof import('./config.js')> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    previous[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+
+  try {
+    const mod = await import(`./config.js?nonce=${Math.random()}`);
+    return mod;
+  } finally {
+    for (const [k, v] of Object.entries(previous)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe('numeric config parsing', () => {
+  const envKeys = [
+    'CONTAINER_TIMEOUT',
+    'CONTAINER_MAX_OUTPUT_SIZE',
+    'IDLE_TIMEOUT',
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of envKeys) saved[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('falls back to default when env vars are non-numeric', async () => {
+    const cfg = await loadConfigWithEnv({
+      CONTAINER_TIMEOUT: 'thirty-minutes',
+      CONTAINER_MAX_OUTPUT_SIZE: 'big',
+      IDLE_TIMEOUT: 'abc',
+    });
+
+    // Before the fix these would be NaN, which setTimeout treats as 1ms —
+    // causing containers to die the instant they start.
+    expect(Number.isFinite(cfg.CONTAINER_TIMEOUT)).toBe(true);
+    expect(Number.isFinite(cfg.CONTAINER_MAX_OUTPUT_SIZE)).toBe(true);
+    expect(Number.isFinite(cfg.IDLE_TIMEOUT)).toBe(true);
+
+    expect(cfg.CONTAINER_TIMEOUT).toBe(1800000);
+    expect(cfg.CONTAINER_MAX_OUTPUT_SIZE).toBe(10485760);
+    expect(cfg.IDLE_TIMEOUT).toBe(1800000);
+  });
+
+  it('clamps zero and negative values to a safe minimum', async () => {
+    const cfg = await loadConfigWithEnv({
+      CONTAINER_TIMEOUT: '0',
+      CONTAINER_MAX_OUTPUT_SIZE: '-5',
+      IDLE_TIMEOUT: '0',
+    });
+
+    // "0" would previously cause setTimeout(fn, 0) — immediate timeout.
+    // Fallback to default on 0, floor of 1 on negatives.
+    expect(cfg.CONTAINER_TIMEOUT).toBeGreaterThanOrEqual(1);
+    expect(cfg.CONTAINER_MAX_OUTPUT_SIZE).toBeGreaterThanOrEqual(1);
+    expect(cfg.IDLE_TIMEOUT).toBeGreaterThanOrEqual(1);
+  });
+
+  it('preserves valid positive numeric env values', async () => {
+    const cfg = await loadConfigWithEnv({
+      CONTAINER_TIMEOUT: '60000',
+      CONTAINER_MAX_OUTPUT_SIZE: '2048',
+      IDLE_TIMEOUT: '5000',
+    });
+
+    expect(cfg.CONTAINER_TIMEOUT).toBe(60000);
+    expect(cfg.CONTAINER_MAX_OUTPUT_SIZE).toBe(2048);
+    expect(cfg.IDLE_TIMEOUT).toBe(5000);
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for numeric env-var parsing in src/config.ts.
+ *
+ * CONTAINER_TIMEOUT, CONTAINER_MAX_OUTPUT_SIZE, and IDLE_TIMEOUT are parsed
+ * with parseInt(), which returns NaN on non-numeric input (e.g. "30min", or a
+ * blank-but-set value). When NaN reaches setTimeout() Node clamps it to 1ms,
+ * which would kill every container the instant it started. The fix wraps each
+ * with Math.max(1, parseInt(...) || DEFAULT) so the parsed value is always a
+ * finite positive integer — matching the idiom already applied to
+ * MAX_MESSAGES_PER_PROMPT and MAX_CONCURRENT_CONTAINERS in the same file.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const NUMERIC_ENV_VARS = [
+  { name: 'CONTAINER_TIMEOUT', exportName: 'CONTAINER_TIMEOUT', defaultValue: 1800000 },
+  { name: 'CONTAINER_MAX_OUTPUT_SIZE', exportName: 'CONTAINER_MAX_OUTPUT_SIZE', defaultValue: 10485760 },
+  { name: 'IDLE_TIMEOUT', exportName: 'IDLE_TIMEOUT', defaultValue: 1800000 },
+] as const;
+
+async function loadConfig(): Promise<typeof import('./config.js')> {
+  // Reset the module registry so the next `import('./config.js')` re-evaluates
+  // the module body — which is where the parseInt(...) reads of process.env
+  // happen. Vite's dynamic-import resolver rejects query-string busting, so
+  // we go through vi.resetModules() instead.
+  vi.resetModules();
+  return await import('./config.js');
+}
+
+describe('numeric env var parsing (#1916)', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const v of NUMERIC_ENV_VARS) {
+      originalEnv[v.name] = process.env[v.name];
+      delete process.env[v.name];
+    }
+  });
+
+  afterEach(() => {
+    for (const v of NUMERIC_ENV_VARS) {
+      if (originalEnv[v.name] === undefined) {
+        delete process.env[v.name];
+      } else {
+        process.env[v.name] = originalEnv[v.name];
+      }
+    }
+  });
+
+  for (const v of NUMERIC_ENV_VARS) {
+    describe(v.name, () => {
+      it('uses the documented default when unset', async () => {
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(v.defaultValue);
+      });
+
+      it('accepts a valid positive integer string', async () => {
+        process.env[v.name] = '60000';
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(60000);
+      });
+
+      it('falls back to the default on non-numeric input', async () => {
+        process.env[v.name] = 'abc';
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(v.defaultValue);
+      });
+
+      it('falls back to the default on blank-but-set value', async () => {
+        process.env[v.name] = '';
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(v.defaultValue);
+      });
+
+      it('clamps zero up to 1 (never returns a non-positive value)', async () => {
+        process.env[v.name] = '0';
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(v.defaultValue);
+      });
+
+      it('clamps negative input up to 1 (never returns a non-positive value)', async () => {
+        process.env[v.name] = '-5';
+        const config = await loadConfig();
+        expect(config[v.exportName]).toBe(1);
+      });
+
+      it('returns a finite positive integer for every code path', async () => {
+        for (const value of ['abc', '', '0', '-5', '60000', 'NaN', '1e3.5']) {
+          process.env[v.name] = value;
+          const config = await loadConfig();
+          const result = config[v.exportName];
+          expect(Number.isFinite(result)).toBe(true);
+          expect(result).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,13 +44,13 @@ export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
-export const CONTAINER_TIMEOUT = parseInt(
-  process.env.CONTAINER_TIMEOUT || '1800000',
-  10,
+export const CONTAINER_TIMEOUT = Math.max(
+  1,
+  parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10) || 1800000,
 );
-export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
-  process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
-  10,
+export const CONTAINER_MAX_OUTPUT_SIZE = Math.max(
+  1,
+  parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10) || 10485760,
 ); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY =
@@ -60,7 +60,10 @@ export const MAX_MESSAGES_PER_PROMPT = Math.max(
   parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10,
 );
 export const IPC_POLL_INTERVAL = 1000;
-export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const IDLE_TIMEOUT = Math.max(
+  1,
+  parseInt(process.env.IDLE_TIMEOUT || '1800000', 10) || 1800000,
+); // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,12 +31,12 @@ export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || getDefaultContaine
 // cleanupOrphans only reaps containers from this install, not peers.
 export const INSTALL_SLUG = getInstallSlug(PROJECT_ROOT);
 export const CONTAINER_INSTALL_LABEL = `nanoclaw-install=${INSTALL_SLUG}`;
-export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10);
-export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
+export const CONTAINER_TIMEOUT = Math.max(1, parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10) || 1800000);
+export const CONTAINER_MAX_OUTPUT_SIZE = Math.max(1, parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10) || 10485760); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);
-export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const IDLE_TIMEOUT = Math.max(1, parseInt(process.env.IDLE_TIMEOUT || '1800000', 10) || 1800000); // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(1, parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5);
 
 function escapeRegex(str: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,10 @@ export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || getDefaultContaine
 export const INSTALL_SLUG = getInstallSlug(PROJECT_ROOT);
 export const CONTAINER_INSTALL_LABEL = `nanoclaw-install=${INSTALL_SLUG}`;
 export const CONTAINER_TIMEOUT = Math.max(1, parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10) || 1800000);
-export const CONTAINER_MAX_OUTPUT_SIZE = Math.max(1, parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10) || 10485760); // 10MB default
+export const CONTAINER_MAX_OUTPUT_SIZE = Math.max(
+  1,
+  parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10) || 10485760,
+); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);


### PR DESCRIPTION
```
## What

Guard CONTAINER_TIMEOUT, CONTAINER_MAX_OUTPUT_SIZE, and IDLE_TIMEOUT in src/config.ts against NaN and non-positive values using the same Math.max(1, parseInt(...) || DEFAULT) idiom already applied to MAX_MESSAGES_PER_PROMPT and MAX_CONCURRENT_CONTAINERS in the same file.

## Why

A non-numeric env var (e.g. CONTAINER_TIMEOUT="30min" or a blank-but-set value) produced NaN. Node clamps setTimeout(NaN) to 1ms, so every container would die the instant it started. CONTAINER_MAX_OUTPUT_SIZE=NaN silently disabled the output-size truncation guard in container-runner.ts since `NaN - stdout.length === NaN` is never > or <= anything.

Zero and negative values had the same class of problem — `setTimeout(fn, 0)` fires on the next tick.

## How it works

- Replaces bare `parseInt(...)` with `Math.max(1, parseInt(...) || DEFAULT)`
- Matches the existing idiom used below for MAX_MESSAGES_PER_PROMPT and MAX_CONCURRENT_CONTAINERS so the whole block is consistent
- NaN and 0 now fall back to the documented default; negatives clamp to 1

## How it was tested

Added src/config.test.ts with three cases:
- Non-numeric env values → fall back to defaults (previously NaN)
- Zero/negative env values → clamped to positive
- Valid positive values → preserved unchanged

Manually verified via:

    node -e "const p = v => Math.max(1, parseInt(v||'1800000',10)||1800000);
             console.log(p('abc'), p('0'), p('-5'), p('60000'))"
    # 1800000 1800000 1 60000

## Checklist

- [x] Fix
```