### PR TITLE
v2: fix setup verify for CLI-only installs

### DIFF
--- a/setup/verify.test.ts
+++ b/setup/verify.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { determineVerifyStatus } from './verify.js';
+
+const healthyBase = {
+  service: 'running' as const,
+  credentials: 'configured',
+  anyChannelConfigured: false,
+  registeredGroups: 1,
+  agentPing: 'ok' as const,
+};
+
+describe('determineVerifyStatus', () => {
+  it('accepts a working CLI-only install', () => {
+    expect(determineVerifyStatus(healthyBase)).toBe('success');
+  });
+
+  it('accepts a messaging-channel install when CLI ping is skipped', () => {
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        anyChannelConfigured: true,
+        agentPing: 'skipped',
+      }),
+    ).toBe('success');
+  });
+
+  it('fails when neither CLI nor messaging channels are usable', () => {
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        agentPing: 'skipped',
+      }),
+    ).toBe('failed');
+  });
+
+  it('fails when the CLI agent does not respond', () => {
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        anyChannelConfigured: true,
+        agentPing: 'no_reply',
+      }),
+    ).toBe('failed');
+  });
+
+  it('fails when no agent groups are registered', () => {
+    expect(
+      determineVerifyStatus({
+        ...healthyBase,
+        registeredGroups: 0,
+      }),
+    ).toBe('failed');
+  });
+});

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -16,7 +16,12 @@ import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
-import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
+import {
+  getPlatform,
+  getServiceManager,
+  hasSystemd,
+  isRoot,
+} from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -33,7 +38,11 @@ export async function run(_args: string[]): Promise<void> {
   // a sibling checkout (common for developers with multiple clones), this
   // repo's `data/cli.sock` won't exist — AGENT_PING would return a
   // misleading `socket_error`. Surface the mismatch directly instead.
-  let service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' = 'not_found';
+  let service:
+    | 'not_found'
+    | 'stopped'
+    | 'running'
+    | 'running_other_checkout' = 'not_found';
   let runningFromPath: string | null = null;
   const mgr = getServiceManager();
 
@@ -65,7 +74,10 @@ export async function run(_args: string[]): Promise<void> {
       execSync(`${prefix} is-active ${systemdUnit}`, { stdio: 'ignore' });
       service = 'running';
       try {
-        const pidStr = execSync(`${prefix} show ${systemdUnit} -p MainPID --value`, { encoding: 'utf-8' }).trim();
+        const pidStr = execSync(
+          `${prefix} show ${systemdUnit} -p MainPID --value`,
+          { encoding: 'utf-8' },
+        ).trim();
         const pid = Number(pidStr);
         if (Number.isInteger(pid) && pid > 0) {
           runningFromPath = resolveBinaryScript(pid);
@@ -103,7 +115,11 @@ export async function run(_args: string[]): Promise<void> {
     }
   }
 
-  if (service === 'running' && runningFromPath && !isPathInside(runningFromPath, projectRoot)) {
+  if (
+    service === 'running' &&
+    runningFromPath &&
+    !isPathInside(runningFromPath, projectRoot)
+  ) {
     service = 'running_other_checkout';
   }
 
@@ -194,7 +210,11 @@ export async function run(_args: string[]): Promise<void> {
 
   // 6. Check mount allowlist
   let mountAllowlist = 'missing';
-  if (fs.existsSync(path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'))) {
+  if (
+    fs.existsSync(
+      path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'),
+    )
+  ) {
     mountAllowlist = 'configured';
   }
 

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -14,14 +14,9 @@ import Database from 'better-sqlite3';
 import { DATA_DIR } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
-import { pingCliAgent } from './lib/agent-ping.js';
+import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
-import {
-  getPlatform,
-  getServiceManager,
-  hasSystemd,
-  isRoot,
-} from './platform.js';
+import { getPlatform, getServiceManager, hasSystemd, isRoot } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -38,11 +33,7 @@ export async function run(_args: string[]): Promise<void> {
   // a sibling checkout (common for developers with multiple clones), this
   // repo's `data/cli.sock` won't exist — AGENT_PING would return a
   // misleading `socket_error`. Surface the mismatch directly instead.
-  let service:
-    | 'not_found'
-    | 'stopped'
-    | 'running'
-    | 'running_other_checkout' = 'not_found';
+  let service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout' = 'not_found';
   let runningFromPath: string | null = null;
   const mgr = getServiceManager();
 
@@ -74,10 +65,7 @@ export async function run(_args: string[]): Promise<void> {
       execSync(`${prefix} is-active ${systemdUnit}`, { stdio: 'ignore' });
       service = 'running';
       try {
-        const pidStr = execSync(
-          `${prefix} show ${systemdUnit} -p MainPID --value`,
-          { encoding: 'utf-8' },
-        ).trim();
+        const pidStr = execSync(`${prefix} show ${systemdUnit} -p MainPID --value`, { encoding: 'utf-8' }).trim();
         const pid = Number(pidStr);
         if (Number.isInteger(pid) && pid > 0) {
           runningFromPath = resolveBinaryScript(pid);
@@ -115,11 +103,7 @@ export async function run(_args: string[]): Promise<void> {
     }
   }
 
-  if (
-    service === 'running' &&
-    runningFromPath &&
-    !isPathInside(runningFromPath, projectRoot)
-  ) {
+  if (service === 'running' && runningFromPath && !isPathInside(runningFromPath, projectRoot)) {
     service = 'running_other_checkout';
   }
 
@@ -210,11 +194,7 @@ export async function run(_args: string[]): Promise<void> {
 
   // 6. Check mount allowlist
   let mountAllowlist = 'missing';
-  if (
-    fs.existsSync(
-      path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'),
-    )
-  ) {
+  if (fs.existsSync(path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'))) {
     mountAllowlist = 'configured';
   }
 
@@ -227,15 +207,15 @@ export async function run(_args: string[]): Promise<void> {
     log.info('Agent ping result', { agentPing });
   }
 
-  // Determine overall status
-  const status =
-    service === 'running' &&
-    credentials !== 'missing' &&
-    anyChannelConfigured &&
-    registeredGroups > 0 &&
-    (agentPing === 'ok' || agentPing === 'skipped')
-      ? 'success'
-      : 'failed';
+  // Determine overall status. A CLI-only install is valid when the local
+  // agent round-trip succeeds; messaging app credentials are optional.
+  const status = determineVerifyStatus({
+    service,
+    credentials,
+    anyChannelConfigured,
+    registeredGroups,
+    agentPing,
+  });
 
   log.info('Verification complete', { status, channelAuth });
 
@@ -253,6 +233,25 @@ export async function run(_args: string[]): Promise<void> {
   });
 
   if (status === 'failed') process.exit(1);
+}
+
+export function determineVerifyStatus(input: {
+  service: 'not_found' | 'stopped' | 'running' | 'running_other_checkout';
+  credentials: string;
+  anyChannelConfigured: boolean;
+  registeredGroups: number;
+  agentPing: PingResult | 'skipped';
+}): 'success' | 'failed' {
+  const cliAgentResponds = input.agentPing === 'ok';
+  const hasUsableChannel = input.anyChannelConfigured || cliAgentResponds;
+
+  return input.service === 'running' &&
+    input.credentials !== 'missing' &&
+    hasUsableChannel &&
+    input.registeredGroups > 0 &&
+    (cliAgentResponds || input.agentPing === 'skipped')
+    ? 'success'
+    : 'failed';
 }
 
 /**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #1971.

`setup/verify.ts` currently requires at least one configured messaging channel before it can report success. That incorrectly fails valid terminal-chat-only installs where the service is running, credentials are configured, a group is registered, and the CLI agent ping returns `ok`.

This changes verification status calculation so a successful CLI round trip is treated as a usable install path alongside configured messaging channels. Messaging app credentials remain optional for CLI-only installs, while failed CLI pings still fail verification.

Changes:

- Extract `determineVerifyStatus(...)` so success semantics are unit-testable without invoking launchd, Docker, SQLite, or the CLI socket.
- Treat `AGENT_PING: ok` as satisfying the usable-channel/install-path requirement.
- Keep existing hard requirements for service running, credentials configured, registered groups, and no failed CLI ping.
- Add unit coverage for CLI-only success, messaging-channel success with skipped ping, and failure cases.

Related: #1970 improves auth-error classification in `pingCliAgent()`. This PR fixes a separate verify success-criteria bug and should remain compatible if `PingResult` gains `auth_error`.

Validation run locally under the same Node runtime as the installed service (`v22.22.0`):

- `pnpm exec vitest run setup/verify.test.ts` — 1 file, 5 tests passed
- `pnpm exec tsx setup/index.ts --step verify` — `STATUS: success` with empty `CONFIGURED_CHANNELS` and `AGENT_PING: ok`
- `pnpm exec vitest run` — 21 files, 186 tests passed

Current check status:

- `CI` is failing in the repo-wide format check on `src/channels/chat-sdk-bridge.ts`, which is outside this PR's diff.
- `Label PR` is failing because the fork PR workflow token has read-only permissions and cannot add labels; labels were applied manually.

## For Skills

N/A — this is not a skill change.