### PR TITLE
fix: suppress duplicate result text when send_message was used

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -141,3 +141,29 @@ export function getUndeliveredMessages(): MessageOutRow[] {
     )
     .all() as MessageOutRow[];
 }
+
+/**
+ * Count chat messages written to outbound since a given seq number.
+ * Used to detect whether the agent already sent output via send_message
+ * during the current turn, so the poll loop can suppress duplicate
+ * result text dispatch.
+ */
+export function countOutboundChatSince(sinceSeq: number): number {
+  const row = getOutboundDb()
+    .prepare(
+      `SELECT COUNT(*) AS cnt FROM messages_out
+       WHERE kind = 'chat' AND seq > $sinceSeq`,
+    )
+    .get({ $sinceSeq: sinceSeq }) as { cnt: number };
+  return row.cnt;
+}
+
+/**
+ * Get the current max seq in outbound DB (0 if empty).
+ */
+export function getMaxOutboundSeq(): number {
+  const row = getOutboundDb()
+    .prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out')
+    .get() as { m: number };
+  return row.m;
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,6 +1,6 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
-import { writeMessageOut } from './db/messages-out.js';
+import { writeMessageOut, countOutboundChatSince, getMaxOutboundSeq } from './db/messages-out.js';
 import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { getStoredSessionId, setStoredSessionId, clearStoredSessionId } from './db/session-state.js';
 import { formatMessages, extractRouting, categorizeMessage, isClearCommand, stripInternalTags, type RoutingContext } from './formatter.js';
@@ -241,6 +241,9 @@ async function processQuery(
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
+  // Snapshot outbound seq before the query — any send_message MCP calls
+  // during the query will produce seq values above this baseline.
+  const outboundSeqBaseline = getMaxOutboundSeq();
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open is
@@ -298,7 +301,16 @@ async function processQuery(
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
         if (event.text) {
-          dispatchResultText(event.text, routing);
+          // Suppress result dispatch if the agent already sent output via
+          // send_message MCP tool during this turn. Without this check,
+          // both paths (MCP + SDK result) independently send to the user,
+          // causing duplicate/triple messages.
+          const mcpMessagesSent = countOutboundChatSince(outboundSeqBaseline);
+          if (mcpMessagesSent > 0) {
+            log(`Result text suppressed (${mcpMessagesSent} send_message(s) already sent during this turn)`);
+          } else {
+            dispatchResultText(event.text, routing);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Fixes duplicate/triple message delivery when the agent uses `send_message` MCP tool during a turn
- Root cause: two independent paths to user — MCP `send_message` writes to outbound DB, then SDK `result` event dispatches same text again via `dispatchResultText`
- Fix: snapshot outbound seq before each query, check on result if any chat messages were written since baseline

## Test plan

- [ ] Agent uses `send_message` → only MCP message arrives, no SDK result duplicate
- [ ] Agent does NOT use `send_message` → SDK result dispatches normally (no regression)
- [ ] Agent uses `send_message` multiple times → all MCP messages arrive, result suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)