### PR TITLE
feat(signal): replyTo shape fix + voice transcription, images, mentions, groupV2

### DIFF
--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -337,7 +337,7 @@ describe('SignalAdapter', () => {
       await adapter.teardown();
     });
 
-    it('skips messages with attachments but no text', async () => {
+    it('forwards image attachments as [Image: <path>] plus structured attachments array', async () => {
       const adapter = createAdapter();
       const cfg = createMockSetup();
       await adapter.setup(cfg);
@@ -352,7 +352,72 @@ describe('SignalAdapter', () => {
       });
 
       await new Promise((r) => setTimeout(r, 50));
-      expect(cfg.onInbound).not.toHaveBeenCalled();
+      expect(cfg.onInbound).toHaveBeenCalledWith(
+        '+15555550123',
+        null,
+        expect.objectContaining({
+          content: expect.objectContaining({
+            text: expect.stringMatching(/^\[Image: .+att123abc\]$/),
+            attachments: [expect.objectContaining({ contentType: 'image/jpeg' })],
+          }),
+        }),
+      );
+
+      await adapter.teardown();
+    });
+  });
+
+  // --- groupV2 ---
+
+  describe('group routing', () => {
+    it('routes to groupV2.id when present, falling back to legacy groupInfo.groupId', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000000000,
+          message: 'hello v2',
+          groupV2: { id: 'v2group=' },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cfg.onInbound).toHaveBeenCalledWith('group:v2group=', null, expect.anything());
+
+      await adapter.teardown();
+    });
+  });
+
+  // --- mention resolution ---
+
+  describe('mention resolution', () => {
+    it('replaces inline mention placeholders with display names', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000000000,
+          message: 'hey ￼ are you here?',
+          mentions: [{ start: 4, length: 1, name: 'Bob', uuid: 'bob-uuid' }],
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cfg.onInbound).toHaveBeenCalledWith(
+        '+15555550123',
+        null,
+        expect.objectContaining({
+          content: expect.objectContaining({ text: 'hey @Bob are you here?' }),
+        }),
+      );
 
       await adapter.teardown();
     });
@@ -361,7 +426,7 @@ describe('SignalAdapter', () => {
   // --- Quote context ---
 
   describe('quote context', () => {
-    it('populates reply_to fields from quoted messages', async () => {
+    it('emits a nested replyTo object matching the formatter contract', async () => {
       const adapter = createAdapter();
       const cfg = createMockSetup();
       await adapter.setup(cfg);
@@ -375,6 +440,7 @@ describe('SignalAdapter', () => {
           quote: {
             id: 1699999999000,
             authorNumber: '+15555550888',
+            authorName: 'Pineapple Pete',
             text: 'Pineapple belongs on pizza',
           },
         },
@@ -387,9 +453,11 @@ describe('SignalAdapter', () => {
         expect.objectContaining({
           content: expect.objectContaining({
             text: 'I disagree',
-            replyToSenderName: '+15555550888',
-            replyToMessageContent: 'Pineapple belongs on pizza',
-            replyToMessageId: '1699999999000',
+            replyTo: {
+              id: '1699999999000',
+              sender: 'Pineapple Pete',
+              text: 'Pineapple belongs on pizza',
+            },
           }),
         }),
       );

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -7,8 +7,8 @@
  *
  * Ported from v1 — see v1 source for commit history.
  */
-import { execFileSync, spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { execFileSync, execSync, spawn } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { createConnection, type Socket } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -281,15 +281,27 @@ class EchoCache {
 
 interface SignalQuote {
   id?: number;
+  author?: string;
   authorNumber?: string;
   authorUuid?: string;
+  authorName?: string;
   text?: string;
+}
+
+interface SignalMention {
+  start?: number;
+  length?: number;
+  uuid?: string;
+  number?: string;
+  name?: string;
 }
 
 interface SignalDataMessage {
   timestamp?: number;
   message?: string;
+  mentions?: SignalMention[];
   groupInfo?: { groupId?: string; groupName?: string; type?: string };
+  groupV2?: { id?: string };
   quote?: SignalQuote;
   attachments?: Array<{
     id?: string;
@@ -316,6 +328,92 @@ interface SignalEnvelope {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Replace inline `@<placeholder>` mention markers with display names so the
+ * agent sees `@Alice` instead of a raw UUID. Signal's protocol uses a single
+ * placeholder character (typically U+FFFC) at each mention's `start` offset.
+ */
+function resolveMentions(text: string, mentions?: SignalMention[]): string {
+  if (!mentions || mentions.length === 0) return text;
+  const sorted = [...mentions].sort((a, b) => (a.start ?? 0) - (b.start ?? 0));
+  let result = '';
+  let cursor = 0;
+  for (const m of sorted) {
+    const start = m.start ?? 0;
+    const length = m.length ?? 1;
+    const name = m.name || m.number || (m.uuid ? m.uuid.slice(0, 8) : 'someone');
+    if (start < cursor) continue;
+    result += text.slice(cursor, start) + `@${name}`;
+    cursor = start + length;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
+/**
+ * Optional voice-note transcription. Tries (in order):
+ *   1. local whisper.cpp CLI when `WHISPER_BIN` is set
+ *   2. OpenAI Whisper API when `OPENAI_API_KEY` is set
+ * Returns null if neither path is configured or transcription fails — caller
+ * falls back to a `[Voice Message]` placeholder.
+ *
+ * Signal voice notes are AAC/ADTS; whisper-cpp wants WAV. ffmpeg is invoked
+ * if available to convert; if ffmpeg is missing the local path is skipped.
+ */
+async function transcribeAudioOptional(filePath: string): Promise<string | null> {
+  const whisperBin = process.env.WHISPER_BIN;
+  if (whisperBin) {
+    try {
+      const wavPath = `${filePath}.wav`;
+      execSync(`ffmpeg -y -loglevel error -i "${filePath}" -ar 16000 -ac 1 "${wavPath}"`, { stdio: 'ignore' });
+      const model = process.env.WHISPER_MODEL || `${homedir()}/.local/share/whisper/models/ggml-base.en.bin`;
+      const out = execSync(`"${whisperBin}" -m "${model}" -f "${wavPath}" -nt -otxt -of "${wavPath}"`, {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      try {
+        unlinkSync(wavPath);
+        unlinkSync(`${wavPath}.txt`);
+      } catch {}
+      const text = out.replace(/\[[^\]]*\]/g, '').trim();
+      if (text) return text;
+    } catch (err) {
+      log.debug('Signal: local whisper transcription failed, trying OpenAI', { err });
+    }
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    try {
+      const buf = readFileSync(filePath);
+      const boundary = `----nanoclaw-${Date.now()}`;
+      const body = Buffer.concat([
+        Buffer.from(
+          `--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\nwhisper-1\r\n--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="audio.aac"\r\nContent-Type: audio/aac\r\n\r\n`,
+        ),
+        buf,
+        Buffer.from(`\r\n--${boundary}--\r\n`),
+      ]);
+      const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': `multipart/form-data; boundary=${boundary}`,
+        },
+        body,
+      });
+      if (res.ok) {
+        const json = (await res.json()) as { text?: string };
+        if (json.text) return json.text.trim();
+      }
+    } catch (err) {
+      log.debug('Signal: OpenAI transcription failed', { err });
+    }
+  }
+
+  return null;
+}
 
 function chunkText(text: string, limit: number): string[] {
   const chunks: string[] = [];
@@ -487,20 +585,26 @@ export function createSignalAdapter(config: {
     const dataMessage = envelope.dataMessage;
     if (!dataMessage) return;
 
-    const text = (dataMessage.message ?? '').trim();
+    const rawText = (dataMessage.message ?? '').trim();
+    const text = rawText ? resolveMentions(rawText, dataMessage.mentions) : '';
 
-    // Check for voice attachments
-    const hasVoice = !text && dataMessage.attachments?.some((a) => a.contentType?.startsWith('audio/'));
+    const audioAttachment = dataMessage.attachments?.find((a) => a.contentType?.startsWith('audio/') && a.id);
+    const imageAttachments = dataMessage.attachments?.filter((a) => a.contentType?.startsWith('image/') && a.id) ?? [];
+    const hasVoice = !text && !!audioAttachment;
 
-    if (!text && !hasVoice) return;
+    if (!text && !hasVoice && imageAttachments.length === 0) return;
 
     const sender = (envelope.sourceNumber ?? envelope.sourceUuid ?? envelope.source ?? '').trim();
     if (!sender) return;
 
     const senderName = (envelope.sourceName?.trim() || sender).trim();
+
+    // Modern Signal groups use groupV2; legacy groupInfo.groupId is the
+    // pre-V2 fallback. Without the V2 read, V2-only groups appear as DMs
+    // because `groupInfo` is undefined.
     const groupInfo = dataMessage.groupInfo;
-    const isGroup = Boolean(groupInfo?.groupId);
-    const groupId = groupInfo?.groupId;
+    const groupId = dataMessage.groupV2?.id ?? groupInfo?.groupId;
+    const isGroup = Boolean(groupId);
 
     const platformId = isGroup ? `group:${groupId}` : sender;
 
@@ -516,29 +620,43 @@ export function createSignalAdapter(config: {
 
     let content = text;
 
-    // Voice attachment — log path, deliver placeholder text.
-    // v2 does not have built-in transcription; a future MCP tool could handle this.
-    if (hasVoice) {
-      const audio = dataMessage.attachments?.find((a) => a.contentType?.startsWith('audio/'));
-      if (audio?.id) {
-        const attachmentPath = join(config.signalDataDir, 'attachments', audio.id);
-        if (existsSync(attachmentPath)) {
-          log.info('Signal: voice attachment received', {
-            platformId,
-            attachmentId: audio.id,
-            path: attachmentPath,
-          });
-          content = '[Voice Message]';
+    // Voice attachment — try transcription if WHISPER_BIN or OPENAI_API_KEY
+    // is configured; otherwise fall back to the original placeholder so
+    // operators who don't want transcription get the same UX as before.
+    if (hasVoice && audioAttachment?.id) {
+      const attachmentPath = join(config.signalDataDir, 'attachments', audioAttachment.id);
+      if (existsSync(attachmentPath)) {
+        log.info('Signal: voice attachment received', {
+          platformId,
+          attachmentId: audioAttachment.id,
+          path: attachmentPath,
+        });
+        const transcript = await transcribeAudioOptional(attachmentPath);
+        if (transcript) {
+          content = `[Voice: ${transcript}]`;
+          log.info('Signal: voice transcribed', { platformId, length: transcript.length });
         } else {
-          log.warn('Signal: voice attachment file not found', {
-            id: audio.id,
-            path: attachmentPath,
-          });
-          content = '[Voice Message - file not found]';
+          content = '[Voice Message]';
         }
       } else {
-        content = '[Voice Message]';
+        log.warn('Signal: voice attachment file not found', {
+          id: audioAttachment.id,
+          path: attachmentPath,
+        });
+        content = '[Voice Message - file not found]';
       }
+    }
+
+    // Image attachments — emit `[Image: <path>]` lines so the agent's Read
+    // tool can pick them up, and surface the structured `attachments` array
+    // for consumers that prefer that shape. Without this, vision-capable
+    // models never see images sent over Signal.
+    const attachmentRefs: Array<{ path: string; contentType: string }> = [];
+    for (const img of imageAttachments) {
+      const imagePath = join(config.signalDataDir, 'attachments', img.id!);
+      const imageLine = `[Image: ${imagePath}]`;
+      content = content ? `${content}\n${imageLine}` : imageLine;
+      attachmentRefs.push({ path: imagePath, contentType: img.contentType || 'image/jpeg' });
     }
 
     const msg: InboundMessage = {
@@ -549,6 +667,7 @@ export function createSignalAdapter(config: {
         sender,
         senderId: `signal:${sender}`,
         senderName,
+        ...(attachmentRefs.length > 0 ? { attachments: attachmentRefs } : {}),
         ...(dataMessage.quote ? quoteToContent(dataMessage.quote) : {}),
       },
       timestamp,
@@ -558,11 +677,25 @@ export function createSignalAdapter(config: {
     log.info('Signal message received', { platformId, sender: senderName });
   }
 
+  /**
+   * Build the `replyTo` object the agent-runner formatter expects (see
+   * `container/agent-runner/src/formatter.ts:formatReplyContext`). The
+   * formatter requires both `sender` and `text` to render the
+   * `<quoted_message>` block; absent either, it omits the block entirely.
+   *
+   * The previous shape (`replyToSenderName` / `replyToMessageContent` /
+   * `replyToMessageId` flat keys) did not match the formatter contract, so
+   * quote-reply context was silently dropped end-to-end.
+   */
   function quoteToContent(quote: SignalQuote): Record<string, unknown> {
+    const sender = quote.authorName || quote.authorNumber || quote.author || quote.authorUuid || 'someone';
+    const text = quote.text || '';
     return {
-      replyToSenderName: quote.authorNumber ?? 'someone',
-      replyToMessageContent: quote.text || undefined,
-      replyToMessageId: quote.id ? String(quote.id) : undefined,
+      replyTo: {
+        id: quote.id ? String(quote.id) : undefined,
+        sender,
+        text,
+      },
     };
   }
 


### PR DESCRIPTION
Builds on the Signal adapter merged in #1953. Six small, additive changes that fill capability gaps and fix one quiet contract bug between the adapter and the agent-runner formatter. Every change preserves the existing factory signature, env var names, and daemon-management flag, so no wiring or operator-side config has to move.

## What's in here

### 1. Quote-reply context now actually reaches the agent (bug fix)

The adapter writes `replyToSenderName` / `replyToMessageContent` / `replyToMessageId` at the top level of `content`. The agent-runner formatter, however, reads a nested `content.replyTo: { sender, text }` and requires both `sender` and `text` to render the `<quoted_message>` block — see `container/agent-runner/src/formatter.ts` `formatReplyContext`. The two halves disagree, so quote context was being silently dropped end-to-end. This PR aligns the adapter to the formatter contract:

```ts
replyTo: {
  id: quote.id ? String(quote.id) : undefined,
  sender: quote.authorName || quote.authorNumber || quote.author || quote.authorUuid || 'someone',
  text: quote.text || '',
}
```

### 2. Voice-note transcription (opt-in, defaults preserve current behavior)

When `WHISPER_BIN` (local whisper.cpp) or `OPENAI_API_KEY` is set, voice notes are transcribed and surface as `[Voice: <transcript>]`. With neither set, behavior matches the prior `[Voice Message]` placeholder exactly. ffmpeg is invoked when present to convert AAC/ADTS → WAV for whisper.cpp; if ffmpeg is missing, the local path is skipped and OpenAI is tried.

### 3. Image attachments are forwarded

Images become `[Image: <path>]` lines in the message text plus a structured `attachments: [{ path, contentType }]` array on `content`. Without this, vision-capable models receive no signal that the user sent a picture.

### 4. Mention resolution

The Signal protocol uses placeholder characters at `mentions[].start` offsets. We rewrite them to `@<displayName>` (falling back to phone, then to a short UUID) so the agent reads `@Bob` instead of a raw UUID or a stray placeholder glyph.

### 5. groupV2 routing

The current code reads `groupInfo.groupId` only. Modern Signal groups arrive on `dataMessage.groupV2.id`, so v2-only groups were being treated as DMs and routed to the wrong messaging group. This PR reads `groupV2.id` first and falls back to the legacy field.

### 6. Quote interface widened

The `SignalQuote` type now also includes `author`, `authorName`, and `authorUuid`, which signal-cli's JSON-RPC envelope does emit on at least some message types. The flat `authorNumber` lookup alone misses some quotes outright.

## Compatibility

- **Factory signature unchanged:** still `createSignalAdapter({ cliPath, account, tcpHost, tcpPort, manageDaemon, signalDataDir })`.
- **Env vars unchanged:** `SIGNAL_ACCOUNT`, `SIGNAL_TCP_HOST`, `SIGNAL_TCP_PORT`, `SIGNAL_CLI_PATH`, `SIGNAL_MANAGE_DAEMON`, `SIGNAL_DATA_DIR`. New optional env vars (`WHISPER_BIN`, `WHISPER_MODEL`, `OPENAI_API_KEY`) have safe-default fallbacks.
- **Daemon management, EchoCache, chunkText, parseSignalStyles** are all left exactly as-is.
- **`src/channels/index.ts` barrel** doesn't change.

## Tests

- Updated existing quote-context test to assert the nested `replyTo` shape.
- Replaced the "skips messages with attachments but no text" test with a positive assertion that image attachments are forwarded as `[Image: …]` plus the `attachments` array.
- Added tests for groupV2 routing and for mention placeholder rewriting.
- Full suite: `pnpm test` → 268/268 pass; `pnpm run build` clean.

## Note on the upstream signal-cli quote field

While preparing this PR we observed that signal-cli 0.13.24 sometimes omits the `quote` field from its JSON-RPC `subscribeReceive` envelope even when the user did long-press → Reply on the mobile client (verified by raw envelope capture; the `JsonDataMessage` Java class declares the field, so the omission is happening before the JSON serializer). That's an upstream concern, not in scope here. The shape fix in this PR is the correct shape for when signal-cli's quote forwarding is reliable; it does no harm when `dataMessage.quote` is absent (the `replyTo` key is simply omitted from `content`).

## Origin / disclosure

These improvements have been running in production in our fork (jorgenclaw/nanoclaw) for the past several weeks. Happy to scope this down into smaller PRs if reviewers prefer — bundling here because each piece touches the same handler and would create merge churn split apart. Code review by AI is welcome and probably more efficient than per-line human review for a change this size; we ran the patch through static analysis and the existing test suite before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)