### PR TITLE
feat(telegram): implement setReaction for status-tracker compatibility

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -90,6 +90,145 @@ function readInboundFields(message: InboundMessage): InboundFields {
  * are logged but never propagated, so a Telegram outage can't undo a successful
  * pairing or trigger the interceptor's fail-open path.
  */
+/**
+ * Telegram bot reactions are constrained to a fixed allow-list (Bot API 7.0+).
+ * Source: https://core.telegram.org/bots/api#reactiontypeemoji
+ * Custom emoji require a premium account + custom_emoji_id and aren't worth
+ * the wiring cost here.
+ */
+const TG_BOT_REACTIONS_ALLOWED = new Set([
+  '👍',
+  '👎',
+  '❤',
+  '🔥',
+  '🥰',
+  '👏',
+  '😁',
+  '🤔',
+  '🤯',
+  '😱',
+  '🤬',
+  '😢',
+  '🎉',
+  '🤩',
+  '🤮',
+  '💩',
+  '🙏',
+  '👌',
+  '🕊',
+  '🤡',
+  '🥱',
+  '🥴',
+  '😍',
+  '🐳',
+  '❤‍🔥',
+  '🌚',
+  '🌭',
+  '💯',
+  '🤣',
+  '⚡',
+  '🍌',
+  '🏆',
+  '💔',
+  '🤨',
+  '😐',
+  '🍓',
+  '🍾',
+  '💋',
+  '🖕',
+  '😈',
+  '😴',
+  '😭',
+  '🤓',
+  '👻',
+  '👨‍💻',
+  '👀',
+  '🎃',
+  '🙈',
+  '😇',
+  '😨',
+  '🤝',
+  '✍',
+  '🤗',
+  '🫡',
+  '🎅',
+  '🎄',
+  '☃',
+  '💅',
+  '🤪',
+  '🗿',
+  '🆒',
+  '💘',
+  '🙉',
+  '🦄',
+  '😘',
+  '💊',
+  '🙊',
+  '😎',
+  '👾',
+  '🤷‍♂',
+  '🤷',
+  '🤷‍♀',
+  '😡',
+]);
+
+/**
+ * Map the status-tracker's intent emoji to a Telegram-allowed bot reaction
+ * when the canonical one isn't on the allow-list. 👀 and 🤔 pass through
+ * (both are in Telegram's allowed set); ⚙️/✅ get substituted to the
+ * closest semantically appropriate allowed emoji. Unknown emoji return
+ * null → reaction cleared instead of API error.
+ */
+const TG_REACTION_FALLBACK: Record<string, string> = {
+  '⚙️': '👨‍💻', // gear → technologist
+  '✅': '👌', // check mark → OK hand
+};
+
+function mapToTelegramReaction(emoji: string | null): string | null {
+  if (emoji === null) return null;
+  if (TG_BOT_REACTIONS_ALLOWED.has(emoji)) return emoji;
+  const fallback = TG_REACTION_FALLBACK[emoji];
+  if (fallback && TG_BOT_REACTIONS_ALLOWED.has(fallback)) return fallback;
+  return null;
+}
+
+async function setTelegramReaction(
+  token: string,
+  platformId: string,
+  platformMsgId: string,
+  emoji: string | null,
+): Promise<void> {
+  const chatId = platformId.split(':').slice(1).join(':');
+  if (!chatId) return;
+  // Chat SDK encodes Telegram message ids as `<chatId>:<msgId>` composite
+  // (e.g. "-5206721973:217"). A bare parseInt on the composite would yield
+  // the chat id, not the message id. Extract just the trailing msg portion;
+  // fall back to parsing the whole string for a bare integer id.
+  const colonIdx = platformMsgId.lastIndexOf(':');
+  const rawMsgId = colonIdx >= 0 ? platformMsgId.slice(colonIdx + 1) : platformMsgId;
+  const messageId = Number.parseInt(rawMsgId, 10);
+  if (!Number.isFinite(messageId)) return;
+  const mapped = mapToTelegramReaction(emoji);
+  const body = {
+    chat_id: chatId,
+    message_id: messageId,
+    reaction: mapped !== null ? [{ type: 'emoji', emoji: mapped }] : [],
+  };
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/setMessageReaction`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      log.warn('Telegram setMessageReaction non-OK', { status: res.status, body: text });
+    }
+  } catch (err) {
+    log.warn('Telegram setMessageReaction failed', { err });
+  }
+}
+
 async function sendPairingConfirmation(token: string, platformId: string): Promise<void> {
   const chatId = platformId.split(':').slice(1).join(':');
   if (!chatId) return;
@@ -231,6 +370,9 @@ registerChannelAdapter('telegram', {
         } catch {
           return null;
         }
+      },
+      async setReaction(platformId: string, _threadId: string | null, platformMsgId: string, emoji: string) {
+        await setTelegramReaction(token, platformId, platformMsgId, emoji);
       },
       async setup(hostConfig: ChannelSetup) {
         const intercepted: ChannelSetup = {


### PR DESCRIPTION
## Summary

Adds `setReaction` to the Telegram channel adapter, implementing the optional `setReaction?(platformId, threadId, platformMsgId, emoji)` capability declared on `ChannelAdapter`. Maps to Telegram's [`setMessageReaction`](https://core.telegram.org/bots/api#setmessagereaction) Bot API method.

This pairs with the `status-tracker` module pattern (mirroring how the `typing` module pairs with `setTyping`): the consumer module calls `adapter.setReaction?.(...)` and channels that don't implement it silently no-op.

## Implementation notes

- **Telegram Bot API allow-list (Bot API 7.0+).** The reaction emoji set is fixed by Telegram. 👀 / 🤔 pass through directly. Lifecycle emoji like ⚙️ / ✅ aren't on the allow-list and would otherwise 400; substituted via `TG_REACTION_FALLBACK` to the closest semantically appropriate allowed emoji (👨‍💻 for "working", 👌 for "done"). Unknown/unmapped emoji clear the reaction rather than rejecting.
- **Composite message-id handling.** The Chat SDK Telegram bridge encodes message ids as `<chatId>:<msgId>`. A bare `parseInt` yields the chat id (negative for groups), so we extract the trailing portion after the last colon. Bare integer ids continue to work.
- **Error handling.** Non-OK responses log a warn with status + body excerpt; network errors log a warn with the error. The function returns `void` either way — reactions are best-effort UX, never load-bearing.

## Why this lives on the channels branch (not in the consumer skill)

Following the same architectural separation the codebase uses for `setTyping`:
- The capability declaration (`setReaction?(...)`) is on whichever skill branch introduced it
- The per-channel implementation lives in the adapter's own file in the channels branch
- Consumer modules call the optional method and gracefully no-op when the adapter doesn't implement it

This keeps Telegram-specific code with other Telegram code, lets future channels (Slack, Discord, iMessage) add their own implementations without coordinating skill-branch changes, and keeps consumer skills install/uninstall-clean.

## Test plan

- [ ] Confirm reactions render on a Telegram message when the consumer calls `adapter.setReaction(...)` with each lifecycle emoji
- [ ] Confirm fallback substitutions work (⚙️ → 👨‍💻, ✅ → 👌)
- [ ] Confirm unknown emoji clear an existing reaction rather than erroring
- [ ] Confirm a non-Telegram channel installed without setReaction stays no-op (no runtime error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)