### PR TITLE
fix(self-mod): coerce MCP server args to string[] before write

### DIFF
--- a/container/agent-runner/src/mcp-tools/self-mod.test.ts
+++ b/container/agent-runner/src/mcp-tools/self-mod.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'bun:test';
+
+import { normalizeStringArray } from './self-mod.js';
+
+describe('normalizeStringArray (container side)', () => {
+  it('passes through a clean string array', () => {
+    expect(normalizeStringArray(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('parses a JSON-encoded array string (the issue #2051 case)', () => {
+    expect(normalizeStringArray('["@playwright/mcp@latest", "--browser=chromium"]')).toEqual([
+      '@playwright/mcp@latest',
+      '--browser=chromium',
+    ]);
+  });
+
+  it('treats a plain non-JSON string as a single-element array', () => {
+    expect(normalizeStringArray('--flag')).toEqual(['--flag']);
+  });
+
+  it('treats malformed JSON-looking strings as a single-element array', () => {
+    expect(normalizeStringArray('[unclosed')).toEqual(['[unclosed']);
+  });
+
+  it('drops non-string elements from arrays', () => {
+    expect(normalizeStringArray(['a', 1, null, 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('returns [] for undefined, null, numbers, and objects', () => {
+    expect(normalizeStringArray(undefined)).toEqual([]);
+    expect(normalizeStringArray(null)).toEqual([]);
+    expect(normalizeStringArray(42)).toEqual([]);
+    expect(normalizeStringArray({ args: ['a'] })).toEqual([]);
+  });
+});

--- a/container/agent-runner/src/mcp-tools/self-mod.ts
+++ b/container/agent-runner/src/mcp-tools/self-mod.ts
@@ -28,6 +28,36 @@ function ok(text: string) {
   return { content: [{ type: 'text' as const, text }] };
 }
 
+/**
+ * Defensive coercion for `args`. The MCP framework's input schema doesn't
+ * strictly reject string inputs, and the LLM occasionally hands us a JSON-
+ * encoded string instead of a real array. Normalize here so the system
+ * action row written below carries the right shape — the host re-coerces
+ * at the request and apply hops as well (issue #2051).
+ *
+ * Exported for unit tests.
+ */
+export function normalizeStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) {
+    return v.filter((x): x is string => typeof x === 'string');
+  }
+  if (typeof v === 'string') {
+    const trimmed = v.trim();
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((x): x is string => typeof x === 'string');
+        }
+      } catch {
+        // Fall through — treat as a single-element array below.
+      }
+    }
+    return [v];
+  }
+  return [];
+}
+
 function err(text: string) {
   return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
 }
@@ -107,7 +137,7 @@ export const addMcpServer: McpToolDefinition = {
         action: 'add_mcp_server',
         name,
         command,
-        args: (args.args as string[]) || [],
+        args: normalizeStringArray(args.args),
         env: (args.env as Record<string, string>) || {},
       }),
     });

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -17,6 +17,7 @@ import { getAgentGroup } from '../../db/agent-groups.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { ApprovalHandler } from '../approvals/index.js';
+import { normalizeStringArray } from './normalize.js';
 
 export const applyInstallPackages: ApprovalHandler = async ({ session, payload, userId, notify }) => {
   const agentGroup = getAgentGroup(session.agent_group_id);
@@ -74,7 +75,7 @@ export const applyAddMcpServer: ApprovalHandler = async ({ session, payload, use
   updateContainerConfig(agentGroup.folder, (cfg) => {
     cfg.mcpServers[payload.name as string] = {
       command: payload.command as string,
-      args: (payload.args as string[]) || [],
+      args: normalizeStringArray(payload.args),
       env: (payload.env as Record<string, string>) || {},
     };
   });

--- a/src/modules/self-mod/normalize.test.ts
+++ b/src/modules/self-mod/normalize.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+
+import { normalizeStringArray } from './normalize.js';
+
+describe('normalizeStringArray', () => {
+  it('passes through a clean string array', () => {
+    expect(normalizeStringArray(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns [] for an empty array', () => {
+    expect(normalizeStringArray([])).toEqual([]);
+  });
+
+  it('parses a JSON-encoded array string (the issue #2051 case)', () => {
+    expect(normalizeStringArray('["@playwright/mcp@latest", "--browser=chromium"]')).toEqual([
+      '@playwright/mcp@latest',
+      '--browser=chromium',
+    ]);
+  });
+
+  it('parses a JSON-encoded array string with leading/trailing whitespace', () => {
+    expect(normalizeStringArray('   ["x", "y"]   ')).toEqual(['x', 'y']);
+  });
+
+  it('treats a plain non-JSON string as a single-element array', () => {
+    expect(normalizeStringArray('--flag')).toEqual(['--flag']);
+  });
+
+  it('treats malformed JSON-looking strings as a single-element array', () => {
+    expect(normalizeStringArray('[unclosed')).toEqual(['[unclosed']);
+  });
+
+  it('drops non-string elements from an array', () => {
+    expect(normalizeStringArray(['a', 1, null, 'b', undefined, { x: 1 }])).toEqual(['a', 'b']);
+  });
+
+  it('drops non-string elements from a JSON-encoded array', () => {
+    expect(normalizeStringArray('["a", 1, null, "b"]')).toEqual(['a', 'b']);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(normalizeStringArray(undefined)).toEqual([]);
+  });
+
+  it('returns [] for null', () => {
+    expect(normalizeStringArray(null)).toEqual([]);
+  });
+
+  it('returns [] for a number', () => {
+    expect(normalizeStringArray(42)).toEqual([]);
+  });
+
+  it('returns [] for an object', () => {
+    expect(normalizeStringArray({ args: ['a', 'b'] })).toEqual([]);
+  });
+
+  it('returns [] for a JSON-encoded object string (not an array)', () => {
+    expect(normalizeStringArray('{"a": 1}')).toEqual(['{"a": 1}']);
+  });
+});

--- a/src/modules/self-mod/normalize.test.ts
+++ b/src/modules/self-mod/normalize.test.ts
@@ -54,7 +54,7 @@ describe('normalizeStringArray', () => {
     expect(normalizeStringArray({ args: ['a', 'b'] })).toEqual([]);
   });
 
-  it('returns [] for a JSON-encoded object string (not an array)', () => {
+  it('treats a JSON-encoded object string (not an array) as a single-element array', () => {
     expect(normalizeStringArray('{"a": 1}')).toEqual(['{"a": 1}']);
   });
 });

--- a/src/modules/self-mod/normalize.ts
+++ b/src/modules/self-mod/normalize.ts
@@ -1,0 +1,32 @@
+/**
+ * Defensive coercion for the MCP server `args` field.
+ *
+ * The MCP framework's input schema (`type: 'array', items: { type: 'string' }`)
+ * does not strictly reject string inputs, and the LLM occasionally hands us a
+ * JSON-encoded string instead of a real array. The TypeScript `as string[]`
+ * casts elsewhere are compile-time only, so a malformed value passes through
+ * to `container.json` and breaks every subsequent container start.
+ *
+ * Normalize at every hop: array → filtered array, JSON-encoded array string
+ * → parsed array, plain string → single-element array, anything else → [].
+ */
+export function normalizeStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) {
+    return v.filter((x): x is string => typeof x === 'string');
+  }
+  if (typeof v === 'string') {
+    const trimmed = v.trim();
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((x): x is string => typeof x === 'string');
+        }
+      } catch {
+        // Fall through — treat as a single-element array below.
+      }
+    }
+    return [v];
+  }
+  return [];
+}

--- a/src/modules/self-mod/request.ts
+++ b/src/modules/self-mod/request.ts
@@ -16,6 +16,7 @@ import { getAgentGroup } from '../../db/agent-groups.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { notifyAgent, requestApproval } from '../approvals/index.js';
+import { normalizeStringArray } from './normalize.js';
 
 export async function handleInstallPackages(content: Record<string, unknown>, session: Session): Promise<void> {
   const agentGroup = getAgentGroup(session.agent_group_id);
@@ -82,7 +83,7 @@ export async function handleAddMcpServer(content: Record<string, unknown>, sessi
     payload: {
       name: serverName,
       command,
-      args: (content.args as string[]) || [],
+      args: normalizeStringArray(content.args),
       env: (content.env as Record<string, string>) || {},
     },
     title: 'Add MCP Request',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #2051.

**What.** Normalize the `args` field of `add_mcp_server` to a real `string[]` at every hop so it can never reach `container.json` as a JSON-encoded string.

**Why.** The MCP framework's input schema (`type: 'array', items: { type: 'string' }`) doesn't strictly reject a stringified array, and the LLM occasionally passes one. The `as string[]` casts in the existing code are TypeScript-only — no runtime check — so a malformed value passes through. Once written, every subsequent agent wake fails with `Error: Claude Code process exited with code 1` because Claude Code's MCP config validation rejects the entry. Recovery requires a manual hand-edit of `container.json`.

**How it works.** A small `normalizeStringArray(v)` helper coerces the value:
- real `string[]` → filtered to drop non-strings
- JSON-encoded array string (`'["a", "b"]'`) → parsed and filtered
- plain string (`'--flag'`) → single-element array
- anything else (`null`, `undefined`, number, object) → `[]`

Applied at all three call sites:
- `container/agent-runner/src/mcp-tools/self-mod.ts` — container request hop (so the queued system action row is correct)
- `src/modules/self-mod/request.ts` — host request hop (so the approval card preview is correct)
- `src/modules/self-mod/apply.ts` — host apply hop (the load-bearing one — last hop before `container.json`)

The host helper lives in a new `src/modules/self-mod/normalize.ts`. The container side is inlined in `self-mod.ts` (the host and container don't share modules).

**How it was tested.**
- Added `normalize.test.ts` (vitest, 13 cases) and `self-mod.test.ts` (bun:test, 6 cases) covering: clean array, empty array, JSON-encoded array, JSON with whitespace, plain non-JSON string, malformed JSON-looking string, mixed-type array, JSON-encoded object string (not an array), `undefined`, `null`, number, object.
- `pnpm run build` clean.
- `tsc --noEmit` for the container tree clean.
- Full host suite (`pnpm test`): 210/210.
- Full container suite (`bun test`): 62/62.