### PR TITLE
chore(format): apply prettier to chat-sdk-bridge.ts

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -125,7 +125,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
   let setupConfig: ChannelSetup;
   let gatewayAbort: AbortController | null = null;
 
-  async function messageToInbound(message: ChatMessage, isMention: boolean, isGroup?: boolean): Promise<InboundMessage> {
+  async function messageToInbound(
+    message: ChatMessage,
+    isMention: boolean,
+    isGroup?: boolean,
+  ): Promise<InboundMessage> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serialized = message.toJSON() as Record<string, any>;
 
@@ -216,7 +220,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // wirings still fire on in-thread mentions.
       chat.onSubscribedMessage(async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, message.isMention === true, true));
+        await setupConfig.onInbound(
+          channelId,
+          thread.id,
+          await messageToInbound(message, message.isMention === true, true),
+        );
       });
 
       // @mention in an unsubscribed thread — SDK-confirmed bot mention.


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only
- [x] **Chore** - formatting, tooling, or maintenance only (no behavior change)

## Description

`main` currently fails `pnpm run format:check` on `src/channels/chat-sdk-bridge.ts`. Two long-line violations were introduced in `d121cd1` (`fix(router): pass isGroup from adapter through to messaging group creation`) when the `isGroup` parameter was added — the new function signature and one call site exceed the prettier `printWidth` limit.

Because `format:check` runs on every PR, this fails CI on **every** PR opened against `main` (not just this one). Fix is isolated to the two lines prettier wants reflowed, so no behavior change is mixed in.

### Validation

```
pnpm run format:check   # Checking formatting... All matched files use Prettier code style!
pnpm run build          # clean
pnpm test               # 20 files, 181 tests passed
```

Related: unblocks #1972 and any other in-flight PR against current `main`.

## For Skills

N/A — not a skill change.