### PR TITLE
fix: parse SQLite datetime() values as UTC in host sweep

### DIFF
--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -5,7 +5,12 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { ABSOLUTE_CEILING_MS, CLAIM_STUCK_MS, decideStuckAction } from './host-sweep.js';
+import {
+  ABSOLUTE_CEILING_MS,
+  CLAIM_STUCK_MS,
+  decideStuckAction,
+  parseSqliteDatetime,
+} from './host-sweep.js';
 
 const BASE = Date.parse('2026-04-20T12:00:00.000Z');
 
@@ -142,5 +147,45 @@ describe('decideStuckAction', () => {
       claims: [{ message_id: 'x', status_changed: 'not-a-date' }],
     });
     expect(res.action).toBe('ok');
+  });
+
+  it("treats SQLite datetime('now') strings as UTC even on a non-UTC host", () => {
+    // Regression: container writes processing_ack.status_changed via
+    // datetime('now'), which is UTC but emits 'YYYY-MM-DD HH:MM:SS' with no
+    // timezone marker. JavaScript's Date.parse treats unmarked strings as
+    // local time, so on a JST host the parsed instant was 9 hours in the
+    // past — every fresh claim looked instantly stuck and the host killed
+    // the container before it could finish its first turn.
+    const sqliteNow = new Date(BASE - 5_000)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, ''); // strip the Z so the value mirrors what SQLite stores
+
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: BASE - 2_000,
+      containerState: null,
+      claims: [{ message_id: 'msg-1', status_changed: sqliteNow }],
+    });
+    expect(res.action).toBe('ok');
+  });
+});
+
+describe('parseSqliteDatetime', () => {
+  it("parses datetime('now') format as UTC", () => {
+    const utc = parseSqliteDatetime('2026-04-25 01:33:04');
+    expect(new Date(utc).toISOString()).toBe('2026-04-25T01:33:04.000Z');
+  });
+
+  it('respects an explicit Z marker', () => {
+    expect(parseSqliteDatetime('2026-04-25T01:33:04.000Z')).toBe(
+      Date.parse('2026-04-25T01:33:04.000Z'),
+    );
+  });
+
+  it('respects an explicit offset', () => {
+    expect(parseSqliteDatetime('2026-04-25T10:33:04+09:00')).toBe(
+      Date.parse('2026-04-25T01:33:04.000Z'),
+    );
   });
 });

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -63,6 +63,20 @@ export type StuckDecision =
   | { action: 'kill-claim'; messageId: string; claimAgeMs: number; toleranceMs: number };
 
 /**
+ * SQLite's `datetime('now')` returns 'YYYY-MM-DD HH:MM:SS' in UTC but with no
+ * timezone marker. JavaScript's `Date.parse` interprets such a string as
+ * *local* time, so on a non-UTC host the parsed instant is wrong by the
+ * offset (e.g. JST → 9 hours in the past). Treat unmarked strings as UTC.
+ */
+export function parseSqliteDatetime(value: string): number {
+  const trimmed = value.trim();
+  if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(trimmed)) {
+    return Date.parse(trimmed);
+  }
+  return Date.parse(trimmed.replace(' ', 'T') + 'Z');
+}
+
+/**
  * Pure decision for whether a running container should be killed this sweep
  * tick. Inputs are all deterministic; filesystem + DB reads happen in the
  * caller.
@@ -94,7 +108,7 @@ export function decideStuckAction(args: {
 
   const tolerance = Math.max(CLAIM_STUCK_MS, declaredBashMs ?? 0);
   for (const claim of claims) {
-    const claimedAt = Date.parse(claim.status_changed);
+    const claimedAt = parseSqliteDatetime(claim.status_changed);
     if (Number.isNaN(claimedAt)) continue;
     const claimAge = now - claimedAt;
     if (claimAge <= tolerance) continue;
@@ -262,7 +276,7 @@ function resetStuckProcessingRows(
     // Already rescheduled for a future retry — don't bump tries again. The
     // wake path (sweep step 2) will fire when process_after elapses and a
     // fresh container will clean the orphan claim on startup.
-    if (msg.processAfter && Date.parse(msg.processAfter) > now) continue;
+    if (msg.processAfter && parseSqliteDatetime(msg.processAfter) > now) continue;
 
     if (msg.tries >= MAX_TRIES) {
       markMessageFailed(inDb, msg.id);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What** — host sweep was killing fresh containers within ~60s of spawn on any non-UTC host, looping until the message hit `MAX_TRIES` and was permanently failed. User-visible symptom: the bot stopped replying.

**Why** — the container writes `processing_ack.status_changed` and `messages_in.process_after` via `datetime('now')`, which emits `'YYYY-MM-DD HH:MM:SS'` in UTC **without a timezone marker**. The host then `Date.parse(...)`s that value, and per the ECMAScript spec unmarked strings parse as **local time**. On JST (UTC+9) the parsed instant is 9 hours earlier than the value the container actually wrote, so `decideStuckAction` saw a multi-hour claim age on every fresh claim and killed the container immediately.

**How it works** — new `parseSqliteDatetime()` helper. If the string already has a `Z` or `±HH:MM` offset, it's `Date.parse`'d as-is; otherwise it's treated as UTC. Used in the two `Date.parse` call sites in `host-sweep.ts` (`decideStuckAction` claim age, `resetStuckProcessingRows` future-retry skip).

**How it was tested** — added a regression test using the exact format SQLite stores (the existing tests passed because they used `new Date(...).toISOString()`, which always emits a `Z` and so hid the bug). `pnpm test`: 14 host-sweep tests pass (was 11), 179 total tests pass. Verified live on a JST host — kill warnings stopped immediately after restart, Slack messages get replies again.