### PR TITLE
fix(setup): register step uses engage_mode columns dropped by migration 010

### DIFF
--- a/setup/register.ts
+++ b/setup/register.ts
@@ -167,18 +167,16 @@ export async function run(args: string[]): Promise<void> {
   if (!existing) {
     newlyWired = true;
     const mgaId = generateId('mga');
-    const triggerRules = parsed.trigger
-      ? JSON.stringify({
-          pattern: parsed.trigger,
-          requiresTrigger: parsed.requiresTrigger,
-        })
-      : null;
+    const engageMode = parsed.trigger || !parsed.requiresTrigger ? 'pattern' : 'mention';
+    const engagePattern = parsed.trigger ? parsed.trigger : (!parsed.requiresTrigger ? '.' : null);
     createMessagingGroupAgent({
       id: mgaId,
       messaging_group_id: messagingGroup.id,
       agent_group_id: agentGroup.id,
-      trigger_rules: triggerRules,
-      response_scope: 'all',
+      engage_mode: engageMode,
+      engage_pattern: engagePattern,
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
       session_mode: parsed.sessionMode,
       priority: 0,
       created_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
Migration `010-engage-modes` replaced `trigger_rules` + `response_scope` with the four explicit columns `engage_mode` / `engage_pattern` / `sender_scope` / `ignored_message_policy`, but `setup/register.ts` was missed. Calling the register step on a fresh v2 install fails with:

```
Missing named parameter "engage_mode"
```

This affects every flow that calls register — the `/add-<channel>` skills, `/manage-channels`, the setup auto driver. Hit it during a v2 migration on macOS Docker Desktop while wiring three Telegram channels.

## Mapping (matches migration 010 backfill rule)

| Old | New |
|-----|-----|
| `trigger_rules.pattern` (string) | `engage_mode='pattern'`, `engage_pattern=<pattern>` |
| `requiresTrigger=false`, no pattern | `engage_mode='pattern'`, `engage_pattern='.'` (sentinel) |
| `requiresTrigger=true`, no pattern | `engage_mode='mention'` |
| `response_scope='all'` | `sender_scope='all'`, `ignored_message_policy='drop'` (conservative default) |

## Test plan
- [x] Registered three Telegram channels (1 DM + 2 groups, mix of trigger / no-trigger) on a fresh v2 install — all succeeded.
- [x] Verified resulting `messaging_group_agents` rows have correct `engage_mode` / `engage_pattern` values.
- [x] Confirmed the wired channels actually route messages and engage as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)