### PR TITLE
fix(slack): receive standalone file uploads in channels

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -253,12 +253,14 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       // Chat SDK dispatch (handling-events.mdx §"Handler dispatch order") is
       // exclusive: subscribed → onSubscribedMessage; unsubscribed+mention →
       // onNewMention; unsubscribed+pattern-match → onNewMessage. Registering
-      // with `/./` lets the router see every plain message on every
-      // unsubscribed thread the bot can see. The router short-circuits via
-      // getMessagingGroupWithAgentCount (~1 DB read) for unwired channels,
-      // so forwarding every one is cheap enough to not need a bridge-side
-      // flood gate.
-      chat.onNewMessage(/./, async (thread, message) => {
+      // with `/^/` lets the router see every plain message on every
+      // unsubscribed thread the bot can see — including standalone file
+      // uploads where message.text is empty (`/./` would not match those,
+      // since `.` requires at least one character). The router short-circuits
+      // via getMessagingGroupWithAgentCount (~1 DB read) for unwired
+      // channels, so forwarding every one is cheap enough to not need a
+      // bridge-side flood gate.
+      chat.onNewMessage(/^/, async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
         await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, false, true));
       });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The chat-sdk bridge registered onNewMessage with /./ to "match every plain message" but `.` requires at least one character, so messages with empty text — notably standalone file uploads with no caption — were dropped at the chat-sdk dispatcher before reaching the router. Switch to /^/ which matches the empty string too.

DM, mention, and subscribed-thread paths were unaffected (they dispatch before pattern matching).
