### PR TITLE
fix(whatsapp): route inbound media through session attachment pipeline

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -33,7 +33,7 @@ import {
 import type { GroupMetadata, WAMessageKey, WAMessage, WASocket } from '@whiskeysockets/baileys';
 
 import { isSafeAttachmentName } from '../attachment-safety.js';
-import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME, DATA_DIR } from '../config.js';
+import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 import { registerChannelAdapter } from './channel-registry.js';
@@ -290,26 +290,31 @@ registerChannelAdapter('whatsapp', {
       }
     }
 
-    /** Download media from an inbound message, save to /workspace/attachments/. */
+    // Download media from an inbound message and return as base64 `data` so
+    // the host attachment pipeline (session-manager.extractAttachmentFiles)
+    // saves it into the per-session inbox dir mounted into the container.
+    // Saving to a shared host-side dir wouldn't be visible from inside the
+    // container, since only the session dir is mounted at /workspace.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async function downloadInboundMedia(
       msg: WAMessage,
       normalized: any,
-    ): Promise<Array<{ type: string; name: string; localPath: string }>> {
+    ): Promise<Array<{ type: string; name: string; data: string }>> {
       const mediaTypes: Array<{ key: string; type: string; ext: string }> = [
         { key: 'imageMessage', type: 'image', ext: '.jpg' },
         { key: 'videoMessage', type: 'video', ext: '.mp4' },
         { key: 'audioMessage', type: 'audio', ext: '.ogg' },
         { key: 'documentMessage', type: 'document', ext: '' },
       ];
-      const results: Array<{ type: string; name: string; localPath: string }> = [];
+      const results: Array<{ type: string; name: string; data: string }> = [];
       for (const { key, type, ext } of mediaTypes) {
         if (!normalized[key]) continue;
         try {
           const buffer = await downloadMediaMessage(msg, 'buffer', {});
           // documentMessage.fileName is attacker-controlled and rides through
-          // WhatsApp's E2E channel — Meta can't sanitize it server-side. Without
-          // this guard, a `..`-laden fileName escapes attachDir on path.join.
+          // WhatsApp's E2E channel — Meta can't sanitize it server-side. The
+          // central session-attachment pipeline uses this name for path.join,
+          // so a `..`-laden fileName must be rejected here.
           const rawFilename = normalized[key].fileName;
           const fallback = `${type}-${Date.now()}${ext}`;
           const filename = isSafeAttachmentName(rawFilename) ? rawFilename : fallback;
@@ -319,12 +324,8 @@ registerChannelAdapter('whatsapp', {
               replacement: filename,
             });
           }
-          const attachDir = path.join(DATA_DIR, 'attachments');
-          fs.mkdirSync(attachDir, { recursive: true });
-          const filePath = path.join(attachDir, filename);
-          fs.writeFileSync(filePath, buffer);
-          results.push({ type, name: filename, localPath: `attachments/${filename}` });
-          log.info('Media downloaded', { type, filename });
+          results.push({ type, name: filename, data: buffer.toString('base64') });
+          log.info('Media downloaded', { type, filename, bytes: buffer.length });
         } catch (err) {
           log.warn('Failed to download media', { type, err });
         }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in \`.claude/skills/<name>/\`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Summary

- Sending a PDF/image/audio in WhatsApp produced an inbound message with \`attachments[0].localPath = "attachments/foo.pdf"\`, pointing at \`data/attachments/foo.pdf\` on the host. That path isn't mounted into the agent container — only the per-session dir at \`/workspace\` is — so the agent saw the attachment listed but couldn't read the bytes.
- The host already has a generic attachment pipeline: \`session-manager.extractAttachmentFiles()\` consumes attachments with a base64 \`data\` field, writes them to the session's \`inbox/<msgId>/\` dir (which **is** mounted into the container), and rewrites to a container-visible \`localPath\`. The Chat SDK bridge already produces that shape; WhatsApp was the outlier.
- Switch \`downloadInboundMedia\` to emit \`{ type, name, data: <base64> }\` and let the central pipeline place the file. Drops the channel-local \`DATA_DIR/attachments\` save and the now-unused \`DATA_DIR\` import.

## Test plan

- [ ] Send a PDF in a WhatsApp DM — agent can \`Read /workspace/inbox/<msgId>/<filename>.pdf\`
- [ ] Send an image — agent sees it via formatter image content blocks
- [ ] Send an audio note — saved similarly
- [ ] Existing outbound \`send_file\` path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)