### PR TITLE
fix(container-runner): honor agent_provider DB columns with session override

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveProviderName } from './container-runner.js';
+
+describe('resolveProviderName', () => {
+  it('prefers session over group and container.json', () => {
+    expect(resolveProviderName('codex', 'opencode', 'claude')).toBe('codex');
+  });
+
+  it('falls back to group when session is null', () => {
+    expect(resolveProviderName(null, 'codex', 'claude')).toBe('codex');
+  });
+
+  it('falls back to container.json when session and group are null', () => {
+    expect(resolveProviderName(null, null, 'opencode')).toBe('opencode');
+  });
+
+  it('defaults to claude when nothing is set', () => {
+    expect(resolveProviderName(null, null, undefined)).toBe('claude');
+  });
+
+  it('lowercases the resolved name', () => {
+    expect(resolveProviderName('CODEX', null, null)).toBe('codex');
+    expect(resolveProviderName(null, 'OpenCode', null)).toBe('opencode');
+    expect(resolveProviderName(null, null, 'Claude')).toBe('claude');
+  });
+
+  it('treats empty string as unset (falls through)', () => {
+    expect(resolveProviderName('', 'codex', null)).toBe('codex');
+    expect(resolveProviderName(null, '', 'opencode')).toBe('opencode');
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -191,12 +191,31 @@ export function killContainer(sessionId: string, reason: string): void {
   }
 }
 
+/**
+ * Resolve the provider name for a session using the precedence documented in
+ * the provider-install skills:
+ *
+ *   sessions.agent_provider
+ *     → agent_groups.agent_provider
+ *     → container.json `provider`
+ *     → 'claude'
+ *
+ * Pure so the precedence can be unit-tested without a DB or filesystem.
+ */
+export function resolveProviderName(
+  sessionProvider: string | null | undefined,
+  agentGroupProvider: string | null | undefined,
+  containerConfigProvider: string | null | undefined,
+): string {
+  return (sessionProvider || agentGroupProvider || containerConfigProvider || 'claude').toLowerCase();
+}
+
 function resolveProviderContribution(
   session: Session,
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
 ): { provider: string; contribution: ProviderContainerContribution } {
-  const provider = (containerConfig.provider || 'claude').toLowerCase();
+  const provider = resolveProviderName(session.agent_provider, agentGroup.agent_provider, containerConfig.provider);
   const fn = getProviderContainerConfig(provider);
   const contribution = fn
     ? fn({


### PR DESCRIPTION
## Summary

`resolveProviderContribution` in `src/container-runner.ts` read only `containerConfig.provider` (from each group's `container.json`) and ignored both `agent_groups.agent_provider` and `sessions.agent_provider`. The provider-install skills (`/add-opencode`, `/add-codex`) and CLAUDE.md all document those DB columns as the source of truth with session-overrides-group precedence, but the code never consulted them.

**Symptom observed while wiring up Codex:**
- Set `agent_groups.agent_provider = 'codex'` on the CLI group via SQL.
- Restarted the service. Sent a test message.
- The spawned container still ran Claude — agent introduced itself as "Claude Sonnet 4.6 from Anthropic."
- The only way to actually route the group to Codex was to edit `groups/cli-with-gav/container.json` and add `"provider": "codex"` by hand.

## Fix

Extract a pure `resolveProviderName(session, group, containerConfig)` with the precedence the skills have always documented:

```
sessions.agent_provider
  → agent_groups.agent_provider
  → container.json `provider`
  → 'claude'
```

`resolveProviderContribution` now calls it. The `container.json` fallback stays so existing installs that only set provider in JSON keep working unchanged. Empty strings are treated as unset (falls through to the next level) so a DB-backed form writing `''` for "no override" doesn't accidentally pin every session to a provider named `""`.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test -- --run src/container-runner src/host-sweep` — 181/181 pass
- [x] New unit tests in `src/container-runner.test.ts` cover precedence, null-fallthrough, empty-string fallthrough, and case normalization
- [ ] Reviewer to verify: on a fresh install, setting only `agent_groups.agent_provider = 'codex'` routes the next container spawn to Codex (no `container.json` edit needed)
- [ ] Reviewer to verify: an install that has `provider` in `container.json` but no DB value continues to use the container.json value (no regression for existing users)
- [ ] Reviewer to verify: setting `sessions.agent_provider` on one session while leaving the group alone routes only that session to the per-session provider

## Related

- `/add-codex` and `/add-opencode` skill docs describe the DB-column behavior this PR now actually implements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)