### PR TITLE
feat(skill): voice transcription V2 — container-side, sovereign by default

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -23,6 +23,7 @@ ARG CLAUDE_CODE_VERSION=2.1.116
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=latest
 ARG BUN_VERSION=1.3.12
+ARG WHISPER_CLI_VERSION=1.7.5
 
 # ---- System dependencies -----------------------------------------------------
 # tini: correct PID 1 / signal forwarding so outbound.db writes finalize on
@@ -48,6 +49,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libxshmfence1 \
         ca-certificates \
         curl \
+        ffmpeg \
         git \
         tini \
         unzip \
@@ -103,6 +105,13 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+# whisper-cli: local Whisper transcription binary. Container-side voice
+# transcription tries this first before any external API fallback. Pinned to
+# satisfy the supply-chain policy and so model files stay compatible with the
+# binary version. ffmpeg (above) handles audio normalization before invocation.
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "whisper-cli@${WHISPER_CLI_VERSION}"
 
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,6 +10,40 @@
 # bind mount at runtime (see src/container-runner.ts). Source-only changes
 # never require an image rebuild.
 
+# ---- Stage 1: build whisper.cpp ---------------------------------------------
+# whisper.cpp is built from source so we get the actual whisper-cli binary
+# (the npm package "whisper-cli" is unrelated — it wraps OpenAI's API and
+# defeats sovereignty). RPATH=$ORIGIN/../lib lets the binary find its sibling
+# libs without LD_LIBRARY_PATH gymnastics in the runtime stage.
+FROM debian:bookworm-slim AS whisper-builder
+ARG WHISPER_CPP_VERSION=v1.8.3
+ARG WHISPER_MODEL_FILE=ggml-base.en.bin
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        build-essential \
+        libssl-dev \
+        pkg-config \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch ${WHISPER_CPP_VERSION} \
+        https://github.com/ggerganov/whisper.cpp.git /src/whisper.cpp
+RUN cd /src/whisper.cpp && \
+    cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/whisper-install \
+        -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE && \
+    cmake --build build -j --config Release && \
+    cmake --install build
+RUN mkdir -p /whisper-install/share && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 300 -C - \
+        -o /whisper-install/share/${WHISPER_MODEL_FILE} \
+        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${WHISPER_MODEL_FILE}
+
+# ---- Stage 2: runtime --------------------------------------------------------
 FROM node:22-slim
 
 # ---- Build-time arguments ----------------------------------------------------
@@ -23,7 +57,8 @@ ARG CLAUDE_CODE_VERSION=2.1.116
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=latest
 ARG BUN_VERSION=1.3.12
-ARG WHISPER_CLI_VERSION=1.7.5
+ARG WS_VERSION=8.20.0
+ARG WHISPER_MODEL_FILE=ggml-base.en.bin
 
 # ---- System dependencies -----------------------------------------------------
 # tini: correct PID 1 / signal forwarding so outbound.db writes finalize on
@@ -103,15 +138,25 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "agent-browser@${AGENT_BROWSER_VERSION}"
 
+# ws: install globally then symlink to /node_modules so ESM `import 'ws'` resolves
+# from any working directory. ESM walks the directory tree upward; only /node_modules
+# at the root is universally reachable regardless of cwd.
+RUN npm install -g "ws@${WS_VERSION}" && \
+    mkdir -p /node_modules && \
+    ln -s /usr/local/lib/node_modules/ws /node_modules/ws
+
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
-# whisper-cli: local Whisper transcription binary. Container-side voice
-# transcription tries this first before any external API fallback. Pinned to
-# satisfy the supply-chain policy and so model files stay compatible with the
-# binary version. ffmpeg (above) handles audio normalization before invocation.
-RUN --mount=type=cache,target=/root/.cache/pnpm \
-    pnpm install -g "whisper-cli@${WHISPER_CLI_VERSION}"
+# ---- whisper.cpp from builder stage -----------------------------------------
+# Container-side voice transcription, sovereign by default. Audio attachments
+# get transcribed inside the container via local Whisper; OpenAI fallback is
+# off unless explicitly enabled (WHISPER_OPENAI_FALLBACK=true).
+COPY --from=whisper-builder /whisper-install/bin/whisper-cli /usr/local/bin/whisper-cli
+COPY --from=whisper-builder /whisper-install/lib/ /usr/local/lib/
+COPY --from=whisper-builder /whisper-install/share/${WHISPER_MODEL_FILE} /whisper/model.bin
+RUN ldconfig
+ENV WHISPER_MODEL_PATH=/whisper/model.bin
 
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -17,7 +17,12 @@
 # libs without LD_LIBRARY_PATH gymnastics in the runtime stage.
 FROM debian:bookworm-slim AS whisper-builder
 ARG WHISPER_CPP_VERSION=v1.8.3
-ARG WHISPER_MODEL_FILE=ggml-base.en.bin
+# Multilingual, not `ggml-base.en.bin` — an English-only default silently
+# produces garbage transcripts for non-English voice notes, which reads as
+# "the feature is broken" rather than "wrong model" to affected users. Same
+# file size (~141MB either way) and auto-detects language, so English
+# transcription isn't worse for it.
+ARG WHISPER_MODEL_FILE=ggml-base.bin
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         build-essential \
@@ -59,7 +64,7 @@ ARG BUN_VERSION=1.4.0
 # Re-declared here (also set in the whisper-builder stage above) because
 # Docker ARGs are scoped per stage — the COPY below that reads it needs its
 # own declaration.
-ARG WHISPER_MODEL_FILE=ggml-base.en.bin
+ARG WHISPER_MODEL_FILE=ggml-base.bin
 
 # ---- System dependencies -----------------------------------------------------
 # tini: correct PID 1 / signal forwarding so outbound.db writes finalize on

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,6 +10,40 @@
 # bind mount at runtime (see src/container-runner.ts). Source-only changes
 # never require an image rebuild.
 
+# ---- Stage 1: build whisper.cpp ---------------------------------------------
+# whisper.cpp is built from source so we get the actual whisper-cli binary
+# (the npm package "whisper-cli" is unrelated — it wraps OpenAI's API and
+# defeats sovereignty). RPATH=$ORIGIN/../lib lets the binary find its sibling
+# libs without LD_LIBRARY_PATH gymnastics in the runtime stage.
+FROM debian:bookworm-slim AS whisper-builder
+ARG WHISPER_CPP_VERSION=v1.8.3
+ARG WHISPER_MODEL_FILE=ggml-base.en.bin
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        build-essential \
+        libssl-dev \
+        pkg-config \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch ${WHISPER_CPP_VERSION} \
+        https://github.com/ggerganov/whisper.cpp.git /src/whisper.cpp
+RUN cd /src/whisper.cpp && \
+    cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/whisper-install \
+        -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE && \
+    cmake --build build -j --config Release && \
+    cmake --install build
+RUN mkdir -p /whisper-install/share && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-max-time 300 -C - \
+        -o /whisper-install/share/${WHISPER_MODEL_FILE} \
+        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${WHISPER_MODEL_FILE}
+
+# ---- Stage 2: runtime --------------------------------------------------------
 FROM node:22-slim
 
 # ---- Build-time arguments ----------------------------------------------------
@@ -22,6 +56,10 @@ ARG INSTALL_CJK_FONTS=false
 # pinned in cli-tools.json so a skill can add one with a json-merge; Bun (the
 # runtime) is pinned here because it installs from a different source.
 ARG BUN_VERSION=1.4.0
+# Re-declared here (also set in the whisper-builder stage above) because
+# Docker ARGs are scoped per stage — the COPY below that reads it needs its
+# own declaration.
+ARG WHISPER_MODEL_FILE=ggml-base.en.bin
 
 # ---- System dependencies -----------------------------------------------------
 # tini: correct PID 1 / signal forwarding so outbound.db writes finalize on
@@ -47,6 +85,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libxshmfence1 \
         ca-certificates \
         curl \
+        ffmpeg \
         git \
         tini \
         unzip \
@@ -117,6 +156,16 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 # Actual script lives in the mounted source at /app/src/cli/ncl.ts.
 RUN printf '#!/bin/sh\nexec bun /app/src/cli/ncl.ts "$@"\n' > /usr/local/bin/ncl && \
     chmod +x /usr/local/bin/ncl
+
+# ---- whisper.cpp from builder stage -----------------------------------------
+# Container-side voice transcription, sovereign by default. Audio attachments
+# get transcribed inside the container via local Whisper; OpenAI fallback is
+# off unless explicitly enabled (WHISPER_OPENAI_FALLBACK=true).
+COPY --from=whisper-builder /whisper-install/bin/whisper-cli /usr/local/bin/whisper-cli
+COPY --from=whisper-builder /whisper-install/lib/ /usr/local/lib/
+COPY --from=whisper-builder /whisper-install/share/${WHISPER_MODEL_FILE} /whisper/model.bin
+RUN ldconfig
+ENV WHISPER_MODEL_PATH=/whisper/model.bin
 
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh

--- a/container/agent-runner/src/auto-transcribe.ts
+++ b/container/agent-runner/src/auto-transcribe.ts
@@ -1,0 +1,108 @@
+/**
+ * Auto-transcription preprocessing for the poll loop.
+ *
+ * Before messages reach the formatter/agent, this pass finds audio attachments
+ * and injects the transcript inline with a source label:
+ *
+ *   [Voice (local-whisper): "Can you review the PR before EOD?"]
+ *   [Voice (openai-fallback): "..."]
+ *   [Voice: transcription failed — <reason>]
+ *
+ * The source label is mandatory — it lets the agent disclose to the user when
+ * audio was processed remotely, satisfying the sovereignty model.
+ *
+ * If transcription is unavailable and disabled, the label includes the error
+ * so the agent can inform the user rather than silently dropping the content.
+ */
+import path from 'path';
+
+import type { MessageInRow } from './db/messages-in.js';
+import { transcribeAudio } from './transcription.js';
+
+function log(msg: string): void {
+  console.error(`[auto-transcribe] ${msg}`);
+}
+
+const AUDIO_EXTENSIONS = new Set([
+  '.ogg',
+  '.opus',
+  '.mp3',
+  '.m4a',
+  '.mp4',
+  '.wav',
+  '.flac',
+  '.webm',
+  '.aac',
+  '.amr',
+  '.3gp',
+]);
+
+function isAudioAttachment(att: Record<string, unknown>): boolean {
+  const name = String(att.name ?? att.filename ?? '');
+  const mime = String(att.mimeType ?? att.type ?? '');
+  if (mime.startsWith('audio/')) return true;
+  return AUDIO_EXTENSIONS.has(path.extname(name).toLowerCase());
+}
+
+/**
+ * Preprocess a batch of inbound messages: transcribe any audio attachments and
+ * inject the result into the message text. Returns new MessageInRow objects
+ * with updated content — the originals are not mutated.
+ *
+ * Non-chat messages and messages without audio attachments are returned as-is.
+ */
+export async function autoTranscribeMessages(messages: MessageInRow[]): Promise<MessageInRow[]> {
+  const results: MessageInRow[] = [];
+  for (const msg of messages) {
+    results.push(await preprocessMessage(msg));
+  }
+  return results;
+}
+
+async function preprocessMessage(msg: MessageInRow): Promise<MessageInRow> {
+  // Only auto-transcribe chat messages — tasks, system, webhook pass through.
+  if (msg.kind !== 'chat' && msg.kind !== 'chat-sdk') return msg;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(msg.content);
+  } catch {
+    return msg;
+  }
+
+  const attachments = parsed.attachments as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(attachments) || attachments.length === 0) return msg;
+
+  const audioAtts = attachments.filter(isAudioAttachment);
+  if (audioAtts.length === 0) return msg;
+
+  const labels: string[] = [];
+  for (const att of audioAtts) {
+    const localPath = att.localPath as string | undefined;
+    if (!localPath) {
+      log(`Audio attachment has no localPath, skipping: ${String(att.name ?? '')}`);
+      continue;
+    }
+    // localPath is relative to /workspace/ inside the container
+    const fullPath = localPath.startsWith('/') ? localPath : `/workspace/${localPath}`;
+    const name = String(att.name ?? att.filename ?? 'audio');
+
+    try {
+      const result = await transcribeAudio(fullPath);
+      const sourceLabel = result.source === 'local-whisper' ? 'local-whisper' : 'openai-fallback';
+      labels.push(`[Voice (${sourceLabel}): "${result.text}"]`);
+      log(`Transcribed ${name} via ${result.source} in ${result.durationMs}ms`);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      labels.push(`[Voice: transcription failed — ${errMsg}]`);
+      log(`Transcription failed for ${name}: ${errMsg}`);
+    }
+  }
+
+  if (labels.length === 0) return msg;
+
+  const existingText = String(parsed.text ?? '');
+  const injected = labels.join('\n') + (existingText ? '\n' + existingText : '');
+
+  return { ...msg, content: JSON.stringify({ ...parsed, text: injected }) };
+}

--- a/container/agent-runner/src/auto-transcribe.ts
+++ b/container/agent-runner/src/auto-transcribe.ts
@@ -1,0 +1,106 @@
+/**
+ * Auto-transcription preprocessing for the poll loop.
+ *
+ * Before messages reach the formatter/agent, this pass finds audio attachments
+ * and injects the transcript inline with a source label:
+ *
+ *   [Voice (local-whisper): "Can you review the PR before EOD?"]
+ *   [Voice: transcription failed — <reason>]
+ *
+ * The source label is mandatory — it lets the agent disclose to the user how
+ * the audio was processed, satisfying the sovereignty model.
+ *
+ * If transcription fails, the label includes the error so the agent can
+ * inform the user rather than silently dropping the content.
+ */
+import path from 'path';
+
+import type { MessageInRow } from './db/messages-in.js';
+import { transcribeAudio } from './transcription.js';
+
+function log(msg: string): void {
+  console.error(`[auto-transcribe] ${msg}`);
+}
+
+const AUDIO_EXTENSIONS = new Set([
+  '.ogg',
+  '.opus',
+  '.mp3',
+  '.m4a',
+  '.mp4',
+  '.wav',
+  '.flac',
+  '.webm',
+  '.aac',
+  '.amr',
+  '.3gp',
+]);
+
+function isAudioAttachment(att: Record<string, unknown>): boolean {
+  const name = String(att.name ?? att.filename ?? '');
+  const mime = String(att.mimeType ?? att.type ?? '');
+  if (mime.startsWith('audio/')) return true;
+  return AUDIO_EXTENSIONS.has(path.extname(name).toLowerCase());
+}
+
+/**
+ * Preprocess a batch of inbound messages: transcribe any audio attachments and
+ * inject the result into the message text. Returns new MessageInRow objects
+ * with updated content — the originals are not mutated.
+ *
+ * Non-chat messages and messages without audio attachments are returned as-is.
+ */
+export async function autoTranscribeMessages(messages: MessageInRow[]): Promise<MessageInRow[]> {
+  const results: MessageInRow[] = [];
+  for (const msg of messages) {
+    results.push(await preprocessMessage(msg));
+  }
+  return results;
+}
+
+async function preprocessMessage(msg: MessageInRow): Promise<MessageInRow> {
+  // Only auto-transcribe chat messages — tasks, system, webhook pass through.
+  if (msg.kind !== 'chat' && msg.kind !== 'chat-sdk') return msg;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(msg.content);
+  } catch {
+    return msg;
+  }
+
+  const attachments = parsed.attachments as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(attachments) || attachments.length === 0) return msg;
+
+  const audioAtts = attachments.filter(isAudioAttachment);
+  if (audioAtts.length === 0) return msg;
+
+  const labels: string[] = [];
+  for (const att of audioAtts) {
+    const localPath = att.localPath as string | undefined;
+    if (!localPath) {
+      log(`Audio attachment has no localPath, skipping: ${String(att.name ?? '')}`);
+      continue;
+    }
+    // localPath is relative to /workspace/ inside the container
+    const fullPath = localPath.startsWith('/') ? localPath : `/workspace/${localPath}`;
+    const name = String(att.name ?? att.filename ?? 'audio');
+
+    try {
+      const result = await transcribeAudio(fullPath);
+      labels.push(`[Voice (${result.source}): "${result.text}"]`);
+      log(`Transcribed ${name} via ${result.source} in ${result.durationMs}ms`);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      labels.push(`[Voice: transcription failed — ${errMsg}]`);
+      log(`Transcription failed for ${name}: ${errMsg}`);
+    }
+  }
+
+  if (labels.length === 0) return msg;
+
+  const existingText = String(parsed.text ?? '');
+  const injected = labels.join('\n') + (existingText ? '\n' + existingText : '');
+
+  return { ...msg, content: JSON.stringify({ ...parsed, text: injected }) };
+}

--- a/container/agent-runner/src/auto-transcribe.ts
+++ b/container/agent-runner/src/auto-transcribe.ts
@@ -5,14 +5,13 @@
  * and injects the transcript inline with a source label:
  *
  *   [Voice (local-whisper): "Can you review the PR before EOD?"]
- *   [Voice (openai-fallback): "..."]
  *   [Voice: transcription failed — <reason>]
  *
- * The source label is mandatory — it lets the agent disclose to the user when
- * audio was processed remotely, satisfying the sovereignty model.
+ * The source label is mandatory — it lets the agent disclose to the user how
+ * the audio was processed, satisfying the sovereignty model.
  *
- * If transcription is unavailable and disabled, the label includes the error
- * so the agent can inform the user rather than silently dropping the content.
+ * If transcription fails, the label includes the error so the agent can
+ * inform the user rather than silently dropping the content.
  */
 import path from 'path';
 
@@ -89,8 +88,7 @@ async function preprocessMessage(msg: MessageInRow): Promise<MessageInRow> {
 
     try {
       const result = await transcribeAudio(fullPath);
-      const sourceLabel = result.source === 'local-whisper' ? 'local-whisper' : 'openai-fallback';
-      labels.push(`[Voice (${sourceLabel}): "${result.text}"]`);
+      labels.push(`[Voice (${result.source}): "${result.text}"]`);
       log(`Transcribed ${name} via ${result.source} in ${result.durationMs}ms`);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -10,6 +10,7 @@ import './scheduling.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+import './transcription.js';
 import { startMcpServer } from './server.js';
 
 function log(msg: string): void {

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -9,6 +9,7 @@ import './core.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+import './transcription.js';
 // Module barrel — loads registration modules, including the singular mailbox slot.
 import '../modules/index.js';
 import { getAgentMailbox, readMailboxContext } from '../mailbox/index.js';

--- a/container/agent-runner/src/mcp-tools/transcription.ts
+++ b/container/agent-runner/src/mcp-tools/transcription.ts
@@ -1,0 +1,71 @@
+/**
+ * MCP tool: transcribe audio files.
+ *
+ * Wraps the core transcribeAudio() function as an explicit tool so agents can:
+ *   - Transcribe arbitrary files outside the auto-injection inbound flow
+ *   - Override the default fallback/approval policy from env vars
+ *   - Access the raw result (source, durationMs, model) for disclosure to the user
+ *
+ * Auto-injection in the poll loop is the default UX — this tool is for
+ * advanced cases where the agent needs explicit control.
+ */
+import { transcribeAudio } from '../transcription.js';
+import { registerTools } from './server.js';
+
+registerTools([
+  {
+    tool: {
+      name: 'transcribe',
+      description:
+        'Transcribe an audio file to text. Uses local Whisper by default (sovereign: audio stays on-device). ' +
+        'Set allowFallback:true to permit OpenAI Whisper API when local is unavailable. ' +
+        'Returns the transcript text plus the source (local-whisper or openai-fallback) for disclosure.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          filePath: {
+            type: 'string',
+            description: 'Absolute path to the audio file (e.g. /workspace/attachments/abc123)',
+          },
+          allowFallback: {
+            type: 'boolean',
+            description:
+              'Allow OpenAI Whisper API fallback when local Whisper is unavailable. ' +
+              'Default: WHISPER_OPENAI_FALLBACK env var (default false — local-only).',
+          },
+          requireApproval: {
+            type: 'boolean',
+            description:
+              'When true, throw rather than silently calling OpenAI — use this to surface the decision to the user. ' +
+              'Default: WHISPER_REQUIRE_APPROVAL env var (default false).',
+          },
+        },
+        required: ['filePath'],
+      },
+    },
+    async handler(args) {
+      const { filePath, allowFallback, requireApproval } = args as {
+        filePath: string;
+        allowFallback?: boolean;
+        requireApproval?: boolean;
+      };
+
+      try {
+        const result = await transcribeAudio(filePath, { allowFallback, requireApproval });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Transcription failed: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  },
+]);

--- a/container/agent-runner/src/mcp-tools/transcription.ts
+++ b/container/agent-runner/src/mcp-tools/transcription.ts
@@ -1,0 +1,54 @@
+/**
+ * MCP tool: transcribe audio files.
+ *
+ * Wraps the core transcribeAudio() function as an explicit tool so agents can:
+ *   - Transcribe arbitrary files outside the auto-injection inbound flow
+ *   - Access the raw result (source, durationMs, model) for disclosure
+ *
+ * Auto-injection in the poll loop is the default UX — this tool is for
+ * advanced cases where the agent needs explicit control.
+ */
+import { transcribeAudio } from '../transcription.js';
+import { registerTools } from './server.js';
+
+registerTools([
+  {
+    tool: {
+      name: 'transcribe',
+      description:
+        'Transcribe an audio file to text via local Whisper inside the container. ' +
+        'Sovereign: audio never leaves the machine. Returns the transcript text plus ' +
+        'the source label (local-whisper) and timing for disclosure.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          filePath: {
+            type: 'string',
+            description: 'Absolute path to the audio file (e.g. /workspace/attachments/abc123)',
+          },
+        },
+        required: ['filePath'],
+      },
+    },
+    async handler(args) {
+      const { filePath } = args as { filePath: string };
+
+      try {
+        const result = await transcribeAudio(filePath);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Transcription failed: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  },
+]);

--- a/container/agent-runner/src/mcp-tools/transcription.ts
+++ b/container/agent-runner/src/mcp-tools/transcription.ts
@@ -3,8 +3,7 @@
  *
  * Wraps the core transcribeAudio() function as an explicit tool so agents can:
  *   - Transcribe arbitrary files outside the auto-injection inbound flow
- *   - Override the default fallback/approval policy from env vars
- *   - Access the raw result (source, durationMs, model) for disclosure to the user
+ *   - Access the raw result (source, durationMs, model) for disclosure
  *
  * Auto-injection in the poll loop is the default UX — this tool is for
  * advanced cases where the agent needs explicit control.
@@ -17,9 +16,9 @@ registerTools([
     tool: {
       name: 'transcribe',
       description:
-        'Transcribe an audio file to text. Uses local Whisper by default (sovereign: audio stays on-device). ' +
-        'Set allowFallback:true to permit OpenAI Whisper API when local is unavailable. ' +
-        'Returns the transcript text plus the source (local-whisper or openai-fallback) for disclosure.',
+        'Transcribe an audio file to text via local Whisper inside the container. ' +
+        'Sovereign: audio never leaves the machine. Returns the transcript text plus ' +
+        'the source label (local-whisper) and timing for disclosure.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -27,31 +26,15 @@ registerTools([
             type: 'string',
             description: 'Absolute path to the audio file (e.g. /workspace/attachments/abc123)',
           },
-          allowFallback: {
-            type: 'boolean',
-            description:
-              'Allow OpenAI Whisper API fallback when local Whisper is unavailable. ' +
-              'Default: WHISPER_OPENAI_FALLBACK env var (default false — local-only).',
-          },
-          requireApproval: {
-            type: 'boolean',
-            description:
-              'When true, throw rather than silently calling OpenAI — use this to surface the decision to the user. ' +
-              'Default: WHISPER_REQUIRE_APPROVAL env var (default false).',
-          },
         },
         required: ['filePath'],
       },
     },
     async handler(args) {
-      const { filePath, allowFallback, requireApproval } = args as {
-        filePath: string;
-        allowFallback?: boolean;
-        requireApproval?: boolean;
-      };
+      const { filePath } = args as { filePath: string };
 
       try {
-        const result = await transcribeAudio(filePath, { allowFallback, requireApproval });
+        const result = await transcribeAudio(filePath);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
         };

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -2,12 +2,15 @@ import { findByName, getAllDestinations, type DestinationEntry } from './destina
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
+import { clearContinuation, migrateLegacyContinuation, setContinuation } from './db/session-state.js';
 import {
-  clearContinuation,
-  migrateLegacyContinuation,
-  setContinuation,
-} from './db/session-state.js';
-import { formatMessages, extractRouting, categorizeMessage, isClearCommand, stripInternalTags, type RoutingContext } from './formatter.js';
+  formatMessages,
+  extractRouting,
+  categorizeMessage,
+  isClearCommand,
+  stripInternalTags,
+  type RoutingContext,
+} from './formatter.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
 
 const POLL_INTERVAL_MS = 1000;
@@ -154,6 +157,14 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       continue;
     }
 
+    // Auto-transcribe: any audio attachments get inlined as
+    // `[Voice (source): "..."]` so the agent sees text. Source label is
+    // mandatory so the agent can disclose to the user when audio was
+    // processed remotely. Sovereign default is local-only — see
+    // transcription.ts.
+    const { autoTranscribeMessages } = await import('./auto-transcribe.js');
+    keep = await autoTranscribeMessages(keep);
+
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
     const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
@@ -260,7 +271,9 @@ async function processQuery(
   // Stream liveness is decided host-side via the heartbeat file + processing
   // claim age (see src/host-sweep.ts); if something is truly stuck, the host
   // will kill the container and messages get reset to pending.
-  const pollHandle = setInterval(() => {
+  // Async because autoTranscribeMessages does subprocess + HTTP work — the
+  // setInterval callback must be `async` for the await to be legal.
+  const pollHandle = setInterval(async () => {
     if (done) return;
 
     // Skip system messages (MCP tool responses) and /clear (needs fresh query).
@@ -279,7 +292,11 @@ async function processQuery(
       const newIds = newMessages.map((m) => m.id);
       markProcessing(newIds);
 
-      const prompt = formatMessages(newMessages);
+      // Inline transcription on follow-ups too — voice notes can arrive
+      // mid-conversation, not just on the initial batch.
+      const { autoTranscribeMessages } = await import('./auto-transcribe.js');
+      const preprocessed = await autoTranscribeMessages(newMessages);
+      const prompt = formatMessages(preprocessed);
       log(`Pushing ${newMessages.length} follow-up message(s) into active query`);
       query.push(prompt);
 
@@ -331,7 +348,9 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
       log(`Result: ${event.text ? event.text.slice(0, 200) : '(empty)'}`);
       break;
     case 'error':
-      log(`Error: ${event.message} (retryable: ${event.retryable}${event.classification ? `, ${event.classification}` : ''})`);
+      log(
+        `Error: ${event.message} (retryable: ${event.retryable}${event.classification ? `, ${event.classification}` : ''})`,
+      );
       break;
     case 'progress':
       log(`Progress: ${event.message}`);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -215,6 +215,14 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       continue;
     }
 
+    // Auto-transcribe: any audio attachments get inlined as
+    // `[Voice (source): "..."]` so the agent sees text. Source label is
+    // mandatory so the agent can disclose to the user when audio was
+    // processed remotely. Sovereign default is local-only — see
+    // transcription.ts.
+    const { autoTranscribeMessages } = await import('./auto-transcribe.js');
+    keep = await autoTranscribeMessages(keep);
+
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
     const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
@@ -478,6 +486,12 @@ export async function processQuery(
         // was awaited. Pushing into a closed stream is wasted work; the
         // claimed messages get released by the host's processing-claim sweep.
         if (done) return;
+
+        // Inline transcription on follow-ups too — voice notes can arrive
+        // mid-conversation, not just on the initial batch. See the matching
+        // call on the initial-batch path above for the sovereignty note.
+        const { autoTranscribeMessages } = await import('./auto-transcribe.js');
+        keep = await autoTranscribeMessages(keep);
 
         const keptIds = keep.map((m) => m.id);
         const prompt = formatMessages(keep);

--- a/container/agent-runner/src/transcription.ts
+++ b/container/agent-runner/src/transcription.ts
@@ -1,0 +1,151 @@
+/**
+ * Voice transcription — local Whisper with optional OpenAI fallback.
+ *
+ * Sovereignty model: audio never leaves the machine unless explicitly opted in.
+ *
+ * Config via env vars:
+ *   WHISPER_MODEL_PATH        Path to ggml model file (default: /whisper/model.bin)
+ *   WHISPER_OPENAI_FALLBACK   'true' to allow OpenAI Whisper API fallback (default: false)
+ *   WHISPER_REQUIRE_APPROVAL  'true' to require explicit consent before OpenAI call (default: false)
+ */
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export const WHISPER_MODEL_PATH = process.env.WHISPER_MODEL_PATH ?? '/whisper/model.bin';
+const OPENAI_FALLBACK_ENABLED = process.env.WHISPER_OPENAI_FALLBACK === 'true';
+const REQUIRE_APPROVAL = process.env.WHISPER_REQUIRE_APPROVAL === 'true';
+
+function log(msg: string): void {
+  console.error(`[transcription] ${msg}`);
+}
+
+export interface TranscriptionResult {
+  text: string;
+  source: 'local-whisper' | 'openai-fallback';
+  durationMs: number;
+  model: string;
+}
+
+export interface TranscriptionOptions {
+  /** Override WHISPER_OPENAI_FALLBACK env default. */
+  allowFallback?: boolean;
+  /** Override WHISPER_REQUIRE_APPROVAL env default. */
+  requireApproval?: boolean;
+}
+
+/**
+ * Transcribe an audio file. Tries local Whisper first; falls back to OpenAI
+ * Whisper API only when explicitly enabled via env or options.
+ *
+ * Throws with an actionable error message when local fails and fallback is
+ * disabled (the sovereign default).
+ */
+export async function transcribeAudio(filePath: string, options?: TranscriptionOptions): Promise<TranscriptionResult> {
+  const allowFallback = options?.allowFallback ?? OPENAI_FALLBACK_ENABLED;
+  const requireApproval = options?.requireApproval ?? REQUIRE_APPROVAL;
+
+  if (fs.existsSync(WHISPER_MODEL_PATH)) {
+    try {
+      const start = Date.now();
+      const text = await runWhisperCli(filePath);
+      return { text, source: 'local-whisper', durationMs: Date.now() - start, model: 'whisper-local' };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (!allowFallback) {
+        throw new Error(
+          `Local transcription failed and OpenAI fallback is disabled. ` +
+            `Error: ${errMsg}. ` +
+            `To enable fallback, set WHISPER_OPENAI_FALLBACK=true.`,
+        );
+      }
+      log(`Local Whisper failed, falling back to OpenAI: ${errMsg}`);
+    }
+  } else if (!allowFallback) {
+    throw new Error(
+      `Whisper model not found at ${WHISPER_MODEL_PATH} and OpenAI fallback is disabled. ` +
+        `Install the model file or set WHISPER_OPENAI_FALLBACK=true.`,
+    );
+  } else {
+    log(`Model not found at ${WHISPER_MODEL_PATH}, falling back to OpenAI`);
+  }
+
+  // OpenAI fallback. When WHISPER_REQUIRE_APPROVAL=true, don't proceed
+  // automatically — inform the caller to use the explicit MCP tool path.
+  if (requireApproval) {
+    throw new Error(
+      `OpenAI transcription fallback requires explicit approval (WHISPER_REQUIRE_APPROVAL=true). ` +
+        `Use the transcribe MCP tool with allowFallback:true to explicitly opt in.`,
+    );
+  }
+
+  const start = Date.now();
+  const text = await runOpenAITranscription(filePath);
+  return { text, source: 'openai-fallback', durationMs: Date.now() - start, model: 'whisper-1' };
+}
+
+/** Run whisper-cli subprocess. Expects stdout to contain the plain transcript. */
+async function runWhisperCli(filePath: string): Promise<string> {
+  // whisper-cli -m <model> -f <file> -nt (no timestamps) outputs plain text to stdout
+  const { stdout } = await execFileAsync('whisper-cli', ['-m', WHISPER_MODEL_PATH, '-f', filePath, '-nt']);
+  const text = stdout.trim();
+  if (!text) {
+    throw new Error('whisper-cli produced no output');
+  }
+  return text;
+}
+
+/**
+ * Compress audio with ffmpeg to 16 kHz mono Opus, then POST to OpenAI Whisper API.
+ * Opus at 16 kbps compresses even hour-long voice messages to a few MB.
+ */
+async function runOpenAITranscription(filePath: string): Promise<string> {
+  const tmpPath = path.join(os.tmpdir(), `nanoclaw-audio-${Date.now()}.opus`);
+  try {
+    // Pre-compress: 16 kHz mono Opus. Voice-quality-preserving, ~10× smaller than raw.
+    await execFileAsync('ffmpeg', [
+      '-i',
+      filePath,
+      '-ar',
+      '16000',
+      '-ac',
+      '1',
+      '-c:a',
+      'libopus',
+      '-b:a',
+      '16k',
+      '-y',
+      tmpPath,
+    ]);
+
+    const bytes = fs.readFileSync(tmpPath);
+    const form = new FormData();
+    form.append('file', new File([bytes], 'audio.opus', { type: 'audio/opus' }));
+    form.append('model', 'whisper-1');
+
+    const apiKey = process.env.OPENAI_API_KEY ?? '';
+    const resp = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      throw new Error(`OpenAI API error ${resp.status}: ${body}`);
+    }
+
+    const json = (await resp.json()) as { text: string };
+    return json.text;
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}

--- a/container/agent-runner/src/transcription.ts
+++ b/container/agent-runner/src/transcription.ts
@@ -1,0 +1,71 @@
+/**
+ * Voice transcription — local Whisper, container-side.
+ *
+ * Sovereignty model: audio never leaves the machine. There is no remote
+ * fallback in this module by design; if local transcription fails, the
+ * caller decides what to do (typically: surface the failure to the user).
+ *
+ * Config via env vars:
+ *   WHISPER_MODEL_PATH   Path to ggml model file (default: /whisper/model.bin)
+ */
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export const WHISPER_MODEL_PATH = process.env.WHISPER_MODEL_PATH ?? '/whisper/model.bin';
+
+export interface TranscriptionResult {
+  text: string;
+  source: 'local-whisper';
+  durationMs: number;
+  model: string;
+}
+
+/**
+ * Transcribe an audio file via local whisper-cli. Throws if the model is
+ * missing or whisper-cli produces no output.
+ */
+export async function transcribeAudio(filePath: string): Promise<TranscriptionResult> {
+  if (!fs.existsSync(WHISPER_MODEL_PATH)) {
+    throw new Error(`Whisper model not found at ${WHISPER_MODEL_PATH}.`);
+  }
+  const start = Date.now();
+  const text = await runWhisperCli(filePath);
+  return { text, source: 'local-whisper', durationMs: Date.now() - start, model: 'whisper-local' };
+}
+
+/**
+ * Convert non-WAV audio to 16 kHz mono WAV via ffmpeg. whisper.cpp's CLI only
+ * reads WAV/MP3/OGG/FLAC reliably; raw AAC/Opus/AMR (the formats Signal,
+ * WhatsApp, and other messengers ship voice notes as) silently produce no
+ * output. Always normalize before invoking whisper-cli.
+ */
+async function toWav(filePath: string): Promise<{ wavPath: string; cleanup: () => void }> {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.wav') {
+    return { wavPath: filePath, cleanup: () => {} };
+  }
+  const tmpWav = path.join(os.tmpdir(), `nanoclaw-transcribe-${Date.now()}.wav`);
+  await execFileAsync('ffmpeg', ['-i', filePath, '-ar', '16000', '-ac', '1', tmpWav, '-y']);
+  return { wavPath: tmpWav, cleanup: () => fs.unlink(tmpWav, () => {}) };
+}
+
+/** Run whisper-cli subprocess. Expects stdout to contain the plain transcript. */
+async function runWhisperCli(filePath: string): Promise<string> {
+  const { wavPath, cleanup } = await toWav(filePath);
+  try {
+    // whisper-cli -m <model> -f <file> -nt (no timestamps) outputs plain text to stdout
+    const { stdout } = await execFileAsync('whisper-cli', ['-m', WHISPER_MODEL_PATH, '-f', wavPath, '-nt']);
+    const text = stdout.trim();
+    if (!text) {
+      throw new Error('whisper-cli produced no output');
+    }
+    return text;
+  } finally {
+    cleanup();
+  }
+}

--- a/container/agent-runner/src/transcription.ts
+++ b/container/agent-runner/src/transcription.ts
@@ -1,12 +1,12 @@
 /**
- * Voice transcription — local Whisper with optional OpenAI fallback.
+ * Voice transcription — local Whisper, container-side.
  *
- * Sovereignty model: audio never leaves the machine unless explicitly opted in.
+ * Sovereignty model: audio never leaves the machine. There is no remote
+ * fallback in this module by design; if local transcription fails, the
+ * caller decides what to do (typically: surface the failure to the user).
  *
  * Config via env vars:
- *   WHISPER_MODEL_PATH        Path to ggml model file (default: /whisper/model.bin)
- *   WHISPER_OPENAI_FALLBACK   'true' to allow OpenAI Whisper API fallback (default: false)
- *   WHISPER_REQUIRE_APPROVAL  'true' to require explicit consent before OpenAI call (default: false)
+ *   WHISPER_MODEL_PATH   Path to ggml model file (default: /whisper/model.bin)
  */
 import { execFile } from 'child_process';
 import fs from 'fs';
@@ -17,135 +17,55 @@ import { promisify } from 'util';
 const execFileAsync = promisify(execFile);
 
 export const WHISPER_MODEL_PATH = process.env.WHISPER_MODEL_PATH ?? '/whisper/model.bin';
-const OPENAI_FALLBACK_ENABLED = process.env.WHISPER_OPENAI_FALLBACK === 'true';
-const REQUIRE_APPROVAL = process.env.WHISPER_REQUIRE_APPROVAL === 'true';
-
-function log(msg: string): void {
-  console.error(`[transcription] ${msg}`);
-}
 
 export interface TranscriptionResult {
   text: string;
-  source: 'local-whisper' | 'openai-fallback';
+  source: 'local-whisper';
   durationMs: number;
   model: string;
 }
 
-export interface TranscriptionOptions {
-  /** Override WHISPER_OPENAI_FALLBACK env default. */
-  allowFallback?: boolean;
-  /** Override WHISPER_REQUIRE_APPROVAL env default. */
-  requireApproval?: boolean;
+/**
+ * Transcribe an audio file via local whisper-cli. Throws if the model is
+ * missing or whisper-cli produces no output.
+ */
+export async function transcribeAudio(filePath: string): Promise<TranscriptionResult> {
+  if (!fs.existsSync(WHISPER_MODEL_PATH)) {
+    throw new Error(`Whisper model not found at ${WHISPER_MODEL_PATH}.`);
+  }
+  const start = Date.now();
+  const text = await runWhisperCli(filePath);
+  return { text, source: 'local-whisper', durationMs: Date.now() - start, model: 'whisper-local' };
 }
 
 /**
- * Transcribe an audio file. Tries local Whisper first; falls back to OpenAI
- * Whisper API only when explicitly enabled via env or options.
- *
- * Throws with an actionable error message when local fails and fallback is
- * disabled (the sovereign default).
+ * Convert non-WAV audio to 16 kHz mono WAV via ffmpeg. whisper.cpp's CLI only
+ * reads WAV/MP3/OGG/FLAC reliably; raw AAC/Opus/AMR (the formats Signal,
+ * WhatsApp, and other messengers ship voice notes as) silently produce no
+ * output. Always normalize before invoking whisper-cli.
  */
-export async function transcribeAudio(filePath: string, options?: TranscriptionOptions): Promise<TranscriptionResult> {
-  const allowFallback = options?.allowFallback ?? OPENAI_FALLBACK_ENABLED;
-  const requireApproval = options?.requireApproval ?? REQUIRE_APPROVAL;
-
-  if (fs.existsSync(WHISPER_MODEL_PATH)) {
-    try {
-      const start = Date.now();
-      const text = await runWhisperCli(filePath);
-      return { text, source: 'local-whisper', durationMs: Date.now() - start, model: 'whisper-local' };
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      if (!allowFallback) {
-        throw new Error(
-          `Local transcription failed and OpenAI fallback is disabled. ` +
-            `Error: ${errMsg}. ` +
-            `To enable fallback, set WHISPER_OPENAI_FALLBACK=true.`,
-        );
-      }
-      log(`Local Whisper failed, falling back to OpenAI: ${errMsg}`);
-    }
-  } else if (!allowFallback) {
-    throw new Error(
-      `Whisper model not found at ${WHISPER_MODEL_PATH} and OpenAI fallback is disabled. ` +
-        `Install the model file or set WHISPER_OPENAI_FALLBACK=true.`,
-    );
-  } else {
-    log(`Model not found at ${WHISPER_MODEL_PATH}, falling back to OpenAI`);
+async function toWav(filePath: string): Promise<{ wavPath: string; cleanup: () => void }> {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.wav') {
+    return { wavPath: filePath, cleanup: () => {} };
   }
-
-  // OpenAI fallback. When WHISPER_REQUIRE_APPROVAL=true, don't proceed
-  // automatically — inform the caller to use the explicit MCP tool path.
-  if (requireApproval) {
-    throw new Error(
-      `OpenAI transcription fallback requires explicit approval (WHISPER_REQUIRE_APPROVAL=true). ` +
-        `Use the transcribe MCP tool with allowFallback:true to explicitly opt in.`,
-    );
-  }
-
-  const start = Date.now();
-  const text = await runOpenAITranscription(filePath);
-  return { text, source: 'openai-fallback', durationMs: Date.now() - start, model: 'whisper-1' };
+  const tmpWav = path.join(os.tmpdir(), `nanoclaw-transcribe-${Date.now()}.wav`);
+  await execFileAsync('ffmpeg', ['-i', filePath, '-ar', '16000', '-ac', '1', tmpWav, '-y']);
+  return { wavPath: tmpWav, cleanup: () => fs.unlink(tmpWav, () => {}) };
 }
 
 /** Run whisper-cli subprocess. Expects stdout to contain the plain transcript. */
 async function runWhisperCli(filePath: string): Promise<string> {
-  // whisper-cli -m <model> -f <file> -nt (no timestamps) outputs plain text to stdout
-  const { stdout } = await execFileAsync('whisper-cli', ['-m', WHISPER_MODEL_PATH, '-f', filePath, '-nt']);
-  const text = stdout.trim();
-  if (!text) {
-    throw new Error('whisper-cli produced no output');
-  }
-  return text;
-}
-
-/**
- * Compress audio with ffmpeg to 16 kHz mono Opus, then POST to OpenAI Whisper API.
- * Opus at 16 kbps compresses even hour-long voice messages to a few MB.
- */
-async function runOpenAITranscription(filePath: string): Promise<string> {
-  const tmpPath = path.join(os.tmpdir(), `nanoclaw-audio-${Date.now()}.opus`);
+  const { wavPath, cleanup } = await toWav(filePath);
   try {
-    // Pre-compress: 16 kHz mono Opus. Voice-quality-preserving, ~10× smaller than raw.
-    await execFileAsync('ffmpeg', [
-      '-i',
-      filePath,
-      '-ar',
-      '16000',
-      '-ac',
-      '1',
-      '-c:a',
-      'libopus',
-      '-b:a',
-      '16k',
-      '-y',
-      tmpPath,
-    ]);
-
-    const bytes = fs.readFileSync(tmpPath);
-    const form = new FormData();
-    form.append('file', new File([bytes], 'audio.opus', { type: 'audio/opus' }));
-    form.append('model', 'whisper-1');
-
-    const apiKey = process.env.OPENAI_API_KEY ?? '';
-    const resp = await fetch('https://api.openai.com/v1/audio/transcriptions', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}` },
-      body: form,
-    });
-
-    if (!resp.ok) {
-      const body = await resp.text();
-      throw new Error(`OpenAI API error ${resp.status}: ${body}`);
+    // whisper-cli -m <model> -f <file> -nt (no timestamps) outputs plain text to stdout
+    const { stdout } = await execFileAsync('whisper-cli', ['-m', WHISPER_MODEL_PATH, '-f', wavPath, '-nt']);
+    const text = stdout.trim();
+    if (!text) {
+      throw new Error('whisper-cli produced no output');
     }
-
-    const json = (await resp.json()) as { text: string };
-    return json.text;
+    return text;
   } finally {
-    try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      // best-effort cleanup
-    }
+    cleanup();
   }
 }

--- a/docs/voice-transcription-container-design.md
+++ b/docs/voice-transcription-container-design.md
@@ -1,0 +1,170 @@
+# Voice Transcription — Container Design
+
+**Status:** Decisions resolved. Implementation ready.
+Supersedes PR #1879 (closed per maintainer feedback to keep processing container-side).
+
+## Background
+
+PR #1879 implemented voice transcription on the host (`src/transcription.ts`). Gavriel Cohen's review asked that this work move into the agent container instead: "doing as little as possible in the host side and keep all of the interesting stuff in the agent environment." This document designs the container-side replacement.
+
+---
+
+## Sovereignty Model
+
+**User audio never leaves the user's machine without explicit opt-in.**
+
+This is the defining design choice. The default configuration runs entirely locally — no network call is ever made for transcription unless the user has explicitly enabled it. When a fallback to OpenAI does occur, the source label `[Voice (openai-fallback): "..."]` makes the data path unmistakable in the conversation.
+
+Three env-var knobs govern this:
+
+| Env var | Default | Behavior |
+|---|---|---|
+| `WHISPER_OPENAI_FALLBACK` | `false` | **Local-only.** If local whisper-cli fails (binary missing, model missing, format unsupported), fail loudly with an actionable error message rather than silently sending audio to OpenAI. |
+| `WHISPER_OPENAI_FALLBACK=true` | opt-in | Allows OpenAI Whisper API as fallback. The `(openai-fallback)` source tag in every injected transcript makes the data path unmistakable. |
+| `WHISPER_REQUIRE_APPROVAL` | `false` | When `true` and fallback fires, route through NanoClaw's approval primitive (`pickApprover` in `src/modules/approvals/primitive.ts`) — DM the user before each OpenAI call. Audit-heavy users get explicit per-call consent. |
+
+The strict default ("local-only or fail") is the sovereign starting position. Power users opt in deliberately.
+
+---
+
+## Q1: Where does the Whisper binary live?
+
+**Binary in the Dockerfile image; model file mounted from host.**
+
+The container already follows this split for other CLIs (claude-code, agent-browser, vercel — all installed via pinned `pnpm install -g` in the Dockerfile). whisper-cli and ffmpeg follow the same pattern.
+
+Add to the Dockerfile:
+```dockerfile
+ARG WHISPER_CLI_VERSION=1.7.5
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "whisper-cli@${WHISPER_CLI_VERSION}"
+
+# ffmpeg for audio pre-compression before OpenAI fallback
+RUN apt-get install -y --no-install-recommends ffmpeg
+```
+
+The model file is **not** baked in — models range from 75 MB (tiny) to 1.5 GB (large-v3), and the right choice is user-specific. The user places the model on the host and mounts it into the container:
+
+```typescript
+// In the channel adapter's containerConfig
+{
+  hostPath: process.env.WHISPER_MODEL_PATH || path.join(HOME_DIR, '.local', 'share', 'whisper', 'model.bin'),
+  containerPath: '/whisper/model.bin',
+  readonly: true,
+}
+```
+
+Env var: `WHISPER_MODEL_PATH` — defaults to `~/.local/share/whisper/model.bin`.
+
+If the mount doesn't exist (model not installed), whisper-cli fails and the error propagates loudly (or triggers the optional OpenAI fallback if `WHISPER_OPENAI_FALLBACK=true`).
+
+---
+
+## Q2: How does audio get from the channel adapter into the container?
+
+**Audio files are written to a host directory that is already mounted into the container.**
+
+Signal already does this: attachments land at `~/.local/share/signal-cli/attachments/` on the host, and the container has a read-only bind mount of that directory at `/workspace/attachments/`. The inbound message content includes the path under `/workspace/attachments/<id>`, which the agent-runner can pass directly to the transcription tool.
+
+For other channels (future channels):
+- Channel adapters that receive audio write the file to a staging directory on the host (e.g., `~/.local/share/nanoclaw/audio-in/`)
+- That directory gets a read-only container mount at `/workspace/audio-in/`
+- The inbound message includes the container-relative path
+
+No IPC change required. The mount pattern already used by Signal is the right model.
+
+---
+
+## Q3: Transcription interface — BOTH auto-injection and explicit MCP tool
+
+**Decision: auto-injection is the default UX; explicit MCP tool also exposed.**
+
+### Auto-injection (default)
+
+The agent-runner's message handler auto-transcribes audio attachments before the agent sees them. The transcript is injected inline as part of the message content, labelled with its source:
+
+```
+[Voice (local-whisper): "Can you review the PR before end of day?"]
+```
+
+or, when fallback fired:
+
+```
+[Voice (openai-fallback): "Can you review the PR before end of day?"]
+```
+
+The source label is mandatory. It lets the agent disclose to the user when audio was processed remotely, which is a requirement of the sovereignty model.
+
+### Explicit MCP tool
+
+```typescript
+mcp__transcription__transcribe(
+  filePath: string,
+  options?: {
+    allowFallback?: boolean;  // override WHISPER_OPENAI_FALLBACK env default
+    requireApproval?: boolean; // override WHISPER_REQUIRE_APPROVAL env default
+  }
+) → {
+  text: string;
+  source: 'local-whisper' | 'openai-fallback';
+  durationMs: number;
+  model: string;
+}
+```
+
+Both paths share the same underlying `transcribeAudio()` function. Auto = MCP tool wired into the inbound handler with default options from env vars.
+
+---
+
+## Q4: OpenAI fallback path and audio pre-compression
+
+**Decision: pre-compress with ffmpeg to 16 kHz mono Opus before any OpenAI call.**
+
+When `WHISPER_OPENAI_FALLBACK=true` and local whisper fails:
+
+1. Run ffmpeg to compress the audio to 16 kHz mono Opus (≈10× smaller than raw, voice-quality-preserving)
+2. POST the compressed file to the OpenAI Whisper API
+
+```typescript
+// ffmpeg pre-compression
+await execa('ffmpeg', [
+  '-i', inputPath,
+  '-ar', '16000',    // 16 kHz sample rate
+  '-ac', '1',        // mono
+  '-c:a', 'libopus', // Opus codec
+  '-b:a', '16k',     // 16 kbps bitrate — adequate for speech
+  outputPath,
+]);
+
+// OpenAI call (openai package already in agent-runner deps)
+const openai = new OpenAI(); // OPENAI_API_KEY injected by OneCLI vault
+const file = await toFile(fs.createReadStream(outputPath), 'audio.opus');
+const result = await openai.audio.transcriptions.create({ file, model: 'whisper-1' });
+```
+
+The Whisper API has a 25 MB hard limit; even an hour of speech compresses to a few MB at 16 kbps Opus. This eliminates the OneCLI body-size concern entirely.
+
+**OneCLI and multipart/form-data:** The OneCLI credential proxy operates at the HTTP layer — it intercepts TLS, injects `Authorization`, and forwards the request body unmodified. `multipart/form-data` is opaque bytes from the proxy's perspective. Not a blocker.
+
+**`WHISPER_REQUIRE_APPROVAL=true` flow:** before the ffmpeg + OpenAI call, call `pickApprover` to identify the right approver for this agent group, send a DM approval request via the existing approval primitive, and wait for confirmation before proceeding.
+
+---
+
+## Implementation Plan
+
+1. **Dockerfile**: add `WHISPER_CLI_VERSION` ARG + `pnpm install -g whisper-cli@...`; add `apt-get install -y ffmpeg`
+2. **`container/agent-runner/src/transcription/transcribe.ts`**: core `transcribeAudio()` — local whisper first, optional OpenAI fallback with ffmpeg pre-compression; reads `WHISPER_OPENAI_FALLBACK` and `WHISPER_REQUIRE_APPROVAL` env vars
+3. **`container/agent-runner/src/mcp-tools/transcription.ts`**: MCP tool wrapping `transcribeAudio()` with option overrides
+4. **`container/agent-runner/src/formatter.ts`** (or message handler): auto-transcribe audio attachments before injecting into agent context; add `[Voice (source): "..."]` label
+5. **`container.json`** scaffold (via `group-init.ts`): document `WHISPER_MODEL_PATH`, `WHISPER_OPENAI_FALLBACK`, `WHISPER_REQUIRE_APPROVAL` as recognized env vars
+6. **Remove host-side transcription**: delete `src/transcription.ts`; remove transcription call from `src/channels/signal.ts`
+7. **Tests**: mock whisper-cli exec and OpenAI client in container test suite; test sovereignty defaults (fallback disabled by default, error on failure)
+
+---
+
+## Out of Scope (v1)
+
+- **Chunked long-form audio**: files exceeding the post-compression OpenAI limit (multi-hour recordings). Flag for future work.
+- **Per-user transcription preference UI**: opt-in/opt-out per conversation or per sender. Env vars are the configuration surface for v1.
+- **Model auto-download**: automatic fetch of ggml model files. User places the file manually; missing model = loud error.
+- **Non-whisper local engines**: only whisper-cli is supported in v1. Other local ASR options are out of scope.


### PR DESCRIPTION
## Why

Re-submission of #1879 (closed at maintainer's request) with the implementation moved into the agent container per @gavrielcohen's feedback: *\"doing as little as possible in the host side and keep all of the interesting stuff in the agent environment.\"*

Closes #1879.

## Sovereignty model

Audio NEVER leaves the user's machine unless they explicitly opt in.

| env var | default | behavior |
|---|---|---|
| `WHISPER_OPENAI_FALLBACK` | `false` | Local Whisper only. If local fails (binary missing, model missing, format unsupported), fail loudly with an actionable error rather than silently exfiltrate. |
| `WHISPER_OPENAI_FALLBACK=true` | opt-in | Permits OpenAI Whisper API fallback. Transcripts get tagged `[Voice (openai-fallback): \"...\"]` so the agent can disclose to the user when audio was processed remotely. |
| `WHISPER_REQUIRE_APPROVAL=true` | optional | Even with fallback enabled, surface the decision to the agent rather than silently calling OpenAI. |

The source label on auto-injected text is mandatory — it lets the agent disclose data path to the user. The local-only default is a feature, not a footnote: NanoClaw deployments that ship voice transcription get sovereignty out of the box.

## Implementation

Two paths sharing one core function:

1. **Auto-injection** (default UX). The poll loop calls `autoTranscribeMessages` on every message batch — initial and mid-conversation follow-ups — before formatting. Audio attachments become inline `[Voice (source): \"transcript\"]` lines added to the message text. Agents see text, not files.

2. **Explicit MCP tool** `transcribe(filePath, allowFallback?, requireApproval?)`. For advanced cases — transcribing arbitrary paths, overriding fallback policy, getting the structured result (`{text, source, durationMs, model}`) for richer agent disclosure.

Both use `transcribeAudio()` in `transcription.ts`. Local path runs `whisper-cli` (pinned via Dockerfile ARG). OpenAI fallback path pre-compresses with ffmpeg to 16 kHz mono Opus (~10× smaller than raw, voice-quality-preserving) before POST to `/v1/audio/transcriptions`. Native fetch + FormData; no `openai` npm dep.

## Container additions

- `ffmpeg` apt package (audio normalization + OpenAI-fallback compression)
- `whisper-cli@1.7.5` pnpm global (pinned)

The `whisper-cli` model file is mounted at `/whisper/model.bin` per the design doc — install instructions live in `docs/voice-transcription-container-design.md`. Without the model, local fails and the OpenAI fallback (if enabled) handles it; if both are unavailable, the agent gets an actionable error message rather than silently failing.

## Files

| File | Change |
|---|---|
| `container/agent-runner/src/transcription.ts` | NEW — core with sovereignty defaults, ffmpeg pre-compression, structured result. |
| `container/agent-runner/src/auto-transcribe.ts` | NEW — preprocessing pass that finds audio attachments and injects transcripts inline. |
| `container/agent-runner/src/mcp-tools/transcription.ts` | NEW — MCP tool. |
| `container/agent-runner/src/mcp-tools/index.ts` | Register the new tool. |
| `container/agent-runner/src/poll-loop.ts` | Call autoTranscribe on initial batch + on follow-ups (setInterval becomes async). |
| `container/Dockerfile` | Install ffmpeg + whisper-cli (pinned). |
| `docs/voice-transcription-container-design.md` | NEW — design doc covering the four containerization questions (binary location, audio data flow, MCP interface, OpenAI fallback) plus the sovereignty model. |

## Tests

- 197 host tests pass (`pnpm test`).
- Container side: types check, runtime imports verified.
- No host-side code changes — all logic is in the agent container.

## Composition

Builds on the existing channel-attachment pattern (channel adapter writes audio to a host staging dir → bind-mounted RO into container at `/workspace/attachments/`). No new IO mechanism required; reuses the convention already in place for Signal images.