### PR TITLE
fix(setup): fail fast when build tools are missing, before pnpm install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -176,6 +176,52 @@ check_build_tools() {
   log "Build tools: $HAS_BUILD_TOOLS"
 }
 
+# Fail-fast with actionable guidance when build tools are missing. pnpm
+# install compiles native modules (better-sqlite3) from source on platforms
+# without a cached prebuild — without gcc/make that fails mid-install with
+# a confusing "node-gyp: ENOENT" error and leaves node_modules half-written.
+# Set NANOCLAW_SKIP_BUILD_TOOLS=1 to bypass this check (for environments
+# where a prebuilt binary is expected to resolve the native dependency).
+require_build_tools_or_exit() {
+  if [ "$HAS_BUILD_TOOLS" = "true" ]; then
+    return
+  fi
+
+  if [ "${NANOCLAW_SKIP_BUILD_TOOLS:-}" = "1" ]; then
+    log "NANOCLAW_SKIP_BUILD_TOOLS=1 — proceeding despite missing build tools"
+    return
+  fi
+
+  echo "" >&2
+  echo "ERROR: build tools not found." >&2
+  case "$PLATFORM" in
+    linux)
+      echo "       gcc and make are required to compile native dependencies (better-sqlite3)." >&2
+      echo "" >&2
+      echo "       Debian/Ubuntu:   sudo apt-get install -y build-essential" >&2
+      echo "       Fedora/RHEL:     sudo dnf groupinstall -y \"Development Tools\"" >&2
+      echo "       Arch:            sudo pacman -S --noconfirm base-devel" >&2
+      echo "       Alpine:          sudo apk add build-base" >&2
+      ;;
+    macos)
+      echo "       Xcode Command Line Tools are required." >&2
+      echo "" >&2
+      echo "       Run: xcode-select --install" >&2
+      ;;
+    *)
+      echo "       A C toolchain (cc / make) is required." >&2
+      ;;
+  esac
+  echo "" >&2
+  echo "       Install the appropriate package, then re-run setup.sh." >&2
+  echo "       To bypass this check (e.g. when a prebuilt binary is available)," >&2
+  echo "       re-run with NANOCLAW_SKIP_BUILD_TOOLS=1 ./setup.sh" >&2
+  echo "" >&2
+
+  log "Exiting: build tools missing (NANOCLAW_SKIP_BUILD_TOOLS not set)"
+  exit 3
+}
+
 # --- Main ---
 
 log "=== Bootstrap started ==="
@@ -193,8 +239,9 @@ if [ "$NODE_OK" = "false" ]; then
     log "install-node.sh failed"
   fi
 fi
-install_deps
 check_build_tools
+require_build_tools_or_exit
+install_deps
 
 # Emit status block
 STATUS="success"


### PR DESCRIPTION
## Summary

`setup.sh` calls `install_deps` (pnpm install) **before** `check_build_tools`, and never consults the result. On a Linux host without `build-essential`, `pnpm install` attempts to compile `better-sqlite3` from source, fails with a deep `node-gyp: ENOENT` error, and leaves `node_modules` half-written. The operator has to `rm -rf node_modules`, install `build-essential`, and retry — losing one aborted run to a condition the script already detected.

This PR:

- Reorders main so `check_build_tools` runs **before** `install_deps`.
- Adds `require_build_tools_or_exit`: when tools are missing, print a platform-specific install command and exit 3 before pnpm install runs.
- Adds `NANOCLAW_SKIP_BUILD_TOOLS=1` as an opt-out for environments where a prebuilt `better-sqlite3` binary is expected to resolve the native dependency without a compiler (rare but possible).

## Messages

### Linux (failure path)
```
ERROR: build tools not found.
       gcc and make are required to compile native dependencies (better-sqlite3).

       Debian/Ubuntu:   sudo apt-get install -y build-essential
       Fedora/RHEL:     sudo dnf groupinstall -y "Development Tools"
       Arch:            sudo pacman -S --noconfirm base-devel
       Alpine:          sudo apk add build-base

       Install the appropriate package, then re-run setup.sh.
       To bypass this check (e.g. when a prebuilt binary is available),
       re-run with NANOCLAW_SKIP_BUILD_TOOLS=1 ./setup.sh
```

### macOS (failure path)
```
ERROR: build tools not found.
       Xcode Command Line Tools are required.

       Run: xcode-select --install
```

## Test plan

Verified `bash -n` syntax and all four code paths by sourcing the two functions in isolated subshells and driving them manually. Not a unit-test framework but sufficient for a pure-shell change of this size:

- [x] **Linux failure path** (no gcc/make, no env var) → correct message, exit 3.
- [x] **Happy path** (tools present) → returns 0, proceeds to `install_deps`.
- [x] **Bypass path** (no tools, `NANOCLAW_SKIP_BUILD_TOOLS=1`) → logs bypass, returns 0.
- [x] **macOS failure path** → correct message pointing at `xcode-select --install`, exit 3.

## Backwards compatibility

- Hosts with build tools already installed are unaffected.
- Hosts that were previously hitting the pnpm install failure now get a clear error and exit before pnpm runs, instead of silently proceeding to a confusing node-gyp crash.
- The bypass env var preserves the old behaviour for anyone who needs it (prebuilt binary workflows).

## Motivation

I hit this during my own install — spent ~15 min digging through the pnpm install log to find the actual gcc-missing root cause, after the script's own preflight had already correctly logged `Build tools: false`. The script knew it would fail but tried regardless. This PR just makes the script act on what it already detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)