### PR TITLE
feat(opencode): custom provider npm, no-auth, and env API key + /add-local-llama skill

### DIFF
--- a/.claude/skills/add-local-llama/SKILL.md
+++ b/.claude/skills/add-local-llama/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: add-local-llama
+description: Wire a NanoClaw agent group to a local/LAN OpenAI-compatible endpoint via the OpenCode provider. Supports two modes — direct to a bare llama.cpp/vLLM server (no auth), or routed through a LiteLLM proxy (virtual key + model zoo). Assumes /add-opencode has already run.
+---
+
+# add-local-llama
+
+Route a NanoClaw agent group at an OpenAI-compatible endpoint on the
+LAN via the OpenCode provider. Two supported modes, pick whichever
+fits:
+
+- **Direct mode** — point OpenCode at a single bare llama.cpp / vLLM
+  server, no auth. Simple. One agent ↔ one model. Swap models by
+  restarting llama.cpp with a different GGUF.
+- **LiteLLM mode** — point OpenCode at a LiteLLM proxy that fronts
+  multiple backends (local or cloud). Swap between models by changing
+  one env string (`OPENCODE_MODEL`) — no NanoClaw restart needed.
+  LiteLLM also gives you virtual keys, spend tracking, and logging.
+
+Both modes rely on the same three env-gated customizations to the
+OpenCode provider (commit:
+`feat(opencode-provider): support custom provider npm, no-auth, + env-supplied API key`):
+
+- `OPENCODE_PROVIDER_NPM` — names the Vercel AI SDK package
+  (`@ai-sdk/openai-compatible`) OpenCode should load.
+- `OPENCODE_PROVIDER_NO_AUTH=1` — skip the placeholder Authorization
+  header (direct-mode only, for servers that ignore auth).
+- `OPENCODE_PROVIDER_API_KEY` — send a real key as the Authorization
+  bearer (LiteLLM mode or any keyed endpoint not behind OneCLI).
+
+## Prereqs
+
+- `/add-opencode` done. `docker run --rm --entrypoint opencode <image> --version`
+  should print 1.4.x.
+- Target agent group exists — create via `/manage-channels` or
+  `setup/index.ts --step register` first.
+
+## Run
+
+### 1. Identify the group
+
+```bash
+node -e "
+const db = require('better-sqlite3')('data/v2.db', {readonly: true});
+console.log(db.prepare(\"SELECT id, name, folder, agent_provider FROM agent_groups\").all());
+"
+```
+
+Pick the `folder` for the group you want to wire (e.g. `codex-local-llm`).
+
+### 2. Flip agent_provider + clear stale sessions
+
+```bash
+FOLDER="codex-local-llm"   # ← replace with your folder
+node -e "
+const db = require('better-sqlite3')('data/v2.db');
+const r = db.prepare(\"UPDATE agent_groups SET agent_provider='opencode' WHERE folder=?\").run(process.env.FOLDER);
+console.log('agent_groups:', r.changes);
+const s = db.prepare(\"UPDATE sessions SET agent_provider=NULL WHERE agent_group_id=(SELECT id FROM agent_groups WHERE folder=?)\").run(process.env.FOLDER);
+console.log('sessions cleared:', s.changes);
+" FOLDER="$FOLDER"
+
+# Wipe any prior Codex/Claude session state and OpenCode XDG to force
+# a fresh session on first message. Harmless if nothing exists yet.
+GID=$(node -e "const db=require('better-sqlite3')('data/v2.db',{readonly:true}); console.log(db.prepare('SELECT id FROM agent_groups WHERE folder=?').get(process.env.FOLDER).id)" FOLDER="$FOLDER")
+for sess in "data/v2-sessions/$GID"/sess-*; do
+  [ -d "$sess" ] || continue
+  node -e "
+const db = require('better-sqlite3')('$sess/outbound.db');
+db.prepare(\"DELETE FROM session_state WHERE key='sdk_session_id'\").run();
+"
+  rm -rf "$sess/opencode-xdg" 2>/dev/null || true
+done
+```
+
+### 3a. Direct-to-llama.cpp mode
+
+Replace `BASE_URL` and `MODEL_ID`.
+
+```bash
+FOLDER="codex-local-llm"
+BASE_URL="http://192.168.1.95:8080/v1"
+MODEL_ID="glm-4.7-flash"
+LAN_HOST=$(echo "$BASE_URL" | sed -E 's|^https?://([^:/]+).*|\1|')
+
+cat > "groups/$FOLDER/container.json" <<EOF
+{
+  "mcpServers": {},
+  "packages": { "apt": [], "npm": [] },
+  "additionalMounts": [],
+  "skills": "all",
+  "provider": "opencode",
+  "env": {
+    "OPENCODE_PROVIDER": "local-llama",
+    "OPENCODE_PROVIDER_NPM": "@ai-sdk/openai-compatible",
+    "OPENCODE_PROVIDER_NO_AUTH": "1",
+    "OPENCODE_MODEL": "local-llama/$MODEL_ID",
+    "OPENCODE_SMALL_MODEL": "local-llama/$MODEL_ID",
+    "ANTHROPIC_BASE_URL": "$BASE_URL",
+    "NO_PROXY": "127.0.0.1,localhost,$LAN_HOST",
+    "no_proxy": "127.0.0.1,localhost,$LAN_HOST"
+  }
+}
+EOF
+```
+
+### 3b. LiteLLM-in-front mode (recommended for multi-model use)
+
+Spin up a LiteLLM virtual key scoped to the models you want the
+agent to access:
+
+```bash
+curl -sS -H "Authorization: Bearer YOUR_LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"models":["glm-4.7-flash","llama-3.3-70b"],"key_alias":"nanoclaw-localllm"}' \
+  http://192.168.1.95:4000/key/generate
+```
+
+Copy the returned `key` into the block below. Then:
+
+```bash
+FOLDER="codex-local-llm"
+LITELLM_URL="http://192.168.1.95:4000/v1"
+LITELLM_KEY="sk-REPLACE_WITH_VIRTUAL_KEY"
+MODEL_ID="glm-4.7-flash"
+LAN_HOST=$(echo "$LITELLM_URL" | sed -E 's|^https?://([^:/]+).*|\1|')
+
+cat > "groups/$FOLDER/container.json" <<EOF
+{
+  "mcpServers": {},
+  "packages": { "apt": [], "npm": [] },
+  "additionalMounts": [],
+  "skills": "all",
+  "provider": "opencode",
+  "env": {
+    "OPENCODE_PROVIDER": "litellm",
+    "OPENCODE_PROVIDER_NPM": "@ai-sdk/openai-compatible",
+    "OPENCODE_PROVIDER_API_KEY": "$LITELLM_KEY",
+    "OPENCODE_MODEL": "litellm/$MODEL_ID",
+    "OPENCODE_SMALL_MODEL": "litellm/$MODEL_ID",
+    "ANTHROPIC_BASE_URL": "$LITELLM_URL",
+    "NO_PROXY": "127.0.0.1,localhost,$LAN_HOST",
+    "no_proxy": "127.0.0.1,localhost,$LAN_HOST"
+  }
+}
+EOF
+```
+
+To swap models later, just change `OPENCODE_MODEL` (and ideally
+`OPENCODE_SMALL_MODEL` to match) to another model LiteLLM exposes —
+e.g. `litellm/llama-3.3-70b`. Cycle the container and the next
+message uses it.
+
+The host will stamp `groupName` / `assistantName` / `agentGroupId`
+back into the file on the next session resolve. The `env` block
+survives that rewrite as of the `container_config.env` passthrough
+patch on `src/container-config.ts`.
+
+### 4. Cycle the container if one is running
+
+```bash
+NAME=$(docker ps --filter "name=nanoclaw-v2-${FOLDER}" --format '{{.Names}}' | head -1)
+[ -n "$NAME" ] && docker stop "$NAME"
+```
+
+Next message to the group's channel spawns a fresh container that
+reads the new `provider` + `env`.
+
+### 5. Verify
+
+Send a test message in the wired channel. The container log should
+show:
+
+```
+[agent-runner] Starting v2 agent-runner (provider: opencode)
+```
+
+For direct mode: llama.cpp's log shows a `POST /v1/chat/completions`
+hit from the container's IP. For LiteLLM mode: LiteLLM's log shows the
+same and resolves to the model backend.
+
+If the container starts but gets no response:
+
+- `docker exec $NAME printenv OPENCODE_PROVIDER OPENCODE_MODEL ANTHROPIC_BASE_URL`
+  should show all three set correctly.
+- `docker exec $NAME curl -sS "$ANTHROPIC_BASE_URL/models"` should list
+  the model ids.
+- For LiteLLM: check that `OPENCODE_PROVIDER_API_KEY` is the virtual
+  key, not the master key, and that the virtual key has the target
+  model in its allow-list.
+- For direct mode: if the server requires auth, unset
+  `OPENCODE_PROVIDER_NO_AUTH` and set `OPENCODE_PROVIDER_API_KEY`
+  instead.
+
+## Undo
+
+Swap the agent group back to its previous provider:
+
+```bash
+FOLDER="codex-local-llm"
+node -e "
+const db = require('better-sqlite3')('data/v2.db');
+db.prepare(\"UPDATE agent_groups SET agent_provider='codex' WHERE folder=?\").run(process.env.FOLDER);
+" FOLDER="$FOLDER"
+# Then edit container.json to restore provider: "codex" and the old env block.
+```
+
+## Notes on durability
+
+This skill + the `OPENCODE_PROVIDER_NPM` / `_NO_AUTH` / `_API_KEY`
+patch on `opencode.ts` are the only places NanoClaw knows about your
+custom endpoint — both survive upstream updates cleanly:
+
+- The skill lives under `.claude/skills/` which upstream doesn't
+  touch.
+- The env-gated `OPENCODE_PROVIDER_*` patches are backwards-compatible
+  additions; pending PR upstream so future `/add-opencode` re-runs
+  don't clobber them.

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -94,6 +94,20 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
   const model = process.env.OPENCODE_MODEL;
   const smallModel = process.env.OPENCODE_SMALL_MODEL;
   const proxyUrl = process.env.ANTHROPIC_BASE_URL;
+  // For custom providers that aren't OpenCode built-ins (e.g. routing to a
+  // local llama.cpp or any OpenAI-compatible endpoint), OPENCODE_PROVIDER_NPM
+  // names the Vercel AI SDK package OpenCode should use. Common value:
+  // "@ai-sdk/openai-compatible". For built-in ids (anthropic, openai,
+  // openrouter, deepseek, zen) leave unset.
+  const providerNpm = process.env.OPENCODE_PROVIDER_NPM;
+  // Bypass the placeholder-key pattern for endpoints that don't need auth
+  // (bare llama.cpp on a trusted LAN). OneCLI's header injection is then
+  // a no-op for this host and the placeholder is skipped.
+  const noAuth = process.env.OPENCODE_PROVIDER_NO_AUTH === '1';
+  // Env-carried API key for endpoints that aren't routed through OneCLI
+  // (local LiteLLM, self-hosted vLLM, etc.). When set, overrides the
+  // 'placeholder' sentinel that normally signals "OneCLI will inject it."
+  const providerApiKey = process.env.OPENCODE_PROVIDER_API_KEY;
 
   const providerModelId = model ? model.replace(new RegExp(`^${provider}/`), '') : undefined;
   const providerSmallModelId = smallModel ? smallModel.replace(new RegExp(`^${provider}/`), '') : undefined;
@@ -106,7 +120,11 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
       ? {}
       : {
           [provider]: {
-            options: { apiKey: 'placeholder', baseURL: proxyUrl },
+            ...(providerNpm ? { npm: providerNpm } : {}),
+            options: {
+              ...(noAuth ? {} : { apiKey: providerApiKey ?? 'placeholder' }),
+              baseURL: proxyUrl,
+            },
             ...(modelsToRegister.length > 0
               ? {
                   models: Object.fromEntries(


### PR DESCRIPTION
## What

Three env-gated additions to the OpenCode provider so it can target custom OpenAI-compatible endpoints that don't fit the current Anthropic/proxy-style assumption, plus a new feature skill `/add-local-llama` that wires a group to one.

**Provider changes** (`container/agent-runner/src/providers/opencode.ts`, +19 −1):

- `OPENCODE_PROVIDER_NPM` — names the npm package OpenCode should load for the given `OPENCODE_PROVIDER`. Emitted as the per-provider `npm` field (e.g. `@ai-sdk/openai-compatible`).
- `OPENCODE_PROVIDER_NO_AUTH=1` — drops the placeholder `apiKey` so no `Authorization` header is sent. For bare llama.cpp / vLLM servers on a trusted LAN that ignore auth.
- `OPENCODE_PROVIDER_API_KEY` — if set, used as the `apiKey` in options instead of the `"placeholder"` sentinel. For endpoints with a real key that aren't routed through OneCLI (local LiteLLM, self-hosted vLLM, etc.).

All three branches are `undefined`-guarded; existing DeepSeek / OpenRouter / Zen flows are untouched.

**Skill** (`.claude/skills/add-local-llama/SKILL.md`, 218 lines):

- **Direct mode** — OpenCode → bare llama.cpp / vLLM, no auth.
- **LiteLLM mode** — OpenCode → LiteLLM proxy fronting multiple backends; swap models by changing `OPENCODE_MODEL` with no NanoClaw restart.

Depends on `/add-opencode` (must run first) and the three env hooks in this PR.

## Why

`buildOpenCodeConfig` currently hardcodes the Anthropic/proxy shape for non-anthropic providers (`apiKey: 'placeholder'`, built-in provider id), which assumes OneCLI injects the real key via `HTTPS_PROXY` and that OpenCode has a built-in for the provider id. That excludes three valid setups users hit on real hardware:

- A homegrown endpoint using `@ai-sdk/openai-compatible` (no built-in).
- A LAN llama.cpp that ignores auth and breaks on the placeholder header.
- A LiteLLM proxy with its own virtual key, not fronted by OneCLI.

This PR makes OpenCode reachable in all three without patching provider source.

Discussion: #1984.

## How it was tested

- Host tests: `pnpm test` (19 files / 172 tests pass)
- Host build: `pnpm run build` clean
- Container typecheck: `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- Locally: ran `/add-local-llama` against a LiteLLM proxy fronting `glm-4.6`, confirmed requests carried the configured virtual key and reached the proxy; separately ran in direct mode against llama.cpp on a LAN host with `OPENCODE_PROVIDER_NO_AUTH=1`, confirmed no `Authorization` header was sent.

## Usage

```
/add-local-llama
```

Prompts for mode (direct / LiteLLM), endpoint URL, model id, and optional API key. Writes the per-group `container.json` env block, runs `pnpm run build`, and kicks the service.

## Related

Closes #1984 (OpenCode half — Codex half in #1994).