### PR TITLE
fix(setup): detect LXC and quiet polkit linger noise

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -182,6 +182,31 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
   esac
 fi
 
+# ─── pre-flight: prime sudo before any spinner ────────────────────────
+# Linux setup needs sudo for nodesource/apt (install-node.sh) and a
+# setfacl on /var/run/docker.sock (service step) when the user was added
+# to the docker group mid-session. Both run inside spinners that capture
+# child stdio, so an interactive sudo password prompt would be invisible
+# and the call would block on /dev/null stdin forever (issue #2025, #2014,
+# #2006). Prime the sudo cache here, before any spinner is drawn, so the
+# prompt lands on a clean TTY. NOPASSWD users get past `sudo -n true`
+# silently with no UI change.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  if ! sudo -n true 2>/dev/null; then
+    printf '  %s\n' \
+      "$(dim "Setup will need sudo a few times (install Node, fix docker socket perms).")"
+    printf '  %s\n\n' \
+      "$(dim "Authenticating once now so we don't prompt mid-spinner.")"
+    if ! sudo -v </dev/tty; then
+      printf '\n  %s %s\n' "$(red '✗')" "Couldn't validate sudo."
+      printf '  %s\n\n' \
+        "$(dim 'Either configure passwordless sudo for your user, or re-run and enter your password when prompted.')"
+      exit 1
+    fi
+    printf '\n'
+  fi
+fi
+
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
 
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -287,10 +287,26 @@ async function main(): Promise<void> {
       await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.');
     }
     if (res.terminal?.fields.DOCKER_GROUP_STALE === 'true') {
+      const stalehint =
+        'Pick one — either is fine:\n\n' +
+        '  A. Log out + back in, then re-run setup. Your docker group will activate\n' +
+        '     and no sudo workaround is needed.\n\n' +
+        '  B. Apply the temporary ACL yourself, then restart the service:\n' +
+        '       sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' +
+        `       systemctl --user restart ${getSystemdUnit()}`;
       p.log.warn("NanoClaw's permissions need a tweak before it can reach Docker.");
-      p.log.message(
-        '  sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' + `  systemctl --user restart ${getSystemdUnit()}`,
-      );
+      p.log.message(k.dim(stalehint));
+      // This is a soft-warn (the unit installed and started; just degraded
+      // until docker access is restored), so we don't fail() — but we still
+      // offer Claude-assisted recovery for users who'd rather have it just
+      // handled. Result is best-effort: if Claude runs the setfacl, great;
+      // if not, the manual hint above stands.
+      await offerClaudeAssist({
+        stepName: 'service',
+        msg: "NanoClaw's systemd service can't reach the Docker socket.",
+        hint: stalehint,
+        rawLogPath: 'logs/setup-steps/06-service.log',
+      });
     }
   }
 

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -38,6 +38,7 @@ import { runWhatsAppChannel } from './channels/whatsapp.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { brightSelect } from './lib/bright-select.js';
 import { offerClaudeAssist } from './lib/claude-assist.js';
+import { detectLxc } from './lib/lxc.js';
 import {
   applyToEnv,
   parseFlags,
@@ -140,7 +141,9 @@ async function main(): Promise<void> {
         await fail(
           'container',
           "Docker isn't available.",
-          'Install Docker Desktop (or start it if already installed), then retry.',
+          appendLxcHint(
+            'Install Docker Desktop (or start it if already installed), then retry.',
+          ),
         );
       }
       if (err === 'docker_group_not_active') {
@@ -153,7 +156,9 @@ async function main(): Promise<void> {
       await fail(
         'container',
         "Couldn't build the sandbox.",
-        'If Docker has a stale cache, try: `docker builder prune -f`, then retry.',
+        appendLxcHint(
+          'If Docker has a stale cache, try: `docker builder prune -f`, then retry.',
+        ),
       );
     }
     maybeReexecUnderSg();
@@ -1087,6 +1092,31 @@ function runInheritScript(cmd: string, args: string[]): Promise<number> {
     const child = spawn(cmd, args, { stdio: 'inherit' });
     child.on('close', (code) => resolve(code ?? 1));
   });
+}
+
+/**
+ * If we're inside an LXC, append the Proxmox-host snippet to a Docker-failure
+ * hint. Docker-in-LXC needs `nesting=1,keyctl=1` features set on the CT —
+ * a setting only the PVE host operator can change (`pct set <CTID>`); a
+ * process inside the CT can't edit its own LXC config. We detect from inside
+ * and surface the snippet so the user knows what to ask their host operator
+ * for, or to run themselves if they have host shell access.
+ */
+function appendLxcHint(baseHint: string): string {
+  const lxc = detectLxc();
+  if (!lxc.inLxc) return baseHint;
+  const privNote =
+    lxc.privileged === false ? ' (your CT is unprivileged)'
+    : lxc.privileged === true ? ' (your CT is privileged)'
+    : '';
+  return (
+    baseHint +
+    `\n\nLooks like you're inside an LXC${privNote}. Docker-in-LXC needs these\n` +
+    'features turned on by your Proxmox host operator (run on the PVE host,\n' +
+    'NOT inside this CT — a process here can\'t change its own config):\n\n' +
+    '    pct set <CTID> -features nesting=1,keyctl=1\n' +
+    '    pct restart <CTID>'
+  );
 }
 
 /**

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 
 import { log } from '../src/log.js';
+import { detectLxc } from './lib/lxc.js';
 import { commandExists, getPlatform, isHeadless, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
@@ -44,6 +45,7 @@ export async function run(_args: string[]): Promise<void> {
   const platform = getPlatform();
   const wsl = isWSL();
   const headless = isHeadless();
+  const lxc = detectLxc();
 
   // Check Docker
   let docker: 'running' | 'installed_not_running' | 'not_found' = 'not_found';
@@ -89,6 +91,8 @@ export async function run(_args: string[]): Promise<void> {
     PLATFORM: platform,
     IS_WSL: wsl,
     IS_HEADLESS: headless,
+    IS_LXC: lxc.inLxc,
+    LXC_PRIVILEGED: lxc.privileged,
     DOCKER: docker,
     HAS_ENV: hasEnv,
     HAS_AUTH: hasAuth,

--- a/setup/lib/lxc.ts
+++ b/setup/lib/lxc.ts
@@ -1,0 +1,84 @@
+/**
+ * LXC detection — used to enrich Docker-failure messages with the
+ * Proxmox-host snippet a user needs to run when their CT is missing the
+ * `nesting=1,keyctl=1` features that Docker-in-LXC requires.
+ *
+ * A process inside the CT can't change its own LXC config — only the
+ * Proxmox host operator can. So this is purely informational: detect we
+ * are in LXC, surface the right `pct set …` snippet at the right moment,
+ * and let the user act on it.
+ *
+ * Detection layers (most reliable first):
+ *   1. systemd-detect-virt --container → `lxc` / `lxc-libvirt`
+ *   2. PID 1's environment has `container=lxc` (the layer systemd itself
+ *      falls back to; Proxmox's lxc-start always sets this)
+ *   3. /dev/.lxc-boot-id exists (set by the lxc package; not formally
+ *      documented but a strong marker on Proxmox CTs)
+ *
+ * Privilege check: /proc/self/uid_map. Privileged shows the identity
+ * mapping `0 0 …`; unprivileged shows a non-zero outer uid (usually
+ * `0 100000 65536`). Conservative — anything we can't parse is treated
+ * as "unknown" and surfaced separately.
+ */
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+
+export type LxcInfo = {
+  /** True if we're running inside an LXC container. */
+  inLxc: boolean;
+  /** True = privileged CT, false = unprivileged, null = unknown. */
+  privileged: boolean | null;
+  /** Which detector fired ('systemd-detect-virt' | 'proc-1-environ' | 'lxc-boot-id' | null). */
+  detector: 'systemd-detect-virt' | 'proc-1-environ' | 'lxc-boot-id' | null;
+};
+
+export function detectLxc(): LxcInfo {
+  const detector = whichDetectorFires();
+  if (!detector) {
+    return { inLxc: false, privileged: null, detector: null };
+  }
+  return { inLxc: true, privileged: readPrivilege(), detector };
+}
+
+function whichDetectorFires(): LxcInfo['detector'] {
+  try {
+    const out = execFileSync('systemd-detect-virt', ['--container'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+    if (out === 'lxc' || out === 'lxc-libvirt') return 'systemd-detect-virt';
+  } catch {
+    // not installed, or returned non-zero (= "none") — fall through
+  }
+  try {
+    const env = fs.readFileSync('/proc/1/environ', 'utf-8');
+    if (env.split('\0').some((kv) => kv === 'container=lxc')) {
+      return 'proc-1-environ';
+    }
+  } catch {
+    // not readable — fall through
+  }
+  try {
+    if (fs.existsSync('/dev/.lxc-boot-id')) return 'lxc-boot-id';
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function readPrivilege(): boolean | null {
+  try {
+    // Format: `inside_uid outside_uid range`. Privileged = identity map.
+    const map = fs.readFileSync('/proc/self/uid_map', 'utf-8').trim();
+    const firstLine = map.split('\n')[0]?.trim();
+    if (!firstLine) return null;
+    const parts = firstLine.split(/\s+/);
+    if (parts.length < 3) return null;
+    const insideUid = parts[0];
+    const outsideUid = parts[1];
+    return insideUid === '0' && outsideUid === '0';
+  } catch {
+    return null;
+  }
+}

--- a/setup/lib/sudo.ts
+++ b/setup/lib/sudo.ts
@@ -1,0 +1,31 @@
+/**
+ * Non-blocking sudo cache check for use inside step children.
+ *
+ * Step children are spawned with stdio piped to the parent (runner.ts:123),
+ * so any sudo call that needs to prompt for a password reads from /dev/null
+ * and blocks forever — the user sees a clean spinner and an indefinite hang.
+ * `nanoclaw.sh` primes the sudo cache visibly before the spinner starts, but
+ * the cache can expire (default 15 min) during user-driven steps like Claude
+ * OAuth. Step code that needs sudo should call `ensureSudoCached()` first
+ * and bail with a clear message if it returns `expired`, instead of running
+ * `sudo …` and hanging.
+ */
+import { execFileSync } from 'child_process';
+
+export type SudoCacheState = 'cached' | 'expired' | 'unavailable';
+
+export function ensureSudoCached(): SudoCacheState {
+  if (process.platform === 'darwin') return 'cached'; // macOS path doesn't sudo from inside steps
+  if (process.getuid?.() === 0) return 'cached'; // already root
+  try {
+    execFileSync('sudo', ['-n', 'true'], { stdio: 'ignore', timeout: 5000 });
+    return 'cached';
+  } catch {
+    try {
+      execFileSync('sudo', ['-V'], { stdio: 'ignore', timeout: 5000 });
+      return 'expired';
+    } catch {
+      return 'unavailable';
+    }
+  }
+}

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -339,10 +339,24 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
+  //
+  // `loginctl enable-linger` (no arg) authorises via polkit — which on
+  // minimal/headless boxes spawns `pkttyagent` to prompt the user, and
+  // pkttyagent isn't installed, producing a noisy "Failed to execute
+  // /usr/bin/pkttyagent" line in the spinner. Going through sudo bypasses
+  // polkit entirely (sudo→root has the privilege directly). `sudo -n`
+  // because the spinner captures stdio and an interactive prompt would
+  // hang on /dev/null; if the cache expired we fall through to the
+  // existing warn-and-continue path.
   if (!runningAsRoot) {
+    const user = execSync('whoami', { encoding: 'utf-8' }).trim();
+    const sudoState = ensureSudoCached();
+    const cmd = sudoState === 'cached'
+      ? `sudo -n loginctl enable-linger ${user}`
+      : 'loginctl enable-linger';
     try {
-      execSync('loginctl enable-linger', { stdio: 'ignore' });
-      log.info('Enabled loginctl linger for current user');
+      execSync(cmd, { stdio: 'ignore' });
+      log.info('Enabled loginctl linger for current user', { via: sudoState === 'cached' ? 'sudo' : 'polkit' });
     } catch (err) {
       log.warn(
         'loginctl enable-linger failed — service may stop on SSH logout',

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -11,6 +11,7 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { ensureSudoCached } from './lib/sudo.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
@@ -308,16 +309,25 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     );
     if (commandExists('setfacl')) {
       const user = execSync('whoami', { encoding: 'utf-8' }).trim();
-      try {
-        execSync(`sudo setfacl -m u:${user}:rw /var/run/docker.sock`, {
-          stdio: 'inherit',
-        });
-        log.info(
-          'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
-        );
-        dockerGroupStale = false;
-      } catch (err) {
-        log.warn('Failed to apply setfacl workaround', { err });
+      // `sudo -n` (non-interactive) — child stdio is piped to the parent
+      // spinner, so an interactive prompt would be invisible AND read from
+      // /dev/null forever. Fail fast if the cache expired and let auto.ts
+      // surface the manual workaround via DOCKER_GROUP_STALE.
+      const sudoState = ensureSudoCached();
+      if (sudoState === 'cached') {
+        try {
+          execSync(`sudo -n setfacl -m u:${user}:rw /var/run/docker.sock`, {
+            stdio: 'pipe',
+          });
+          log.info(
+            'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
+          );
+          dockerGroupStale = false;
+        } catch (err) {
+          log.warn('Failed to apply setfacl workaround', { err });
+        }
+      } else {
+        log.warn('Sudo cache not available for setfacl workaround', { sudoState });
       }
     } else {
       log.warn('setfacl not installed — cannot apply automatic workaround');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

> **Depends on #2054.** This branch carries that PR's commit so it builds and tests standalone. Once #2054 merges, this rebases to a single commit (`detect LXC and quiet polkit linger noise`).

**What.** Adds LXC environment awareness to setup, surfaces the host-side `pct set -features nesting=1,keyctl=1` snippet on Docker failures, and bypasses polkit/`pkttyagent` when enabling user-systemd linger.

**Why.** On a fresh Proxmox LXC, three things go wrong silently:
1. Setup has no idea it's inside LXC, so Docker-failure messages give Linux-host advice that doesn't apply.
2. The user has no clue they need to flip `nesting=1,keyctl=1` on the Proxmox host (a `pct` command that can only be run from outside the container).
3. `loginctl enable-linger` triggers polkit, which forks `pkttyagent` — usually missing on minimal LXC images, producing scary stderr noise.

**How it works.**
- New `setup/lib/lxc.ts` exposes `detectLxc()` returning `{ inLxc, privileged, detector }`. Layered detection: `systemd-detect-virt --container` → `/proc/1/environ` (`container=lxc`) → `/dev/.lxc-boot-id`. Privilege from `/proc/self/uid_map` identity check.
- `setup/environment.ts` emits `IS_LXC` + `LXC_PRIVILEGED` in the environment status block.
- `setup/auto.ts` adds `appendLxcHint()` which enriches Docker-failure messages with the `pct set <CTID> -features nesting=1,keyctl=1` snippet. Wired into `runtime_not_available` and generic build-failure paths.
- `setup/service.ts` switches `loginctl enable-linger` to `sudo -n loginctl enable-linger $USER` when sudo cache is warm — bypasses polkit and silences the `pkttyagent` noise.

**How it was tested.** Fresh privileged Proxmox LXC end-to-end: `is_lxc: true`, `lxc_privileged: true`, zero `pkttyagent` lines in `setup.log`, `loginctl show-user` reports `Linger=yes State=active`. The `appendLxcHint` text actually surfaced verbatim on a prior unprivileged-LXC run and led the user to flip the host-side flag. `pnpm exec tsc --noEmit` clean. `pnpm test` 197/197.

Closes #2006
Closes #413
