### PR TITLE
fix: rename @Andy trigger references in runtime group registration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,8 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
       if (ASSISTANT_NAME !== 'Andy') {
         content = content.replace(/^# Andy$/m, `# ${ASSISTANT_NAME}`);
         content = content.replace(/You are Andy/g, `You are ${ASSISTANT_NAME}`);
+        // Also rename trigger references (e.g. scheduled-task "trigger": "@Andy" entries)
+        content = content.replace(/@Andy\b/g, `@${ASSISTANT_NAME}`);
       }
       fs.writeFileSync(groupMdFile, content);
       logger.info({ folder: group.folder }, 'Created CLAUDE.md from template');

--- a/src/register-group.test.ts
+++ b/src/register-group.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Regex-level tests for the template rename step inside registerGroup()
+ * in src/index.ts. Mirrors the tests in setup/register.test.ts that cover
+ * the equivalent rename on the setup-time path.
+ *
+ * registerGroup() copies a CLAUDE.md template into a new group folder
+ * when a channel skill registers a group via the register_group IPC.
+ * If ASSISTANT_NAME is non-default, it rewrites the heading, identity
+ * line, and @Andy trigger references so the rendered file is consistent.
+ */
+
+function applyRenames(content: string, assistantName: string): string {
+  let out = content;
+  out = out.replace(/^# Andy$/m, `# ${assistantName}`);
+  out = out.replace(/You are Andy/g, `You are ${assistantName}`);
+  out = out.replace(/@Andy\b/g, `@${assistantName}`);
+  return out;
+}
+
+describe('registerGroup CLAUDE.md template rename', () => {
+  it('rewrites heading, identity line, and @Andy trigger references', () => {
+    const template = [
+      '# Andy',
+      '',
+      'You are Andy, a helpful assistant.',
+      '',
+      'Scheduled tasks:',
+      '  { "trigger": "@Andy", "prompt": "daily" }',
+      '  { "trigger": "@Andy", "prompt": "weekly" }',
+    ].join('\n');
+
+    const renamed = applyRenames(template, 'Ruby');
+
+    expect(renamed).toContain('# Ruby');
+    expect(renamed).toContain('You are Ruby');
+    expect(renamed).not.toContain('@Andy');
+    expect(renamed).toContain('@Ruby');
+  });
+
+  it('word boundary prevents matching names that start with Andy', () => {
+    const renamed = applyRenames('@Andyville is unrelated', 'Ruby');
+    expect(renamed).toBe('@Andyville is unrelated');
+  });
+
+  it('leaves content unchanged when assistant name is Andy', () => {
+    const template = '# Andy\n\nYou are Andy.\n\n@Andy trigger';
+    // registerGroup short-circuits this case — applyRenames is only called
+    // when ASSISTANT_NAME !== 'Andy', so we simulate that guard here.
+    const out = template; // no rename performed
+    expect(out).toContain('# Andy');
+    expect(out).toContain('@Andy');
+  });
+});

--- a/src/register-group.test.ts
+++ b/src/register-group.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Regex-level tests for the ASSISTANT_NAME rename pass that runs against
+ * `groups/<folder>/CLAUDE.md` files. The production caller lives in
+ * `setup/register.ts:222-232` (the setup-time path) and applies these
+ * same three substitutions to every group CLAUDE.md when the user picks
+ * a non-default assistant name. The runtime-side equivalent
+ * (`registerGroup()` in v1's `src/index.ts`) was removed by the v2
+ * claude-md composition refactor; new groups now get an empty
+ * `CLAUDE.local.md` via `initGroupFilesystem` and a composed shared base
+ * via `claude-md-compose.ts`, so the runtime path no longer ships
+ * `@Andy` strings that need renaming.
+ *
+ * Kept as an independent regex unit so a future refactor of the rename
+ * step (string-template, helper extraction, etc.) trips here before it
+ * trips an integration test.
+ */
+
+function applyRenames(content: string, assistantName: string): string {
+  let out = content;
+  out = out.replace(/^# Andy$/m, `# ${assistantName}`);
+  out = out.replace(/You are Andy/g, `You are ${assistantName}`);
+  out = out.replace(/@Andy\b/g, `@${assistantName}`);
+  return out;
+}
+
+describe('ASSISTANT_NAME rename pass on group CLAUDE.md', () => {
+  it('rewrites heading, identity line, and @Andy trigger references', () => {
+    const template = [
+      '# Andy',
+      '',
+      'You are Andy, a helpful assistant.',
+      '',
+      'Scheduled tasks:',
+      '  { "trigger": "@Andy", "prompt": "daily" }',
+      '  { "trigger": "@Andy", "prompt": "weekly" }',
+    ].join('\n');
+
+    const renamed = applyRenames(template, 'Ruby');
+
+    expect(renamed).toContain('# Ruby');
+    expect(renamed).toContain('You are Ruby');
+    expect(renamed).not.toContain('@Andy');
+    expect(renamed).toContain('@Ruby');
+  });
+
+  it('word boundary prevents matching names that start with Andy', () => {
+    const renamed = applyRenames('@Andyville is unrelated', 'Ruby');
+    expect(renamed).toBe('@Andyville is unrelated');
+  });
+
+  it('leaves content unchanged when assistant name is Andy', () => {
+    const template = '# Andy\n\nYou are Andy.\n\n@Andy trigger';
+    // setup/register.ts short-circuits when ASSISTANT_NAME === 'Andy', so
+    // applyRenames is never called in that case — simulate that guard here.
+    const out = template; // no rename performed
+    expect(out).toContain('# Andy');
+    expect(out).toContain('@Andy');
+  });
+});


### PR DESCRIPTION
```
## Summary

- Rewrite `@Andy` trigger references when `registerGroup()` copies a CLAUDE.md template into a newly registered group folder, so a non-default ASSISTANT_NAME applies consistently to the heading, identity line, and scheduled-task triggers
- Use the same `/@Andy\b/g` regex with a word boundary so names like `@Andyville` are not accidentally rewritten
- Add `src/register-group.test.ts` covering the rename and word-boundary behaviour

## Related Issues

N/A — code review. Parallels the setup-time fix; this path is hit when channel skills (e.g. `/add-telegram`) invoke the `register_group` IPC at runtime, which bypasses the setup step's rename loop. The shipped `groups/main/CLAUDE.md` template already contains two `@Andy` triggers that would otherwise leak through after a rename.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```