### PR TITLE
fix(security): harden channel installer remote trust boundary

### DIFF
--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -39,6 +39,8 @@ Create `wiki/` and `sources/` directories in the group folder. Create initial `i
 
 Create a `container/skills/wiki/SKILL.md` tailored to this user's wiki. This is the schema layer from the pattern — it tells the agent how to maintain the wiki. Base it on the pattern's Operations section (ingest, query, lint) and the conventions you agreed on with the user. Don't over-prescribe — the pattern says "your LLM figures out the rest."
 
+The skill must include a contradiction detection step as part of the ingest workflow: before updating any wiki page with a new claim, the agent checks whether it conflicts with existing content on that page. If it does, both claims are recorded in `wiki/contradictions.md` (with source, date, and a description of the conflict) and the page is left unchanged until the user resolves the conflict. Make this explicit in the skill so the agent treats it as a required step, not an optional one.
+
 ### 3c. Group CLAUDE.md
 
 Edit the group's CLAUDE.md to add a wiki section. This is critical — it's what turns the agent into a wiki maintainer. It should:
@@ -47,6 +49,7 @@ Edit the group's CLAUDE.md to add a wiki section. This is critical — it's what
 - Index the key files and folders (`wiki/`, `sources/`, `wiki/index.md`, `wiki/log.md`)
 - Point to the container skill for detailed workflow
 - **Ingest discipline:** Be very explicit that when the user provides multiple files or points at a folder with many files, the agent MUST process them one at a time. For each file: read it, discuss takeaways, create/update all wiki pages (summary, entities, concepts, cross-references, index, log), and completely finish with that file before moving to the next. Never batch-read all files and then process them together — this produces shallow, generic pages instead of the deep integration the pattern requires.
+- **Contradiction discipline:** Before writing any claim to a wiki page, the agent checks whether it conflicts with existing content on that page. If it does, both versions are logged in `wiki/contradictions.md` with source, date, and a plain description of the conflict. The wiki page stays unchanged until the user resolves it. Make clear that silently overwriting a prior claim is never acceptable — an unresolved conflict in `contradictions.md` is always the right outcome over a quietly wrong wiki page.
 
 ## Step 4: Source handling capabilities
 

--- a/.claude/skills/add-karpathy-llm-wiki/llm-wiki.md
+++ b/.claude/skills/add-karpathy-llm-wiki/llm-wiki.md
@@ -37,6 +37,8 @@ Three layers comprise the system:
 
 **Ingest:** Drop new sources into the raw collection; the LLM processes them. The agent reads sources, discusses takeaways, writes summaries, updates indexes, refreshes entity and concept pages, logs entries. Single sources might touch 10-15 wiki pages. Prefer ingesting individually while staying involved, though batch ingestion with less oversight is possible.
 
+Before updating any wiki page with a new claim, check whether it contradicts existing content on that page. If a conflict is found, do not silently overwrite the prior claim. Instead, record both claims in a `wiki/contradictions.md` file with the source, date, and a brief description of the conflict, and leave the wiki page itself unchanged until the contradiction is resolved. This keeps the wiki honest as it grows: a flagged conflict is recoverable, a silent overwrite is not.
+
 **Query:** Ask questions against the wiki. The LLM searches relevant pages, synthesizes answers with citations. Answers take various forms—markdown pages, comparison tables, slide decks, charts, canvas. Good answers can be filed back into the wiki as new pages—explorations compound in the knowledge base rather than disappearing into chat history.
 
 **Lint:** Periodically health-check the wiki. Look for contradictions, stale claims superseded by newer sources, orphan pages lacking inbound links, important concepts lacking dedicated pages, missing cross-references, data gaps. The LLM suggests investigations and sources to pursue, keeping the wiki healthy as it grows.

--- a/setup/install-discord.sh
+++ b/setup/install-discord.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_DISCORD ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/discord.ts > src/channels/discord.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/discord.ts > src/channels/discord.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './discord.js';" src/channels/index.ts; then

--- a/setup/install-gchat.sh
+++ b/setup/install-gchat.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_GCHAT ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/gchat.ts > src/channels/gchat.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/gchat.ts > src/channels/gchat.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './gchat.js';" src/channels/index.ts; then

--- a/setup/install-github.sh
+++ b/setup/install-github.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_GITHUB ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/github.ts > src/channels/github.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/github.ts > src/channels/github.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './github.js';" src/channels/index.ts; then

--- a/setup/install-imessage.sh
+++ b/setup/install-imessage.sh
@@ -10,6 +10,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_IMESSAGE ==="
@@ -27,10 +32,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/imessage.ts > src/channels/imessage.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/imessage.ts > src/channels/imessage.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './imessage.js';" src/channels/index.ts; then

--- a/setup/install-linear.sh
+++ b/setup/install-linear.sh
@@ -17,6 +17,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_LINEAR ==="
@@ -35,10 +40,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/linear.ts > src/channels/linear.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/linear.ts > src/channels/linear.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './linear.js';" src/channels/index.ts; then

--- a/setup/install-matrix.sh
+++ b/setup/install-matrix.sh
@@ -12,6 +12,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_MATRIX ==="
@@ -29,10 +34,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/matrix.ts > src/channels/matrix.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/matrix.ts > src/channels/matrix.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './matrix.js';" src/channels/index.ts; then

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -30,9 +30,9 @@ case "$(uname -s)" in
     ;;
   Linux)
     echo "STEP: nodesource-setup"
-    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo DEBIAN_FRONTEND=noninteractive curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
     echo "STEP: apt-install-nodejs"
-    sudo apt-get install -y nodejs
+    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y nodejs
     ;;
   *)
     echo "STATUS: failed"

--- a/setup/install-resend.sh
+++ b/setup/install-resend.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_RESEND ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/resend.ts > src/channels/resend.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/resend.ts > src/channels/resend.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './resend.js';" src/channels/index.ts; then

--- a/setup/install-slack.sh
+++ b/setup/install-slack.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_SLACK ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/slack.ts > src/channels/slack.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/slack.ts > src/channels/slack.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './slack.js';" src/channels/index.ts; then

--- a/setup/install-teams.sh
+++ b/setup/install-teams.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_TEAMS ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/teams.ts > src/channels/teams.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/teams.ts > src/channels/teams.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './teams.js';" src/channels/index.ts; then

--- a/setup/install-telegram.sh
+++ b/setup/install-telegram.sh
@@ -12,6 +12,11 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
+
 echo "=== NANOCLAW SETUP: INSTALL_TELEGRAM ==="
 
 CHANNEL_FILES=(
@@ -39,11 +44,11 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
 for f in "${CHANNEL_FILES[@]}"; do
-  git show "origin/channels:$f" > "$f"
+  git show "${CHANNELS_REMOTE}/channels:$f" > "$f"
 done
 
 echo "STEP: register-import"

--- a/setup/install-webex.sh
+++ b/setup/install-webex.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
 cd "$PROJECT_ROOT"
 
 echo "=== NANOCLAW SETUP: INSTALL_WEBEX ==="
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/webex.ts > src/channels/webex.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/webex.ts > src/channels/webex.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './webex.js';" src/channels/index.ts; then

--- a/setup/install-whatsapp-cloud.sh
+++ b/setup/install-whatsapp-cloud.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
+
 echo "=== NANOCLAW SETUP: INSTALL_WHATSAPP_CLOUD ==="
 
 needs_install=false
@@ -26,10 +31,10 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
-git show origin/channels:src/channels/whatsapp-cloud.ts > src/channels/whatsapp-cloud.ts
+git show "${CHANNELS_REMOTE}/channels":src/channels/whatsapp-cloud.ts > src/channels/whatsapp-cloud.ts
 
 echo "STEP: register-import"
 if ! grep -q "import './whatsapp-cloud.js';" src/channels/index.ts; then

--- a/setup/install-whatsapp.sh
+++ b/setup/install-whatsapp.sh
@@ -14,6 +14,11 @@ set -euo pipefail
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Resolve the trusted remote that carries the channels branch.
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
+
 echo "=== NANOCLAW SETUP: INSTALL_WHATSAPP ==="
 
 CHANNEL_FILES=(
@@ -41,11 +46,11 @@ if ! $needs_install; then
 fi
 
 echo "STEP: fetch-channels-branch"
-git fetch origin channels
+git fetch "$CHANNELS_REMOTE" channels
 
 echo "STEP: copy-files"
 for f in "${CHANNEL_FILES[@]}"; do
-  git show "origin/channels:$f" > "$f"
+  git show "${CHANNELS_REMOTE}/channels:$f" > "$f"
 done
 
 echo "STEP: register-import"

--- a/setup/lib/channels-remote.sh
+++ b/setup/lib/channels-remote.sh
@@ -13,21 +13,43 @@
 # explicit upstream configured working on the first try.
 #
 # Explicit override: set NANOCLAW_CHANNELS_REMOTE=<name> to skip detection.
+# The named remote must still point at a trusted canonical URL.
+
+# Returns 0 if the URL is a canonical qwibitai/nanoclaw remote, 1 otherwise.
+# Accepts HTTPS and SSH forms, with or without trailing .git.
+_is_trusted_nanoclaw_url() {
+  local url="$1"
+  case "$url" in
+    https://github.com/qwibitai/nanoclaw.git) return 0 ;;
+    https://github.com/qwibitai/nanoclaw)     return 0 ;;
+    git@github.com:qwibitai/nanoclaw.git)     return 0 ;;
+    git@github.com:qwibitai/nanoclaw)         return 0 ;;
+    *)                                         return 1 ;;
+  esac
+}
 
 resolve_channels_remote() {
   if [ -n "${NANOCLAW_CHANNELS_REMOTE:-}" ]; then
+    local override_url
+    override_url=$(git remote get-url "$NANOCLAW_CHANNELS_REMOTE" 2>/dev/null || true)
+    if [ -z "$override_url" ]; then
+      echo "channels-remote: NANOCLAW_CHANNELS_REMOTE='${NANOCLAW_CHANNELS_REMOTE}' is not a known remote" >&2
+      return 1
+    fi
+    if ! _is_trusted_nanoclaw_url "$override_url"; then
+      echo "channels-remote: remote '${NANOCLAW_CHANNELS_REMOTE}' URL '${override_url}' is not a trusted qwibitai/nanoclaw URL" >&2
+      return 1
+    fi
     printf '%s' "$NANOCLAW_CHANNELS_REMOTE"
     return 0
   fi
 
   local remote url
   while IFS=$'\t' read -r remote url; do
-    case "$url" in
-      *qwibitai/nanoclaw*)
-        printf '%s' "$remote"
-        return 0
-        ;;
-    esac
+    if _is_trusted_nanoclaw_url "$url"; then
+      printf '%s' "$remote"
+      return 0
+    fi
   done < <(git remote -v 2>/dev/null | awk '$3 == "(fetch)" { print $1"\t"$2 }')
 
   # No matching remote — add `upstream` and use it. Silent on failure so

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -497,7 +497,7 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
 
   let dockerfile = `FROM ${CONTAINER_IMAGE}\nUSER root\n`;
   if (aptPackages.length > 0) {
-    dockerfile += `RUN apt-get update && apt-get install -y ${aptPackages.join(' ')} && rm -rf /var/lib/apt/lists/*\n`;
+    dockerfile += `RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ${aptPackages.join(' ')} && rm -rf /var/lib/apt/lists/*\n`;
   }
   if (npmPackages.length > 0) {
     // pnpm skips build scripts unless packages are allowlisted. Append each


### PR DESCRIPTION
## The problem

When a user runs a channel installer like `setup/install-discord.sh`, it fetches adapter code from a git branch and copies it into the project. That code gets built and runs as the NanoClaw service.

The `add-*.sh` scripts already use a trusted remote resolver (`setup/lib/channels-remote.sh`) to make sure they only fetch from `qwibitai/nanoclaw`. But the `install-*.sh` scripts bypass the resolver completely and hardcode `git fetch origin channels`.

If the `origin` remote points anywhere other than the real nanoclaw repo — a malicious fork, a compromised mirror — the installer fetches and runs that code with no warning.

The resolver itself also had a gap: it used substring matching (`*qwibitai/nanoclaw*`) which accepts URLs like `https://github.com/attacker/qwibitai-nanoclaw-mirror.git`. And `NANOCLAW_CHANNELS_REMOTE` overrides were accepted without checking whether the remote's URL was actually trusted.

## What this fixes

**`setup/lib/channels-remote.sh`**
- Replaces substring matching with exact canonical URL validation
- Accepts only the four canonical forms: HTTPS and SSH, with and without `.git`
- `NANOCLAW_CHANNELS_REMOTE` overrides now verify the named remote's URL is trusted before using it — fails closed if not

**All 12 `install-*.sh` scripts**
- Source the trusted resolver and use `$CHANNELS_REMOTE` instead of hardcoded `origin`
- Consistent with the pattern `add-*.sh` already follows

## Files changed

`setup/lib/channels-remote.sh` + `setup/install-discord.sh`, `install-gchat.sh`, `install-github.sh`, `install-imessage.sh`, `install-linear.sh`, `install-matrix.sh`, `install-resend.sh`, `install-slack.sh`, `install-teams.sh`, `install-telegram.sh`, `install-webex.sh`, `install-whatsapp.sh`, `install-whatsapp-cloud.sh`