### PR TITLE
feat(ollama): images field for multimodal models via inbox paths

### DIFF
--- a/container/agent-runner/src/ollama-helpers.test.ts
+++ b/container/agent-runner/src/ollama-helpers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the Ollama MCP wrapper's path resolution and body assembly.
+ *
+ * These helpers live in ollama-helpers.ts so they can be exercised without
+ * importing ollama-mcp-stdio.ts (that module starts the MCP server on load).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { resolveWorkspacePath, buildGenerateBody } from './ollama-helpers.js';
+
+let tmpRoot: string;
+const HI_BYTES = Buffer.from([0x68, 0x69]); // "hi"
+const HI_BASE64 = 'aGk=';
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ollama-helpers-'));
+  fs.mkdirSync(path.join(tmpRoot, 'inbox', 'abc'), { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, 'inbox', 'abc', 'photo.jpg'), HI_BYTES);
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveWorkspacePath', () => {
+  it('accepts a workspace-relative path', () => {
+    const out = resolveWorkspacePath('inbox/abc/photo.jpg', tmpRoot);
+    expect(out).toBe(path.join(tmpRoot, 'inbox/abc/photo.jpg'));
+  });
+
+  it('accepts an absolute path that already resolves under the workspace root', () => {
+    const abs = path.join(tmpRoot, 'inbox/abc/photo.jpg');
+    const out = resolveWorkspacePath(abs, tmpRoot);
+    expect(out).toBe(abs);
+  });
+
+  it('strips a leading "/workspace/" prefix so agents can pass paths verbatim from the formatter', () => {
+    // The formatter shows paths like "/workspace/inbox/<msgid>/<file>" to the
+    // agent. The resolver should accept that form even when the actual root
+    // (in tests) is elsewhere.
+    const out = resolveWorkspacePath('/workspace/inbox/abc/photo.jpg', tmpRoot);
+    expect(out).toBe(path.join(tmpRoot, 'inbox/abc/photo.jpg'));
+  });
+
+  it('rejects a relative path that escapes via ".."', () => {
+    expect(() => resolveWorkspacePath('../outside.txt', tmpRoot)).toThrow(/escapes workspace/);
+  });
+
+  it('rejects an absolute path outside the workspace root', () => {
+    // Use a path that definitely won't be inside macOS tmpdir
+    expect(() => resolveWorkspacePath('/var/empty/outside.txt', tmpRoot)).toThrow(/escapes workspace/);
+  });
+});
+
+describe('buildGenerateBody', () => {
+  it('omits images when the field is absent', () => {
+    const body = buildGenerateBody({ model: 'gemma3:4b', prompt: 'hi' }, tmpRoot);
+    expect(body).toEqual({ model: 'gemma3:4b', prompt: 'hi', stream: false });
+    expect('images' in body).toBe(false);
+  });
+
+  it('omits images when an empty array is passed', () => {
+    const body = buildGenerateBody({ model: 'gemma3:4b', prompt: 'hi', images: [] }, tmpRoot);
+    expect('images' in body).toBe(false);
+  });
+
+  it('includes a system prompt when provided', () => {
+    const body = buildGenerateBody(
+      { model: 'gemma3:4b', prompt: 'hi', system: 'you are terse' },
+      tmpRoot,
+    );
+    expect(body.system).toBe('you are terse');
+  });
+
+  it('reads each image path under the workspace and base64-encodes the bytes', () => {
+    const body = buildGenerateBody(
+      { model: 'gemma3:4b', prompt: 'describe', images: ['inbox/abc/photo.jpg'] },
+      tmpRoot,
+    );
+    expect(body.images).toEqual([HI_BASE64]);
+  });
+
+  it('encodes multiple images in order', () => {
+    fs.writeFileSync(path.join(tmpRoot, 'inbox', 'abc', 'second.jpg'), Buffer.from([0x6f, 0x6b])); // "ok"
+    const body = buildGenerateBody(
+      {
+        model: 'gemma3:4b',
+        prompt: 'compare',
+        images: ['inbox/abc/photo.jpg', 'inbox/abc/second.jpg'],
+      },
+      tmpRoot,
+    );
+    expect(body.images).toEqual([HI_BASE64, 'b2s=']);
+  });
+
+  it('propagates the workspace-escape error when an image path tries to break out', () => {
+    expect(() =>
+      buildGenerateBody(
+        { model: 'gemma3:4b', prompt: 'x', images: ['../outside.txt'] },
+        tmpRoot,
+      ),
+    ).toThrow(/escapes workspace/);
+  });
+});

--- a/container/agent-runner/src/ollama-helpers.ts
+++ b/container/agent-runner/src/ollama-helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for the Ollama MCP wrapper.
+ *
+ * Extracted so they can be unit-tested without importing ollama-mcp-stdio.ts
+ * (which starts the MCP server on load).
+ */
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_WORKSPACE_ROOT = '/workspace';
+const WORKSPACE_LITERAL_PREFIX = '/workspace/';
+
+/**
+ * Resolve a path that the agent passed (e.g. an inbox attachment) to an
+ * absolute path under `root`. Accepts:
+ *   - workspace-relative paths: "inbox/<msgid>/photo.jpg"
+ *   - absolute paths under the root
+ *   - paths verbatim from the formatter ("/workspace/inbox/<msgid>/photo.jpg")
+ *
+ * Throws if the resolved path would escape `root`.
+ */
+export function resolveWorkspacePath(p: string, root: string = DEFAULT_WORKSPACE_ROOT): string {
+  let cleaned = p;
+  if (cleaned === '/workspace') {
+    cleaned = '';
+  } else if (cleaned.startsWith(WORKSPACE_LITERAL_PREFIX)) {
+    cleaned = cleaned.slice(WORKSPACE_LITERAL_PREFIX.length);
+  }
+
+  const abs = path.resolve(root, cleaned);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    throw new Error(`path escapes workspace: ${p}`);
+  }
+  return abs;
+}
+
+export interface GenerateArgs {
+  model: string;
+  prompt: string;
+  system?: string;
+  images?: string[];
+}
+
+/**
+ * Build the JSON body for a POST /api/generate request, reading + base64-
+ * encoding any image files referenced by `images`. Pure relative to the
+ * filesystem at call time — no network calls.
+ */
+export function buildGenerateBody(
+  args: GenerateArgs,
+  root: string = DEFAULT_WORKSPACE_ROOT,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: args.model,
+    prompt: args.prompt,
+    stream: false,
+  };
+  if (args.system) {
+    body.system = args.system;
+  }
+  if (args.images && args.images.length > 0) {
+    body.images = args.images.map(p =>
+      fs.readFileSync(resolveWorkspacePath(p, root)).toString('base64'),
+    );
+  }
+  return body;
+}

--- a/container/agent-runner/src/ollama-mcp-stdio.ts
+++ b/container/agent-runner/src/ollama-mcp-stdio.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 
+import { buildGenerateBody } from './ollama-helpers.js';
+
 const OLLAMA_HOST = process.env.OLLAMA_HOST || 'http://host.docker.internal:11434';
 const OLLAMA_ADMIN_TOOLS = process.env.OLLAMA_ADMIN_TOOLS === 'true';
 const OLLAMA_STATUS_FILE = '/workspace/ipc/ollama_status.json';
@@ -88,24 +90,24 @@ server.tool(
 
 server.tool(
   'ollama_generate',
-  'Send a prompt to a local Ollama model and get a response. Good for cheaper/faster tasks like summarization, translation, or general queries. Use ollama_list_models first to see available models.',
+  'Send a prompt to a local Ollama model and get a response. Good for cheaper/faster tasks like summarization, translation, or general queries. Pass image files via the `images` field for multimodal models like gemma3 or llava. Use ollama_list_models first to see available models.',
   {
-    model: z.string().describe('The model name (e.g., "llama3.2", "mistral", "gemma2")'),
+    model: z.string().describe('The model name (e.g., "llama3.2", "mistral", "gemma3:4b")'),
     prompt: z.string().describe('The prompt to send to the model'),
     system: z.string().optional().describe('Optional system prompt to set model behavior'),
+    images: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Workspace-relative paths to image files for multimodal models (e.g. ["inbox/<msgid>/photo.jpg"]). Each path must resolve under /workspace; the wrapper reads the file and base64-encodes it before sending to Ollama.',
+      ),
   },
   async (args) => {
-    log(`>>> Generating with ${args.model} (${args.prompt.length} chars)...`);
+    const imageCount = args.images?.length ?? 0;
+    log(`>>> Generating with ${args.model} (${args.prompt.length} chars${imageCount > 0 ? `, ${imageCount} image${imageCount === 1 ? '' : 's'}` : ''})...`);
     writeStatus('generating', `Generating with ${args.model}`);
     try {
-      const body: Record<string, unknown> = {
-        model: args.model,
-        prompt: args.prompt,
-        stream: false,
-      };
-      if (args.system) {
-        body.system = args.system;
-      }
+      const body = buildGenerateBody(args);
 
       const res = await ollamaFetch('/api/generate', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- `ollama_generate` now accepts an optional `images` array of workspace-relative paths (e.g. `inbox/<msgid>/photo.jpg`) — the same form the formatter already shows the agent for attachments
- The wrapper resolves each path under `/workspace`, base64-encodes the bytes, and forwards them on `/api/generate`, so multimodal models like gemma3 / llava can analyze user attachments without any host-side plumbing changes
- Path resolution rejects `..` escapes and absolute paths outside `/workspace`
- Helpers extracted to `ollama-helpers.ts` with 11 unit tests so they're testable without booting the MCP server (the stdio module starts the server on import)

## Test plan
- [x] `bun test src/ollama-helpers.test.ts` — 11 passing
- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- [x] End-to-end on a real install: a multimodal Ollama model correctly described an attached image passed via `images: ['inbox/<msgid>/<file>']`
- [ ] Negative test: agent passes `../etc/hostname` as an image path → wrapper surfaces `path escapes workspace` error to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)