### PR TITLE
fix: disable autoSelectFamily on hosts with broken IPv6 routing

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -21,6 +21,8 @@
  * confirmed with the user, and free-text replies fall through to a
  * headless `claude -p` call for IANA-zone resolution.
  */
+import '../src/net-init.js';
+
 import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -2,6 +2,8 @@
  * Setup CLI entry point.
  * Usage: pnpm exec tsx setup/index.ts --step <name> [args...]
  */
+import '../src/net-init.js';
+
 import { log } from '../src/log.js';
 import { emitStatus } from './status.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
+import './net-init.js';
+
 import path from 'path';
 
 import { DATA_DIR } from './config.js';

--- a/src/net-init.ts
+++ b/src/net-init.ts
@@ -1,0 +1,26 @@
+/**
+ * Disable Node's `autoSelectFamily` (Happy Eyeballs) for built-in fetch.
+ *
+ * Why: hosts whose DNS resolver returns AAAA records but have no working
+ * IPv6 default route (e.g. a box on an IPv4-only LAN where upstream DNS
+ * still hands out v6) cause undici-backed `fetch()` to fail with an
+ * aggregated `ETIMEDOUT` — the v6 attempt errors with `ENETUNREACH` and
+ * the race surfaces as a generic `NetworkError` to callers like
+ * `@chat-adapter/telegram`. Curl falls back gracefully; Node's fetch
+ * does not.
+ *
+ * Disabling autoSelectFamily removes the family race. Node then connects
+ * to a single address per `dns.lookup`, and getaddrinfo's `AI_ADDRCONFIG`
+ * filter generally returns the family the host can actually reach — so
+ * v4-broken/v6-healthy hosts use v6, v6-broken/v4-healthy hosts use v4,
+ * and dual-stack hosts use whichever family the system prefers (RFC 6724
+ * default; v4 on most Linux/macOS). DNS ordering is left at Node's
+ * default so this doesn't force a family preference globally.
+ *
+ * Imported first from each Node entry point (`src/index.ts`,
+ * `setup/auto.ts`, `setup/index.ts`) so the change is in effect before
+ * any module opens a socket.
+ */
+import net from 'node:net';
+
+net.setDefaultAutoSelectFamily(false);


### PR DESCRIPTION
## Problem

On hosts that have AAAA DNS records for outbound APIs but no working IPv6 default route (common on IPv4-only LANs whose upstream resolver still returns v6), Node 22's default `autoSelectFamily` (Happy Eyeballs) races IPv6 + IPv4. The v6 attempt errors with `ENETUNREACH`, the race aggregates that into a generic `ETIMEDOUT`, and undici-backed `fetch()` fails on what should be a healthy IPv4 path. `curl` to the same URL works fine because it falls back gracefully; Node's fetch does not.

This affects every outbound HTTPS call from the host process, but it surfaces most visibly during setup's `telegram-validate` step (the first user-facing fetch). On a fresh install where the LAN has this property, the user sees:

> ■  Couldn't reach Telegram.
> Check your internet connection and retry setup.

…even though the bot token is valid and `curl https://api.telegram.org/...` returns 200.

## Fix

A new `src/net-init.ts` calls, at process start, before any other module loads:

```ts
net.setDefaultAutoSelectFamily(false);
```

It's imported as the first import in the three Node entry points:

- `src/index.ts` — host process
- `setup/auto.ts` — setup driver (`pnpm run setup:auto`)
- `setup/index.ts` — per-step CLI (`pnpm exec tsx setup/index.ts --step …`)

Disabling `autoSelectFamily` removes the family race. Node then connects to a single address per `dns.lookup`, and `getaddrinfo`'s `AI_ADDRCONFIG` filter generally returns the family the host can actually reach — so v4-broken/v6-healthy hosts use v6, v6-broken/v4-healthy hosts use v4, and dual-stack hosts use whichever family the system prefers (RFC 6724 default policy; v4 on most Linux/macOS). DNS ordering is left at Node's default so this doesn't force a family preference globally.

No new dependencies; built-in Node APIs only.

## Repro

On a host where:
- DNS returns AAAA for `api.telegram.org`
- `ip -6 route show default` is empty

…run setup with a valid `TELEGRAM_BOT_TOKEN`. Before this PR, setup aborts at `telegram-validate` with `error: fetch failed` in ~270ms. After, the call returns 200 and setup proceeds.

Verified that the single-flag fix is sufficient (vs. also forcing `dns.setDefaultResultOrder('ipv4first')`, which an earlier revision included):

| Configuration | Result on broken-v6 Pi |
|---|---|
| `dns-result-order=ipv4first` only | ❌ ETIMEDOUT (autoSelect still races) |
| `network-family-autoselection-attempt-timeout=250` only | ❌ ETIMEDOUT |
| **`no-network-family-autoselection` only** | ✅ **HTTP 200** |

## Test plan

- [x] Reproduced on a Raspberry Pi with `getent hosts api.telegram.org` returning the AAAA first and no v6 default route — `node -e "fetch('https://api.telegram.org/...')"` failed with `ETIMEDOUT` aggregating an `ENETUNREACH`.
- [x] After the fix, the same fetch returns HTTP 200; full setup completes through `telegram-validate`; host receives Telegram DMs normally.
- [x] `pnpm run typecheck` clean.
- [x] `pnpm run build` clean.
