### PR TITLE
docs: add historical banners to pre-v2 architecture references

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,5 +1,11 @@
 # NanoClaw Specification
 
+> Historical note: this document describes an older NanoClaw architecture and
+> should not be used as the source of truth for current `main`. For current
+> runtime behavior, start with `docs/build-and-runtime.md`, `docs/db.md`,
+> `docs/db-session.md`, `docs/setup-flow.md`, and the active code under
+> `src/`, `src/db/`, and `container/agent-runner/src/`.
+
 A personal Claude assistant with multi-channel support, persistent memory per conversation, scheduled tasks, and container-isolated agent execution.
 
 ---

--- a/docs/agent-runner-details.md
+++ b/docs/agent-runner-details.md
@@ -1,5 +1,10 @@
 # NanoClaw Agent-Runner Details
 
+> Historical note: this document was written for an older architecture draft
+> and is not the authoritative description of the current container runner on
+> `main`. For current behavior, check `container/agent-runner/src/`,
+> `docs/build-and-runtime.md`, and `docs/db-session.md`.
+
 Implementation-level details for the agent-runner inside the container. See [architecture.md](architecture.md) for the high-level design.
 
 ## Separation of Concerns

--- a/docs/api-details.md
+++ b/docs/api-details.md
@@ -1,5 +1,10 @@
 # NanoClaw API Details
 
+> Historical note: this document contains implementation details for an older
+> architecture draft and should not be treated as current API reference for
+> `main`. Verify behavior against the active code and newer docs before using
+> any interface or schema names from this file.
+
 Implementation-level details for the architecture. See [architecture.md](architecture.md) for the high-level design.
 
 ## Channel Adapter Interface

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,11 @@
 # NanoClaw Architecture (Draft)
 
+> Historical note: this draft reflects an older architecture model and is not
+> authoritative for current `main`. Current runtime behavior is host-owned
+> routing with a central `data/v2.db` plus per-session `inbound.db` and
+> `outbound.db`. Prefer `docs/build-and-runtime.md`, `docs/db.md`,
+> `docs/db-session.md`, and the active code for maintainer work.
+
 ## Core Idea
 
 Each agent session has a mounted SQLite DB. The DB is the one and only IO mechanism between host and container. No IPC files, no stdin piping. Two tables: messages_in (host → agent-runner) and messages_out (agent-runner → host). Everything is a message.


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [ ] **Fix**
- [ ] **Simplification**
- [x] **Documentation** - docs changes only

## Description

Four architecture-reference docs still describe earlier drafts of the NanoClaw system:

- `docs/SPEC.md`
- `docs/architecture.md`
- `docs/api-details.md`
- `docs/agent-runner-details.md`

They're valuable as design history but mislead maintainers looking for current-truth references. Rather than rewriting each wholesale, this PR adds a one-block banner at the top of each file that:

1. Flags the doc as historical.
2. Names the authoritative sources for current behavior (`docs/build-and-runtime.md`, `docs/db.md`, `docs/db-session.md`, `docs/setup-flow.md`, and the live code under `src/`, `src/db/`, `container/agent-runner/src/`).

Cost: 4 blocks of ~6 lines each, no content deleted, no behavior change. Benefit: a maintainer landing on any of these pages via search or a broken-internal-link has an immediate signpost to the right place.

## Context

Extracted from a fork-side maintainer documentation audit. Companion PRs (separate): chore removing pre-v2 group prompt files, schema/terminology refresh on mixed-status docs, and a CLAUDE.md update for current schema + slug-scoped service labels.