### PR TITLE
fix(whatsapp): set real mimetype for document attachments

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -125,6 +125,24 @@ function formatWhatsApp(text: string): string {
   return segments.map(({ content, isProtected }) => (isProtected ? content : transformForWhatsApp(content))).join('');
 }
 
+/** Extension → mimetype for documents. Without a real mimetype WhatsApp
+ * labels the file as octet-stream and mobile clients can't open it inline
+ * (shows up as ".bin" on iOS/Android). */
+const DOCUMENT_MIMETYPES: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.csv': 'text/csv',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.md': 'text/markdown',
+  '.json': 'application/json',
+  '.zip': 'application/zip',
+};
+
 /** Map file extension to Baileys media message type. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildMediaMessage(data: Buffer, filename: string, ext: string, caption?: string): any {
@@ -141,8 +159,11 @@ function buildMediaMessage(data: Buffer, filename: string, ext: string, caption?
   if (audioExts.includes(ext)) {
     return { audio: data, mimetype: `audio/${ext.slice(1) === 'mp3' ? 'mpeg' : ext.slice(1)}` };
   }
-  // Default: send as document
-  return { document: data, fileName: filename, caption, mimetype: 'application/octet-stream' };
+  // Document: map known extensions to real mimetypes so the recipient client
+  // renders them with the correct icon and opens them inline instead of
+  // treating the file as a ".bin" blob.
+  const mimetype = DOCUMENT_MIMETYPES[ext] ?? 'application/octet-stream';
+  return { document: data, fileName: filename, caption, mimetype };
 }
 
 registerChannelAdapter('whatsapp', {


### PR DESCRIPTION
## Summary
- Document files sent via `send_file` were being tagged `application/octet-stream`, which causes WhatsApp mobile clients to render them as opaque `.bin` blobs that users can't open inline.
- Adds a small extension → mimetype map for common document types (PDF, DOC/DOCX, XLS/XLSX, CSV, TXT, HTML/HTM, MD, JSON, ZIP). The existing `application/octet-stream` fallback is preserved for unknown extensions.

## Test plan
- [ ] Built with `pnpm run build` — no TS errors
- [ ] Sent an `.html` file to a WhatsApp group — iOS rendered it as an HTML doc (opens in browser) instead of a `.bin`
- [ ] Existing image/video/audio paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)