### PR TITLE
fix(chat-sdk-bridge): encode option index in callback_data for Telegram 64-byte cap

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -81,6 +81,26 @@ export interface ChatSdkBridgeConfig {
  * chunk boundary will render as two independent blocks on the receiving
  * platform, which is the same behavior as manually re-opening a fence.
  */
+/**
+ * Decode the actual option value from a button callback. Buttons are encoded
+ * with an integer index (to keep under Telegram's 64-byte callback_data cap),
+ * and the real value is looked up via `getAskQuestionRender(questionId)`.
+ * Falls back to treating the tail as a literal value so old in-flight cards
+ * (encoded before this shortening landed) still resolve.
+ */
+function resolveSelectedOption(
+  render: { options: NormalizedOption[] } | undefined,
+  eventValue: string | undefined,
+  tail: string | undefined,
+): string {
+  const candidate = eventValue ?? tail ?? '';
+  if (render && /^\d+$/.test(candidate)) {
+    const idx = Number(candidate);
+    if (render.options[idx]) return render.options[idx].value;
+  }
+  return candidate;
+}
+
 export function splitForLimit(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];
@@ -240,11 +260,15 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         const parts = event.actionId.split(':');
         if (parts.length < 3) return;
         const questionId = parts[1];
-        const selectedOption = event.value || '';
+        const tail = parts.slice(2).join(':');
         const userId = event.user?.userId || '';
 
         // Resolve render metadata BEFORE dispatching onAction (which deletes the row).
         const render = getAskQuestionRender(questionId);
+        // New format: button id/value is an integer index into options (kept
+        // short to fit Telegram's 64-byte callback_data cap). Old format:
+        // the full value is embedded in actionId/value directly.
+        const selectedOption = resolveSelectedOption(render, event.value, tail);
         const title = render?.title ?? '❓ Question';
         const matched = render?.options.find((o) => o.value === selectedOption);
         const selectedLabel = matched?.selectedLabel ?? selectedOption ?? '(clicked)';
@@ -348,8 +372,13 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           children: [
             CardText(question),
             Actions(
-              options.map((opt) =>
-                Button({ id: `ncq:${questionId}:${opt.value}`, label: opt.label, value: opt.value }),
+              // Encode button id/value with the option index rather than the
+              // full value. Telegram caps callback_data at 64 bytes, and
+              // long values (e.g. ISO datetimes, URLs) push the JSON payload
+              // well past that. The onAction handlers resolve the index back
+              // to the real value via getAskQuestionRender(questionId).
+              options.map((opt, idx) =>
+                Button({ id: `ncq:${questionId}:${idx}`, label: opt.label, value: String(idx) }),
               ),
             ),
           ],
@@ -507,12 +536,12 @@ async function handleForwardedEvent(
 
       // Parse the selected option from custom_id
       let questionId: string | undefined;
-      let selectedOption: string | undefined;
+      let tail: string | undefined;
       if (customId?.startsWith('ncq:')) {
         const colonIdx = customId.indexOf(':', 4); // after "ncq:"
         if (colonIdx !== -1) {
           questionId = customId.slice(4, colonIdx);
-          selectedOption = customId.slice(colonIdx + 1);
+          tail = customId.slice(colonIdx + 1);
         }
       }
 
@@ -521,6 +550,9 @@ async function handleForwardedEvent(
         ((interaction.message as Record<string, unknown>)?.embeds as Array<Record<string, unknown>>) || [];
       const originalDescription = (originalEmbeds[0]?.description as string) || '';
       const render = questionId ? getAskQuestionRender(questionId) : undefined;
+      // Discord custom_id mirrors the new index-based encoding (see Button
+      // construction). Decode back to the real option value for downstream.
+      const selectedOption = resolveSelectedOption(render, tail, tail);
       const cardTitle = render?.title ?? ((originalEmbeds[0]?.title as string) || '❓ Question');
       const matchedOpt = render?.options.find((o) => o.value === selectedOption);
       const selectedLabel = matchedOpt?.selectedLabel ?? selectedOption ?? customId;


### PR DESCRIPTION
## Summary

`ask_question` cards fail to deliver on Telegram whenever any option has a non-trivial `value` (e.g. an ISO datetime, a URL, or a long token). Telegram limits inline-keyboard `callback_data` to **64 bytes**, and the previous encoding embedded both the questionId and the full option value into each button, producing payloads well over the cap:

- actionId: `` `ncq:${questionId}:${value}` `` (e.g. `ncq:msg-1776962696458-5yvl5i:2026-04-27T10:00:00+03:00` — 54 bytes)
- plus the full value again as `value`
- wrapped by the adapter as `` `chat:${JSON.stringify({a, v})}` `` — total ~100 bytes

Symptom: adapter throws `ValidationError: Callback payload too large for Telegram (max 64 bytes)`, delivery is marked permanently failed after retries (compounded by a separate non-idempotent `pending_questions` insert — noted below but not fixed here), and the agent sits waiting on an answer that never reached the user. Seen live with the scheduling card `"Pick a time for your meeting with Gavriel"` emitting ISO datetime options.

## Fix

Short encoding:
- Button `id` becomes `` `ncq:${questionId}:${idx}` `` and button `value` becomes `String(idx)`. Callback payloads shrink from ~100 bytes to ~40 and fit the 64-byte cap for any option list under ~100 items.
- Both callback-decode sites resolve the index back to the real option value via `getAskQuestionRender(questionId)` before dispatching to `setupConfig.onAction`:
  - `chat.onAction` (Chat SDK path — Telegram, Slack, Teams, gChat, Matrix, Webex, etc.)
  - Discord Gateway `GATEWAY_INTERACTION_CREATE` handler (Discord uses its own `custom_id` path, parallel encoding)
- Downstream handlers (`pending_questions`, `pending_approvals`) are unchanged — they still see the canonical option value.

Backward compatibility:
- `resolveSelectedOption` treats a non-numeric tail as a literal value, so any card delivered under the old encoding still resolves if a user clicks it post-deploy. (`/^\d+$/` check avoids accidentally parsing strings like `"2026-…"` as index `2026`.)

## Out of scope (noted for follow-up)

- **Retry non-idempotency**: `pending_questions` INSERT runs *before* the Telegram send, so when send fails and delivery retries, the retry hits `UNIQUE constraint failed: pending_questions.question_id` and can't make progress. With this fix, normal payloads will no longer trip the 64-byte limit, so the retry path is less likely to trigger — but the underlying non-idempotency should still get a dedicated fix.
- **Adapter-side error quality**: `@chat-adapter/telegram` throws `ValidationError` but the host's delivery layer treats that as a generic retryable error. A future enhancement could inspect the specific error and either skip retry (terminal) or fall back to a plain-text rendering.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test -- --run src/channels src/host-core` — 173/173 pass
- [ ] Reviewer to verify: live deploy handles a `ask_question` with long ISO datetime values (reproducer) — card renders, buttons work, answer routes back into the session
- [ ] Reviewer to verify: Discord still works (custom_id mirrors the same encoding)
- [ ] Reviewer to verify: approval flow (`Approve` / `Deny`, 2 options, short values) still works — this exercises the same code path, just with payloads that were already under the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)