### PR TITLE
fix(delivery): make pending_questions/approvals insert idempotent

### DIFF
--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -97,10 +97,16 @@ export function deleteSession(id: string): void {
 
 // ── Pending Questions ──
 
-export function createPendingQuestion(pq: PendingQuestion): void {
-  getDb()
+/**
+ * Insert a pending question row. Idempotent: when delivery fails and retries,
+ * the second attempt calls this with the same question_id — without `OR
+ * IGNORE` that would throw UNIQUE and prevent the retry from reaching the
+ * actual send step. Returns true if a new row was inserted.
+ */
+export function createPendingQuestion(pq: PendingQuestion): boolean {
+  const result = getDb()
     .prepare(
-      `INSERT INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
+      `INSERT OR IGNORE INTO pending_questions (question_id, session_id, message_out_id, platform_id, channel_type, thread_id, title, options_json, created_at)
        VALUES (@question_id, @session_id, @message_out_id, @platform_id, @channel_type, @thread_id, @title, @options_json, @created_at)`,
     )
     .run({
@@ -114,6 +120,7 @@ export function createPendingQuestion(pq: PendingQuestion): void {
       options_json: JSON.stringify(pq.options),
       created_at: pq.created_at,
     });
+  return result.changes > 0;
 }
 
 export function getPendingQuestion(questionId: string): PendingQuestion | undefined {
@@ -131,16 +138,21 @@ export function deletePendingQuestion(questionId: string): void {
 
 // ── Pending Approvals ──
 
+/**
+ * Insert a pending approval row. Idempotent for the same reason as
+ * createPendingQuestion: delivery retries with the same approval_id must not
+ * fail on UNIQUE before the send step gets a chance to succeed.
+ */
 export function createPendingApproval(
   pa: Partial<PendingApproval> &
     Pick<
       PendingApproval,
       'approval_id' | 'request_id' | 'action' | 'payload' | 'created_at' | 'title' | 'options_json'
     >,
-): void {
-  getDb()
+): boolean {
+  const result = getDb()
     .prepare(
-      `INSERT INTO pending_approvals
+      `INSERT OR IGNORE INTO pending_approvals
          (approval_id, session_id, request_id, action, payload, created_at,
           agent_group_id, channel_type, platform_id, platform_message_id, expires_at, status,
           title, options_json)
@@ -159,6 +171,7 @@ export function createPendingApproval(
       status: 'pending',
       ...pa,
     });
+  return result.changes > 0;
 }
 
 export function getPendingApproval(approvalId: string): PendingApproval | undefined {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -321,7 +321,7 @@ async function deliverMessage(
         questionId: content.questionId,
       });
     } else {
-      createPendingQuestion({
+      const inserted = createPendingQuestion({
         question_id: content.questionId,
         session_id: session.id,
         message_out_id: msg.id,
@@ -332,7 +332,9 @@ async function deliverMessage(
         options: normalizeOptions(rawOptions as never),
         created_at: new Date().toISOString(),
       });
-      log.info('Pending question created', { questionId: content.questionId, sessionId: session.id });
+      if (inserted) {
+        log.info('Pending question created', { questionId: content.questionId, sessionId: session.id });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`createPendingQuestion` and `createPendingApproval` both run before the adapter delivery call in `deliverMessage`. When the adapter send fails, the message goes back into the retry loop, which reinvokes `deliverMessage` with the same `questionId` / `approvalId`. The second attempt hits a plain `INSERT` and fails with:

```
SqliteError: UNIQUE constraint failed: pending_questions.question_id
```

…before ever reaching the send step. Every subsequent retry fails the same way until max-attempts marks the message permanently failed. The agent ends up waiting on an answer the user never gets the chance to give.

Live repro (observed today with a scheduling card on Telegram):

```
16:44:57 Pending question created           questionId=msg-1776962696458-5yvl5i
16:44:57 Message delivery failed, will retry attempt=1 err=ValidationError: Callback payload too large for Telegram (max 64 bytes)
16:44:58 Message delivery failed, will retry attempt=2 err=SqliteError: UNIQUE constraint failed: pending_questions.question_id
16:44:59 Message delivery failed permanently attempts=3 err=SqliteError: UNIQUE constraint failed: pending_questions.question_id
```

The first failure is a separate bug (Telegram 64-byte callback_data limit, fixed in #1942). The second and third failures are this bug — and this bug applies to **any** transient delivery failure: adapter 5xx, rate limit, network blip, etc.

## Fix

Both inserts switch to `INSERT OR IGNORE`. The functions now return `boolean` indicating whether a new row was actually inserted, so the delivery-side log `"Pending question created"` can avoid firing twice for the same card on retry.

Existing callers of `createPendingApproval` discard the return value — safe no-op change.

## Why SQL-layer, not call-site?

- Single place to change, protects any future caller
- No extra DB round-trip (a check-then-insert version would need a SELECT)
- `question_id` / `approval_id` are already PRIMARY KEY — the semantics of "upsert this pending row" are already encoded in the schema
- `OR IGNORE` not `OR REPLACE`: preserves the original `created_at` and any downstream fields from the first attempt, which is the right behavior for retries (the retry has identical intent, not new intent)

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test -- --run` — 173/173 pass
- [ ] Reviewer to verify: trigger a simulated adapter failure (throw during `adapter.deliver`) — retry path now reaches the send step instead of dying at the DB step
- [ ] Reviewer to verify: successful first-attempt path still logs `"Pending question created"` exactly once
- [ ] Reviewer to verify: approval flow still behaves the same on success (no regression from the return-type change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)