### PR TITLE
docs: refresh schema + terminology on mixed-status docs

### DIFF
--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -4,6 +4,10 @@ Complete reference for `data/v2.db`, the host-owned admin-plane database. Start 
 
 Access layer: `src/db/`. Authoritative schema reference: `src/db/schema.ts` (comments only — actual creation runs via migrations in `src/db/migrations/`).
 
+> Maintainer note: this reference follows the current v2 schema. Historical
+> migrations still mention `trigger_rules` and `response_scope`, but current
+> runtime code uses the explicit engagement fields documented below.
+
 ---
 
 ## 1. Tables
@@ -52,20 +56,25 @@ Wiring: which agent group handles which messaging group. Many-to-many — the sa
 
 ```sql
 CREATE TABLE messaging_group_agents (
-  id                 TEXT PRIMARY KEY,
-  messaging_group_id TEXT NOT NULL REFERENCES messaging_groups(id),
-  agent_group_id     TEXT NOT NULL REFERENCES agent_groups(id),
-  trigger_rules      TEXT,
-  response_scope     TEXT DEFAULT 'all',
-  session_mode       TEXT DEFAULT 'shared',
-  priority           INTEGER DEFAULT 0,
-  created_at         TEXT NOT NULL,
+  id                     TEXT PRIMARY KEY,
+  messaging_group_id     TEXT NOT NULL REFERENCES messaging_groups(id),
+  agent_group_id         TEXT NOT NULL REFERENCES agent_groups(id),
+  engage_mode            TEXT NOT NULL DEFAULT 'mention',
+  engage_pattern         TEXT,
+  sender_scope           TEXT NOT NULL DEFAULT 'all',
+  ignored_message_policy TEXT NOT NULL DEFAULT 'drop',
+  session_mode           TEXT DEFAULT 'shared',
+  priority               INTEGER DEFAULT 0,
+  created_at             TEXT NOT NULL,
   UNIQUE(messaging_group_id, agent_group_id)
 );
 ```
 
 - `session_mode`: `shared` (one session per channel), `per-thread` (one per thread), `agent-shared` (one per agent group across all channels).
-- `trigger_rules`: JSON; e.g. regex for native channels.
+- `engage_mode`: `pattern`, `mention`, or `mention-sticky`.
+- `engage_pattern`: regex source used when `engage_mode='pattern'`; `'.'` means match every message.
+- `sender_scope`: `all` or `known`.
+- `ignored_message_policy`: `drop` or `accumulate`.
 - **Side effect:** creating a wiring must also populate `agent_destinations` — don't mutate one without the other (see §1.10).
 
 ### 1.4 `users`

--- a/docs/isolation-model.md
+++ b/docs/isolation-model.md
@@ -2,6 +2,10 @@
 
 NanoClaw decouples messaging channels from agent groups. When you connect a channel (Discord, Telegram, Slack, GitHub, etc.), you decide how it relates to your existing agents. There are three isolation levels.
 
+> Maintainer note: current wiring uses `engage_mode`, `engage_pattern`,
+> `sender_scope`, and `ignored_message_policy`. Older `trigger_rules`
+> terminology should be read as historical.
+
 ## The Three Levels
 
 ### 1. Shared Session
@@ -80,7 +84,14 @@ agent_groups (workspace, memory, CLAUDE.md, personality)
     ↕ many-to-many
 messaging_groups (a specific channel/chat/group on a platform)
     via
-messaging_group_agents (session_mode, trigger_rules, priority)
+messaging_group_agents (
+  engage_mode,
+  engage_pattern,
+  sender_scope,
+  ignored_message_policy,
+  session_mode,
+  priority
+)
 ```
 
 - **Shared session:** multiple messaging_groups → same agent_group, `session_mode = 'agent-shared'`

--- a/docs/setup-wiring.md
+++ b/docs/setup-wiring.md
@@ -2,6 +2,11 @@
 
 Last updated: 2026-04-09
 
+> Maintainer note: this document is partially stale. The runtime wiring model
+> now uses `engage_mode`, `engage_pattern`, `sender_scope`, and
+> `ignored_message_policy` on `messaging_group_agents`; older references to
+> `trigger_rules` and `response_scope` describe pre-migration terminology.
+
 ## What's Done
 
 ### Two-DB Split (session DB write isolation)
@@ -69,7 +74,16 @@ agent_groups (id, name, folder, agent_provider, container_config)
     ↕ many-to-many
 messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy)
     via
-messaging_group_agents (messaging_group_id, agent_group_id, trigger_rules, session_mode, priority)
+messaging_group_agents (
+  messaging_group_id,
+  agent_group_id,
+  engage_mode,
+  engage_pattern,
+  sender_scope,
+  ignored_message_policy,
+  session_mode,
+  priority
+)
 
 users (id, kind, display_name)          -- namespaced as "<channel>:<handle>"
 user_roles (user_id, role, agent_group_id)    -- owner / admin (global or scoped)
@@ -99,3 +113,15 @@ Channel adapter → routeInbound() → resolve messaging_group → resolve agent
 | `setup/register.ts` | Creates entities (agent_group, messaging_group, wiring) |
 | `setup/verify.ts` | Checks central DB for registered groups |
 | `container/agent-runner/src/db/connection.ts` | Two-DB connection layer (inbound read-only, outbound read-write) |
+
+### Wiring engagement fields
+
+`messaging_group_agents` uses four explicit engagement/access fields:
+
+- `engage_mode`: `pattern`, `mention`, or `mention-sticky`
+- `engage_pattern`: regex source used when `engage_mode='pattern'`; `'.'`
+  means match every message
+- `sender_scope`: `all` or `known`
+- `ignored_message_policy`: `drop` or `accumulate`
+
+These replace the old `trigger_rules` JSON and `response_scope` enum.


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [ ] **Fix**
- [ ] **Simplification**
- [x] **Documentation** - docs changes only

## Description

Three docs still contain older wiring schema and terminology (`trigger_rules`, `response_scope`, older entity-model snippets) that don't match the runtime path in `src/db/messaging-groups.ts` / `src/db/schema.ts`:

- `docs/db-central.md` — `messaging_group_agents` schema example updated to the current columns: `engage_mode`, `engage_pattern`, `sender_scope`, `ignored_message_policy`.
- `docs/isolation-model.md` — stale entity snippets refreshed so the three-level isolation explanation lines up with current field names.
- `docs/setup-wiring.md` — old `trigger_rules` framing replaced with the current `engage_mode` / `engage_pattern` / `sender_scope` vocabulary actually used by the setup flow and runtime.

Each doc keeps its role and structure — only schema references are brought forward. No behavior change.

## Context

Extracted from a fork-side maintainer documentation audit. Companion PRs: chore removing pre-v2 group prompt files, historical banners on obsolete architecture refs, and a CLAUDE.md update for current schema + slug-scoped service labels.