### PR TITLE
fix(setup): prevent invisible-sudo hangs in spinner-driven setup

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -218,6 +218,31 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
   esac
 fi
 
+# ─── pre-flight: prime sudo before any spinner ────────────────────────
+# Linux setup needs sudo for nodesource/apt (install-node.sh) and a
+# setfacl on /var/run/docker.sock (service step) when the user was added
+# to the docker group mid-session. Both run inside spinners that capture
+# child stdio, so an interactive sudo password prompt would be invisible
+# and the call would block on /dev/null stdin forever (issue #2025, #2014,
+# #2006). Prime the sudo cache here, before any spinner is drawn, so the
+# prompt lands on a clean TTY. NOPASSWD users get past `sudo -n true`
+# silently with no UI change.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  if ! sudo -n true 2>/dev/null; then
+    printf '  %s\n' \
+      "$(dim "Setup will need sudo a few times (install Node, fix docker socket perms).")"
+    printf '  %s\n\n' \
+      "$(dim "Authenticating once now so we don't prompt mid-spinner.")"
+    if ! sudo -v </dev/tty; then
+      printf '\n  %s %s\n' "$(red '✗')" "Couldn't validate sudo."
+      printf '  %s\n\n' \
+        "$(dim 'Either configure passwordless sudo for your user, or re-run and enter your password when prompted.')"
+      exit 1
+    fi
+    printf '\n'
+  fi
+fi
+
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
 
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -304,12 +304,24 @@ async function main(): Promise<void> {
       await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.');
     }
     if (res.terminal?.fields.DOCKER_GROUP_STALE === 'true') {
+      const stalehint =
+        'Pick one — either is fine:\n\n' +
+        '  A. Log out + back in, then re-run setup. Your docker group will activate\n' +
+        '     and no sudo workaround is needed.\n\n' +
+        '  B. Apply the temporary ACL yourself, then restart the service:\n' +
+        '       sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' +
+        `       systemctl --user restart ${getSystemdUnit()}`;
       p.log.warn(brandBody("NanoClaw's permissions need a tweak before it can reach Docker."));
-      p.log.message(
-        brandBody(
-          '  sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' + `  systemctl --user restart ${getSystemdUnit()}`,
-        ),
-      );
+      p.log.message(brandBody(stalehint));
+      // Soft-warn: unit installed and started, just degraded until docker
+      // access is restored — so we don't fail(). Still offer Claude-assist
+      // for users who'd rather have it handled.
+      await offerClaudeAssist({
+        stepName: 'service',
+        msg: "NanoClaw's systemd service can't reach the Docker socket.",
+        hint: stalehint,
+        rawLogPath: 'logs/setup-steps/06-service.log',
+      });
     }
   }
 

--- a/setup/lib/sudo.ts
+++ b/setup/lib/sudo.ts
@@ -1,0 +1,31 @@
+/**
+ * Non-blocking sudo cache check for use inside step children.
+ *
+ * Step children are spawned with stdio piped to the parent (runner.ts:123),
+ * so any sudo call that needs to prompt for a password reads from /dev/null
+ * and blocks forever — the user sees a clean spinner and an indefinite hang.
+ * `nanoclaw.sh` primes the sudo cache visibly before the spinner starts, but
+ * the cache can expire (default 15 min) during user-driven steps like Claude
+ * OAuth. Step code that needs sudo should call `ensureSudoCached()` first
+ * and bail with a clear message if it returns `expired`, instead of running
+ * `sudo …` and hanging.
+ */
+import { execFileSync } from 'child_process';
+
+export type SudoCacheState = 'cached' | 'expired' | 'unavailable';
+
+export function ensureSudoCached(): SudoCacheState {
+  if (process.platform === 'darwin') return 'cached'; // macOS path doesn't sudo from inside steps
+  if (process.getuid?.() === 0) return 'cached'; // already root
+  try {
+    execFileSync('sudo', ['-n', 'true'], { stdio: 'ignore', timeout: 5000 });
+    return 'cached';
+  } catch {
+    try {
+      execFileSync('sudo', ['-V'], { stdio: 'ignore', timeout: 5000 });
+      return 'expired';
+    } catch {
+      return 'unavailable';
+    }
+  }
+}

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -11,6 +11,7 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { ensureSudoCached } from './lib/sudo.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
@@ -308,16 +309,25 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     );
     if (commandExists('setfacl')) {
       const user = execSync('whoami', { encoding: 'utf-8' }).trim();
-      try {
-        execSync(`sudo setfacl -m u:${user}:rw /var/run/docker.sock`, {
-          stdio: 'inherit',
-        });
-        log.info(
-          'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
-        );
-        dockerGroupStale = false;
-      } catch (err) {
-        log.warn('Failed to apply setfacl workaround', { err });
+      // `sudo -n` (non-interactive) — child stdio is piped to the parent
+      // spinner, so an interactive prompt would be invisible AND read from
+      // /dev/null forever. Fail fast if the cache expired and let auto.ts
+      // surface the manual workaround via DOCKER_GROUP_STALE.
+      const sudoState = ensureSudoCached();
+      if (sudoState === 'cached') {
+        try {
+          execSync(`sudo -n setfacl -m u:${user}:rw /var/run/docker.sock`, {
+            stdio: 'pipe',
+          });
+          log.info(
+            'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
+          );
+          dockerGroupStale = false;
+        } catch (err) {
+          log.warn('Failed to apply setfacl workaround', { err });
+        }
+      } else {
+        log.warn('Sudo cache not available for setfacl workaround', { sudoState });
       }
     } else {
       log.warn('setfacl not installed — cannot apply automatic workaround');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Fixes setup hangs caused by sudo prompts being invisible inside spinner-driven steps.

**Why.** Setup steps spawn child processes with `stdio: ['ignore','pipe','pipe']` (`setup/lib/runner.ts`). Any in-step `sudo` reads from `/dev/null` and hangs silently behind the spinner. The user sees the spinner stop progressing with no prompt and no error.

**How it works.** Three small pieces:
1. `nanoclaw.sh` primes `sudo -v` upfront before any spinner starts, with visible "Setup will need sudo a few times" text.
2. New `setup/lib/sudo.ts` exposes `ensureSudoCached(): 'cached' | 'expired' | 'unavailable'` for in-step non-prompting checks (uses `sudo -n true`).
3. `setup/service.ts` switches the docker-socket setfacl call to `sudo -n setfacl …`, gated by `ensureSudoCached()`.

If the sudo cache has expired by the time a step runs, the helper returns `expired` and the caller surfaces a clear error rather than hanging.

**How it was tested.** Fresh privileged Proxmox LXC end-to-end: visible sudo prompt at top of setup, no spinner hangs. The setfacl branch was not exercised on this LXC (nanoclaw user already in docker group), so that path is verified by inspection only. `pnpm exec tsc --noEmit` clean. `pnpm test` 197/197.

Closes #2025
Closes #414
Refs #2014
