### PR TITLE
feat: add /add-weixin skill — WeChat channel via iLink bot protocol

### DIFF
--- a/.claude/skills/add-weixin/SKILL.md
+++ b/.claude/skills/add-weixin/SKILL.md
@@ -138,11 +138,21 @@ tail -f logs/nanoclaw.log | grep weixin
 - **Session expiry (errcode -14)**: After 7+ days of inactivity the server
   revokes the session. The monitor sleeps 1 hour and retries; permanent
   recovery needs a fresh QR login.
-- **Media (MVP limitation)**: Image / video / file / voice send-and-receive
-  are **not** implemented. Inbound media messages are surfaced to the agent
-  as `[图片]` / `[视频]` / `[文件]` / `[语音]` placeholders. Adding full
-  media support requires porting the CDN AES-128-ECB upload/download layer
-  and SILK voice transcoding from the Tencent plugin — track as a follow-up.
+- **Outbound media**: image / video / generic file attachments are sent via
+  the iLink CDN (AES-128-ECB upload, then a dedicated `sendmessage` with an
+  IMAGE / VIDEO / FILE item). MIME type is derived from the file extension
+  (see `media/mime.ts`). The agent triggers a media send by embedding one of
+  these markers in its reply text:
+    - `![alt](/abs/host/path.png)` — markdown image syntax
+    - `![](file:///abs/host/path.png)` — `file://` URL form
+    - `<file:/abs/host/path.pdf>` — generic attachment (any MIME)
+  Paths must be absolute on the host. The container-local shortcut
+  `/workspace/group/…` is auto-translated to the host `groups/<folder>/…`
+  path by `WeixinChannel.resolveContainerPath`, so agents writing output
+  files to their CWD can reference them with just the container path.
+- **Inbound media**: image / video / file / voice are still surfaced to the
+  agent as `[图片]` / `[视频]` / `[文件]` / `[语音]` placeholders. Decoding
+  the inbound CDN payload and SILK voice transcoding remain open tasks.
 - **Multi-account**: The storage layout supports it (`store/weixin/accounts/*`)
   but the current `WeixinChannel` registers only the default account. To run
   multiple bots, extend the factory in `src/channels/weixin.ts`.

--- a/.claude/skills/add-weixin/SKILL.md
+++ b/.claude/skills/add-weixin/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: add-weixin
+description: Add WeChat (微信) as a channel. Uses the iLink bot protocol (ported from Tencent's @tencent-weixin/openclaw-weixin plugin). Supports QR-code login and text message send/receive. This skill walks through base-URL configuration, QR login, and registering the main chat.
+---
+
+# Add WeChat Channel
+
+This skill adds WeChat (微信) support to NanoClaw. It is a direct port of the
+HTTP protocol used by Tencent's official OpenClaw WeChat plugin — rewritten
+to plug into NanoClaw's `Channel` interface with no OpenClaw SDK dependency.
+
+The code is shipped in-tree under `src/channels/weixin/` and self-registers
+via `src/channels/weixin.ts`. No git branch merge is required.
+
+## Phase 1: Pre-flight
+
+### Check installation state
+
+Verify the code is present (it ships with this NanoClaw checkout):
+
+```bash
+ls src/channels/weixin/ && ls src/channels/weixin.ts
+```
+
+If any of these are missing, this skill is not applicable — the port was
+removed or never applied. Stop and ask the user.
+
+### iLink base URL (optional)
+
+The login script defaults to Tencent's public iLink backend
+(`https://ilinkai.weixin.qq.com`), which is the same endpoint the official
+`@tencent-weixin/openclaw-weixin` plugin uses. No approval or onboarding is
+required — anyone with a WeChat account can scan a bot QR and log in.
+
+Only override this if you're pointing at a staging/private deployment:
+
+```bash
+echo "WEIXIN_BASE_URL=<url>" >> .env
+```
+
+## Phase 2: Apply Configuration
+
+### Install optional dep
+
+Terminal QR rendering uses `qrcode-terminal`. Install it if missing:
+
+```bash
+npm install --save qrcode-terminal
+```
+
+(If the user says "no new dependencies", the login script falls back to
+printing the QR URL in plain text — users can scan from another device that
+has a QR renderer.)
+
+### Build
+
+```bash
+npm run build
+```
+
+### Run tests
+
+```bash
+npx vitest run src/channels/weixin.test.ts
+```
+
+All tests must pass before continuing.
+
+## Phase 3: QR Login
+
+Run the interactive login script:
+
+```bash
+npx tsx scripts/weixin-login.ts
+```
+
+Walk the user through:
+
+1. The script fetches a QR code from `WEIXIN_BASE_URL`.
+2. It prints the QR in the terminal. User scans it with WeChat.
+3. After scanning, the terminal shows `👀 已扫码，请在微信中继续确认...`.
+4. User confirms on phone.
+5. On success, the script prints `✅ 与微信连接成功！` plus `accountId` and
+   `userId`. These are saved to `store/weixin/accounts/<accountId>.account.json`.
+
+If the QR expires, the script auto-refreshes up to 3 times.
+
+## Phase 4: Register the Main Chat
+
+The bot only receives and replies to users who have had at least one
+prior message exchange (iLink requires a `context_token` obtained from
+an inbound message before outbound is accepted).
+
+1. Have the user send any test message to the bot on WeChat.
+2. NanoClaw logs show: `inbound message: from=<userId>`.
+3. The chat JID is `wx:<userId>`. Register it as the main group:
+
+```bash
+npx tsx -e "
+import { setRegisteredGroup, initDatabase } from './src/db.js';
+initDatabase();
+setRegisteredGroup('wx:<userId>', {
+  name: 'WeChat Main',
+  folder: 'main',
+  trigger: '',
+  added_at: new Date().toISOString(),
+  isMain: true,
+  requiresTrigger: false,
+});
+"
+```
+
+Replace `<userId>` with the actual iLink user id.
+
+4. Restart NanoClaw so the channel connects:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# or: systemctl --user restart nanoclaw           # Linux
+```
+
+## Phase 5: Verify
+
+User sends another message on WeChat. The agent should reply. Check logs:
+
+```bash
+tail -f logs/nanoclaw.log | grep weixin
+```
+
+## Architecture Notes
+
+- **JID scheme**: `wx:<ilink_user_id>`. 1:1 direct chats only (WeChat iLink
+  bot protocol does not currently expose group chats).
+- **context_token**: Required by the iLink server on every outbound message.
+  The channel caches the most recent token per user in
+  `store/weixin/accounts/<accountId>.context-tokens.json` and refreshes it
+  from every inbound message.
+- **Session expiry (errcode -14)**: After 7+ days of inactivity the server
+  revokes the session. The monitor sleeps 1 hour and retries; permanent
+  recovery needs a fresh QR login.
+- **Media (MVP limitation)**: Image / video / file / voice send-and-receive
+  are **not** implemented. Inbound media messages are surfaced to the agent
+  as `[图片]` / `[视频]` / `[文件]` / `[语音]` placeholders. Adding full
+  media support requires porting the CDN AES-128-ECB upload/download layer
+  and SILK voice transcoding from the Tencent plugin — track as a follow-up.
+- **Multi-account**: The storage layout supports it (`store/weixin/accounts/*`)
+  but the current `WeixinChannel` registers only the default account. To run
+  multiple bots, extend the factory in `src/channels/weixin.ts`.
+
+## Troubleshooting
+
+- **QR fetch fails**: Check `WEIXIN_BASE_URL` is reachable from the host
+  (`curl $WEIXIN_BASE_URL/ilink/bot/get_bot_qrcode?bot_type=3`).
+- **"session paused 1h"** in logs: session expired (errcode -14). Re-run
+  `scripts/weixin-login.ts` and restart NanoClaw.
+- **"weixin sendMessage: no contextToken cached"**: the bot hasn't received
+  a message from that user yet. The first outbound can only follow an
+  inbound — this is a protocol constraint.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# NanoClaw non-secret configuration
+#
+# All real credentials (API keys, OAuth tokens, bot tokens, etc.) are stored
+# in the OneCLI Agent Vault, NOT in this file. OneCLI injects them into the
+# container's HTTPS traffic at request time. See `onecli secrets list`.
+#
+# This file should stay free of secrets so it can safely be committed.
+
+# Local OneCLI gateway. Default installation listens on 127.0.0.1:10254.
+# ONECLI_URL=http://127.0.0.1:10254
+# ONECLI_API_KEY=
+
+# Custom Anthropic-compatible backend (Kimi, Moonshot, etc.).
+# Forwarded into the container as-is. The OneCLI secret whose `hostPattern`
+# matches this host is what actually authorises requests.
+# Example: Kimi Coding endpoint
+# ANTHROPIC_BASE_URL=https://api.kimi.com/coding/
+
+# Override the container's timezone. Defaults to the host's detected TZ.
+# TZ=Asia/Shanghai
+
+# -------- Channel-specific tokens (stored in OneCLI in production) --------
+# Only needed if you run without OneCLI.
+# TELEGRAM_BOT_TOKEN=
+# SLACK_BOT_TOKEN=
+# SLACK_APP_TOKEN=
+# DISCORD_BOT_TOKEN=
+
+# -------- WeChat (iLink) --------
+# Optional. Defaults to Tencent's public iLink endpoint
+# https://ilinkai.weixin.qq.com — only override if you are routing through a
+# private iLink deployment.
+# WEIXIN_BASE_URL=

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -40,6 +40,18 @@ interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  progress?: AgentProgress;
+}
+
+/**
+ * Intermediate step notification streamed to the host so users can see what
+ * the agent is currently doing (tool calls, thinking). Never carries the
+ * final answer — that stays in `result`.
+ */
+interface AgentProgress {
+  kind: 'tool_use' | 'tool_result' | 'thinking';
+  tool?: string;
+  summary: string;
 }
 
 interface SessionEntry {
@@ -125,6 +137,83 @@ function writeOutput(output: ContainerOutput): void {
 
 function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
+}
+
+const TOOL_USE_PREVIEW_KEYS = [
+  'command',
+  'path',
+  'file_path',
+  'pattern',
+  'url',
+  'query',
+  'description',
+  'prompt',
+  'old_string',
+  'new_string',
+];
+
+function truncate(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+function summariseToolUseInput(input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const obj = input as Record<string, unknown>;
+  for (const key of TOOL_USE_PREVIEW_KEYS) {
+    const v = obj[key];
+    if (typeof v === 'string' && v.trim()) {
+      return truncate(v, 160);
+    }
+  }
+  const firstString = Object.values(obj).find(
+    (v) => typeof v === 'string' && v.trim(),
+  );
+  if (typeof firstString === 'string') return truncate(firstString, 160);
+  try {
+    return truncate(JSON.stringify(obj), 160);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Emit `tool_use` items and non-final `text` blocks inside an assistant
+ * message as progress markers. The final result text is delivered via the
+ * dedicated `type === 'result'` branch, so we never forward text blocks that
+ * are identical to the final answer — but short intermediate reasoning blobs
+ * still show up as `thinking` progress.
+ */
+function emitAssistantProgress(message: unknown, newSessionId?: string): void {
+  const content = (
+    message as {
+      message?: {
+        content?: Array<{
+          type?: string;
+          text?: string;
+          name?: string;
+          input?: unknown;
+        }>;
+      };
+    }
+  ).message?.content;
+  if (!Array.isArray(content)) return;
+
+  for (const block of content) {
+    if (block.type === 'tool_use' && typeof block.name === 'string') {
+      const preview = summariseToolUseInput(block.input);
+      writeOutput({
+        status: 'success',
+        result: null,
+        newSessionId,
+        progress: {
+          kind: 'tool_use',
+          tool: block.name,
+          summary: preview,
+        },
+      });
+    }
+  }
 }
 
 function getSessionSummary(
@@ -501,6 +590,7 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+      emitAssistantProgress(message, newSessionId);
     }
 
     if (message.type === 'system' && message.subtype === 'init') {

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -45,9 +45,12 @@ When you learn something important:
 
 ## Message Formatting
 
-Format messages based on the channel. Check the group folder name prefix:
+Format messages based on the channel. The channel name is available as the
+`$NANOCLAW_CHANNEL` environment variable (`weixin`, `telegram`, `whatsapp`,
+`slack`, `discord`, …). Fall back to the group folder name prefix (e.g.
+`slack_`, `telegram_`, `weixin_`) if the variable is unset.
 
-### Slack channels (folder starts with `slack_`)
+### Slack channels (`$NANOCLAW_CHANNEL=slack`, or folder starts with `slack_`)
 
 Use Slack mrkdwn syntax. Run `/slack-formatting` for the full reference. Key rules:
 - `*bold*` (single asterisks)
@@ -58,7 +61,7 @@ Use Slack mrkdwn syntax. Run `/slack-formatting` for the full reference. Key rul
 - `>` for block quotes
 - No `##` headings — use `*Bold text*` instead
 
-### WhatsApp/Telegram (folder starts with `whatsapp_` or `telegram_`)
+### WhatsApp / Telegram (`$NANOCLAW_CHANNEL` is `whatsapp` or `telegram`, or folder starts with `whatsapp_` / `telegram_`)
 
 - `*bold*` (single asterisks, NEVER **double**)
 - `_italic_` (underscores)
@@ -67,29 +70,33 @@ Use Slack mrkdwn syntax. Run `/slack-formatting` for the full reference. Key rul
 
 No `##` headings. No `[links](url)`. No `**double stars**`.
 
-### Discord (folder starts with `discord_`)
+### Discord (`$NANOCLAW_CHANNEL=discord`, or folder starts with `discord_`)
 
 Standard Markdown: `**bold**`, `*italic*`, `[links](url)`, `# headings`.
 
-### WeChat (folder starts with `weixin_` or JID starts with `wx:`)
+### WeChat (`$NANOCLAW_CHANNEL=weixin`, or folder starts with `weixin_`, or JID starts with `wx:`)
 
 Plain text. WeChat iLink has no rich Markdown rendering — the receiver sees
 exactly what you write, so drop `**bold**`, headings, and tables.
 
-To send an image, video, or file, embed one of these markers in your reply:
+To send an image, video, or file, embed one of these markers directly in
+your reply text:
 
-- `![caption](/abs/host/path.png)` — image, rendered inline
-- `<file:/abs/host/path.pdf>` — any file attachment (pdf, zip, office, …)
+- `![caption](/workspace/group/chart.png)` — image, rendered inline
+- `<file:/workspace/group/report.pdf>` — any file attachment (pdf, zip, office, …)
 
-Paths must be absolute. The container-local shortcut `/workspace/group/…` is
-auto-translated to the corresponding host path, so the simplest flow is:
+The easiest flow: save the file under your CWD (which is
+`/workspace/group/` inside the container) and reference it with that
+path — NanoClaw auto-translates it back to the host's
+`groups/<folder>/…` before uploading to the WeChat CDN. Absolute host
+paths (e.g. `~/Workspace/foo.png`) also work if the file lives outside
+the group directory.
 
-1. Write the file under your CWD, e.g. `./chart.png` (which is
-   `/workspace/group/chart.png` inside the container).
-2. In your reply, write `![](/workspace/group/chart.png)`.
-
-Text that surrounds an attachment marker is delivered as a separate text
-message in order — keep captions short and put them on their own line.
+Each marker becomes one media message. Any text that surrounds it is
+delivered as a separate text message in order, so keep captions short
+and put them on their own line. Do NOT describe the attachment with
+phrases like "图片如下" / "here is the file" — just emit the marker
+and the channel will display the media inline.
 
 ---
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -71,6 +71,26 @@ No `##` headings. No `[links](url)`. No `**double stars**`.
 
 Standard Markdown: `**bold**`, `*italic*`, `[links](url)`, `# headings`.
 
+### WeChat (folder starts with `weixin_` or JID starts with `wx:`)
+
+Plain text. WeChat iLink has no rich Markdown rendering — the receiver sees
+exactly what you write, so drop `**bold**`, headings, and tables.
+
+To send an image, video, or file, embed one of these markers in your reply:
+
+- `![caption](/abs/host/path.png)` — image, rendered inline
+- `<file:/abs/host/path.pdf>` — any file attachment (pdf, zip, office, …)
+
+Paths must be absolute. The container-local shortcut `/workspace/group/…` is
+auto-translated to the corresponding host path, so the simplest flow is:
+
+1. Write the file under your CWD, e.g. `./chart.png` (which is
+   `/workspace/group/chart.png` inside the container).
+2. In your reply, write `![](/workspace/group/chart.png)`.
+
+Text that surrounds an attachment marker is delivered as a separate text
+message in order — keep captions short and put them on their own line.
+
 ---
 
 ## Admin Context

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@onecli-sh/sdk": "^0.2.0",
         "better-sqlite3": "11.10.0",
-        "cron-parser": "5.5.0"
+        "cron-parser": "5.5.0",
+        "qrcode-terminal": "^0.12.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -2715,6 +2716,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@onecli-sh/sdk": "^0.2.0",
     "better-sqlite3": "11.10.0",
-    "cron-parser": "5.5.0"
+    "cron-parser": "5.5.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/scripts/weixin-login.ts
+++ b/scripts/weixin-login.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Interactive WeChat QR-code login.
+ *
+ * Usage:  npx tsx scripts/weixin-login.ts [--base-url <url>]
+ *
+ * Reads WEIXIN_BASE_URL from .env if --base-url is not given.
+ * Renders the QR code to the terminal and writes bot_token, baseUrl, userId
+ * to store/weixin/accounts/<accountId>.account.json on success.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DEFAULT_WEIXIN_BASE_URL } from '../src/channels/weixin/api.js';
+import { runQrLogin } from '../src/channels/weixin/auth.js';
+
+function parseArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function readEnvBaseUrl(): string | undefined {
+  const envPath = path.resolve(process.cwd(), '.env');
+  try {
+    const lines = fs.readFileSync(envPath, 'utf-8').split('\n');
+    for (const line of lines) {
+      const m = /^\s*WEIXIN_BASE_URL\s*=\s*(.+?)\s*$/.exec(line);
+      if (m) {
+        return m[1].replace(/^['"]|['"]$/g, '');
+      }
+    }
+  } catch {
+    /* no .env */
+  }
+  return undefined;
+}
+
+async function renderQrToTerminal(qrUrl: string): Promise<void> {
+  try {
+    const qrterm = await import('qrcode-terminal');
+    await new Promise<void>((resolve) => {
+      qrterm.default.generate(qrUrl, { small: true }, (qr: string) => {
+        process.stdout.write(qr + '\n');
+        resolve();
+      });
+    });
+  } catch {
+    process.stdout.write(
+      '(qrcode-terminal not available — open this URL on another device to scan)\n',
+    );
+  }
+  process.stdout.write(
+    `\n二维码链接（如果终端渲染失败可手动打开）：\n${qrUrl}\n\n`,
+  );
+}
+
+async function main(): Promise<void> {
+  const baseUrl =
+    parseArg('--base-url') ||
+    process.env.WEIXIN_BASE_URL ||
+    readEnvBaseUrl() ||
+    DEFAULT_WEIXIN_BASE_URL;
+
+  process.stdout.write(`正在获取登录二维码... (baseUrl=${baseUrl})\n\n`);
+
+  const result = await runQrLogin({
+    baseUrl,
+    events: {
+      onQr: async (qrUrl, isRefresh) => {
+        if (isRefresh) {
+          process.stdout.write('\n🔄 二维码已刷新，请重新扫描：\n\n');
+        } else {
+          process.stdout.write('使用微信扫描以下二维码以登录：\n\n');
+        }
+        await renderQrToTerminal(qrUrl);
+      },
+      onScanned: () => {
+        process.stdout.write('\n👀 已扫码，请在微信中继续确认...\n');
+      },
+    },
+  });
+
+  if (result.connected) {
+    process.stdout.write(
+      `\n${result.message}\naccountId=${result.accountId}\nuserId=${result.userId ?? '(unknown)'}\n`,
+    );
+    process.exit(0);
+  }
+  process.stderr.write(`\n${result.message}\n`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Login failed: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/weixin-send-media.ts
+++ b/scripts/weixin-send-media.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env tsx
+/**
+ * Manual smoke test for the outbound WeChat media pipeline.
+ *
+ * Usage:
+ *   npx tsx scripts/weixin-send-media.ts <filePath> [--to <ilink_user_id>]
+ *
+ * Reads the default account from store/weixin/, resolves a recipient
+ * (either explicit --to, or the most recent inbound user from the
+ * context-tokens cache), then uploads the file and sends it.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  DEFAULT_WEIXIN_BASE_URL,
+  DEFAULT_WEIXIN_CDN_BASE_URL,
+} from '../src/channels/weixin/api.js';
+import { sendWeixinMediaFile } from '../src/channels/weixin/send-media.js';
+import {
+  getDefaultAccount,
+  loadContextTokens,
+  loadWeixinAccount,
+} from '../src/channels/weixin/storage.js';
+
+function parseArg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+async function main() {
+  const filePath = process.argv[2];
+  if (!filePath || filePath.startsWith('--')) {
+    console.error(
+      'Usage: npx tsx scripts/weixin-send-media.ts <filePath> [--to <userId>] [--caption "…"]',
+    );
+    process.exit(2);
+  }
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    console.error(`file not found: ${resolved}`);
+    process.exit(2);
+  }
+
+  const accountId = getDefaultAccount();
+  if (!accountId) {
+    console.error('no weixin default account — run scripts/weixin-login.ts');
+    process.exit(2);
+  }
+  const account = loadWeixinAccount(accountId);
+  if (!account?.token || !account.baseUrl) {
+    console.error(`weixin account ${accountId} incomplete`);
+    process.exit(2);
+  }
+
+  const tokens = loadContextTokens(accountId);
+  const explicitTo = parseArg('--to');
+  const to = explicitTo ?? Object.keys(tokens)[0];
+  if (!to) {
+    console.error(
+      'no recipient: pass --to <userId>, or send yourself a text first so a context token is cached',
+    );
+    process.exit(2);
+  }
+  const contextToken = tokens[to];
+
+  console.log(
+    `sending file=${resolved} to=${to} via baseUrl=${account.baseUrl ?? DEFAULT_WEIXIN_BASE_URL}`,
+  );
+  console.log(
+    `contextToken=${contextToken ? '[cached]' : '[missing — server will likely reject]'}`,
+  );
+
+  await sendWeixinMediaFile({
+    filePath: resolved,
+    to,
+    caption: parseArg('--caption'),
+    opts: {
+      baseUrl: account.baseUrl,
+      token: account.token,
+      contextToken,
+    },
+    cdnBaseUrl: DEFAULT_WEIXIN_CDN_BASE_URL,
+  });
+  console.log('ok');
+}
+
+main().catch((err) => {
+  console.error('weixin-send-media failed:', err);
+  process.exit(1);
+});

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -122,6 +122,17 @@ export async function run(_args: string[]): Promise<void> {
     channelAuth.whatsapp = 'authenticated';
   }
 
+  // WeChat: check for a logged-in default account under store/weixin/
+  const weixinDefaultAccount = path.join(
+    projectRoot,
+    'store',
+    'weixin',
+    'default-account',
+  );
+  if (fs.existsSync(weixinDefaultAccount)) {
+    channelAuth.weixin = 'authenticated';
+  }
+
   // Token-based channels: check .env
   if (process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN) {
     channelAuth.telegram = 'configured';

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -10,3 +10,5 @@
 // telegram
 
 // whatsapp
+
+import './weixin.js';

--- a/src/channels/weixin.test.ts
+++ b/src/channels/weixin.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { buildTextMessage, sendMessage } from './weixin/api.js';
+import { parseWeixinMessage } from './weixin/inbound.js';
+import { normalizeAccountId } from './weixin/storage.js';
+import {
+  MessageItemType,
+  MessageState,
+  MessageType,
+  type WeixinMessage,
+} from './weixin/types.js';
+
+describe('weixin normalizeAccountId', () => {
+  it('replaces @ and . so accountId is filesystem-safe', () => {
+    expect(normalizeAccountId('abc123@im.bot')).toBe('abc123-im-bot');
+    expect(normalizeAccountId('plain')).toBe('plain');
+  });
+});
+
+describe('weixin parseWeixinMessage', () => {
+  it('returns null when from_user_id is empty', () => {
+    expect(parseWeixinMessage({ from_user_id: '' }, undefined)).toBeNull();
+  });
+
+  it('filters messages sent by ourselves', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'bot',
+      item_list: [{ type: MessageItemType.TEXT, text_item: { text: 'hi' } }],
+    };
+    expect(parseWeixinMessage(msg, 'bot')).toBeNull();
+  });
+
+  it('decodes plain text messages', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'u-1',
+      create_time_ms: 1_700_000_000_000,
+      context_token: 'ctx-1',
+      client_id: 'cid-1',
+      item_list: [{ type: MessageItemType.TEXT, text_item: { text: 'hello' } }],
+    };
+    const parsed = parseWeixinMessage(msg, 'other-bot');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.jid).toBe('wx:u-1');
+    expect(parsed!.contextToken).toBe('ctx-1');
+    expect(parsed!.message.content).toBe('hello');
+    expect(parsed!.message.id).toBe('cid-1');
+    expect(parsed!.message.sender).toBe('u-1');
+    expect(parsed!.message.is_from_me).toBe(false);
+  });
+
+  it('prefixes the current text with a quoted-context block when ref_msg has text', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'u-2',
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: 'reply' },
+          ref_msg: {
+            title: 'orig',
+            message_item: {
+              type: MessageItemType.TEXT,
+              text_item: { text: 'body' },
+            },
+          },
+        },
+      ],
+    };
+    const parsed = parseWeixinMessage(msg, undefined);
+    expect(parsed!.message.content).toBe('[引用: orig | body]\nreply');
+  });
+
+  it('keeps only the current text when the quoted message is media', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'u-3',
+      item_list: [
+        {
+          type: MessageItemType.TEXT,
+          text_item: { text: 'look' },
+          ref_msg: { message_item: { type: MessageItemType.IMAGE } },
+        },
+      ],
+    };
+    const parsed = parseWeixinMessage(msg, undefined);
+    expect(parsed!.message.content).toBe('look');
+  });
+
+  it('falls back to a media placeholder for image-only messages', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'u-4',
+      item_list: [{ type: MessageItemType.IMAGE }],
+    };
+    const parsed = parseWeixinMessage(msg, undefined);
+    expect(parsed!.message.content).toBe('[图片]');
+  });
+
+  it('uses the transcript when a voice item carries text', () => {
+    const msg: WeixinMessage = {
+      from_user_id: 'u-5',
+      item_list: [
+        { type: MessageItemType.VOICE, voice_item: { text: 'hi from voice' } },
+      ],
+    };
+    const parsed = parseWeixinMessage(msg, undefined);
+    expect(parsed!.message.content).toBe('hi from voice');
+  });
+});
+
+describe('weixin buildTextMessage', () => {
+  it('builds a SendMessageReq wrapping a single TEXT item', () => {
+    const req = buildTextMessage({
+      to: 'u-1',
+      text: 'hi',
+      contextToken: 'ctx',
+      clientId: 'cid',
+    });
+    expect(req.msg).toMatchObject({
+      to_user_id: 'u-1',
+      from_user_id: '',
+      client_id: 'cid',
+      message_type: MessageType.BOT,
+      message_state: MessageState.FINISH,
+      context_token: 'ctx',
+      item_list: [{ type: MessageItemType.TEXT, text_item: { text: 'hi' } }],
+    });
+  });
+
+  it('omits item_list when text is empty', () => {
+    const req = buildTextMessage({ to: 'u-1', text: '', clientId: 'cid' });
+    expect(req.msg?.item_list).toBeUndefined();
+  });
+});
+
+describe('weixin sendMessage API', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('POSTs to ilink/bot/sendmessage with Bearer auth and JSON body', async () => {
+    const mock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const body = buildTextMessage({ to: 'u-1', text: 'hi', clientId: 'cid' });
+    await sendMessage({
+      baseUrl: 'https://example.com/api',
+      token: 'secret-token',
+      body,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    const [url, init] = mock.mock.calls[0];
+    expect(url).toBe('https://example.com/api/ilink/bot/sendmessage');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer secret-token');
+    expect(headers.AuthorizationType).toBe('ilink_bot_token');
+    const parsedBody = JSON.parse(init.body as string);
+    expect(parsedBody.msg.to_user_id).toBe('u-1');
+    expect(parsedBody.base_info).toBeDefined();
+  });
+
+  it('throws with the HTTP status when the server rejects the request', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('nope', { status: 403 }),
+      ) as unknown as typeof fetch;
+
+    await expect(
+      sendMessage({
+        baseUrl: 'https://example.com/api',
+        token: 't',
+        body: buildTextMessage({ to: 'u', text: 'x', clientId: 'c' }),
+      }),
+    ).rejects.toThrow(/403/);
+  });
+});

--- a/src/channels/weixin.test.ts
+++ b/src/channels/weixin.test.ts
@@ -19,26 +19,28 @@ describe('weixin normalizeAccountId', () => {
 
 describe('weixin parseWeixinMessage', () => {
   it('returns null when from_user_id is empty', () => {
-    expect(parseWeixinMessage({ from_user_id: '' }, undefined)).toBeNull();
+    expect(parseWeixinMessage({ from_user_id: '' })).toBeNull();
   });
 
-  it('filters messages sent by ourselves', () => {
+  it('filters messages whose message_type is BOT (authored by ourselves)', () => {
     const msg: WeixinMessage = {
-      from_user_id: 'bot',
+      from_user_id: 'u-1',
+      message_type: MessageType.BOT,
       item_list: [{ type: MessageItemType.TEXT, text_item: { text: 'hi' } }],
     };
-    expect(parseWeixinMessage(msg, 'bot')).toBeNull();
+    expect(parseWeixinMessage(msg)).toBeNull();
   });
 
   it('decodes plain text messages', () => {
     const msg: WeixinMessage = {
       from_user_id: 'u-1',
+      message_type: MessageType.USER,
       create_time_ms: 1_700_000_000_000,
       context_token: 'ctx-1',
       client_id: 'cid-1',
       item_list: [{ type: MessageItemType.TEXT, text_item: { text: 'hello' } }],
     };
-    const parsed = parseWeixinMessage(msg, 'other-bot');
+    const parsed = parseWeixinMessage(msg);
     expect(parsed).not.toBeNull();
     expect(parsed!.jid).toBe('wx:u-1');
     expect(parsed!.contextToken).toBe('ctx-1');
@@ -65,7 +67,7 @@ describe('weixin parseWeixinMessage', () => {
         },
       ],
     };
-    const parsed = parseWeixinMessage(msg, undefined);
+    const parsed = parseWeixinMessage(msg);
     expect(parsed!.message.content).toBe('[引用: orig | body]\nreply');
   });
 
@@ -80,7 +82,7 @@ describe('weixin parseWeixinMessage', () => {
         },
       ],
     };
-    const parsed = parseWeixinMessage(msg, undefined);
+    const parsed = parseWeixinMessage(msg);
     expect(parsed!.message.content).toBe('look');
   });
 
@@ -89,7 +91,7 @@ describe('weixin parseWeixinMessage', () => {
       from_user_id: 'u-4',
       item_list: [{ type: MessageItemType.IMAGE }],
     };
-    const parsed = parseWeixinMessage(msg, undefined);
+    const parsed = parseWeixinMessage(msg);
     expect(parsed!.message.content).toBe('[图片]');
   });
 
@@ -100,7 +102,7 @@ describe('weixin parseWeixinMessage', () => {
         { type: MessageItemType.VOICE, voice_item: { text: 'hi from voice' } },
       ],
     };
-    const parsed = parseWeixinMessage(msg, undefined);
+    const parsed = parseWeixinMessage(msg);
     expect(parsed!.message.content).toBe('hi from voice');
   });
 });

--- a/src/channels/weixin.ts
+++ b/src/channels/weixin.ts
@@ -1,0 +1,169 @@
+/**
+ * NanoClaw WeChat channel.
+ *
+ * Wraps the iLink HTTP protocol (ported from @tencent-weixin/openclaw-weixin)
+ * into NanoClaw's Channel interface. Credentials are obtained via a separate
+ * QR-code login step (scripts/weixin-login.ts) and persisted to STORE_DIR.
+ *
+ * JID scheme: `wx:<ilink_user_id>`. WeChat iLink bot chats are 1-on-1 only,
+ * so every JID is a direct chat.
+ */
+import crypto from 'node:crypto';
+
+import { logger } from '../logger.js';
+import { Channel } from '../types.js';
+
+import {
+  buildTextMessage,
+  sendMessage as sendMessageApi,
+} from './weixin/api.js';
+import { runMonitorLoop } from './weixin/monitor.js';
+import { registerChannel } from './registry.js';
+import {
+  getDefaultAccount,
+  loadContextTokens,
+  loadWeixinAccount,
+  saveContextTokens,
+} from './weixin/storage.js';
+
+const WX_JID_PREFIX = 'wx:';
+
+export class WeixinChannel implements Channel {
+  readonly name = 'weixin';
+
+  private accountId: string;
+  private baseUrl: string;
+  private token: string;
+  private botUserId: string | undefined;
+
+  private contextTokens: Record<string, string>;
+  private abortController: AbortController | null = null;
+  private monitorDone: Promise<void> | null = null;
+  private connected = false;
+
+  private onMessage: (
+    chatJid: string,
+    message: import('../types.js').NewMessage,
+  ) => void;
+  private onChatMetadata: import('../types.js').OnChatMetadata;
+
+  constructor(
+    accountId: string,
+    account: { token: string; baseUrl: string; userId?: string },
+    callbacks: {
+      onMessage: (
+        chatJid: string,
+        message: import('../types.js').NewMessage,
+      ) => void;
+      onChatMetadata: import('../types.js').OnChatMetadata;
+    },
+  ) {
+    this.accountId = accountId;
+    this.baseUrl = account.baseUrl;
+    this.token = account.token;
+    this.botUserId = account.userId;
+    this.contextTokens = loadContextTokens(accountId);
+    this.onMessage = callbacks.onMessage;
+    this.onChatMetadata = callbacks.onChatMetadata;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith(WX_JID_PREFIX);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    this.abortController = new AbortController();
+    this.connected = true;
+
+    this.monitorDone = runMonitorLoop({
+      accountId: this.accountId,
+      baseUrl: this.baseUrl,
+      token: this.token,
+      ownBotUserId: this.botUserId,
+      abortSignal: this.abortController.signal,
+      onInbound: (parsed) => {
+        if (parsed.contextToken) {
+          this.contextTokens[parsed.message.sender] = parsed.contextToken;
+          saveContextTokens(this.accountId, this.contextTokens);
+        }
+        this.onChatMetadata(
+          parsed.jid,
+          parsed.message.timestamp,
+          undefined,
+          this.name,
+          false,
+        );
+        this.onMessage(parsed.jid, parsed.message);
+      },
+    });
+
+    logger.info(
+      { accountId: this.accountId, baseUrl: this.baseUrl },
+      'weixin channel connected',
+    );
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.connected) return;
+    this.connected = false;
+    this.abortController?.abort();
+    if (this.monitorDone) {
+      try {
+        await this.monitorDone;
+      } catch {
+        // monitor loop exits via its own abort handling — ignore
+      }
+    }
+    this.abortController = null;
+    this.monitorDone = null;
+    logger.info({ accountId: this.accountId }, 'weixin channel disconnected');
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.ownsJid(jid)) {
+      throw new Error(`weixin: not owner of jid ${jid}`);
+    }
+    const userId = jid.slice(WX_JID_PREFIX.length);
+    const contextToken = this.contextTokens[userId];
+    if (!contextToken) {
+      logger.warn(
+        { accountId: this.accountId, userId },
+        'weixin sendMessage: no contextToken cached — reply may be rejected by server',
+      );
+    }
+
+    const req = buildTextMessage({
+      to: userId,
+      text,
+      contextToken,
+      clientId: crypto.randomUUID(),
+    });
+
+    await sendMessageApi({
+      baseUrl: this.baseUrl,
+      token: this.token,
+      body: req,
+    });
+  }
+}
+
+registerChannel('weixin', ({ onMessage, onChatMetadata }) => {
+  const accountId = getDefaultAccount();
+  if (!accountId) {
+    logger.info(
+      'weixin channel not configured (no account logged in) — skipping',
+    );
+    return null;
+  }
+  const account = loadWeixinAccount(accountId);
+  if (!account?.token || !account.baseUrl) {
+    logger.warn({ accountId }, 'weixin account file is incomplete — skipping');
+    return null;
+  }
+  return new WeixinChannel(accountId, account, { onMessage, onChatMetadata });
+});

--- a/src/channels/weixin.ts
+++ b/src/channels/weixin.ts
@@ -9,15 +9,22 @@
  * so every JID is a direct chat.
  */
 import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
+import { GROUPS_DIR } from '../config.js';
 import { logger } from '../logger.js';
-import { Channel } from '../types.js';
+import { Channel, RegisteredGroup } from '../types.js';
 
 import {
   buildTextMessage,
+  DEFAULT_WEIXIN_CDN_BASE_URL,
   sendMessage as sendMessageApi,
 } from './weixin/api.js';
 import { runMonitorLoop } from './weixin/monitor.js';
+import { parseOutboundSegments } from './weixin/outbound-parse.js';
+import { sendWeixinMediaFile } from './weixin/send-media.js';
 import { registerChannel } from './registry.js';
 import {
   getDefaultAccount,
@@ -45,6 +52,7 @@ export class WeixinChannel implements Channel {
     message: import('../types.js').NewMessage,
   ) => void;
   private onChatMetadata: import('../types.js').OnChatMetadata;
+  private registeredGroups: () => Record<string, RegisteredGroup>;
 
   constructor(
     accountId: string,
@@ -55,6 +63,7 @@ export class WeixinChannel implements Channel {
         message: import('../types.js').NewMessage,
       ) => void;
       onChatMetadata: import('../types.js').OnChatMetadata;
+      registeredGroups: () => Record<string, RegisteredGroup>;
     },
   ) {
     this.accountId = accountId;
@@ -63,6 +72,7 @@ export class WeixinChannel implements Channel {
     this.contextTokens = loadContextTokens(accountId);
     this.onMessage = callbacks.onMessage;
     this.onChatMetadata = callbacks.onChatMetadata;
+    this.registeredGroups = callbacks.registeredGroups;
   }
 
   ownsJid(jid: string): boolean {
@@ -134,13 +144,34 @@ export class WeixinChannel implements Channel {
       );
     }
 
+    const segments = parseOutboundSegments(text);
+    if (segments.length === 0) return;
+
+    for (const segment of segments) {
+      if (segment.kind === 'text') {
+        await this.sendTextSegment(userId, segment.text, contextToken);
+      } else {
+        await this.sendAttachmentSegment(
+          jid,
+          userId,
+          segment.filePath,
+          contextToken,
+        );
+      }
+    }
+  }
+
+  private async sendTextSegment(
+    userId: string,
+    text: string,
+    contextToken: string | undefined,
+  ): Promise<void> {
     const req = buildTextMessage({
       to: userId,
       text,
       contextToken,
       clientId: crypto.randomUUID(),
     });
-
     try {
       await sendMessageApi({
         baseUrl: this.baseUrl,
@@ -164,9 +195,69 @@ export class WeixinChannel implements Channel {
       throw err;
     }
   }
+
+  private resolveContainerPath(jid: string, rawPath: string): string | null {
+    const CONTAINER_PREFIX = '/workspace/group/';
+    if (!rawPath.startsWith(CONTAINER_PREFIX)) return null;
+    const group = this.registeredGroups()[jid];
+    if (!group?.folder) return null;
+    const rest = rawPath.slice(CONTAINER_PREFIX.length);
+    return path.join(GROUPS_DIR, group.folder, rest);
+  }
+
+  private async sendAttachmentSegment(
+    jid: string,
+    userId: string,
+    rawPath: string,
+    contextToken: string | undefined,
+  ): Promise<void> {
+    const resolved =
+      this.resolveContainerPath(jid, rawPath) ?? expandTilde(rawPath);
+    if (!path.isAbsolute(resolved) || !fs.existsSync(resolved)) {
+      logger.warn(
+        { accountId: this.accountId, userId, rawPath, resolved },
+        'weixin attachment not found on host — falling back to link text',
+      );
+      await this.sendTextSegment(
+        userId,
+        `[attachment missing: ${rawPath}]`,
+        contextToken,
+      );
+      return;
+    }
+
+    try {
+      await sendWeixinMediaFile({
+        filePath: resolved,
+        to: userId,
+        opts: {
+          baseUrl: this.baseUrl,
+          token: this.token,
+          contextToken,
+        },
+        cdnBaseUrl: DEFAULT_WEIXIN_CDN_BASE_URL,
+      });
+    } catch (err) {
+      logger.error(
+        { accountId: this.accountId, userId, rawPath, err: String(err) },
+        'weixin send attachment failed',
+      );
+      await this.sendTextSegment(
+        userId,
+        `[attachment send failed: ${path.basename(resolved)}]`,
+        contextToken,
+      );
+    }
+  }
 }
 
-registerChannel('weixin', ({ onMessage, onChatMetadata }) => {
+function expandTilde(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+registerChannel('weixin', ({ onMessage, onChatMetadata, registeredGroups }) => {
   const accountId = getDefaultAccount();
   if (!accountId) {
     logger.info(
@@ -179,5 +270,9 @@ registerChannel('weixin', ({ onMessage, onChatMetadata }) => {
     logger.warn({ accountId }, 'weixin account file is incomplete — skipping');
     return null;
   }
-  return new WeixinChannel(accountId, account, { onMessage, onChatMetadata });
+  return new WeixinChannel(accountId, account, {
+    onMessage,
+    onChatMetadata,
+    registeredGroups,
+  });
 });

--- a/src/channels/weixin.ts
+++ b/src/channels/weixin.ts
@@ -34,7 +34,6 @@ export class WeixinChannel implements Channel {
   private accountId: string;
   private baseUrl: string;
   private token: string;
-  private botUserId: string | undefined;
 
   private contextTokens: Record<string, string>;
   private abortController: AbortController | null = null;
@@ -61,7 +60,6 @@ export class WeixinChannel implements Channel {
     this.accountId = accountId;
     this.baseUrl = account.baseUrl;
     this.token = account.token;
-    this.botUserId = account.userId;
     this.contextTokens = loadContextTokens(accountId);
     this.onMessage = callbacks.onMessage;
     this.onChatMetadata = callbacks.onChatMetadata;
@@ -84,7 +82,6 @@ export class WeixinChannel implements Channel {
       accountId: this.accountId,
       baseUrl: this.baseUrl,
       token: this.token,
-      ownBotUserId: this.botUserId,
       abortSignal: this.abortController.signal,
       onInbound: (parsed) => {
         if (parsed.contextToken) {
@@ -144,11 +141,28 @@ export class WeixinChannel implements Channel {
       clientId: crypto.randomUUID(),
     });
 
-    await sendMessageApi({
-      baseUrl: this.baseUrl,
-      token: this.token,
-      body: req,
-    });
+    try {
+      await sendMessageApi({
+        baseUrl: this.baseUrl,
+        token: this.token,
+        body: req,
+      });
+      logger.info(
+        {
+          accountId: this.accountId,
+          userId,
+          len: text.length,
+          hasContextToken: Boolean(contextToken),
+        },
+        'weixin sendMessage ok',
+      );
+    } catch (err) {
+      logger.error(
+        { accountId: this.accountId, userId, err: String(err) },
+        'weixin sendMessage failed',
+      );
+      throw err;
+    }
   }
 }
 

--- a/src/channels/weixin/api.ts
+++ b/src/channels/weixin/api.ts
@@ -23,6 +23,16 @@ import { MessageItemType, MessageState, MessageType } from './types.js';
 
 const CHANNEL_VERSION = 'nanoclaw-weixin/0.1.0';
 
+/**
+ * Values copied from the Tencent `@tencent-weixin/openclaw-weixin` v2.1.9
+ * package.json — the iLink backend (and the CDN it redirects you to) checks
+ * both of these headers. Mismatched / missing values surface as opaque
+ * 500 / -5102031 CDN errors, so keep them in sync with the upstream plugin.
+ */
+const ILINK_APP_ID = 'bot';
+/** 2.1.9 -> (2<<16) | (1<<8) | 9 = 131593. */
+const ILINK_APP_CLIENT_VERSION = (2 << 16) | (1 << 8) | 9;
+
 /** Tencent's public iLink bot backend. No auth/approval needed to hit it. */
 export const DEFAULT_WEIXIN_BASE_URL = 'https://ilinkai.weixin.qq.com';
 
@@ -56,6 +66,8 @@ function buildHeaders(token?: string, body?: string): Record<string, string> {
     'Content-Type': 'application/json',
     AuthorizationType: 'ilink_bot_token',
     'X-WECHAT-UIN': randomWechatUin(),
+    'iLink-App-Id': ILINK_APP_ID,
+    'iLink-App-ClientVersion': String(ILINK_APP_CLIENT_VERSION),
   };
   if (body) {
     headers['Content-Length'] = String(Buffer.byteLength(body, 'utf-8'));
@@ -107,7 +119,10 @@ async function apiGet(params: {
   const timer = setTimeout(() => controller.abort(), params.timeoutMs);
   try {
     const res = await fetch(url.toString(), {
-      headers: { 'iLink-App-ClientVersion': '1' },
+      headers: {
+        'iLink-App-Id': ILINK_APP_ID,
+        'iLink-App-ClientVersion': String(ILINK_APP_CLIENT_VERSION),
+      },
       signal: controller.signal,
     });
     const rawText = await res.text();

--- a/src/channels/weixin/api.ts
+++ b/src/channels/weixin/api.ts
@@ -1,0 +1,218 @@
+/**
+ * WeChat iLink HTTP API wrapper.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v1.0.3 (src/api/api.ts,
+ * src/auth/login-qr.ts). Adapted for NanoClaw: OpenClaw SDK dependencies
+ * removed (logger, redact, config-route-tag), Node's native fetch used
+ * directly, all state and persistence moved to the caller.
+ */
+import crypto from 'node:crypto';
+
+import { logger } from '../../logger.js';
+
+import type {
+  GetUpdatesResp,
+  QRCodeResponse,
+  QRStatusResponse,
+  SendMessageReq,
+  WeixinMessage,
+} from './types.js';
+import { MessageItemType, MessageState, MessageType } from './types.js';
+
+const CHANNEL_VERSION = 'nanoclaw-weixin/0.1.0';
+
+/** Tencent's public iLink bot backend. No auth/approval needed to hit it. */
+export const DEFAULT_WEIXIN_BASE_URL = 'https://ilinkai.weixin.qq.com';
+
+const DEFAULT_LONG_POLL_TIMEOUT_MS = 35_000;
+const DEFAULT_API_TIMEOUT_MS = 15_000;
+const QR_LONG_POLL_TIMEOUT_MS = 35_000;
+
+export const DEFAULT_ILINK_BOT_TYPE = '3';
+
+export interface WeixinApiOptions {
+  baseUrl: string;
+  token?: string;
+  timeoutMs?: number;
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function randomWechatUin(): string {
+  const uint32 = crypto.randomBytes(4).readUInt32BE(0);
+  return Buffer.from(String(uint32), 'utf-8').toString('base64');
+}
+
+function buildHeaders(token?: string, body?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    AuthorizationType: 'ilink_bot_token',
+    'X-WECHAT-UIN': randomWechatUin(),
+  };
+  if (body) {
+    headers['Content-Length'] = String(Buffer.byteLength(body, 'utf-8'));
+  }
+  if (token?.trim()) {
+    headers.Authorization = `Bearer ${token.trim()}`;
+  }
+  return headers;
+}
+
+async function apiPost(params: {
+  baseUrl: string;
+  endpoint: string;
+  body: string;
+  token?: string;
+  timeoutMs: number;
+  label: string;
+}): Promise<string> {
+  const url = new URL(params.endpoint, ensureTrailingSlash(params.baseUrl));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), params.timeoutMs);
+  try {
+    const res = await fetch(url.toString(), {
+      method: 'POST',
+      headers: buildHeaders(params.token, params.body),
+      body: params.body,
+      signal: controller.signal,
+    });
+    const rawText = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `${params.label} ${res.status}: ${rawText.slice(0, 200)}`,
+      );
+    }
+    return rawText;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function apiGet(params: {
+  baseUrl: string;
+  endpoint: string;
+  timeoutMs: number;
+  label: string;
+}): Promise<string> {
+  const url = new URL(params.endpoint, ensureTrailingSlash(params.baseUrl));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), params.timeoutMs);
+  try {
+    const res = await fetch(url.toString(), {
+      headers: { 'iLink-App-ClientVersion': '1' },
+      signal: controller.signal,
+    });
+    const rawText = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `${params.label} ${res.status}: ${rawText.slice(0, 200)}`,
+      );
+    }
+    return rawText;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function getUpdates(
+  opts: WeixinApiOptions & {
+    get_updates_buf?: string;
+    longPollTimeoutMs?: number;
+  },
+): Promise<GetUpdatesResp> {
+  const timeout = opts.longPollTimeoutMs ?? DEFAULT_LONG_POLL_TIMEOUT_MS;
+  try {
+    const raw = await apiPost({
+      baseUrl: opts.baseUrl,
+      endpoint: 'ilink/bot/getupdates',
+      body: JSON.stringify({
+        get_updates_buf: opts.get_updates_buf ?? '',
+        base_info: { channel_version: CHANNEL_VERSION },
+      }),
+      token: opts.token,
+      timeoutMs: timeout,
+      label: 'getUpdates',
+    });
+    return JSON.parse(raw) as GetUpdatesResp;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { ret: 0, msgs: [], get_updates_buf: opts.get_updates_buf };
+    }
+    throw err;
+  }
+}
+
+export async function sendMessage(
+  opts: WeixinApiOptions & {
+    body: SendMessageReq;
+  },
+): Promise<void> {
+  await apiPost({
+    baseUrl: opts.baseUrl,
+    endpoint: 'ilink/bot/sendmessage',
+    body: JSON.stringify({
+      ...opts.body,
+      base_info: { channel_version: CHANNEL_VERSION },
+    }),
+    token: opts.token,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_API_TIMEOUT_MS,
+    label: 'sendMessage',
+  });
+}
+
+/** Build a SendMessageReq carrying a single plain-text item. */
+export function buildTextMessage(params: {
+  to: string;
+  text: string;
+  contextToken?: string;
+  clientId: string;
+}): SendMessageReq {
+  const msg: WeixinMessage = {
+    from_user_id: '',
+    to_user_id: params.to,
+    client_id: params.clientId,
+    message_type: MessageType.BOT,
+    message_state: MessageState.FINISH,
+    item_list: params.text
+      ? [{ type: MessageItemType.TEXT, text_item: { text: params.text } }]
+      : undefined,
+    context_token: params.contextToken,
+  };
+  return { msg };
+}
+
+export async function fetchQRCode(
+  baseUrl: string,
+  botType = DEFAULT_ILINK_BOT_TYPE,
+): Promise<QRCodeResponse> {
+  const raw = await apiGet({
+    baseUrl,
+    endpoint: `ilink/bot/get_bot_qrcode?bot_type=${encodeURIComponent(botType)}`,
+    timeoutMs: DEFAULT_API_TIMEOUT_MS,
+    label: 'fetchQRCode',
+  });
+  return JSON.parse(raw) as QRCodeResponse;
+}
+
+export async function pollQRStatus(
+  baseUrl: string,
+  qrcode: string,
+): Promise<QRStatusResponse> {
+  try {
+    const raw = await apiGet({
+      baseUrl,
+      endpoint: `ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
+      timeoutMs: QR_LONG_POLL_TIMEOUT_MS,
+      label: 'pollQRStatus',
+    });
+    return JSON.parse(raw) as QRStatusResponse;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { status: 'wait' };
+    }
+    logger.warn({ err: String(err) }, 'pollQRStatus error');
+    throw err;
+  }
+}

--- a/src/channels/weixin/api.ts
+++ b/src/channels/weixin/api.ts
@@ -12,6 +12,8 @@ import { logger } from '../../logger.js';
 
 import type {
   GetUpdatesResp,
+  GetUploadUrlReq,
+  GetUploadUrlResp,
   QRCodeResponse,
   QRStatusResponse,
   SendMessageReq,
@@ -23,6 +25,10 @@ const CHANNEL_VERSION = 'nanoclaw-weixin/0.1.0';
 
 /** Tencent's public iLink bot backend. No auth/approval needed to hit it. */
 export const DEFAULT_WEIXIN_BASE_URL = 'https://ilinkai.weixin.qq.com';
+
+/** Tencent's public iLink CDN for encrypted media upload/download. */
+export const DEFAULT_WEIXIN_CDN_BASE_URL =
+  'https://novac2c.cdn.weixin.qq.com/c2c';
 
 const DEFAULT_LONG_POLL_TIMEOUT_MS = 35_000;
 const DEFAULT_API_TIMEOUT_MS = 15_000;
@@ -142,6 +148,33 @@ export async function getUpdates(
     }
     throw err;
   }
+}
+
+export async function getUploadUrl(
+  opts: WeixinApiOptions & GetUploadUrlReq,
+): Promise<GetUploadUrlResp> {
+  const raw = await apiPost({
+    baseUrl: opts.baseUrl,
+    endpoint: 'ilink/bot/getuploadurl',
+    body: JSON.stringify({
+      filekey: opts.filekey,
+      media_type: opts.media_type,
+      to_user_id: opts.to_user_id,
+      rawsize: opts.rawsize,
+      rawfilemd5: opts.rawfilemd5,
+      filesize: opts.filesize,
+      thumb_rawsize: opts.thumb_rawsize,
+      thumb_rawfilemd5: opts.thumb_rawfilemd5,
+      thumb_filesize: opts.thumb_filesize,
+      no_need_thumb: opts.no_need_thumb,
+      aeskey: opts.aeskey,
+      base_info: { channel_version: CHANNEL_VERSION },
+    }),
+    token: opts.token,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_API_TIMEOUT_MS,
+    label: 'getUploadUrl',
+  });
+  return JSON.parse(raw) as GetUploadUrlResp;
 }
 
 export async function sendMessage(

--- a/src/channels/weixin/auth.ts
+++ b/src/channels/weixin/auth.ts
@@ -1,0 +1,103 @@
+/**
+ * Interactive QR-code login flow for WeChat.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v1.0.3 (src/auth/login-qr.ts).
+ * Stateless: caller drives the polling loop and persists the resulting token.
+ */
+import { fetchQRCode, pollQRStatus } from './api.js';
+import {
+  normalizeAccountId,
+  saveWeixinAccount,
+  setDefaultAccount,
+} from './storage.js';
+
+const MAX_QR_REFRESH = 3;
+const POLL_INTERVAL_MS = 1000;
+const DEFAULT_LOGIN_TIMEOUT_MS = 8 * 60_000;
+
+export interface LoginResult {
+  connected: boolean;
+  accountId?: string;
+  userId?: string;
+  message: string;
+}
+
+export interface LoginEvents {
+  onQr: (qrUrl: string, isRefresh: boolean) => void | Promise<void>;
+  onScanned?: () => void;
+  onWaiting?: () => void;
+}
+
+/**
+ * Drive a full QR-login session against the given baseUrl.
+ * Resolves when the user confirms on phone, the QR is abandoned too many
+ * times, or the total timeout expires. Saves credentials on success.
+ */
+export async function runQrLogin(params: {
+  baseUrl: string;
+  botType?: string;
+  timeoutMs?: number;
+  events: LoginEvents;
+}): Promise<LoginResult> {
+  const timeoutMs = params.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  let qr = await fetchQRCode(params.baseUrl, params.botType);
+  await params.events.onQr(qr.qrcode_img_content, false);
+
+  let refreshCount = 1;
+  let scannedNotified = false;
+
+  while (Date.now() < deadline) {
+    const status = await pollQRStatus(params.baseUrl, qr.qrcode);
+
+    switch (status.status) {
+      case 'wait':
+        params.events.onWaiting?.();
+        break;
+      case 'scaned':
+        if (!scannedNotified) {
+          scannedNotified = true;
+          params.events.onScanned?.();
+        }
+        break;
+      case 'expired':
+        refreshCount += 1;
+        if (refreshCount > MAX_QR_REFRESH) {
+          return {
+            connected: false,
+            message: '二维码已过期多次，请重新启动登录。',
+          };
+        }
+        qr = await fetchQRCode(params.baseUrl, params.botType);
+        scannedNotified = false;
+        await params.events.onQr(qr.qrcode_img_content, true);
+        break;
+      case 'confirmed': {
+        if (!status.ilink_bot_id || !status.bot_token) {
+          return {
+            connected: false,
+            message: '登录已确认但服务器未返回 bot_token / ilink_bot_id。',
+          };
+        }
+        const accountId = normalizeAccountId(status.ilink_bot_id);
+        saveWeixinAccount(accountId, {
+          token: status.bot_token,
+          baseUrl: status.baseurl ?? params.baseUrl,
+          userId: status.ilink_user_id,
+        });
+        setDefaultAccount(accountId);
+        return {
+          connected: true,
+          accountId,
+          userId: status.ilink_user_id,
+          message: '✅ 与微信连接成功！',
+        };
+      }
+    }
+
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  return { connected: false, message: '登录超时。' };
+}

--- a/src/channels/weixin/cdn/aes-ecb.ts
+++ b/src/channels/weixin/cdn/aes-ecb.ts
@@ -1,0 +1,21 @@
+/**
+ * AES-128-ECB helpers used by the WeChat iLink CDN upload/download protocol.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/cdn/aes-ecb.ts).
+ */
+import { createCipheriv, createDecipheriv } from 'node:crypto';
+
+export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
+  const cipher = createCipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+}
+
+export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-128-ecb', key, null);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/** Ciphertext size after AES-128-ECB with PKCS7 padding (always multiple of 16). */
+export function aesEcbPaddedSize(plaintextSize: number): number {
+  return Math.ceil((plaintextSize + 1) / 16) * 16;
+}

--- a/src/channels/weixin/cdn/cdn-upload.ts
+++ b/src/channels/weixin/cdn/cdn-upload.ts
@@ -44,6 +44,15 @@ export async function uploadBufferToCdn(params: {
       `${label}: CDN upload URL missing (need upload_full_url or upload_param)`,
     );
   }
+  logger.debug(
+    {
+      label,
+      cdnUrl,
+      ciphertextLen: ciphertext.length,
+      plaintextLen: buf.length,
+    },
+    'weixin cdn upload request',
+  );
 
   let lastError: unknown;
   for (let attempt = 1; attempt <= UPLOAD_MAX_RETRIES; attempt++) {
@@ -60,8 +69,19 @@ export async function uploadBufferToCdn(params: {
         throw new Error(`${label}: CDN client error ${res.status}: ${errMsg}`);
       }
       if (res.status !== 200) {
-        const errMsg =
-          res.headers.get('x-error-message') ?? `status ${res.status}`;
+        const xErr = res.headers.get('x-error-message');
+        const body = await res.text().catch(() => '');
+        logger.warn(
+          {
+            label,
+            status: res.status,
+            xErr,
+            bodyPreview: body.slice(0, 400),
+            allHeaders: Object.fromEntries(res.headers.entries()),
+          },
+          'weixin cdn upload server error — details',
+        );
+        const errMsg = xErr ?? (body.slice(0, 200) || `status ${res.status}`);
         throw new Error(`${label}: CDN server error: ${errMsg}`);
       }
       const downloadParam = res.headers.get('x-encrypted-param') ?? undefined;

--- a/src/channels/weixin/cdn/cdn-upload.ts
+++ b/src/channels/weixin/cdn/cdn-upload.ts
@@ -1,0 +1,93 @@
+/**
+ * POST encrypted buffer to the iLink CDN. The CDN returns the download
+ * encrypted_query_param on the `x-encrypted-param` response header, which the
+ * caller then stores on the outbound MessageItem.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/cdn/cdn-upload.ts).
+ */
+import { logger } from '../../../logger.js';
+
+import { encryptAesEcb } from './aes-ecb.js';
+import { buildCdnUploadUrl } from './cdn-url.js';
+
+const UPLOAD_MAX_RETRIES = 3;
+
+export async function uploadBufferToCdn(params: {
+  buf: Buffer;
+  uploadFullUrl?: string;
+  uploadParam?: string;
+  filekey: string;
+  cdnBaseUrl: string;
+  label: string;
+  aeskey: Buffer;
+}): Promise<{ downloadParam: string }> {
+  const {
+    buf,
+    uploadFullUrl,
+    uploadParam,
+    filekey,
+    cdnBaseUrl,
+    label,
+    aeskey,
+  } = params;
+
+  const ciphertext = encryptAesEcb(buf, aeskey);
+  const trimmedFull = uploadFullUrl?.trim();
+
+  let cdnUrl: string;
+  if (trimmedFull) {
+    cdnUrl = trimmedFull;
+  } else if (uploadParam) {
+    cdnUrl = buildCdnUploadUrl({ cdnBaseUrl, uploadParam, filekey });
+  } else {
+    throw new Error(
+      `${label}: CDN upload URL missing (need upload_full_url or upload_param)`,
+    );
+  }
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= UPLOAD_MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(cdnUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: new Uint8Array(ciphertext),
+      });
+      if (res.status >= 400 && res.status < 500) {
+        const errMsg =
+          res.headers.get('x-error-message') ??
+          (await res.text().catch(() => ''));
+        throw new Error(`${label}: CDN client error ${res.status}: ${errMsg}`);
+      }
+      if (res.status !== 200) {
+        const errMsg =
+          res.headers.get('x-error-message') ?? `status ${res.status}`;
+        throw new Error(`${label}: CDN server error: ${errMsg}`);
+      }
+      const downloadParam = res.headers.get('x-encrypted-param') ?? undefined;
+      if (!downloadParam) {
+        throw new Error(
+          `${label}: CDN response missing x-encrypted-param header`,
+        );
+      }
+      return { downloadParam };
+    } catch (err) {
+      lastError = err;
+      const clientErr =
+        err instanceof Error && err.message.includes('client error');
+      if (clientErr) throw err;
+      if (attempt < UPLOAD_MAX_RETRIES) {
+        logger.warn(
+          { label, attempt, err: String(err) },
+          'weixin cdn upload attempt failed — retrying',
+        );
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `${label}: CDN upload failed after ${UPLOAD_MAX_RETRIES} attempts`,
+      );
+}

--- a/src/channels/weixin/cdn/cdn-url.ts
+++ b/src/channels/weixin/cdn/cdn-url.ts
@@ -1,0 +1,19 @@
+/**
+ * CDN URL builders for WeChat iLink upload/download.
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/cdn/cdn-url.ts).
+ */
+
+export function buildCdnDownloadUrl(
+  encryptedQueryParam: string,
+  cdnBaseUrl: string,
+): string {
+  return `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptedQueryParam)}`;
+}
+
+export function buildCdnUploadUrl(params: {
+  cdnBaseUrl: string;
+  uploadParam: string;
+  filekey: string;
+}): string {
+  return `${params.cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.filekey)}`;
+}

--- a/src/channels/weixin/cdn/upload.ts
+++ b/src/channels/weixin/cdn/upload.ts
@@ -1,0 +1,120 @@
+/**
+ * Local-file → iLink CDN upload pipeline. Produces an UploadedFileInfo the
+ * caller can embed into an outbound MessageItem.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/cdn/upload.ts) —
+ * OpenClaw SDK dependencies stripped, NanoClaw logger used instead.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+
+import { logger } from '../../../logger.js';
+import { getUploadUrl, type WeixinApiOptions } from '../api.js';
+import {
+  UploadMediaType,
+  type UploadMediaTypeValue,
+  type UploadedFileInfo,
+} from '../types.js';
+
+import { aesEcbPaddedSize } from './aes-ecb.js';
+import { uploadBufferToCdn } from './cdn-upload.js';
+
+async function uploadMediaToCdn(params: {
+  filePath: string;
+  toUserId: string;
+  opts: WeixinApiOptions;
+  cdnBaseUrl: string;
+  mediaType: UploadMediaTypeValue;
+  label: string;
+}): Promise<UploadedFileInfo> {
+  const { filePath, toUserId, opts, cdnBaseUrl, mediaType, label } = params;
+
+  const plaintext = await fs.readFile(filePath);
+  const rawsize = plaintext.length;
+  const rawfilemd5 = crypto.createHash('md5').update(plaintext).digest('hex');
+  const filesize = aesEcbPaddedSize(rawsize);
+  const filekey = crypto.randomBytes(16).toString('hex');
+  const aeskey = crypto.randomBytes(16);
+
+  const urlResp = await getUploadUrl({
+    ...opts,
+    filekey,
+    media_type: mediaType,
+    to_user_id: toUserId,
+    rawsize,
+    rawfilemd5,
+    filesize,
+    no_need_thumb: true,
+    aeskey: aeskey.toString('hex'),
+  });
+
+  const uploadFullUrl = urlResp.upload_full_url?.trim();
+  const uploadParam = urlResp.upload_param;
+  if (!uploadFullUrl && !uploadParam) {
+    throw new Error(
+      `${label}: getUploadUrl returned no upload URL (resp=${JSON.stringify(urlResp)})`,
+    );
+  }
+
+  const { downloadParam } = await uploadBufferToCdn({
+    buf: plaintext,
+    uploadFullUrl: uploadFullUrl || undefined,
+    uploadParam: uploadParam ?? undefined,
+    filekey,
+    cdnBaseUrl,
+    aeskey,
+    label: `${label}[filekey=${filekey}]`,
+  });
+
+  logger.info(
+    { label, filekey, rawsize, filesize },
+    'weixin cdn upload complete',
+  );
+
+  return {
+    filekey,
+    downloadEncryptedQueryParam: downloadParam,
+    aeskey: aeskey.toString('hex'),
+    fileSize: rawsize,
+    fileSizeCiphertext: filesize,
+  };
+}
+
+export async function uploadImageToWeixin(params: {
+  filePath: string;
+  toUserId: string;
+  opts: WeixinApiOptions;
+  cdnBaseUrl: string;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({
+    ...params,
+    mediaType: UploadMediaType.IMAGE,
+    label: 'uploadImageToWeixin',
+  });
+}
+
+export async function uploadVideoToWeixin(params: {
+  filePath: string;
+  toUserId: string;
+  opts: WeixinApiOptions;
+  cdnBaseUrl: string;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({
+    ...params,
+    mediaType: UploadMediaType.VIDEO,
+    label: 'uploadVideoToWeixin',
+  });
+}
+
+export async function uploadFileAttachmentToWeixin(params: {
+  filePath: string;
+  toUserId: string;
+  opts: WeixinApiOptions;
+  cdnBaseUrl: string;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({
+    ...params,
+    mediaType: UploadMediaType.FILE,
+    label: 'uploadFileAttachmentToWeixin',
+  });
+}

--- a/src/channels/weixin/inbound.ts
+++ b/src/channels/weixin/inbound.ts
@@ -1,0 +1,108 @@
+/**
+ * Inbound message parsing for WeChat.
+ *
+ * Converts a WeixinMessage from the getUpdates long-poll into the NanoClaw
+ * NewMessage shape that the router can persist and route. Media items are
+ * collapsed into a placeholder string in MVP — full decryption/download is
+ * deferred (requires AES-128-ECB + SILK transcoding from the upstream plugin).
+ */
+import crypto from 'node:crypto';
+
+import { NewMessage } from '../../types.js';
+
+import type { MessageItem, WeixinMessage } from './types.js';
+import { MessageItemType } from './types.js';
+
+function isMediaItem(item: MessageItem): boolean {
+  return (
+    item.type === MessageItemType.IMAGE ||
+    item.type === MessageItemType.VIDEO ||
+    item.type === MessageItemType.FILE ||
+    item.type === MessageItemType.VOICE
+  );
+}
+
+function mediaPlaceholder(item: MessageItem): string {
+  switch (item.type) {
+    case MessageItemType.IMAGE:
+      return '[图片]';
+    case MessageItemType.VIDEO:
+      return '[视频]';
+    case MessageItemType.FILE:
+      return '[文件]';
+    case MessageItemType.VOICE:
+      return '[语音]';
+    default:
+      return '[媒体]';
+  }
+}
+
+function bodyFromItemList(itemList?: MessageItem[]): string {
+  if (!itemList?.length) return '';
+  for (const item of itemList) {
+    if (item.type === MessageItemType.TEXT && item.text_item?.text != null) {
+      const text = String(item.text_item.text);
+      const ref = item.ref_msg;
+      if (!ref) return text;
+      if (ref.message_item && isMediaItem(ref.message_item)) return text;
+      const parts: string[] = [];
+      if (ref.title) parts.push(ref.title);
+      if (ref.message_item) {
+        const inner = bodyFromItemList([ref.message_item]);
+        if (inner) parts.push(inner);
+      }
+      if (!parts.length) return text;
+      return `[引用: ${parts.join(' | ')}]\n${text}`;
+    }
+    // Voice-to-text: use transcript when provided by upstream.
+    if (item.type === MessageItemType.VOICE && item.voice_item?.text) {
+      return String(item.voice_item.text);
+    }
+  }
+  // No text found — surface a media placeholder so Claude at least knows
+  // something was sent.
+  const mediaItem = itemList.find(isMediaItem);
+  if (mediaItem) return mediaPlaceholder(mediaItem);
+  return '';
+}
+
+export interface ParsedInbound {
+  jid: string;
+  message: NewMessage;
+  contextToken?: string;
+}
+
+export function parseWeixinMessage(
+  msg: WeixinMessage,
+  ownBotUserId: string | undefined,
+): ParsedInbound | null {
+  const fromUserId = msg.from_user_id ?? '';
+  if (!fromUserId) return null;
+  if (ownBotUserId && fromUserId === ownBotUserId) return null;
+
+  const content = bodyFromItemList(msg.item_list);
+  if (!content) return null;
+
+  const ts = msg.create_time_ms ?? Date.now();
+  const timestamp = new Date(ts).toISOString();
+  const jid = `wx:${fromUserId}`;
+
+  const id =
+    msg.client_id?.trim() ||
+    (msg.message_id != null ? String(msg.message_id) : undefined) ||
+    crypto.randomUUID();
+
+  return {
+    jid,
+    message: {
+      id,
+      chat_jid: jid,
+      sender: fromUserId,
+      sender_name: fromUserId,
+      content,
+      timestamp,
+      is_from_me: false,
+    },
+    contextToken: msg.context_token,
+  };
+}

--- a/src/channels/weixin/inbound.ts
+++ b/src/channels/weixin/inbound.ts
@@ -11,7 +11,7 @@ import crypto from 'node:crypto';
 import { NewMessage } from '../../types.js';
 
 import type { MessageItem, WeixinMessage } from './types.js';
-import { MessageItemType } from './types.js';
+import { MessageItemType, MessageType } from './types.js';
 
 function isMediaItem(item: MessageItem): boolean {
   return (
@@ -72,13 +72,12 @@ export interface ParsedInbound {
   contextToken?: string;
 }
 
-export function parseWeixinMessage(
-  msg: WeixinMessage,
-  ownBotUserId: string | undefined,
-): ParsedInbound | null {
+export function parseWeixinMessage(msg: WeixinMessage): ParsedInbound | null {
   const fromUserId = msg.from_user_id ?? '';
   if (!fromUserId) return null;
-  if (ownBotUserId && fromUserId === ownBotUserId) return null;
+  // Drop messages authored by the bot itself. The inbound userId of the person
+  // who scanned the QR is the normal counterpart, not us.
+  if (msg.message_type === MessageType.BOT) return null;
 
   const content = bodyFromItemList(msg.item_list);
   if (!content) return null;

--- a/src/channels/weixin/media/mime.ts
+++ b/src/channels/weixin/media/mime.ts
@@ -1,0 +1,43 @@
+/**
+ * MIME routing for outbound WeChat media.
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/media/mime.ts).
+ */
+import path from 'node:path';
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.csv': 'text/csv',
+  '.json': 'application/json',
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.avi': 'video/x-msvideo',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+};
+
+export function getMimeFromFilename(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  return EXTENSION_TO_MIME[ext] ?? 'application/octet-stream';
+}

--- a/src/channels/weixin/monitor.ts
+++ b/src/channels/weixin/monitor.ts
@@ -20,7 +20,6 @@ export interface MonitorOptions {
   accountId: string;
   baseUrl: string;
   token: string;
-  ownBotUserId?: string;
   onInbound: (parsed: ParsedInbound) => void;
   abortSignal: AbortSignal;
 }
@@ -119,7 +118,16 @@ export async function runMonitorLoop(opts: MonitorOptions): Promise<void> {
       }
 
       for (const msg of resp.msgs ?? []) {
-        const parsed = parseWeixinMessage(msg, opts.ownBotUserId);
+        logger.info(
+          {
+            accountId,
+            fromUserId: msg.from_user_id,
+            messageType: msg.message_type,
+            itemTypes: msg.item_list?.map((i) => i.type).join(',') ?? 'none',
+          },
+          'weixin inbound message',
+        );
+        const parsed = parseWeixinMessage(msg);
         if (!parsed) continue;
         try {
           onInbound(parsed);

--- a/src/channels/weixin/monitor.ts
+++ b/src/channels/weixin/monitor.ts
@@ -1,0 +1,154 @@
+/**
+ * Long-poll loop for a single WeChat account.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v1.0.3 (src/monitor/monitor.ts),
+ * simplified to plain callbacks so it plugs into the NanoClaw Channel
+ * abstraction rather than the OpenClaw plugin runtime.
+ */
+import { logger } from '../../logger.js';
+import { getUpdates } from './api.js';
+import { parseWeixinMessage, type ParsedInbound } from './inbound.js';
+import { loadSyncBuf, saveSyncBuf } from './storage.js';
+
+const SESSION_EXPIRED_ERRCODE = -14;
+const MAX_CONSECUTIVE_FAILURES = 3;
+const BACKOFF_DELAY_MS = 30_000;
+const RETRY_DELAY_MS = 2_000;
+const SESSION_PAUSE_MS = 60 * 60_000;
+
+export interface MonitorOptions {
+  accountId: string;
+  baseUrl: string;
+  token: string;
+  ownBotUserId?: string;
+  onInbound: (parsed: ParsedInbound) => void;
+  abortSignal: AbortSignal;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        reject(new Error('aborted'));
+      },
+      { once: true },
+    );
+  });
+}
+
+export async function runMonitorLoop(opts: MonitorOptions): Promise<void> {
+  const { accountId, baseUrl, token, onInbound, abortSignal } = opts;
+
+  let getUpdatesBuf = loadSyncBuf(accountId) ?? '';
+  let consecutiveFailures = 0;
+  let nextTimeoutMs = 35_000;
+
+  logger.info(
+    { accountId, hasPrevBuf: Boolean(getUpdatesBuf) },
+    'weixin monitor started',
+  );
+
+  while (!abortSignal.aborted) {
+    try {
+      const resp = await getUpdates({
+        baseUrl,
+        token,
+        get_updates_buf: getUpdatesBuf,
+        longPollTimeoutMs: nextTimeoutMs,
+      });
+
+      if (resp.longpolling_timeout_ms && resp.longpolling_timeout_ms > 0) {
+        nextTimeoutMs = resp.longpolling_timeout_ms;
+      }
+
+      const isApiError =
+        (resp.ret !== undefined && resp.ret !== 0) ||
+        (resp.errcode !== undefined && resp.errcode !== 0);
+
+      if (isApiError) {
+        const expired =
+          resp.errcode === SESSION_EXPIRED_ERRCODE ||
+          resp.ret === SESSION_EXPIRED_ERRCODE;
+        if (expired) {
+          logger.error(
+            { accountId, ret: resp.ret, errcode: resp.errcode },
+            'weixin session expired, pausing 1h',
+          );
+          consecutiveFailures = 0;
+          try {
+            await sleep(SESSION_PAUSE_MS, abortSignal);
+          } catch {
+            return;
+          }
+          continue;
+        }
+        consecutiveFailures += 1;
+        logger.error(
+          {
+            accountId,
+            ret: resp.ret,
+            errcode: resp.errcode,
+            errmsg: resp.errmsg,
+          },
+          'getUpdates returned error',
+        );
+        try {
+          await sleep(
+            consecutiveFailures >= MAX_CONSECUTIVE_FAILURES
+              ? BACKOFF_DELAY_MS
+              : RETRY_DELAY_MS,
+            abortSignal,
+          );
+        } catch {
+          return;
+        }
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          consecutiveFailures = 0;
+        }
+        continue;
+      }
+
+      consecutiveFailures = 0;
+
+      if (resp.get_updates_buf && resp.get_updates_buf !== getUpdatesBuf) {
+        getUpdatesBuf = resp.get_updates_buf;
+        saveSyncBuf(accountId, getUpdatesBuf);
+      }
+
+      for (const msg of resp.msgs ?? []) {
+        const parsed = parseWeixinMessage(msg, opts.ownBotUserId);
+        if (!parsed) continue;
+        try {
+          onInbound(parsed);
+        } catch (err) {
+          logger.error(
+            { accountId, err: String(err) },
+            'onInbound callback threw',
+          );
+        }
+      }
+    } catch (err) {
+      if (abortSignal.aborted) return;
+      consecutiveFailures += 1;
+      logger.error({ accountId, err: String(err) }, 'getUpdates threw');
+      try {
+        await sleep(
+          consecutiveFailures >= MAX_CONSECUTIVE_FAILURES
+            ? BACKOFF_DELAY_MS
+            : RETRY_DELAY_MS,
+          abortSignal,
+        );
+      } catch {
+        return;
+      }
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        consecutiveFailures = 0;
+      }
+    }
+  }
+
+  logger.info({ accountId }, 'weixin monitor stopped');
+}

--- a/src/channels/weixin/outbound-parse.test.ts
+++ b/src/channels/weixin/outbound-parse.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseOutboundSegments } from './outbound-parse.js';
+
+describe('parseOutboundSegments', () => {
+  it('returns a single text segment when no markers are present', () => {
+    expect(parseOutboundSegments('hello world')).toEqual([
+      { kind: 'text', text: 'hello world' },
+    ]);
+  });
+
+  it('returns nothing for empty / whitespace-only input', () => {
+    expect(parseOutboundSegments('')).toEqual([]);
+    expect(parseOutboundSegments('   \n  ')).toEqual([]);
+  });
+
+  it('extracts a markdown image with plain absolute path', () => {
+    const segments = parseOutboundSegments(
+      'look:\n![shot](/tmp/foo.png)\nnice',
+    );
+    expect(segments).toEqual([
+      { kind: 'text', text: 'look:' },
+      { kind: 'attachment', filePath: '/tmp/foo.png' },
+      { kind: 'text', text: 'nice' },
+    ]);
+  });
+
+  it('extracts a markdown image with a file:// URL', () => {
+    const segments = parseOutboundSegments('![](file:///tmp/bar.jpg)');
+    expect(segments).toEqual([
+      { kind: 'attachment', filePath: '/tmp/bar.jpg' },
+    ]);
+  });
+
+  it('extracts <file:...> markers and preserves ordering', () => {
+    const segments = parseOutboundSegments(
+      'first <file:/tmp/a.pdf> then <file:/tmp/b.png> done',
+    );
+    expect(segments).toEqual([
+      { kind: 'text', text: 'first' },
+      { kind: 'attachment', filePath: '/tmp/a.pdf' },
+      { kind: 'text', text: 'then' },
+      { kind: 'attachment', filePath: '/tmp/b.png' },
+      { kind: 'text', text: 'done' },
+    ]);
+  });
+
+  it('ignores non-absolute paths', () => {
+    const segments = parseOutboundSegments('![](relative.png) hi');
+    expect(segments).toEqual([{ kind: 'text', text: '![](relative.png) hi' }]);
+  });
+
+  it('keeps ~ paths (caller expands)', () => {
+    const segments = parseOutboundSegments('<file:~/Workspace/x.png>');
+    expect(segments).toEqual([
+      { kind: 'attachment', filePath: '~/Workspace/x.png' },
+    ]);
+  });
+});

--- a/src/channels/weixin/outbound-parse.ts
+++ b/src/channels/weixin/outbound-parse.ts
@@ -1,0 +1,74 @@
+/**
+ * Parse an outbound WeChat reply into an ordered list of text / attachment
+ * segments. Supported attachment markers:
+ *
+ *   ![alt](file:///abs/path)  — markdown image with a `file:` URL
+ *   ![alt](/abs/path)         — markdown image with a plain path
+ *   <file:/abs/path>          — generic attachment marker (image, pdf, zip…)
+ *
+ * Paths must be absolute (on the host). The `~` prefix is expanded by the
+ * caller. Anything outside these markers is treated as plain text and
+ * delivered as a separate TEXT message in order.
+ */
+export type OutboundSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'attachment'; filePath: string };
+
+const MARKDOWN_IMG_RE = /!\[[^\]]*\]\(((?:file:\/\/)?[^)\s]+)\)/g;
+const FILE_TAG_RE = /<file:([^>\s]+)>/g;
+
+function isAttachmentPath(raw: string): string | null {
+  let path = raw.trim();
+  if (path.startsWith('file://')) path = path.slice('file://'.length);
+  if (!path) return null;
+  if (path.startsWith('/') || path.startsWith('~')) return path;
+  return null;
+}
+
+interface Marker {
+  start: number;
+  end: number;
+  path: string;
+}
+
+function collectMarkers(text: string): Marker[] {
+  const markers: Marker[] = [];
+  for (const re of [MARKDOWN_IMG_RE, FILE_TAG_RE]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text))) {
+      const resolved = isAttachmentPath(m[1]);
+      if (!resolved) continue;
+      markers.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        path: resolved,
+      });
+    }
+  }
+  return markers.sort((a, b) => a.start - b.start);
+}
+
+export function parseOutboundSegments(text: string): OutboundSegment[] {
+  const markers = collectMarkers(text);
+  if (markers.length === 0) {
+    const trimmed = text.trim();
+    return trimmed ? [{ kind: 'text', text: trimmed }] : [];
+  }
+
+  const out: OutboundSegment[] = [];
+  let cursor = 0;
+  for (const m of markers) {
+    if (m.start > cursor) {
+      const chunk = text.slice(cursor, m.start).trim();
+      if (chunk) out.push({ kind: 'text', text: chunk });
+    }
+    out.push({ kind: 'attachment', filePath: m.path });
+    cursor = m.end;
+  }
+  if (cursor < text.length) {
+    const tail = text.slice(cursor).trim();
+    if (tail) out.push({ kind: 'text', text: tail });
+  }
+  return out;
+}

--- a/src/channels/weixin/send-media.ts
+++ b/src/channels/weixin/send-media.ts
@@ -1,0 +1,178 @@
+/**
+ * High-level "send a local media file to WeChat" helper. Handles MIME routing
+ * and splits the request into two separate sendMessage calls when a caption
+ * accompanies the media — iLink's item_list only accepts one media item per
+ * message.
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v2.1.9 (src/messaging/send-media.ts
+ * + src/messaging/send.ts) — OpenClaw SDK stripped, NanoClaw logger used.
+ */
+import crypto from 'node:crypto';
+import path from 'node:path';
+
+import { logger } from '../../logger.js';
+
+import { sendMessage as sendMessageApi, type WeixinApiOptions } from './api.js';
+import {
+  uploadFileAttachmentToWeixin,
+  uploadImageToWeixin,
+  uploadVideoToWeixin,
+} from './cdn/upload.js';
+import { getMimeFromFilename } from './media/mime.js';
+import {
+  MessageItemType,
+  MessageState,
+  MessageType,
+  type MessageItem,
+  type SendMessageReq,
+  type UploadedFileInfo,
+} from './types.js';
+
+function generateClientId(): string {
+  return `nanoclaw-weixin-${crypto.randomUUID()}`;
+}
+
+function buildCdnMediaBlock(uploaded: UploadedFileInfo) {
+  return {
+    encrypt_query_param: uploaded.downloadEncryptedQueryParam,
+    aes_key: Buffer.from(uploaded.aeskey).toString('base64'),
+    encrypt_type: 1,
+  };
+}
+
+function buildImageItem(uploaded: UploadedFileInfo): MessageItem {
+  return {
+    type: MessageItemType.IMAGE,
+    image_item: {
+      media: buildCdnMediaBlock(uploaded),
+      mid_size: uploaded.fileSizeCiphertext,
+    },
+  };
+}
+
+function buildVideoItem(uploaded: UploadedFileInfo): MessageItem {
+  return {
+    type: MessageItemType.VIDEO,
+    video_item: {
+      media: buildCdnMediaBlock(uploaded),
+      video_size: uploaded.fileSizeCiphertext,
+    },
+  };
+}
+
+function buildFileItem(
+  uploaded: UploadedFileInfo,
+  fileName: string,
+): MessageItem {
+  return {
+    type: MessageItemType.FILE,
+    file_item: {
+      media: buildCdnMediaBlock(uploaded),
+      file_name: fileName,
+      len: String(uploaded.fileSize),
+    },
+  };
+}
+
+async function sendOneItem(params: {
+  to: string;
+  item: MessageItem;
+  opts: WeixinApiOptions & { contextToken?: string };
+}): Promise<void> {
+  const body: SendMessageReq = {
+    msg: {
+      from_user_id: '',
+      to_user_id: params.to,
+      client_id: generateClientId(),
+      message_type: MessageType.BOT,
+      message_state: MessageState.FINISH,
+      item_list: [params.item],
+      context_token: params.opts.contextToken,
+    },
+  };
+  await sendMessageApi({
+    baseUrl: params.opts.baseUrl,
+    token: params.opts.token,
+    timeoutMs: params.opts.timeoutMs,
+    body,
+  });
+}
+
+/**
+ * Upload a local file and send it as a WeChat message, routed by MIME:
+ *   video/*  → VIDEO item
+ *   image/*  → IMAGE item
+ *   other    → FILE attachment
+ *
+ * If a caption is supplied it is sent as a separate TEXT message first, so the
+ * media `item_list` stays single-item (iLink requirement).
+ */
+export async function sendWeixinMediaFile(params: {
+  filePath: string;
+  to: string;
+  caption?: string;
+  opts: WeixinApiOptions & { contextToken?: string };
+  cdnBaseUrl: string;
+}): Promise<void> {
+  const { filePath, to, caption, opts, cdnBaseUrl } = params;
+  const mime = getMimeFromFilename(filePath);
+  const uploadOpts: WeixinApiOptions = {
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+  };
+
+  let item: MessageItem;
+  if (mime.startsWith('video/')) {
+    const uploaded = await uploadVideoToWeixin({
+      filePath,
+      toUserId: to,
+      opts: uploadOpts,
+      cdnBaseUrl,
+    });
+    item = buildVideoItem(uploaded);
+  } else if (mime.startsWith('image/')) {
+    const uploaded = await uploadImageToWeixin({
+      filePath,
+      toUserId: to,
+      opts: uploadOpts,
+      cdnBaseUrl,
+    });
+    item = buildImageItem(uploaded);
+  } else {
+    const uploaded = await uploadFileAttachmentToWeixin({
+      filePath,
+      toUserId: to,
+      opts: uploadOpts,
+      cdnBaseUrl,
+    });
+    item = buildFileItem(uploaded, path.basename(filePath));
+  }
+
+  if (caption && caption.trim()) {
+    const textBody: SendMessageReq = {
+      msg: {
+        from_user_id: '',
+        to_user_id: to,
+        client_id: generateClientId(),
+        message_type: MessageType.BOT,
+        message_state: MessageState.FINISH,
+        item_list: [
+          { type: MessageItemType.TEXT, text_item: { text: caption } },
+        ],
+        context_token: opts.contextToken,
+      },
+    };
+    await sendMessageApi({
+      baseUrl: opts.baseUrl,
+      token: opts.token,
+      timeoutMs: opts.timeoutMs,
+      body: textBody,
+    });
+  }
+
+  await sendOneItem({ to, item, opts });
+  logger.info(
+    { to, filePath, mime, hasCaption: Boolean(caption?.trim()) },
+    'weixin sendWeixinMediaFile ok',
+  );
+}

--- a/src/channels/weixin/storage.ts
+++ b/src/channels/weixin/storage.ts
@@ -1,0 +1,145 @@
+/**
+ * On-disk persistence for WeChat accounts.
+ *
+ * Layout under STORE_DIR/weixin/:
+ *   accounts/<accountId>.account.json         - { token, baseUrl, userId }
+ *   accounts/<accountId>.context-tokens.json  - { [userId]: contextToken }
+ *   accounts/<accountId>.sync.json            - { get_updates_buf }
+ *   default-account                           - plain-text file, the accountId to auto-load
+ *
+ * All filenames use a normalized accountId: the raw iLink bot id
+ * `xxx@im.bot` is rewritten to `xxx-im-bot` so it's filesystem-safe.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { STORE_DIR } from '../../config.js';
+import { logger } from '../../logger.js';
+
+export const WEIXIN_STORE_DIR = path.join(STORE_DIR, 'weixin');
+const ACCOUNTS_DIR = path.join(WEIXIN_STORE_DIR, 'accounts');
+const DEFAULT_ACCOUNT_FILE = path.join(WEIXIN_STORE_DIR, 'default-account');
+
+export interface WeixinAccountData {
+  token: string;
+  baseUrl: string;
+  userId?: string;
+}
+
+export function normalizeAccountId(rawAccountId: string): string {
+  return rawAccountId.replace(/[@.]/g, '-');
+}
+
+function accountFilePath(accountId: string, suffix: string): string {
+  return path.join(ACCOUNTS_DIR, `${accountId}.${suffix}`);
+}
+
+function ensureAccountsDir(): void {
+  fs.mkdirSync(ACCOUNTS_DIR, { recursive: true });
+}
+
+export function saveWeixinAccount(
+  accountId: string,
+  data: WeixinAccountData,
+): void {
+  ensureAccountsDir();
+  fs.writeFileSync(
+    accountFilePath(accountId, 'account.json'),
+    JSON.stringify(data, null, 2),
+    'utf-8',
+  );
+}
+
+export function loadWeixinAccount(
+  accountId: string,
+): WeixinAccountData | undefined {
+  try {
+    const raw = fs.readFileSync(
+      accountFilePath(accountId, 'account.json'),
+      'utf-8',
+    );
+    return JSON.parse(raw) as WeixinAccountData;
+  } catch {
+    return undefined;
+  }
+}
+
+export function listWeixinAccountIds(): string[] {
+  if (!fs.existsSync(ACCOUNTS_DIR)) return [];
+  return fs
+    .readdirSync(ACCOUNTS_DIR)
+    .filter((f) => f.endsWith('.account.json'))
+    .map((f) => f.replace(/\.account\.json$/, ''));
+}
+
+export function setDefaultAccount(accountId: string): void {
+  fs.mkdirSync(WEIXIN_STORE_DIR, { recursive: true });
+  fs.writeFileSync(DEFAULT_ACCOUNT_FILE, accountId, 'utf-8');
+}
+
+export function getDefaultAccount(): string | undefined {
+  try {
+    const raw = fs.readFileSync(DEFAULT_ACCOUNT_FILE, 'utf-8').trim();
+    return raw || undefined;
+  } catch {
+    // If no explicit default, fall back to the first account we find.
+    const ids = listWeixinAccountIds();
+    return ids[0];
+  }
+}
+
+export function loadContextTokens(accountId: string): Record<string, string> {
+  try {
+    const raw = fs.readFileSync(
+      accountFilePath(accountId, 'context-tokens.json'),
+      'utf-8',
+    );
+    return JSON.parse(raw) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+export function saveContextTokens(
+  accountId: string,
+  tokens: Record<string, string>,
+): void {
+  ensureAccountsDir();
+  try {
+    fs.writeFileSync(
+      accountFilePath(accountId, 'context-tokens.json'),
+      JSON.stringify(tokens),
+      'utf-8',
+    );
+  } catch (err) {
+    logger.warn({ err: String(err) }, 'weixin: persist context tokens failed');
+  }
+}
+
+export function loadSyncBuf(accountId: string): string | undefined {
+  try {
+    const raw = fs.readFileSync(
+      accountFilePath(accountId, 'sync.json'),
+      'utf-8',
+    );
+    const data = JSON.parse(raw) as { get_updates_buf?: string };
+    return typeof data.get_updates_buf === 'string'
+      ? data.get_updates_buf
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveSyncBuf(accountId: string, buf: string): void {
+  ensureAccountsDir();
+  try {
+    fs.writeFileSync(
+      accountFilePath(accountId, 'sync.json'),
+      JSON.stringify({ get_updates_buf: buf }),
+      'utf-8',
+    );
+  } catch (err) {
+    logger.warn({ err: String(err) }, 'weixin: persist sync buf failed');
+  }
+}

--- a/src/channels/weixin/types.ts
+++ b/src/channels/weixin/types.ts
@@ -41,6 +41,46 @@ export interface RefMessage {
   title?: string;
 }
 
+/** CDN media reference; aes_key is base64-encoded bytes. */
+export interface CDNMedia {
+  encrypt_query_param?: string;
+  aes_key?: string;
+  /** 0 = only fileid encrypted, 1 = packed thumb + mid info. */
+  encrypt_type?: number;
+  full_url?: string;
+}
+
+export interface ImageItem {
+  media?: CDNMedia;
+  thumb_media?: CDNMedia;
+  aeskey?: string;
+  url?: string;
+  mid_size?: number;
+  thumb_size?: number;
+  thumb_height?: number;
+  thumb_width?: number;
+  hd_size?: number;
+}
+
+export interface FileItem {
+  media?: CDNMedia;
+  file_name?: string;
+  md5?: string;
+  /** Plaintext byte length as a decimal string. */
+  len?: string;
+}
+
+export interface VideoItem {
+  media?: CDNMedia;
+  video_size?: number;
+  play_length?: number;
+  video_md5?: string;
+  thumb_media?: CDNMedia;
+  thumb_size?: number;
+  thumb_height?: number;
+  thumb_width?: number;
+}
+
 export interface MessageItem {
   type?: number;
   create_time_ms?: number;
@@ -49,12 +89,56 @@ export interface MessageItem {
   msg_id?: string;
   ref_msg?: RefMessage;
   text_item?: TextItem;
-  // Media items are present in the protocol but not decoded in MVP.
-  // They're kept as unknown pass-through so we don't crash on receive.
-  image_item?: unknown;
+  image_item?: ImageItem;
   voice_item?: { text?: string; [k: string]: unknown };
-  file_item?: unknown;
-  video_item?: unknown;
+  file_item?: FileItem;
+  video_item?: VideoItem;
+}
+
+/** proto: UploadMediaType */
+export const UploadMediaType = {
+  IMAGE: 1,
+  VIDEO: 2,
+  FILE: 3,
+  VOICE: 4,
+} as const;
+
+export type UploadMediaTypeValue =
+  (typeof UploadMediaType)[keyof typeof UploadMediaType];
+
+export interface GetUploadUrlReq {
+  filekey?: string;
+  media_type?: number;
+  to_user_id?: string;
+  rawsize?: number;
+  rawfilemd5?: string;
+  /** Ciphertext size (AES-128-ECB with PKCS7 padding). */
+  filesize?: number;
+  thumb_rawsize?: number;
+  thumb_rawfilemd5?: string;
+  thumb_filesize?: number;
+  no_need_thumb?: boolean;
+  /** hex-encoded AES-128 key. */
+  aeskey?: string;
+}
+
+export interface GetUploadUrlResp {
+  upload_param?: string;
+  thumb_upload_param?: string;
+  /** Full URL preferred when the server returns it. */
+  upload_full_url?: string;
+}
+
+export interface UploadedFileInfo {
+  filekey: string;
+  /** CDN-returned download encrypted_query_param. */
+  downloadEncryptedQueryParam: string;
+  /** Hex-encoded AES-128 key. */
+  aeskey: string;
+  /** Plaintext size in bytes. */
+  fileSize: number;
+  /** Ciphertext size in bytes (AES-128-ECB padded). */
+  fileSizeCiphertext: number;
 }
 
 export interface WeixinMessage {

--- a/src/channels/weixin/types.ts
+++ b/src/channels/weixin/types.ts
@@ -1,0 +1,108 @@
+/**
+ * WeChat iLink protocol types (subset).
+ *
+ * Ported from @tencent-weixin/openclaw-weixin v1.0.3 (src/api/types.ts).
+ * MVP subset: only the fields used for text getUpdates / sendMessage.
+ * Media (image/voice/file/video) fields are kept in enums but not currently
+ * decoded or constructed — they remain as pass-through for forward compat.
+ */
+
+export interface BaseInfo {
+  channel_version?: string;
+}
+
+export const MessageType = {
+  NONE: 0,
+  USER: 1,
+  BOT: 2,
+} as const;
+
+export const MessageItemType = {
+  NONE: 0,
+  TEXT: 1,
+  IMAGE: 2,
+  VOICE: 3,
+  FILE: 4,
+  VIDEO: 5,
+} as const;
+
+export const MessageState = {
+  NEW: 0,
+  GENERATING: 1,
+  FINISH: 2,
+} as const;
+
+export interface TextItem {
+  text?: string;
+}
+
+export interface RefMessage {
+  message_item?: MessageItem;
+  title?: string;
+}
+
+export interface MessageItem {
+  type?: number;
+  create_time_ms?: number;
+  update_time_ms?: number;
+  is_completed?: boolean;
+  msg_id?: string;
+  ref_msg?: RefMessage;
+  text_item?: TextItem;
+  // Media items are present in the protocol but not decoded in MVP.
+  // They're kept as unknown pass-through so we don't crash on receive.
+  image_item?: unknown;
+  voice_item?: { text?: string; [k: string]: unknown };
+  file_item?: unknown;
+  video_item?: unknown;
+}
+
+export interface WeixinMessage {
+  seq?: number;
+  message_id?: number;
+  from_user_id?: string;
+  to_user_id?: string;
+  client_id?: string;
+  create_time_ms?: number;
+  update_time_ms?: number;
+  delete_time_ms?: number;
+  session_id?: string;
+  group_id?: string;
+  message_type?: number;
+  message_state?: number;
+  item_list?: MessageItem[];
+  context_token?: string;
+}
+
+export interface GetUpdatesReq {
+  get_updates_buf?: string;
+}
+
+export interface GetUpdatesResp {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  msgs?: WeixinMessage[];
+  get_updates_buf?: string;
+  longpolling_timeout_ms?: number;
+}
+
+export interface SendMessageReq {
+  msg?: WeixinMessage;
+}
+
+/** QR login responses from ilink/bot/get_bot_qrcode and ilink/bot/get_qrcode_status. */
+export interface QRCodeResponse {
+  qrcode: string;
+  qrcode_img_content: string;
+}
+
+export type QRStatus = 'wait' | 'scaned' | 'confirmed' | 'expired';
+
+export interface QRStatusResponse {
+  status: QRStatus;
+  bot_token?: string;
+  ilink_bot_id?: string;
+  baseurl?: string;
+  ilink_user_id?: string;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const envConfig = readEnvFile([
   'ONECLI_URL',
   'ONECLI_API_KEY',
   'TZ',
+  'ANTHROPIC_BASE_URL',
 ]);
 
 export const ASSISTANT_NAME =
@@ -55,6 +56,8 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY =
   process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+export const ANTHROPIC_BASE_URL =
+  process.env.ANTHROPIC_BASE_URL || envConfig.ANTHROPIC_BASE_URL;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(
   1,
   parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10,

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -8,6 +8,7 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
 // Mock config
 vi.mock('./config.js', () => ({
+  ANTHROPIC_BASE_URL: undefined,
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -45,6 +45,16 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  /** Channel name the inbound arrived on (e.g. `weixin`, `telegram`). Forwarded
+   *  to the agent as `NANOCLAW_CHANNEL` so per-channel formatting rules in
+   *  CLAUDE.md can match by channel regardless of folder name. */
+  channelName?: string;
+}
+
+export interface AgentProgress {
+  kind: 'tool_use' | 'tool_result' | 'thinking';
+  tool?: string;
+  summary: string;
 }
 
 export interface ContainerOutput {
@@ -52,6 +62,7 @@ export interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  progress?: AgentProgress;
 }
 
 interface VolumeMount {
@@ -248,6 +259,7 @@ async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   agentIdentifier?: string,
+  channelName?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
@@ -258,6 +270,12 @@ async function buildContainerArgs(
   // Credentials for this host are still injected by the OneCLI gateway.
   if (ANTHROPIC_BASE_URL) {
     args.push('-e', `ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}`);
+  }
+
+  // Forward the channel the inbound arrived on (weixin / telegram / …) so
+  // the agent can pick channel-specific formatting rules from CLAUDE.md.
+  if (channelName) {
+    args.push('-e', `NANOCLAW_CHANNEL=${channelName}`);
   }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
@@ -323,6 +341,7 @@ export async function runContainerAgent(
     mounts,
     containerName,
     agentIdentifier,
+    input.channelName,
   );
 
   logger.debug(

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  ANTHROPIC_BASE_URL,
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
@@ -252,6 +253,12 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Forward custom Anthropic base URL (e.g. for Kimi / Moonshot proxies).
+  // Credentials for this host are still injected by the OneCLI gateway.
+  if (ANTHROPIC_BASE_URL) {
+    args.push('-e', `ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}`);
+  }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   getRegisteredChannelNames,
 } from './channels/registry.js';
 import {
+  AgentProgress,
   ContainerOutput,
   runContainerAgent,
   writeGroupsSnapshot,
@@ -283,32 +284,52 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
-    if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
-      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
-      if (text) {
-        await channel.sendMessage(chatJid, text);
-        outputSentToUser = true;
+  const output = await runAgent(
+    group,
+    prompt,
+    chatJid,
+    channel.name,
+    async (result) => {
+      // Streaming output callback — called for each agent result
+      if (result.progress) {
+        const line = formatProgressLine(result.progress);
+        if (line) {
+          try {
+            await channel.sendMessage(chatJid, line);
+          } catch (err) {
+            logger.warn(
+              { group: group.name, err: String(err) },
+              'failed to stream progress to channel',
+            );
+          }
+        }
       }
-      // Only reset idle timer on actual results, not session-update markers (result: null)
-      resetIdleTimer();
-    }
 
-    if (result.status === 'success') {
-      queue.notifyIdle(chatJid);
-    }
+      if (result.result) {
+        const raw =
+          typeof result.result === 'string'
+            ? result.result
+            : JSON.stringify(result.result);
+        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+        // Only reset idle timer on actual results, not session-update markers (result: null)
+        resetIdleTimer();
+      }
 
-    if (result.status === 'error') {
-      hadError = true;
-    }
-  });
+      if (result.status === 'success') {
+        queue.notifyIdle(chatJid);
+      }
+
+      if (result.status === 'error') {
+        hadError = true;
+      }
+    },
+  );
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
@@ -336,10 +357,38 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   return true;
 }
 
+const TOOL_ICON: Record<string, string> = {
+  Bash: '🖥',
+  Read: '📄',
+  Write: '✏️',
+  Edit: '✏️',
+  StrReplace: '✏️',
+  Glob: '🔎',
+  Grep: '🔎',
+  WebSearch: '🌐',
+  WebFetch: '🌐',
+  Task: '🤖',
+};
+
+function formatProgressLine(progress: AgentProgress): string {
+  if (progress.kind === 'tool_use') {
+    const icon = progress.tool ? (TOOL_ICON[progress.tool] ?? '🔧') : '🔧';
+    const name = progress.tool ?? 'tool';
+    return progress.summary
+      ? `> ${icon} **${name}** — ${progress.summary}`
+      : `> ${icon} **${name}**`;
+  }
+  if (progress.kind === 'tool_result') {
+    return progress.summary ? `> ↳ ${progress.summary}` : '';
+  }
+  return progress.summary ? `> 💭 ${progress.summary}` : '';
+}
+
 async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
+  channelName: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
@@ -392,6 +441,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        channelName,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),


### PR DESCRIPTION
## Summary

Adds `/add-weixin` as a new feature skill — a NanoClaw channel that speaks the Tencent iLink bot protocol (same backend the official `@tencent-weixin/openclaw-weixin` plugin uses) so NanoClaw can be driven from WeChat via QR-code login.

The skill lives on this branch (`skill/add-weixin`), matching the other channel skills. Once merged, users run it with `/add-weixin` (or `npx tsx scripts/apply-skill.ts .claude/skills/add-weixin && npm run build`).

### What's inside

- `src/channels/weixin/` — iLink HTTP API wrapper, QR-code auth flow, inbound long-poll monitor, per-user context-token cache, on-disk account persistence.
- `src/channels/weixin.ts` — adapter to NanoClaw's `Channel` interface, self-registers at startup.
- `scripts/weixin-login.ts` — interactive terminal QR login (uses `qrcode-terminal`).
- `src/channels/weixin.test.ts` — 12 unit tests covering JID ownership, inbound parsing, outbound build, storage roundtrip.
- `.claude/skills/add-weixin/SKILL.md` — install / usage / troubleshooting docs.
- `.env.example` — new file documenting non-secret knobs and explicitly calling out that real credentials belong in OneCLI.
- `setup/verify.ts` — recognises WeChat authentication (`store/weixin/default-account`) so `/setup` verify doesn't report failed when weixin is the only configured channel.
- `src/container-runner.ts` + `src/config.ts` — plumb `ANTHROPIC_BASE_URL` through to containers so OneCLI can MITM Anthropic-compatible upstreams (Kimi, Moonshot, etc.). The URL itself isn't a secret; API keys remain in OneCLI.

### Design notes

- **JID scheme**: `wx:<ilink_user_id>`. iLink direct chats only (no groups yet).
- **Context tokens**: iLink's `sendmessage` requires echoing back the per-message `context_token` from `getupdates`. Cached per-userId on disk; missing token logs a warning but still attempts send.
- **No OpenClaw SDK dependency**: ported the HTTP shape, dropped all `@openclaw/*` imports (logger, redact, config-route-tag) in favor of native `fetch` + NanoClaw's own logger.
- **Public endpoint default**: `https://ilinkai.weixin.qq.com` is hardcoded as fallback so users don't need to configure `WEIXIN_BASE_URL` unless they route through a private iLink deployment.

## Test plan

- [x] `npm run build` — no TS errors.
- [x] `npm test` — 258 tests pass (19 files, incl. 12 new weixin tests).
- [x] Manual E2E: QR login → message ClawBot → agent runs in container with OneCLI-proxied Kimi → reply arrives in WeChat. Verified `injections_applied=1` on OneCLI side and `weixin sendMessage ok` in NanoClaw logs.
- [ ] Reviewer: cross-check iLink endpoint list against Tencent's upstream plugin (`@tencent-weixin/openclaw-weixin` v1.0.3).
- [ ] Reviewer: confirm JID prefix `wx:` doesn't clash with any existing channel.

Made with [Cursor](https://cursor.com)