### PR TITLE
v2 docs: update capability installer model

### DIFF
--- a/.claude/skills/update-skills/SKILL.md
+++ b/.claude/skills/update-skills/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: update-skills
-description: Check for and apply updates to installed skill branches from upstream.
+description: Check for and apply updates to installed branch-based capabilities from upstream.
 ---
 
 # About
 
-Skills are distributed as git branches (`skill/*`). When you install a skill, you merge its branch into your repo. This skill checks upstream for newer commits on those skill branches and helps you update.
+This skill updates branch-based capabilities that still live under `skill/*`.
+Channel installers copy files from `channels`, and provider installers copy
+files from `providers`; they are not detected by this workflow.
+
+When you install a branch-based capability, you merge its `skill/*` branch into
+your repo. This skill checks upstream for newer commits on those branches and
+helps you update.
 
 Run `/update-skills` in Claude Code.
 
@@ -13,7 +19,7 @@ Run `/update-skills` in Claude Code.
 
 **Preflight**: checks for clean working tree and upstream remote.
 
-**Detection**: fetches upstream, lists all `upstream/skill/*` branches, determines which ones you've previously merged (via merge-base), and checks if any have new commits.
+**Detection**: fetches upstream, lists all `upstream/skill/*` branches, determines which branch-based capabilities you've previously merged (via merge-base), and checks if any have new commits.
 
 **Selection**: presents a list of skills with available updates. You pick which to update.
 
@@ -26,7 +32,7 @@ Help users update their installed skill branches from upstream without losing lo
 
 # Operating principles
 - Never proceed with a dirty working tree.
-- Only offer updates for skills the user has already merged (installed).
+- Only offer updates for branch-based capabilities the user has already merged.
 - Use git-native operations. Do not manually rewrite files except conflict markers.
 - Keep token usage low: rely on `git` commands, only open files with actual conflicts.
 
@@ -65,13 +71,13 @@ For each `upstream/skill/<name>`:
 Build three lists:
 - **Updates available**: skills that are merged AND have new commits
 - **Up to date**: skills that are merged and have no new commits
-- **Not installed**: skills that have never been merged
+- **Not installed**: branch-based capabilities that have never been merged
 
 # Step 2: Present results
 
 If no skills have updates available:
 - Tell the user all installed skills are up to date. List them.
-- If there are uninstalled skills, mention them briefly (e.g., "3 other skills available in upstream that you haven't installed").
+- If there are uninstalled branch-based capabilities, mention them briefly (e.g., "3 other skill branches are available in upstream that you haven't installed").
 - Stop here.
 
 If updates are available:
@@ -80,7 +86,7 @@ If updates are available:
   skill/<name>: 3 new commits
   skill/<other>: 1 new commit
   ```
-- Also show skills that are up to date (for context).
+- Also show branch-based capabilities that are up to date (for context).
 - Use AskUserQuestion with `multiSelect: true` to let the user pick which skills to update.
   - One option per skill with updates, labeled with the skill name and commit count.
   - Add an option: "Skip — don't update any skills now"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 
 ## Skills
 
-NanoClaw uses [Claude Code skills](https://code.claude.com/docs/en/skills) — markdown files with optional supporting files that teach Claude how to do something. There are four types of skills in NanoClaw, each serving a different purpose.
+NanoClaw uses [Claude Code skills](https://code.claude.com/docs/en/skills) — markdown files with optional supporting files that teach Claude how to do something. Skills can modify the checkout, run maintenance workflows, or teach the runtime agent inside the container.
 
 ### Why skills?
 
@@ -29,28 +29,47 @@ Every user should have clean and minimal code that does exactly what they need. 
 
 ### Skill types
 
-#### 1. Feature skills (branch-based)
+#### 1. Channel and provider installer skills
 
-Add capabilities to NanoClaw by merging a git branch. The SKILL.md contains setup instructions; the actual code lives on a `skill/*` branch.
+Add optional channel adapters or agent providers to a user's checkout. The
+SKILL.md contains setup instructions; the source modules live on long-lived
+capability branches.
 
-**Location:** `.claude/skills/` on `main` (instructions only), code on `skill/*` branch
+**Location:** `.claude/skills/add-*/` on `main`; channel code on `channels`; provider code on `providers`
 
-**Examples:** `/add-telegram`, `/add-slack`, `/add-discord`, `/add-gmail`
+**Examples:** `/add-telegram`, `/add-slack`, `/add-discord`, `/add-codex`, `/add-opencode`
 
 **How they work:**
 1. User runs `/add-telegram`
-2. Claude follows the SKILL.md: fetches and merges the `skill/telegram` branch
-3. Claude walks through interactive setup (env vars, bot creation, etc.)
+2. Claude Code follows the SKILL.md: fetches `channels`, copies the Telegram-owned files, appends the registration import, installs pinned dependencies, and builds
+3. Claude walks through interactive setup and then hands off to `/manage-channels`
 
-**Contributing a feature skill:**
-1. Fork `qwibitai/nanoclaw` and branch from `main`
-2. Make the code changes (new files, modified source, updated `package.json`, etc.)
-3. Add a SKILL.md in `.claude/skills/<name>/` with setup instructions — step 1 should be merging the branch
-4. Open a PR. We'll create the `skill/<name>` branch from your work
+Provider installers follow the same pattern, but copy from `providers` and wire both host-side and container-side provider barrels.
 
-See `/add-telegram` for a good example. See [docs/skills-as-branches.md](docs/skills-as-branches.md) for the full system design.
+Installer skills are separate from NanoClaw's runtime agent provider. A user can install `/add-codex` with Claude Code and then run an agent group on the Codex provider.
 
-#### 2. Utility skills (with code files)
+**Contributing channel or provider support:**
+1. Put channel implementation changes on a branch based on `channels`, or provider implementation changes on a branch based on `providers`
+2. Put installer instructions and any core registry/infrastructure changes on a separate branch based on `main`
+3. Add or update `.claude/skills/add-<name>/SKILL.md` on the `main` branch PR
+4. Keep each PR scoped to the branch it targets: optional implementation code on `channels` or `providers`, installer and shared infrastructure on `main`
+
+See `/add-telegram`, `/add-discord`, `/add-codex`, or `/add-opencode` for current examples. See [docs/skills-as-branches.md](docs/skills-as-branches.md) for the current installer model.
+
+#### 2. Branch-based capability skills
+
+Some non-channel capabilities still use a `skill/*` branch when the capability is naturally represented as a branch merge.
+
+**Location:** `.claude/skills/<name>/` on `main`, code on `skill/<name>`
+
+**How they work:**
+1. User runs the skill
+2. Claude Code fetches and merges `upstream/skill/<name>`
+3. Claude validates the result and handles any setup
+
+Do not create channel-specific `skill/*` branches for normal channel adapters. Use `channels`. Do not create provider-specific `skill/*` branches for normal providers. Use `providers`.
+
+#### 3. Utility skills (with code files)
 
 Standalone tools that ship code files alongside the SKILL.md. The SKILL.md tells Claude how to install the tool; the code lives in the skill directory itself (e.g. in a `scripts/` subfolder).
 
@@ -58,14 +77,14 @@ Standalone tools that ship code files alongside the SKILL.md. The SKILL.md tells
 
 **Examples:** `/claw` (Python CLI in `scripts/claw`)
 
-**Key difference from feature skills:** No branch merge needed. The code is self-contained in the skill directory and gets copied into place during installation.
+**Key difference from branch-based capabilities:** No branch merge needed. The code is self-contained in the skill directory and gets copied into place during installation.
 
 **Guidelines:**
 - Put code in separate files, not inline in the SKILL.md
 - Use `${CLAUDE_SKILL_DIR}` to reference files in the skill directory
 - SKILL.md contains installation instructions, usage docs, and troubleshooting
 
-#### 3. Operational skills (instruction-only)
+#### 4. Operational skills (instruction-only)
 
 Workflows and guides with no code changes. The SKILL.md is the entire skill — Claude follows the instructions to perform a task.
 
@@ -78,7 +97,7 @@ Workflows and guides with no code changes. The SKILL.md is the entire skill — 
 - Use `AskUserQuestion` for interactive prompts
 - These stay on `main` and are always available to every user
 
-#### 4. Container skills (agent runtime)
+#### 5. Container skills (agent runtime)
 
 Skills that run inside the agent container, not on the host. These teach the container agent how to use tools, format output, or perform tasks. They are synced into each group's `.claude/skills/` directory when a container starts.
 

--- a/docs/BRANCH-FORK-MAINTENANCE.md
+++ b/docs/BRANCH-FORK-MAINTENANCE.md
@@ -1,81 +1,120 @@
-# Branch & Fork Maintenance Guidelines
+# Branch maintenance guidelines
 
-## Structure
+NanoClaw uses a small set of long-lived branches to keep optional capability
+code out of `main` while still making it easy for installer skills to copy or
+merge the pieces a user asks for.
 
-**`qwibitai/nanoclaw`** (upstream) — core engine with skill definitions (`.claude/skills/`). No channel code on `main`.
+## Branch roles
 
-**Channel forks** (`nanoclaw-whatsapp`, `nanoclaw-telegram`, `nanoclaw-slack`, etc.) — each fork = upstream + one channel's code applied. Users clone upstream, then merge a fork into their clone to add a channel.
+| Branch | Purpose |
+|---|---|
+| `main` | Core runtime, setup flow, registries, shared infrastructure, and installer skill definitions. |
+| `channels` | Channel adapters and channel-specific setup helpers. |
+| `providers` | Non-default agent providers and provider-specific host/container setup. |
+| `skill/*` | Residual branch-based capabilities that do not fit the `channels` or `providers` branches. |
 
-**`skill/*` and `feat/*` branches on upstream** — add features unrelated to channels (e.g. `skill/compact`, `skill/apple-container`). Users merge these into their clone to add capabilities. Channel-specific skill branches that duplicate the forks (e.g. `skill/whatsapp`, `skill/telegram`) are legacy.
+Do not maintain one fork per channel as the normal channel distribution model.
+Channel installers should copy modules from `channels`. Provider installers
+should copy modules from `providers`.
 
 ## How users add capabilities
 
+Users run Claude Code installer skills from `.claude/skills/`.
+
+```text
+/add-discord   -> copy Discord files from channels
+/add-telegram  -> copy Telegram files from channels
+/add-codex     -> copy Codex files from providers
+/add-opencode  -> copy OpenCode files from providers
+/add-compact   -> merge or apply the relevant skill capability
 ```
-user clones upstream main
-  ├── merges nanoclaw-whatsapp fork  → adds WhatsApp
-  ├── merges skill/compact branch    → adds /compact command
-  └── merges skill/apple-container   → switches to Apple Container
-```
+
+The installer skill is a repository-modification workflow. It is separate from
+the runtime provider selected for an agent group. A user can install
+`/add-codex` with Claude Code and then run an agent on the Codex provider.
 
 ## Merge directions
 
-```
-upstream main ──→ channel forks     (forward merge to keep forks caught up)
-upstream main ──→ skill branches    (forward merge to keep branches caught up)
+Long-lived capability branches should be kept current with `main`.
+
+```text
+main -> channels
+main -> providers
+main -> skill/*
 ```
 
-Forks and skill branches carry applied code changes. Users merge them into their own clones/forks to add capabilities. They are never merged back into upstream `main`.
+Use merge-forward, not rebase, for branches that users or installer skills may
+already rely on. Preserving history keeps later merges understandable and avoids
+rewriting branch ancestry.
 
 ## Forward merge procedure
 
+The examples below use `origin` for the canonical `qwibitai/nanoclaw` remote.
+If you are working from a fork, replace `origin` with the remote that points to
+`qwibitai/nanoclaw`, usually `upstream`, and push your PR branch to your fork.
+
 ```bash
-# In your local nanoclaw checkout
-git checkout main && git pull
-
-# For a fork:
-git fetch nanoclaw-whatsapp
-git checkout -B whatsapp-merge nanoclaw-whatsapp/main
-git merge main
-# Resolve conflicts (see below)
-# Remove upstream-only workflows (re-added by every merge since main has them):
-git rm .github/workflows/bump-version.yml .github/workflows/update-tokens.yml 2>/dev/null
-git push nanoclaw-whatsapp HEAD:main
-git checkout main && git branch -D whatsapp-merge
-
-# For a skill branch:
-git checkout -B skill/compact origin/skill/compact
-git merge main
-# Resolve conflicts (see below)
-git push origin skill/compact
-git checkout main && git branch -D skill/compact
+git fetch origin
+git checkout channels          # or providers / skill/<name>
+git merge origin/main
+# resolve conflicts
+pnpm run build
+pnpm test
+git push origin HEAD
 ```
+
+For provider changes, also run the container typecheck when provider files under
+`container/agent-runner/` are touched:
+
+```bash
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+```
+
+For channel changes, run the smallest channel-specific verification described in
+the relevant `.claude/skills/add-*/SKILL.md` file.
 
 ## Conflict resolution
 
-The same files conflict every time:
+Common conflict points:
 
 | File | Resolution |
-|------|------------|
-| `package.json` | Take main's version + keep fork/branch-specific deps |
-| `pnpm-lock.yaml` | `git checkout main -- pnpm-lock.yaml && pnpm install` |
-| `.env.example` | Combine: main's entries + fork/branch-specific entries |
-| `repo-tokens/badge.svg` | Take main's version (auto-generated) |
+|---|---|
+| `package.json` | Keep `main` changes and preserve capability-specific dependencies. |
+| `pnpm-lock.yaml` | Regenerate after resolving `package.json` rather than hand-editing. |
+| `container/agent-runner/package.json` / `bun.lock` | Keep provider-specific runtime deps and regenerate with the correct package manager. |
+| `src/channels/index.ts` | Preserve one self-registration import per installed channel module. |
+| `src/providers/index.ts` | Preserve one self-registration import per installed host provider. |
+| `container/agent-runner/src/providers/index.ts` | Preserve one self-registration import per installed container provider. |
+| `repo-tokens/badge.svg` | Take `main` unless the branch intentionally regenerated it. |
 
-Source code changes (e.g. `src/types.ts`, `src/index.ts`) usually auto-merge cleanly, but can conflict if both sides modify the same lines. **Always build and test after every forward merge** — auto-merged code can be silently wrong (e.g. referencing a renamed function or using a removed parameter) even when git reports no conflicts.
+Always build after resolving conflicts. A clean git merge can still be
+semantically wrong if a shared interface changed.
 
-## When to merge forward
+## Creating a new channel installer
 
-After any main change that touches shared files (`package.json`, `src/index.ts`, `CLAUDE.md`, etc.). Small frequent merges = trivial conflicts. Large infrequent merges = painful.
+1. Add the channel module and tests on `channels`.
+2. Add or update `.claude/skills/add-<channel>/SKILL.md` on `main`.
+3. The skill should fetch `channels`, copy only the owned channel files, append
+   the barrel import, install pinned dependencies, build, and hand off to
+   `/manage-channels`.
+4. Do not create a permanent channel fork as the distribution mechanism.
 
-## Fork setup
+## Creating a new provider installer
 
-When creating a new channel fork:
+1. Add host-side and container-side provider modules on `providers`.
+2. Add or update `.claude/skills/add-<provider>/SKILL.md` on `main`.
+3. The skill should fetch `providers`, copy only the owned provider files, append
+   both provider barrel imports, install pinned dependencies or CLIs, typecheck,
+   build, and rebuild the agent image.
 
-1. Fork `nanoclaw` to `nanoclaw-{channel}`
-2. Remove upstream-only workflows: `bump-version.yml`, `update-tokens.yml`
-3. Add channel code, deps, env vars
-4. Forward-merge main immediately to establish a clean baseline
+## Creating a `skill/*` capability branch
 
-## Dependencies
+Use `skill/*` only when the capability is not a normal channel or provider and
+is easier to maintain as a branch merge than as file copies. The installer skill
+must state exactly which branch it merges and how to validate the result.
 
-Forks and branches add their own deps on top of upstream's. When upstream adds or removes a dependency, verify that forks/branches still build after the next forward merge — transitive dependency changes can break downstream code.
+## User forks
+
+Users should still keep their own fork for personal customizations and backups.
+Those forks are not the channel distribution model. They are user-owned working
+copies where installer skills and local changes accumulate.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -128,7 +128,7 @@ A personal Claude assistant accessible via messaging, with minimal custom code.
 
 ### Channels
 - WhatsApp (baileys), Telegram (grammy), Discord (discord.js), Slack (@slack/bolt), Gmail (googleapis)
-- Each channel lives in a separate fork repo and is added via skills (e.g., `/add-whatsapp`, `/add-telegram`)
+- Channels live together on the `channels` branch and are copied into a user's fork by `/add-<channel>` skills (e.g., `/add-whatsapp`, `/add-telegram`)
 - Messages stored in SQLite, polled by router
 - Channels self-register at startup — unconfigured channels are skipped with a warning
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -499,7 +499,11 @@ The architecture is **flexible for code changes, not configurable for everything
 
 ### Code Structure for Skill Customization
 
-NanoClaw is customized via skills — branches that get merged into the user's installation. Different skills add different capabilities (channels, integrations, behaviors). The code must be structured so that:
+NanoClaw is customized via skills. Channel and provider installers copy owned
+files from the long-lived `channels` and `providers` branches; residual
+branch-based capabilities can still merge `skill/*` branches. Different skills
+add different capabilities (channels, integrations, behaviors). The code must be
+structured so that:
 
 1. **Different customizations don't conflict.** Adding Slack and adding Telegram should not produce merge conflicts. Adding a new MCP tool should not conflict with adding a channel. Each type of customization should touch its own file(s).
 

--- a/docs/skills-as-branches.md
+++ b/docs/skills-as-branches.md
@@ -1,677 +1,106 @@
-# Skills as Branches
+# Capability installer model
 
-## Overview
+This file keeps the old `skills-as-branches.md` path for existing links, but the
+model has changed. NanoClaw no longer treats every add-on as a dedicated
+`skill/*` branch, and channel-specific forks are not the intended maintenance
+model.
 
-This document covers **feature skills** — skills that add capabilities via git branch merges. This is the most complex skill type and the primary way NanoClaw is extended.
+## Current model
 
-NanoClaw has four types of skills overall. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full taxonomy:
+NanoClaw keeps the base checkout small. Installer skills add only the capability
+the user asks for.
 
-| Type | Location | How it works |
-|------|----------|-------------|
-| **Feature** (this doc) | `.claude/skills/` + `skill/*` branch | SKILL.md has instructions; code lives on a branch, applied via `git merge` |
-| **Utility** | `.claude/skills/<name>/` with code files | Self-contained tools; code in skill directory, copied into place on install |
-| **Operational** | `.claude/skills/` on `main` | Instruction-only workflows (setup, debug, update) |
-| **Container** | `container/skills/` | Loaded inside agent containers at runtime |
+| Source | Purpose |
+|---|---|
+| `main` | Core runtime, registries, setup flow, operational skills, and installer skill definitions. |
+| `channels` | Long-lived branch that stores channel adapter modules and channel setup helpers. |
+| `providers` | Long-lived branch that stores non-default agent provider modules. |
+| `skill/*` | Remaining branch-based capabilities when a normal branch merge is still the right shape. |
 
----
+## Installer skills are not runtime providers
 
-Feature skills are distributed as git branches on the upstream repository. Applying a skill is a `git merge`. Updating core is a `git merge`. Everything is standard git.
+Host-side installer skills live under `.claude/skills/` and are run by Claude
+Code in the user's checkout. They modify the repository: copy files, append
+self-registration imports, install dependencies, rebuild images, or merge a
+capability branch.
 
-This replaces the previous `skills-engine/` system (three-way file merging, `.nanoclaw/` state, manifest files, replay, backup/restore) with plain git operations and Claude for conflict resolution.
+The runtime provider is separate. After installation, an agent group can run on
+Claude, Codex, OpenCode, or another installed provider through the
+agent-runner's provider interface. Installing `/add-codex` or `/add-opencode`
+uses Claude Code as the repo-modification harness, but the resulting agent can
+run on Codex or OpenCode.
 
-## How It Works
+## Channel installer skills
 
-### Repository structure
+Channel skills such as `/add-discord`, `/add-telegram`, `/add-slack`, and
+`/add-whatsapp` copy the relevant module from the `channels` branch into the
+user's checkout. They then wire the adapter barrel, install pinned dependencies,
+and hand the user back to `/manage-channels` or setup.
 
-The upstream repo (`qwibitai/nanoclaw`) maintains:
-
-- `main` — core NanoClaw (no skill code)
-- `skill/discord` — main + Discord integration
-- `skill/telegram` — main + Telegram integration
-- `skill/slack` — main + Slack integration
-- `skill/gmail` — main + Gmail integration
-- etc.
-
-Each skill branch contains all the code changes for that skill: new files, modified source files, updated `package.json` dependencies, `.env.example` additions — everything. No manifest, no structured operations, no separate `add/` and `modify/` directories.
-
-### Skill discovery and installation
-
-Skills are split into two categories:
-
-**Operational skills** (on `main`, always available):
-- `/setup`, `/debug`, `/update-nanoclaw`, `/customize`, `/update-skills`
-- These are instruction-only SKILL.md files — no code changes, just workflows
-- Live in `.claude/skills/` on `main`, immediately available to every user
-
-**Feature skills** (in marketplace, installed on demand):
-- `/add-discord`, `/add-telegram`, `/add-slack`, `/add-gmail`, etc.
-- Each has a SKILL.md with setup instructions and a corresponding `skill/*` branch with code
-- Live in the marketplace repo (`qwibitai/nanoclaw-skills`)
-
-Users never interact with the marketplace directly. The operational skills `/setup` and `/customize` handle plugin installation transparently:
+Typical shape:
 
 ```bash
-# Claude runs this behind the scenes — users don't see it
-claude plugin install nanoclaw-skills@nanoclaw-skills --scope project
+git fetch origin channels
+git show origin/channels:src/channels/<channel>.ts > src/channels/<channel>.ts
+# append import './<channel>.js'; to src/channels/index.ts
+# install pinned channel dependency
+pnpm run build
 ```
 
-Skills are hot-loaded after `claude plugin install` — no restart needed. This means `/setup` can install the marketplace plugin, then immediately run any feature skill, all in one session.
+## Provider installer skills
 
-### Selective skill installation
+Provider skills such as `/add-codex` and `/add-opencode` copy host-side and
+container-side provider modules from the `providers` branch. They wire both
+provider barrels, install pinned runtime dependencies or CLIs, and rebuild the
+agent image.
 
-`/setup` asks users what channels they want, then only offers relevant skills:
-
-1. "Which messaging channels do you want to use?" → Discord, Telegram, Slack, WhatsApp
-2. User picks Telegram → Claude installs the plugin and runs `/add-telegram`
-3. After Telegram is set up: "Want to add Agent Swarm support for Telegram?" → offers `/add-telegram-swarm`
-4. "Want to enable community skills?" → installs community marketplace plugins
-
-Dependent skills (e.g., `telegram-swarm` depends on `telegram`) are only offered after their parent is installed. `/customize` follows the same pattern for post-setup additions.
-
-### Marketplace configuration
-
-NanoClaw's `.claude/settings.json` registers the official marketplace:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "nanoclaw-skills": {
-      "source": {
-        "source": "github",
-        "repo": "qwibitai/nanoclaw-skills"
-      }
-    }
-  }
-}
-```
-
-The marketplace repo uses Claude Code's plugin structure:
-
-```
-qwibitai/nanoclaw-skills/
-  .claude-plugin/
-    marketplace.json              # Plugin catalog
-  plugins/
-    nanoclaw-skills/              # Single plugin bundling all official skills
-      .claude-plugin/
-        plugin.json               # Plugin manifest
-      skills/
-        add-discord/
-          SKILL.md                # Setup instructions; step 1 is "merge the branch"
-        add-telegram/
-          SKILL.md
-        add-slack/
-          SKILL.md
-        ...
-```
-
-Multiple skills are bundled in one plugin — installing `nanoclaw-skills` makes all feature skills available at once. Individual skills don't need separate installation.
-
-Each SKILL.md tells Claude to merge the corresponding skill branch as step 1, then walks through interactive setup (env vars, bot creation, etc.).
-
-### Applying a skill
-
-User runs `/add-discord` (discovered via marketplace). Claude follows the SKILL.md:
-
-1. `git fetch upstream skill/discord`
-2. `git merge upstream/skill/discord`
-3. Interactive setup (create bot, get token, configure env vars, etc.)
-
-Or manually:
+Typical shape:
 
 ```bash
-git fetch upstream skill/discord
-git merge upstream/skill/discord
+git fetch origin providers
+git show origin/providers:src/providers/<provider>.ts > src/providers/<provider>.ts
+git show origin/providers:container/agent-runner/src/providers/<provider>.ts > container/agent-runner/src/providers/<provider>.ts
+# append provider imports to both barrels
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
 ```
 
-### Applying multiple skills
+These snippets match the current installer skills, which expect `origin` to
+contain NanoClaw's long-lived branches. In a forked checkout, use the remote that
+points to `qwibitai/nanoclaw` if the fork does not have those branches.
+
+## Branch-based capability skills
+
+Some non-channel capabilities still use `skill/*` branches. In that case the
+installer skill can still fetch and merge the branch:
 
 ```bash
-git merge upstream/skill/discord
-git merge upstream/skill/telegram
+git fetch upstream skill/<name>
+git merge upstream/skill/<name>
 ```
 
-Git handles the composition. If both skills modify the same lines, it's a real conflict and Claude resolves it.
+Use this only when a capability is naturally represented as a coordinated branch
+of changes. Do not create channel-specific `skill/*` branches for normal channel
+adapters; use the `channels` branch. Do not create provider-specific `skill/*`
+branches for normal providers; use the `providers` branch.
 
-### Updating core
+## Updating installed capabilities
 
-```bash
-git fetch upstream main
-git merge upstream/main
-```
+Installer skills should be idempotent. Re-running a channel or provider
+installer should:
 
-Since skill branches are kept merged-forward with main (see CI section), the user's merged-in skill changes and upstream changes have proper common ancestors.
+1. Check whether the expected files/imports/dependencies already exist.
+2. Copy or update only the owned files from `channels` or `providers`.
+3. Preserve user-owned configuration.
+4. Validate with the smallest relevant build or typecheck.
 
-### Checking for skill updates
+For branch-based `skill/*` capabilities, `/update-skills` can still detect and
+merge updates using git history.
 
-Users who previously merged a skill branch can check for updates. For each `upstream/skill/*` branch, check whether the branch has commits that aren't in the user's HEAD:
+## Legacy material
 
-```bash
-git fetch upstream
-for branch in $(git branch -r | grep 'upstream/skill/'); do
-  # Check if user has merged this skill at some point
-  merge_base=$(git merge-base HEAD "$branch" 2>/dev/null) || continue
-  # Check if the skill branch has new commits beyond what the user has
-  if ! git merge-base --is-ancestor "$branch" HEAD 2>/dev/null; then
-    echo "$branch has updates available"
-  fi
-done
-```
-
-This requires no state — it uses git history to determine which skills were previously merged and whether they have new commits.
-
-This logic is available in two ways:
-- Built into `/update-nanoclaw` — after merging main, optionally check for skill updates
-- Standalone `/update-skills` — check and merge skill updates independently
-
-### Conflict resolution
-
-At any merge step, conflicts may arise. Claude resolves them — reading the conflicted files, understanding the intent of both sides, and producing the correct result. This is what makes the branch approach viable at scale: conflict resolution that previously required human judgment is now automated.
-
-### Skill dependencies
-
-Some skills depend on other skills. E.g., `skill/telegram-swarm` requires `skill/telegram`. Dependent skill branches are branched from their parent skill branch, not from `main`.
-
-This means `skill/telegram-swarm` includes all of telegram's changes plus its own additions. When a user merges `skill/telegram-swarm`, they get both — no need to merge telegram separately.
-
-Dependencies are implicit in git history — `git merge-base --is-ancestor` determines whether one skill branch is an ancestor of another. No separate dependency file is needed.
-
-### Uninstalling a skill
-
-```bash
-# Find the merge commit
-git log --merges --oneline | grep discord
-
-# Revert it
-git revert -m 1 <merge-commit>
-```
-
-This creates a new commit that undoes the skill's changes. Claude can handle the whole flow.
-
-If the user has modified the skill's code since merging (custom changes on top), the revert might conflict — Claude resolves it.
-
-If the user later wants to re-apply the skill, they need to revert the revert first (git treats reverted changes as "already applied and undone"). Claude handles this too.
-
-## CI: Keeping Skill Branches Current
-
-A GitHub Action runs on every push to `main`:
-
-1. List all `skill/*` branches
-2. For each skill branch, merge `main` into it (merge-forward, not rebase)
-3. Run build and tests on the merged result
-4. If tests pass, push the updated skill branch
-5. If a skill fails (conflict, build error, test failure), open a GitHub issue for manual resolution
-
-**Why merge-forward instead of rebase:**
-- No force-push — preserves history for users who already merged the skill
-- Users can re-merge a skill branch to pick up skill updates (bug fixes, improvements)
-- Git has proper common ancestors throughout the merge graph
-
-**Why this scales:** With a few hundred skills and a few commits to main per day, the CI cost is trivial. Haiku is fast and cheap. The approach that wouldn't have been feasible a year or two ago is now practical because Claude can resolve conflicts at scale.
-
-## Installation Flow
-
-### New users (recommended)
-
-1. Fork `qwibitai/nanoclaw` on GitHub (click the Fork button)
-2. Clone your fork:
-   ```bash
-   git clone https://github.com/<you>/nanoclaw.git
-   cd nanoclaw
-   ```
-3. Run Claude Code:
-   ```bash
-   claude
-   ```
-4. Run `/setup` — Claude handles dependencies, authentication, container setup, service configuration, and adds `upstream` remote if not present
-
-Forking is recommended because it gives users a remote to push their customizations to. Clone-only works for trying things out but provides no remote backup.
-
-### Existing users migrating from clone
-
-Users who previously ran `git clone https://github.com/qwibitai/nanoclaw.git` and have local customizations:
-
-1. Fork `qwibitai/nanoclaw` on GitHub
-2. Reroute remotes:
-   ```bash
-   git remote rename origin upstream
-   git remote add origin https://github.com/<you>/nanoclaw.git
-   git push --force origin main
-   ```
-   The `--force` is needed because the fresh fork's main is at upstream's latest, but the user wants their (possibly behind) version. The fork was just created so there's nothing to lose.
-3. From this point, `origin` = their fork, `upstream` = qwibitai/nanoclaw
-
-### Existing users migrating from the old skills engine
-
-Users who previously applied skills via the `skills-engine/` system have skill code in their tree but no merge commits linking to skill branches. Git doesn't know these changes came from a skill, so merging a skill branch on top would conflict or duplicate.
-
-**For new skills going forward:** just merge skill branches as normal. No issue.
-
-**For existing old-engine skills**, two migration paths:
-
-**Option A: Per-skill reapply (keep your fork)**
-1. For each old-engine skill: identify and revert the old changes, then merge the skill branch fresh
-2. Claude assists with identifying what to revert and resolving any conflicts
-3. Custom modifications (non-skill changes) are preserved
-
-**Option B: Fresh start (cleanest)**
-1. Create a new fork from upstream
-2. Merge the skill branches you want
-3. Manually re-apply your custom (non-skill) changes
-4. Claude assists by diffing your old fork against the new one to identify custom changes
-
-In both cases:
-- Delete the `.nanoclaw/` directory (no longer needed)
-- The `skills-engine/` code will be removed from upstream once all skills are migrated
-- `/update-skills` only tracks skills applied via branch merge — old-engine skills won't appear in update checks
-
-## User Workflows
-
-### Custom changes
-
-Users make custom changes directly on their main branch. This is the standard fork workflow — their `main` IS their customized version.
-
-```bash
-# Make changes
-vim src/config.ts
-git commit -am "change trigger word to @Bob"
-git push origin main
-```
-
-Custom changes, skills, and core updates all coexist on their main branch. Git handles the three-way merging at each merge step because it can trace common ancestors through the merge history.
-
-### Applying a skill
-
-Run `/add-discord` in Claude Code (discovered via the marketplace plugin), or manually:
-
-```bash
-git fetch upstream skill/discord
-git merge upstream/skill/discord
-# Follow setup instructions for configuration
-git push origin main
-```
-
-If the user is behind upstream's main when they merge a skill branch, the merge might bring in some core changes too (since skill branches are merged-forward with main). This is generally fine — they get a compatible version of everything.
-
-### Updating core
-
-```bash
-git fetch upstream main
-git merge upstream/main
-git push origin main
-```
-
-This is the same as the existing `/update-nanoclaw` skill's merge path.
-
-### Updating skills
-
-Run `/update-skills` or let `/update-nanoclaw` check after a core update. For each previously-merged skill branch that has new commits, Claude offers to merge the updates.
-
-### Contributing back to upstream
-
-Users who want to submit a PR to upstream:
-
-```bash
-git fetch upstream main
-git checkout -b my-fix upstream/main
-# Make changes
-git push origin my-fix
-# Create PR from my-fix to qwibitai/nanoclaw:main
-```
-
-Standard fork contribution workflow. Their custom changes stay on their main and don't leak into the PR.
-
-## Contributing a Skill
-
-The flow below is for **feature skills** (branch-based). For utility skills (self-contained tools) and container skills, the contributor opens a PR that adds files directly to `.claude/skills/<name>/` or `container/skills/<name>/` — no branch extraction needed. See [CONTRIBUTING.md](../CONTRIBUTING.md) for all skill types.
-
-### Contributor flow (feature skills)
-
-1. Fork `qwibitai/nanoclaw`
-2. Branch from `main`
-3. Make the code changes (new channel file, modified integration points, updated package.json, .env.example additions, etc.)
-4. Open a PR to `main`
-
-The contributor opens a normal PR — they don't need to know about skill branches or marketplace repos. They just make code changes and submit.
-
-### Maintainer flow
-
-When a skill PR is reviewed and approved:
-
-1. Create a `skill/<name>` branch from the PR's commits:
-   ```bash
-   git fetch origin pull/<PR_NUMBER>/head:skill/<name>
-   git push origin skill/<name>
-   ```
-2. Force-push to the contributor's PR branch, replacing it with a single commit that adds the contributor to `CONTRIBUTORS.md` (removing all code changes)
-3. Merge the slimmed PR into `main` (just the contributor addition)
-4. Add the skill's SKILL.md to the marketplace repo (`qwibitai/nanoclaw-skills`)
-
-This way:
-- The contributor gets merge credit (their PR is merged)
-- They're added to CONTRIBUTORS.md automatically by the maintainer
-- The skill branch is created from their work
-- `main` stays clean (no skill code)
-- The contributor only had to do one thing: open a PR with code changes
-
-**Note:** GitHub PRs from forks have "Allow edits from maintainers" checked by default, so the maintainer can push to the contributor's PR branch.
-
-### Skill SKILL.md
-
-The contributor can optionally provide a SKILL.md (either in the PR or separately). This goes into the marketplace repo and contains:
-
-1. Frontmatter (name, description, triggers)
-2. Step 1: Merge the skill branch
-3. Steps 2-N: Interactive setup (create bot, get token, configure env vars, verify)
-
-If the contributor doesn't provide a SKILL.md, the maintainer writes one based on the PR.
-
-## Community Marketplaces
-
-Anyone can maintain their own fork with skill branches and their own marketplace repo. This enables a community-driven skill ecosystem without requiring write access to the upstream repo.
-
-### How it works
-
-A community contributor:
-
-1. Maintains a fork of NanoClaw (e.g., `alice/nanoclaw`)
-2. Creates `skill/*` branches on their fork with their custom skills
-3. Creates a marketplace repo (e.g., `alice/nanoclaw-skills`) with a `.claude-plugin/marketplace.json` and plugin structure
-
-### Adding a community marketplace
-
-If the community contributor is trusted, they can open a PR to add their marketplace to NanoClaw's `.claude/settings.json`:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "nanoclaw-skills": {
-      "source": {
-        "source": "github",
-        "repo": "qwibitai/nanoclaw-skills"
-      }
-    },
-    "alice-nanoclaw-skills": {
-      "source": {
-        "source": "github",
-        "repo": "alice/nanoclaw-skills"
-      }
-    }
-  }
-}
-```
-
-Once merged, all NanoClaw users automatically discover the community marketplace alongside the official one.
-
-### Installing community skills
-
-`/setup` and `/customize` ask users whether they want to enable community skills. If yes, Claude installs community marketplace plugins via `claude plugin install`:
-
-```bash
-claude plugin install alice-skills@alice-nanoclaw-skills --scope project
-```
-
-Community skills are hot-loaded and immediately available — no restart needed. Dependent skills are only offered after their prerequisites are met (e.g., community Telegram add-ons only after Telegram is installed).
-
-Users can also browse and install community plugins manually via `/plugin`.
-
-### Properties of this system
-
-- **No gatekeeping required.** Anyone can create skills on their fork without permission. They only need approval to be listed in the auto-discovered marketplaces.
-- **Multiple marketplaces coexist.** Users see skills from all trusted marketplaces in `/plugin`.
-- **Community skills use the same merge pattern.** The SKILL.md just points to a different remote:
-  ```bash
-  git remote add alice https://github.com/alice/nanoclaw.git
-  git fetch alice skill/my-cool-feature
-  git merge alice/skill/my-cool-feature
-  ```
-- **Users can also add marketplaces manually.** Even without being listed in settings.json, users can run `/plugin marketplace add alice/nanoclaw-skills` to discover skills from any source.
-- **CI is per-fork.** Each community maintainer runs their own CI to keep their skill branches merged-forward. They can use the same GitHub Action as the upstream repo.
-
-## Flavors
-
-A flavor is a curated fork of NanoClaw — a combination of skills, custom changes, and configuration tailored for a specific use case (e.g., "NanoClaw for Sales," "NanoClaw Minimal," "NanoClaw for Developers").
-
-### Creating a flavor
-
-1. Fork `qwibitai/nanoclaw`
-2. Merge in the skills you want
-3. Make custom changes (trigger word, prompts, integrations, etc.)
-4. Your fork's `main` IS the flavor
-
-### Installing a flavor
-
-During `/setup`, users are offered a choice of flavors before any configuration happens. The setup skill reads `flavors.yaml` from the repo (shipped with upstream, always up to date) and presents options:
-
-AskUserQuestion: "Start with a flavor or default NanoClaw?"
-- Default NanoClaw
-- NanoClaw for Sales — Gmail + Slack + CRM (maintained by alice)
-- NanoClaw Minimal — Telegram-only, lightweight (maintained by bob)
-
-If a flavor is chosen:
-
-```bash
-git remote add <flavor-name> https://github.com/alice/nanoclaw.git
-git fetch <flavor-name> main
-git merge <flavor-name>/main
-```
-
-Then setup continues normally (dependencies, auth, container, service).
-
-**This choice is only offered on a fresh fork** — when the user's main matches or is close to upstream's main with no local commits. If `/setup` detects significant local changes (re-running setup on an existing install), it skips the flavor selection and goes straight to configuration.
-
-After installation, the user's fork has three remotes:
-- `origin` — their fork (push customizations here)
-- `upstream` — `qwibitai/nanoclaw` (core updates)
-- `<flavor-name>` — the flavor fork (flavor updates)
-
-### Updating a flavor
-
-```bash
-git fetch <flavor-name> main
-git merge <flavor-name>/main
-```
-
-The flavor maintainer keeps their fork updated (merging upstream, updating skills). Users pull flavor updates the same way they pull core updates.
-
-### Flavors registry
-
-`flavors.yaml` lives in the upstream repo:
-
-```yaml
-flavors:
-  - name: NanoClaw for Sales
-    repo: alice/nanoclaw
-    description: Gmail + Slack + CRM integration, daily pipeline summaries
-    maintainer: alice
-
-  - name: NanoClaw Minimal
-    repo: bob/nanoclaw
-    description: Telegram-only, no container overhead
-    maintainer: bob
-```
-
-Anyone can PR to add their flavor. The file is available locally when `/setup` runs since it's part of the cloned repo.
-
-### Discoverability
-
-- **During setup** — flavor selection is offered as part of the initial setup flow
-- **`/browse-flavors` skill** — reads `flavors.yaml` and presents options at any time
-- **GitHub topics** — flavor forks can tag themselves with `nanoclaw-flavor` for searchability
-- **Discord / website** — community-curated lists
-
-## Migration
-
-Migration from the old skills engine to branches is complete. All feature skills now live on `skill/*` branches, and the skills engine has been removed.
-
-### Skill branches
-
-| Branch | Base | Description |
-|--------|------|-------------|
-| `skill/whatsapp` | `main` | WhatsApp channel |
-| `skill/telegram` | `main` | Telegram channel |
-| `skill/slack` | `main` | Slack channel |
-| `skill/discord` | `main` | Discord channel |
-| `skill/gmail` | `main` | Gmail channel |
-| `skill/voice-transcription` | `skill/whatsapp` | OpenAI Whisper voice transcription |
-| `skill/image-vision` | `skill/whatsapp` | Image attachment processing |
-| `skill/pdf-reader` | `skill/whatsapp` | PDF attachment reading |
-| `skill/local-whisper` | `skill/voice-transcription` | Local whisper.cpp transcription |
-| `skill/ollama-tool` | `main` | Ollama MCP server for local models |
-| `skill/apple-container` | `main` | Apple Container runtime |
-| `skill/reactions` | `main` | WhatsApp emoji reactions |
-
-### What was removed
-
-- `skills-engine/` directory (entire engine)
-- `scripts/apply-skill.ts`, `scripts/uninstall-skill.ts`, `scripts/rebase.ts`
-- `scripts/fix-skill-drift.ts`, `scripts/validate-all-skills.ts`
-- `.github/workflows/skill-drift.yml`, `.github/workflows/skill-pr.yml`
-- All `add/`, `modify/`, `tests/`, and `manifest.yaml` from skill directories
-- `.nanoclaw/` state directory
-
-Operational skills (`setup`, `debug`, `update-nanoclaw`, `customize`, `update-skills`) remain on main in `.claude/skills/`.
-
-## What Changes
-
-### README Quick Start
-
-Before:
-```bash
-git clone https://github.com/qwibitai/NanoClaw.git
-cd NanoClaw
-claude
-```
-
-After:
-```
-1. Fork qwibitai/nanoclaw on GitHub
-2. git clone https://github.com/<you>/nanoclaw.git
-3. cd nanoclaw
-4. claude
-5. /setup
-```
-
-### Setup skill (`/setup`)
-
-Updates to the setup flow:
-
-- Check if `upstream` remote exists; if not, add it: `git remote add upstream https://github.com/qwibitai/nanoclaw.git`
-- Check if `origin` points to the user's fork (not qwibitai). If it points to qwibitai, guide them through the fork migration.
-- **Install marketplace plugin:** `claude plugin install nanoclaw-skills@nanoclaw-skills --scope project` — makes all feature skills available (hot-loaded, no restart)
-- **Ask which channels to add:** present channel options (Discord, Telegram, Slack, WhatsApp, Gmail), run corresponding `/add-*` skills for selected channels
-- **Offer dependent skills:** after a channel is set up, offer relevant add-ons (e.g., Agent Swarm after Telegram, voice transcription after WhatsApp)
-- **Optionally enable community marketplaces:** ask if the user wants community skills, install those marketplace plugins too
-
-### `.claude/settings.json`
-
-Marketplace configuration so the official marketplace is auto-registered:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "nanoclaw-skills": {
-      "source": {
-        "source": "github",
-        "repo": "qwibitai/nanoclaw-skills"
-      }
-    }
-  }
-}
-```
-
-### Skills directory on main
-
-The `.claude/skills/` directory on `main` retains only operational skills (setup, debug, update-nanoclaw, customize, update-skills). Feature skills (add-discord, add-telegram, etc.) live in the marketplace repo, installed via `claude plugin install` during `/setup` or `/customize`.
-
-### Skills engine removal
-
-The following can be removed:
-
-- `skills-engine/` — entire directory (apply, merge, replay, state, backup, etc.)
-- `scripts/apply-skill.ts`
-- `scripts/uninstall-skill.ts`
-- `scripts/fix-skill-drift.ts`
-- `scripts/validate-all-skills.ts`
-- `.nanoclaw/` — state directory
-- `add/` and `modify/` subdirectories from all skill directories
-- Feature skill SKILL.md files from `.claude/skills/` on main (they now live in the marketplace)
-
-Operational skills (`setup`, `debug`, `update-nanoclaw`, `customize`, `update-skills`) remain on main in `.claude/skills/`.
-
-### New infrastructure
-
-- **Marketplace repo** (`qwibitai/nanoclaw-skills`) — single Claude Code plugin bundling SKILL.md files for all feature skills
-- **CI GitHub Action** — merge-forward `main` into all `skill/*` branches on every push to `main`, using Claude (Haiku) for conflict resolution
-- **`/update-skills` skill** — checks for and applies skill branch updates using git history
-- **`CONTRIBUTORS.md`** — tracks skill contributors
-
-### Update skill (`/update-nanoclaw`)
-
-The update skill gets simpler with the branch-based approach. The old skills engine required replaying all applied skills after merging core updates — that entire step disappears. Skill changes are already in the user's git history, so `git merge upstream/main` just works.
-
-**What stays the same:**
-- Preflight (clean working tree, upstream remote)
-- Backup branch + tag
-- Preview (git log, git diff, file buckets)
-- Merge/cherry-pick/rebase options
-- Conflict preview (dry-run merge)
-- Conflict resolution
-- Build + test validation
-- Rollback instructions
-
-**What's removed:**
-- Skill replay step (was needed by the old skills engine to re-apply skills after core update)
-- Re-running structured operations (npm deps, env vars — these are part of git history now)
-
-**What's added:**
-- Optional step at the end: "Check for skill updates?" which runs the `/update-skills` logic
-- This checks whether any previously-merged skill branches have new commits (bug fixes, improvements to the skill itself — not just merge-forwards from main)
-
-**Why users don't need to re-merge skills after a core update:**
-When the user merged a skill branch, those changes became part of their git history. When they later merge `upstream/main`, git performs a normal three-way merge — the skill changes in their tree are untouched, and only core changes are brought in. The merge-forward CI ensures skill branches stay compatible with latest main, but that's for new users applying the skill fresh. Existing users who already merged the skill don't need to do anything.
-
-Users only need to re-merge a skill branch if the skill itself was updated (not just merged-forward with main). The `/update-skills` check detects this.
-
-## Discord Announcement
-
-### For existing users
-
-> **Skills are now git branches**
->
-> We've simplified how skills work in NanoClaw. Instead of a custom skills engine, skills are now git branches that you merge in.
->
-> **What this means for you:**
-> - Applying a skill: `git fetch upstream skill/discord && git merge upstream/skill/discord`
-> - Updating core: `git fetch upstream main && git merge upstream/main`
-> - Checking for skill updates: `/update-skills`
-> - No more `.nanoclaw/` state directory or skills engine
->
-> **We now recommend forking instead of cloning.** This gives you a remote to push your customizations to.
->
-> **If you currently have a clone with local changes**, migrate to a fork:
-> 1. Fork `qwibitai/nanoclaw` on GitHub
-> 2. Run:
->    ```
->    git remote rename origin upstream
->    git remote add origin https://github.com/<you>/nanoclaw.git
->    git push --force origin main
->    ```
->    This works even if you're way behind — just push your current state.
->
-> **If you previously applied skills via the old system**, your code changes are already in your working tree — nothing to redo. You can delete the `.nanoclaw/` directory. Future skills and updates use the branch-based approach.
->
-> **Discovering skills:** Skills are now available through Claude Code's plugin marketplace. Run `/plugin` in Claude Code to browse and install available skills.
-
-### For skill contributors
-
-> **Contributing skills**
->
-> To contribute a skill:
-> 1. Fork `qwibitai/nanoclaw`
-> 2. Branch from `main` and make your code changes
-> 3. Open a regular PR
->
-> That's it. We'll create a `skill/<name>` branch from your PR, add you to CONTRIBUTORS.md, and add the SKILL.md to the marketplace. CI automatically keeps skill branches merged-forward with `main` using Claude to resolve any conflicts.
->
-> **Want to run your own skill marketplace?** Maintain skill branches on your fork and create a marketplace repo. Open a PR to add it to NanoClaw's auto-discovered marketplaces — or users can add it manually via `/plugin marketplace add`.
+Earlier design notes described a plugin marketplace and many channel-specific
+`skill/*` branches. That model is not the source of truth for NanoClaw v2, and
+there is no committed marketplace launch path in this document.
+For branch maintenance, see [BRANCH-FORK-MAINTENANCE.md](BRANCH-FORK-MAINTENANCE.md).


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Updates the upstream contribution and branch maintenance docs to match the current NanoClaw v2 capability model:

- channel adapters live together on `channels` and are copied by `/add-<channel>` installer skills
- alternate providers live on `providers` and are copied by provider installer skills
- `skill/*` remains only for residual branch-based capabilities
- per-channel forks and marketplace/flavor material are no longer documented as the active model

Also updates `/update-skills` so it only claims to update branch-based `skill/*` capabilities, not channel or provider installers.

Validation:

- `git diff --check`
- local Markdown link check for changed files
- verified upstream branch refs: `upstream/channels`, `upstream/providers`, `upstream/skill/compact`
- verified sample files exist on `channels`/`providers`: Discord, Telegram, Codex, OpenCode

## For Skills

Existing `/update-skills` instruction update only; no new skill code was added.

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
