### PR TITLE
fix: handle duplicate message ID in session DB insert

### DIFF
--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -102,14 +102,20 @@ export function insertMessage(
     trigger?: 0 | 1;
   },
 ): void {
-  db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
+  const trigger = message.trigger ?? 1;
+  const result = db.prepare(
+    `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
      VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger)`,
   ).run({
     ...message,
-    trigger: message.trigger ?? 1,
+    trigger,
     seq: nextEvenSeq(db),
   });
+  // If the row already existed and this write wants to wake the agent,
+  // escalate: flip trigger 0→1 so the message isn't silently swallowed.
+  if (result.changes === 0 && trigger === 1) {
+    db.prepare(`UPDATE messages_in SET trigger = 1 WHERE id = ? AND trigger = 0`).run(message.id);
+  }
 }
 
 export function countDueMessages(db: Database.Database): number {

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -8,6 +8,7 @@
 import Database from 'better-sqlite3';
 
 import { INBOUND_SCHEMA, OUTBOUND_SCHEMA } from './schema.js';
+import { log } from '../log.js';
 
 /** Apply the inbound or outbound schema to a DB file. Idempotent. */
 export function ensureSchema(dbPath: string, schema: 'inbound' | 'outbound'): void {
@@ -113,10 +114,11 @@ export function insertMessage(
       trigger,
       seq: nextEvenSeq(db),
     });
-  // If the row already existed and this write wants to wake the agent,
-  // escalate: flip trigger 0→1 so the message isn't silently swallowed.
-  if (result.changes === 0 && trigger === 1) {
-    db.prepare(`UPDATE messages_in SET trigger = 1 WHERE id = ? AND trigger = 0`).run(message.id);
+  if (result.changes === 0) {
+    log.warn('Duplicate message ID ignored', { id: message.id });
+    if (trigger === 1) {
+      db.prepare(`UPDATE messages_in SET trigger = 1 WHERE id = ? AND trigger = 0`).run(message.id);
+    }
   }
 }
 

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -103,14 +103,16 @@ export function insertMessage(
   },
 ): void {
   const trigger = message.trigger ?? 1;
-  const result = db.prepare(
-    `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
      VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger)`,
-  ).run({
-    ...message,
-    trigger,
-    seq: nextEvenSeq(db),
-  });
+    )
+    .run({
+      ...message,
+      trigger,
+      seq: nextEvenSeq(db),
+    });
   // If the row already existed and this write wants to wake the agent,
   // escalate: flip trigger 0→1 so the message isn't silently swallowed.
   if (result.changes === 0 && trigger === 1) {


### PR DESCRIPTION
## Summary

- `insertMessage` now uses `INSERT OR IGNORE` instead of `INSERT`, and escalates `trigger` from 0→1 when the row already exists

## Problem

When a new sender mentions the bot, some platforms deliver duplicate events for the same message. The first is dropped by the access gate (triggering an approval card), while the second gets accumulated into the session with `trigger=0`. On approval, the replay tries to insert the same message ID — `UNIQUE constraint failed` — and the sender never gets a reply.

## Fix

One change in `src/db/session-db.ts`: if the row already exists and the new write wants to wake the agent (`trigger=1`), flip the existing row's trigger from 0 to 1. No duplicate rows, no silent swallowing. Platform-agnostic.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` — 198/198 pass
- [x] End-to-end: new Slack user mentions bot → approval → single reply (tested 2x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)