### PR TITLE
feat: per-group container env vars, DB-managed via ncl groups config set-env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ ncl help
 
 | Resource | Verbs | What it is |
 |----------|-------|------------|
-| groups | list, get, create, update, delete, restart, config get/update, config add-mcp-server/remove-mcp-server, config add-package/remove-package | Agent groups (workspace, personality, container config) |
+| groups | list, get, create, update, delete, restart, config get/update, config add-mcp-server/remove-mcp-server, config add-package/remove-package, config set-env/unset-env | Agent groups (workspace, personality, container config) |
 | messaging-groups | list, get, create, update, delete | A single chat/channel on one platform |
 | wirings | list, get, create, update, delete | Links a messaging group to an agent group (session mode, triggers) |
 | users | list, get, create, update | Platform identities (`<channel>:<handle>`) |

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -316,6 +316,7 @@ CREATE TABLE container_configs (
   packages_npm           TEXT NOT NULL DEFAULT '[]',
   additional_mounts      TEXT NOT NULL DEFAULT '[]',
   cli_scope              TEXT NOT NULL DEFAULT 'group',   -- disabled | group | global
+  env                    TEXT NOT NULL DEFAULT '{}',      -- JSON: Record<string,string>, passed as -e flags at spawn
   updated_at             TEXT NOT NULL
 );
 ```
@@ -344,6 +345,7 @@ Migrations live in `src/db/migrations/`, one file per migration. Runner: `runMig
 | 009 | `009-drop-pending-credentials.ts` | Drop the defunct `pending_credentials` table |
 | 014 | `014-container-configs.ts` | `container_configs` — per-agent-group container runtime config |
 | 015 | `015-cli-scope.ts` | `ALTER TABLE container_configs ADD COLUMN cli_scope` |
+| 019 | `019-container-config-env.ts` | `ALTER TABLE container_configs ADD COLUMN env` — per-group container env vars |
 
 Numbers 005 and 006 are intentionally absent — migrations were renumbered during early development.
 

--- a/src/backfill-container-configs.ts
+++ b/src/backfill-container-configs.ts
@@ -24,6 +24,7 @@ interface LegacyContainerJson {
   provider?: string;
   assistantName?: string;
   maxMessagesPerPrompt?: number;
+  env?: Record<string, string>;
 }
 
 export function backfillContainerConfigs(): void {
@@ -65,6 +66,7 @@ export function backfillContainerConfigs(): void {
       packages_npm: JSON.stringify(legacy.packages?.npm ?? []),
       additional_mounts: JSON.stringify(legacy.additionalMounts ?? []),
       cli_scope: 'group',
+      env: JSON.stringify(legacy.env ?? {}),
       updated_at: new Date().toISOString(),
     };
 

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -32,6 +32,7 @@ function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
     packages_npm: JSON.parse(row.packages_npm),
     additional_mounts: JSON.parse(row.additional_mounts),
     cli_scope: row.cli_scope,
+    env: JSON.parse(row.env),
     updated_at: row.updated_at,
   };
 }
@@ -397,6 +398,49 @@ registerResource({
           removed: { apt: apt || null, npm: npm || null },
           note: 'Image rebuild required for package changes to take effect.',
         };
+      },
+    },
+    'config set-env': {
+      access: 'approval',
+      description:
+        'Set a container env var for a group. Requires `ncl groups restart` to take effect. Use --id <group-id> --key <VAR_NAME> --value <val>.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('--id is required');
+        const key = args.key as string | undefined;
+        const value = args.value as string | undefined;
+        if (!key) throw new Error('--key is required');
+        if (value === undefined) throw new Error('--value is required');
+
+        const row = getContainerConfig(id);
+        if (!row) throw new Error(`No container config for group: ${id}`);
+
+        const env = JSON.parse(row.env) as Record<string, string>;
+        env[key] = value;
+        updateContainerConfigJson(id, 'env', env);
+
+        return { set: { [key]: value }, env };
+      },
+    },
+    'config unset-env': {
+      access: 'approval',
+      description:
+        'Remove a container env var from a group. Requires `ncl groups restart` to take effect. Use --id <group-id> --key <VAR_NAME>.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('--id is required');
+        const key = args.key as string | undefined;
+        if (!key) throw new Error('--key is required');
+
+        const row = getContainerConfig(id);
+        if (!row) throw new Error(`No container config for group: ${id}`);
+
+        const env = JSON.parse(row.env) as Record<string, string>;
+        if (!(key in env)) throw new Error(`Env var "${key}" not set on this group`);
+        delete env[key];
+        updateContainerConfigJson(id, 'env', env);
+
+        return { unset: key, env };
       },
     },
   },

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -43,6 +43,8 @@ export interface ContainerConfig {
   maxMessagesPerPrompt?: number;
   model?: string;
   effort?: string;
+  /** Extra environment variables to pass to the container. */
+  env?: Record<string, string>;
 }
 
 /** Build a `ContainerConfig` from a DB row + agent group identity. */
@@ -63,6 +65,7 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
     maxMessagesPerPrompt: row.max_messages_per_prompt ?? undefined,
     model: row.model ?? undefined,
     effort: row.effort ?? undefined,
+    env: JSON.parse(row.env) as Record<string, string>,
   };
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -442,6 +442,15 @@ async function buildContainerArgs(
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
 
+  // Per-group env vars from the container config (DB-managed via
+  // `ncl groups config set-env`) — e.g. an API key a proxy can't inject,
+  // or a NO_PROXY override for one group's tooling.
+  if (containerConfig.env) {
+    for (const [key, value] of Object.entries(containerConfig.env)) {
+      args.push('-e', `${key}=${value}`);
+    }
+  }
+
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {
     for (const [key, value] of Object.entries(providerContribution.env)) {

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -10,7 +10,7 @@ const SCALAR_COLUMNS = new Set([
   'max_messages_per_prompt',
   'cli_scope',
 ]);
-const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
+const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts', 'env']);
 
 export function getContainerConfig(agentGroupId: string): ContainerConfigRow | undefined {
   return getDb().prepare('SELECT * FROM container_configs WHERE agent_group_id = ?').get(agentGroupId) as
@@ -29,11 +29,11 @@ export function createContainerConfig(config: ContainerConfigRow): void {
       `INSERT INTO container_configs (
         agent_group_id, provider, model, effort, image_tag, assistant_name,
         max_messages_per_prompt, skills, mcp_servers, packages_apt, packages_npm,
-        additional_mounts, updated_at
+        additional_mounts, env, updated_at
       ) VALUES (
         @agent_group_id, @provider, @model, @effort, @image_tag, @assistant_name,
         @max_messages_per_prompt, @skills, @mcp_servers, @packages_apt, @packages_npm,
-        @additional_mounts, @updated_at
+        @additional_mounts, @env, @updated_at
       )`,
     )
     .run(config);
@@ -79,10 +79,10 @@ export function updateContainerConfigScalars(
     .run(values);
 }
 
-/** Overwrite a JSON column wholesale. Used for skills, mcp_servers, packages_*, additional_mounts. */
+/** Overwrite a JSON column wholesale. Used for skills, mcp_servers, packages_*, additional_mounts, env. */
 export function updateContainerConfigJson(
   agentGroupId: string,
-  column: 'skills' | 'mcp_servers' | 'packages_apt' | 'packages_npm' | 'additional_mounts',
+  column: 'skills' | 'mcp_servers' | 'packages_apt' | 'packages_npm' | 'additional_mounts' | 'env',
   value: unknown,
 ): void {
   if (!JSON_COLUMNS.has(column)) throw new Error(`Invalid JSON column: ${column}`);

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -31,6 +31,9 @@ import {
   createPendingQuestion,
   getPendingQuestion,
   deletePendingQuestion,
+  ensureContainerConfig,
+  getContainerConfig,
+  updateContainerConfigJson,
 } from './index.js';
 
 function now() {
@@ -426,5 +429,36 @@ describe('pending questions', () => {
     });
     deletePendingQuestion('q-1');
     expect(getPendingQuestion('q-1')).toBeUndefined();
+  });
+});
+
+// ── Container config env vars ──
+
+describe('container config env', () => {
+  function makeGroup(id: string) {
+    createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: now() });
+    ensureContainerConfig(id);
+  }
+
+  it('defaults to an empty object on new rows', () => {
+    makeGroup('ag-env-1');
+    const row = getContainerConfig('ag-env-1');
+    expect(row).toBeDefined();
+    expect(JSON.parse(row!.env)).toEqual({});
+  });
+
+  it('round-trips env vars through updateContainerConfigJson', () => {
+    makeGroup('ag-env-2');
+    updateContainerConfigJson('ag-env-2', 'env', { MY_API_KEY: 'abc123', NO_PROXY: 'example.com' });
+
+    const row = getContainerConfig('ag-env-2');
+    expect(JSON.parse(row!.env)).toEqual({ MY_API_KEY: 'abc123', NO_PROXY: 'example.com' });
+
+    // Unset one key by writing the filtered object back (what
+    // `ncl groups config unset-env` does).
+    const env = JSON.parse(row!.env) as Record<string, string>;
+    delete env.MY_API_KEY;
+    updateContainerConfigJson('ag-env-2', 'env', env);
+    expect(JSON.parse(getContainerConfig('ag-env-2')!.env)).toEqual({ NO_PROXY: 'example.com' });
   });
 });

--- a/src/db/migrations/019-container-config-env.ts
+++ b/src/db/migrations/019-container-config-env.ts
@@ -1,0 +1,10 @@
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration019: Migration = {
+  version: 19,
+  name: 'container-config-env',
+  up(db: Database.Database) {
+    db.prepare("ALTER TABLE container_configs ADD COLUMN env TEXT NOT NULL DEFAULT '{}'").run();
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -17,6 +17,7 @@ import { migration016 } from './016-messaging-group-instance.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 import { migration018 } from './018-approvals-approver-user-id.js';
+import { migration019 } from './019-container-config-env.js';
 
 export interface Migration {
   version: number;
@@ -50,6 +51,7 @@ export const migrations: Migration[] = [
   migration014,
   migration015,
   migration016,
+  migration019,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ContainerConfigRow {
   packages_npm: string; // JSON: string[]
   additional_mounts: string; // JSON: AdditionalMountConfig[]
   cli_scope: string; // 'disabled' | 'group' | 'global'
+  env: string; // JSON: Record<string, string>
   updated_at: string;
 }
 


### PR DESCRIPTION
> **Refreshed 2026-07-04.** The original April revision of this PR added `env` to the file-based `container.json` — which predated container config moving to the DB (migration 014) and had gone stale/conflicting. This revision implements the same capability the DB-native way. History note: my fork has run exactly this shape in production since late May.

## Problem

Some per-group tooling needs an env var that credential injection can't cover — e.g. a Google API key (proxies commonly treat `*.googleapis.com` as OAuth-only), or a `NO_PROXY` override for one group's scripts. There is currently no supported way to pass a per-group env var into an agent container: `container.json` is regenerated from the DB at every spawn, so hand-editing it is silently undone.

## Change

Adds an `env` JSON column to `container_configs`, managed like every other config field:

- **Migration** `container-config-env`: `ALTER TABLE container_configs ADD COLUMN env TEXT NOT NULL DEFAULT '{}'`
- **CLI**: `ncl groups config set-env --id <group> --key VAR --value val` and `config unset-env` (approval-gated, matching the other config verbs); `config get` displays the map
- **Spawn path**: `configFromDb()` carries `env` into the materialized `container.json`; the container runner passes each entry as a `-e` flag
- **Backfill**: legacy `container.json` files with an `env` field are picked up; `createContainerConfig` now includes the column in its INSERT (previously a supplied env would have been silently dropped)
- **Docs**: schema + migration table in `docs/db-central.md`, `ncl` verb table in `CLAUDE.md`

## Tests

`db-v2.test.ts`: new-row default (`{}`) and a set/unset round-trip through `updateContainerConfigJson` (the exact write path the CLI verbs use). Full suite: 597 passed. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)