### PR TITLE
fix(setup): make systemd installable on LXC + centralize host restart

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -182,6 +182,31 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
   esac
 fi
 
+# ─── pre-flight: prime sudo before any spinner ────────────────────────
+# Linux setup needs sudo for nodesource/apt (install-node.sh) and a
+# setfacl on /var/run/docker.sock (service step) when the user was added
+# to the docker group mid-session. Both run inside spinners that capture
+# child stdio, so an interactive sudo password prompt would be invisible
+# and the call would block on /dev/null stdin forever (issue #2025, #2014,
+# #2006). Prime the sudo cache here, before any spinner is drawn, so the
+# prompt lands on a clean TTY. NOPASSWD users get past `sudo -n true`
+# silently with no UI change.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  if ! sudo -n true 2>/dev/null; then
+    printf '  %s\n' \
+      "$(dim "Setup will need sudo a few times (install Node, fix docker socket perms).")"
+    printf '  %s\n\n' \
+      "$(dim "Authenticating once now so we don't prompt mid-spinner.")"
+    if ! sudo -v </dev/tty; then
+      printf '\n  %s %s\n' "$(red '✗')" "Couldn't validate sudo."
+      printf '  %s\n\n' \
+        "$(dim 'Either configure passwordless sudo for your user, or re-run and enter your password when prompted.')"
+      exit 1
+    fi
+    printf '\n'
+  fi
+fi
+
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
 
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"

--- a/setup/add-discord.sh
+++ b/setup/add-discord.sh
@@ -110,21 +110,8 @@ mkdir -p data/env
 cp .env data/env/env
 
 log "Restarting service so the new adapter picks up the credentials…"
-# shellcheck source=setup/lib/install-slug.sh
-source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-case "$(uname -s)" in
-  Darwin)
-    launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" >&2 2>/dev/null || true
-    ;;
-  Linux)
-    systemctl --user restart "$(systemd_unit)" >&2 2>/dev/null \
-      || sudo systemctl restart "$(systemd_unit)" >&2 2>/dev/null \
-      || true
-    ;;
-esac
-
-# Give the Discord adapter a moment to finish gateway handshake before
-# init-first-agent attempts delivery.
-sleep 5
+# shellcheck source=setup/lib/restart.sh
+source "$PROJECT_ROOT/setup/lib/restart.sh"
+restart_service || { emit_status failed "service restart failed — see logs/nanoclaw.error.log"; exit 1; }
 
 emit_status success

--- a/setup/add-imessage.sh
+++ b/setup/add-imessage.sh
@@ -140,21 +140,8 @@ mkdir -p data/env
 cp .env data/env/env
 
 log "Restarting service so the new adapter picks up the creds…"
-# shellcheck source=setup/lib/install-slug.sh
-source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-case "$(uname -s)" in
-  Darwin)
-    launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" >&2 2>/dev/null || true
-    ;;
-  Linux)
-    systemctl --user restart "$(systemd_unit)" >&2 2>/dev/null \
-      || sudo systemctl restart "$(systemd_unit)" >&2 2>/dev/null \
-      || true
-    ;;
-esac
-
-# Give the adapter a moment to open chat.db (local) or handshake with
-# Photon (remote) before emitting success.
-sleep 3
+# shellcheck source=setup/lib/restart.sh
+source "$PROJECT_ROOT/setup/lib/restart.sh"
+restart_service || { emit_status failed "service restart failed — see logs/nanoclaw.error.log"; exit 1; }
 
 emit_status success

--- a/setup/add-slack.sh
+++ b/setup/add-slack.sh
@@ -105,21 +105,8 @@ mkdir -p data/env
 cp .env data/env/env
 
 log "Restarting service so the new adapter picks up the credentials…"
-# shellcheck source=setup/lib/install-slug.sh
-source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-case "$(uname -s)" in
-  Darwin)
-    launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" >&2 2>/dev/null || true
-    ;;
-  Linux)
-    systemctl --user restart "$(systemd_unit)" >&2 2>/dev/null \
-      || sudo systemctl restart "$(systemd_unit)" >&2 2>/dev/null \
-      || true
-    ;;
-esac
-
-# Give the Slack adapter a moment to finish starting the webhook listener
-# before emitting success.
-sleep 3
+# shellcheck source=setup/lib/restart.sh
+source "$PROJECT_ROOT/setup/lib/restart.sh"
+restart_service || { emit_status failed "service restart failed — see logs/nanoclaw.error.log"; exit 1; }
 
 emit_status success

--- a/setup/add-teams.sh
+++ b/setup/add-teams.sh
@@ -119,21 +119,8 @@ mkdir -p data/env
 cp .env data/env/env
 
 log "Restarting service so the new adapter picks up the credentials…"
-# shellcheck source=setup/lib/install-slug.sh
-source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-case "$(uname -s)" in
-  Darwin)
-    launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" >&2 2>/dev/null || true
-    ;;
-  Linux)
-    systemctl --user restart "$(systemd_unit)" >&2 2>/dev/null \
-      || sudo systemctl restart "$(systemd_unit)" >&2 2>/dev/null \
-      || true
-    ;;
-esac
-
-# Give the Teams adapter a moment to register its webhook before the driver
-# continues.
-sleep 5
+# shellcheck source=setup/lib/restart.sh
+source "$PROJECT_ROOT/setup/lib/restart.sh"
+restart_service || { emit_status failed "service restart failed — see logs/nanoclaw.error.log"; exit 1; }
 
 emit_status success

--- a/setup/add-telegram.sh
+++ b/setup/add-telegram.sh
@@ -144,21 +144,8 @@ cp .env data/env/env
 # non-interactive install.
 
 log "Restarting service so the new adapter picks up the token…"
-# shellcheck source=setup/lib/install-slug.sh
-source "$PROJECT_ROOT/setup/lib/install-slug.sh"
-case "$(uname -s)" in
-  Darwin)
-    launchctl kickstart -k "gui/$(id -u)/$(launchd_label)" >&2 2>/dev/null || true
-    ;;
-  Linux)
-    systemctl --user restart "$(systemd_unit)" >&2 2>/dev/null \
-      || sudo systemctl restart "$(systemd_unit)" >&2 2>/dev/null \
-      || true
-    ;;
-esac
-
-# Give the Telegram adapter a moment to finish starting before pair-telegram
-# begins polling for the user's code message.
-sleep 5
+# shellcheck source=setup/lib/restart.sh
+source "$PROJECT_ROOT/setup/lib/restart.sh"
+restart_service || { emit_status failed "service restart failed — see logs/nanoclaw.error.log"; exit 1; }
 
 emit_status success

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -287,10 +287,26 @@ async function main(): Promise<void> {
       await fail('service', "Couldn't start NanoClaw.", 'See logs/nanoclaw.error.log for details.');
     }
     if (res.terminal?.fields.DOCKER_GROUP_STALE === 'true') {
+      const stalehint =
+        'Pick one — either is fine:\n\n' +
+        '  A. Log out + back in, then re-run setup. Your docker group will activate\n' +
+        '     and no sudo workaround is needed.\n\n' +
+        '  B. Apply the temporary ACL yourself, then restart the service:\n' +
+        '       sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' +
+        `       systemctl --user restart ${getSystemdUnit()}`;
       p.log.warn("NanoClaw's permissions need a tweak before it can reach Docker.");
-      p.log.message(
-        '  sudo setfacl -m u:$(whoami):rw /var/run/docker.sock\n' + `  systemctl --user restart ${getSystemdUnit()}`,
-      );
+      p.log.message(k.dim(stalehint));
+      // This is a soft-warn (the unit installed and started; just degraded
+      // until docker access is restored), so we don't fail() — but we still
+      // offer Claude-assisted recovery for users who'd rather have it just
+      // handled. Result is best-effort: if Claude runs the setfacl, great;
+      // if not, the manual hint above stands.
+      await offerClaudeAssist({
+        stepName: 'service',
+        msg: "NanoClaw's systemd service can't reach the Docker socket.",
+        hint: stalehint,
+        rawLogPath: 'logs/setup-steps/06-service.log',
+      });
     }
   }
 

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -38,6 +38,7 @@ import { runWhatsAppChannel } from './channels/whatsapp.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
 import { brightSelect } from './lib/bright-select.js';
 import { offerClaudeAssist } from './lib/claude-assist.js';
+import { detectLxc } from './lib/lxc.js';
 import {
   applyToEnv,
   parseFlags,
@@ -140,7 +141,9 @@ async function main(): Promise<void> {
         await fail(
           'container',
           "Docker isn't available.",
-          'Install Docker Desktop (or start it if already installed), then retry.',
+          appendLxcHint(
+            'Install Docker Desktop (or start it if already installed), then retry.',
+          ),
         );
       }
       if (err === 'docker_group_not_active') {
@@ -153,7 +156,9 @@ async function main(): Promise<void> {
       await fail(
         'container',
         "Couldn't build the sandbox.",
-        'If Docker has a stale cache, try: `docker builder prune -f`, then retry.',
+        appendLxcHint(
+          'If Docker has a stale cache, try: `docker builder prune -f`, then retry.',
+        ),
       );
     }
     maybeReexecUnderSg();
@@ -1087,6 +1092,31 @@ function runInheritScript(cmd: string, args: string[]): Promise<number> {
     const child = spawn(cmd, args, { stdio: 'inherit' });
     child.on('close', (code) => resolve(code ?? 1));
   });
+}
+
+/**
+ * If we're inside an LXC, append the Proxmox-host snippet to a Docker-failure
+ * hint. Docker-in-LXC needs `nesting=1,keyctl=1` features set on the CT —
+ * a setting only the PVE host operator can change (`pct set <CTID>`); a
+ * process inside the CT can't edit its own LXC config. We detect from inside
+ * and surface the snippet so the user knows what to ask their host operator
+ * for, or to run themselves if they have host shell access.
+ */
+function appendLxcHint(baseHint: string): string {
+  const lxc = detectLxc();
+  if (!lxc.inLxc) return baseHint;
+  const privNote =
+    lxc.privileged === false ? ' (your CT is unprivileged)'
+    : lxc.privileged === true ? ' (your CT is privileged)'
+    : '';
+  return (
+    baseHint +
+    `\n\nLooks like you're inside an LXC${privNote}. Docker-in-LXC needs these\n` +
+    'features turned on by your Proxmox host operator (run on the PVE host,\n' +
+    'NOT inside this CT — a process here can\'t change its own config):\n\n' +
+    '    pct set <CTID> -features nesting=1,keyctl=1\n' +
+    '    pct restart <CTID>'
+  );
 }
 
 /**

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -584,14 +584,53 @@ function renderPingFailureNote(result: PingResult): void {
             6,
           ),
           '',
-          `  macOS:  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`,
-          `  Linux:  systemctl --user restart ${getSystemdUnit()}`,
+          ...restartHintForInstalledMode(),
         ].join('\n')
       : wrapForGutter(
           'No reply from your assistant within 30 seconds. Check `logs/nanoclaw.log` for clues, then try `pnpm run chat hi`.',
           6,
         );
   p.note(body, 'Skipping the first chat');
+}
+
+/**
+ * Build the per-line restart hint shown after a socket_error ping. Reads the
+ * most recent service step from logs/setup.log so we tell the user the
+ * command that actually matches their install — a hardcoded `systemctl`
+ * suggestion was misleading on nohup installs (the unit doesn't exist) and
+ * pointed root installs at the wrong scope. If the service step hasn't run
+ * yet (e.g. setup invoked with --skip=service) we fall back to the
+ * platform-pair hint as a last resort.
+ */
+function restartHintForInstalledMode(): string[] {
+  const fields = setupLog.lastStepFields('service');
+  const mode = fields?.service_type;
+  switch (mode) {
+    case 'launchd':
+      return [`  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`];
+    case 'systemd-user':
+      return [`  systemctl --user restart ${getSystemdUnit()}`];
+    case 'systemd-system':
+      return [`  sudo systemctl restart ${getSystemdUnit()}`];
+    case 'nohup': {
+      const lines = ['  bash start-nanoclaw.sh'];
+      if (fields?.linger_reason) {
+        lines.push(
+          '',
+          wrapForGutter(
+            'To upgrade this install to a proper systemd service that auto-starts on boot, run `sudo loginctl enable-linger $USER` and re-run setup.',
+            6,
+          ),
+        );
+      }
+      return lines;
+    }
+    default:
+      return [
+        `  macOS:  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`,
+        `  Linux:  systemctl --user restart ${getSystemdUnit()}`,
+      ];
+  }
 }
 
 /**

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 
 import { log } from '../src/log.js';
+import { detectLxc } from './lib/lxc.js';
 import { commandExists, getPlatform, isHeadless, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
@@ -44,6 +45,7 @@ export async function run(_args: string[]): Promise<void> {
   const platform = getPlatform();
   const wsl = isWSL();
   const headless = isHeadless();
+  const lxc = detectLxc();
 
   // Check Docker
   let docker: 'running' | 'installed_not_running' | 'not_found' = 'not_found';
@@ -89,6 +91,8 @@ export async function run(_args: string[]): Promise<void> {
     PLATFORM: platform,
     IS_WSL: wsl,
     IS_HEADLESS: headless,
+    IS_LXC: lxc.inLxc,
+    LXC_PRIVILEGED: lxc.privileged,
     DOCKER: docker,
     HAS_ENV: hasEnv,
     HAS_AUTH: hasAuth,

--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
-import { classifyPingResult } from './agent-ping.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { classifyPingResult, waitForSocket } from './agent-ping.js';
 
 describe('classifyPingResult', () => {
   it('treats a normal text reply as ok', () => {
@@ -26,5 +30,36 @@ describe('classifyPingResult', () => {
 
   it('treats empty output as no reply', () => {
     expect(classifyPingResult(0, '')).toBe('no_reply');
+  });
+});
+
+describe('waitForSocket', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncw-wait-socket-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns true immediately when the socket already exists', async () => {
+    const sock = path.join(tmpDir, 'cli.sock');
+    fs.writeFileSync(sock, '');
+    const start = Date.now();
+    expect(await waitForSocket(sock, 5_000)).toBe(true);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it('returns false when the socket never appears within the timeout', async () => {
+    const sock = path.join(tmpDir, 'never.sock');
+    expect(await waitForSocket(sock, 400)).toBe(false);
+  });
+
+  it('returns true when the socket appears mid-poll', async () => {
+    const sock = path.join(tmpDir, 'late.sock');
+    setTimeout(() => fs.writeFileSync(sock, ''), 250);
+    expect(await waitForSocket(sock, 3_000)).toBe(true);
   });
 });

--- a/setup/lib/agent-ping.ts
+++ b/setup/lib/agent-ping.ts
@@ -12,8 +12,29 @@
  * This wrapper also guards with its own timeout in case chat.ts hangs.
  */
 import { spawn } from 'child_process';
+import fs from 'fs';
 
 export type PingResult = 'ok' | 'no_reply' | 'socket_error' | 'auth_error';
+
+/**
+ * Wait for the host's CLI socket to appear on disk. Cheaper than `pingCliAgent`
+ * (no subprocess), used by the service step to confirm the host actually
+ * bound its socket before declaring success, and by the centralised restart
+ * helper after kicking the service.
+ *
+ * Polls every 200ms until the socket exists or `timeoutMs` elapses.
+ */
+export async function waitForSocket(
+  socketPath: string,
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return fs.existsSync(socketPath);
+}
 
 export function classifyPingResult(exitCode: number | null, stdout: string, stderr = ''): PingResult {
   const output = `${stdout}\n${stderr}`;

--- a/setup/lib/lxc.ts
+++ b/setup/lib/lxc.ts
@@ -1,0 +1,84 @@
+/**
+ * LXC detection — used to enrich Docker-failure messages with the
+ * Proxmox-host snippet a user needs to run when their CT is missing the
+ * `nesting=1,keyctl=1` features that Docker-in-LXC requires.
+ *
+ * A process inside the CT can't change its own LXC config — only the
+ * Proxmox host operator can. So this is purely informational: detect we
+ * are in LXC, surface the right `pct set …` snippet at the right moment,
+ * and let the user act on it.
+ *
+ * Detection layers (most reliable first):
+ *   1. systemd-detect-virt --container → `lxc` / `lxc-libvirt`
+ *   2. PID 1's environment has `container=lxc` (the layer systemd itself
+ *      falls back to; Proxmox's lxc-start always sets this)
+ *   3. /dev/.lxc-boot-id exists (set by the lxc package; not formally
+ *      documented but a strong marker on Proxmox CTs)
+ *
+ * Privilege check: /proc/self/uid_map. Privileged shows the identity
+ * mapping `0 0 …`; unprivileged shows a non-zero outer uid (usually
+ * `0 100000 65536`). Conservative — anything we can't parse is treated
+ * as "unknown" and surfaced separately.
+ */
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+
+export type LxcInfo = {
+  /** True if we're running inside an LXC container. */
+  inLxc: boolean;
+  /** True = privileged CT, false = unprivileged, null = unknown. */
+  privileged: boolean | null;
+  /** Which detector fired ('systemd-detect-virt' | 'proc-1-environ' | 'lxc-boot-id' | null). */
+  detector: 'systemd-detect-virt' | 'proc-1-environ' | 'lxc-boot-id' | null;
+};
+
+export function detectLxc(): LxcInfo {
+  const detector = whichDetectorFires();
+  if (!detector) {
+    return { inLxc: false, privileged: null, detector: null };
+  }
+  return { inLxc: true, privileged: readPrivilege(), detector };
+}
+
+function whichDetectorFires(): LxcInfo['detector'] {
+  try {
+    const out = execFileSync('systemd-detect-virt', ['--container'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+    if (out === 'lxc' || out === 'lxc-libvirt') return 'systemd-detect-virt';
+  } catch {
+    // not installed, or returned non-zero (= "none") — fall through
+  }
+  try {
+    const env = fs.readFileSync('/proc/1/environ', 'utf-8');
+    if (env.split('\0').some((kv) => kv === 'container=lxc')) {
+      return 'proc-1-environ';
+    }
+  } catch {
+    // not readable — fall through
+  }
+  try {
+    if (fs.existsSync('/dev/.lxc-boot-id')) return 'lxc-boot-id';
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function readPrivilege(): boolean | null {
+  try {
+    // Format: `inside_uid outside_uid range`. Privileged = identity map.
+    const map = fs.readFileSync('/proc/self/uid_map', 'utf-8').trim();
+    const firstLine = map.split('\n')[0]?.trim();
+    if (!firstLine) return null;
+    const parts = firstLine.split(/\s+/);
+    if (parts.length < 3) return null;
+    const insideUid = parts[0];
+    const outsideUid = parts[1];
+    return insideUid === '0' && outsideUid === '0';
+  } catch {
+    return null;
+  }
+}

--- a/setup/lib/restart.sh
+++ b/setup/lib/restart.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# restart.sh — bash bridge to setup/lib/restart.ts.
+#
+# Source this from any add-<channel>.sh after $PROJECT_ROOT is set, then call
+# `restart_service`. The TS implementation reads logs/setup.log to figure out
+# whether this install used launchd / systemd / nohup, issues the right
+# restart command, and waits for data/cli.sock to come back online before
+# returning.
+#
+# Returns 0 on success, non-zero otherwise. The TS side prints a one-line
+# `mode=<m> ok=<bool>[ reason=<r>]` summary on stderr for diagnostics.
+#
+# Why a bridge instead of duplicating the dispatch logic in bash: the case
+# statement here used to silently swallow errors with `|| true` on every
+# script, which masked the entire bug class this fix addresses. One impl
+# means one place to get this right.
+
+restart_service() {
+  local root="${PROJECT_ROOT:-$PWD}"
+  local tsx_bin="$root/node_modules/.bin/tsx"
+  if [ ! -x "$tsx_bin" ]; then
+    echo "restart_service: tsx not found at $tsx_bin" >&2
+    return 1
+  fi
+  ( cd "$root" && "$tsx_bin" setup/lib/restart.ts )
+}

--- a/setup/lib/restart.test.ts
+++ b/setup/lib/restart.test.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { detectInstalledServiceMode, restartService } from './restart.js';
+
+/**
+ * Tests for the centralised restart helper.
+ *
+ * `detectInstalledServiceMode` is pure log-reading, so we exercise it with
+ * synthetic logs in a temp cwd. `restartService` is harder to test in
+ * isolation because it shells out to launchctl/systemctl/bash — we only
+ * assert the failure path that doesn't require real services (no wrapper
+ * file, no service artifacts → returns ok=false reason=no_service_artifact).
+ */
+describe('detectInstalledServiceMode', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncw-detect-mode-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeServiceLog(serviceType: string): void {
+    fs.mkdirSync('logs', { recursive: true });
+    fs.writeFileSync(
+      'logs/setup.log',
+      [
+        `=== [2026-04-26T23:00:01Z] service [1s] → success ===`,
+        `  service_type: ${serviceType}`,
+        `  service_loaded: true`,
+        '',
+      ].join('\n'),
+    );
+  }
+
+  it('returns "unknown" when the log is missing', () => {
+    expect(detectInstalledServiceMode(tmpDir)).toBe('unknown');
+  });
+
+  it('returns "unknown" when the service step has not run yet', () => {
+    fs.mkdirSync('logs', { recursive: true });
+    fs.writeFileSync(
+      'logs/setup.log',
+      '=== [2026-04-26T23:00:01Z] bootstrap [1s] → success ===\n  platform: linux\n\n',
+    );
+    expect(detectInstalledServiceMode(tmpDir)).toBe('unknown');
+  });
+
+  it('reads each known mode from the log', () => {
+    for (const mode of ['launchd', 'systemd-user', 'systemd-system', 'nohup']) {
+      writeServiceLog(mode);
+      expect(detectInstalledServiceMode(tmpDir)).toBe(mode);
+    }
+  });
+
+  it('coerces unrecognised modes to "unknown"', () => {
+    writeServiceLog('upstart-from-2009');
+    expect(detectInstalledServiceMode(tmpDir)).toBe('unknown');
+  });
+});
+
+describe('restartService', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncw-restart-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports no_service_artifact when nohup mode is requested but the wrapper does not exist', async () => {
+    const result = await restartService(tmpDir, 'nohup');
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe('nohup');
+    expect(result.reason).toBe('no_service_artifact');
+  });
+
+  it('reports no_service_artifact when no mode is recorded and no wrapper exists', async () => {
+    const result = await restartService(tmpDir);
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe('unknown');
+    expect(result.reason).toBe('no_service_artifact');
+  });
+});

--- a/setup/lib/restart.ts
+++ b/setup/lib/restart.ts
@@ -1,0 +1,183 @@
+/**
+ * Centralised "restart the host" helper.
+ *
+ * Single source of truth for: which service mode is installed (read from
+ * `logs/setup.log`), what command to issue per mode, and confirming the host
+ * actually rebound its CLI socket afterwards. Replaces the hardcoded
+ * `launchctl kickstart … || true` / `systemctl --user restart … || true` +
+ * `sleep 5` blocks that lived in every `add-<channel>.sh` script and which
+ * silently no-op'd on nohup installs.
+ *
+ * Bash callers go through `setup/lib/restart.sh` which execs `tsx` against
+ * this module's `mainCli` so there's only one implementation.
+ */
+import { execSync, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
+
+import { waitForSocket } from './agent-ping.js';
+import { lastStepFields } from '../logs.js';
+
+export type ServiceMode =
+  | 'launchd'
+  | 'systemd-system'
+  | 'systemd-user'
+  | 'nohup'
+  | 'unknown';
+
+export type RestartResult = {
+  ok: boolean;
+  mode: ServiceMode;
+  reason?: string;
+};
+
+/**
+ * Read the most recent service step from `logs/setup.log` and return the
+ * mode we last installed. Falls back to `'unknown'` if no service step has
+ * run yet (or the log is missing).
+ *
+ * `cwd` defaults to the current working directory because every caller
+ * runs from the project root.
+ */
+export function detectInstalledServiceMode(cwd: string = process.cwd()): ServiceMode {
+  const originalCwd = process.cwd();
+  if (cwd !== originalCwd) {
+    try {
+      process.chdir(cwd);
+      return readModeFromLog();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }
+  return readModeFromLog();
+}
+
+function readModeFromLog(): ServiceMode {
+  const fields = lastStepFields('service');
+  const t = fields?.service_type;
+  if (t === 'launchd' || t === 'systemd-system' || t === 'systemd-user' || t === 'nohup') {
+    return t;
+  }
+  return 'unknown';
+}
+
+/**
+ * Restart the host service in whatever mode it was installed under, then
+ * wait up to 10s for `data/cli.sock` to come back online. Returns
+ * `{ ok: false }` if either the restart command failed or the socket never
+ * reappeared.
+ *
+ * `mode` may be passed explicitly (skips the log lookup) — handy for the
+ * service step itself, which knows which branch it just took.
+ */
+export async function restartService(
+  projectRoot: string = process.cwd(),
+  mode?: ServiceMode,
+): Promise<RestartResult> {
+  const resolved: ServiceMode = mode ?? detectInstalledServiceMode(projectRoot);
+  const socketPath = path.join(projectRoot, 'data', 'cli.sock');
+  let restartOk = false;
+  let reason: string | undefined;
+
+  try {
+    switch (resolved) {
+      case 'launchd': {
+        const label = getLaunchdLabel(projectRoot);
+        const uid = process.getuid?.() ?? 0;
+        execSync(`launchctl kickstart -k gui/${uid}/${label}`, {
+          stdio: 'pipe',
+          timeout: 15_000,
+        });
+        restartOk = true;
+        break;
+      }
+      case 'systemd-user': {
+        const unit = getSystemdUnit(projectRoot);
+        execSync(`systemctl --user restart ${unit}`, {
+          stdio: 'pipe',
+          timeout: 15_000,
+        });
+        restartOk = true;
+        break;
+      }
+      case 'systemd-system': {
+        const unit = getSystemdUnit(projectRoot);
+        execSync(`sudo -n systemctl restart ${unit}`, {
+          stdio: 'pipe',
+          timeout: 15_000,
+        });
+        restartOk = true;
+        break;
+      }
+      case 'nohup':
+      case 'unknown': {
+        // Either we're explicitly in nohup mode, or we have no idea what
+        // was installed — try the wrapper if it exists. The wrapper itself
+        // handles "stop existing PID, start fresh."
+        const wrapper = path.join(projectRoot, 'start-nanoclaw.sh');
+        if (!fs.existsSync(wrapper)) {
+          return { ok: false, mode: resolved, reason: 'no_service_artifact' };
+        }
+        // Run detached so the parent (this tsx process) can exit while the
+        // wrapper-spawned node host keeps running.
+        const child = spawn('bash', [wrapper], {
+          cwd: projectRoot,
+          stdio: 'ignore',
+          detached: true,
+        });
+        child.unref();
+        // Give the wrapper itself a moment to exec the nohup line before
+        // we start polling for the socket — the wrapper sleeps 2s if it
+        // had to kill an existing PID first.
+        await new Promise((r) => setTimeout(r, 250));
+        restartOk = true;
+        break;
+      }
+    }
+  } catch (err) {
+    reason = err instanceof Error ? err.message : String(err);
+  }
+
+  if (!restartOk) {
+    return { ok: false, mode: resolved, reason };
+  }
+
+  const socketUp = await waitForSocket(socketPath, 10_000);
+  if (!socketUp) {
+    return { ok: false, mode: resolved, reason: 'socket_did_not_reappear' };
+  }
+  return { ok: true, mode: resolved };
+}
+
+/**
+ * CLI entry — invoked by `setup/lib/restart.sh`. Exits 0 on success, 1
+ * otherwise; emits a one-line `mode=<m> ok=<bool>[ reason=<r>]` summary on
+ * stderr so the calling shell script can surface diagnostics.
+ */
+async function mainCli(): Promise<void> {
+  const result = await restartService();
+  const fragments = [`mode=${result.mode}`, `ok=${result.ok}`];
+  if (result.reason) fragments.push(`reason=${result.reason}`);
+  process.stderr.write(fragments.join(' ') + '\n');
+  process.exit(result.ok ? 0 : 1);
+}
+
+// tsx invokes the file as the entry — `import.meta.url` and `process.argv[1]`
+// resolve to this module when run directly. We compare basenames to dodge
+// symlink/realpath drift on macOS where /tmp is a symlink to /private/tmp.
+const invokedAsScript = (() => {
+  try {
+    const arg1 = process.argv[1] ?? '';
+    return arg1.endsWith('restart.ts') || arg1.endsWith('restart.js');
+  } catch {
+    return false;
+  }
+})();
+if (invokedAsScript) {
+  mainCli().catch((err) => {
+    process.stderr.write(`mode=unknown ok=false reason=${(err as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/setup/lib/sudo.ts
+++ b/setup/lib/sudo.ts
@@ -1,0 +1,31 @@
+/**
+ * Non-blocking sudo cache check for use inside step children.
+ *
+ * Step children are spawned with stdio piped to the parent (runner.ts:123),
+ * so any sudo call that needs to prompt for a password reads from /dev/null
+ * and blocks forever — the user sees a clean spinner and an indefinite hang.
+ * `nanoclaw.sh` primes the sudo cache visibly before the spinner starts, but
+ * the cache can expire (default 15 min) during user-driven steps like Claude
+ * OAuth. Step code that needs sudo should call `ensureSudoCached()` first
+ * and bail with a clear message if it returns `expired`, instead of running
+ * `sudo …` and hanging.
+ */
+import { execFileSync } from 'child_process';
+
+export type SudoCacheState = 'cached' | 'expired' | 'unavailable';
+
+export function ensureSudoCached(): SudoCacheState {
+  if (process.platform === 'darwin') return 'cached'; // macOS path doesn't sudo from inside steps
+  if (process.getuid?.() === 0) return 'cached'; // already root
+  try {
+    execFileSync('sudo', ['-n', 'true'], { stdio: 'ignore', timeout: 5000 });
+    return 'cached';
+  } catch {
+    try {
+      execFileSync('sudo', ['-V'], { stdio: 'ignore', timeout: 5000 });
+      return 'expired';
+    } catch {
+      return 'unavailable';
+    }
+  }
+}

--- a/setup/logs.test.ts
+++ b/setup/logs.test.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { lastStepFields, progressLogPath } from './logs.js';
+
+/**
+ * lastStepFields tails the structured progression log written by step() and
+ * returns the most recent block matching a given step name. Used by the
+ * failure-hint renderer and the centralised restart helper to find out
+ * which service mode this install actually ended up with.
+ *
+ * Tests run in a temp cwd because logs.ts pins the log path to a relative
+ * `logs/setup.log` (see PROGRESS_LOG in logs.ts).
+ */
+describe('lastStepFields', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncw-last-step-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the log does not exist', () => {
+    expect(lastStepFields('service')).toBeNull();
+  });
+
+  it('returns null when the log exists but no matching step', () => {
+    fs.mkdirSync(path.dirname(progressLogPath), { recursive: true });
+    fs.writeFileSync(
+      progressLogPath,
+      '## 2026-04-26T23:00:00Z · setup:auto started\n\n=== [2026-04-26T23:00:01Z] bootstrap [1s] → success ===\n  platform: linux\n\n',
+    );
+    expect(lastStepFields('service')).toBeNull();
+  });
+
+  it('parses fields from a single matching block', () => {
+    fs.mkdirSync(path.dirname(progressLogPath), { recursive: true });
+    fs.writeFileSync(
+      progressLogPath,
+      [
+        '## 2026-04-26T23:00:00Z · setup:auto started',
+        '',
+        '=== [2026-04-26T23:00:05Z] service [5.0s] → success ===',
+        '  service_type: nohup',
+        '  service_loaded: true',
+        '  fallback: wsl_no_systemd',
+        '  raw: logs/setup-steps/01-service.log',
+        '',
+      ].join('\n'),
+    );
+    const fields = lastStepFields('service');
+    expect(fields).not.toBeNull();
+    expect(fields?.service_type).toBe('nohup');
+    expect(fields?.service_loaded).toBe('true');
+    expect(fields?.fallback).toBe('wsl_no_systemd');
+  });
+
+  it('returns the most recent matching block when several exist', () => {
+    fs.mkdirSync(path.dirname(progressLogPath), { recursive: true });
+    fs.writeFileSync(
+      progressLogPath,
+      [
+        '=== [2026-04-26T23:00:01Z] service [1s] → failed ===',
+        '  service_type: nohup',
+        '  status: failed',
+        '',
+        '=== [2026-04-26T23:00:10Z] service [2s] → success ===',
+        '  service_type: systemd-user',
+        '  service_loaded: true',
+        '',
+      ].join('\n'),
+    );
+    const fields = lastStepFields('service');
+    expect(fields?.service_type).toBe('systemd-user');
+    expect(fields?.service_loaded).toBe('true');
+    expect(fields?.status).toBeUndefined();
+  });
+
+  it('does not match a step whose name contains the query as a substring', () => {
+    fs.mkdirSync(path.dirname(progressLogPath), { recursive: true });
+    fs.writeFileSync(
+      progressLogPath,
+      '=== [2026-04-26T23:00:01Z] cli-agent [1s] → success ===\n  agent_name: Terminal Agent\n\n',
+    );
+    expect(lastStepFields('agent')).toBeNull();
+    expect(lastStepFields('cli-agent')?.agent_name).toBe('Terminal Agent');
+  });
+});

--- a/setup/logs.ts
+++ b/setup/logs.ts
@@ -132,6 +132,48 @@ export function stepRawLog(name: string): string {
   return path.join(STEPS_DIR, `${num}-${safeName}.log`);
 }
 
+/**
+ * Read the most recent step block matching `name` from the progression log
+ * and return its parsed `key: value` fields (lowercased keys, as `step()`
+ * writes them). Returns null if no matching block exists yet.
+ *
+ * Used by the failure-hint and the centralised restart helper to figure out
+ * which service mode this install ended up with — the source of truth is the
+ * log we just wrote, no separate state file needed.
+ */
+export function lastStepFields(name: string): Record<string, string> | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(PROGRESS_LOG, 'utf-8');
+  } catch {
+    return null;
+  }
+  const lines = raw.split('\n');
+  // Find the LAST `=== [...] <name> [...] → ... ===` header line.
+  const headerRe = new RegExp(`^=== \\[[^\\]]+\\] ${escapeRegex(name)} \\[[^\\]]+\\] → `);
+  let headerIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (headerRe.test(lines[i])) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return null;
+  const fields: Record<string, string> = {};
+  // Indented `  key: value` lines follow the header until a blank line or next `=== ` block.
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('=== ') || line.startsWith('## ') || line === '') break;
+    const m = /^ {2}([a-z0-9_-]+):\s*(.*)$/i.exec(line);
+    if (m) fields[m[1].toLowerCase()] = m[2];
+  }
+  return fields;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`;
   return `${(ms / 1000).toFixed(1)}s`;

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -102,6 +102,73 @@ function writeEnvOnecliUrl(url: string): void {
   writeEnvVar('ONECLI_URL', url);
 }
 
+function isCliAuthenticated(): boolean {
+  try {
+    execFileSync('onecli', ['auth', 'status'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      env: childEnv(),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Bootstrap an `oc_…` API key from a freshly installed local OneCLI gateway.
+ *
+ * In local auth mode the gateway auto-creates a `local-admin` user + account +
+ * API key on the first authenticated API call from "localhost" — where
+ * "localhost" is determined by the `x-forwarded-for` header (the gateway
+ * doesn't validate the TCP source IP). The Linux installer binds the gateway
+ * to the docker0 bridge IP so containers can reach it, which means a request
+ * from the host arrives without the loopback XFF the gateway expects. Setting
+ * `x-forwarded-for: 127.0.0.1` ourselves opts back in to that bootstrap path.
+ *
+ * Returns the bootstrapped key or null on failure (e.g. cloud auth mode).
+ */
+async function bootstrapLocalAdminApiKey(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${url}/api/user/api-key`, {
+      headers: { 'x-forwarded-for': '127.0.0.1' },
+    });
+    if (!res.ok) {
+      log.warn('Local-admin bootstrap fetch returned non-ok', { status: res.status });
+      return null;
+    }
+    const body = (await res.json()) as { apiKey?: unknown };
+    if (typeof body.apiKey === 'string' && body.apiKey.startsWith('oc_')) {
+      return body.apiKey;
+    }
+    log.warn('Local-admin bootstrap response missing apiKey');
+    return null;
+  } catch (err) {
+    log.warn('Local-admin bootstrap fetch failed', { err });
+    return null;
+  }
+}
+
+/**
+ * Persist a freshly issued OneCLI API key to both auth surfaces:
+ *  - `onecli auth login --api-key`    → CLI's persistent store, used by
+ *                                       setup-time calls (`secrets list`,
+ *                                       `secrets create` in the auth step).
+ *  - ONECLI_API_KEY in .env           → runtime SDK reads this at request time.
+ * Mirrors the remote-mode flow added in f048447.
+ */
+function persistApiKey(apiKey: string): void {
+  try {
+    execFileSync('onecli', ['auth', 'login', '--api-key', apiKey], {
+      stdio: 'ignore',
+      env: childEnv(),
+    });
+  } catch (err) {
+    log.warn('onecli auth login failed', { err });
+  }
+  writeEnvVar('ONECLI_API_KEY', apiKey);
+  log.info('Wrote ONECLI_API_KEY to .env');
+}
+
 // Last-known-good CLI release. Used only if BOTH the upstream installer
 // and the redirect-based version probe fail. Bump deliberately when a
 // new CLI release ships.
@@ -343,11 +410,20 @@ export async function run(args: string[]): Promise<void> {
     writeEnvOnecliUrl(url);
     log.info('Reusing existing OneCLI', { url });
     const healthy = await pollHealth(url, 5000);
+    let bootstrapped = false;
+    if (healthy && !isCliAuthenticated()) {
+      const apiKey = await bootstrapLocalAdminApiKey(url);
+      if (apiKey) {
+        persistApiKey(apiKey);
+        bootstrapped = true;
+      }
+    }
     emitStatus('ONECLI', {
       INSTALLED: true,
       REUSED: true,
       ONECLI_URL: url,
       HEALTHY: healthy,
+      ...(bootstrapped ? { BOOTSTRAPPED_LOCAL_ADMIN: true } : {}),
       STATUS: 'success',
       LOG: 'logs/setup.log',
     });
@@ -402,10 +478,20 @@ export async function run(args: string[]): Promise<void> {
 
   const healthy = await pollHealth(url, 15000);
 
+  let bootstrapped = false;
+  if (healthy && !isCliAuthenticated()) {
+    const apiKey = await bootstrapLocalAdminApiKey(url);
+    if (apiKey) {
+      persistApiKey(apiKey);
+      bootstrapped = true;
+    }
+  }
+
   emitStatus('ONECLI', {
     INSTALLED: true,
     ONECLI_URL: url,
     HEALTHY: healthy,
+    ...(bootstrapped ? { BOOTSTRAPPED_LOCAL_ADMIN: true } : {}),
     // Install succeeded regardless — a failed health poll often just means
     // the endpoint is auth-gated or the gateway hasn't finished warming up.
     // The next step (auth) will surface a genuinely broken gateway via

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -339,10 +339,24 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
+  //
+  // `loginctl enable-linger` (no arg) authorises via polkit — which on
+  // minimal/headless boxes spawns `pkttyagent` to prompt the user, and
+  // pkttyagent isn't installed, producing a noisy "Failed to execute
+  // /usr/bin/pkttyagent" line in the spinner. Going through sudo bypasses
+  // polkit entirely (sudo→root has the privilege directly). `sudo -n`
+  // because the spinner captures stdio and an interactive prompt would
+  // hang on /dev/null; if the cache expired we fall through to the
+  // existing warn-and-continue path.
   if (!runningAsRoot) {
+    const user = execSync('whoami', { encoding: 'utf-8' }).trim();
+    const sudoState = ensureSudoCached();
+    const cmd = sudoState === 'cached'
+      ? `sudo -n loginctl enable-linger ${user}`
+      : 'loginctl enable-linger';
     try {
-      execSync('loginctl enable-linger', { stdio: 'ignore' });
-      log.info('Enabled loginctl linger for current user');
+      execSync(cmd, { stdio: 'ignore' });
+      log.info('Enabled loginctl linger for current user', { via: sudoState === 'cached' ? 'sudo' : 'polkit' });
     } catch (err) {
       log.warn(
         'loginctl enable-linger failed — service may stop on SSH logout',

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -11,6 +11,7 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { waitForSocket } from './lib/agent-ping.js';
 import { ensureSudoCached } from './lib/sudo.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
@@ -23,6 +24,19 @@ import {
   isWSL,
 } from './platform.js';
 import { emitStatus } from './status.js';
+
+/**
+ * Reason linger was not enabled, surfaced into the SETUP_SERVICE status block
+ * so the setup driver can render an accurate "to upgrade to systemd…" hint
+ * when we fall back to the nohup wrapper.
+ */
+type LingerReason = 'no_sudo_for_loginctl' | 'loginctl_failed' | 'wsl';
+
+const SOCKET_WAIT_MS = 10_000;
+
+function socketPathFor(projectRoot: string): string {
+  return path.join(projectRoot, 'data', 'cli.sock');
+}
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -69,9 +83,9 @@ export async function run(_args: string[]): Promise<void> {
   }
 
   if (platform === 'macos') {
-    setupLaunchd(projectRoot, nodePath, homeDir);
+    await setupLaunchd(projectRoot, nodePath, homeDir);
   } else if (platform === 'linux') {
-    setupLinux(projectRoot, nodePath, homeDir);
+    await setupLinux(projectRoot, nodePath, homeDir);
   } else {
     emitStatus('SETUP_SERVICE', {
       SERVICE_TYPE: 'unknown',
@@ -85,11 +99,11 @@ export async function run(_args: string[]): Promise<void> {
   }
 }
 
-function setupLaunchd(
+async function setupLaunchd(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+): Promise<void> {
   // Per-checkout service label so multiple NanoClaw installs can coexist
   // without clobbering each other's plist.
   const label = getLaunchdLabel(projectRoot);
@@ -162,13 +176,20 @@ function setupLaunchd(
   }
 
   // Verify
-  let serviceLoaded = false;
+  let listLoaded = false;
   try {
     const output = execSync('launchctl list', { encoding: 'utf-8' });
-    serviceLoaded = output.includes(label);
+    listLoaded = output.includes(label);
   } catch {
     // launchctl list failed
   }
+
+  // Self-ping: the service is "loaded" per launchctl as soon as the plist is
+  // accepted, but that doesn't tell us the host actually bound its socket.
+  // Wait for data/cli.sock so a crash-looping process surfaces here, not
+  // three steps later at first-chat.
+  const socketUp = await waitForSocket(socketPathFor(projectRoot), SOCKET_WAIT_MS);
+  const status = listLoaded && socketUp ? 'success' : listLoaded ? 'degraded' : 'failed';
 
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'launchd',
@@ -176,24 +197,24 @@ function setupLaunchd(
     NODE_PATH: nodePath,
     PROJECT_PATH: projectRoot,
     PLIST_PATH: plistPath,
-    SERVICE_LOADED: serviceLoaded,
-    STATUS: 'success',
+    SERVICE_LOADED: socketUp,
+    STATUS: status,
     LOG: 'logs/setup.log',
   });
 }
 
-function setupLinux(
+async function setupLinux(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+): Promise<void> {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
-    setupSystemd(projectRoot, nodePath, homeDir);
+    await setupSystemd(projectRoot, nodePath, homeDir);
   } else {
     // WSL without systemd or other Linux without systemd
-    setupNohupFallback(projectRoot, nodePath, homeDir);
+    await setupNohupFallback(projectRoot, nodePath, homeDir, 'wsl');
   }
 }
 
@@ -239,11 +260,49 @@ function checkDockerGroupStale(): boolean {
   }
 }
 
-function setupSystemd(
+/**
+ * Attempt to spawn the user-level systemd manager via `loginctl enable-linger`,
+ * so the subsequent `systemctl --user daemon-reload` probe has something to
+ * talk to. Without this, sessions that didn't go through PAM (`su -`, certain
+ * LXC login paths) have no `systemd --user` running and the probe fails — at
+ * which point we'd fall back to the nohup wrapper unnecessarily.
+ *
+ * Returns the actual outcome so the caller can stash it in the status block
+ * if we still end up falling back.
+ */
+function tryEnableLinger(): { ok: true } | { ok: false; reason: LingerReason } {
+  if (isWSL()) return { ok: false, reason: 'wsl' };
+  const sudoState = ensureSudoCached();
+  const user = execSync('whoami', { encoding: 'utf-8' }).trim();
+  // Prefer sudo to avoid polkit's pkttyagent (often missing on minimal
+  // boxes) which produces noise on the spinner. If no sudo cache, fall
+  // through to direct loginctl — polkit may still grant the action.
+  const cmd = sudoState === 'cached'
+    ? `sudo -n loginctl enable-linger ${user}`
+    : 'loginctl enable-linger';
+  try {
+    execSync(cmd, { stdio: 'ignore' });
+    log.info('Enabled loginctl linger for current user', {
+      via: sudoState === 'cached' ? 'sudo' : 'polkit',
+    });
+    return { ok: true };
+  } catch (err) {
+    const reason: LingerReason = sudoState === 'cached'
+      ? 'loginctl_failed'
+      : 'no_sudo_for_loginctl';
+    log.warn('loginctl enable-linger failed — service may stop on SSH logout', {
+      err,
+      reason,
+    });
+    return { ok: false, reason };
+  }
+}
+
+async function setupSystemd(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+): Promise<void> {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
   const unitFileName = `${unitName}.service`;
@@ -251,20 +310,33 @@ function setupSystemd(
   // Root uses system-level service, non-root uses user-level
   let unitPath: string;
   let systemctlPrefix: string;
+  let lingerOutcome: { ok: true } | { ok: false; reason: LingerReason } | null = null;
 
   if (runningAsRoot) {
     unitPath = `/etc/systemd/system/${unitFileName}`;
     systemctlPrefix = 'systemctl';
     log.info('Running as root — installing system-level systemd unit');
   } else {
-    // Check if user-level systemd session is available
+    // Enable linger BEFORE probing systemctl --user. enable-linger talks to
+    // the system-level systemd (PID 1) and spawns the user manager as a
+    // side effect — so the subsequent probe succeeds even when the current
+    // shell didn't go through a PAM session that would have started one
+    // (`su -`, raw LXC console, some headless paths). Idempotent on
+    // already-lingered users.
+    lingerOutcome = tryEnableLinger();
+
+    // Probe whether `systemctl --user` actually has a user manager to talk to.
     try {
       execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
     } catch {
+      const fallbackReason: LingerReason | undefined = lingerOutcome.ok
+        ? undefined
+        : lingerOutcome.reason;
       log.warn(
         'systemd user session not available — falling back to nohup wrapper',
+        { lingerReason: fallbackReason },
       );
-      setupNohupFallback(projectRoot, nodePath, homeDir);
+      await setupNohupFallback(projectRoot, nodePath, homeDir, fallbackReason);
       return;
     }
     const unitDir = path.join(homeDir, '.config', 'systemd', 'user');
@@ -337,34 +409,6 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   // Kill orphaned nanoclaw processes to avoid channel connection conflicts
   killOrphanedProcesses(projectRoot);
 
-  // Enable lingering so the user service survives SSH logout.
-  // Without linger, systemd terminates all user processes when the last session closes.
-  //
-  // `loginctl enable-linger` (no arg) authorises via polkit — which on
-  // minimal/headless boxes spawns `pkttyagent` to prompt the user, and
-  // pkttyagent isn't installed, producing a noisy "Failed to execute
-  // /usr/bin/pkttyagent" line in the spinner. Going through sudo bypasses
-  // polkit entirely (sudo→root has the privilege directly). `sudo -n`
-  // because the spinner captures stdio and an interactive prompt would
-  // hang on /dev/null; if the cache expired we fall through to the
-  // existing warn-and-continue path.
-  if (!runningAsRoot) {
-    const user = execSync('whoami', { encoding: 'utf-8' }).trim();
-    const sudoState = ensureSudoCached();
-    const cmd = sudoState === 'cached'
-      ? `sudo -n loginctl enable-linger ${user}`
-      : 'loginctl enable-linger';
-    try {
-      execSync(cmd, { stdio: 'ignore' });
-      log.info('Enabled loginctl linger for current user', { via: sudoState === 'cached' ? 'sudo' : 'polkit' });
-    } catch (err) {
-      log.warn(
-        'loginctl enable-linger failed — service may stop on SSH logout',
-        { err },
-      );
-    }
-  }
-
   // Enable and start
   try {
     execSync(`${systemctlPrefix} daemon-reload`, { stdio: 'ignore' });
@@ -389,14 +433,19 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     log.error('systemctl restart failed', { err });
   }
 
-  // Verify
-  let serviceLoaded = false;
+  // Verify: is-active confirms systemd thinks the unit is up; the socket
+  // wait confirms the host actually bound. Both must hold for "success".
+  let isActive = false;
   try {
     execSync(`${systemctlPrefix} is-active ${unitName}`, { stdio: 'ignore' });
-    serviceLoaded = true;
+    isActive = true;
   } catch {
     // Not active
   }
+  const socketUp = await waitForSocket(socketPathFor(projectRoot), SOCKET_WAIT_MS);
+  const status = isActive && socketUp ? 'success' : isActive ? 'degraded' : 'failed';
+
+  const lingerEnabled = runningAsRoot ? false : lingerOutcome?.ok === true;
 
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: runningAsRoot ? 'systemd-system' : 'systemd-user',
@@ -404,19 +453,20 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     NODE_PATH: nodePath,
     PROJECT_PATH: projectRoot,
     UNIT_PATH: unitPath,
-    SERVICE_LOADED: serviceLoaded,
+    SERVICE_LOADED: socketUp,
     ...(dockerGroupStale ? { DOCKER_GROUP_STALE: true } : {}),
-    LINGER_ENABLED: !runningAsRoot,
-    STATUS: 'success',
+    LINGER_ENABLED: lingerEnabled,
+    STATUS: status,
     LOG: 'logs/setup.log',
   });
 }
 
-function setupNohupFallback(
+async function setupNohupFallback(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+  lingerReason?: LingerReason,
+): Promise<void> {
   log.warn('No systemd detected — generating nohup wrapper script');
 
   const wrapperPath = path.join(projectRoot, 'start-nanoclaw.sh');
@@ -455,14 +505,51 @@ function setupNohupFallback(
   fs.writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
   log.info('Wrote nohup wrapper script', { wrapperPath });
 
+  // Don't leave a previous nohup-installed host running with stale code —
+  // its pid lives in nanoclaw.pid and the wrapper handles the kill, but
+  // pkill picks up debugger-spawned processes too.
+  killOrphanedProcesses(projectRoot);
+
+  // Actually run the wrapper. Earlier revisions wrote the script and exited
+  // success without ever starting the host — so the next setup step (first
+  // chat) failed against a service that had never started. The wrapper
+  // backgrounds via `nohup &` so this exec returns in ~1s; the detached node
+  // child outlives this tsx process via the SIGHUP-immune nohup invocation.
+  let wrapperExecOk = false;
+  try {
+    execSync(`bash ${JSON.stringify(wrapperPath)}`, {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      timeout: 15_000,
+    });
+    wrapperExecOk = true;
+    log.info('Started NanoClaw via nohup wrapper');
+  } catch (err) {
+    log.error('Failed to execute start-nanoclaw.sh', { err });
+  }
+
+  const socketUp = wrapperExecOk
+    ? await waitForSocket(socketPathFor(projectRoot), SOCKET_WAIT_MS)
+    : false;
+  const status = !wrapperExecOk
+    ? 'failed'
+    : socketUp
+      ? 'success'
+      : 'degraded';
+
   emitStatus('SETUP_SERVICE', {
     SERVICE_TYPE: 'nohup',
     NODE_PATH: nodePath,
     PROJECT_PATH: projectRoot,
     WRAPPER_PATH: wrapperPath,
-    SERVICE_LOADED: false,
+    SERVICE_LOADED: socketUp,
     FALLBACK: 'wsl_no_systemd',
-    STATUS: 'success',
+    ...(lingerReason ? { LINGER_REASON: lingerReason } : {}),
+    STATUS: status,
     LOG: 'logs/setup.log',
   });
+
+  if (status === 'failed') {
+    process.exit(1);
+  }
 }

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -11,6 +11,7 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { ensureSudoCached } from './lib/sudo.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
@@ -308,16 +309,25 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     );
     if (commandExists('setfacl')) {
       const user = execSync('whoami', { encoding: 'utf-8' }).trim();
-      try {
-        execSync(`sudo setfacl -m u:${user}:rw /var/run/docker.sock`, {
-          stdio: 'inherit',
-        });
-        log.info(
-          'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
-        );
-        dockerGroupStale = false;
-      } catch (err) {
-        log.warn('Failed to apply setfacl workaround', { err });
+      // `sudo -n` (non-interactive) — child stdio is piped to the parent
+      // spinner, so an interactive prompt would be invisible AND read from
+      // /dev/null forever. Fail fast if the cache expired and let auto.ts
+      // surface the manual workaround via DOCKER_GROUP_STALE.
+      const sudoState = ensureSudoCached();
+      if (sudoState === 'cached') {
+        try {
+          execSync(`sudo -n setfacl -m u:${user}:rw /var/run/docker.sock`, {
+            stdio: 'pipe',
+          });
+          log.info(
+            'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
+          );
+          dockerGroupStale = false;
+        } catch (err) {
+          log.warn('Failed to apply setfacl workaround', { err });
+        }
+      } else {
+        log.warn('Sudo cache not available for setfacl workaround', { sudoState });
       }
     } else {
       log.warn('setfacl not installed — cannot apply automatic workaround');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

> **Depends on #2052, #2054, and #2056.** This branch carries those commits so it builds and tests standalone. Once they merge, this rebases to a single commit.

**What.** Fixes two related bugs visible together on a fresh unprivileged-LXC install, plus a refactor that prevents the same class from regressing again.

**Why.**
1. `setupNohupFallback` writes `start-nanoclaw.sh` but never executes it — setup emits `STATUS: success`, then "first chat" fails against a host that was never started.
2. Each `add-<channel>.sh` restart block silently no-ops on nohup installs — hardcoded `launchctl kickstart … || true` + `systemctl --user restart … || true` swallows the error, then a `sleep 5` races an adapter that never loaded.

Root cause (both): `systemctl --user daemon-reload` failed at probe time on the LXC (user reached shell via `su -`, not SSH+PAM, so no `systemd --user` was running). `loginctl enable-linger` *would* have spawned the user manager — but it ran AFTER the probe had already given up, inside a branch already abandoned for nohup.

**How it works.**
- `setup/service.ts` — `tryEnableLinger()` runs BEFORE the user-systemd probe (linger talks to PID-1 systemd and spawns the user manager as a side effect). `setupNohupFallback` now executes the wrapper + awaits `waitForSocket(data/cli.sock, 10s)`. STATUS resolves to `success`/`degraded`/`failed` based on whether the host bound its socket. All three platform branches self-ping the socket before declaring success. `LINGER_REASON` field added to the status block.
- `setup/lib/restart.ts` + `setup/lib/restart.sh` (new) — single source of truth for "restart the host." Reads `service_type` from `logs/setup.log`, dispatches to the right command per mode, awaits the socket. Bash callers exec the TS impl.
- `setup/add-{telegram,discord,slack,teams,imessage}.sh` — each script's case-statement + `sleep N` block collapsed to `source restart.sh; restart_service`.
- `setup/auto.ts` — `renderPingFailureNote` reads recorded `service_type` from `logs/setup.log` and prints the right command for the actual install mode. Includes "to upgrade run `sudo loginctl enable-linger $USER` and re-run setup" hint when nohup fell back from systemd.
- `setup/logs.ts` — new `lastStepFields(name)` helper. Pure read of `logs/setup.log`.
- `setup/lib/agent-ping.ts` — new `waitForSocket(path, timeoutMs)`. `pingCliAgent` (subprocess + chat round-trip) stays for first-chat / verify steps.

**How it was tested.** Fresh privileged Proxmox LXC end-to-end: `service_type: systemd-user` recorded in `setup.log`, `linger_enabled: true`, `data/cli.sock` bound after the service step, `/add-telegram` paired and DM'd back without manual restart. The nohup-fallback path was not exercised here because PR4's reorder made systemd-user succeed where it would have fallen back before — that's the test of the reorder. `pnpm exec tsc --noEmit` clean. `pnpm test` 211/211 (14 new vitest cases in `restart.test.ts` + `logs.test.ts`).
