### PR TITLE
feat(container): add configurable resource caps (--memory, --cpus, --pids-limit)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ Non-Chat-SDK channels (WhatsApp via Baileys, Gmail, custom integrations) impleme
 The host is an orchestrator:
 1. **Spawn** — when wakeUpAgent is called and no container exists for the session
 2. **Idle kill** — when a container has no unprocessed messages for some timeout period
-3. **Limits** — MAX_CONCURRENT_CONTAINERS caps active containers
+3. **Limits** — MAX_CONCURRENT_CONTAINERS caps active containers; per-container `--memory` / `--cpus` / `--pids-limit` (`CONTAINER_MEMORY`, `CONTAINER_CPUS`, `CONTAINER_PIDS_LIMIT`) cap individual agents — `0` disables a given cap
 
 When a container spins up, the agent-runner immediately starts polling its session DB. Messages are already there waiting.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,18 @@ export const INSTALL_SLUG = getInstallSlug(PROJECT_ROOT);
 export const CONTAINER_INSTALL_LABEL = `nanoclaw-install=${INSTALL_SLUG}`;
 export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10);
 export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
+
+// Per-container resource caps. Defend against runaway agents (LLM loops, fork
+// bombs, accidental Promise.all-of-shell-commands) taking out the whole host.
+// Set any value to `0` to disable that specific cap (Docker's unlimited convention).
+//   - CONTAINER_MEMORY: hard memory ceiling (Docker `--memory` syntax: `512m`, `1g`)
+//   - CONTAINER_CPUS:   CPU quota in fractional cores (`1`, `0.5`, `2`)
+//   - CONTAINER_PIDS_LIMIT: max processes/threads in cgroup; 512 leaves headroom
+//     for Chromium-via-agent-browser (renderer/GPU/network/utility) and build
+//     tool subprocesses while still defending against fork-bomb-class failures.
+export const CONTAINER_MEMORY = process.env.CONTAINER_MEMORY ?? '512m';
+export const CONTAINER_CPUS = process.env.CONTAINER_CPUS ?? '1';
+export const CONTAINER_PIDS_LIMIT = process.env.CONTAINER_PIDS_LIMIT ?? '512';
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveProviderName } from './container-runner.js';
+import { buildResourceLimitArgs, resolveProviderName } from './container-runner.js';
 
 describe('resolveProviderName', () => {
   it('prefers session over group and container.json', () => {
@@ -28,5 +28,39 @@ describe('resolveProviderName', () => {
   it('treats empty string as unset (falls through)', () => {
     expect(resolveProviderName('', 'codex', null)).toBe('codex');
     expect(resolveProviderName(null, '', 'opencode')).toBe('opencode');
+  });
+});
+
+describe('buildResourceLimitArgs', () => {
+  it('emits all three flags when all values are set', () => {
+    expect(buildResourceLimitArgs('512m', '1', '512')).toEqual([
+      '--memory',
+      '512m',
+      '--cpus',
+      '1',
+      '--pids-limit',
+      '512',
+    ]);
+  });
+
+  it('omits a flag when its value is "0" (Docker unlimited convention)', () => {
+    expect(buildResourceLimitArgs('0', '1', '512')).toEqual(['--cpus', '1', '--pids-limit', '512']);
+    expect(buildResourceLimitArgs('512m', '0', '512')).toEqual(['--memory', '512m', '--pids-limit', '512']);
+    expect(buildResourceLimitArgs('512m', '1', '0')).toEqual(['--memory', '512m', '--cpus', '1']);
+  });
+
+  it('omits a flag when its value is empty', () => {
+    expect(buildResourceLimitArgs('', '', '')).toEqual([]);
+  });
+
+  it('passes values through verbatim — runtime is the unit-validation authority', () => {
+    expect(buildResourceLimitArgs('1g', '0.5', '1024')).toEqual([
+      '--memory',
+      '1g',
+      '--cpus',
+      '0.5',
+      '--pids-limit',
+      '1024',
+    ]);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -10,9 +10,12 @@ import path from 'path';
 import { OneCLI } from '@onecli-sh/sdk';
 
 import {
+  CONTAINER_CPUS,
   CONTAINER_IMAGE,
   CONTAINER_IMAGE_BASE,
   CONTAINER_INSTALL_LABEL,
+  CONTAINER_MEMORY,
+  CONTAINER_PIDS_LIMIT,
   DATA_DIR,
   GROUPS_DIR,
   ONECLI_API_KEY,
@@ -412,6 +415,24 @@ function ensureRuntimeFields(
   }
 }
 
+/**
+ * Per-container resource caps (`--memory`, `--cpus`, `--pids-limit`).
+ *
+ * Each value is passed through to the Docker / Apple Container CLI as-is.
+ * `0` (or empty) is the documented escape hatch for "no cap" — we omit the
+ * flag entirely so the runtime applies its own default (i.e. unlimited),
+ * mirroring Docker's own convention. We don't try to validate units here:
+ * the runtime is the source of truth, and a malformed value should fail loud
+ * at container start rather than be silently coerced.
+ */
+export function buildResourceLimitArgs(memory: string, cpus: string, pidsLimit: string): string[] {
+  const args: string[] = [];
+  if (memory && memory !== '0') args.push('--memory', memory);
+  if (cpus && cpus !== '0') args.push('--cpus', cpus);
+  if (pidsLimit && pidsLimit !== '0') args.push('--pids-limit', pidsLimit);
+  return args;
+}
+
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
@@ -422,6 +443,11 @@ async function buildContainerArgs(
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+
+  // Resource caps — defend the host against runaway agents (LLM loops, fork
+  // bombs, accidental Promise.all-of-shell-commands). Tunable via env vars in
+  // config.ts; `0` per-flag disables that cap (Docker's unlimited convention).
+  args.push(...buildResourceLimitArgs(CONTAINER_MEMORY, CONTAINER_CPUS, CONTAINER_PIDS_LIMIT));
 
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #2029.

Each agent container previously ran with no resource caps, so a runaway agent could OOM the host, saturate all CPUs, or fork-bomb the PID space — taking down unrelated containers before reaping the offender. @kosm1x reported hitting this in production.

Adds three env vars in `config.ts` threaded through `buildContainerArgs`:

| Env var | Default |
|---|---|
| `CONTAINER_MEMORY` | `512m` |
| `CONTAINER_CPUS` | `1` |
| `CONTAINER_PIDS_LIMIT` | `512` |

Setting any value to `0` disables that specific cap (Docker's unlimited convention). `512` for `--pids-limit` (vs. the issue's initial 256) leaves headroom for Chromium-via-`agent-browser` and build-tool subprocesses — see the [#2029 thread](https://github.com/qwibitai/nanoclaw/issues/2029) for the discussion.

The flag-emitting helper is extracted as a pure function (`buildResourceLimitArgs`) so the omit-on-zero behavior is unit-testable.

**Compatibility:** existing installs implicitly relying on unlimited resources will start receiving the defaults. Per-flag `0` opt-out is the escape hatch.

## How it was tested

- `pnpm test` (201/201 pass)
- `pnpm run build` (tsc clean)
- Unit tests cover: all flags set, each flag omitted via `0`, all-empty input, verbatim pass-through of unit-suffixed values