### PR TITLE
fix(reactions): use canonical chat-sdk composite id for inbound lookups

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -80,8 +80,11 @@ export function writeMessageOut(msg: WriteMessageOut): number {
  * Look up a message's platform ID by seq number.
  * Searches both inbound and outbound DBs since seq spans both.
  *
- * For inbound messages, the Chat SDK message ID is already the platform message ID
- * (e.g., "6037840640:42" for Telegram).
+ * For inbound chat-sdk messages, the column `id` is suffixed with the agent
+ * group id to keep rows unique across agent groups (e.g.
+ * "8236653927:118:ag-XXXX"). The chat-sdk adapter expects the original 2-part
+ * composite ("8236653927:118") for edit / addReaction / etc., which is preserved
+ * verbatim in the content JSON's `id` field — read from there.
  *
  * For outbound messages, the internal ID (msg-xxx) won't work for edits/reactions.
  * Instead, look up the platform_message_id from the delivered table (host writes this
@@ -90,11 +93,20 @@ export function writeMessageOut(msg: WriteMessageOut): number {
 export function getMessageIdBySeq(seq: number): string | null {
   const inbound = getInboundDb();
 
-  // Inbound messages: ID is already the platform message ID
-  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as
-    | { id: string }
-    | undefined;
-  if (inRow) return inRow.id;
+  const inRow = inbound
+    .prepare('SELECT id, kind, content FROM messages_in WHERE seq = ?')
+    .get(seq) as { id: string; kind: string; content: string } | undefined;
+  if (inRow) {
+    if (inRow.kind === 'chat-sdk') {
+      try {
+        const parsed = JSON.parse(inRow.content) as { id?: string };
+        if (typeof parsed.id === 'string' && parsed.id.length > 0) return parsed.id;
+      } catch {
+        /* fall through to column id */
+      }
+    }
+    return inRow.id;
+  }
 
   // Outbound messages: look up platform message ID from delivered table
   const outRow = getOutboundDb().prepare('SELECT id FROM messages_out WHERE seq = ?').get(seq) as


### PR DESCRIPTION
## Summary

`getMessageIdBySeq` returned the raw `messages_in.id` column for inbound rows, but the host suffixes that column with `:<agentGroupId>` to keep rows unique across agent groups (e.g. `8236653927:118:ag-XXXXXX`). The chat-sdk adapters expect the original 2-part composite (`8236653927:118`) — passing the 3-part id silently fails because the adapter's `decodeCompositeMessageId` parses the wrong message_id, then the platform returns OK on a stale target. End-user effect: `add_reaction` and `edit_message` look like they succeeded but nothing visible happens to the original message.

This affects every chat-sdk channel (Slack, Discord, Linear, Telegram, etc.) — not Telegram-specific.

## Root cause

- Inbound chat-sdk row written by host with `id = '<chatId>:<msgId>:<agentGroupId>'` for cross-group uniqueness.
- `getMessageIdBySeq` returned that column id verbatim.
- `bridge.deliver` passed it to `adapter.addReaction(threadId, messageId, emoji)`.
- `decodeCompositeMessageId` split on `:`, took the wrong segment as `messageId`, the API returned 200 OK on a non-existent target → silent no-op.

## Fix

For inbound chat-sdk rows, read the canonical `id` field from the message JSON content (which the chat-adapter writes verbatim before the host adds its agent-group suffix). Native `chat` rows fall through to the column id unchanged.

Diff is 19 insertions / 7 deletions in `container/agent-runner/src/db/messages-out.ts`.

## Test plan

- [x] Container typecheck passes (`bun run typecheck`)
- [x] Verified live on a Telegram install: before fix, agent's `add_reaction` returned success but no reaction appeared; after fix, reaction lands on the correct message.
- [ ] Add bun:test coverage for `getMessageIdBySeq` chat-sdk path (will follow up)