### PR TITLE
feat(sandbox): Docker Sandbox readiness (proxy, CA cert, DinD self-kill fix)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -16,6 +16,16 @@ FROM node:22-slim
 # CJK fonts add ~200MB. Opt in only if you render Chinese/Japanese/Korean text.
 ARG INSTALL_CJK_FONTS=false
 
+# Sandbox/proxy support: accept proxy build args so pnpm install succeeds
+# when the Docker Sandbox MITM proxy is active (HTTPS_PROXY env on the host).
+# Non-sandbox users: these default to empty and have no effect.
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG NODE_EXTRA_CA_CERTS
+ARG npm_config_strict_ssl=true
+RUN npm config set strict-ssl ${npm_config_strict_ssl}
+
 # Pin CLI versions for reproducibility. Bump deliberately — unpinned installs
 # mean every rebuild silently picks up the latest and can break in lockstep
 # across all users.
@@ -79,6 +89,10 @@ COPY agent-runner/package.json agent-runner/bun.lock ./
 
 RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install --frozen-lockfile
+
+# Restore strict-ssl after bun install (proxy build args set it to false).
+# Non-sandbox users: this is a no-op (strict-ssl was already true).
+RUN npm config set strict-ssl true
 
 # ---- pnpm + global Node CLIs -------------------------------------------------
 # Most stable first, most frequently bumped last. Bumping claude-code

--- a/container/build.sh
+++ b/container/build.sh
@@ -32,6 +32,18 @@ if [ "${INSTALL_CJK_FONTS:-false}" = "true" ]; then
     BUILD_ARGS+=(--build-arg INSTALL_CJK_FONTS=true)
 fi
 
+# Sandbox/proxy support: forward proxy env vars as build args so pnpm/npm
+# inside the image can reach the internet through the Docker Sandbox MITM proxy.
+# Gate on HTTPS_PROXY being set so non-sandbox users see no change.
+if [ -n "${HTTPS_PROXY:-$https_proxy}" ]; then
+    BUILD_ARGS+=(
+        --build-arg http_proxy="${http_proxy:-$HTTP_PROXY}"
+        --build-arg https_proxy="${https_proxy:-$HTTPS_PROXY}"
+        --build-arg no_proxy="${no_proxy:-$NO_PROXY}"
+        --build-arg npm_config_strict_ssl=false
+    )
+fi
+
 echo "Building NanoClaw agent container image..."
 echo "Image: ${IMAGE_NAME}:${TAG}"
 

--- a/docs/docker-sandboxes.md
+++ b/docs/docker-sandboxes.md
@@ -1,5 +1,7 @@
 # Running NanoClaw in Docker Sandboxes (Manual Setup)
 
+> **Fast path:** All six sandbox-readiness patches from this guide have already been applied on the [`sandbox-ready` branch of `ealeyner/nanoclaw`](https://github.com/ealeyner/nanoclaw/tree/sandbox-ready). Clone that branch and skip Steps 4a–4f — `pnpm install`, `pnpm run build`, and `bash container/build.sh` are all you need.
+
 This guide walks through setting up NanoClaw inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) from scratch — no install script, no pre-built fork. You'll clone the upstream repo, apply the necessary patches, and have agents running in full hypervisor-level isolation.
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "better-sqlite3": "11.10.0",
     "chat": "^4.24.0",
     "cron-parser": "5.5.0",
+    "https-proxy-agent": "^9.0.0",
     "kleur": "^4.1.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
+      https-proxy-agent:
+        specifier: ^9.0.0
+        version: 9.0.0
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -545,6 +548,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -828,6 +835,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  https-proxy-agent@9.0.0:
+    resolution: {integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==}
+    engines: {node: '>= 20'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -1898,6 +1909,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@9.0.0: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2200,6 +2213,13 @@ snapshots:
   globals@15.15.0: {}
 
   has-flag@4.0.0: {}
+
+  https-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -175,6 +175,22 @@ export async function run(args: string[]): Promise<void> {
     // .env is optional; absence is normal on a fresh checkout
   }
 
+  // Sandbox/proxy: forward proxy env vars as build args so pnpm/npm inside
+  // the image can reach the internet through the Docker Sandbox MITM proxy.
+  // Mirrors container/build.sh (step 4b). Gate on HTTPS_PROXY so
+  // non-sandbox users see no change.
+  if (process.env.HTTPS_PROXY || process.env.https_proxy) {
+    const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy || '';
+    const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy || '';
+    const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
+    buildArgs.push(
+      `--build-arg http_proxy=${httpProxy}`,
+      `--build-arg https_proxy=${httpsProxy}`,
+      `--build-arg no_proxy=${noProxy}`,
+      '--build-arg npm_config_strict_ssl=false',
+    );
+  }
+
   // Build — stdio inherit so the parent setup runner can tail docker's
   // per-step output and render it in a rolling window. Previously we used
   // execSync which buffered everything; users couldn't tell whether a

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -227,6 +227,21 @@ function resolveProviderContribution(
   return { provider, contribution };
 }
 
+/**
+ * Ensure an empty file exists at `data/empty.env` for use as a shadow mount.
+ * Docker Sandbox rejects `/dev/null` bind mounts; an empty regular file is
+ * the portable alternative. Non-sandbox users benefit too — the file is
+ * harmless and avoids the need for `/dev/null` workarounds in any caller.
+ */
+function ensureEmptyEnvFile(): string {
+  const emptyEnvPath = path.join(DATA_DIR, 'empty.env');
+  if (!fs.existsSync(emptyEnvPath)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(emptyEnvPath, '');
+  }
+  return emptyEnvPath;
+}
+
 function buildMounts(
   agentGroup: AgentGroup,
   session: Session,
@@ -317,6 +332,25 @@ function buildMounts(
   // Provider-contributed mounts (e.g. opencode-xdg)
   if (providerContribution.mounts) {
     mounts.push(...providerContribution.mounts);
+  }
+
+  // Sandbox/proxy: mount the MITM CA certificate so container processes
+  // can verify TLS through the proxy. Only when HTTPS_PROXY is set.
+  if (process.env.HTTPS_PROXY || process.env.https_proxy) {
+    const caCertPath =
+      process.env.NODE_EXTRA_CA_CERTS ||
+      process.env.SSL_CERT_FILE ||
+      '';
+    if (caCertPath && fs.existsSync(caCertPath)) {
+      // Copy to a stable path inside DATA_DIR so container can read it RO.
+      const destCaPath = path.join(DATA_DIR, 'sandbox-ca.crt');
+      fs.copyFileSync(caCertPath, destCaPath);
+      mounts.push({ hostPath: destCaPath, containerPath: '/etc/ssl/certs/sandbox-ca.crt', readonly: true });
+    }
+    // Ensure the empty.env sentinel exists (used to shadow .env if the project
+    // root is ever mounted). Docker Sandbox rejects /dev/null bind mounts;
+    // emptyEnvPath is the portable replacement.
+    ensureEmptyEnvFile();
   }
 
   return mounts;
@@ -431,6 +465,23 @@ async function buildContainerArgs(
   if (providerContribution.env) {
     for (const [key, value] of Object.entries(providerContribution.env)) {
       args.push('-e', `${key}=${value}`);
+    }
+  }
+
+  // Sandbox/proxy: forward proxy env vars so container outbound requests
+  // route through the Docker Sandbox MITM proxy. Gate on HTTPS_PROXY so
+  // non-sandbox users see no change.
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (httpsProxy) {
+    args.push('-e', `HTTPS_PROXY=${httpsProxy}`);
+    const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+    if (httpProxy) args.push('-e', `HTTP_PROXY=${httpProxy}`);
+    const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+    if (noProxy) args.push('-e', `NO_PROXY=${noProxy}`);
+    const caCertPath = process.env.NODE_EXTRA_CA_CERTS || process.env.SSL_CERT_FILE;
+    if (caCertPath) {
+      args.push('-e', 'NODE_EXTRA_CA_CERTS=/etc/ssl/certs/sandbox-ca.crt');
+      args.push('-e', 'SSL_CERT_FILE=/etc/ssl/certs/sandbox-ca.crt');
     }
   }
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -73,7 +73,15 @@ export function cleanupOrphans(): void {
         encoding: 'utf-8',
       },
     );
-    const orphans = output.trim().split('\n').filter(Boolean);
+    const orphans = output
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      // Sandbox/proxy: Docker Sandbox runs the host process inside a container
+      // whose name equals os.hostname(). Filter it out so cleanupOrphans never
+      // tries to stop the sandbox container itself (self-kill). Gated on
+      // HTTPS_PROXY so non-sandbox users see no change.
+      .filter((name) => !(process.env.HTTPS_PROXY || process.env.https_proxy) || name !== os.hostname());
     for (const name of orphans) {
       try {
         stopContainer(name);

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -1,0 +1,130 @@
+/**
+ * Credential proxy for container isolation.
+ * Containers connect here instead of directly to the Anthropic API.
+ * The proxy injects real credentials so containers never see them.
+ *
+ * Two auth modes:
+ *   API key:  Proxy injects x-api-key on every request.
+ *   OAuth:    Container CLI exchanges its placeholder token for a temp
+ *             API key via /api/oauth/claude_cli/create_api_key.
+ *             Proxy injects real OAuth token on that exchange request;
+ *             subsequent requests carry the temp key which is valid as-is.
+ *
+ * Sandbox/proxy support: when HTTPS_PROXY is set (Docker Sandbox environment),
+ * upstream requests are routed through the MITM proxy via HttpsProxyAgent.
+ * Non-sandbox users see no change (HTTPS_PROXY is unset).
+ */
+import { createServer, Server } from 'http';
+import { request as httpsRequest } from 'https';
+import { request as httpRequest, RequestOptions } from 'http';
+
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+import { readEnvFile } from './env.js';
+import { log } from './log.js';
+
+export type AuthMode = 'api-key' | 'oauth';
+
+export interface ProxyConfig {
+  authMode: AuthMode;
+}
+
+export function startCredentialProxy(port: number, host = '127.0.0.1'): Promise<Server> {
+  const secrets = readEnvFile([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_BASE_URL',
+  ]);
+
+  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+  const oauthToken = secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
+
+  const upstreamUrl = new URL(secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com');
+  const isHttps = upstreamUrl.protocol === 'https:';
+  const makeRequest = isHttps ? httpsRequest : httpRequest;
+
+  // Sandbox/proxy: route upstream requests through MITM proxy when HTTPS_PROXY
+  // is set (Docker Sandbox environment). Non-sandbox users: proxyUrl is
+  // undefined and agent is not created — no change in behaviour.
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy;
+  const upstreamAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
+
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        const body = Buffer.concat(chunks);
+        const headers: Record<string, string | number | string[] | undefined> = {
+          ...(req.headers as Record<string, string>),
+          host: upstreamUrl.host,
+          'content-length': body.length,
+        };
+
+        // Strip hop-by-hop headers that must not be forwarded by proxies
+        delete headers['connection'];
+        delete headers['keep-alive'];
+        delete headers['transfer-encoding'];
+
+        if (authMode === 'api-key') {
+          // API key mode: inject x-api-key on every request
+          delete headers['x-api-key'];
+          headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
+        } else {
+          // OAuth mode: replace placeholder Bearer token with the real one
+          // only when the container actually sends an Authorization header
+          // (exchange request + auth probes). Post-exchange requests use
+          // x-api-key only, so they pass through without token injection.
+          if (headers['authorization']) {
+            delete headers['authorization'];
+            if (oauthToken) {
+              headers['authorization'] = `Bearer ${oauthToken}`;
+            }
+          }
+        }
+
+        const upstream = makeRequest(
+          {
+            hostname: upstreamUrl.hostname,
+            port: upstreamUrl.port || (isHttps ? 443 : 80),
+            path: req.url,
+            method: req.method,
+            headers,
+            // Sandbox/proxy: agent is an HttpsProxyAgent when HTTPS_PROXY is
+            // set, undefined otherwise — standard https.request() handles both.
+            agent: upstreamAgent,
+          } as RequestOptions,
+          (upRes) => {
+            res.writeHead(upRes.statusCode!, upRes.headers);
+            upRes.pipe(res);
+          },
+        );
+
+        upstream.on('error', (err) => {
+          log.error('Credential proxy upstream error', { err, url: req.url });
+          if (!res.headersSent) {
+            res.writeHead(502);
+            res.end('Bad Gateway');
+          }
+        });
+
+        upstream.write(body);
+        upstream.end();
+      });
+    });
+
+    server.listen(port, host, () => {
+      log.info('Credential proxy started', { port, host, authMode });
+      resolve(server);
+    });
+
+    server.on('error', reject);
+  });
+}
+
+/** Detect which auth mode the host is configured for. */
+export function detectAuthMode(): AuthMode {
+  const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
+  return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
+}


### PR DESCRIPTION
Six patches to make NanoClaw run inside Docker Sandbox environments where a MITM proxy is active. All changes are gated on `HTTPS_PROXY` being set, so non-sandbox users see no behaviour change.

- `container/Dockerfile`: accept proxy build args; toggle `strict-ssl` during `bun install`
- `container/build.sh`: forward proxy env vars as `--build-arg` flags when `HTTPS_PROXY` is set
- `src/container-runner.ts`: forward proxy env vars to agent containers; mount MITM CA cert; add `ensureEmptyEnvFile()` helper (portable `/dev/null` replacement for Docker Sandbox)
- `src/container-runtime.ts`: filter `os.hostname()` from `cleanupOrphans()` to prevent self-kill inside DinD
- `src/credential-proxy.ts` (new): credential-injecting proxy with `HttpsProxyAgent` routing when `HTTPS_PROXY` is set
- `setup/container.ts`: mirror build.sh proxy `--build-arg` flags in the setup flow
- `docs/docker-sandboxes.md`: Fast path note pointing at this branch

Testing: `pnpm test` — 197 tests pass. `pnpm run build` — clean TypeScript compilation.