### PR TITLE
fix: detect Apple Container bridge by subnet, not by bridge number

### DIFF
--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -13,17 +13,24 @@ export const CONTAINER_RUNTIME_BIN = 'container';
 
 /**
  * IP address containers use to reach the host machine.
- * Apple Container VMs use a bridge network (192.168.64.x); the host is at the gateway.
- * Detected from the bridge0 interface, falling back to 192.168.64.1.
+ * Apple Container VMs use a bridge network on the 192.168.64.0/24 subnet;
+ * the host sits at the gateway on that subnet.
  */
 export const CONTAINER_HOST_GATEWAY = detectHostGateway();
 
 function detectHostGateway(): string {
-  // Apple Container on macOS: containers reach the host via the bridge network gateway
+  // Apple Container always uses 192.168.64.0/24, but the bridge number
+  // that hosts that subnet is not stable — bridge100 is often already
+  // claimed by Parallels/VMware, pushing Apple Container onto bridge101
+  // or bridge102. Scan every bridge* interface for one on the expected
+  // subnet rather than hard-coding the bridge number.
   const ifaces = os.networkInterfaces();
-  const bridge = ifaces['bridge100'] || ifaces['bridge0'];
-  if (bridge) {
-    const ipv4 = bridge.find((a) => a.family === 'IPv4');
+  for (const name of Object.keys(ifaces)) {
+    if (!name.startsWith('bridge')) continue;
+    const addrs = ifaces[name] || [];
+    const ipv4 = addrs.find(
+      (a) => a.family === 'IPv4' && a.address.startsWith('192.168.64.'),
+    );
     if (ipv4) return ipv4.address;
   }
   // Fallback: Apple Container's default gateway


### PR DESCRIPTION
## Summary

`detectHostGateway()` in `src/container-runtime.ts` hard-codes a lookup of `bridge100` (then `bridge0`) to find the host address containers use to reach the host. Apple Container *does* always use the 192.168.64.0/24 subnet, but the **bridge number** that hosts it is not stable: on machines with Parallels Desktop or VMware Fusion installed, `bridge100` (and sometimes `bridge101`) is already claimed by the other VM runtime before Apple Container starts, and Apple Container lands on `bridge102`.

In that situation the current lookup returns a foreign-network IP (e.g. Parallels' `10.211.55.2`), containers route API traffic to a host with nothing listening on port 3001, and you get `ENOTFOUND` / retry storms with the bot "typing…" then silently giving up.

## Change

Scan every `bridge*` interface for one whose IPv4 address is on `192.168.64.0/24`, instead of hard-coding the bridge number. Falls back to `192.168.64.1` as before if no matching interface is found.

## Test plan

- [x] `npx vitest run src/container-runtime.test.ts` — all 10 tests pass
- [x] `npm run build` — clean
- [x] End-to-end on a Mac with Parallels (bridge100=10.211.55.2, Apple Container on bridge102=192.168.64.1): before → container failed with `api_retry` loop routing to 10.211.55.2; after → gateway resolves to 192.168.64.1, container reaches the credential proxy and the bot responds.

Refs #1103