### PR TITLE
Fix poll-loop test teardown — abort signal propagates to active query

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -41,6 +41,7 @@ describe('poll loop integration', () => {
 
     await waitFor(() => getUndeliveredMessages().length > 0, 2000);
     controller.abort();
+    await loopPromise.catch(() => {});
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
@@ -52,8 +53,6 @@ describe('poll loop integration', () => {
     // Input message should be acked (not pending)
     const pending = getPendingMessages();
     expect(pending).toHaveLength(0);
-
-    await loopPromise.catch(() => {});
   });
 
   it('should process multiple messages in a batch', async () => {
@@ -66,12 +65,11 @@ describe('poll loop integration', () => {
 
     await waitFor(() => getUndeliveredMessages().length > 0, 2000);
     controller.abort();
+    await loopPromise.catch(() => {});
 
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
     expect(JSON.parse(out[0].content).text).toBe('Got both messages');
-
-    await loopPromise.catch(() => {});
   });
 
   it('should process messages arriving after loop starts', async () => {
@@ -85,24 +83,24 @@ describe('poll loop integration', () => {
 
     await waitFor(() => getUndeliveredMessages().length > 0, 2000);
     controller.abort();
+    await loopPromise.catch(() => {});
 
     const out = getUndeliveredMessages();
     expect(out.length).toBeGreaterThanOrEqual(1);
-
-    await loopPromise.catch(() => {});
   });
 });
 
-// Helper: run poll loop until aborted or timeout
+// Helper: run the poll loop until aborted or timeout. The loop now honours the
+// abort signal directly, so we just race against the timeout as a safety net
+// — the abort path no longer leaves an unawaited inner loop polling after the
+// test completes.
 async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
   return Promise.race([
     runPollLoop({
       provider,
       providerName: 'mock',
       cwd: '/tmp',
-    }),
-    new Promise<void>((_, reject) => {
-      signal.addEventListener('abort', () => reject(new Error('aborted')));
+      signal,
     }),
     new Promise<void>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
   ]);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -33,6 +33,14 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * Optional abort signal. When aborted, the loop exits cleanly between
+   * iterations. Production runs the loop until the process is killed and
+   * doesn't pass this; tests pass it so the loop stops alongside the test
+   * (otherwise it keeps polling after `closeSessionDb()` in afterEach and
+   * crashes trying to reopen `/workspace/inbound.db`).
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -63,6 +71,8 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
   let pollCount = 0;
   while (true) {
+    if (config.signal?.aborted) return;
+
     // Skip system messages — they're responses for MCP tools (e.g., ask_user_question)
     const messages = getPendingMessages().filter((m) => m.kind !== 'system');
     pollCount++;
@@ -171,7 +181,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     const skippedSet = new Set(skipped);
     const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
+      const result = await processQuery(query, routing, processingIds, config.providerName, config.signal);
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -250,9 +260,22 @@ async function processQuery(
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  signal?: AbortSignal,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
+
+  // If the loop is being torn down (test abort, future SIGTERM handling),
+  // proactively call query.abort() so the provider's events generator
+  // unblocks instead of awaiting forever (the mock provider in particular
+  // sleeps until push/end/abort).
+  const onAbort = (): void => {
+    query.abort();
+  };
+  if (signal) {
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open is
@@ -317,6 +340,7 @@ async function processQuery(
   } finally {
     done = true;
     clearInterval(pollHandle);
+    signal?.removeEventListener('abort', onAbort);
   }
 
   return { continuation: queryContinuation };


### PR DESCRIPTION
## Summary

`runPollLoop` had no abort mechanism, so `integration.test.ts`'s `Promise.race` against an `AbortController` only resolved the outer wait — the inner `while (true)` loop kept polling after the test completed. Once `closeSessionDb()` ran in `afterEach`, the next iteration crashed with `SQLiteError: unable to open /workspace/inbound.db` (the production default path). That cascaded into `factory.test.ts` failing to register: *"Cannot call describe() after the test run has completed."*

Net effect on `bun test` from `container/agent-runner/`:

| | pass | fail | errors |
|---|---|---|---|
| stock `upstream/main` | 56 | 0 | 1 |
| this PR | 59 | 0 | 0 |

The 3 recovered tests are `factory.test.ts`'s `createProvider` cases, which were silently broken on `main` because the file never finished loading.

## Changes

- Add optional `signal?: AbortSignal` to `PollLoopConfig`. Production (`src/index.ts`) doesn't pass one — the loop runs until SIGTERM as before. The integration test passes its controller's signal so teardown is cooperative.
- Check `signal.aborted` between iterations of the outer poll loop.
- Propagate abort into `processQuery`: a one-shot listener calls `query.abort()` so providers whose events generator awaits indefinitely (the mock provider sleeps until `push/end/abort`) actually unblock. Listener is removed in `finally`.
- Simplify `runPollLoopWithTimeout` in the test: pass the signal through to `runPollLoop` directly and drop the now-redundant abort-listener leg from `Promise.race`. Tests `await loopPromise.catch(...)` before asserting so the loop has fully exited before `afterEach` tears down the in-memory DBs.

## Backwards compatibility

The new `signal` field on `PollLoopConfig` is optional. The production caller in `src/index.ts` is unchanged. Provider-side, abort propagation reuses the existing `query.abort()` API which all providers already implement (`MockProvider`, `ClaudeProvider`).

## Verification

```bash
cd container/agent-runner
bun test
```

Tested on Pi 5 / ARM64 with `bun 1.3.13`.