### PR TITLE
fix(channels): strip :ag-<agentGroupId> suffix before adapter ops

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { Adapter } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, splitForLimit, stripAgentSuffix } from './chat-sdk-bridge.js';
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
@@ -33,6 +33,30 @@ describe('splitForLimit', () => {
     expect(chunks.length).toBe(Math.ceil(100 / 30));
     for (const c of chunks) expect(c.length).toBeLessThanOrEqual(30);
     expect(chunks.join('')).toBe(text);
+  });
+});
+
+describe('stripAgentSuffix', () => {
+  it('removes a trailing :ag-<id> namespace from a 3-part platform id', () => {
+    expect(stripAgentSuffix('74404502:233:ag-1700000000000-abc123')).toBe('74404502:233');
+  });
+
+  it('leaves a 2-part platform id untouched (Telegram chatId:messageId)', () => {
+    expect(stripAgentSuffix('74404502:233')).toBe('74404502:233');
+  });
+
+  it('leaves Discord 3-part guild:channel:message ids untouched (no ag- prefix on the tail)', () => {
+    expect(stripAgentSuffix('123456789:987654321:111222333')).toBe(
+      '123456789:987654321:111222333',
+    );
+  });
+
+  it('only strips the agent suffix, never an embedded ag- segment in the middle', () => {
+    expect(stripAgentSuffix('ag-foo:42:ag-bar')).toBe('ag-foo:42');
+  });
+
+  it('returns the input unchanged when there is no suffix at all', () => {
+    expect(stripAgentSuffix('plain-id')).toBe('plain-id');
   });
 });
 

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -101,6 +101,23 @@ function resolveSelectedOption(
   return candidate;
 }
 
+/**
+ * Strip the per-agent namespace suffix (`:ag-...`) from a stored `messages_in.id`
+ * before handing it to a Chat SDK adapter as a platform message ID.
+ *
+ * `router.ts:messageIdForAgent` appends `:<agent_group_id>` to the inbound
+ * platform id so the same message landing in N fanned-out session DBs gets N
+ * distinct primary keys. The agent later passes that 3-part id through
+ * `add_reaction` / `edit_message`, but adapters expect the raw 2-part platform
+ * id (e.g. Telegram's `chatId:messageId` regex `^([^:]+):(\d+)$`). Without
+ * stripping, Telegram's `setMessageReaction` falls back to misparsing the
+ * second segment as the message id and the API rejects with
+ * "Bad Request: message to react not found".
+ */
+export function stripAgentSuffix(messageId: string): string {
+  return messageId.replace(/:ag-[^:]+$/, '');
+}
+
 export function splitForLimit(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];
@@ -355,14 +372,18 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       const content = message.content as Record<string, unknown>;
 
       if (content.operation === 'edit' && content.messageId) {
-        await adapter.editMessage(tid, content.messageId as string, {
+        await adapter.editMessage(tid, stripAgentSuffix(content.messageId as string), {
           markdown: transformText((content.text as string) || (content.markdown as string) || ''),
         });
         return;
       }
 
       if (content.operation === 'reaction' && content.messageId && content.emoji) {
-        await adapter.addReaction(tid, content.messageId as string, content.emoji as string);
+        await adapter.addReaction(
+          tid,
+          stripAgentSuffix(content.messageId as string),
+          content.emoji as string,
+        );
         return;
       }
 


### PR DESCRIPTION
```
## Summary

`router.ts:messageIdForAgent` namespaces inbound platform message IDs by
appending `:<agent_group_id>` (an `ag-…` value) so fanned-out session DBs
don't collide on `messages_in.id`. The agent's `add_reaction` /
`edit_message` MCP tools later forward that 3-part ID through the bridge,
but Chat SDK adapters expect the original 2-part platform ID — Telegram's
`setMessageReaction` parses with `^([^:]+):(\d+)$` and rejects the 3-part
form with "Bad Request: message to react not found".

## Why

Currently `add_reaction` silently fails in Telegram group chats because
the 3-part ID makes the adapter's regex fall back to misparsing the second
segment as the message id. The same issue affects Discord-side
`editMessage` for any agent-fanned-out session.

## How it works

Adds a `stripAgentSuffix(messageId)` helper in
`src/channels/chat-sdk-bridge.ts` that removes a trailing `:ag-…` segment
(only that exact tail — embedded `ag-` segments and 3-part Discord IDs
without an `ag-` prefix on the tail are left untouched). Calls it at the
two `deliver` sites that hand a stored message id to an adapter:
`adapter.editMessage` (operation === 'edit') and `adapter.addReaction`
(operation === 'reaction').

The button-click handler at line ~288 (`adapter.editMessage(tid,
event.messageId, ...)`) is intentionally left alone — that ID comes from
the platform's gateway event for a card the bot itself sent and never
carries the agent suffix.

## How it was tested

Added `describe('stripAgentSuffix', …)` in `chat-sdk-bridge.test.ts`
covering 5 cases: 3-part ID with `:ag-` suffix gets stripped; 2-part
Telegram IDs untouched; 3-part Discord IDs (no `ag-` tail) untouched;
embedded `ag-` segment in the middle untouched; suffix-less plain IDs
untouched.

Closes #2042
```