### PR TITLE
fix: defer task messages from follow-up polling to main loop

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -272,6 +272,7 @@ async function processQuery(
     // host-generated welcome trigger with null thread vs a Discord DM reply).
     const newMessages = getPendingMessages().filter((m) => {
       if (m.kind === 'system') return false;
+      if (m.kind === 'task') return false; // tasks need applyPreTaskScripts — defer to main loop
       if ((m.kind === 'chat' || m.kind === 'chat-sdk') && isClearCommand(m)) return false;
       return true;
     });


### PR DESCRIPTION
## Summary

- Filter `kind === 'task'` messages out of the follow-up polling inside `processQuery`, deferring them to the next main-loop iteration where `applyPreTaskScripts` runs
- One-line change in `container/agent-runner/src/poll-loop.ts`

## Problem

The follow-up poll (lines 263-288) picks up new pending messages while a query is active and pushes them directly into the stream. Task messages with pre-check scripts were not excluded, so they bypassed `applyPreTaskScripts` entirely — the `wakeAgent: false` gate never ran, and the LLM received the raw prompt with unresolved template variables like `{{data.failures}}`.

This only reproduces when the container is mid-query at the moment a scheduled task becomes due. The main poll loop correctly gates tasks through `applyPreTaskScripts`, but follow-ups skip it.

## Test plan

- [ ] Create a recurring task with a script that returns `{"wakeAgent": false}`
- [ ] Send a chat message to the same session to keep the container in an active query
- [ ] Verify the task is NOT pushed as a follow-up (check logs for absence of "Pushing 1 follow-up" for the task)
- [ ] Verify the task is picked up on the next main-loop iteration and correctly gated by the pre-check script

Fixes #2032