### PR TITLE
fix: container restart recovery — stale heartbeat + orphan claim loop

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,7 +36,7 @@ import {
   type ProviderContainerContribution,
   type VolumeMount,
 } from './providers/provider-container-registry.js';
-import { markContainerRunning, markContainerStopped, sessionDir, writeSessionRouting } from './session-manager.js';
+import { heartbeatPath, markContainerRunning, markContainerStopped, sessionDir, writeSessionRouting } from './session-manager.js';
 import type { AgentGroup, Session } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
@@ -130,6 +130,12 @@ async function spawnContainer(session: Session): Promise<void> {
   );
 
   log.info('Spawning container', { sessionId: session.id, agentGroup: agentGroup.name, containerName });
+
+  // Clear any orphan heartbeat from a previous container instance — the
+  // sweep's ceiling check treats a missing file as "fresh spawn, give grace"
+  // (host-sweep.ts line 87). Without this, the stale mtime can trigger an
+  // immediate kill before the new container touches the file itself.
+  fs.rmSync(heartbeatPath(agentGroup.id, session.id), { force: true });
 
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,7 +36,13 @@ import {
   type ProviderContainerContribution,
   type VolumeMount,
 } from './providers/provider-container-registry.js';
-import { heartbeatPath, markContainerRunning, markContainerStopped, sessionDir, writeSessionRouting } from './session-manager.js';
+import {
+  heartbeatPath,
+  markContainerRunning,
+  markContainerStopped,
+  sessionDir,
+  writeSessionRouting,
+} from './session-manager.js';
 import type { AgentGroup, Session } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -139,10 +139,10 @@ export function getMessageForRetry(
   db: Database.Database,
   messageId: string,
   status: string,
-): { id: string; tries: number } | undefined {
-  return db.prepare('SELECT id, tries FROM messages_in WHERE id = ? AND status = ?').get(messageId, status) as
-    | { id: string; tries: number }
-    | undefined;
+): { id: string; tries: number; processAfter: string | null } | undefined {
+  return db
+    .prepare('SELECT id, tries, process_after as processAfter FROM messages_in WHERE id = ? AND status = ?')
+    .get(messageId, status) as { id: string; tries: number; processAfter: string | null } | undefined;
 }
 
 export function syncProcessingAcks(inDb: Database.Database, outDb: Database.Database): void {

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -159,23 +159,31 @@ async function sweepSession(session: Session): Promise<void> {
       syncProcessingAcks(inDb, outDb);
     }
 
-    const alive = isContainerRunning(session.id);
-
-    // 2. Crashed-container cleanup: processing rows left behind get retried.
-    if (!alive && outDb) {
-      resetStuckProcessingRows(inDb, outDb, session, 'container not running');
+    // 2. Wake a container if work is due and nothing is running. Ordered
+    // before the crashed-container cleanup so a fresh container gets a chance
+    // to clean its own orphan processing_ack rows on startup (see
+    // container/agent-runner/src/db/connection.ts). Otherwise the reset path
+    // would keep bumping process_after into the future, dueCount would stay 0,
+    // and the wake would never fire.
+    const dueCount = countDueMessages(inDb);
+    if (dueCount > 0 && !isContainerRunning(session.id)) {
+      log.info('Waking container for due messages', { sessionId: session.id, count: dueCount });
+      await wakeContainer(session);
     }
+
+    const alive = isContainerRunning(session.id);
 
     // 3. Running-container SLA: absolute ceiling + per-claim stuck rules.
     if (alive && outDb) {
       enforceRunningContainerSla(inDb, outDb, session, agentGroup.id);
     }
 
-    // 4. Wake a container if new work is due and nothing is running.
-    const dueCount = countDueMessages(inDb);
-    if (dueCount > 0 && !isContainerRunning(session.id)) {
-      log.info('Waking container for due messages', { sessionId: session.id, count: dueCount });
-      await wakeContainer(session);
+    // 4. Crashed-container cleanup: processing rows left behind get retried.
+    // Only fires when wake in step 2 didn't pick up the work (no due messages,
+    // or wake failed). resetStuckProcessingRows itself is idempotent — it
+    // skips messages already scheduled for a future retry.
+    if (!alive && outDb) {
+      resetStuckProcessingRows(inDb, outDb, session, 'container not running');
     }
 
     // 5. Recurrence fanout for completed recurring tasks.
@@ -246,9 +254,15 @@ function resetStuckProcessingRows(
   reason: string,
 ): void {
   const claims = getProcessingClaims(outDb);
+  const now = Date.now();
   for (const { message_id } of claims) {
     const msg = getMessageForRetry(inDb, message_id, 'pending');
     if (!msg) continue;
+
+    // Already rescheduled for a future retry — don't bump tries again. The
+    // wake path (sweep step 2) will fire when process_after elapses and a
+    // fresh container will clean the orphan claim on startup.
+    if (msg.processAfter && Date.parse(msg.processAfter) > now) continue;
 
     if (msg.tries >= MAX_TRIES) {
       markMessageFailed(inDb, msg.id);


### PR DESCRIPTION
## Summary

Fixes two related bugs that combined to silently drop inbound messages whenever a container restarted. Symptom: user sends a Telegram (or any channel) message, host logs show the message routed and a container spawned, but the bot never replies — instead the error log fills with `Killing container past absolute ceiling` warnings and eventually `Message marked as failed after max retries`.

### Bug 1: stale `.heartbeat` triggers false ceiling-kill

`src/container-runner.ts`

When a container exits, its `.heartbeat` file is left on disk with the mtime of its last SDK activity. When the same session spawns a new container, the sweep's ceiling check reads that stale mtime and kills the freshly-spawned container within ~1s — before the new instance has had a chance to touch the file itself.

The sweep already has a carve-out for "no heartbeat file" (treated as a fresh spawn, given grace), so removing the orphan file at spawn time restores the intended semantics.

### Bug 2: orphan `processing_ack` claims cause an infinite reset loop

`src/host-sweep.ts`, `src/db/session-db.ts`

When a container exits mid-message, the `processing_ack` row it wrote stays at `status='processing'` in `outbound.db`. The sweep's crashed-container cleanup sees the claim, resets the matching inbound message with `tries++` and a future `process_after`, which drops `dueCount` to 0 and prevents the wake step from firing in the same tick. On the next tick the claim is still there, so the same reset runs again, bumping `tries` and pushing `process_after` further out. The message reaches `MAX_TRIES` and is marked failed without a container ever being spawned to handle it.

Two changes:

1. Reorder sweep so the wake step runs **before** crashed-container cleanup. A fresh container deletes orphan `'processing'` rows on startup (`container/agent-runner/src/db/connection.ts:142`), so once we get it running the claim resolves itself.
2. Make `resetStuckProcessingRows` idempotent: skip messages whose `process_after` is already in the future. The wake path will pick them up when the backoff elapses. Requires returning `process_after` from `getMessageForRetry`.

Bug 1 on its own is what triggers the false kills that produce the orphan claims in the first place. Bug 2 is what makes those orphan claims unrecoverable. Both needed fixing — with bug 1 unfixed, bug 2 strands messages; with bug 2 unfixed, any legitimate crash would have the same effect.

## Test plan

- [x] Host test suite passes (`pnpm test` — 214/214)
- [x] Verified live: sent a Telegram DM, container spawned cleanly, bot replied normally
- [ ] Reviewer to verify: no regression in the normal "container claimed and completed a message" path (step 1 `syncProcessingAcks` still runs first)
- [ ] Reviewer to verify: if wake in step 2 fails (e.g. spawn error), step 4 still resets orphan claims on the next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)