### PR TITLE
fix(workflows): label PRs from forks that follow the contributing template

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,12 @@
 name: Label PR
 
+# SECURITY: this workflow runs with write access to the base repo on fork PRs,
+# because `pull_request_target` executes in the context of the base branch.
+# Keep it metadata-only — do NOT add actions/checkout or any step that
+# executes PR-supplied content (install scripts, build commands, etc.).
+# See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### Problem

The `label` workflow 403s on any fork PR that has the `[x] **...**` Type-of-Change checkbox filled in. On fork `pull_request` events GitHub demotes `GITHUB_TOKEN` to read-only regardless of the `permissions:` block, so `issues.addLabels()` rejects. Result:

- Fork PRs that skip the template → no labels to add → workflow exits 0 (green) ✅
- Fork PRs that actually follow the template → `addLabels()` 403 → red `label` check ❌

That's a hostile incentive for the very contributor behavior the template is trying to encourage. Concretely: of 30 currently-open PRs, the only fork one hitting the failure is #1972, which filled in `[x] **Fix**`.

### Fix

Swap the trigger from `pull_request` to `pull_request_target`. The latter runs in the context of the **base branch** with full declared permissions, including on fork PRs. It's the documented GitHub-canonical fix for labeling/commenting workflows.

### Why it's safe

`pull_request_target` is only unsafe when combined with checking out or executing PR-supplied code. This workflow:

- has no `actions/checkout`
- only reads `context.payload.pull_request.body` (a string from the API)
- only calls `github.rest.issues.addLabels(...)`

All metadata-only. Matches GitHub Security Lab's explicit [safe pattern](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) for labeling workflows. A `# SECURITY:` comment above the trigger future-proofs the file against someone later adding a checkout step without realizing the implication.

### Validation

- Diff is 5 added comment lines + 1 trigger swap; no script changes.
- Workflow file remains valid YAML (GitHub parser will validate on merge).
- Because `pull_request_target` workflows run the file from the **base branch**, not the PR branch, the new trigger only takes effect after merge — this is GitHub's documented behavior and is itself a safety feature (a malicious PR can't tamper with the labeler).

### Related

- Unblocks #1972 without maintainer re-run
- Unblocks any future fork PR that follows the contributing template

## For Skills

N/A — workflow change only.

## References

- [Events that trigger workflows — `pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target)
- [GitHub Security Lab — Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
- [actions/labeler#121 — Clarify why this needs `pull_request_target`](https://github.com/actions/labeler/issues/121)