### PR TITLE
fix: fail closed on invalid engage_pattern regex

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -350,8 +350,14 @@ function evaluateEngage(
       try {
         return new RegExp(pat).test(text);
       } catch {
-        // Bad regex: fail open so admin sees the agent responding + can fix.
-        return true;
+        // Bad regex: fail closed. A broken restriction silently becoming
+        // unrestricted is worse than an agent going quiet. Log so the
+        // operator can find and fix the pattern.
+        log.warn('Invalid engage_pattern — failing closed', {
+          agentGroupId: agent.agent_group_id,
+          pattern: pat,
+        });
+        return false;
       }
     }
     case 'mention':


### PR DESCRIPTION
## Summary

- An invalid `engage_pattern` regex (e.g. using Python/PCRE `(?i)` syntax instead of JS) causes `new RegExp(pat)` to throw a `SyntaxError`
- The previous catch block returned `true` (fail open), silently turning a broken restriction into no restriction — the agent would respond to every message
- This changes the behavior to fail closed: log a warning with the invalid pattern and return `false`, so the agent goes quiet until the pattern is fixed

Fail closed is the safer default: an agent unexpectedly going quiet is noticeable; an agent unexpectedly responding to everything (including messages from group members it shouldn't respond to) is not.

## Test plan

- [ ] Set an invalid `engage_pattern` (e.g. `(?i)@bot`) on a wiring and verify the agent does not engage
- [ ] Verify a warning appears in the host log with the invalid pattern
- [ ] Verify a valid pattern still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)