### PR TITLE
fix(agent-to-agent): cap routing volume to prevent self-loops and politeness loops

### DIFF
--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { isSafeAttachmentName } from './agent-route.js';
+import { checkAgentRouteRateLimit, isSafeAttachmentName, resetAgentRouteRateLimit } from './agent-route.js';
 
 /**
  * `forwardAttachedFiles` has a filesystem side that's awkward to unit-test
@@ -42,5 +42,96 @@ describe('isSafeAttachmentName', () => {
   it('rejects non-string input', () => {
     expect(isSafeAttachmentName(null as unknown as string)).toBe(false);
     expect(isSafeAttachmentName(undefined as unknown as string)).toBe(false);
+  });
+});
+
+/**
+ * Backstop for runaway agent-to-agent traffic. Two distinct loop classes
+ * are reachable from normal LLM behaviour:
+ *   - self-loop (agent writes to itself, post-approval-notes path)
+ *   - peer politeness loop (two agents reciprocate acks)
+ *
+ * Both are bounded here by a sliding window with separate self/peer caps.
+ */
+describe('checkAgentRouteRateLimit', () => {
+  const A = 'ag-aaa';
+  const B = 'ag-bbb';
+  const C = 'ag-ccc';
+
+  beforeEach(() => resetAgentRouteRateLimit());
+
+  it('allows a single peer route', () => {
+    expect(checkAgentRouteRateLimit(A, B).ok).toBe(true);
+  });
+
+  it('allows a single self route', () => {
+    expect(checkAgentRouteRateLimit(A, A).ok).toBe(true);
+  });
+
+  it('allows up to the self-route limit within the window', () => {
+    const t = 1000;
+    for (let i = 0; i < 3; i++) {
+      const r = checkAgentRouteRateLimit(A, A, t + i);
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('rejects the self-route over the limit within the window', () => {
+    const t = 1000;
+    for (let i = 0; i < 3; i++) checkAgentRouteRateLimit(A, A, t + i);
+    const r = checkAgentRouteRateLimit(A, A, t + 4);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.recent).toBe(3);
+      expect(r.limit).toBe(3);
+    }
+  });
+
+  it('allows up to the peer-route limit within the window', () => {
+    const t = 1000;
+    for (let i = 0; i < 10; i++) {
+      const r = checkAgentRouteRateLimit(A, B, t + i);
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('rejects the peer-route over the limit within the window', () => {
+    const t = 1000;
+    for (let i = 0; i < 10; i++) checkAgentRouteRateLimit(A, B, t + i);
+    const r = checkAgentRouteRateLimit(A, B, t + 11);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.recent).toBe(10);
+      expect(r.limit).toBe(10);
+    }
+  });
+
+  it('peer-route limit is looser than self-route limit', () => {
+    const t = 1000;
+    // Push 4 peer routes — past self-limit (3) but under peer-limit (10).
+    for (let i = 0; i < 4; i++) {
+      expect(checkAgentRouteRateLimit(A, B, t + i).ok).toBe(true);
+    }
+  });
+
+  it('resets after the window expires', () => {
+    const t = 1000;
+    for (let i = 0; i < 3; i++) checkAgentRouteRateLimit(A, A, t + i);
+    const r = checkAgentRouteRateLimit(A, A, t + 60_001);
+    expect(r.ok).toBe(true);
+  });
+
+  it('keeps separate counts per (from, to) pair', () => {
+    const t = 1000;
+    for (let i = 0; i < 3; i++) checkAgentRouteRateLimit(A, A, t + i);
+    expect(checkAgentRouteRateLimit(A, B, t + 4).ok).toBe(true);
+    expect(checkAgentRouteRateLimit(B, A, t + 4).ok).toBe(true);
+    expect(checkAgentRouteRateLimit(C, A, t + 4).ok).toBe(true);
+  });
+
+  it('A->B count is independent of B->A count', () => {
+    const t = 1000;
+    for (let i = 0; i < 10; i++) checkAgentRouteRateLimit(A, B, t + i);
+    expect(checkAgentRouteRateLimit(B, A, t + 11).ok).toBe(true);
   });
 });

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -120,6 +120,57 @@ export interface RoutableAgentMessage {
   content: string;
 }
 
+/**
+ * Rate-limit backstop for agent-to-agent routing.
+ *
+ * Without this, two failure modes are reachable from normal LLM behavior:
+ *   - **Self-loop.** Self-targets are intentionally allowed (line ~131) for
+ *     post-approval system notes. An agent that emits a self-targeted
+ *     message wakes its own container, which can emit another self-message,
+ *     and so on. Observed in production: ten self-messages in 40 s,
+ *     no useful output, agent broke the loop only by pattern-matching
+ *     "(silently waiting)" / "(no response)" responses.
+ *   - **Politeness loop.** Two bidirectionally wired agents reciprocate
+ *     each other's acknowledgements (reactions, "Ready", "Acknowledged"),
+ *     each acknowledgement waking the peer's container. Observed in
+ *     production: ~30 messages in 2 min, zero substantive content, the
+ *     user's actual question never answered.
+ *
+ * Self ceiling is tighter than peer ceiling because legitimate self-routes
+ * (post-approval system notes) are rare. Peer ceiling is loose enough for
+ * normal back-and-forth coordination but bounded.
+ *
+ * In-memory sliding window. Resets on host restart by design — this is a
+ * backstop against a transient bug, not durable policy.
+ */
+const A2A_RATE_LIMIT_WINDOW_MS = 60_000;
+const A2A_SELF_ROUTE_MAX = 3;
+const A2A_PEER_ROUTE_MAX = 10;
+const a2aRecentRoutes = new Map<string, number[]>();
+
+export function checkAgentRouteRateLimit(
+  fromId: string,
+  toId: string,
+  now: number = Date.now(),
+): { ok: true } | { ok: false; recent: number; limit: number } {
+  const key = `${fromId}->${toId}`;
+  const limit = fromId === toId ? A2A_SELF_ROUTE_MAX : A2A_PEER_ROUTE_MAX;
+  const cutoff = now - A2A_RATE_LIMIT_WINDOW_MS;
+  const recent = (a2aRecentRoutes.get(key) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= limit) {
+    a2aRecentRoutes.set(key, recent);
+    return { ok: false, recent: recent.length, limit };
+  }
+  recent.push(now);
+  a2aRecentRoutes.set(key, recent);
+  return { ok: true };
+}
+
+/** Test-only — reset rate-limit state between cases. */
+export function resetAgentRouteRateLimit(): void {
+  a2aRecentRoutes.clear();
+}
+
 export async function routeAgentMessage(msg: RoutableAgentMessage, session: Session): Promise<void> {
   const targetAgentGroupId = msg.platform_id;
   if (!targetAgentGroupId) {
@@ -135,6 +186,18 @@ export async function routeAgentMessage(msg: RoutableAgentMessage, session: Sess
   }
   if (!getAgentGroup(targetAgentGroupId)) {
     throw new Error(`target agent group ${targetAgentGroupId} not found for message ${msg.id}`);
+  }
+  const rl = checkAgentRouteRateLimit(session.agent_group_id, targetAgentGroupId);
+  if (!rl.ok) {
+    log.warn('agent-to-agent: rate limit exceeded, dropping', {
+      from: session.agent_group_id,
+      to: targetAgentGroupId,
+      msgId: msg.id,
+      recent: rl.recent,
+      limit: rl.limit,
+      selfRoute: session.agent_group_id === targetAgentGroupId,
+    });
+    return;
   }
   const { session: targetSession } = resolveSession(targetAgentGroupId, null, null, 'agent-shared');
   const a2aMsgId = `a2a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;


### PR DESCRIPTION
## Summary

`routeAgentMessage` accepts unbounded successive messages between the same source/target pair, including from an agent to itself. Two failure modes are reachable from normal LLM behaviour and have been observed in production.

**Self-loop.** Self-targets are intentionally allowed for the post-approval-notes path. Nothing constrains the volume, so an agent that emits one self-targeted message wakes its own container, which can emit another, and so on. Observed: ten self-messages in 40 s, no useful output, agent broke the loop only by pattern-matching `(silently waiting)` / `(no response)` responses against itself.

**Politeness loop.** Two bidirectionally wired agents reciprocate each other's acknowledgements (reactions, "Ready", "Acknowledged"). Each acknowledgement wakes the peer's container. Observed: ~30 messages in 2 min, zero substantive content, the user's actual question never answered.

## Fix

In-memory sliding window per `(from, to)` pair with separate caps:

- **Self-route:** 3 messages per 60 s. Tighter, because legitimate self-routes (post-approval system notes) are rare.
- **Peer-route:** 10 messages per 60 s. Loose enough for normal back-and-forth coordination but bounded.

Excess routes drop with a warn-level log. The window resets on host restart by design — this is a backstop against transient bugs, not durable policy. No new dependencies, no schema changes.

## Test plan

- [x] Existing `agent-route.test.ts` coverage unchanged
- [x] New tests cover: single message ok, self at limit, self over limit, peer at limit, peer over limit, peer limit looser than self, window expiry resets, separate counts per pair, directional asymmetry (A→B independent of B→A)
- [x] `pnpm test` — all 207 tests pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec prettier --check` — clean

## Open follow-ups (not in this PR)

Two adjacent issues surfaced during diagnosis. Filing as separate issues if maintainers want them:

1. `resolveSession(_, null, null, 'agent-shared')` returns mg-bound sessions, which splits an agent's context across parallel sessions when the agent is wired to multiple messaging groups. Visible symptom: agent-to-agent traffic lands in a different session than the one currently serving the user's chat. Needs design discussion before a PR.
2. The Claude provider surfaces compaction status (`Context compacted (N tokens compacted)`) as a user-visible reply. Cosmetic, one-line fix candidate.