### PR TITLE
[security] fix(container): reject symlinked host-managed directories

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -19,15 +19,17 @@
  */
 import { Database } from 'bun:sqlite';
 import fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
-const DEFAULT_INBOUND_PATH = '/workspace/inbound.db';
-const DEFAULT_OUTBOUND_PATH = '/workspace/outbound.db';
+let inboundDbPath = '/workspace/inbound.db';
+let outboundDbPath = '/workspace/outbound.db';
 const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
 
 let _inbound: Database | null = null;
 let _outbound: Database | null = null;
 let _heartbeatPath: string = DEFAULT_HEARTBEAT_PATH;
-let _testMode = false;
+let _testDbDir: string | null = null;
 
 /**
  * Avoid all cached db reads; open inbound.db read-only with mmap and page cache disabled.
@@ -43,14 +45,7 @@ let _testMode = false;
  * Cost is microseconds per query, so safe for universal use.
  */
 export function openInboundDb(): Database {
-  // In test mode return a thin wrapper over the in-memory singleton.
-  // Callers do try/finally { db.close() } — the wrapper no-ops close()
-  // so the singleton survives for the rest of the test.
-  if (_testMode && _inbound) {
-    const db = _inbound;
-    return { prepare: (sql: string) => db.prepare(sql), exec: (sql: string) => db.exec(sql), close: () => {} } as unknown as Database;
-  }
-  const db = new Database(DEFAULT_INBOUND_PATH, { readonly: true });
+  const db = new Database(inboundDbPath, { readonly: true });
   db.exec('PRAGMA busy_timeout = 5000');
   db.exec('PRAGMA mmap_size = 0');
   return db;
@@ -64,7 +59,7 @@ export function openInboundDb(): Database {
  */
 export function getInboundDb(): Database {
   if (!_inbound) {
-    _inbound = new Database(DEFAULT_INBOUND_PATH, { readonly: true });
+    _inbound = new Database(inboundDbPath, { readonly: true });
     _inbound.exec('PRAGMA busy_timeout = 5000');
     _inbound.exec('PRAGMA mmap_size = 0');
   }
@@ -74,7 +69,7 @@ export function getInboundDb(): Database {
 /** Outbound DB — container owns this file (sole writer). */
 export function getOutboundDb(): Database {
   if (!_outbound) {
-    _outbound = new Database(DEFAULT_OUTBOUND_PATH);
+    _outbound = new Database(outboundDbPath);
     _outbound.exec('PRAGMA journal_mode = DELETE');
     _outbound.exec('PRAGMA busy_timeout = 5000');
     _outbound.exec('PRAGMA foreign_keys = ON');
@@ -178,8 +173,14 @@ export function clearStaleProcessingAcks(): void {
 
 /** For tests — creates in-memory DBs with the session schemas. */
 export function initTestSessionDb(): { inbound: Database; outbound: Database } {
-  _testMode = true;
-  _inbound = new Database(':memory:');
+  closeSessionDb();
+
+  _testDbDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-agent-runner-'));
+  inboundDbPath = path.join(_testDbDir, 'inbound.db');
+  outboundDbPath = path.join(_testDbDir, 'outbound.db');
+  _heartbeatPath = path.join(_testDbDir, '.heartbeat');
+
+  _inbound = new Database(inboundDbPath);
   _inbound.exec('PRAGMA foreign_keys = ON');
   _inbound.exec(`
     CREATE TABLE messages_in (
@@ -214,7 +215,7 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
     );
   `);
 
-  _outbound = new Database(':memory:');
+  _outbound = new Database(outboundDbPath);
   _outbound.exec('PRAGMA foreign_keys = ON');
   _outbound.exec(`
     CREATE TABLE messages_out (
@@ -255,9 +256,15 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
 export function closeSessionDb(): void {
   _inbound?.close();
   _inbound = null;
-  _testMode = false;
   _outbound?.close();
   _outbound = null;
+  inboundDbPath = '/workspace/inbound.db';
+  outboundDbPath = '/workspace/outbound.db';
+  _heartbeatPath = DEFAULT_HEARTBEAT_PATH;
+  if (_testDbDir) {
+    fs.rmSync(_testDbDir, { recursive: true, force: true });
+    _testDbDir = null;
+  }
 }
 
 /**

--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import { GROUPS_DIR } from './config.js';
+import type { AgentGroup } from './types.js';
+
+const cleanupPaths: string[] = [];
+
+function remember(pathToClean: string): string {
+  cleanupPaths.push(pathToClean);
+  return pathToClean;
+}
+
+function tmpDir(): string {
+  return remember(fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-claude-compose-')));
+}
+
+afterEach(() => {
+  for (const p of cleanupPaths.splice(0)) {
+    fs.rmSync(p, { recursive: true, force: true });
+  }
+});
+
+describe('composeGroupClaudeMd', () => {
+  it('does not follow a container-controlled .claude-fragments symlink', () => {
+    const folder = `test-symlink-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const groupDir = remember(path.join(GROUPS_DIR, folder));
+    const outside = tmpDir();
+    fs.mkdirSync(groupDir, { recursive: true });
+
+    const victim = path.join(outside, 'mount-allowlist.json');
+    fs.writeFileSync(victim, 'keep me');
+    fs.symlinkSync(outside, path.join(groupDir, '.claude-fragments'), 'dir');
+
+    const group: AgentGroup = {
+      id: `ag-${folder}`,
+      name: 'Symlink Test',
+      folder,
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    };
+
+    expect(() => composeGroupClaudeMd(group)).toThrow(/CLAUDE fragment directory.*not a symlink/);
+    expect(fs.readFileSync(victim, 'utf8')).toBe('keep me');
+  });
+});

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import { GROUPS_DIR } from './config.js';
 import { readContainerConfig } from './container-config.js';
 import { log } from './log.js';
+import { ensureManagedDirectory } from './safe-managed-path.js';
 import type { AgentGroup } from './types.js';
 
 // Symlink targets are container paths — dangling on host (hence the readlink
@@ -49,9 +50,7 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   syncSymlink(sharedLink, SHARED_CLAUDE_MD_CONTAINER_PATH);
 
   const fragmentsDir = path.join(groupDir, '.claude-fragments');
-  if (!fs.existsSync(fragmentsDir)) {
-    fs.mkdirSync(fragmentsDir, { recursive: true });
-  }
+  ensureManagedDirectory(groupDir, fragmentsDir, 'CLAUDE fragment directory');
 
   // Desired fragment set.
   const config = readContainerConfig(group.folder);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -28,6 +28,7 @@ import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
+import { ensureManagedDirectory } from './safe-managed-path.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
 import './providers/index.js';
@@ -340,10 +341,11 @@ function buildMounts(
  * so it's dangling on the host but valid inside the container.
  */
 function syncSkillSymlinks(claudeDir: string, containerConfig: import('./container-config.js').ContainerConfig): void {
-  const skillsDir = path.join(claudeDir, 'skills');
-  if (!fs.existsSync(skillsDir)) {
-    fs.mkdirSync(skillsDir, { recursive: true });
+  if (!fs.existsSync(claudeDir)) {
+    fs.mkdirSync(claudeDir, { recursive: true });
   }
+  const skillsDir = path.join(claudeDir, 'skills');
+  ensureManagedDirectory(claudeDir, skillsDir, 'Claude skills directory');
 
   // Determine desired skill set
   const projectRoot = process.cwd();

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -312,6 +312,10 @@ function resetStuckProcessingRows(
   // would re-read them, see the old status_changed timestamp, conclude the
   // freshly respawned container is stuck, and SIGKILL it before its
   // agent-runner has a chance to run clearStaleProcessingAcks() on startup.
+  // We're safe to write outbound.db here because we just killed the container
+  // that owned it (or it crashed and left no writer behind). Production sweep
+  // opens outbound.db readonly for normal reads, so reopen the real DB with
+  // write access unless tests supplied an in-memory writable handle.
   const ownsDb = !writableOutDb;
   let useDb: Database.Database | null = writableOutDb ?? null;
   try {

--- a/src/safe-managed-path.test.ts
+++ b/src/safe-managed-path.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ensureManagedDirectory } from './safe-managed-path.js';
+
+const tmpRoots: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-managed-path-'));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('ensureManagedDirectory', () => {
+  it('creates a missing managed directory under its parent', () => {
+    const root = tmpDir();
+    const child = path.join(root, 'managed');
+
+    ensureManagedDirectory(root, child, 'managed test directory');
+
+    expect(fs.statSync(child).isDirectory()).toBe(true);
+  });
+
+  it('rejects symlinked managed directories without touching the target', () => {
+    const root = tmpDir();
+    const outside = tmpDir();
+    const victim = path.join(outside, 'mount-allowlist.json');
+    fs.writeFileSync(victim, 'keep me');
+    fs.symlinkSync(outside, path.join(root, 'managed'), 'dir');
+
+    expect(() => ensureManagedDirectory(root, path.join(root, 'managed'), 'managed test directory')).toThrow(
+      /not a symlink/,
+    );
+
+    expect(fs.readFileSync(victim, 'utf8')).toBe('keep me');
+  });
+
+  it('rejects child paths that escape the managed parent', () => {
+    const root = tmpDir();
+    const outside = tmpDir();
+
+    expect(() => ensureManagedDirectory(root, outside, 'managed test directory')).toThrow(/must be inside/);
+  });
+});

--- a/src/safe-managed-path.ts
+++ b/src/safe-managed-path.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Ensure a host-managed directory that lives under a container-writable parent
+ * is a real directory and does not escape that parent through a symlink.
+ *
+ * Host maintenance code must not follow paths that the container can replace
+ * with symlinks. Otherwise a prompt-injected or compromised agent can make the
+ * host delete or write files outside the intended group/session directory on
+ * the next spawn.
+ */
+export function ensureManagedDirectory(parentDir: string, childDir: string, label: string): void {
+  const resolvedParent = path.resolve(parentDir);
+  const resolvedChild = path.resolve(childDir);
+
+  if (!isPathInside(resolvedParent, resolvedChild)) {
+    throw new Error(`${label} must be inside ${resolvedParent}: ${resolvedChild}`);
+  }
+
+  const parentReal = fs.realpathSync(resolvedParent);
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(resolvedChild);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') throw err;
+    fs.mkdirSync(resolvedChild, { recursive: true });
+    stat = fs.lstatSync(resolvedChild);
+  }
+
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a real directory, not a symlink: ${resolvedChild}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`${label} must be a directory: ${resolvedChild}`);
+  }
+
+  const childReal = fs.realpathSync(resolvedChild);
+  if (!isPathInside(parentReal, childReal)) {
+    throw new Error(`${label} escapes ${parentReal}: ${childReal}`);
+  }
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}


### PR DESCRIPTION
## Summary

This PR hardens NanoClaw's host/container filesystem boundary for host-managed directories that live under container-writable mounts.

- Adds a shared guard that requires host-managed child directories to be real directories, not symlinks.
- Applies the guard to `.claude-fragments` before host-side CLAUDE.md composition reconciles fragment files.
- Applies the same guard to `.claude-shared/skills` before host-side skill symlink reconciliation.
- Adds regression coverage proving a symlinked fragment directory is rejected without touching the symlink target.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Container-writable symlink into `.claude-fragments` | A compromised or prompt-injected agent can make the host delete/write files outside the group directory on the next spawn | High |
| Same unsafe host-managed-directory pattern in `.claude-shared/skills` | A container can redirect host skill-symlink reconciliation into another writable host directory | Medium |

## Before this PR

- `groups/<folder>` is mounted read-write into the agent container at `/workspace/agent`.
- On each spawn, the host runs `composeGroupClaudeMd()` and reconciles files under `groups/<folder>/.claude-fragments`.
- The host used `fs.existsSync()` before `readdirSync()`, `unlinkSync()`, and writes, so a container-created symlink at `.claude-fragments` was followed.
- `syncSkillSymlinks()` had the same pattern for `.claude-shared/skills`, which also sits under a container-writable host directory.
- There was no regression test covering host maintenance paths that operate under container-writable directories.

## After this PR

- Host-managed child directories are validated with `lstatSync()` before use.
- Symlinked managed directories are rejected before any reconcile/delete/write loop runs.
- The resolved child path must remain inside the resolved parent directory.
- Missing managed directories are still created normally.
- Regression tests cover both the shared guard and the `.claude-fragments` call site.

## Why this matters

NanoClaw intentionally separates host-managed security/configuration state from container-writable workspace state. That boundary fails if the host later follows a symlink planted by the container inside a writable mount.

A compromised or prompt-injected agent already has write access to `/workspace/agent`. Before this patch, it could replace `.claude-fragments` with a symlink to another writable host directory. On the next container spawn, the host would treat the symlink target as its fragment directory and reconcile files there as the NanoClaw host user.

## Attack flow

```text
agent writes inside /workspace/agent
    -> replaces .claude-fragments with a symlink to a writable host directory
        -> host composeGroupClaudeMd() follows the symlink on next spawn
            -> host readdir/unlink/write operations affect files outside the group directory
```

## Affected code

| Issue | Files |
|-------|-------|
| `.claude-fragments` symlink escape | `src/claude-md-compose.ts`, `src/safe-managed-path.ts`, `src/claude-md-compose.test.ts` |
| `.claude-shared/skills` symlink hardening | `src/container-runner.ts`, `src/safe-managed-path.ts`, `src/safe-managed-path.test.ts` |

## Root cause

Issue 1: `.claude-fragments` symlink escape
- Direct cause: host composition used `existsSync()` and then operated on `.claude-fragments` without checking `lstatSync()`.
- Boundary failure: `.claude-fragments` is under a directory that the container can write, but the host treated that path as trusted during spawn-time maintenance.

Issue 2: `.claude-shared/skills` symlink hardening
- Direct cause: host skill synchronization created/reconciled `skills/` under a container-writable `.claude-shared` directory without rejecting symlinks.
- Boundary failure: host maintenance followed a path whose directory entry could be replaced by the container.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Container-writable host-managed directory symlink escape | 7.1 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:H` |

Rationale:
- The primitive is local to the agent/container boundary: an actor that can cause writes from inside the agent container can influence host-side file operations on the next spawn.
- Scope changes because the host process performs filesystem operations outside the container namespace.
- Impact is bounded to paths writable by the NanoClaw host user, but can include integrity loss, deletion of configuration files, and host-side denial of service.

## Safe reproduction steps

### 1. `.claude-fragments` symlink escape

1. In a vulnerable checkout, create a group folder and a separate writable host directory with a harmless marker file, for example `mount-allowlist.json`.
2. Replace `groups/<folder>/.claude-fragments` with a symlink to that separate directory.
3. Trigger `composeGroupClaudeMd()` for that group, as happens during container spawn.
4. Observe that vulnerable code follows the symlink and reconciles files in the target directory.

The regression test added in this PR uses a safe temporary directory variant of the same flow and verifies the marker file remains unchanged.

## Expected vulnerable behavior

- A directory entry controlled from a writable container mount should not cause host maintenance code to operate outside the group/session directory.
- Pre-patch code followed `.claude-fragments` when it was a symlink and then ran `readdirSync()`, `unlinkSync()`, and fragment writes through the symlink.

## Changes in this PR

- Adds `ensureManagedDirectory(parentDir, childDir, label)`.
- Uses `lstatSync()` to reject symlinked managed directories before following them.
- Verifies the managed child path is syntactically inside the parent before creation/use.
- Verifies the real resolved child path remains inside the real resolved parent path.
- Applies the guard to `.claude-fragments` composition.
- Applies the guard to `.claude-shared/skills` synchronization.
- Adds focused unit tests for the shared helper and the CLAUDE fragment composition call site.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Host path hardening | `src/safe-managed-path.ts` | New helper for validating host-managed child directories under container-writable parents |
| CLAUDE.md composition | `src/claude-md-compose.ts` | Rejects symlinked `.claude-fragments` before reconcile/write operations |
| Container spawn preparation | `src/container-runner.ts` | Rejects symlinked `.claude-shared/skills` before skill symlink reconciliation |
| Regression tests | `src/safe-managed-path.test.ts`, `src/claude-md-compose.test.ts` | Covers symlink rejection and verifies targets are not touched |

## Maintainer impact

- The patch is narrow and only affects host-managed directories that NanoClaw itself creates/reconciles.
- Normal missing-directory creation still works.
- Existing real directories under the intended parent continue to work.
- No channel, provider, database, or UI behavior is changed.

## Fix rationale

The durable boundary is: host-managed paths under container-writable parents must be validated as real directories before the host performs maintenance operations inside them.

Checking the additional-mount allowlist is not sufficient here because the attack does not require adding a mount. It pivots through a writable directory that is already part of the intended container workspace. `lstatSync()` plus realpath containment prevents the host from following a container-controlled directory symlink while preserving the normal managed-directory workflow.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Installed dependencies with the pinned package manager.
- [x] Ran the Vitest command used for the new regression coverage. In this repo's script wiring, the command executed the full test suite: 25 files / 201 tests passed.
- [x] Ran TypeScript type checking.
- [x] Checked formatting.
- [x] Ran ESLint on the new files.
- [ ] Full `pnpm run lint` is not green on current `main`; it reports pre-existing unrelated errors in `src/channels/cli.ts`, `src/container-runner.ts`, and `src/session-manager.ts`.

Executed with:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm test -- --run src/safe-managed-path.test.ts src/claude-md-compose.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run format:check`
- `corepack pnpm exec eslint src/safe-managed-path.ts src/safe-managed-path.test.ts src/claude-md-compose.test.ts`
- `corepack pnpm run lint`

## Disclosure notes

- This PR is intentionally bounded to host-managed directory symlink handling under container-writable mounts.
- It does not claim arbitrary host filesystem access; impact is limited to paths writable by the NanoClaw host user and reachable through the planted symlink path.
- I checked for duplicate public issues/PRs. I found adjacent prior work around mount allowlist symlink resolution in #14 and proposed container file-tool path containment in #1956, but did not find an existing issue or PR covering `.claude-fragments` / `.claude-shared/skills` host maintenance following container-controlled symlinks.
- No unrelated files were changed.
