### PR TITLE
feat(web): new-agent wizard — create agent groups end-to-end (closes #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ groups/*
 .nanoclaw/
 
 agents-sdk-docs
+
+# TypeScript incremental build info
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Paraclaw — the Parachute distribution of NanoClaw
+
+> **You're looking at a fork.** Paraclaw is the [Parachute](https://parachute.computer) distribution of [NanoClaw](https://github.com/qwibitai/nanoclaw) — same trunk, plus a small additive layer that grants each agent group access to a [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) over MCP. We track upstream NanoClaw closely; the entire diff lives in `src/parachute/`, `scripts/parachute.ts`, `docs/parachute-integration.md`, plus one back-compat-preserving widening of `McpServerConfig` in `src/container-config.ts`. Everything else is upstream.
+>
+> **What Parachute brings:** scoped vault tokens (`vault:read` / `vault:write` / `vault:admin`) as the agent's identity primitive, the user's open knowledge graph as the substrate for whatever the agent reads or writes, and (next) a web UI for spinning up claws without dropping into the terminal.
+>
+> **What NanoClaw brings:** containerized per-agent-group isolation, multi-channel messaging adapters, the message-queue model, the agent runner, OneCLI integration for third-party credentials. We don't reinvent any of it.
+>
+> **Quick start for the Parachute path:** see [`docs/parachute-integration.md`](docs/parachute-integration.md). The full upstream NanoClaw documentation that follows is the substrate we compose with.
+
+---
+
 <p align="center">
   <img src="assets/nanoclaw-logo.png" alt="NanoClaw" width="400">
 </p>

--- a/docs/parachute-integration.md
+++ b/docs/parachute-integration.md
@@ -1,0 +1,100 @@
+# Parachute integration
+
+Paraclaw is the Parachute distribution of NanoClaw — same trunk, plus a small additive layer that grants each agent group access to a [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) over MCP.
+
+## What's added
+
+| File | Purpose |
+|---|---|
+| `src/container-config.ts` | `McpServerConfig` widened to a discriminated union supporting `type: 'http'` (for vault) alongside the existing stdio shape. Back-compat preserved via the `LegacyMcpServerConfig` variant. **The only edit to an existing NanoClaw file.** |
+| `src/parachute/types.ts` | `VaultScope`, `VaultAttachment`, `BuildVaultMcpOpts`. |
+| `src/parachute/vault-mcp.ts` | Helpers: `buildVaultMcpServer`, `attachVaultToGroup`, `detachVaultFromGroup`, `readVaultAttachment`. |
+| `src/parachute/README.md` | What this directory is for, and what it deliberately doesn't do. |
+| `scripts/parachute.ts` | CLI: `pnpm run parachute attach-vault <group>` / `detach-vault` / `status`. |
+
+That's the whole footprint today. Everything else in the repo is untouched.
+
+## Workflow
+
+Pre-reqs: a running [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault) (`parachute install vault` from the [Parachute CLI](https://github.com/ParachuteComputer/parachute-cli)) and a NanoClaw agent group already created.
+
+```sh
+# 1. Mint a scoped vault token for this claw.
+parachute vault tokens create --scope vault:read --label claw-research-bot
+# → pvt_...
+
+# 2. Attach the vault to the agent group's container.json.
+pnpm run parachute attach-vault research-bot --token pvt_... --scope vault:read
+
+# 3. Send a message to the claw — NanoClaw spawns the container, which now
+#    has the vault MCP available with the nine vault tools (query-notes,
+#    create-note, update-note, delete-note, list-tags, update-tag,
+#    delete-tag, find-path, vault-info).
+
+# Inspect:
+pnpm run parachute status               # all groups
+pnpm run parachute status research-bot  # just one
+
+# Detach (does NOT revoke the token):
+pnpm run parachute detach-vault research-bot
+parachute vault tokens revoke claw-research-bot
+```
+
+## What gets written
+
+`groups/<folder>/container.json` — the existing NanoClaw config gains a new entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "parachute-vault": {
+      "type": "http",
+      "url": "http://127.0.0.1:1940/vault/default/mcp",
+      "headers": { "Authorization": "Bearer pvt_..." },
+      "instructions": "You have access to a Parachute Vault at ..."
+    }
+  }
+}
+```
+
+`groups/<folder>/parachute.json` — a sibling record (separate from `container.json` so upstream NanoClaw never sees fields it doesn't know):
+
+```json
+{
+  "vault": {
+    "parachute-vault": {
+      "vaultBaseUrl": "http://127.0.0.1:1940/vault/default",
+      "scope": "vault:read",
+      "tokenLabel": "claw-research-bot",
+      "attachedAt": "2026-04-26T..."
+    }
+  }
+}
+```
+
+The container reads `container.json` and uses the new entry as part of its normal MCP setup. The agent runner inside the container passes the `mcpServers` object straight through to Claude Agent SDK's `query()`, which already supports HTTP-transport MCPs natively.
+
+## What the integration deliberately does NOT impose
+
+- **No vault note path layout.** The agent group has access to vault; what it writes (and where) is the agent's business. We don't bake in a `claws/<name>` tree, we don't auto-mirror runs to vault, we don't auto-sync CLAUDE.md to a note. Those would impose a vault organization on every user; we don't.
+- **No replacement of OneCLI.** Third-party API credentials (Telegram, Slack, OpenAI, etc.) keep flowing through OneCLI's gateway exactly as in upstream NanoClaw. Vault is for the user's knowledge graph; OneCLI is for outbound credential injection. They're complementary.
+- **No replacement of the SQLite session-DB pattern.** Per-session `inbound.db` / `outbound.db` are right for transient message handling. Vault is for durable, queryable, user-facing state — different concern.
+- **No web UI yet.** That's the next layer (a real Phase B add); see the top-level README's roadmap.
+
+## Threat model
+
+- **Token scope is the boundary.** A `vault:read` claw physically cannot create or delete vault notes. A `vault:write` claw cannot delete the vault itself or revoke other tokens. A `vault:admin` claw is fully trusted; use sparingly.
+- **Token is in the container's `container.json`.** Container-side it lives in `/workspace/agent/container.json` (read-only mount). Anyone with shell access to the container can read it. That's the same posture as any other MCP credential NanoClaw handles — OneCLI gives you a stronger "credentials never enter the container" guarantee for third-party APIs but vault MCP itself uses standard Bearer auth.
+- **Revocation is per-token.** `parachute vault tokens revoke <label>` invalidates the claw's access immediately. Claw will start getting 401s from vault on the next request.
+
+## Upstream-merge stance
+
+Everything here is additive except the `McpServerConfig` widening, which is a back-compat-preserving union. Pulling upstream NanoClaw changes should produce zero merge conflicts in the parachute layer. The McpServerConfig edit could be contributed back upstream as a stand-alone improvement (HTTP MCP support is generally useful, not Parachute-specific) — that would shrink our diff to zero NanoClaw-source edits.
+
+## Where this is heading
+
+See [README.md §Where this is heading](../README.md). Short version:
+
+1. **Today (this PR):** vault attached as an HTTP MCP via CLI. Working end-to-end (assuming a NanoClaw install).
+2. **Next:** web UI for managing claws — list groups, create new ones with a wizard that includes scope selection + token minting in-flow.
+3. **After that:** OAuth handoff (Paraclaw web UI is an OAuth client of vault — user approves once; per-claw scoped tokens get minted automatically without ever showing a `pvt_…` to the user).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "setup:auto": "tsx setup/auto.ts",
     "chat": "tsx scripts/chat.ts",
     "auth": "tsx src/whatsapp-auth.ts",
+    "parachute": "tsx scripts/parachute.ts",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "chat": "tsx scripts/chat.ts",
     "auth": "tsx src/whatsapp-auth.ts",
     "parachute": "tsx scripts/parachute.ts",
+    "web": "tsx web/server/src/server.ts",
+    "web:build": "cd web/ui && pnpm install --ignore-workspace && pnpm build",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",

--- a/scripts/parachute.ts
+++ b/scripts/parachute.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env tsx
+/**
+ * Paraclaw — Parachute integration CLI.
+ *
+ *   pnpm run parachute attach-vault <group> --token pvt_… [--scope vault:read] [--vault-url URL]
+ *   pnpm run parachute detach-vault <group> [--name parachute-vault]
+ *   pnpm run parachute status [<group>]
+ *
+ * Wires (or unwires) a Parachute Vault as an HTTP MCP server in the named
+ * agent group's `container.json`, and records the attachment metadata in a
+ * sibling `parachute.json` for visibility / future tooling.
+ *
+ * The CLI does NOT mint vault tokens — that's the user's job, via:
+ *
+ *   parachute vault tokens create --scope vault:read --label claw-<group>
+ *
+ * Once you have a `pvt_…` token, paste it here. Detach also doesn't revoke
+ * tokens — see vault-mcp.ts comments for why (one-way op; deliberate).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from '../src/config.js';
+import {
+  DEFAULT_VAULT_MCP_NAME,
+  attachVaultToGroup,
+  detachVaultFromGroup,
+  readVaultAttachment,
+} from '../src/parachute/vault-mcp.js';
+import type { VaultScope } from '../src/parachute/types.js';
+
+const SUBCOMMANDS = ['attach-vault', 'detach-vault', 'status'] as const;
+type Subcommand = (typeof SUBCOMMANDS)[number];
+
+function usage(exit = 0): never {
+  console.error(`usage:
+  pnpm run parachute attach-vault <group> --token <pvt_...> [--scope vault:read|vault:write|vault:admin]
+                                          [--vault-url http://127.0.0.1:1940/vault/default]
+                                          [--label <token-label>] [--name <mcp-name>]
+  pnpm run parachute detach-vault <group> [--name parachute-vault]
+  pnpm run parachute status [<group>]
+
+Notes:
+  - Mint a token with: parachute vault tokens create --scope vault:read --label claw-<group>
+  - --vault-url defaults to http://127.0.0.1:1940/vault/default
+  - --scope defaults to vault:read (the safest default; granted scope is recorded only)
+  - --name defaults to '${DEFAULT_VAULT_MCP_NAME}' (the key under mcpServers)
+`);
+  process.exit(exit);
+}
+
+function arg(name: string, args: string[]): string | undefined {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function parseScope(s: string | undefined): VaultScope {
+  const allowed: VaultScope[] = ['vault:read', 'vault:write', 'vault:admin'];
+  if (!s) return 'vault:read';
+  if ((allowed as string[]).includes(s)) return s as VaultScope;
+  console.error(`unrecognized scope "${s}". Allowed: ${allowed.join(', ')}`);
+  process.exit(2);
+}
+
+function listGroupFolders(): string[] {
+  if (!fs.existsSync(GROUPS_DIR)) return [];
+  return fs
+    .readdirSync(GROUPS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+}
+
+function main(): void {
+  const [, , raw, ...rest] = process.argv;
+  if (!raw || raw === '--help' || raw === '-h') usage(0);
+  if (!(SUBCOMMANDS as readonly string[]).includes(raw)) {
+    console.error(`unknown subcommand: ${raw}\n`);
+    usage(2);
+  }
+  const sub = raw as Subcommand;
+
+  if (sub === 'attach-vault') {
+    const group = rest[0];
+    if (!group) {
+      console.error('attach-vault requires <group> as the first positional argument.');
+      usage(2);
+    }
+    const token = arg('token', rest);
+    if (!token) {
+      console.error('attach-vault requires --token <pvt_...>');
+      usage(2);
+    }
+    const vaultBaseUrl = arg('vault-url', rest) ?? 'http://127.0.0.1:1940/vault/default';
+    const scope = parseScope(arg('scope', rest));
+    const tokenLabel = arg('label', rest) ?? `claw-${group}`;
+    const mcpName = arg('name', rest);
+
+    attachVaultToGroup({
+      folder: group,
+      vaultBaseUrl,
+      vaultToken: token,
+      scope,
+      tokenLabel,
+      mcpName,
+      instructions: `You have access to a Parachute Vault at ${vaultBaseUrl} via the \`${mcpName ?? DEFAULT_VAULT_MCP_NAME}\` MCP server. Scope: ${scope}. The vault is the user's open knowledge graph — notes, tags, links. Use it as you would any tool: query when you need context, write when you have something durable to capture. The user decides how their vault is organized; respect that.`,
+    });
+
+    console.log(`✓ vault attached to group "${group}"`);
+    console.log(`  vault: ${vaultBaseUrl}`);
+    console.log(`  scope: ${scope}`);
+    console.log(`  token label: ${tokenLabel}  (revoke with: parachute vault tokens revoke ${tokenLabel})`);
+    console.log(`  mcp name: ${mcpName ?? DEFAULT_VAULT_MCP_NAME}`);
+    console.log('');
+    console.log('Next: restart the agent\'s container so it picks up the new MCP entry.');
+    console.log(`  (or just send the next message — NanoClaw spawns lazily on wake.)`);
+    return;
+  }
+
+  if (sub === 'detach-vault') {
+    const group = rest[0];
+    if (!group) {
+      console.error('detach-vault requires <group> as the first positional argument.');
+      usage(2);
+    }
+    const mcpName = arg('name', rest) ?? DEFAULT_VAULT_MCP_NAME;
+    detachVaultFromGroup(group, mcpName);
+    console.log(`✓ vault detached from group "${group}" (mcp: ${mcpName})`);
+    console.log(`  Token NOT revoked — run: parachute vault tokens revoke <label>`);
+    return;
+  }
+
+  if (sub === 'status') {
+    const target = rest[0];
+    const groups = target ? [target] : listGroupFolders();
+    if (groups.length === 0) {
+      console.log('no agent groups found in', GROUPS_DIR);
+      return;
+    }
+    let any = false;
+    for (const g of groups) {
+      const att = readVaultAttachment(g);
+      if (!att) {
+        if (target) console.log(`${g}: no vault attached`);
+        continue;
+      }
+      any = true;
+      console.log(`${g}:`);
+      console.log(`  vault: ${att.vaultBaseUrl}`);
+      console.log(`  scope: ${att.scope}`);
+      console.log(`  token label: ${att.tokenLabel}`);
+      console.log(`  attached: ${att.attachedAt}`);
+    }
+    if (!any && !target) console.log('no agent groups have a vault attached.');
+    return;
+  }
+}
+
+main();

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -14,13 +14,53 @@ import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
 
-export interface McpServerConfig {
+/**
+ * MCP server configuration. Two transports supported (matches Claude Agent
+ * SDK's native `mcpServers` shape — both pass through `sdkQuery({mcpServers})`
+ * unchanged in `container/agent-runner/src/providers/claude.ts`):
+ *
+ *   - **stdio** (the historical default): `command` + optional `args`/`env`,
+ *     spawned in-process by the agent runner.
+ *   - **http**: an HTTP-transport MCP endpoint reachable from the container
+ *     (`url` + optional `headers`). Used by Paraclaw to wire a Parachute
+ *     Vault MCP server in via `Authorization: Bearer pvt_…`.
+ *
+ * The `type` field is optional for back-compat — when absent, presence of
+ * `command` implies stdio. New entries should set `type` explicitly.
+ *
+ * `instructions` is transport-agnostic: when set, the host writes the
+ * content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
+ * into the composed CLAUDE.md.
+ */
+export type McpServerConfig =
+  | StdioMcpServerConfig
+  | HttpMcpServerConfig
+  | LegacyMcpServerConfig;
+
+export interface StdioMcpServerConfig {
+  type: 'stdio';
   command: string;
   args?: string[];
   env?: Record<string, string>;
-  // Optional always-in-context guidance. When set, the host writes the
-  // content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
-  // into the composed CLAUDE.md.
+  instructions?: string;
+}
+
+export interface HttpMcpServerConfig {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+  instructions?: string;
+}
+
+/**
+ * Pre-`type` stdio shape. Treated as `{ type: 'stdio', ... }`; kept as its
+ * own variant so existing container.json files (and any legacy code paths
+ * that construct configs without `type`) still type-check.
+ */
+export interface LegacyMcpServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
   instructions?: string;
 }
 

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -32,10 +32,7 @@ import { GROUPS_DIR } from './config.js';
  * content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
  * into the composed CLAUDE.md.
  */
-export type McpServerConfig =
-  | StdioMcpServerConfig
-  | HttpMcpServerConfig
-  | LegacyMcpServerConfig;
+export type McpServerConfig = StdioMcpServerConfig | HttpMcpServerConfig | LegacyMcpServerConfig;
 
 export interface StdioMcpServerConfig {
   type: 'stdio';

--- a/src/parachute/README.md
+++ b/src/parachute/README.md
@@ -1,0 +1,30 @@
+# src/parachute/
+
+Parachute integration for Paraclaw — additive on top of NanoClaw's trunk.
+
+## What this brings
+
+Each NanoClaw agent-group gets optional access to a [Parachute Vault](https://github.com/ParachuteComputer/parachute-vault). The vault is the user's open knowledge graph — notes, tags, links, structured metadata — already running on their machine and already used by every other AI client they've connected (Claude Code, Notes, etc.).
+
+Composing the two:
+
+- **Each claw gets a scoped vault token** (`vault:read` / `vault:write` / `vault:admin`) at attach time. Token-as-capability is the boundary; the agent literally can't exceed its scope.
+- **The vault MCP server is wired into the agent's container** as an `http` transport entry in `container.json`. The agent uses the same nine MCP tools any other Parachute client gets (`query-notes`, `create-note`, `update-note`, etc.).
+- **What the claw does with vault access is up to the claw.** This integration grants capability; it doesn't dictate convention. A claw might write nothing to vault (read-only researcher); another might capture every message into structured note paths; another might not use vault at all even though it has access. The framework is opinion-free here.
+
+## Files
+
+- **`vault-mcp.ts`** — pure helpers: `buildVaultMcpServer(opts)` constructs the `McpServerConfig` for a vault attach, `attachVaultToGroup(folder, opts)` upserts that entry into the group's `container.json`, `detachVaultFromGroup(folder, name)` removes it.
+- **`types.ts`** — narrow types for vault attachments + scope strings.
+
+The matching CLI surface lives in [`scripts/parachute.ts`](../../scripts/parachute.ts) (`pnpm run parachute attach-vault <group>` etc.).
+
+## What we deliberately do NOT do here
+
+- **No vault note path conventions.** No `claws/<name>` tree, no auto-mirroring of agent runs to vault, no auto-CLAUDE.md sync. Those would impose a vault layout on every user; we don't.
+- **No replacement of OneCLI.** Third-party API credentials (Telegram bot tokens, OpenAI keys, etc.) keep flowing through OneCLI's gateway exactly as in upstream NanoClaw. Vault is for the user's knowledge graph; OneCLI is for outbound credential injection. They're complementary, not competing.
+- **No replacement of NanoClaw's SQLite session queues.** Per-session inbound.db / outbound.db are the right pattern for transient message handling. Vault is for durable, queryable, user-facing state — different concern.
+
+## Upstream-merge stance
+
+Everything in this directory is **additive** — new files, no edits to existing NanoClaw source files. The one exception is the type widening in [`src/container-config.ts`](../container-config.ts) that adds `HttpMcpServerConfig` to the `McpServerConfig` union (back-compat preserved via the `LegacyMcpServerConfig` variant). That edit is small enough to merge upstream cleanly, and could be contributed back to qwibitai/nanoclaw as a stand-alone improvement (HTTP MCP support is generally useful, not Parachute-specific).

--- a/src/parachute/create-agent.ts
+++ b/src/parachute/create-agent.ts
@@ -11,10 +11,7 @@
  * (`init-first-agent.ts` etc.) stay on the same NanoClaw helpers and are
  * untouched.
  */
-import {
-  createAgentGroup as dbCreateAgentGroup,
-  getAgentGroupByFolder,
-} from '../db/agent-groups.js';
+import { createAgentGroup as dbCreateAgentGroup, getAgentGroupByFolder } from '../db/agent-groups.js';
 import { initGroupFilesystem } from '../group-init.js';
 import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
 import type { AgentGroup } from '../types.js';
@@ -42,8 +39,7 @@ export function validateFolderSlug(slug: string): FolderValidation {
   if (!FOLDER_RE.test(slug)) {
     return {
       ok: false,
-      reason:
-        'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
+      reason: 'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
     };
   }
   return { ok: true };

--- a/src/parachute/create-agent.ts
+++ b/src/parachute/create-agent.ts
@@ -1,0 +1,129 @@
+/**
+ * Create a Parachute agent group from a single call.
+ *
+ * Wraps NanoClaw's central-DB write (`createAgentGroup`) and on-disk init
+ * (`initGroupFilesystem`) into one shim, with optional inline vault
+ * attachment via `attachVaultToGroup`. Channel wiring is intentionally NOT
+ * here — the wizard creates a channel-less group; channel install is its
+ * own surface (paraclaw#2).
+ *
+ * The shim is the seam the web server uses; the existing CLI scripts
+ * (`init-first-agent.ts` etc.) stay on the same NanoClaw helpers and are
+ * untouched.
+ */
+import {
+  createAgentGroup as dbCreateAgentGroup,
+  getAgentGroupByFolder,
+} from '../db/agent-groups.js';
+import { initGroupFilesystem } from '../group-init.js';
+import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
+import type { AgentGroup } from '../types.js';
+
+import type { VaultAttachment, VaultScope } from './types.js';
+import { attachVaultToGroup, readVaultAttachment } from './vault-mcp.js';
+
+const FOLDER_RE = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/;
+const FOLDER_MAX = 48;
+
+export interface FolderValidationOk {
+  ok: true;
+}
+export interface FolderValidationFail {
+  ok: false;
+  reason: string;
+}
+export type FolderValidation = FolderValidationOk | FolderValidationFail;
+
+export function validateFolderSlug(slug: string): FolderValidation {
+  if (!slug) return { ok: false, reason: 'folder slug is required' };
+  if (slug.length > FOLDER_MAX) {
+    return { ok: false, reason: `folder slug must be ≤ ${FOLDER_MAX} chars` };
+  }
+  if (!FOLDER_RE.test(slug)) {
+    return {
+      ok: false,
+      reason:
+        'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
+    };
+  }
+  return { ok: true };
+}
+
+export function suggestFolderSlug(name: string): string {
+  return normalizeName(name).slice(0, FOLDER_MAX);
+}
+
+export function isFolderTaken(folder: string): boolean {
+  return getAgentGroupByFolder(folder) !== undefined;
+}
+
+export interface CreateAgentGroupVaultOpts {
+  scope: VaultScope;
+  vaultBaseUrl?: string;
+  tokenLabel?: string;
+  /** If absent, callers higher up the stack mint via `parachute vault tokens create`. */
+  token: string;
+  mcpName?: string;
+  instructions?: string;
+}
+
+export interface CreateAgentGroupOpts {
+  name: string;
+  folder: string;
+  instructions?: string;
+  /** Optional inline vault attachment. The token must already be in hand. */
+  vault?: CreateAgentGroupVaultOpts;
+}
+
+export interface CreateAgentGroupResult {
+  group: AgentGroup;
+  vault: VaultAttachment | null;
+}
+
+/**
+ * Create a new agent group: validate, write DB row, initialize filesystem,
+ * optionally attach a vault. NOT idempotent — `isFolderTaken` is the gate
+ * the caller must check; this throws if the folder already exists.
+ */
+export function createParachuteAgentGroup(opts: CreateAgentGroupOpts): CreateAgentGroupResult {
+  const folderCheck = validateFolderSlug(opts.folder);
+  if (!folderCheck.ok) {
+    throw new Error(`invalid folder slug: ${folderCheck.reason}`);
+  }
+  const trimmedName = opts.name.trim();
+  if (!trimmedName) {
+    throw new Error('agent name is required');
+  }
+  if (isFolderTaken(opts.folder)) {
+    throw new Error(`agent group folder already exists: ${opts.folder}`);
+  }
+
+  const id = `ag-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const created_at = new Date().toISOString();
+  const group: AgentGroup = {
+    id,
+    name: trimmedName,
+    folder: opts.folder,
+    agent_provider: null,
+    created_at,
+  };
+
+  dbCreateAgentGroup(group);
+  initGroupFilesystem(group, { instructions: opts.instructions });
+
+  let vault: VaultAttachment | null = null;
+  if (opts.vault) {
+    attachVaultToGroup({
+      folder: group.folder,
+      vaultBaseUrl: opts.vault.vaultBaseUrl ?? 'http://127.0.0.1:1940/vault/default',
+      vaultToken: opts.vault.token,
+      scope: opts.vault.scope,
+      tokenLabel: opts.vault.tokenLabel ?? `claw-${group.folder}`,
+      mcpName: opts.vault.mcpName,
+      instructions: opts.vault.instructions,
+    });
+    vault = readVaultAttachment(group.folder, opts.vault.mcpName);
+  }
+
+  return { group, vault };
+}

--- a/src/parachute/types.ts
+++ b/src/parachute/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Types for the Parachute integration. Narrow on purpose — the broader
+ * NanoClaw types live unchanged in `src/types.ts` and `src/container-config.ts`.
+ */
+
+/**
+ * Scopes the vault recognizes. Format: `<service>:<resource>:<action>` per
+ * `parachute-patterns/patterns/oauth-scopes.md`. Today the vault ships with
+ * the action-only set; per-vault-name resource scoping (`vault:<name>:read`)
+ * is planned.
+ */
+export type VaultScope = 'vault:read' | 'vault:write' | 'vault:admin';
+
+/**
+ * What we record on the host side when a claw is attached to a vault. Lives
+ * in `groups/<folder>/parachute.json` (separate from `container.json` so
+ * upstream doesn't see Parachute fields it doesn't know how to handle).
+ */
+export interface VaultAttachment {
+  /** Vault base URL — `http://127.0.0.1:1940/vault/<name>` (no trailing slash, no `/mcp` suffix). */
+  vaultBaseUrl: string;
+  /** The scope granted to this claw. */
+  scope: VaultScope;
+  /** Token label registered with the vault — used for revocation, not the secret. */
+  tokenLabel: string;
+  /** When this attachment was created. */
+  attachedAt: string;
+}
+
+/**
+ * Options for `buildVaultMcpServer` — what the helper needs to produce a
+ * valid `McpServerConfig` HTTP entry.
+ */
+export interface BuildVaultMcpOpts {
+  /** Vault base URL (no `/mcp` suffix — we append it). */
+  vaultBaseUrl: string;
+  /** The `pvt_…` token to use as Bearer auth. */
+  vaultToken: string;
+  /** Optional: in-context guidance that lands in the composed CLAUDE.md. */
+  instructions?: string;
+}

--- a/src/parachute/vault-mcp.ts
+++ b/src/parachute/vault-mcp.ts
@@ -84,10 +84,7 @@ export function attachVaultToGroup(opts: AttachVaultOpts): void {
     tokenLabel: opts.tokenLabel,
     attachedAt: new Date().toISOString(),
   };
-  fs.writeFileSync(
-    parachuteJsonPath(opts.folder),
-    JSON.stringify({ vault: { [name]: attachment } }, null, 2) + '\n',
-  );
+  fs.writeFileSync(parachuteJsonPath(opts.folder), JSON.stringify({ vault: { [name]: attachment } }, null, 2) + '\n');
 }
 
 /**

--- a/src/parachute/vault-mcp.ts
+++ b/src/parachute/vault-mcp.ts
@@ -1,0 +1,142 @@
+/**
+ * Helpers for attaching a Parachute Vault as an MCP server to a NanoClaw
+ * agent group.
+ *
+ * The vault MCP is HTTP-transport (`type: 'http'` + `url` + `Authorization`
+ * header). Attaching writes the entry into the group's `container.json`
+ * `mcpServers.<name>` slot and persists the attach record to a sibling
+ * `parachute.json` so we can list/detach later without re-asking for
+ * configuration.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from '../config.js';
+import type { McpServerConfig, HttpMcpServerConfig, ContainerConfig } from '../container-config.js';
+import { readContainerConfig, writeContainerConfig } from '../container-config.js';
+import type { BuildVaultMcpOpts, VaultAttachment, VaultScope } from './types.js';
+
+/** Default name under which we register the vault MCP server. */
+export const DEFAULT_VAULT_MCP_NAME = 'parachute-vault';
+
+/** Path to the per-group Parachute attachment record. */
+function parachuteJsonPath(folder: string): string {
+  return path.join(GROUPS_DIR, folder, 'parachute.json');
+}
+
+/**
+ * Build the `McpServerConfig` for a vault attach. Pure — does not touch
+ * disk. The result is suitable for writing into `container.json`'s
+ * `mcpServers.<name>` slot.
+ */
+export function buildVaultMcpServer(opts: BuildVaultMcpOpts): HttpMcpServerConfig {
+  const baseUrl = opts.vaultBaseUrl.replace(/\/+$/, '');
+  return {
+    type: 'http',
+    url: `${baseUrl}/mcp`,
+    headers: {
+      Authorization: `Bearer ${opts.vaultToken}`,
+    },
+    instructions: opts.instructions,
+  };
+}
+
+export interface AttachVaultOpts {
+  /** Group folder name (matches `groups/<folder>`). */
+  folder: string;
+  /** Vault base URL, no trailing slash, no `/mcp` suffix. */
+  vaultBaseUrl: string;
+  /** The `pvt_…` token to bake into the MCP entry. */
+  vaultToken: string;
+  /** Scope this token was minted at — recorded in parachute.json for visibility. */
+  scope: VaultScope;
+  /** Token label (matches what's registered with the vault). */
+  tokenLabel: string;
+  /** Optional MCP name override. Defaults to `parachute-vault`. */
+  mcpName?: string;
+  /** Optional in-context instructions for the agent. */
+  instructions?: string;
+}
+
+/**
+ * Attach a vault to an agent group. Idempotent — re-attaching with the same
+ * `mcpName` updates the entry in place.
+ */
+export function attachVaultToGroup(opts: AttachVaultOpts): void {
+  const name = opts.mcpName ?? DEFAULT_VAULT_MCP_NAME;
+  const groupPath = path.join(GROUPS_DIR, opts.folder);
+  if (!fs.existsSync(groupPath)) {
+    throw new Error(`agent group folder not found: ${groupPath}`);
+  }
+
+  const cfg: ContainerConfig = readContainerConfig(opts.folder);
+  const mcpEntry: McpServerConfig = buildVaultMcpServer({
+    vaultBaseUrl: opts.vaultBaseUrl,
+    vaultToken: opts.vaultToken,
+    instructions: opts.instructions,
+  });
+  cfg.mcpServers[name] = mcpEntry;
+  writeContainerConfig(opts.folder, cfg);
+
+  const attachment: VaultAttachment = {
+    vaultBaseUrl: opts.vaultBaseUrl.replace(/\/+$/, ''),
+    scope: opts.scope,
+    tokenLabel: opts.tokenLabel,
+    attachedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(
+    parachuteJsonPath(opts.folder),
+    JSON.stringify({ vault: { [name]: attachment } }, null, 2) + '\n',
+  );
+}
+
+/**
+ * Read the Parachute attach record for a group, if any. Returns null when
+ * the file doesn't exist (group was never attached, or attached pre-record).
+ */
+export function readVaultAttachment(folder: string, mcpName = DEFAULT_VAULT_MCP_NAME): VaultAttachment | null {
+  const p = parachuteJsonPath(folder);
+  if (!fs.existsSync(p)) return null;
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, 'utf8')) as {
+      vault?: Record<string, VaultAttachment>;
+    };
+    return raw.vault?.[mcpName] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detach a vault from an agent group. Removes the MCP entry from
+ * `container.json` and the attach record from `parachute.json`. Does NOT
+ * revoke the vault token — caller is responsible for `parachute vault
+ * tokens revoke <label>` since revocation is one-way and we don't want a
+ * detach to silently nuke a token an operator might still want.
+ */
+export function detachVaultFromGroup(folder: string, mcpName = DEFAULT_VAULT_MCP_NAME): void {
+  const cfg = readContainerConfig(folder);
+  if (cfg.mcpServers[mcpName]) {
+    delete cfg.mcpServers[mcpName];
+    writeContainerConfig(folder, cfg);
+  }
+
+  const p = parachuteJsonPath(folder);
+  if (fs.existsSync(p)) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(p, 'utf8')) as {
+        vault?: Record<string, VaultAttachment>;
+      };
+      if (raw.vault?.[mcpName]) {
+        delete raw.vault[mcpName];
+        if (Object.keys(raw.vault).length === 0) {
+          fs.unlinkSync(p);
+        } else {
+          fs.writeFileSync(p, JSON.stringify(raw, null, 2) + '\n');
+        }
+      }
+    } catch {
+      // best-effort — don't fail detach on a malformed record
+    }
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,63 @@
+# web/
+
+Paraclaw's web UI — the management surface for vault attachments per agent group.
+
+## Two pieces
+
+- **`server/`** — a small Node http server. Reads NanoClaw's central `data/v2.db` (agent_groups table) read-only, exposes `/api/groups` + attach/detach endpoints, shells out to the `parachute` CLI to mint scoped vault tokens. Static-serves the built UI bundle from `../ui/dist`.
+- **`ui/`** — Vite + React + TypeScript. Lists agent groups, drills into one to see its current vault attachment, has a form to attach a vault (mints a fresh scoped token via the server, or accepts a pasted one). Detach button and confirmation flow.
+
+## Run (dev)
+
+You need a Parachute Vault running on `127.0.0.1:1940` and NanoClaw initialized at least once (so `data/v2.db` exists).
+
+```sh
+# Terminal 1 — server
+cd web/server
+pnpm install --ignore-workspace
+PARACLAW_WEB_PORT=4944 pnpm dev
+# → http://127.0.0.1:4944
+
+# Terminal 2 — UI dev server (hot reload)
+cd web/ui
+pnpm install --ignore-workspace
+pnpm dev
+# → http://localhost:5173
+# (Vite proxies /api/* to the server on 4944)
+```
+
+Open `http://localhost:5173/` to use the UI in dev mode.
+
+## Run (built)
+
+```sh
+cd web/ui && pnpm build       # → dist/
+cd ../server && pnpm start    # serves dist/ at the server's root
+# → http://127.0.0.1:4944
+```
+
+## Auth model
+
+**v1 (today):** server runs locally, binds `127.0.0.1`, no auth. The minted vault tokens never round-trip to the browser — the server runs `parachute vault tokens create` and writes the result straight into `groups/<folder>/container.json`.
+
+If the user opts to paste an existing token instead of minting, that token *does* land in the browser briefly; the `paraclaw-web-server` doesn't persist it anywhere except where it would already go (the per-group container.json that the agent runner reads at startup).
+
+**Phase B:** server registers as an OAuth client of the user's vault (RFC 7591 DCR), the user approves once via the vault's consent page, the server holds the resulting admin token. Per-claw scoped tokens are minted from there. Users never see `pvt_…` tokens.
+
+## Why the bootstrap.ts dance
+
+NanoClaw's `src/config.ts` resolves `DATA_DIR` and `GROUPS_DIR` via `process.cwd()`. The web server is invoked from `web/server/`, which would resolve those to the wrong paths. `web/server/src/bootstrap.ts` is imported FIRST in `server.ts` and chdirs to the project root before any NanoClaw module loads.
+
+A more upstream-friendly fix would be to make NanoClaw's config compute paths from `import.meta.url` instead of `process.cwd()`. That'd be a one-line change worth proposing upstream eventually; for now bootstrap chdir is the smallest patch.
+
+## Pinned to canonical port?
+
+Not yet. `4944` is a placeholder while paraclaw is exploratory. If the project earns its keep, we file an issue against `parachute-cli` to claim a slot in `PORT_RESERVATIONS` (1944–1949 range was unassigned at last check). Per `parachute-patterns/patterns/canonical-ports.md`: claim a slot when you ship, not before.
+
+## What's next
+
+See [`../docs/parachute-integration.md`](../docs/parachute-integration.md) for the full trajectory. Near-term:
+
+- **OAuth handshake** — replace the admin-token-as-env path in the server with vault OAuth. Phase B's biggest single add.
+- **New-agent wizard** — currently the UI manages vault attachment for *existing* agent groups (created via NanoClaw's setup flow). Adding a wizard for "spin up a new agent group + attach vault in one flow" is the next natural step, requires wrapping NanoClaw's `init-first-agent` / `create-agent` paths.
+- **Live status** — show whether a group's container is currently running, recent activity. Reads from NanoClaw's session tables.

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@paraclaw/web-server",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "module": "src/server.ts",
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "dev": "tsx watch src/server.ts",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.2-rc.1",
+  "version": "0.0.3-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.1",
+  "version": "0.0.2-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/pnpm-lock.yaml
+++ b/web/server/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/web/server/src/bootstrap.ts
+++ b/web/server/src/bootstrap.ts
@@ -1,0 +1,15 @@
+/**
+ * Side-effect-only bootstrap. Imported FIRST in server.ts so that
+ * NanoClaw's `src/config.ts` sees the correct `process.cwd()` when its
+ * top-level path constants (DATA_DIR, GROUPS_DIR, …) are evaluated.
+ *
+ * Without this: starting the server from any cwd that isn't the paraclaw
+ * project root makes config.ts resolve `<cwd>/data` and `<cwd>/groups`,
+ * which point at the wrong directories.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '../../..');
+process.chdir(projectRoot);

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -1,0 +1,354 @@
+/**
+ * Paraclaw web UI server.
+ *
+ * Thin Node http surface over:
+ *   - NanoClaw's central v2.db (agent_groups table) — read-only
+ *   - The Parachute attach helpers in src/parachute/vault-mcp.ts — write
+ *   - The `parachute` CLI for token minting (shells out)
+ *
+ * Static-serves the built UI bundle from ../ui/dist when present; otherwise
+ * just exposes /api/*. In dev, run vite separately on port 5173 with the
+ * proxy in vite.config.ts pointing back to this server.
+ *
+ * Auth model for v1: server runs locally, binds 127.0.0.1, no auth.
+ * Anyone with shell access to your laptop can act as you. Phase B replaces
+ * with vault OAuth handshake.
+ */
+// MUST be first — chdirs to project root so NanoClaw's config.ts resolves
+// DATA_DIR / GROUPS_DIR correctly regardless of where the server was invoked.
+import './bootstrap.js';
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+
+import { DATA_DIR, GROUPS_DIR } from '../../../src/config.js';
+import {
+  attachVaultToGroup,
+  detachVaultFromGroup,
+  readVaultAttachment,
+  DEFAULT_VAULT_MCP_NAME,
+} from '../../../src/parachute/vault-mcp.js';
+import type { VaultScope } from '../../../src/parachute/types.js';
+
+const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const UI_DIST = path.resolve(__dirname, '../../ui/dist');
+const PORT = Number(process.env.PARACLAW_WEB_PORT ?? 4944);
+const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
+
+interface AgentGroupRow {
+  id: string;
+  name: string;
+  folder: string;
+  agent_provider: string | null;
+  created_at: string;
+}
+
+interface AgentGroupView extends AgentGroupRow {
+  vault: ReturnType<typeof readVaultAttachment>;
+}
+
+function getDb(): Database.Database {
+  if (!fs.existsSync(CENTRAL_DB_PATH)) {
+    throw new Error(
+      `central db not found at ${CENTRAL_DB_PATH} — has NanoClaw been initialized? Run \`pnpm setup\` or \`pnpm dev\` first.`,
+    );
+  }
+  return new Database(CENTRAL_DB_PATH, { readonly: true });
+}
+
+function listAgentGroups(): AgentGroupView[] {
+  const db = getDb();
+  try {
+    const rows = db
+      .prepare(
+        'SELECT id, name, folder, agent_provider, created_at FROM agent_groups ORDER BY created_at DESC',
+      )
+      .all() as AgentGroupRow[];
+    return rows.map((r) => ({
+      ...r,
+      vault: readVaultAttachment(r.folder),
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+function getAgentGroup(folder: string): AgentGroupView | null {
+  const db = getDb();
+  try {
+    const row = db
+      .prepare(
+        'SELECT id, name, folder, agent_provider, created_at FROM agent_groups WHERE folder = ?',
+      )
+      .get(folder) as AgentGroupRow | undefined;
+    if (!row) return null;
+    return { ...row, vault: readVaultAttachment(row.folder) };
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Shell out to `parachute vault tokens create`. Captures stdout, parses the
+ * `pvt_…` line. Used by the attach flow so the user never types/pastes a
+ * raw token through the UI.
+ */
+function mintVaultToken(opts: {
+  scope: VaultScope;
+  label: string;
+}): Promise<{ token: string; label: string }> {
+  return new Promise((resolve, reject) => {
+    const args = ['vault', 'tokens', 'create', '--scope', opts.scope, '--label', opts.label];
+    const proc = spawn('parachute', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    proc.on('error', (err) => reject(err));
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `parachute vault tokens create exited ${code}: ${stderr.trim() || stdout.trim()}`,
+          ),
+        );
+        return;
+      }
+      // Output shape (vault 0.3.x):
+      //   Created token for vault "<vault>":
+      //     Token:      pvt_...
+      //     Permission: ...
+      //     Scopes:     ...
+      const m = stdout.match(/Token:\s+(pvt_[A-Za-z0-9_-]+)/);
+      if (!m) {
+        reject(new Error(`could not parse pvt_… from CLI output:\n${stdout}`));
+        return;
+      }
+      resolve({ token: m[1], label: opts.label });
+    });
+  });
+}
+
+// --- HTTP plumbing -----------------------------------------------------------
+
+const json = (
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+const error = (res: http.ServerResponse, status: number, message: string): void =>
+  json(res, status, { error: message });
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return {} as T;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+const VALID_SCOPES: VaultScope[] = ['vault:read', 'vault:write', 'vault:admin'];
+
+async function handleApi(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: URL,
+): Promise<void> {
+  const { pathname } = url;
+  const method = req.method ?? 'GET';
+
+  if (pathname === '/api/health' && method === 'GET') {
+    json(res, 200, {
+      service: 'paraclaw-web-server',
+      version: '0.0.1',
+      data_dir: DATA_DIR,
+      groups_dir: GROUPS_DIR,
+    });
+    return;
+  }
+
+  if (pathname === '/api/groups' && method === 'GET') {
+    try {
+      const groups = listAgentGroups();
+      json(res, 200, { groups });
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
+  // /api/groups/:folder/...
+  const groupRoute = pathname.match(/^\/api\/groups\/([^/]+)(\/.*)?$/);
+  if (groupRoute) {
+    const folder = decodeURIComponent(groupRoute[1]);
+    const sub = groupRoute[2] ?? '';
+
+    const group = getAgentGroup(folder);
+    if (!group) {
+      error(res, 404, `agent group not found: ${folder}`);
+      return;
+    }
+
+    if (sub === '' && method === 'GET') {
+      json(res, 200, { group });
+      return;
+    }
+
+    // POST /api/groups/:folder/attach-vault
+    if (sub === '/attach-vault' && method === 'POST') {
+      try {
+        const body = await readJsonBody<{
+          scope?: string;
+          vaultBaseUrl?: string;
+          tokenLabel?: string;
+          mcpName?: string;
+          token?: string; // optional — if absent, server mints via CLI
+        }>(req);
+        const scope = (body.scope ?? 'vault:read') as VaultScope;
+        if (!VALID_SCOPES.includes(scope)) {
+          error(res, 400, `invalid scope: ${scope}`);
+          return;
+        }
+        const vaultBaseUrl = body.vaultBaseUrl ?? 'http://127.0.0.1:1940/vault/default';
+        const tokenLabel = body.tokenLabel ?? `claw-${folder}`;
+
+        let token = body.token;
+        if (!token) {
+          const minted = await mintVaultToken({ scope, label: tokenLabel });
+          token = minted.token;
+        }
+
+        attachVaultToGroup({
+          folder,
+          vaultBaseUrl,
+          vaultToken: token,
+          scope,
+          tokenLabel,
+          mcpName: body.mcpName,
+        });
+
+        // Re-read so the response reflects the persisted state.
+        const updated = getAgentGroup(folder);
+        json(res, 200, { group: updated, mintedToken: !body.token });
+      } catch (err) {
+        error(res, 500, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
+    // POST /api/groups/:folder/detach-vault
+    if (sub === '/detach-vault' && method === 'POST') {
+      try {
+        const body = await readJsonBody<{ mcpName?: string }>(req);
+        detachVaultFromGroup(folder, body.mcpName ?? DEFAULT_VAULT_MCP_NAME);
+        const updated = getAgentGroup(folder);
+        json(res, 200, { group: updated });
+      } catch (err) {
+        error(res, 500, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
+    error(res, 405, `method not allowed: ${method} ${pathname}`);
+    return;
+  }
+
+  error(res, 404, `not found: ${pathname}`);
+}
+
+// --- Static file serving (built UI) -----------------------------------------
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function serveStatic(req: http.IncomingMessage, res: http.ServerResponse, urlPath: string): void {
+  if (!fs.existsSync(UI_DIST)) {
+    res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end(
+      'UI bundle not found at ' +
+        UI_DIST +
+        '\n\nIn dev: run `pnpm --filter @paraclaw/web-ui dev` and open http://localhost:5173/.\n' +
+        'In prod: run `pnpm --filter @paraclaw/web-ui build` first.',
+    );
+    return;
+  }
+
+  // Map / → index.html. Strip leading slash.
+  let rel = urlPath.replace(/^\/+/, '') || 'index.html';
+
+  // Path traversal guard.
+  if (rel.includes('..')) {
+    res.writeHead(400);
+    res.end('bad path');
+    return;
+  }
+
+  let abs = path.join(UI_DIST, rel);
+  // SPA fallback — any unknown route under root falls back to index.html so
+  // BrowserRouter routes resolve.
+  if (!fs.existsSync(abs)) {
+    abs = path.join(UI_DIST, 'index.html');
+    rel = 'index.html';
+  }
+  const ext = path.extname(abs).toLowerCase();
+  const mime = MIME_TYPES[ext] ?? 'application/octet-stream';
+  const stream = fs.createReadStream(abs);
+  res.writeHead(200, { 'content-type': mime });
+  stream.pipe(res);
+}
+
+// --- Server ------------------------------------------------------------------
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    if (url.pathname.startsWith('/api/')) {
+      await handleApi(req, res, url);
+      return;
+    }
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      serveStatic(req, res, url.pathname);
+      return;
+    }
+    error(res, 405, `method not allowed: ${req.method} ${url.pathname}`);
+  } catch (err) {
+    if (!res.headersSent) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    } else {
+      res.end();
+    }
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`paraclaw-web listening on http://${HOST}:${PORT}`);
+  console.log(`  data_dir:   ${DATA_DIR}`);
+  console.log(`  groups_dir: ${GROUPS_DIR}`);
+  if (fs.existsSync(UI_DIST)) {
+    console.log(`  ui:         serving from ${UI_DIST}`);
+  } else {
+    console.log(`  ui:         (not built — run pnpm --filter @paraclaw/web-ui build, or dev separately on :5173)`);
+  }
+});

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -27,6 +27,8 @@ import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
 import { DATA_DIR, GROUPS_DIR } from '../../../src/config.js';
+import { initDb } from '../../../src/db/connection.js';
+import { runMigrations } from '../../../src/db/migrations/index.js';
 import {
   attachVaultToGroup,
   detachVaultFromGroup,
@@ -34,6 +36,12 @@ import {
   DEFAULT_VAULT_MCP_NAME,
 } from '../../../src/parachute/vault-mcp.js';
 import type { VaultScope } from '../../../src/parachute/types.js';
+import {
+  createParachuteAgentGroup,
+  isFolderTaken,
+  suggestFolderSlug,
+  validateFolderSlug,
+} from '../../../src/parachute/create-agent.js';
 
 const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 
@@ -41,6 +49,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UI_DIST = path.resolve(__dirname, '../../ui/dist');
 const PORT = Number(process.env.PARACLAW_WEB_PORT ?? 4944);
 const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
+
+// NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
+// process-singleton DB connection (`getDb`). Initialize it once at boot so
+// the wizard endpoint can write. WAL mode + foreign_keys ON are set inside.
+// Concurrent with a running NanoClaw service (also WAL) is fine — SQLite
+// handles multiple writers per file. Migrations are idempotent.
+const centralDb = initDb(CENTRAL_DB_PATH);
+runMigrations(centralDb);
 
 interface AgentGroupRow {
   id: string;
@@ -174,7 +190,7 @@ async function handleApi(
   if (pathname === '/api/health' && method === 'GET') {
     json(res, 200, {
       service: 'paraclaw-web-server',
-      version: '0.0.1',
+      version: '0.0.3-rc.1',
       data_dir: DATA_DIR,
       groups_dir: GROUPS_DIR,
     });
@@ -188,6 +204,100 @@ async function handleApi(
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));
     }
+    return;
+  }
+
+  if (pathname === '/api/groups' && method === 'POST') {
+    try {
+      const body = await readJsonBody<{
+        name?: string;
+        folder?: string;
+        instructions?: string;
+        vault?: {
+          scope?: string;
+          vaultBaseUrl?: string;
+          tokenLabel?: string;
+          token?: string;
+          mcpName?: string;
+        };
+      }>(req);
+
+      const name = (body.name ?? '').trim();
+      const folder = (body.folder ?? '').trim();
+      if (!name) {
+        error(res, 400, 'name is required');
+        return;
+      }
+      const folderCheck = validateFolderSlug(folder);
+      if (!folderCheck.ok) {
+        error(res, 400, folderCheck.reason);
+        return;
+      }
+      if (isFolderTaken(folder)) {
+        error(res, 409, `agent group folder already exists: ${folder}`);
+        return;
+      }
+
+      let vaultArg:
+        | Parameters<typeof createParachuteAgentGroup>[0]['vault']
+        | undefined;
+      let mintedVaultToken = false;
+      if (body.vault) {
+        const scope = (body.vault.scope ?? 'vault:read') as VaultScope;
+        if (!VALID_SCOPES.includes(scope)) {
+          error(res, 400, `invalid vault.scope: ${scope}`);
+          return;
+        }
+        const tokenLabel = body.vault.tokenLabel ?? `claw-${folder}`;
+        let token = body.vault.token;
+        if (!token) {
+          const minted = await mintVaultToken({ scope, label: tokenLabel });
+          token = minted.token;
+          mintedVaultToken = true;
+        }
+        vaultArg = {
+          scope,
+          vaultBaseUrl: body.vault.vaultBaseUrl,
+          tokenLabel,
+          token,
+          mcpName: body.vault.mcpName,
+        };
+      }
+
+      const created = createParachuteAgentGroup({
+        name,
+        folder,
+        instructions: body.instructions?.trim() || undefined,
+        vault: vaultArg,
+      });
+
+      const view = getAgentGroup(created.group.folder);
+      json(res, 201, { group: view, mintedVaultToken });
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
+  // GET /api/folder-availability/:slug — used by the new-agent wizard for
+  // live "is this slug free?" feedback.
+  const folderAvail = pathname.match(/^\/api\/folder-availability\/([^/]+)$/);
+  if (folderAvail && method === 'GET') {
+    const slug = decodeURIComponent(folderAvail[1]);
+    const v = validateFolderSlug(slug);
+    if (!v.ok) {
+      json(res, 200, { slug, valid: false, available: false, reason: v.reason });
+      return;
+    }
+    json(res, 200, { slug, valid: true, available: !isFolderTaken(slug) });
+    return;
+  }
+
+  // GET /api/folder-suggestion?name=... — wizard uses this to seed the slug
+  // input from the agent name.
+  if (pathname === '/api/folder-suggestion' && method === 'GET') {
+    const name = url.searchParams.get('name') ?? '';
+    json(res, 200, { name, slug: suggestFolderSlug(name) });
     return;
   }
 

--- a/web/server/tsconfig.json
+++ b/web/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "../../src/**/*.ts"]
+}

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paraclaw</title>
+    <meta name="description" content="Manage Parachute Vault access for your NanoClaw agents." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.1",
+  "version": "0.0.2-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@paraclaw/web-ui",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.2-rc.1",
+  "version": "0.0.3-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/pnpm-lock.yaml
+++ b/web/ui/pnpm-lock.yaml
@@ -1,0 +1,1178 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.0.0
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.2)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.23:
+    resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.23: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.23
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001791: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.344: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
+  react@19.2.5: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { GroupList } from "./routes/GroupList.tsx";
 import { GroupDetail } from "./routes/GroupDetail.tsx";
+import { NewGroupWizard } from "./routes/NewGroupWizard.tsx";
 
 export function App() {
   return (
@@ -21,6 +22,7 @@ export function App() {
 
       <Routes>
         <Route path="/" element={<GroupList />} />
+        <Route path="/groups/new" element={<NewGroupWizard />} />
         <Route path="/groups/:folder" element={<GroupDetail />} />
         <Route path="*" element={<div className="empty">404 — back to <Link to="/">groups</Link>.</div>} />
       </Routes>

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,0 +1,29 @@
+import { Link, Route, Routes } from "react-router-dom";
+import { GroupList } from "./routes/GroupList.tsx";
+import { GroupDetail } from "./routes/GroupDetail.tsx";
+
+export function App() {
+  return (
+    <div className="page">
+      <nav className="nav">
+        <Link to="/" className="brand">
+          Paraclaw <span className="sub">claws &amp; vaults</span>
+        </Link>
+        <Link to="/">Agent groups</Link>
+        <a
+          href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Docs
+        </a>
+      </nav>
+
+      <Routes>
+        <Route path="/" element={<GroupList />} />
+        <Route path="/groups/:folder" element={<GroupDetail />} />
+        <Route path="*" element={<div className="empty">404 — back to <Link to="/">groups</Link>.</div>} />
+      </Routes>
+    </div>
+  );
+}

--- a/web/ui/src/components/ScopeGrants.tsx
+++ b/web/ui/src/components/ScopeGrants.tsx
@@ -1,0 +1,74 @@
+import type { VaultScope } from "../lib/api.ts";
+
+const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
+const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
+
+export const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
+  { value: "vault:read", label: "vault:read — query, can't modify" },
+  { value: "vault:write", label: "vault:write — capture and update notes" },
+  { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
+];
+
+export function scopeGrants(scope: VaultScope): {
+  summary: string;
+  granted: readonly string[];
+  withheld: readonly string[];
+  adminNote?: string;
+} {
+  if (scope === "vault:read") {
+    return {
+      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
+      granted: READ_TOOLS,
+      withheld: WRITE_TOOLS,
+    };
+  }
+  if (scope === "vault:write") {
+    return {
+      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
+      granted: [...READ_TOOLS, ...WRITE_TOOLS],
+      withheld: [],
+    };
+  }
+  return {
+    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
+    granted: [...READ_TOOLS, ...WRITE_TOOLS],
+    withheld: [],
+    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
+  };
+}
+
+export function ScopeGrants({ scope }: { scope: VaultScope }) {
+  const grants = scopeGrants(scope);
+  return (
+    <div className="scope-grants">
+      <p className="scope-grants-summary">{grants.summary}</p>
+      <div className="scope-grants-tools">
+        <div>
+          <span className="scope-grants-label">Allows</span>
+          <ul>
+            {grants.granted.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {grants.withheld.length > 0 && (
+          <div>
+            <span className="scope-grants-label">Blocks</span>
+            <ul>
+              {grants.withheld.map((t) => (
+                <li key={t} className="dim">
+                  <code>{t}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      {grants.adminNote && (
+        <p className="scope-grants-warn">{grants.adminNote}</p>
+      )}
+    </div>
+  );
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1,0 +1,92 @@
+/**
+ * HTTP client to the Paraclaw web server.
+ *
+ * In dev: Vite proxies /api/* to localhost:4944.
+ * In prod: server serves the built UI under /claw/, /api/* on the same origin.
+ */
+
+const API_BASE = "/api";
+
+export type VaultScope = "vault:read" | "vault:write" | "vault:admin";
+
+export interface VaultAttachment {
+  vaultBaseUrl: string;
+  scope: VaultScope;
+  tokenLabel: string;
+  attachedAt: string;
+}
+
+export interface AgentGroupView {
+  id: string;
+  name: string;
+  folder: string;
+  agent_provider: string | null;
+  created_at: string;
+  vault: VaultAttachment | null;
+}
+
+async function request<T>(
+  path: string,
+  init?: RequestInit & { json?: unknown },
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...((init?.headers as Record<string, string>) ?? {}),
+  };
+  let body: BodyInit | undefined = init?.body as BodyInit | undefined;
+  if (init?.json !== undefined) {
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(init.json);
+  }
+  const res = await fetch(`${API_BASE}${path}`, { ...init, headers, body });
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const text = await res.text();
+      const parsed = JSON.parse(text) as { error?: string };
+      if (parsed.error) message = parsed.error;
+      else if (text) message = text;
+    } catch {
+      // not JSON, use status
+    }
+    throw new Error(message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export async function listGroups(): Promise<AgentGroupView[]> {
+  const r = await request<{ groups: AgentGroupView[] }>("/groups");
+  return r.groups;
+}
+
+export async function getGroup(folder: string): Promise<AgentGroupView> {
+  const r = await request<{ group: AgentGroupView }>(
+    `/groups/${encodeURIComponent(folder)}`,
+  );
+  return r.group;
+}
+
+export async function attachVault(
+  folder: string,
+  input: {
+    scope: VaultScope;
+    vaultBaseUrl?: string;
+    tokenLabel?: string;
+    token?: string;
+    mcpName?: string;
+  },
+): Promise<{ group: AgentGroupView; mintedToken: boolean }> {
+  return request<{ group: AgentGroupView; mintedToken: boolean }>(
+    `/groups/${encodeURIComponent(folder)}/attach-vault`,
+    { method: "POST", json: input },
+  );
+}
+
+export async function detachVault(folder: string, mcpName?: string): Promise<AgentGroupView> {
+  const r = await request<{ group: AgentGroupView }>(
+    `/groups/${encodeURIComponent(folder)}/detach-vault`,
+    { method: "POST", json: { mcpName } },
+  );
+  return r.group;
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -90,3 +90,46 @@ export async function detachVault(folder: string, mcpName?: string): Promise<Age
   );
   return r.group;
 }
+
+export interface FolderAvailability {
+  slug: string;
+  valid: boolean;
+  available: boolean;
+  reason?: string;
+}
+
+export async function checkFolderAvailability(slug: string): Promise<FolderAvailability> {
+  return request<FolderAvailability>(
+    `/folder-availability/${encodeURIComponent(slug)}`,
+  );
+}
+
+export async function fetchFolderSuggestion(name: string): Promise<string> {
+  const r = await request<{ name: string; slug: string }>(
+    `/folder-suggestion?name=${encodeURIComponent(name)}`,
+  );
+  return r.slug;
+}
+
+export interface CreateGroupInput {
+  name: string;
+  folder: string;
+  instructions?: string;
+  vault?: {
+    scope: VaultScope;
+    vaultBaseUrl?: string;
+    tokenLabel?: string;
+    token?: string;
+    mcpName?: string;
+  };
+}
+
+export async function createGroup(input: CreateGroupInput): Promise<{
+  group: AgentGroupView;
+  mintedVaultToken: boolean;
+}> {
+  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(
+    `/groups`,
+    { method: "POST", json: input },
+  );
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App.tsx";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  attachVault,
+  detachVault,
+  getGroup,
+  type AgentGroupView,
+  type VaultScope,
+} from "../lib/api.ts";
+
+const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
+  { value: "vault:read", label: "vault:read — query, can't modify" },
+  { value: "vault:write", label: "vault:write — capture and update notes" },
+  { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
+];
+
+export function GroupDetail() {
+  const { folder } = useParams<{ folder: string }>();
+  const [group, setGroup] = useState<AgentGroupView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Attach form state.
+  const [scope, setScope] = useState<VaultScope>("vault:read");
+  const [vaultBaseUrl, setVaultBaseUrl] = useState("http://127.0.0.1:1940/vault/default");
+  const [pasteToken, setPasteToken] = useState("");
+  const [tokenLabel, setTokenLabel] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [flash, setFlash] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!folder) return;
+    try {
+      setLoading(true);
+      const g = await getGroup(folder);
+      setGroup(g);
+      setError(null);
+      // Default the token-label field to claw-<folder> when not set.
+      if (!tokenLabel) setTokenLabel(`claw-${folder}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folder]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const onAttach = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!folder) return;
+    setSubmitting(true);
+    setFlash(null);
+    try {
+      const result = await attachVault(folder, {
+        scope,
+        vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ""),
+        tokenLabel: tokenLabel.trim() || undefined,
+        token: pasteToken.trim() || undefined,
+      });
+      setGroup(result.group);
+      setFlash({
+        kind: "ok",
+        text: result.mintedToken
+          ? `Vault attached (server minted a fresh ${scope} token via parachute CLI).`
+          : `Vault attached using your pasted token.`,
+      });
+      setPasteToken("");
+    } catch (err) {
+      setFlash({
+        kind: "error",
+        text: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDetach = async () => {
+    if (!folder) return;
+    if (!window.confirm("Detach vault from this agent group? Token is NOT revoked — that's a separate action.")) {
+      return;
+    }
+    setSubmitting(true);
+    setFlash(null);
+    try {
+      const updated = await detachVault(folder);
+      setGroup(updated);
+      setFlash({
+        kind: "ok",
+        text: "Vault detached. To revoke the token: parachute vault tokens revoke <label>",
+      });
+    } catch (err) {
+      setFlash({
+        kind: "error",
+        text: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading && !group) {
+    return <div className="status-banner">Loading {folder}…</div>;
+  }
+
+  if (error) {
+    return (
+      <div>
+        <Link to="/" className="muted">← All groups</Link>
+        <div className="error-banner" style={{ marginTop: "1rem" }}>{error}</div>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div>
+        <Link to="/" className="muted">← All groups</Link>
+        <div className="empty">Group not found.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Link to="/" className="muted">← All groups</Link>
+      <h2 style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
+        {group.name}
+        {group.vault ? (
+          <span className="tag">{group.vault.scope}</span>
+        ) : (
+          <span className="tag muted">no vault attached</span>
+        )}
+      </h2>
+
+      {flash && (
+        <div className={flash.kind === "ok" ? "status-banner" : "error-banner"}>
+          {flash.text}
+        </div>
+      )}
+
+      <div className="section">
+        <h3>Agent group</h3>
+        <div className="kv">
+          <div>name</div><div>{group.name}</div>
+          <div>folder</div><div><code>{group.folder}</code></div>
+          <div>id</div><div><code>{group.id}</code></div>
+          <div>provider</div><div>{group.agent_provider ?? <em className="dim">default</em>}</div>
+          <div>created</div><div>{new Date(group.created_at).toLocaleString()}</div>
+        </div>
+      </div>
+
+      {group.vault ? (
+        <div className="section">
+          <h3>Vault attachment</h3>
+          <div className="kv">
+            <div>vault url</div><div><code>{group.vault.vaultBaseUrl}</code></div>
+            <div>scope</div><div><span className="tag">{group.vault.scope}</span></div>
+            <div>token label</div><div><code>{group.vault.tokenLabel}</code></div>
+            <div>attached</div><div>{new Date(group.vault.attachedAt).toLocaleString()}</div>
+          </div>
+          <hr className="sep" />
+          <div className="dim" style={{ marginBottom: "0.75rem" }}>
+            The agent's container.json has a <code>parachute-vault</code> MCP entry pointing at this URL with a Bearer token. Detach removes the entry; the token stays valid until you revoke it via{" "}
+            <code>parachute vault tokens revoke {group.vault.tokenLabel}</code>.
+          </div>
+          <button className="danger" onClick={onDetach} disabled={submitting}>
+            {submitting ? "Working…" : "Detach vault"}
+          </button>
+        </div>
+      ) : (
+        <div className="section">
+          <h3>Attach vault</h3>
+          <form onSubmit={onAttach}>
+            <div className="row">
+              <label htmlFor="vaultBaseUrl">Vault URL</label>
+              <input
+                id="vaultBaseUrl"
+                type="text"
+                value={vaultBaseUrl}
+                onChange={(e) => setVaultBaseUrl(e.target.value)}
+                disabled={submitting}
+              />
+              <p className="dim">
+                The agent will reach this at{" "}
+                <code>{vaultBaseUrl.replace(/\/+$/, "")}/mcp</code>. Default
+                is the local vault at <code>http://127.0.0.1:1940/vault/default</code>.
+              </p>
+            </div>
+
+            <div className="row">
+              <label htmlFor="scope">Scope</label>
+              <select
+                id="scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value as VaultScope)}
+                disabled={submitting}
+              >
+                {SCOPE_OPTIONS.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+              <p className="dim">
+                Token capability — the agent literally cannot exceed this. Default <code>vault:read</code>.
+              </p>
+            </div>
+
+            <div className="row">
+              <label htmlFor="tokenLabel">Token label</label>
+              <input
+                id="tokenLabel"
+                type="text"
+                value={tokenLabel}
+                onChange={(e) => setTokenLabel(e.target.value)}
+                disabled={submitting}
+                placeholder={`claw-${folder}`}
+              />
+              <p className="dim">
+                Used for revocation. Default: <code>claw-{folder}</code>.
+              </p>
+            </div>
+
+            <div className="row">
+              <label htmlFor="pasteToken">Paste an existing token (optional)</label>
+              <input
+                id="pasteToken"
+                type="text"
+                value={pasteToken}
+                onChange={(e) => setPasteToken(e.target.value)}
+                disabled={submitting}
+                placeholder="pvt_…  (leave blank to mint a fresh one via the parachute CLI)"
+              />
+              <p className="dim">
+                When blank: the server runs{" "}
+                <code>parachute vault tokens create --scope {scope} --label {tokenLabel || `claw-${folder}`}</code>
+                {" "}for you. (Until vault OAuth is wired in Phase B; then
+                you'll never see <code>pvt_…</code> tokens at all.)
+              </p>
+            </div>
+
+            <div className="actions">
+              <button type="submit" disabled={submitting}>
+                {submitting ? "Attaching…" : "Attach vault"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="section">
+        <h3>What the agent gets</h3>
+        <p className="muted">
+          When attached, the agent's container has a{" "}
+          <code>parachute-vault</code> MCP server available with the nine
+          vault tools: <code>query-notes</code>, <code>create-note</code>,{" "}
+          <code>update-note</code>, <code>delete-note</code>,{" "}
+          <code>list-tags</code>, <code>update-tag</code>,{" "}
+          <code>delete-tag</code>, <code>find-path</code>,{" "}
+          <code>vault-info</code>. Constrained by the scope you chose.
+        </p>
+        <p className="muted">
+          Paraclaw doesn't impose a vault-note layout on the agent — the
+          claw decides how to use vault access. (See{" "}
+          <a
+            href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs/parachute-integration.md
+          </a>
+          .)
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
 import {
   attachVault,
   detachVault,
@@ -7,43 +8,6 @@ import {
   type AgentGroupView,
   type VaultScope,
 } from "../lib/api.ts";
-
-const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
-  { value: "vault:read", label: "vault:read — query, can't modify" },
-  { value: "vault:write", label: "vault:write — capture and update notes" },
-  { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
-];
-
-const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
-const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
-
-function scopeGrants(scope: VaultScope): {
-  summary: string;
-  granted: readonly string[];
-  withheld: readonly string[];
-  adminNote?: string;
-} {
-  if (scope === "vault:read") {
-    return {
-      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
-      granted: READ_TOOLS,
-      withheld: WRITE_TOOLS,
-    };
-  }
-  if (scope === "vault:write") {
-    return {
-      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
-      granted: [...READ_TOOLS, ...WRITE_TOOLS],
-      withheld: [],
-    };
-  }
-  return {
-    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
-    granted: [...READ_TOOLS, ...WRITE_TOOLS],
-    withheld: [],
-    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
-  };
-}
 
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
@@ -328,38 +292,3 @@ export function GroupDetail() {
   );
 }
 
-function ScopeGrants({ scope }: { scope: VaultScope }) {
-  const grants = scopeGrants(scope);
-  return (
-    <div className="scope-grants">
-      <p className="scope-grants-summary">{grants.summary}</p>
-      <div className="scope-grants-tools">
-        <div>
-          <span className="scope-grants-label">Allows</span>
-          <ul>
-            {grants.granted.map((t) => (
-              <li key={t}>
-                <code>{t}</code>
-              </li>
-            ))}
-          </ul>
-        </div>
-        {grants.withheld.length > 0 && (
-          <div>
-            <span className="scope-grants-label">Blocks</span>
-            <ul>
-              {grants.withheld.map((t) => (
-                <li key={t} className="dim">
-                  <code>{t}</code>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-      {grants.adminNote && (
-        <p className="scope-grants-warn">{grants.adminNote}</p>
-      )}
-    </div>
-  );
-}

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -14,6 +14,37 @@ const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
   { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
 ];
 
+const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
+const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
+
+function scopeGrants(scope: VaultScope): {
+  summary: string;
+  granted: readonly string[];
+  withheld: readonly string[];
+  adminNote?: string;
+} {
+  if (scope === "vault:read") {
+    return {
+      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
+      granted: READ_TOOLS,
+      withheld: WRITE_TOOLS,
+    };
+  }
+  if (scope === "vault:write") {
+    return {
+      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
+      granted: [...READ_TOOLS, ...WRITE_TOOLS],
+      withheld: [],
+    };
+  }
+  return {
+    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
+    granted: [...READ_TOOLS, ...WRITE_TOOLS],
+    withheld: [],
+    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
+  };
+}
+
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
   const [group, setGroup] = useState<AgentGroupView | null>(null);
@@ -104,7 +135,17 @@ export function GroupDetail() {
   };
 
   if (loading && !group) {
-    return <div className="status-banner">Loading {folder}…</div>;
+    return (
+      <div>
+        <Link to="/" className="muted">← All groups</Link>
+        <div className="skeleton skeleton-heading" style={{ marginTop: "1rem" }} />
+        <div className="section">
+          <div className="skeleton skeleton-line" style={{ width: "30%" }} />
+          <div className="skeleton skeleton-line" />
+          <div className="skeleton skeleton-line" style={{ width: "70%" }} />
+        </div>
+      </div>
+    );
   }
 
   if (error) {
@@ -112,6 +153,11 @@ export function GroupDetail() {
       <div>
         <Link to="/" className="muted">← All groups</Link>
         <div className="error-banner" style={{ marginTop: "1rem" }}>{error}</div>
+        <div className="actions" style={{ marginTop: "1rem" }}>
+          <button onClick={reload} disabled={loading}>
+            {loading ? "Retrying…" : "Retry"}
+          </button>
+        </div>
       </div>
     );
   }
@@ -209,6 +255,7 @@ export function GroupDetail() {
               <p className="dim">
                 Token capability — the agent literally cannot exceed this. Default <code>vault:read</code>.
               </p>
+              <ScopeGrants scope={scope} />
             </div>
 
             <div className="row">
@@ -277,6 +324,42 @@ export function GroupDetail() {
           .)
         </p>
       </div>
+    </div>
+  );
+}
+
+function ScopeGrants({ scope }: { scope: VaultScope }) {
+  const grants = scopeGrants(scope);
+  return (
+    <div className="scope-grants">
+      <p className="scope-grants-summary">{grants.summary}</p>
+      <div className="scope-grants-tools">
+        <div>
+          <span className="scope-grants-label">Allows</span>
+          <ul>
+            {grants.granted.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {grants.withheld.length > 0 && (
+          <div>
+            <span className="scope-grants-label">Blocks</span>
+            <ul>
+              {grants.withheld.map((t) => (
+                <li key={t} className="dim">
+                  <code>{t}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      {grants.adminNote && (
+        <p className="scope-grants-warn">{grants.adminNote}</p>
+      )}
     </div>
   );
 }

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { listGroups, type AgentGroupView } from "../lib/api.ts";
 
@@ -8,6 +8,12 @@ export function GroupList() {
     | { kind: "ok"; groups: AgentGroupView[] }
     | { kind: "error"; message: string }
   >({ kind: "loading" });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => {
+    setState({ kind: "loading" });
+    setReloadKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -24,25 +30,38 @@ export function GroupList() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
 
   if (state.kind === "loading") {
-    return <div className="status-banner">Loading agent groups…</div>;
+    return (
+      <div>
+        <h2>Agent groups</h2>
+        <ul className="skeleton-list" aria-busy="true" aria-label="Loading agent groups">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
   }
 
   if (state.kind === "error") {
     return (
       <div>
+        <h2>Agent groups</h2>
         <div className="error-banner">
           Couldn't load groups: <code>{state.message}</code>
         </div>
         <p className="muted">
           Make sure the web server is running:{" "}
-          <code>pnpm --filter @paraclaw/web-server dev</code>. It needs the
+          <code>cd web/server &amp;&amp; pnpm dev</code>. It needs the
           NanoClaw central DB at <code>data/v2.db</code> — that gets created
           the first time you run <code>pnpm setup</code> or{" "}
-          <code>pnpm dev</code>.
+          <code>pnpm dev</code> from the repo root.
         </p>
+        <div className="actions" style={{ marginTop: "1rem" }}>
+          <button onClick={reload}>Retry</button>
+        </div>
       </div>
     );
   }
@@ -51,13 +70,34 @@ export function GroupList() {
     return (
       <div>
         <h2>Agent groups</h2>
-        <div className="empty">
-          <p>No agent groups yet.</p>
-          <p className="dim">
-            NanoClaw spawns agent groups via channel skills (e.g.{" "}
-            <code>/init-first-agent</code>) or the setup flow. Once you have
-            one, refresh this page to manage its vault attachment here.
+        <div className="empty empty-rich">
+          <p className="empty-headline">No agent groups yet.</p>
+          <p className="muted">
+            Paraclaw will spin up agent groups from here soon
+            {" "}
+            (
+            <a
+              href="https://github.com/ParachuteComputer/paraclaw/issues/1"
+              target="_blank"
+              rel="noreferrer"
+            >
+              #1: new-agent wizard
+            </a>
+            ). Until then, bootstrap your first group via:
           </p>
+          <ul className="empty-paths">
+            <li>
+              <strong>Claude Code skill</strong> —
+              run <code>/init-first-agent</code> to walk through channel pick + identity + welcome DM.
+            </li>
+            <li>
+              <strong>CLI setup</strong> —
+              run <code>pnpm setup</code> from the repo root.
+            </li>
+          </ul>
+          <div className="actions" style={{ justifyContent: "center", marginTop: "1rem" }}>
+            <button className="secondary" onClick={reload}>Refresh</button>
+          </div>
         </div>
       </div>
     );

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -73,22 +73,17 @@ export function GroupList() {
         <div className="empty empty-rich">
           <p className="empty-headline">No agent groups yet.</p>
           <p className="muted">
-            Paraclaw will spin up agent groups from here soon
-            {" "}
-            (
-            <a
-              href="https://github.com/ParachuteComputer/paraclaw/issues/1"
-              target="_blank"
-              rel="noreferrer"
-            >
-              #1: new-agent wizard
-            </a>
-            ). Until then, bootstrap your first group via:
+            Spin up your first agent group in a few clicks — or bootstrap from
+            the CLI if you prefer.
           </p>
           <ul className="empty-paths">
             <li>
+              <strong>New agent wizard</strong> —
+              name + folder + optional vault attach.
+            </li>
+            <li>
               <strong>Claude Code skill</strong> —
-              run <code>/init-first-agent</code> to walk through channel pick + identity + welcome DM.
+              run <code>/init-first-agent</code> for channel pick + identity + welcome DM.
             </li>
             <li>
               <strong>CLI setup</strong> —
@@ -96,6 +91,7 @@ export function GroupList() {
             </li>
           </ul>
           <div className="actions" style={{ justifyContent: "center", marginTop: "1rem" }}>
+            <Link to="/groups/new"><button>+ New agent group</button></Link>
             <button className="secondary" onClick={reload}>Refresh</button>
           </div>
         </div>
@@ -105,7 +101,10 @@ export function GroupList() {
 
   return (
     <div>
-      <h2>Agent groups ({state.groups.length})</h2>
+      <div className="list-header">
+        <h2>Agent groups ({state.groups.length})</h2>
+        <Link to="/groups/new"><button>+ New agent group</button></Link>
+      </div>
       {state.groups.map((g) => (
         <Link
           key={g.id}

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { listGroups, type AgentGroupView } from "../lib/api.ts";
+
+export function GroupList() {
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "ok"; groups: AgentGroupView[] }
+    | { kind: "error"; message: string }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    listGroups()
+      .then((groups) => !cancelled && setState({ kind: "ok", groups }))
+      .catch(
+        (err) =>
+          !cancelled &&
+          setState({
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+          }),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "loading") {
+    return <div className="status-banner">Loading agent groups…</div>;
+  }
+
+  if (state.kind === "error") {
+    return (
+      <div>
+        <div className="error-banner">
+          Couldn't load groups: <code>{state.message}</code>
+        </div>
+        <p className="muted">
+          Make sure the web server is running:{" "}
+          <code>pnpm --filter @paraclaw/web-server dev</code>. It needs the
+          NanoClaw central DB at <code>data/v2.db</code> — that gets created
+          the first time you run <code>pnpm setup</code> or{" "}
+          <code>pnpm dev</code>.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.groups.length === 0) {
+    return (
+      <div>
+        <h2>Agent groups</h2>
+        <div className="empty">
+          <p>No agent groups yet.</p>
+          <p className="dim">
+            NanoClaw spawns agent groups via channel skills (e.g.{" "}
+            <code>/init-first-agent</code>) or the setup flow. Once you have
+            one, refresh this page to manage its vault attachment here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Agent groups ({state.groups.length})</h2>
+      {state.groups.map((g) => (
+        <Link
+          key={g.id}
+          to={`/groups/${encodeURIComponent(g.folder)}`}
+          className="group-row"
+        >
+          <div className="name">
+            {g.name}
+            {g.vault ? (
+              <span className="tag">{g.vault.scope}</span>
+            ) : (
+              <span className="tag muted">no vault</span>
+            )}
+          </div>
+          <div className="meta">
+            folder: <code>{g.folder}</code>
+            {g.agent_provider && (
+              <> &middot; provider: <code>{g.agent_provider}</code></>
+            )}
+            {g.vault && (
+              <>
+                {" "}
+                &middot; vault:{" "}
+                <code>{g.vault.vaultBaseUrl}</code>
+              </>
+            )}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/web/ui/src/routes/NewGroupWizard.tsx
+++ b/web/ui/src/routes/NewGroupWizard.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
+import {
+  checkFolderAvailability,
+  createGroup,
+  fetchFolderSuggestion,
+  type FolderAvailability,
+  type VaultScope,
+} from "../lib/api.ts";
+
+type Step = "identity" | "vault" | "confirm";
+
+const DEFAULT_VAULT_URL = "http://127.0.0.1:1940/vault/default";
+
+export function NewGroupWizard() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>("identity");
+
+  // Identity.
+  const [name, setName] = useState("");
+  const [folder, setFolder] = useState("");
+  const [folderTouched, setFolderTouched] = useState(false);
+  const [instructions, setInstructions] = useState("");
+  const [folderCheck, setFolderCheck] = useState<FolderAvailability | null>(null);
+  const [folderChecking, setFolderChecking] = useState(false);
+
+  // Vault.
+  const [attachVault, setAttachVault] = useState(false);
+  const [scope, setScope] = useState<VaultScope>("vault:read");
+  const [vaultBaseUrl, setVaultBaseUrl] = useState(DEFAULT_VAULT_URL);
+  const [pasteToken, setPasteToken] = useState("");
+  const [tokenLabel, setTokenLabel] = useState("");
+
+  // Submit.
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Suggest a folder slug from the name when the user hasn't typed one.
+  useEffect(() => {
+    if (folderTouched) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setFolder("");
+      return;
+    }
+    let cancelled = false;
+    fetchFolderSuggestion(trimmed)
+      .then((slug) => {
+        if (!cancelled && !folderTouched) setFolder(slug);
+      })
+      .catch(() => {
+        // Suggestion failure is non-fatal; user can type their own.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, folderTouched]);
+
+  // Debounce folder availability check.
+  const folderCheckTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!folder) {
+      setFolderCheck(null);
+      return;
+    }
+    if (folderCheckTimer.current) clearTimeout(folderCheckTimer.current);
+    setFolderChecking(true);
+    folderCheckTimer.current = setTimeout(async () => {
+      try {
+        const result = await checkFolderAvailability(folder);
+        setFolderCheck(result);
+      } catch (err) {
+        setFolderCheck({
+          slug: folder,
+          valid: false,
+          available: false,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setFolderChecking(false);
+      }
+    }, 250);
+    return () => {
+      if (folderCheckTimer.current) clearTimeout(folderCheckTimer.current);
+    };
+  }, [folder]);
+
+  const identityReady =
+    name.trim().length > 0 &&
+    folder.length > 0 &&
+    folderCheck?.valid === true &&
+    folderCheck?.available === true;
+
+  const onFolderChange = useCallback((next: string) => {
+    setFolderTouched(true);
+    setFolder(next);
+  }, []);
+
+  const onCreate = async () => {
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const result = await createGroup({
+        name: name.trim(),
+        folder,
+        instructions: instructions.trim() || undefined,
+        vault: attachVault
+          ? {
+              scope,
+              vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL,
+              tokenLabel: tokenLabel.trim() || undefined,
+              token: pasteToken.trim() || undefined,
+            }
+          : undefined,
+      });
+      navigate(`/groups/${encodeURIComponent(result.group.folder)}`);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <Link to="/" className="muted">← All groups</Link>
+      <h2 style={{ marginTop: "0.5rem" }}>New agent group</h2>
+      <WizardSteps current={step} />
+
+      {step === "identity" && (
+        <div className="section">
+          <h3>Identity</h3>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (identityReady) setStep("vault");
+            }}
+          >
+            <div className="row">
+              <label htmlFor="name">Name</label>
+              <input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Forge"
+                autoFocus
+              />
+              <p className="dim">
+                The display name. Folder slug is derived from this — you can override below.
+              </p>
+            </div>
+
+            <div className="row">
+              <label htmlFor="folder">Folder slug</label>
+              <input
+                id="folder"
+                type="text"
+                value={folder}
+                onChange={(e) => onFolderChange(e.target.value)}
+                placeholder="e.g. forge"
+              />
+              <FolderHint folder={folder} checking={folderChecking} check={folderCheck} />
+            </div>
+
+            <div className="row">
+              <label htmlFor="instructions">Instructions (optional)</label>
+              <textarea
+                id="instructions"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Goes into CLAUDE.local.md. Leave blank for the default."
+              />
+              <p className="dim">
+                What the agent should know about itself. Empty = the standard scaffold.
+              </p>
+            </div>
+
+            <div className="actions">
+              <button type="submit" disabled={!identityReady}>Next: vault</button>
+              <Link to="/" className="muted" style={{ marginLeft: "0.5rem" }}>Cancel</Link>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {step === "vault" && (
+        <div className="section">
+          <h3>Vault attachment</h3>
+          <p className="muted">
+            Attach the parachute vault now, or skip and attach later from the group's detail page.
+          </p>
+
+          <div className="row" style={{ marginTop: "0.5rem" }}>
+            <label className="wizard-toggle">
+              <input
+                type="checkbox"
+                checked={attachVault}
+                onChange={(e) => setAttachVault(e.target.checked)}
+              />
+              <span>Attach vault now</span>
+            </label>
+          </div>
+
+          {attachVault && (
+            <>
+              <div className="row">
+                <label htmlFor="vaultBaseUrl">Vault URL</label>
+                <input
+                  id="vaultBaseUrl"
+                  type="text"
+                  value={vaultBaseUrl}
+                  onChange={(e) => setVaultBaseUrl(e.target.value)}
+                />
+                <p className="dim">
+                  Default is the local vault at <code>{DEFAULT_VAULT_URL}</code>.
+                </p>
+              </div>
+
+              <div className="row">
+                <label htmlFor="scope">Scope</label>
+                <select
+                  id="scope"
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value as VaultScope)}
+                >
+                  {SCOPE_OPTIONS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+                <ScopeGrants scope={scope} />
+              </div>
+
+              <div className="row">
+                <label htmlFor="tokenLabel">Token label</label>
+                <input
+                  id="tokenLabel"
+                  type="text"
+                  value={tokenLabel}
+                  onChange={(e) => setTokenLabel(e.target.value)}
+                  placeholder={`claw-${folder || "<folder>"}`}
+                />
+                <p className="dim">
+                  Used for revocation. Default: <code>claw-{folder || "<folder>"}</code>.
+                </p>
+              </div>
+
+              <div className="row">
+                <label htmlFor="pasteToken">Paste an existing token (optional)</label>
+                <input
+                  id="pasteToken"
+                  type="text"
+                  value={pasteToken}
+                  onChange={(e) => setPasteToken(e.target.value)}
+                  placeholder="pvt_…  (leave blank to mint via the parachute CLI)"
+                />
+                <p className="dim">
+                  When blank, the server runs <code>parachute vault tokens create</code> for you.
+                </p>
+              </div>
+            </>
+          )}
+
+          <div className="actions" style={{ marginTop: "1rem" }}>
+            <button className="secondary" onClick={() => setStep("identity")}>Back</button>
+            <button onClick={() => setStep("confirm")}>Next: confirm</button>
+          </div>
+        </div>
+      )}
+
+      {step === "confirm" && (
+        <div className="section">
+          <h3>Confirm</h3>
+          <div className="kv">
+            <div>name</div><div>{name}</div>
+            <div>folder</div><div><code>{folder}</code></div>
+            <div>instructions</div>
+            <div>{instructions.trim() ? <em>(custom)</em> : <span className="dim">default</span>}</div>
+            <div>vault</div>
+            <div>
+              {attachVault ? (
+                <>
+                  <span className="tag">{scope}</span>{" "}
+                  <code>{vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL}</code>
+                </>
+              ) : (
+                <span className="dim">skip — attach later</span>
+              )}
+            </div>
+            {attachVault && (
+              <>
+                <div>token label</div>
+                <div><code>{tokenLabel.trim() || `claw-${folder}`}</code></div>
+                <div>token</div>
+                <div>
+                  {pasteToken.trim()
+                    ? <span className="dim">using pasted token</span>
+                    : <span className="dim">server will mint a fresh token</span>}
+                </div>
+              </>
+            )}
+          </div>
+
+          {submitError && (
+            <div className="error-banner" style={{ marginTop: "1rem" }}>{submitError}</div>
+          )}
+
+          <div className="actions" style={{ marginTop: "1rem" }}>
+            <button className="secondary" onClick={() => setStep("vault")} disabled={submitting}>
+              Back
+            </button>
+            <button onClick={onCreate} disabled={submitting}>
+              {submitting ? "Creating…" : "Create agent group"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FolderHint({
+  folder,
+  checking,
+  check,
+}: {
+  folder: string;
+  checking: boolean;
+  check: FolderAvailability | null;
+}) {
+  if (!folder) {
+    return (
+      <p className="dim">
+        Lowercase letters, digits, and dashes; ≤ 48 chars. Becomes <code>groups/&lt;slug&gt;/</code>.
+      </p>
+    );
+  }
+  if (checking || !check) {
+    return <p className="dim">Checking <code>{folder}</code>…</p>;
+  }
+  if (!check.valid) {
+    return <p className="wizard-folder-error">{check.reason ?? "Invalid slug."}</p>;
+  }
+  if (!check.available) {
+    return <p className="wizard-folder-error">{check.reason ?? "Already taken."}</p>;
+  }
+  return (
+    <p className="wizard-folder-ok">
+      <code>groups/{folder}/</code> is available.
+    </p>
+  );
+}
+
+function WizardSteps({ current }: { current: Step }) {
+  const steps: { key: Step; label: string }[] = [
+    { key: "identity", label: "1. Identity" },
+    { key: "vault", label: "2. Vault" },
+    { key: "confirm", label: "3. Confirm" },
+  ];
+  return (
+    <ol className="wizard-steps">
+      {steps.map((s) => (
+        <li
+          key={s.key}
+          className={`wizard-step${s.key === current ? " active" : ""}`}
+        >
+          {s.label}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -297,3 +297,62 @@ hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
   font-size: 0.82rem;
   color: var(--warn);
 }
+
+/* List header (with CTA on the right) */
+.list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.list-header h2 { margin: 0; }
+
+/* Wizard step indicator */
+.wizard-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  display: flex;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+.wizard-step {
+  padding: 0.4rem 0.8rem;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.wizard-step.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+  font-weight: 500;
+}
+
+/* Wizard form bits */
+.wizard-toggle {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: var(--fg) !important;
+  font-size: 0.95rem !important;
+  font-weight: 400 !important;
+  margin: 0 !important;
+}
+.wizard-toggle input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+.wizard-folder-ok {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+.wizard-folder-error {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--error);
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -203,3 +203,97 @@ form .actions { display: flex; gap: 0.6rem; align-items: center; }
 .kv code { word-break: break-all; }
 
 hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
+
+/* Skeleton loaders */
+@keyframes skeleton-shimmer {
+  0% { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--bg-soft) 0%,
+    #ece8df 50%,
+    var(--bg-soft) 100%
+  );
+  background-size: 800px 100%;
+  animation: skeleton-shimmer 1.4s linear infinite;
+  border-radius: 6px;
+}
+.skeleton-list { list-style: none; padding: 0; margin: 0; }
+.skeleton-row { height: 4.5rem; margin-bottom: 0.75rem; }
+.skeleton-heading { height: 1.6rem; width: 40%; margin-bottom: 1rem; }
+.skeleton-line { height: 0.9rem; margin-bottom: 0.6rem; width: 100%; }
+
+/* Richer empty state */
+.empty-rich { text-align: left; padding: 2rem 1.75rem; background: white; border: 1px solid var(--border); }
+.empty-rich .empty-headline { font-size: 1.05rem; color: var(--fg); margin: 0 0 0.5rem; font-weight: 500; }
+.empty-paths {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+.empty-paths li {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  padding: 0.7rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.92rem;
+  color: var(--fg-muted);
+}
+.empty-paths li strong { color: var(--fg); margin-right: 0.4rem; font-weight: 500; }
+
+/* Scope grants explainer */
+.scope-grants {
+  margin-top: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+}
+.scope-grants-summary {
+  margin: 0 0 0.6rem;
+  font-size: 0.88rem;
+  color: var(--fg);
+}
+.scope-grants-tools {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.scope-grants-tools > div:only-child { grid-column: 1 / -1; }
+.scope-grants-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+.scope-grants-tools ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.scope-grants-tools li code {
+  font-size: 0.78rem;
+  background: white;
+  border: 1px solid var(--border);
+  padding: 0.15em 0.45em;
+}
+.scope-grants-tools li.dim code {
+  background: transparent;
+  color: var(--fg-dim);
+  text-decoration: line-through;
+}
+.scope-grants-warn {
+  margin: 0.75rem 0 0;
+  font-size: 0.82rem;
+  color: var(--warn);
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1,0 +1,205 @@
+:root {
+  --bg: #faf8f4;
+  --bg-soft: #f3f0ea;
+  --fg: #2c2a26;
+  --fg-muted: #6b6860;
+  --fg-dim: #9a9690;
+  --accent: #4a7c59;
+  --accent-soft: rgba(74, 124, 89, 0.08);
+  --accent-hover: #3d6849;
+  --border: #e6e1d8;
+  --error: #8c3a3a;
+  --error-soft: rgba(140, 58, 58, 0.06);
+  --warn: #b08023;
+  --warn-soft: rgba(176, 128, 35, 0.08);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+button {
+  font: inherit;
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+button:hover { background: var(--accent-hover); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+button.secondary {
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+button.secondary:hover { background: var(--bg-soft); }
+button.danger {
+  background: var(--error);
+}
+button.danger:hover { background: #6f2d2d; }
+
+input, select, textarea {
+  font: inherit;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  color: var(--fg);
+}
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+code {
+  font-family: "SF Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.85em;
+  background: var(--bg-soft);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 6rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+.nav .brand {
+  font-weight: 600;
+  font-family: serif;
+  font-size: 1.1rem;
+  margin-right: auto;
+}
+.nav .brand .sub {
+  color: var(--fg-dim);
+  font-size: 0.78rem;
+  font-weight: 400;
+  margin-left: 0.4rem;
+}
+.nav a { color: var(--fg-muted); font-size: 0.95rem; }
+.nav a:hover { text-decoration: none; color: var(--fg); }
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+
+.section {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.section h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+}
+
+.muted { color: var(--fg-muted); font-size: 0.92rem; }
+.dim { color: var(--fg-dim); font-size: 0.85rem; }
+
+.error-banner {
+  background: var(--error-soft);
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.warn-banner {
+  background: var(--warn-soft);
+  border: 1px solid var(--warn);
+  color: var(--warn);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.status-banner {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--fg-muted);
+}
+
+.empty {
+  padding: 3rem 1.5rem;
+  text-align: center;
+  color: var(--fg-muted);
+  background: var(--bg-soft);
+  border-radius: 10px;
+}
+
+.group-row {
+  display: block;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 0.75rem;
+  background: white;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease;
+}
+.group-row:hover { border-color: var(--accent); text-decoration: none; }
+.group-row .name {
+  font-size: 1.05rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.group-row .meta {
+  margin-top: 0.4rem;
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.1em 0.55em;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 4px;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+.tag.muted { background: var(--bg-soft); color: var(--fg-muted); }
+.tag.error { background: var(--error-soft); color: var(--error); }
+.tag.warn { background: var(--warn-soft); color: var(--warn); }
+
+form .row { margin-bottom: 1rem; }
+form label { display: block; font-size: 0.9rem; color: var(--fg-muted); margin-bottom: 0.3rem; font-weight: 500; }
+form input[type="text"], form select, form textarea { width: 100%; }
+form textarea { min-height: 6rem; font-family: inherit; }
+form .actions { display: flex; gap: 0.6rem; align-items: center; }
+
+.kv { display: grid; grid-template-columns: 8.5rem 1fr; gap: 0.5rem 1rem; font-size: 0.92rem; }
+.kv > div:nth-child(odd) { color: var(--fg-muted); }
+.kv code { word-break: break-all; }
+
+hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }

--- a/web/ui/src/vite-env.d.ts
+++ b/web/ui/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly BASE_URL: string;
+  readonly VITE_PARACLAW_WEB_SERVER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/web/ui/tsconfig.json
+++ b/web/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  // Default: served at the server's root (paraclaw runs standalone on a
+  // dedicated port — UI at `/`, API at `/api/*`). Override via
+  // `VITE_BASE_PATH=/claw/ pnpm build` when serving under the Parachute hub
+  // at `https://<host>/claw/` (matches the parachute-notes mount pattern).
+  base: process.env.VITE_BASE_PATH ?? "/",
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: process.env.PARACLAW_WEB_SERVER_URL ?? "http://127.0.0.1:4944",
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Closes #1. Paraclaw can now create agent groups from the web UI without
Claude Code — the load-bearing piece for \"work easily end-to-end\".

- **`src/parachute/create-agent.ts`** — integration shim:
  `validateFolderSlug`, `suggestFolderSlug`, `isFolderTaken`,
  `createParachuteAgentGroup({ name, folder, instructions?, vault? })`.
  Wraps NanoClaw's central-DB write + on-disk init (`initGroupFilesystem`)
  + optional inline `attachVaultToGroup`. **No upstream NanoClaw files
  modified.** Channel wiring intentionally out of scope (issue #2).
- **`web/server`** — `POST /api/groups`, `GET /api/folder-availability/:slug`,
  `GET /api/folder-suggestion?name=...`. Server now `initDb()` +
  `runMigrations()` at boot so the shared DB connection covers writes.
- **`web/ui`** — new `NewGroupWizard` route: 3-step form
  Identity → Vault → Confirm. Reuses the existing scope-picker via a
  shared `components/ScopeGrants.tsx` (extracted from `GroupDetail`).
  \"+ New agent group\" CTAs added to the empty state and list header.
- Versions bumped `0.0.2-rc.1 → 0.0.3-rc.1` for both server + UI.

Provider selection is omitted from wizard v1 (claude default only) — the
\"other provider\" surface lands once channel wiring is on the table.
The wizard creates a channel-less group; channel install stays its own
issue (#2).

## Test plan

- [ ] `cd web/ui && pnpm typecheck` — clean
- [ ] `cd web/ui && pnpm build` — clean
- [ ] `cd web/server && pnpm typecheck` — clean
- [ ] `pnpm typecheck` at repo root — clean
- [ ] Smoke: `pnpm dev` (web/server + web/ui), open `/groups/new`,
      create a group with no vault → group shows in list, detail page renders
- [ ] Smoke: create another with `vault:read` (mint flow) → vault attached,
      detail shows scope tag + scope-grants explainer
- [ ] Smoke: folder-availability hint shows red for \"main\" / \"global\" if those rows exist, green for unused slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)