### PR TITLE
fix(codex): route per-group custom OpenAI-compat endpoints

### DIFF
--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -389,5 +389,21 @@ export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>)
 }
 
 export function createCodexConfigOverrides(): string[] {
-  return ['features.use_linux_sandbox_bwrap=false'];
+  const overrides = ['features.use_linux_sandbox_bwrap=false'];
+
+  // If OPENAI_BASE_URL is set, route through the plain `openai` provider
+  // (Chat Completions REST). Without this override Codex defaults to the
+  // `openai-codex` provider which targets the ChatGPT subscription
+  // WebSocket endpoint at api.openai.com and ignores OPENAI_BASE_URL.
+  const baseUrl = process.env.OPENAI_BASE_URL;
+  if (baseUrl) {
+    overrides.push(
+      'model_provider="openai-custom"',
+      'model_providers.openai-custom.name="Custom OpenAI-compatible"',
+      `model_providers.openai-custom.base_url=${tomlBasicString(baseUrl)}`,
+      'model_providers.openai-custom.wire_api="responses"',
+      'model_providers.openai-custom.env_key="OPENAI_API_KEY"',
+    );
+  }
+  return overrides;
 }

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -38,6 +38,8 @@ export interface ContainerConfig {
   packages: { apt: string[]; npm: string[] };
   imageTag?: string;
   additionalMounts: AdditionalMountConfig[];
+  /** Per-group env vars passed to the container as `-e KEY=VALUE` at spawn. */
+  env?: Record<string, string>;
 }
 
 function emptyConfig(): ContainerConfig {
@@ -71,6 +73,7 @@ export function readContainerConfig(folder: string): ContainerConfig {
       },
       imageTag: raw.imageTag,
       additionalMounts: raw.additionalMounts ?? [],
+      env: raw.env,
     };
   } catch (err) {
     console.error(`[container-config] failed to parse ${p}: ${String(err)}`);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -257,6 +257,14 @@ async function buildContainerArgs(
     }
   }
 
+  // Per-group env from container.json — overrides provider defaults.
+  const containerConfig = readContainerConfig(agentGroup.folder);
+  if (containerConfig.env) {
+    for (const [key, value] of Object.entries(containerConfig.env)) {
+      args.push('-e', `${key}=${value}`);
+    }
+  }
+
   // Users allowed to run admin commands (e.g. /clear) inside this container.
   // Computed at wake time: owners + global admins + admins scoped to this
   // agent group. Role changes take effect on next container spawn.
@@ -325,7 +333,6 @@ async function buildContainerArgs(
   }
 
   // Pass additional MCP servers from container config (groups/<folder>/container.json)
-  const containerConfig = readContainerConfig(agentGroup.folder);
   if (containerConfig.mcpServers && Object.keys(containerConfig.mcpServers).length > 0) {
     args.push('-e', `NANOCLAW_MCP_SERVERS=${JSON.stringify(containerConfig.mcpServers)}`);
   }

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -19,17 +19,28 @@
 import fs from 'fs';
 import path from 'path';
 
+import { getAgentGroup } from '../db/agent-groups.js';
+import { readContainerConfig } from '../container-config.js';
 import { registerProviderContainerConfig } from './provider-container-registry.js';
 
 registerProviderContainerConfig('codex', (ctx) => {
   const codexDir = path.join(ctx.sessionDir, 'codex');
   fs.mkdirSync(codexDir, { recursive: true });
 
+  // If the per-group container.json env sets OPENAI_BASE_URL, this group is
+  // routed to a custom OpenAI-compat endpoint (LiteLLM, llama.cpp, etc.)
+  // rather than the ChatGPT subscription. Codex prefers auth.json over an
+  // API key when both are present, so we skip the auth.json copy in that
+  // case to force the OPENAI_API_KEY path against the custom endpoint.
+  const group = getAgentGroup(ctx.agentGroupId);
+  const groupEnv = group ? (readContainerConfig(group.folder).env ?? {}) : {};
+  const usesCustomEndpoint = !!groupEnv.OPENAI_BASE_URL;
+
   // Copy the host's auth.json into the per-session dir if it exists.
   // We only copy auth.json, not the full ~/.codex — config.toml would
   // get clobbered by the container on every wake anyway.
   const hostHome = ctx.hostEnv.HOME;
-  if (hostHome) {
+  if (hostHome && !usesCustomEndpoint) {
     const hostAuth = path.join(hostHome, '.codex', 'auth.json');
     if (fs.existsSync(hostAuth)) {
       fs.copyFileSync(hostAuth, path.join(codexDir, 'auth.json'));


### PR DESCRIPTION
## What

Two Codex provider fixes that together let a per-group `container.json` point at a custom OpenAI-compatible endpoint (LiteLLM, llama.cpp, vLLM, a local proxy) instead of the ChatGPT subscription backend.

1. **Host: skip `auth.json` copy when the group targets a custom endpoint.** If `container.json` env sets `OPENAI_BASE_URL`, the group is clearly not on the subscription path — but Codex prefers `auth.json` over `OPENAI_API_KEY` when both are present, so the subscription token silently wins and every request still hits `chatgpt-backend-api`. Now the host skips the copy in that case.

2. **Container: emit `-c model_provider=openai-custom` overrides when `OPENAI_BASE_URL` is set.** Codex 0.124 removed `wire_api="chat"` and reserves the built-in `openai` provider id. Just setting `OPENAI_BASE_URL` no longer works — Codex falls through to `openai-codex` and hits `wss://api.openai.com/v1/responses` regardless of the env var. The fix defines a custom `openai-custom` provider inline (`wire_api="responses"`, `env_key="OPENAI_API_KEY"`, `base_url=<env>`) and pins `model_provider` to it.

## Why

Per-group custom endpoints are documented as **Option C — BYO OpenAI-compatible endpoint (experimental)** in `/add-codex`'s SKILL.md, but neither half of the path actually worked in practice. This makes that documented option a supported first-class path.

Context: this is the replacement for the `-c model_provider_base_url=...` override originally shipped in #1843 and removed in 138c277 (after Codex 0.118 honored `OPENAI_BASE_URL` natively). That behavior regressed by 0.124 — the correct replacement is the nested-key form in this PR. Discussed in #1984.

## How it works

- **`src/providers/codex.ts`:** reads the group's `container.json` via `readContainerConfig(group.folder)`; if `env.OPENAI_BASE_URL` is set, skips the `auth.json` copy. `OPENAI_API_KEY` path takes over.
- **`container/agent-runner/src/providers/codex-app-server.ts`:** when `process.env.OPENAI_BASE_URL` is set, `createCodexConfigOverrides()` emits the five `-c` lines to define `openai-custom` and set `model_provider` to it.

Existing subscription / no-env setups get exactly the previous behavior — both branches are `OPENAI_BASE_URL`-gated.

## Dependency / stacking note

The first commit (`fix(container-runner): wire per-group container.json env into spawn`) is a small backport of #1983 onto the `providers` branch. #1983 targets `main`; `providers` needs the same two-line change for `container.json` `env` to actually reach the container. Once `providers` next merges `main` and picks up #1983, that commit drops on rebase and this PR shrinks to just the two Codex fixes.

Happy to split differently or rebase once #1983 lands if you'd prefer.

## How it was tested

- Host tests: `pnpm test` (19 files / 172 tests pass)
- Host build: `pnpm run build` clean
- Container typecheck: `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- Locally: group wired to a LiteLLM front for `glm-4.6` via `container.json` env; confirmed requests hit the LiteLLM endpoint (not `api.openai.com`) with `OPENAI_API_KEY` auth, and the per-group config isolation works alongside a subscription group in the same install.

## Related

Closes #1984 (Codex half — OpenCode half in a separate PR).