### PR TITLE
feat(wiki): add pre-ingest contradiction detection to llm-wiki skill

### DIFF
--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -39,6 +39,8 @@ Create `wiki/` and `sources/` directories in the group folder. Create initial `i
 
 Create a `container/skills/wiki/SKILL.md` tailored to this user's wiki. This is the schema layer from the pattern — it tells the agent how to maintain the wiki. Base it on the pattern's Operations section (ingest, query, lint) and the conventions you agreed on with the user. Don't over-prescribe — the pattern says "your LLM figures out the rest."
 
+The skill must include a contradiction detection step as part of the ingest workflow: before updating any wiki page with a new claim, the agent checks whether it conflicts with existing content on that page. If it does, both claims are recorded in `wiki/contradictions.md` (with source, date, and a description of the conflict) and the page is left unchanged until the user resolves the conflict. Make this explicit in the skill so the agent treats it as a required step, not an optional one.
+
 ### 3c. Group CLAUDE.md
 
 Edit the group's CLAUDE.md to add a wiki section. This is critical — it's what turns the agent into a wiki maintainer. It should:
@@ -47,6 +49,7 @@ Edit the group's CLAUDE.md to add a wiki section. This is critical — it's what
 - Index the key files and folders (`wiki/`, `sources/`, `wiki/index.md`, `wiki/log.md`)
 - Point to the container skill for detailed workflow
 - **Ingest discipline:** Be very explicit that when the user provides multiple files or points at a folder with many files, the agent MUST process them one at a time. For each file: read it, discuss takeaways, create/update all wiki pages (summary, entities, concepts, cross-references, index, log), and completely finish with that file before moving to the next. Never batch-read all files and then process them together — this produces shallow, generic pages instead of the deep integration the pattern requires.
+- **Contradiction discipline:** Before writing any claim to a wiki page, the agent checks whether it conflicts with existing content on that page. If it does, both versions are logged in `wiki/contradictions.md` with source, date, and a plain description of the conflict. The wiki page stays unchanged until the user resolves it. Make clear that silently overwriting a prior claim is never acceptable — an unresolved conflict in `contradictions.md` is always the right outcome over a quietly wrong wiki page.
 
 ## Step 4: Source handling capabilities
 

--- a/.claude/skills/add-karpathy-llm-wiki/llm-wiki.md
+++ b/.claude/skills/add-karpathy-llm-wiki/llm-wiki.md
@@ -37,6 +37,8 @@ Three layers comprise the system:
 
 **Ingest:** Drop new sources into the raw collection; the LLM processes them. The agent reads sources, discusses takeaways, writes summaries, updates indexes, refreshes entity and concept pages, logs entries. Single sources might touch 10-15 wiki pages. Prefer ingesting individually while staying involved, though batch ingestion with less oversight is possible.
 
+Before updating any wiki page with a new claim, check whether it contradicts existing content on that page. If a conflict is found, do not silently overwrite the prior claim. Instead, record both claims in a `wiki/contradictions.md` file with the source, date, and a brief description of the conflict, and leave the wiki page itself unchanged until the contradiction is resolved. This keeps the wiki honest as it grows: a flagged conflict is recoverable, a silent overwrite is not.
+
 **Query:** Ask questions against the wiki. The LLM searches relevant pages, synthesizes answers with citations. Answers take various forms—markdown pages, comparison tables, slide decks, charts, canvas. Good answers can be filed back into the wiki as new pages—explorations compound in the knowledge base rather than disappearing into chat history.
 
 **Lint:** Periodically health-check the wiki. Look for contradictions, stale claims superseded by newer sources, orphan pages lacking inbound links, important concepts lacking dedicated pages, missing cross-references, data gaps. The LLM suggests investigations and sources to pursue, keeping the wiki healthy as it grows.


### PR DESCRIPTION
## What this fixes

The wiki ingest workflow currently has no contradiction detection step. When a new source contains a claim that conflicts with existing wiki content, the agent silently overwrites the prior claim. There is no record of what changed or why.

Contradiction detection is mentioned in the Lint operation (periodic health checks), but by the time lint runs the damage is already done. The conflict needs to be caught before the wiki page is updated, not after.

For knowledge bases where accuracy carries real consequences, silently wrong is far more dangerous than openly uncertain.

## What this changes

Two files in the `add-karpathy-llm-wiki` skill:

**`llm-wiki.md`** — Extends the Ingest operation description to require a contradiction check before updating any wiki page. If a conflict is found, both claims are recorded in `wiki/contradictions.md` with source, date, and description. The page stays unchanged until the conflict is resolved.

**`SKILL.md`** — Adds explicit contradiction discipline to the container skill setup (3b) and the group CLAUDE.md setup (3c), so agents generated by this skill treat contradiction checking as a required ingest step rather than an optional one.

## What stays the same

No infrastructure changes. No new dependencies. The fix lives entirely in the skill instructions that shape agent behavior, which is how this project is designed to evolve.