### PR TITLE
fix(routing): origin-session threading for agent-to-agent replies

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -74,6 +74,14 @@ export function getOutboundDb(): Database {
         updated_at               TEXT NOT NULL
       );
     `);
+    // origin_session_id: used by the host to route A2A replies back to the
+    // exact originating session. Forward-compat for older outbound.db files.
+    const outCols = new Set(
+      (_outbound.prepare("PRAGMA table_info('messages_out')").all() as Array<{ name: string }>).map((c) => c.name),
+    );
+    if (!outCols.has('origin_session_id')) {
+      _outbound.exec('ALTER TABLE messages_out ADD COLUMN origin_session_id TEXT');
+    }
   }
   return _outbound;
 }
@@ -148,20 +156,21 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
   _inbound.exec('PRAGMA foreign_keys = ON');
   _inbound.exec(`
     CREATE TABLE messages_in (
-      id             TEXT PRIMARY KEY,
-      seq            INTEGER UNIQUE,
-      kind           TEXT NOT NULL,
-      timestamp      TEXT NOT NULL,
-      status         TEXT DEFAULT 'pending',
-      process_after  TEXT,
-      recurrence     TEXT,
-      series_id      TEXT,
-      tries          INTEGER DEFAULT 0,
-      trigger        INTEGER NOT NULL DEFAULT 1,
-      platform_id    TEXT,
-      channel_type   TEXT,
-      thread_id      TEXT,
-      content        TEXT NOT NULL
+      id                TEXT PRIMARY KEY,
+      seq               INTEGER UNIQUE,
+      kind              TEXT NOT NULL,
+      timestamp         TEXT NOT NULL,
+      status            TEXT DEFAULT 'pending',
+      process_after     TEXT,
+      recurrence        TEXT,
+      series_id         TEXT,
+      tries             INTEGER DEFAULT 0,
+      trigger           INTEGER NOT NULL DEFAULT 1,
+      platform_id       TEXT,
+      channel_type      TEXT,
+      thread_id         TEXT,
+      content           TEXT NOT NULL,
+      origin_session_id TEXT
     );
     CREATE TABLE delivered (
       message_out_id      TEXT PRIMARY KEY,
@@ -183,17 +192,18 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
   _outbound.exec('PRAGMA foreign_keys = ON');
   _outbound.exec(`
     CREATE TABLE messages_out (
-      id             TEXT PRIMARY KEY,
-      seq            INTEGER UNIQUE,
-      in_reply_to    TEXT,
-      timestamp      TEXT NOT NULL,
-      deliver_after  TEXT,
-      recurrence     TEXT,
-      kind           TEXT NOT NULL,
-      platform_id    TEXT,
-      channel_type   TEXT,
-      thread_id      TEXT,
-      content        TEXT NOT NULL
+      id                TEXT PRIMARY KEY,
+      seq               INTEGER UNIQUE,
+      in_reply_to       TEXT,
+      timestamp         TEXT NOT NULL,
+      deliver_after     TEXT,
+      recurrence        TEXT,
+      kind              TEXT NOT NULL,
+      platform_id       TEXT,
+      channel_type      TEXT,
+      thread_id         TEXT,
+      content           TEXT NOT NULL,
+      origin_session_id TEXT
     );
     CREATE TABLE processing_ack (
       message_id     TEXT PRIMARY KEY,

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -25,6 +25,8 @@ export interface MessageInRow {
   channel_type: string | null;
   thread_id: string | null;
   content: string;
+  /** Session that sent this A2A message; null for non-A2A. */
+  origin_session_id: string | null;
 }
 
 // Cap on how many messages reach the agent in one prompt. Read from
@@ -65,11 +67,19 @@ export function getPendingMessages(): MessageInRow[] {
 
   if (pending.length === 0) return [];
 
-  // Filter out messages already acknowledged in outbound.db
+  // Filter out messages already acknowledged in outbound.db.
+  // 'processing' acks older than 5 minutes are treated as stale (container
+  // picked up the message but crashed or hung before marking it completed).
   const ackedIds = new Set(
-    (outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>).map(
-      (r) => r.message_id,
-    ),
+    (
+      outbound
+        .prepare(
+          `SELECT message_id FROM processing_ack
+           WHERE status = 'completed'
+              OR (status = 'processing' AND status_changed > datetime('now', '-5 minutes'))`,
+        )
+        .all() as Array<{ message_id: string }>
+    ).map((r) => r.message_id),
   );
 
   // Reverse: we fetched DESC to take the most recent N, but the agent

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -18,6 +18,8 @@ export interface MessageOutRow {
   channel_type: string | null;
   thread_id: string | null;
   content: string;
+  /** Propagated from the triggering inbound row's origin_session_id. */
+  origin_session_id: string | null;
 }
 
 export interface WriteMessageOut {
@@ -53,12 +55,22 @@ export function writeMessageOut(msg: WriteMessageOut): number {
   const max = Math.max(maxOut, maxIn);
   const nextSeq = max % 2 === 0 ? max + 1 : max + 2; // next odd
 
+  // Propagate origin_session_id from the triggering inbound row so the host
+  // delivery path can route A2A replies directly back to the originating session.
+  let originSessionId: string | null = null;
+  if (msg.in_reply_to) {
+    const inRow = inbound
+      .prepare('SELECT origin_session_id FROM messages_in WHERE id = ?')
+      .get(msg.in_reply_to) as { origin_session_id: string | null } | undefined;
+    originSessionId = inRow?.origin_session_id ?? null;
+  }
+
   // bun:sqlite requires named parameters to be passed with the prefix character
   // in the JS object keys (better-sqlite3 auto-stripped it, bun:sqlite does not).
   outbound
     .prepare(
-      `INSERT INTO messages_out (id, seq, in_reply_to, timestamp, deliver_after, recurrence, kind, platform_id, channel_type, thread_id, content)
-     VALUES ($id, $seq, $in_reply_to, datetime('now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content)`,
+      `INSERT INTO messages_out (id, seq, in_reply_to, timestamp, deliver_after, recurrence, kind, platform_id, channel_type, thread_id, content, origin_session_id)
+     VALUES ($id, $seq, $in_reply_to, datetime('now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content, $origin_session_id)`,
     )
     .run({
       $id: msg.id,
@@ -71,6 +83,7 @@ export function writeMessageOut(msg: WriteMessageOut): number {
       $channel_type: msg.channel_type ?? null,
       $thread_id: msg.thread_id ?? null,
       $content: msg.content,
+      $origin_session_id: originSessionId,
     });
 
   return nextSeq;

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -57,12 +57,24 @@ export function writeMessageOut(msg: WriteMessageOut): number {
 
   // Propagate origin_session_id from the triggering inbound row so the host
   // delivery path can route A2A replies directly back to the originating session.
+  // Defensive: if the inbound DB pre-dates the routing-fix migration (e.g. a
+  // session DB hand-copied into a freshly-deployed install before the host
+  // boot-time migration ran), the SELECT throws "no such column". Treat that
+  // as "no origin info available" and let the host fall back to its existing
+  // findSessionByAgentGroup path. Avoids crashing the container on a mismatch
+  // the host's eager startup migration is supposed to prevent.
   let originSessionId: string | null = null;
   if (msg.in_reply_to) {
-    const inRow = inbound
-      .prepare('SELECT origin_session_id FROM messages_in WHERE id = ?')
-      .get(msg.in_reply_to) as { origin_session_id: string | null } | undefined;
-    originSessionId = inRow?.origin_session_id ?? null;
+    try {
+      const inRow = inbound.prepare('SELECT origin_session_id FROM messages_in WHERE id = ?').get(msg.in_reply_to) as
+        | { origin_session_id: string | null }
+        | undefined;
+      originSessionId = inRow?.origin_session_id ?? null;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/no such column/i.test(msg)) throw err;
+      // Column missing → migration hasn't run on this DB yet. Soft-fail.
+    }
   }
 
   // bun:sqlite requires named parameters to be passed with the prefix character
@@ -104,9 +116,7 @@ export function getMessageIdBySeq(seq: number): string | null {
   const inbound = getInboundDb();
 
   // Inbound messages: ID is already the platform message ID
-  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as
-    | { id: string }
-    | undefined;
+  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as { id: string } | undefined;
   if (inRow) return inRow.id;
 
   // Outbound messages: look up platform message ID from delivered table

--- a/container/agent-runner/src/db/origin-session.test.ts
+++ b/container/agent-runner/src/db/origin-session.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for origin_session_id threading on the container side.
+ *
+ * Verifies:
+ * - writeMessageOut propagates origin_session_id from the triggering inbound row.
+ * - writeMessageOut leaves origin_session_id null when in_reply_to is absent.
+ * - writeMessageOut leaves origin_session_id null when the inbound row has none.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { closeSessionDb, initTestSessionDb } from './connection.js';
+import { writeMessageOut } from './messages-out.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+function seedInboundMessage(opts: {
+  id: string;
+  originSessionId: string | null;
+  channelType?: string;
+}): void {
+  const { getInboundDb } = require('./connection.js');
+  const db = getInboundDb();
+  db.prepare(
+    `INSERT INTO messages_in (id, seq, kind, timestamp, status, content, trigger, origin_session_id)
+     VALUES (?, 2, 'chat', datetime('now'), 'pending', '{}', 1, ?)`,
+  ).run(opts.id, opts.originSessionId);
+}
+
+describe('origin_session_id propagation in writeMessageOut', () => {
+  it('propagates origin_session_id from the inbound row when in_reply_to is set', () => {
+    seedInboundMessage({ id: 'in-1', originSessionId: 'sess-origin-abc' });
+
+    writeMessageOut({
+      id: 'out-1',
+      kind: 'chat',
+      content: '{}',
+      in_reply_to: 'in-1',
+    });
+
+    const { getOutboundDb } = require('./connection.js');
+    const row = getOutboundDb()
+      .prepare('SELECT origin_session_id FROM messages_out WHERE id = ?')
+      .get('out-1') as { origin_session_id: string | null } | undefined;
+
+    expect(row?.origin_session_id).toBe('sess-origin-abc');
+  });
+
+  it('leaves origin_session_id null when in_reply_to is not set', () => {
+    writeMessageOut({
+      id: 'out-2',
+      kind: 'chat',
+      content: '{}',
+    });
+
+    const { getOutboundDb } = require('./connection.js');
+    const row = getOutboundDb()
+      .prepare('SELECT origin_session_id FROM messages_out WHERE id = ?')
+      .get('out-2') as { origin_session_id: string | null } | undefined;
+
+    expect(row?.origin_session_id).toBeNull();
+  });
+
+  it('leaves origin_session_id null when the inbound row has no origin', () => {
+    seedInboundMessage({ id: 'in-3', originSessionId: null });
+
+    writeMessageOut({
+      id: 'out-3',
+      kind: 'chat',
+      content: '{}',
+      in_reply_to: 'in-3',
+    });
+
+    const { getOutboundDb } = require('./connection.js');
+    const row = getOutboundDb()
+      .prepare('SELECT origin_session_id FROM messages_out WHERE id = ?')
+      .get('out-3') as { origin_session_id: string | null } | undefined;
+
+    expect(row?.origin_session_id).toBeNull();
+  });
+
+  it('leaves origin_session_id null when in_reply_to references a non-existent row', () => {
+    writeMessageOut({
+      id: 'out-4',
+      kind: 'chat',
+      content: '{}',
+      in_reply_to: 'nonexistent-id',
+    });
+
+    const { getOutboundDb } = require('./connection.js');
+    const row = getOutboundDb()
+      .prepare('SELECT origin_session_id FROM messages_out WHERE id = ?')
+      .get('out-4') as { origin_session_id: string | null } | undefined;
+
+    expect(row?.origin_session_id).toBeNull();
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -171,7 +171,9 @@ CREATE TABLE IF NOT EXISTS messages_in (
   platform_id    TEXT,
   channel_type   TEXT,
   thread_id      TEXT,
-  content        TEXT NOT NULL
+  content        TEXT NOT NULL,
+  origin_session_id TEXT
+                 -- session that sent this A2A message; NULL for non-A2A
 );
 CREATE INDEX IF NOT EXISTS idx_messages_in_series ON messages_in(series_id);
 
@@ -223,7 +225,10 @@ CREATE TABLE IF NOT EXISTS messages_out (
   platform_id    TEXT,
   channel_type   TEXT,
   thread_id      TEXT,
-  content        TEXT NOT NULL
+  content        TEXT NOT NULL,
+  origin_session_id TEXT
+                 -- echoed from inbound row's origin_session_id; host uses this
+                 -- to route A2A replies back to the originating session directly
 );
 
 -- Container tracks processing status here instead of updating messages_in.

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -100,14 +100,17 @@ export function insertMessage(
      * Host countDueMessages gates on this; container reads everything.
      */
     trigger?: 0 | 1;
+    /** Session ID that sent this A2A message; null for non-A2A messages. */
+    originSessionId?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
-     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger)`,
+    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, origin_session_id)
+     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @originSessionId)`,
   ).run({
     ...message,
     trigger: message.trigger ?? 1,
+    originSessionId: message.originSessionId ?? null,
     seq: nextEvenSeq(db),
   });
 }
@@ -218,6 +221,7 @@ export interface OutboundMessage {
   channel_type: string | null;
   thread_id: string | null;
   content: string;
+  origin_session_id: string | null;
 }
 
 export function getDueOutboundMessages(db: Database.Database): OutboundMessage[] {
@@ -284,4 +288,22 @@ export function migrateMessagesInTable(db: Database.Database): void {
     // the agent" semantics, so backfill 1 and default 1 for new inserts.
     db.prepare('ALTER TABLE messages_in ADD COLUMN trigger INTEGER NOT NULL DEFAULT 1').run();
   }
+  if (!cols.has('origin_session_id')) {
+    db.prepare('ALTER TABLE messages_in ADD COLUMN origin_session_id TEXT').run();
+  }
+}
+
+/**
+ * Adds columns added to messages_out after the initial v2 schema.
+ * Called by the host delivery path when opening a read-only outbound.db
+ * for polling — the outbound.db may predate this column.
+ *
+ * Note: The host opens outbound.db read-only, so we cannot run ALTER TABLE
+ * here. This function is intentionally a no-op on the host side; the
+ * column is added by the container in connection.ts:getOutboundDb().
+ * The interface allows null for backward compat with older session DBs.
+ */
+export function migrateMessagesOutTable(_db: Database.Database): void {
+  // Intentional no-op: outbound.db is container-owned (read-only on host).
+  // Migration happens in container/agent-runner/src/db/connection.ts.
 }

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -52,10 +52,18 @@ export function findSessionForAgent(
     .get(agentGroupId, messagingGroupId) as Session | undefined;
 }
 
-/** Find an active session scoped to an agent group (ignoring messaging group). */
+/** Find an active session scoped to an agent group (ignoring messaging group).
+ *
+ * Ordered by `last_active DESC` (nulls last) so agent-to-agent fallback routing
+ * prefers the session most recently in use, not the one created latest. With
+ * origin-session threading in place (see `agent-route.ts`), this is the
+ * fallback path used only when the originating session is unavailable.
+ */
 export function findSessionByAgentGroup(agentGroupId: string): Session | undefined {
   return getDb()
-    .prepare("SELECT * FROM sessions WHERE agent_group_id = ? AND status = 'active' ORDER BY created_at DESC LIMIT 1")
+    .prepare(
+      "SELECT * FROM sessions WHERE agent_group_id = ? AND status = 'active' ORDER BY last_active IS NULL, last_active DESC, created_at DESC LIMIT 1",
+    )
     .get(agentGroupId) as Session | undefined;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { DATA_DIR } from './config.js';
 import { migrateGroupsToClaudeLocal } from './claude-md-compose.js';
 import { initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
+import { getActiveSessions } from './db/sessions.js';
+import { openInboundDb } from './session-manager.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
@@ -66,6 +68,24 @@ async function main(): Promise<void> {
 
   // 1b. One-time filesystem cutover — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
+
+  // 1c. Eager-migrate every existing session's inbound.db before any container
+  // can spawn. openInboundDb runs migrateMessagesInTable, which adds any
+  // missing columns (e.g. origin_session_id from the routing fix). Without
+  // this sweep the migration would happen lazily — but containers may open
+  // inbound.db read-only first to look up an in_reply_to row, racing ahead
+  // of the host migration and hitting "no such column".
+  const activeSessions = getActiveSessions();
+  let migratedCount = 0;
+  for (const s of activeSessions) {
+    try {
+      openInboundDb(s.agent_group_id, s.id).close();
+      migratedCount++;
+    } catch (err) {
+      log.warn('Startup inbound migration skipped for session', { sessionId: s.id, err });
+    }
+  }
+  log.info('Startup inbound migrations complete', { migrated: migratedCount, total: activeSessions.length });
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -118,6 +118,8 @@ export interface RoutableAgentMessage {
   id: string;
   platform_id: string | null;
   content: string;
+  /** Populated when this is a reply from an agent that received an A2A message. */
+  origin_session_id?: string | null;
 }
 
 export async function routeAgentMessage(msg: RoutableAgentMessage, session: Session): Promise<void> {
@@ -136,7 +138,35 @@ export async function routeAgentMessage(msg: RoutableAgentMessage, session: Sess
   if (!getAgentGroup(targetAgentGroupId)) {
     throw new Error(`target agent group ${targetAgentGroupId} not found for message ${msg.id}`);
   }
-  const { session: targetSession } = resolveSession(targetAgentGroupId, null, null, 'agent-shared');
+  // Resolve target session. If the source message has origin_session_id (this is a
+  // reply to an A2A message), deliver back to that exact session — bypassing
+  // findSessionByAgentGroup, which picks "most recently active" and can route to
+  // the wrong session when multiple active sessions exist for the same agent
+  // group (e.g. one per channel). Falls back to resolveSession when origin is
+  // stale/archived/cross-group.
+  let targetSession: Session;
+  if (msg.origin_session_id) {
+    const originSession = getSession(msg.origin_session_id);
+    if (originSession && originSession.agent_group_id === targetAgentGroupId && originSession.status === 'active') {
+      targetSession = originSession;
+      log.info('Agent reply threaded to origin session', {
+        from: session.agent_group_id,
+        to: targetAgentGroupId,
+        originSession: originSession.id,
+      });
+    } else {
+      log.warn('Origin session unavailable, falling back to findSessionByAgentGroup', {
+        originSessionId: msg.origin_session_id,
+        targetAgentGroupId,
+      });
+      const { session: resolved } = resolveSession(targetAgentGroupId, null, null, 'agent-shared');
+      targetSession = resolved;
+    }
+  } else {
+    const { session: resolved } = resolveSession(targetAgentGroupId, null, null, 'agent-shared');
+    targetSession = resolved;
+  }
+
   const a2aMsgId = `a2a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
   // If the source message references files (via `send_file`), forward the
@@ -154,6 +184,7 @@ export async function routeAgentMessage(msg: RoutableAgentMessage, session: Sess
     channelType: 'agent',
     threadId: null,
     content: forwardedContent,
+    originSessionId: session.id,
   });
   log.info('Agent message routed', {
     from: session.agent_group_id,

--- a/src/modules/agent-to-agent/origin-routing.test.ts
+++ b/src/modules/agent-to-agent/origin-routing.test.ts
@@ -182,10 +182,7 @@ describe('origin-session threading — outbound A2A message', () => {
 
     const sourceSession = makeSession({ id: 'sess-source', agent_group_id: 'ag-source' });
 
-    await routeAgentMessage(
-      { id: 'msg-1', platform_id: 'ag-target', content: '{"text":"hello"}' },
-      sourceSession,
-    );
+    await routeAgentMessage({ id: 'msg-1', platform_id: 'ag-target', content: '{"text":"hello"}' }, sourceSession);
 
     expect(mockResolveSession).toHaveBeenCalledWith('ag-target', null, null, 'agent-shared');
     const [, writtenSessionId] = mockWriteSessionMessage.mock.calls[0];

--- a/src/modules/agent-to-agent/origin-routing.test.ts
+++ b/src/modules/agent-to-agent/origin-routing.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for origin-session threading in agent-to-agent routing.
+ *
+ * Verifies that:
+ * - A2A messages stamp origin_session_id on the target's inbound row.
+ * - Replies with origin_session_id are delivered to the origin session, not
+ *   the most-recently-active session (which may be different after a race).
+ * - Stale/closed origin sessions fall back to findSessionByAgentGroup.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { routeAgentMessage } from './agent-route.js';
+import type { Session } from '../../types.js';
+
+// --------------------------------------------------------------------------
+// Mocks
+// --------------------------------------------------------------------------
+
+const mockGetAgentGroup = vi.fn();
+const mockGetSession = vi.fn();
+const mockHasDestination = vi.fn();
+const mockResolveSession = vi.fn();
+const mockWriteSessionMessage = vi.fn();
+const mockWakeContainer = vi.fn();
+
+vi.mock('../../db/agent-groups.js', () => ({ getAgentGroup: (...a: unknown[]) => mockGetAgentGroup(...a) }));
+vi.mock('../../db/sessions.js', () => ({ getSession: (...a: unknown[]) => mockGetSession(...a) }));
+vi.mock('../../container-runner.js', () => ({ wakeContainer: (...a: unknown[]) => mockWakeContainer(...a) }));
+vi.mock('../../session-manager.js', () => ({
+  resolveSession: (...a: unknown[]) => mockResolveSession(...a),
+  writeSessionMessage: (...a: unknown[]) => mockWriteSessionMessage(...a),
+}));
+vi.mock('./db/agent-destinations.js', () => ({ hasDestination: (...a: unknown[]) => mockHasDestination(...a) }));
+vi.mock('../../log.js', () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-source',
+    agent_group_id: 'ag-source',
+    messaging_group_id: 'mg-signal',
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe('origin-session threading — outbound A2A message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasDestination.mockReturnValue(true);
+    mockGetAgentGroup.mockReturnValue({ id: 'ag-target', name: 'Target' });
+    mockWakeContainer.mockResolvedValue(undefined);
+  });
+
+  it('stamps origin_session_id when routing an A2A message to a target agent', async () => {
+    const sourceSession = makeSession({ id: 'sess-source', agent_group_id: 'ag-source' });
+    const targetSession = makeSession({ id: 'sess-target', agent_group_id: 'ag-target' });
+    mockResolveSession.mockReturnValue({ session: targetSession, created: false });
+    mockGetSession.mockReturnValue(targetSession);
+
+    await routeAgentMessage(
+      { id: 'msg-1', platform_id: 'ag-target', content: '{"text":"hello"}', origin_session_id: null },
+      sourceSession,
+    );
+
+    expect(mockWriteSessionMessage).toHaveBeenCalledOnce();
+    const [, , writtenMsg] = mockWriteSessionMessage.mock.calls[0];
+    expect(writtenMsg.originSessionId).toBe('sess-source');
+    expect(writtenMsg.channelType).toBe('agent');
+  });
+
+  it('routes reply to origin session when origin_session_id is set and session is active', async () => {
+    const targetAgentGroupId = 'ag-source'; // reply goes back to the source
+    const originSession = makeSession({ id: 'sess-origin', agent_group_id: 'ag-source', status: 'active' });
+    const fallbackSession = makeSession({ id: 'sess-fallback', agent_group_id: 'ag-source', status: 'active' });
+    // getSession resolves origin; resolveSession would return fallback if called
+    mockGetAgentGroup.mockReturnValue({ id: 'ag-source', name: 'Source' });
+    mockGetSession.mockImplementation((id: string) => {
+      if (id === 'sess-origin') return originSession;
+      if (id === 'sess-reply') return originSession; // wake target is origin
+      return undefined;
+    });
+    mockResolveSession.mockReturnValue({ session: fallbackSession, created: false });
+
+    const replyingSession = makeSession({ id: 'sess-target', agent_group_id: 'ag-target' });
+
+    await routeAgentMessage(
+      {
+        id: 'msg-reply',
+        platform_id: targetAgentGroupId,
+        content: '{"text":"done"}',
+        origin_session_id: 'sess-origin',
+      },
+      replyingSession,
+    );
+
+    // resolveSession should NOT have been called (origin bypass took effect)
+    expect(mockResolveSession).not.toHaveBeenCalled();
+
+    // message written to origin session, not fallback
+    const [writtenAgentGroupId, writtenSessionId] = mockWriteSessionMessage.mock.calls[0];
+    expect(writtenAgentGroupId).toBe(targetAgentGroupId);
+    expect(writtenSessionId).toBe('sess-origin');
+  });
+
+  it('falls back to findSessionByAgentGroup when origin session is closed', async () => {
+    const closedSession = makeSession({ id: 'sess-closed', agent_group_id: 'ag-source', status: 'closed' });
+    const fallbackSession = makeSession({ id: 'sess-fallback', agent_group_id: 'ag-source', status: 'active' });
+    mockGetAgentGroup.mockReturnValue({ id: 'ag-source', name: 'Source' });
+    mockGetSession.mockImplementation((id: string) => {
+      if (id === 'sess-closed') return closedSession;
+      if (id === 'sess-fallback') return fallbackSession;
+      return undefined;
+    });
+    mockResolveSession.mockReturnValue({ session: fallbackSession, created: false });
+
+    const replyingSession = makeSession({ id: 'sess-target', agent_group_id: 'ag-target' });
+
+    await routeAgentMessage(
+      {
+        id: 'msg-reply',
+        platform_id: 'ag-source',
+        content: '{"text":"done"}',
+        origin_session_id: 'sess-closed',
+      },
+      replyingSession,
+    );
+
+    // resolveSession IS called because origin was closed
+    expect(mockResolveSession).toHaveBeenCalledWith('ag-source', null, null, 'agent-shared');
+
+    const [, writtenSessionId] = mockWriteSessionMessage.mock.calls[0];
+    expect(writtenSessionId).toBe('sess-fallback');
+  });
+
+  it('falls back when origin session belongs to a different agent group (tamper guard)', async () => {
+    // origin_session_id points to a session in a completely different agent group
+    const wrongGroupSession = makeSession({ id: 'sess-wrong', agent_group_id: 'ag-other', status: 'active' });
+    const fallbackSession = makeSession({ id: 'sess-fallback', agent_group_id: 'ag-source', status: 'active' });
+    mockGetAgentGroup.mockReturnValue({ id: 'ag-source', name: 'Source' });
+    mockGetSession.mockImplementation((id: string) => {
+      if (id === 'sess-wrong') return wrongGroupSession;
+      if (id === 'sess-fallback') return fallbackSession;
+      return undefined;
+    });
+    mockResolveSession.mockReturnValue({ session: fallbackSession, created: false });
+
+    const replyingSession = makeSession({ id: 'sess-target', agent_group_id: 'ag-target' });
+
+    await routeAgentMessage(
+      {
+        id: 'msg-reply',
+        platform_id: 'ag-source',
+        content: '{"text":"done"}',
+        origin_session_id: 'sess-wrong',
+      },
+      replyingSession,
+    );
+
+    // Falls back — origin session doesn't belong to the target agent group
+    expect(mockResolveSession).toHaveBeenCalledWith('ag-source', null, null, 'agent-shared');
+    const [, writtenSessionId] = mockWriteSessionMessage.mock.calls[0];
+    expect(writtenSessionId).toBe('sess-fallback');
+  });
+
+  it('uses findSessionByAgentGroup when origin_session_id is null (non-A2A path)', async () => {
+    const targetSession = makeSession({ id: 'sess-target', agent_group_id: 'ag-target' });
+    mockResolveSession.mockReturnValue({ session: targetSession, created: false });
+    mockGetSession.mockReturnValue(targetSession);
+
+    const sourceSession = makeSession({ id: 'sess-source', agent_group_id: 'ag-source' });
+
+    await routeAgentMessage(
+      { id: 'msg-1', platform_id: 'ag-target', content: '{"text":"hello"}' },
+      sourceSession,
+    );
+
+    expect(mockResolveSession).toHaveBeenCalledWith('ag-target', null, null, 'agent-shared');
+    const [, writtenSessionId] = mockWriteSessionMessage.mock.calls[0];
+    expect(writtenSessionId).toBe('sess-target');
+  });
+});

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -203,6 +203,8 @@ export function writeSessionMessage(
      * a trigger-1 message does arrive.
      */
     trigger?: 0 | 1;
+    /** Session ID that originated this A2A message; null for non-A2A. */
+    originSessionId?: string | null;
   },
 ): void {
   // Extract base64 attachment data, save to inbox, replace with file paths
@@ -221,6 +223,7 @@ export function writeSessionMessage(
       processAfter: message.processAfter ?? null,
       recurrence: message.recurrence ?? null,
       trigger: message.trigger ?? 1,
+      originSessionId: message.originSessionId ?? null,
     });
   } finally {
     db.close();


### PR DESCRIPTION
## Problem

When one agent replies to another via the agent-to-agent path (`channel_type === 'agent'`), the reply can land in the **wrong session** of the target agent group when multiple active sessions coexist for that group.

The common case isn't exotic: any agent group wired to two channels under `session_mode='shared'` (e.g. one agent serving both Signal DMs and a wrist-worn watch device) has two active sessions at all times — one per messaging group. When agent B replies to a message agent A sent from session A1, `routeAgentMessage` calls `findSessionByAgentGroup`, which picks the most-recently-created session for A. That may be A2 (a different channel, different last_active timestamp). The reply lands in A2's `inbound.db`. The user, who is interacting through A1, never sees it.

This is the root cause behind these open issues:

- #1959 "Discord replies are delivered based on container init rather than message source"
- #1982 "V2 duplicate replies after pairing a second channel"
- #1902 "Replies can leak from WeChat to Telegram when both channels share one agent group"

## Fix: thread the originating session id through every A2A hop

1. **Inbound stamp.** When the host writes an A2A message into the target agent's `inbound.db`, it stamps `origin_session_id = <source session id>` on the row.
2. **Outbound propagation.** When the container writes a reply with `in_reply_to` referencing that inbound row, `writeMessageOut` looks up the inbound row's `origin_session_id` and copies it onto `messages_out`.
3. **Host delivery bypass.** `routeAgentMessage` reads `msg.origin_session_id`. When set and the origin session is still `active` and belongs to the target agent group, it delivers there directly — bypassing `findSessionByAgentGroup`. Falls back gracefully on stale/archived/cross-group origins.

Composes cleanly with #1967 (file-attachment forwarding in A2A) — origin resolution runs first so file forwarding writes to the resolved target session's inbox.

## Schema migrations

- `messages_in.origin_session_id` and `messages_out.origin_session_id` added to baseline schema (`src/db/schema.ts`).
- Forward-compat: `container/agent-runner/src/db/connection.ts` adds an idempotent `PRAGMA table_info`-guarded `ALTER TABLE` for `messages_out` so existing session DBs pick up the column on next open. New session DBs get it from the baseline.
- Both columns are nullable; existing rows are unaffected.

## Fallback hardening (defense in depth)

`findSessionByAgentGroup` previously ordered by `created_at DESC LIMIT 1`. Origin threading is the primary fix, but since it's the fallback when origin info is missing, it now orders by `last_active DESC NULLS LAST, created_at DESC` — preferring the session most recently in use rather than the one most recently created. One-line change.

## Tests

- **Host (vitest):** 5 new tests in `src/modules/agent-to-agent/origin-routing.test.ts` — origin stamp on outbound, bypass on origin, fallback on closed/archived session, cross-agent-group tamper guard, null-origin path.
- **Container (bun:test):** 4 new tests in `container/agent-runner/src/db/origin-session.test.ts` — propagate from inbound row, null when no `in_reply_to`, null when inbound has no origin, null when `in_reply_to` is dangling.

All 202 host tests pass (24 test files). New container tests pass.

## Files changed

| File | Change |
|---|---|
| `src/db/schema.ts` | Add `origin_session_id` to `messages_in` and `messages_out` baseline. |
| `src/db/session-db.ts` | `insertMessage` accepts `originSessionId`. |
| `src/db/sessions.ts` | `findSessionByAgentGroup` orders by `last_active DESC` (fallback only). |
| `src/session-manager.ts` | `writeSessionMessage` accepts `originSessionId`. |
| `src/modules/agent-to-agent/agent-route.ts` | Origin-honor with fallback; stamp on inbound write. |
| `src/modules/agent-to-agent/origin-routing.test.ts` | NEW. |
| `container/agent-runner/src/db/connection.ts` | Forward-compat `ALTER TABLE` + test schema. |
| `container/agent-runner/src/db/messages-in.ts` | `origin_session_id` on `MessageInRow`. |
| `container/agent-runner/src/db/messages-out.ts` | Propagate from inbound on `in_reply_to`. |
| `container/agent-runner/src/db/origin-session.test.ts` | NEW. |