### PR TITLE
fix: start credential proxy and load CREDENTIAL_PROXY_HOST from .env

### DIFF
--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 
+import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 
 /** The container runtime binary name. */
@@ -37,7 +38,9 @@ function detectHostGateway(): string {
  * but the proxy must start before any container.
  * The /convert-to-apple-container skill sets this during setup.
  */
-export const PROXY_BIND_HOST = process.env.CREDENTIAL_PROXY_HOST;
+export const PROXY_BIND_HOST =
+  process.env.CREDENTIAL_PROXY_HOST ||
+  readEnvFile(['CREDENTIAL_PROXY_HOST']).CREDENTIAL_PROXY_HOST;
 if (!PROXY_BIND_HOST) {
   throw new Error(
     'CREDENTIAL_PROXY_HOST is not set in .env. Run /convert-to-apple-container to configure.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { OneCLI } from '@onecli-sh/sdk';
 
 import {
   ASSISTANT_NAME,
+  CREDENTIAL_PROXY_PORT,
   DEFAULT_TRIGGER,
   getTriggerPattern,
   GROUPS_DIR,
@@ -28,7 +29,9 @@ import {
 import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
+  PROXY_BIND_HOST,
 } from './container-runtime.js';
+import { startCredentialProxy } from './credential-proxy.js';
 import {
   getAllChats,
   getAllRegisteredGroups,
@@ -548,6 +551,11 @@ function ensureContainerSystemRunning(): void {
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  await startCredentialProxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST);
+  logger.info(
+    { port: CREDENTIAL_PROXY_PORT, host: PROXY_BIND_HOST },
+    'Credential proxy listening',
+  );
   initDatabase();
   logger.info('Database initialized');
   loadState();


### PR DESCRIPTION
## Summary

Two bugs on `skill/apple-container` prevent any Apple Container agent from ever producing a response:

1. **`startCredentialProxy` is never called.** It's defined in `src/credential-proxy.ts` and referenced only from tests. Containers get `ANTHROPIC_BASE_URL=http://<host-gateway>:3001` injected but nothing listens on that port → endless `api_retry` loop inside the container.
2. **`PROXY_BIND_HOST` reads only from `process.env.CREDENTIAL_PROXY_HOST`**, not from `.env`. The rest of the codebase uses `readEnvFile` so values don't pollute `process.env`. As a result `npm test` and the production launchd service both fail with `CREDENTIAL_PROXY_HOST is not set in .env` even when it *is* set in `.env`.

## Changes

- `src/index.ts` — invoke `startCredentialProxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST)` at the top of `main()` and log the bind address.
- `src/container-runtime.ts` — fall back to `readEnvFile(['CREDENTIAL_PROXY_HOST'])` when `process.env` is unset, matching the pattern used in `src/config.ts`.

## Test plan

- [x] `npm test` — 245 tests pass (up from 240; the three previously-crashing suites — `container-runtime`, `routing`, `task-scheduler` — now run)
- [x] `npm run build` — clean
- [x] End-to-end: after applying, a freshly-set-up Telegram bot produced a Claude response through the credential proxy. Before: endless `api_retry`.

Closes #1934