### PR TITLE
fix: include /opt/homebrew/bin in launchd plist PATH

### DIFF
--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -37,7 +37,7 @@ function generatePlist(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -120,7 +120,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>


### PR DESCRIPTION
## Summary

The launchd plist generated in `setup/service.ts` hard-codes

```
PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
```

On Apple Silicon Macs, Homebrew installs to `/opt/homebrew/bin` — both `brew install node` and Apple Container's `container` binary end up there by default. With the current PATH, an Apple-Silicon user who picks Apple Container as their container runtime sees the service crash immediately with "FATAL: Container runtime failed to start", because `ensureContainerRuntimeRunning()` can't find the `container` binary on launchd's PATH. `KeepAlive` loops the failure forever.

`npm run dev` works fine because the interactive shell gets `/opt/homebrew/bin` via `brew shellenv`. The bug only surfaces once launchd takes over.

## Change

Prepend `/opt/homebrew/bin` to the PATH in the generated plist. This is a no-op on Intel Macs (the directory usually doesn't exist) and fixes every Apple Silicon brew install.

Also updated `setup/service.test.ts` which maintains its own copy of the expected plist string.

## Test plan

- [x] `npx vitest run setup/service.test.ts` — all 10 tests pass
- [x] End-to-end: after applying, `container` resolves correctly from launchd on an Apple Silicon Mac with Homebrew Node + Homebrew Apple Container. Before: PID `-` with non-zero exit every 2s.

Closes #1935