### PR TITLE
fix(mount-security): clear errors for malformed mount + allowlist shapes

### DIFF
--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -19,15 +19,37 @@ Show the current config to the user in a readable format: which directories are 
 
 Ask which directories the user wants agents to access. For each path:
 - Validate the path exists
-- Ask if it should be read-only for non-main agents (default: yes)
+- Ask whether non-main agents should be allowed to **write** (default: no — i.e. read-only)
 
-Build the JSON config and write it:
+Build the JSON config and write it. Each `allowedRoots` entry **must** be an object with `path` (string) and `allowReadWrite` (boolean). Bare strings (e.g. `["/foo"]`) or `readOnly` keys are rejected by the validator with a clear error.
 
 ```bash
-npx tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{"path":"/path/to/dir","readOnly":false}],"blockedPatterns":[],"nonMainReadOnly":true}'
+npx tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{"path":"/path/to/dir","allowReadWrite":false,"description":"why this is mounted"}],"blockedPatterns":[],"nonMainReadOnly":true}'
 ```
 
 Use `--force` to overwrite the existing config.
+
+## Wire a mount into an agent group
+
+The allowlist only declares what *can* be mounted. To actually mount a path into a specific agent group, add an entry to that group's `groups/<folder>/container.json` `additionalMounts` array. Each entry must use these keys (Docker shorthand `source`/`target`/`mode` is **not** accepted):
+
+```json
+{
+  "additionalMounts": [
+    {
+      "hostPath": "~/notes",
+      "containerPath": "notes",
+      "readonly": true
+    }
+  ]
+}
+```
+
+- `hostPath` (required, string) — must resolve under one of the allowlist's `allowedRoots`.
+- `containerPath` (optional, string) — **relative**; the mount lands at `/workspace/extra/<containerPath>`. Defaults to `basename(hostPath)`.
+- `readonly` (optional, boolean) — host-side request. The mount is forced read-only if the agent group is non-main and the allowlist has `nonMainReadOnly: true`, or if the matching allowed root has `allowReadWrite: false`.
+
+After editing `container.json`, kill any running container for that agent group so the next message spawns a fresh one with the new mount: `docker rm -f nanoclaw-v2-<folder>-*`.
 
 ## Remove Directories
 

--- a/src/modules/mount-security/index.test.ts
+++ b/src/modules/mount-security/index.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { MOUNT_ALLOWLIST_PATH } from '../../config.js';
+
+// The module caches the parsed allowlist process-wide. To exercise multiple
+// allowlist shapes from one test file we need a fresh import every time —
+// which means dynamic import() inside vi.resetModules() boundaries.
+async function freshImport() {
+  vi.resetModules();
+  return import('./index.js');
+}
+
+let tmpHome: string;
+let originalAllowlistPath: string;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nc-mount-test-'));
+  // The module reads from a path resolved at config-import time, so we can't
+  // redirect cleanly without overriding HOME for a separate process. Instead,
+  // back up the real allowlist (if any) and write into the live location.
+  originalAllowlistPath = MOUNT_ALLOWLIST_PATH;
+  fs.mkdirSync(path.dirname(originalAllowlistPath), { recursive: true });
+  if (fs.existsSync(originalAllowlistPath)) {
+    fs.copyFileSync(originalAllowlistPath, path.join(tmpHome, 'allowlist.bak'));
+  }
+});
+
+afterEach(() => {
+  // Restore (or delete) the real allowlist after each test
+  const backup = path.join(tmpHome, 'allowlist.bak');
+  if (fs.existsSync(backup)) {
+    fs.copyFileSync(backup, originalAllowlistPath);
+  } else if (fs.existsSync(originalAllowlistPath)) {
+    fs.unlinkSync(originalAllowlistPath);
+  }
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function writeAllowlist(content: unknown) {
+  fs.writeFileSync(MOUNT_ALLOWLIST_PATH, JSON.stringify(content));
+}
+
+describe('validateMount — structural validation', () => {
+  beforeEach(() => {
+    writeAllowlist({
+      allowedRoots: [{ path: tmpHome, allowReadWrite: false }],
+      blockedPatterns: [],
+    });
+  });
+
+  it('rejects mount missing hostPath with a clear message', async () => {
+    const { validateMount } = await freshImport();
+    const result = validateMount({} as never);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/missing required field "hostPath"/);
+  });
+
+  it('rejects Docker shorthand (source/target/mode) with a hint to the right keys', async () => {
+    const { validateMount } = await freshImport();
+    const result = validateMount({ source: tmpHome, target: 'foo', mode: 'ro' } as never);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/Docker shorthand/);
+    expect(result.reason).toMatch(/hostPath/);
+    expect(result.reason).toMatch(/containerPath/);
+    expect(result.reason).toMatch(/readonly/);
+  });
+
+  it('rejects null mount entry without throwing', async () => {
+    const { validateMount } = await freshImport();
+    expect(() => validateMount(null as never)).not.toThrow();
+    const result = validateMount(null as never);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/Mount entry must be an object/);
+  });
+
+  it('rejects non-string containerPath', async () => {
+    const { validateMount } = await freshImport();
+    const result = validateMount({ hostPath: tmpHome, containerPath: 42 as unknown as string });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/"containerPath" must be a string/);
+  });
+
+  it('rejects non-boolean readonly', async () => {
+    const { validateMount } = await freshImport();
+    const result = validateMount({ hostPath: tmpHome, readonly: 'yes' as unknown as boolean });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/"readonly" must be a boolean/);
+  });
+
+  it('accepts a well-formed mount under an allowed root', async () => {
+    const { validateMount } = await freshImport();
+    const result = validateMount({ hostPath: tmpHome, containerPath: 'data', readonly: true });
+    expect(result.allowed).toBe(true);
+    expect(result.resolvedContainerPath).toBe('data');
+    expect(result.effectiveReadonly).toBe(true);
+  });
+});
+
+describe('loadMountAllowlist — allowedRoots structural validation', () => {
+  it('rejects bare-string allowedRoots entries with a clear message', async () => {
+    writeAllowlist({
+      // Intentionally malformed — bare strings instead of objects
+      allowedRoots: ['/some/path'],
+      blockedPatterns: [],
+    });
+    const { loadMountAllowlist } = await freshImport();
+    const result = loadMountAllowlist();
+    expect(result).toBeNull();
+  });
+
+  it('rejects entries missing path', async () => {
+    writeAllowlist({
+      allowedRoots: [{ allowReadWrite: false }],
+      blockedPatterns: [],
+    });
+    const { loadMountAllowlist } = await freshImport();
+    const result = loadMountAllowlist();
+    expect(result).toBeNull();
+  });
+
+  it('accepts a properly shaped allowlist', async () => {
+    writeAllowlist({
+      allowedRoots: [{ path: tmpHome, allowReadWrite: false, description: 'test' }],
+      blockedPatterns: [],
+    });
+    const { loadMountAllowlist } = await freshImport();
+    const result = loadMountAllowlist();
+    expect(result).not.toBeNull();
+    expect(result?.allowedRoots).toHaveLength(1);
+    expect(result?.allowedRoots[0].path).toBe(tmpHome);
+  });
+});

--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -90,6 +90,33 @@ export function loadMountAllowlist(): MountAllowlist | null {
       throw new Error('allowedRoots must be an array');
     }
 
+    // Each entry must be an object with at least { path: string }. Bare strings
+    // (e.g. `"allowedRoots": ["/foo"]`) are a common mistake — accepting them
+    // silently means findAllowedRoot() can't read root.path and every mount
+    // gets rejected with a confusing "no allowed root" error. Reject up-front
+    // so the operator sees the real problem.
+    for (let i = 0; i < allowlist.allowedRoots.length; i++) {
+      const root = allowlist.allowedRoots[i] as unknown;
+      if (typeof root !== 'object' || root === null || Array.isArray(root)) {
+        throw new Error(
+          `allowedRoots[${i}] must be an object like { "path": "/abs/path", "allowReadWrite": false }, got ${
+            root === null ? 'null' : Array.isArray(root) ? 'array' : typeof root
+          }`,
+        );
+      }
+      const { path: rootPath, allowReadWrite } = root as { path?: unknown; allowReadWrite?: unknown };
+      if (typeof rootPath !== 'string' || rootPath.length === 0) {
+        throw new Error(
+          `allowedRoots[${i}].path must be a non-empty string`,
+        );
+      }
+      if (allowReadWrite !== undefined && typeof allowReadWrite !== 'boolean') {
+        throw new Error(
+          `allowedRoots[${i}].allowReadWrite must be a boolean if provided`,
+        );
+      }
+    }
+
     if (!Array.isArray(allowlist.blockedPatterns)) {
       throw new Error('blockedPatterns must be an array');
     }
@@ -238,6 +265,46 @@ export function validateMount(mount: AdditionalMount): MountValidationResult {
     };
   }
 
+  // Structural validation up-front. The two repeat mistakes here are
+  // (a) using Docker's shorthand keys (source/target/mode) instead of
+  //     hostPath/containerPath/readonly, and
+  // (b) omitting hostPath entirely.
+  // Without these guards the code falls into path.basename(undefined) and
+  // throws a TypeError that propagates out of validateAdditionalMounts and
+  // crashes the spawn — the operator sees a stack trace, not a useful
+  // explanation. Catch it here and return a structured rejection.
+  if (typeof mount !== 'object' || mount === null || Array.isArray(mount)) {
+    return {
+      allowed: false,
+      reason: `Mount entry must be an object with { hostPath, containerPath?, readonly? }, got ${
+        mount === null ? 'null' : Array.isArray(mount) ? 'array' : typeof mount
+      }`,
+    };
+  }
+  if (typeof mount.hostPath !== 'string' || mount.hostPath.length === 0) {
+    const keys = Object.keys(mount as unknown as Record<string, unknown>);
+    const hint =
+      keys.includes('source') || keys.includes('target') || keys.includes('mode')
+        ? ` (looks like Docker shorthand — use "hostPath"/"containerPath"/"readonly" instead of "source"/"target"/"mode")`
+        : '';
+    return {
+      allowed: false,
+      reason: `Mount entry missing required field "hostPath" (string). Got keys: [${keys.join(', ')}]${hint}`,
+    };
+  }
+  if (mount.containerPath !== undefined && typeof mount.containerPath !== 'string') {
+    return {
+      allowed: false,
+      reason: `Mount entry "containerPath" must be a string if provided, got ${typeof mount.containerPath}`,
+    };
+  }
+  if (mount.readonly !== undefined && typeof mount.readonly !== 'boolean') {
+    return {
+      allowed: false,
+      reason: `Mount entry "readonly" must be a boolean if provided, got ${typeof mount.readonly}`,
+    };
+  }
+
   // Derive containerPath from hostPath basename if not specified
   const containerPath = mount.containerPath || path.basename(mount.hostPath);
 
@@ -343,10 +410,13 @@ export function validateAdditionalMounts(
         reason: result.reason,
       });
     } else {
+      // mount may be malformed (null, string, etc.) — read fields defensively
+      // so the warn log itself can't throw.
+      const m = (mount ?? {}) as Partial<AdditionalMount>;
       log.warn('Additional mount REJECTED', {
         group: groupName,
-        requestedPath: mount.hostPath,
-        containerPath: mount.containerPath,
+        requestedPath: typeof m.hostPath === 'string' ? m.hostPath : '<missing>',
+        containerPath: typeof m.containerPath === 'string' ? m.containerPath : undefined,
         reason: result.reason,
       });
     }


### PR DESCRIPTION
## Summary

The mount validator crashes with `TypeError: path.basename(undefined)` when `container.json` uses the wrong key shape — most commonly Docker shorthand `source`/`target`/`mode` instead of `hostPath`/`containerPath`/`readonly`. The error propagates out of `validateAdditionalMounts`, kills `spawnContainer`, and the operator gets a stack trace with no hint of the real fix. Same class of bug in `loadMountAllowlist`: bare strings in `allowedRoots` (e.g. `[\"/foo\"]`) are silently accepted, then every mount fails with a confusing _\"not under any allowed root\"_ message because `findAllowedRoot` can't read `root.path`.

## What's in this PR

- **`src/modules/mount-security/index.ts`** — both `validateMount` and `loadMountAllowlist` now reject bad shapes up-front with structured errors. When Docker shorthand keys (`source`/`target`/`mode`) are detected, the error includes a hint pointing at the right key names. The warn log in `validateAdditionalMounts` reads its fields defensively so it can't itself throw on a malformed entry.
- **`src/modules/mount-security/index.test.ts`** — new test file with 9 cases covering missing fields, Docker-shorthand detection, null entries, wrong types, well-formed acceptance, and allowlist structural checks.
- **`.claude/skills/manage-mounts/SKILL.md`** — corrects the example (`readOnly` → `allowReadWrite`) and adds a _Wire a mount into an agent group_ section showing the correct `container.json` shape with each field documented.

## Repro before the fix

```jsonc
// groups/<group>/container.json
{ \"additionalMounts\": [ { \"source\": \"/foo\", \"target\": \"foo\", \"mode\": \"ro\" } ] }
```

Then any inbound message → \`TypeError: The \"path\" argument must be of type string\` deep in container-runner, no useful log. With this PR: a structured rejection in the warn log:

> Mount entry missing required field \"hostPath\" (string). Got keys: [source, target, mode] (looks like Docker shorthand — use \"hostPath\"/\"containerPath\"/\"readonly\" instead of \"source\"/\"target\"/\"mode\")

## Test plan

- [x] \`pnpm exec tsc --noEmit -p tsconfig.json\` — clean (exit 0)
- [x] \`pnpm test\` — 24 files / 206 tests pass (9 new)
- [x] Manually verified end-to-end against a Slack-wired GodFather agent: bad shape → structured warn, container still spawns (with the bad mount skipped); good shape → mount appears in \`docker inspect\` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)