### PR TITLE
fix: recover or fail conversational turns with no visible reply

### DIFF
--- a/container/agent-runner/src/delivery-activity.test.ts
+++ b/container/agent-runner/src/delivery-activity.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendSendMessageActivity,
+  consumeSendMessageCount,
+  hasVisibleReply,
+  stripInternalTags,
+} from './delivery-activity.js';
+
+function makeActivityFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-activity-'));
+  return path.join(dir, 'activity.log');
+}
+
+function cleanupActivityFile(filePath: string): void {
+  fs.rmSync(path.dirname(filePath), { force: true, recursive: true });
+}
+
+describe('stripInternalTags', () => {
+  it('keeps visible text while removing internal sections', () => {
+    expect(
+      stripInternalTags(
+        'visible <internal>secret</internal> text <internal>hidden</internal>',
+      ),
+    ).toBe('visible  text');
+  });
+});
+
+describe('hasVisibleReply', () => {
+  it('returns false for internal-only and whitespace-only values', () => {
+    expect(hasVisibleReply('<internal>secret</internal>')).toBe(false);
+    expect(hasVisibleReply('   \n\t  ')).toBe(false);
+    expect(hasVisibleReply(undefined)).toBe(false);
+    expect(hasVisibleReply(null)).toBe(false);
+  });
+});
+
+describe('send_message activity', () => {
+  it('treats blank send_message writes as zero delivery activity', () => {
+    const activityFile = makeActivityFile();
+
+    try {
+      appendSendMessageActivity(activityFile, '   \n\t  ');
+
+      expect(consumeSendMessageCount(activityFile)).toBe(0);
+    } finally {
+      cleanupActivityFile(activityFile);
+    }
+  });
+
+  it('counts non-empty send_message delivery exactly once', () => {
+    const activityFile = makeActivityFile();
+
+    try {
+      appendSendMessageActivity(activityFile, 'Message sent');
+
+      expect(consumeSendMessageCount(activityFile)).toBe(1);
+      expect(consumeSendMessageCount(activityFile)).toBe(0);
+    } finally {
+      cleanupActivityFile(activityFile);
+    }
+  });
+});

--- a/container/agent-runner/src/delivery-activity.ts
+++ b/container/agent-runner/src/delivery-activity.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+export function stripInternalTags(text: string): string {
+  return text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+}
+
+export function hasVisibleReply(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return stripInternalTags(text).length > 0;
+}
+
+export function appendSendMessageActivity(
+  filePath: string | undefined,
+  text: string,
+): void {
+  if (!filePath || !text.trim()) return;
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, '1\n', 'utf8');
+}
+
+export function resetSendMessageActivity(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '', 'utf8');
+}
+
+export function consumeSendMessageCount(filePath: string): number {
+  if (!fs.existsSync(filePath)) return 0;
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const count = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean).length;
+
+  resetSendMessageActivity(filePath);
+
+  return count;
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -23,6 +23,15 @@ import {
   PreCompactHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import {
+  consumeSendMessageCount,
+  resetSendMessageActivity,
+} from './delivery-activity.js';
+import {
+  PromptQueue,
+  QueryRunnerMessage,
+  runQueryRunner,
+} from './query-runner.js';
 
 interface ContainerInput {
   prompt: string;
@@ -53,54 +62,9 @@ interface SessionsIndex {
   entries: SessionEntry[];
 }
 
-interface SDKUserMessage {
-  type: 'user';
-  message: { role: 'user'; content: string };
-  parent_tool_use_id: null;
-  session_id: string;
-}
-
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
-
-/**
- * Push-based async iterable for streaming user messages to the SDK.
- * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
- */
-class MessageStream {
-  private queue: SDKUserMessage[] = [];
-  private waiting: (() => void) | null = null;
-  private done = false;
-
-  push(text: string): void {
-    this.queue.push({
-      type: 'user',
-      message: { role: 'user', content: text },
-      parent_tool_use_id: null,
-      session_id: '',
-    });
-    this.waiting?.();
-  }
-
-  end(): void {
-    this.done = true;
-    this.waiting?.();
-  }
-
-  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
-    while (true) {
-      while (this.queue.length > 0) {
-        yield this.queue.shift()!;
-      }
-      if (this.done) return;
-      await new Promise<void>((r) => {
-        this.waiting = r;
-      });
-      this.waiting = null;
-    }
-  }
-}
 
 async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -125,6 +89,13 @@ function writeOutput(output: ContainerOutput): void {
 
 function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
+}
+
+function createSendMessageActivityFilePath(): string {
+  return path.join(
+    '/tmp',
+    `nanoclaw-send-message-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.log`,
+  );
 }
 
 function getSessionSummary(
@@ -383,8 +354,9 @@ async function runQuery(
   lastAssistantUuid?: string;
   closedDuringQuery: boolean;
 }> {
-  const stream = new MessageStream();
-  stream.push(prompt);
+  const promptQueue = new PromptQueue(prompt);
+  const activityFile = createSendMessageActivityFilePath();
+  resetSendMessageActivity(activityFile);
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;
@@ -394,23 +366,18 @@ async function runQuery(
     if (shouldClose()) {
       log('Close sentinel detected during query, ending stream');
       closedDuringQuery = true;
-      stream.end();
+      promptQueue.end();
       ipcPolling = false;
       return;
     }
     const messages = drainIpcInput();
     for (const text of messages) {
       log(`Piping IPC message into active query (${text.length} chars)`);
-      stream.push(text);
+      promptQueue.enqueuePrompt(text);
     }
     setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
   };
   setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
-
-  let newSessionId: string | undefined;
-  let lastAssistantUuid: string | undefined;
-  let messageCount = 0;
-  let resultCount = 0;
 
   // Load global CLAUDE.md as additional system context (shared across all groups)
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
@@ -435,113 +402,83 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
-  for await (const message of query({
-    prompt: stream,
-    options: {
-      cwd: '/workspace/group',
-      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
-      resume: sessionId,
-      resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
-        ? {
-            type: 'preset' as const,
-            preset: 'claude_code' as const,
-            append: globalClaudeMd,
-          }
-        : undefined,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        'TeamCreate',
-        'TeamDelete',
-        'SendMessage',
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*',
-      ],
-      env: sdkEnv,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+  try {
+    const sdkMessages = query({
+      prompt: promptQueue,
+      options: {
+        cwd: '/workspace/group',
+        additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+        resume: sessionId,
+        resumeSessionAt: resumeAt,
+        systemPrompt: globalClaudeMd
+          ? {
+              type: 'preset' as const,
+              preset: 'claude_code' as const,
+              append: globalClaudeMd,
+            }
+          : undefined,
+        allowedTools: [
+          'Bash',
+          'Read',
+          'Write',
+          'Edit',
+          'Glob',
+          'Grep',
+          'WebSearch',
+          'WebFetch',
+          'Task',
+          'TaskOutput',
+          'TaskStop',
+          'TeamCreate',
+          'TeamDelete',
+          'SendMessage',
+          'TodoWrite',
+          'ToolSearch',
+          'Skill',
+          'NotebookEdit',
+          'mcp__nanoclaw__*',
+        ],
+        env: sdkEnv,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        settingSources: ['project', 'user'],
+        mcpServers: {
+          nanoclaw: {
+            command: 'node',
+            args: [mcpServerPath],
+            env: {
+              NANOCLAW_CHAT_JID: containerInput.chatJid,
+              NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+              NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+              NANOCLAW_OUTPUT_ACTIVITY_FILE: activityFile,
+            },
           },
         },
+        hooks: {
+          PreCompact: [
+            { hooks: [createPreCompactHook(containerInput.assistantName)] },
+          ],
+        },
       },
-      hooks: {
-        PreCompact: [
-          { hooks: [createPreCompactHook(containerInput.assistantName)] },
-        ],
-      },
-    },
-  })) {
-    messageCount++;
-    const msgType =
-      message.type === 'system'
-        ? `system/${(message as { subtype?: string }).subtype}`
-        : message.type;
-    log(`[msg #${messageCount}] type=${msgType}`);
+    }) as AsyncIterable<QueryRunnerMessage>;
 
-    if (message.type === 'assistant' && 'uuid' in message) {
-      lastAssistantUuid = (message as { uuid: string }).uuid;
-    }
-
-    if (message.type === 'system' && message.subtype === 'init') {
-      newSessionId = message.session_id;
-      log(`Session initialized: ${newSessionId}`);
-    }
-
-    if (
-      message.type === 'system' &&
-      (message as { subtype?: string }).subtype === 'task_notification'
-    ) {
-      const tn = message as {
-        task_id: string;
-        status: string;
-        summary: string;
-      };
-      log(
-        `Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
-      );
-    }
-
-    if (message.type === 'result') {
-      resultCount++;
-      const textResult =
-        'result' in message ? (message as { result?: string }).result : null;
-      log(
-        `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
-      );
-      writeOutput({
-        status: 'success',
-        result: textResult || null,
-        newSessionId,
-      });
+    return await runQueryRunner({
+      promptQueue,
+      messages: sdkMessages,
+      isScheduledTask: containerInput.isScheduledTask === true,
+      getClosedDuringQuery: () => closedDuringQuery,
+      consumeSendMessageCount: () => consumeSendMessageCount(activityFile),
+      writeOutput,
+    });
+  } finally {
+    ipcPolling = false;
+    promptQueue.end();
+    try {
+      fs.unlinkSync(activityFile);
+    } catch {
+      /* ignore */
     }
   }
-
-  ipcPolling = false;
-  log(
-    `Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`,
-  );
-  return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
 interface ScriptResult {

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
+import { appendSendMessageActivity } from './delivery-activity.js';
 
 const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
@@ -62,6 +63,10 @@ server.tool(
     };
 
     writeIpcFile(MESSAGES_DIR, data);
+    appendSendMessageActivity(
+      process.env.NANOCLAW_OUTPUT_ACTIVITY_FILE,
+      args.text,
+    );
 
     return { content: [{ type: 'text' as const, text: 'Message sent.' }] };
   },

--- a/container/agent-runner/src/query-loop.test.ts
+++ b/container/agent-runner/src/query-loop.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createQueryLoopGuard,
+  NO_REPLY_RECOVERY_PROMPT,
+  QUERY_EXIT_ERROR,
+  RECOVERY_EXHAUSTED_ERROR,
+} from './query-loop.js';
+
+describe('createQueryLoopGuard', () => {
+  it('resolves a conversational round when the final result has visible text', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({ subtype: 'success', resultText: 'visible reply' }),
+    ).toEqual({ type: 'emit-success', resultText: 'visible reply' });
+    expect(guard.onQueryExit({ closedDuringQuery: false })).toEqual({
+      type: 'none',
+    });
+  });
+
+  it('keeps later visible results attached to the same delivered round until the next queued prompt is actually dispatched', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('first prompt');
+    guard.enqueueConversationalPrompt('second prompt');
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({ subtype: 'success', resultText: 'first visible reply' }),
+    ).toEqual({ type: 'emit-success', resultText: 'first visible reply' });
+    expect(
+      guard.onResult({
+        subtype: 'success',
+        resultText: 'second visible reply in same round',
+      }),
+    ).toEqual({
+      type: 'emit-success',
+      resultText: 'second visible reply in same round',
+    });
+
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({ subtype: 'success', resultText: 'next round reply' }),
+    ).toEqual({ type: 'emit-success', resultText: 'next round reply' });
+  });
+
+  it('does not trigger recovery when a later result is empty but the current round already delivered visible output', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({ subtype: 'success', resultText: 'visible reply' }),
+    ).toEqual({ type: 'emit-success', resultText: 'visible reply' });
+    expect(guard.onResult({ subtype: 'success', resultText: '   ' })).toEqual({
+      type: 'none',
+    });
+  });
+
+  it('retries a conversational round once when a success result is empty or internal-only', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(guard.onResult({ subtype: 'success', resultText: '   ' })).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+
+    const secondGuard = createQueryLoopGuard({ isScheduledTask: false });
+    secondGuard.enqueueConversationalPrompt('user prompt');
+    secondGuard.markPromptDispatched();
+
+    expect(
+      secondGuard.onResult({
+        subtype: 'success',
+        resultText: '<internal>secret</internal>',
+      }),
+    ).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+  });
+
+  it('returns an explicit error after a second silent success result', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(guard.onResult({ subtype: 'success', resultText: '' })).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({
+        subtype: 'success',
+        resultText: '<internal>still hidden</internal>',
+      }),
+    ).toEqual({
+      type: 'emit-error',
+      error: RECOVERY_EXHAUSTED_ERROR,
+    });
+  });
+
+  it('counts non-empty send_message as delivery and skips recovery', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+    guard.noteSendMessageDelivery(true);
+
+    expect(guard.onResult({ subtype: 'success', resultText: ' ' })).toEqual({
+      type: 'none',
+    });
+  });
+
+  it('does not count blank send_message activity as delivery', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+    guard.noteSendMessageDelivery(false);
+
+    expect(guard.onResult({ subtype: 'success', resultText: ' ' })).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+  });
+
+  it('does not carry send_message delivery from one resolved round into the next round', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('first prompt');
+    guard.enqueueConversationalPrompt('second prompt');
+    guard.markPromptDispatched();
+    guard.noteSendMessageDelivery(true);
+
+    expect(guard.onResult({ subtype: 'success', resultText: '' })).toEqual({
+      type: 'none',
+    });
+
+    guard.markPromptDispatched();
+
+    expect(guard.onResult({ subtype: 'success', resultText: '' })).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+  });
+
+  it('treats SDK error_* results as explicit errors without recovery', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({
+        subtype: 'error_during_execution',
+        resultText: 'sdk failed',
+      }),
+    ).toEqual({
+      type: 'emit-error',
+      error: 'Claude query returned error_during_execution: sdk failed',
+    });
+  });
+
+  it('returns an explicit error when query exits with an accepted conversational round and no result', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(guard.onQueryExit({ closedDuringQuery: false })).toEqual({
+      type: 'emit-error',
+      error: QUERY_EXIT_ERROR,
+    });
+  });
+
+  it('returns an explicit error when close-sentinel shutdown ends an unresolved conversational round', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('user prompt');
+    guard.markPromptDispatched();
+
+    expect(guard.onQueryExit({ closedDuringQuery: true })).toEqual({
+      type: 'emit-error',
+      error: QUERY_EXIT_ERROR,
+    });
+  });
+
+  it('allows scheduled-task rounds to finish silently on success results and query exit', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: true });
+
+    guard.enqueueConversationalPrompt('scheduled prompt');
+    guard.markPromptDispatched();
+
+    expect(guard.onResult({ subtype: 'success', resultText: '' })).toEqual({
+      type: 'none',
+    });
+    expect(guard.onQueryExit({ closedDuringQuery: false })).toEqual({
+      type: 'none',
+    });
+  });
+
+  it('applies the same guard to follow-up IPC prompts on an existing session', () => {
+    const guard = createQueryLoopGuard({ isScheduledTask: false });
+
+    guard.enqueueConversationalPrompt('first prompt');
+    guard.enqueueConversationalPrompt('follow-up prompt');
+    guard.markPromptDispatched();
+
+    expect(
+      guard.onResult({ subtype: 'success', resultText: 'visible reply' }),
+    ).toEqual({ type: 'emit-success', resultText: 'visible reply' });
+
+    guard.markPromptDispatched();
+
+    expect(guard.onResult({ subtype: 'success', resultText: '' })).toEqual({
+      type: 'recover',
+      prompt: NO_REPLY_RECOVERY_PROMPT,
+    });
+  });
+});

--- a/container/agent-runner/src/query-loop.ts
+++ b/container/agent-runner/src/query-loop.ts
@@ -1,0 +1,135 @@
+import { hasVisibleReply } from './delivery-activity.js';
+
+export const NO_REPLY_RECOVERY_PROMPT =
+  "You completed work for the user's last message but no reply was delivered. Finish.";
+
+export const RECOVERY_EXHAUSTED_ERROR =
+  'Conversational turn completed without a delivered reply after one recovery attempt';
+
+export const QUERY_EXIT_ERROR =
+  'Conversational turn ended without a delivered reply before the query exited';
+
+export type GuardAction =
+  | { type: 'none' }
+  | { type: 'emit-success'; resultText: string | null }
+  | { type: 'recover'; prompt: string }
+  | { type: 'emit-error'; error: string };
+
+interface ActiveRound {
+  delivered: boolean;
+  recoveryAttempted: boolean;
+}
+
+interface QueryLoopOptions {
+  isScheduledTask: boolean;
+}
+
+interface QueryResult {
+  subtype: string;
+  resultText: string | null | undefined;
+}
+
+interface QueryExit {
+  closedDuringQuery: boolean;
+}
+
+export interface QueryLoopGuard {
+  enqueueConversationalPrompt(prompt: string): void;
+  markPromptDispatched(): void;
+  noteSendMessageDelivery(delivered: boolean): void;
+  onResult(result: QueryResult): GuardAction;
+  onQueryExit(exit: QueryExit): GuardAction;
+}
+
+function formatSdkError(result: QueryResult): string {
+  const detail = typeof result.resultText === 'string' ? result.resultText.trim() : '';
+  return detail
+    ? `Claude query returned ${result.subtype}: ${detail}`
+    : `Claude query returned ${result.subtype}`;
+}
+
+export function createQueryLoopGuard(
+  options: QueryLoopOptions,
+): QueryLoopGuard {
+  let queuedPromptCount = 0;
+  let recoveryPromptQueued = false;
+  let activeRound: ActiveRound | null = null;
+
+  function startNextQueuedRound(): void {
+    if (queuedPromptCount === 0) return;
+    queuedPromptCount -= 1;
+    activeRound = { delivered: false, recoveryAttempted: false };
+  }
+
+  return {
+    enqueueConversationalPrompt(_prompt: string): void {
+      queuedPromptCount += 1;
+    },
+
+    markPromptDispatched(): void {
+      if (recoveryPromptQueued) {
+        recoveryPromptQueued = false;
+        return;
+      }
+
+      if (activeRound === null) {
+        startNextQueuedRound();
+        return;
+      }
+
+      if (activeRound.delivered) {
+        startNextQueuedRound();
+      }
+    },
+
+    noteSendMessageDelivery(delivered: boolean): void {
+      if (!delivered || activeRound === null) return;
+      activeRound.delivered = true;
+    },
+
+    onResult(result: QueryResult): GuardAction {
+      if (result.subtype.startsWith('error_')) {
+        return { type: 'emit-error', error: formatSdkError(result) };
+      }
+
+      if (result.subtype !== 'success') {
+        return { type: 'none' };
+      }
+
+      if (hasVisibleReply(result.resultText)) {
+        if (activeRound !== null) {
+          activeRound.delivered = true;
+        }
+        return {
+          type: 'emit-success',
+          resultText: result.resultText ?? null,
+        };
+      }
+
+      if (options.isScheduledTask || activeRound?.delivered) {
+        return { type: 'none' };
+      }
+
+      if (activeRound === null) {
+        return { type: 'none' };
+      }
+
+      if (activeRound.recoveryAttempted) {
+        return { type: 'emit-error', error: RECOVERY_EXHAUSTED_ERROR };
+      }
+
+      activeRound.recoveryAttempted = true;
+      recoveryPromptQueued = true;
+
+      return { type: 'recover', prompt: NO_REPLY_RECOVERY_PROMPT };
+    },
+
+    onQueryExit(_exit: QueryExit): GuardAction {
+      if (!options.isScheduledTask && activeRound !== null && !activeRound.delivered) {
+        return { type: 'emit-error', error: QUERY_EXIT_ERROR };
+      }
+
+      return { type: 'none' };
+    },
+  };
+}

--- a/container/agent-runner/src/query-runner.test.ts
+++ b/container/agent-runner/src/query-runner.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContainerOutput, QueryRunnerMessage } from './query-runner.js';
+import { PromptQueue, runQueryRunner } from './query-runner.js';
+import {
+  NO_REPLY_RECOVERY_PROMPT,
+  QUERY_EXIT_ERROR,
+  RECOVERY_EXHAUSTED_ERROR,
+} from './query-loop.js';
+
+async function* createMessageStream(
+  promptQueue: PromptQueue,
+  steps: Array<
+    (
+      prompt: string,
+    ) => Promise<QueryRunnerMessage[]> | QueryRunnerMessage[]
+  >,
+): AsyncGenerator<QueryRunnerMessage> {
+  const iterator = promptQueue[Symbol.asyncIterator]();
+
+  for (const step of steps) {
+    const next = await iterator.next();
+    expect(next.done).toBe(false);
+
+    const messages = await step(next.value.message.content);
+    for (const message of messages) {
+      yield message;
+    }
+  }
+}
+
+function createHarness(options?: {
+  initialPrompt?: string;
+  followUps?: string[];
+  isScheduledTask?: boolean;
+}) {
+  const promptQueue = new PromptQueue(options?.initialPrompt ?? 'user prompt');
+  for (const prompt of options?.followUps ?? []) {
+    promptQueue.enqueuePrompt(prompt);
+  }
+
+  const outputs: ContainerOutput[] = [];
+  const dispatchedPrompts: string[] = [];
+  let sendMessageCount = 0;
+
+  return {
+    promptQueue,
+    outputs,
+    dispatchedPrompts,
+    recordSendMessage(text = 'sent'): void {
+      if (text.trim()) {
+        sendMessageCount += 1;
+      }
+    },
+    run(
+      messages: AsyncIterable<QueryRunnerMessage>,
+      closedDuringQuery = false,
+    ) {
+      return runQueryRunner({
+        promptQueue,
+        messages,
+        isScheduledTask: options?.isScheduledTask ?? false,
+        closedDuringQuery,
+        consumeSendMessageCount: () => {
+          const current = sendMessageCount;
+          sendMessageCount = 0;
+          return current;
+        },
+        onPromptDispatched: (prompt) => {
+          dispatchedPrompts.push(prompt);
+        },
+        writeOutput: async (output) => {
+          outputs.push(output);
+        },
+      });
+    },
+  };
+}
+
+describe('runQueryRunner', () => {
+  it('throws the query-exit error when a conversational round emits assistant activity but no final result or send_message delivery', async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            return [{ type: 'assistant', uuid: 'assistant-1' }];
+          },
+        ]),
+      ),
+    ).rejects.toThrow(QUERY_EXIT_ERROR);
+
+    expect(harness.outputs).toEqual([]);
+    expect(harness.dispatchedPrompts).toEqual(['user prompt']);
+  });
+
+  it('throws the query-exit error when close-sentinel shutdown ends an unresolved conversational round', async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            return [{ type: 'assistant', uuid: 'assistant-1' }];
+          },
+        ]),
+        true,
+      ),
+    ).rejects.toThrow(QUERY_EXIT_ERROR);
+
+    expect(harness.outputs).toEqual([]);
+    expect(harness.dispatchedPrompts).toEqual(['user prompt']);
+  });
+
+  it('inserts NO_REPLY_RECOVERY_PROMPT ahead of already-buffered follow-up prompts after the first silent success result', async () => {
+    const harness = createHarness({ followUps: ['follow-up prompt'] });
+
+    await harness.run(
+      createMessageStream(harness.promptQueue, [
+        async (prompt) => {
+          expect(prompt).toBe('user prompt');
+          return [{ type: 'result', subtype: 'success', result: '' }];
+        },
+        async (prompt) => {
+          expect(prompt).toBe(NO_REPLY_RECOVERY_PROMPT);
+          return [
+            {
+              type: 'result',
+              subtype: 'success',
+              result: 'Recovered reply',
+            },
+          ];
+        },
+        async (prompt) => {
+          expect(prompt).toBe('follow-up prompt');
+          return [
+            {
+              type: 'result',
+              subtype: 'success',
+              result: 'Follow-up reply',
+            },
+          ];
+        },
+      ]),
+    );
+
+    expect(harness.dispatchedPrompts).toEqual([
+      'user prompt',
+      NO_REPLY_RECOVERY_PROMPT,
+      'follow-up prompt',
+    ]);
+  });
+
+  it('writes the recovered visible result, then leaves the buffered follow-up prompt queued until it is actually dispatched', async () => {
+    const harness = createHarness({ followUps: ['follow-up prompt'] });
+
+    await harness.run(
+      createMessageStream(harness.promptQueue, [
+        async (prompt) => {
+          expect(prompt).toBe('user prompt');
+          return [
+            { type: 'system', subtype: 'init', session_id: 'session-123' },
+            { type: 'result', subtype: 'success', result: '   ' },
+          ];
+        },
+        async (prompt) => {
+          expect(prompt).toBe(NO_REPLY_RECOVERY_PROMPT);
+          return [
+            {
+              type: 'result',
+              subtype: 'success',
+              result: 'Recovered reply',
+            },
+          ];
+        },
+        async (prompt) => {
+          expect(prompt).toBe('follow-up prompt');
+          return [
+            {
+              type: 'result',
+              subtype: 'success',
+              result: 'Follow-up reply',
+            },
+          ];
+        },
+      ]),
+    );
+
+    expect(harness.outputs).toEqual([
+      {
+        status: 'success',
+        result: 'Recovered reply',
+        newSessionId: 'session-123',
+      },
+      {
+        status: 'success',
+        result: 'Follow-up reply',
+        newSessionId: 'session-123',
+      },
+    ]);
+    expect(harness.dispatchedPrompts).toEqual([
+      'user prompt',
+      NO_REPLY_RECOVERY_PROMPT,
+      'follow-up prompt',
+    ]);
+  });
+
+  it('treats a second silent success result as the explicit recovery-exhausted error', async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            return [{ type: 'result', subtype: 'success', result: '' }];
+          },
+          async (prompt) => {
+            expect(prompt).toBe(NO_REPLY_RECOVERY_PROMPT);
+            return [
+              {
+                type: 'result',
+                subtype: 'success',
+                result: '<internal>still hidden</internal>',
+              },
+            ];
+          },
+        ]),
+      ),
+    ).rejects.toThrow(RECOVERY_EXHAUSTED_ERROR);
+
+    expect(harness.outputs).toEqual([]);
+  });
+
+  it('treats a send_message-only conversational round as delivered when query exits cleanly', async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            harness.recordSendMessage();
+            return [{ type: 'assistant', uuid: 'assistant-1' }];
+          },
+        ]),
+      ),
+    ).resolves.toEqual({
+      closedDuringQuery: false,
+      lastAssistantUuid: 'assistant-1',
+      newSessionId: undefined,
+    });
+
+    expect(harness.outputs).toEqual([]);
+  });
+
+  it('does not trigger recovery for a round that already emitted visible result output', async () => {
+    const harness = createHarness();
+
+    await harness.run(
+      createMessageStream(harness.promptQueue, [
+        async (prompt) => {
+          expect(prompt).toBe('user prompt');
+          return [
+            {
+              type: 'result',
+              subtype: 'success',
+              result: 'Visible reply',
+            },
+            { type: 'result', subtype: 'success', result: '' },
+          ];
+        },
+      ]),
+    );
+
+    expect(harness.outputs).toEqual([
+      {
+        status: 'success',
+        result: 'Visible reply',
+        newSessionId: undefined,
+      },
+    ]);
+    expect(harness.dispatchedPrompts).toEqual(['user prompt']);
+  });
+
+  it('surfaces SDK result/error_* immediately without emitting success', async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            return [
+              {
+                type: 'result',
+                subtype: 'error_during_execution',
+                result: 'sdk failed',
+              },
+            ];
+          },
+        ]),
+      ),
+    ).rejects.toThrow('Claude query returned error_during_execution: sdk failed');
+
+    expect(harness.outputs).toEqual([]);
+  });
+
+  it('allows scheduled-task silent success and silent exit without emitted errors', async () => {
+    const harness = createHarness({ isScheduledTask: true });
+
+    await expect(
+      harness.run(
+        createMessageStream(harness.promptQueue, [
+          async (prompt) => {
+            expect(prompt).toBe('user prompt');
+            return [{ type: 'result', subtype: 'success', result: null }];
+          },
+        ]),
+      ),
+    ).resolves.toEqual({
+      closedDuringQuery: false,
+      lastAssistantUuid: undefined,
+      newSessionId: undefined,
+    });
+
+    expect(harness.outputs).toEqual([]);
+  });
+});

--- a/container/agent-runner/src/query-runner.ts
+++ b/container/agent-runner/src/query-runner.ts
@@ -1,0 +1,226 @@
+import {
+  createQueryLoopGuard,
+  GuardAction,
+  QueryLoopGuard,
+} from './query-loop.js';
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+export interface QueryRunnerMessage {
+  type: 'assistant' | 'result' | 'system';
+  subtype?: string;
+  result?: string | null;
+  session_id?: string;
+  uuid?: string;
+}
+
+export interface PromptInput {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+type PromptDispatchListener = (prompt: string) => void;
+type PromptQueuedListener = (prompt: string) => void;
+
+interface QueuedPrompt {
+  prompt: string;
+  isRecovery: boolean;
+}
+
+export class PromptQueue implements AsyncIterable<PromptInput> {
+  private queue: QueuedPrompt[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+  private dispatchListener: PromptDispatchListener | null = null;
+  private queuedListener: PromptQueuedListener | null = null;
+
+  constructor(initialPrompt: string) {
+    this.enqueuePrompt(initialPrompt);
+  }
+
+  setDispatchListener(listener: PromptDispatchListener): void {
+    this.dispatchListener = listener;
+  }
+
+  setQueuedListener(listener: PromptQueuedListener): void {
+    this.queuedListener = listener;
+  }
+
+  getQueuedUserPromptCount(): number {
+    return this.queue.filter((entry) => !entry.isRecovery).length;
+  }
+
+  enqueuePrompt(prompt: string): void {
+    this.queue.push({ prompt, isRecovery: false });
+    this.queuedListener?.(prompt);
+    this.waiting?.();
+  }
+
+  enqueuePriorityPrompt(prompt: string): void {
+    this.queue.unshift({ prompt, isRecovery: true });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<PromptInput> {
+    while (true) {
+      while (this.queue.length > 0) {
+        const entry = this.queue.shift()!;
+        this.dispatchListener?.(entry.prompt);
+        yield {
+          type: 'user',
+          message: { role: 'user', content: entry.prompt },
+          parent_tool_use_id: null,
+          session_id: '',
+        };
+      }
+
+      if (this.done) {
+        return;
+      }
+
+      await new Promise<void>((resolve) => {
+        this.waiting = resolve;
+      });
+      this.waiting = null;
+    }
+  }
+}
+
+interface RunQueryRunnerOptions {
+  promptQueue: PromptQueue;
+  messages: AsyncIterable<QueryRunnerMessage>;
+  isScheduledTask: boolean;
+  closedDuringQuery?: boolean;
+  getClosedDuringQuery?: () => boolean;
+  consumeSendMessageCount: () => number;
+  onPromptDispatched?: (prompt: string) => void;
+  writeOutput: (output: ContainerOutput) => Promise<void> | void;
+}
+
+interface RunQueryRunnerResult {
+  newSessionId?: string;
+  lastAssistantUuid?: string;
+  closedDuringQuery: boolean;
+}
+
+function applyGuardAction(
+  action: GuardAction,
+  promptQueue: PromptQueue,
+  writeOutput: (output: ContainerOutput) => Promise<void> | void,
+  newSessionId: string | undefined,
+): Promise<void> | void {
+  if (action.type === 'recover') {
+    promptQueue.enqueuePriorityPrompt(action.prompt);
+    return;
+  }
+
+  if (action.type === 'emit-error') {
+    throw new Error(action.error);
+  }
+
+  if (action.type === 'emit-success') {
+    return writeOutput({
+      status: 'success',
+      result: action.resultText,
+      newSessionId,
+    });
+  }
+}
+
+function noteBoundaryDelivery(
+  guard: QueryLoopGuard,
+  consumeSendMessageCount: () => number,
+): void {
+  guard.noteSendMessageDelivery(consumeSendMessageCount() > 0);
+}
+
+function resolveClosedDuringQuery(options: RunQueryRunnerOptions): boolean {
+  if (options.getClosedDuringQuery) {
+    return options.getClosedDuringQuery();
+  }
+
+  return options.closedDuringQuery ?? false;
+}
+
+export async function runQueryRunner(
+  options: RunQueryRunnerOptions,
+): Promise<RunQueryRunnerResult> {
+  const guard = createQueryLoopGuard({
+    isScheduledTask: options.isScheduledTask,
+  });
+
+  for (let index = 0; index < options.promptQueue.getQueuedUserPromptCount(); index += 1) {
+    guard.enqueueConversationalPrompt(`queued-prompt-${index}`);
+  }
+
+  options.promptQueue.setQueuedListener((prompt) => {
+    guard.enqueueConversationalPrompt(prompt);
+  });
+  options.promptQueue.setDispatchListener((prompt) => {
+    guard.markPromptDispatched();
+    options.onPromptDispatched?.(prompt);
+  });
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+
+  for await (const message of options.messages) {
+    if (message.type === 'assistant' && message.uuid) {
+      lastAssistantUuid = message.uuid;
+      continue;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      continue;
+    }
+
+    if (message.type !== 'result') {
+      continue;
+    }
+
+    noteBoundaryDelivery(guard, options.consumeSendMessageCount);
+
+    const action = guard.onResult({
+      subtype: message.subtype ?? 'success',
+      resultText: message.result ?? null,
+    });
+
+    await applyGuardAction(
+      action,
+      options.promptQueue,
+      options.writeOutput,
+      newSessionId,
+    );
+  }
+
+  noteBoundaryDelivery(guard, options.consumeSendMessageCount);
+  const closedDuringQuery = resolveClosedDuringQuery(options);
+  const exitAction = guard.onQueryExit({
+    closedDuringQuery,
+  });
+  await applyGuardAction(
+    exitAction,
+    options.promptQueue,
+    options.writeOutput,
+    newSessionId,
+  );
+
+  return {
+    newSessionId,
+    lastAssistantUuid,
+    closedDuringQuery,
+  };
+}

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -227,4 +227,42 @@ describe('container-runner timeout behavior', () => {
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
   });
+
+  it('returns explicit streamed error markers and preserves newSessionId', async () => {
+    const onOutput = vi.fn(async () => {});
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      onOutput,
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'error',
+      result: null,
+      error:
+        'Conversational turn ended without a delivered reply before the query exited',
+      newSessionId: 'session-789',
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 1);
+    await vi.advanceTimersByTimeAsync(10);
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      status: 'error',
+      result: null,
+      error:
+        'Conversational turn ended without a delivered reply before the query exited',
+      newSessionId: 'session-789',
+    });
+    expect(onOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error:
+          'Conversational turn ended without a delivered reply before the query exited',
+      }),
+    );
+  });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -362,6 +362,7 @@ export async function runContainerAgent(
     // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
     let parseBuffer = '';
     let newSessionId: string | undefined;
+    let lastStreamedOutput: ContainerOutput | undefined;
     let outputChain = Promise.resolve();
 
     container.stdout.on('data', (data) => {
@@ -397,6 +398,7 @@ export async function runContainerAgent(
 
           try {
             const parsed: ContainerOutput = JSON.parse(jsonStr);
+            lastStreamedOutput = parsed;
             if (parsed.newSessionId) {
               newSessionId = parsed.newSessionId;
             }
@@ -588,6 +590,19 @@ export async function runContainerAgent(
 
       fs.writeFileSync(logFile, logLines.join('\n'));
       logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
+
+      const streamedErrorOutput =
+        lastStreamedOutput?.status === 'error' ? lastStreamedOutput : null;
+      if (streamedErrorOutput) {
+        outputChain.then(() => {
+          resolve({
+            ...streamedErrorOutput,
+            newSessionId:
+              streamedErrorOutput.newSessionId || newSessionId || undefined,
+          });
+        });
+        return;
+      }
 
       if (code !== 0) {
         logger.error(

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('./container-runner.js', () => ({
+  runContainerAgent: vi.fn(),
+  writeTasksSnapshot: vi.fn(),
+}));
+
+import { runContainerAgent } from './container-runner.js';
 import { _initTestDatabase, createTask, getTaskById } from './db.js';
 import {
   _resetSchedulerLoopForTests,
@@ -12,6 +18,7 @@ describe('task scheduler', () => {
     _initTestDatabase();
     _resetSchedulerLoopForTests();
     vi.useFakeTimers();
+    vi.mocked(runContainerAgent).mockReset();
   });
 
   afterEach(() => {
@@ -125,5 +132,72 @@ describe('task scheduler', () => {
     const offset =
       (new Date(nextRun!).getTime() - new Date(scheduledTime).getTime()) % ms;
     expect(offset).toBe(0);
+  });
+
+  it('allows scheduled tasks to finish silently without sending a message', async () => {
+    createTask({
+      id: 'task-silent-success',
+      group_folder: 'test-group',
+      chat_jid: 'test@g.us',
+      prompt: 'run silently',
+      schedule_type: 'once',
+      schedule_value: '2026-02-22T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+      status: 'active',
+      created_at: '2026-02-22T00:00:00.000Z',
+    });
+
+    const notifyIdle = vi.fn();
+    const closeStdin = vi.fn();
+    const sendMessage = vi.fn(async () => {});
+
+    vi.mocked(runContainerAgent).mockImplementation(
+      async (_group, _input, _onProcess, onOutput) => {
+        await onOutput?.({ status: 'success', result: null });
+        return { status: 'success', result: null };
+      },
+    );
+
+    startSchedulerLoop({
+      registeredGroups: () => ({
+        'test@g.us': {
+          name: 'Test Group',
+          folder: 'test-group',
+          trigger: '@Andy',
+          added_at: new Date().toISOString(),
+        },
+      }),
+      getSessions: () => ({}),
+      queue: {
+        enqueueTask: (
+          _groupJid: string,
+          _taskId: string,
+          fn: () => Promise<void>,
+        ) => {
+          void fn();
+        },
+        notifyIdle,
+        closeStdin,
+      } as any,
+      onProcess: () => {},
+      sendMessage,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(notifyIdle).toHaveBeenCalledWith('test@g.us');
+    expect(closeStdin).not.toHaveBeenCalled();
+    expect(vi.mocked(runContainerAgent)).toHaveBeenCalledWith(
+      expect.objectContaining({ folder: 'test-group' }),
+      expect.objectContaining({ isScheduledTask: true }),
+      expect.any(Function),
+      expect.any(Function),
+    );
+
+    const task = getTaskById('task-silent-success');
+    expect(task?.status).toBe('completed');
+    expect(task?.last_result).toBe('Completed');
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'setup/**/*.test.ts',
+      'container/agent-runner/src/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## What

Fix a bug where a normal conversational turn could complete successfully without delivering any user-visible reply.

The new behavior is:

- visible final text still succeeds normally
- non-empty `send_message` still counts as a delivered reply
- scheduled tasks may still complete silently
- a conversational turn that finishes with no visible reply gets one bounded recovery prompt
- if the retry is still silent, or the query exits with the conversational round still unresolved, the runner now emits an explicit error instead of silently succeeding

## Why

Today the container runner treats every streamed SDK `result` marker as success, even when the result text is empty or internal-only. That makes `result: null` / empty-success valid for both scheduled tasks and conversational turns.

For scheduled tasks that is intentional. For conversational turns it is not: the host has already advanced the message cursor, so a silent "success" can consume the user's message with no reply ever reaching them.

This PR restores the conversational invariant without changing cursor semantics.

## How It Works

- Track delivery at the container query-loop level instead of assuming every `result/success` is user-visible.
- Treat a conversational round as delivered only if one of these happens:
  - the final result contains visible text after stripping `<internal>...</internal>` blocks
  - a non-empty `send_message` call is made
- On the first silent conversational success, enqueue one recovery prompt:
  - `You completed work for the user's last message but no reply was delivered. Finish.`
- If the retry is still silent, or the query exits before the conversational round is resolved, emit an explicit error.
- Preserve streamed error markers on the host side so the caller gets the precise failure reason instead of a generic non-zero exit message.

## Scope / Non-goals

- No cursor-handling changes
- No channel-delivery rewrite
- No change to scheduled-task silent success semantics

## Testing

- `npm test`
- `npm run typecheck`
- `npx tsc --noEmit -p container/agent-runner/tsconfig.json`
- `npm --prefix container/agent-runner run build`

The new tests cover:

- silent conversational success recovering via one bounded retry
- second silent success turning into an explicit error
- clean query exit / `_close` with an unresolved conversational round
- `send_message`-only conversational delivery
- scheduled tasks remaining allowed to finish silently
- host-side preservation of streamed error markers