### PR TITLE
fix(v2): findSessionByAgentGroup prefers most-recently-active session

### DIFF
--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -52,10 +52,24 @@ export function findSessionForAgent(
     .get(agentGroupId, messagingGroupId) as Session | undefined;
 }
 
-/** Find an active session scoped to an agent group (ignoring messaging group). */
+/**
+ * Find an active session scoped to an agent group (ignoring messaging group).
+ *
+ * Order preference: most-recently-active session first, falling back to
+ * most-recently-created. Sessions with NULL `last_active` (never touched
+ * since creation) sort last so a stale never-used session can't beat a
+ * session that's actively in use.
+ *
+ * Used as the destination resolver when a synthesized message (e.g. an
+ * agent-to-agent reply) lacks channel context to bind to a specific
+ * (messaging_group, session) pair. Picking the most-active session avoids
+ * misrouting replies into a dormant session for the same agent group.
+ */
 export function findSessionByAgentGroup(agentGroupId: string): Session | undefined {
   return getDb()
-    .prepare("SELECT * FROM sessions WHERE agent_group_id = ? AND status = 'active' ORDER BY created_at DESC LIMIT 1")
+    .prepare(
+      "SELECT * FROM sessions WHERE agent_group_id = ? AND status = 'active' ORDER BY last_active IS NULL, last_active DESC, created_at DESC LIMIT 1",
+    )
     .get(agentGroupId) as Session | undefined;
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** — bug fix or security fix to source code

## Description

**What** — `findSessionByAgentGroup` was ordering active sessions by `created_at DESC LIMIT 1`. When an agent group has multiple active sessions (a common shape under `session_mode='shared'` — e.g. one session bound to Signal DMs, another to a watch device, both under one agent group), the function returned whichever session was created most recently, regardless of which one was actually in use. Replies that fall back to this resolver (notably synthesized agent-to-agent messages without channel context) could land in a dormant session, manifesting as the wrong-thread / wrong-channel symptoms in #1959, #1982, #1902.

**Why** — `created_at` is fixed at session creation; it has no relationship to which session a user is currently interacting with. `last_active` is the column already maintained for that purpose.

**How it works** — one-line change to the ordering clause:

```diff
- ORDER BY created_at DESC LIMIT 1
+ ORDER BY last_active IS NULL, last_active DESC, created_at DESC LIMIT 1
```

`last_active IS NULL` first sorts NULL values last (SQLite-portable equivalent of `NULLS LAST`), so a never-touched session can't outrank an actively-used one. `last_active DESC` then prefers the most-recently-active. `created_at DESC` is retained as a deterministic tiebreaker when two sessions share a `last_active` value.

Function-level docstring expanded to describe the order preference and when this fallback resolver is used.

**How it was tested** — host vitest passes. Manual: in a two-session agent group, deliberately interacted with the older-created session, then triggered an A2A reply path; before the fix the reply went to the newer-created (dormant) session, after the fix it goes to the older-created (active) one.

## Relationship to #2002

This PR is one half of a split out of #2002 per maintainer feedback. #2002 addresses the underlying A2A correctness problem comprehensively by threading `origin_session_id` through every A2A hop so the originating session is the deterministic destination, using this ordering change as the fallback when origin info is missing. The two changes are independently defensible:

- **This PR** — small, no schema changes, improves the fallback resolver for *any* multi-session lookup. Lands easily and partially closes the listed issues.
- **#2002 (rebased after this lands)** — A2A-specific origin threading + schema columns. Stands on the principle that the originating session is the only correct destination, with this ordering change as the fallback.

Partially addresses #1959, #1982, #1902.