### PR TITLE
fix(channels): resolve clicker user from interaction.user in DM-context approvals

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -501,7 +501,10 @@ async function handleForwardedEvent(
     // type 3 = MessageComponent (button/select)
     if (interaction.type === 3) {
       const customId = (interaction.data as Record<string, unknown>)?.custom_id as string;
-      const user = (interaction.member as Record<string, unknown>)?.user as Record<string, string> | undefined;
+      // Guild-context interactions put the user at interaction.member.user;
+      // DM-context interactions put it at interaction.user (no member wrapper).
+      const user = ((interaction.member as Record<string, unknown>)?.user
+        ?? interaction.user) as Record<string, string> | undefined;
       const interactionId = interaction.id as string;
       const interactionToken = interaction.token as string;
 


### PR DESCRIPTION
## Summary

The button-click handler in `chat-sdk-bridge.ts` only reads `interaction.member.user` to identify who clicked. That field exists on guild-context interactions but not on DM-context interactions — Discord puts the user at `interaction.user` directly when the click happens in a DM (no guild member wrapper).

Channel-registration approval cards from `picks.ts` are normally delivered to the approver's DM with the bot, so every DM-delivered approval click was rejected by the host with:

```
WARN  Channel registration click rejected — unauthorized clicker
      messagingGroupId="mg-..."  clickerId=null  expectedApprover="discord:..."
```

The wiring was never created → the channel stayed unregistered → the agent never engaged.

## Fix

Fall back to `interaction.user` when `interaction.member.user` is absent.

```ts
const user = ((interaction.member as Record<string, unknown>)?.user
  ?? interaction.user) as Record<string, string> | undefined;
```

## Test plan

- [ ] Trigger a channel-registration approval card (mention the bot in an unwired guild channel) so the card is delivered to the operator's DM with the bot.
- [ ] Click "Approve" in the DM.
- [ ] Confirm host log shows `Channel registration approved — wiring created` (no `unauthorized clicker` warning).
- [ ] Confirm subsequent messages in the channel route to the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)