### PR TITLE
fix(skill): repair /add-dashboard install after src/ refactors

### DIFF
--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
@@ -10,11 +10,11 @@ import Database from 'better-sqlite3';
 import { getAllAgentGroups, getAgentGroup } from './db/agent-groups.js';
 import { getSessionsByAgentGroup } from './db/sessions.js';
 import { getAllMessagingGroups, getMessagingGroupAgents } from './db/messaging-groups.js';
-import { getDestinations } from './db/agent-destinations.js';
-import { getMembers } from './db/agent-group-members.js';
-import { getAllUsers, getUser } from './db/users.js';
-import { getUserRoles, getAdminsOfAgentGroup } from './db/user-roles.js';
-import { getUserDmsForUser } from './db/user-dms.js';
+import { getDestinations } from './modules/agent-to-agent/db/agent-destinations.js';
+import { getMembers } from './modules/permissions/db/agent-group-members.js';
+import { getAllUsers, getUser } from './modules/permissions/db/users.js';
+import { getUserRoles, getAdminsOfAgentGroup } from './modules/permissions/db/user-roles.js';
+import { getUserDmsForUser } from './modules/permissions/db/user-dms.js';
 import { getActiveAdapters, getRegisteredChannelNames } from './channels/channel-registry.js';
 import { DATA_DIR, ASSISTANT_NAME } from './config.js';
 import { getDb } from './db/connection.js';
@@ -157,7 +157,6 @@ function collectAgentGroups() {
       name: g.name,
       folder: g.folder,
       agent_provider: g.agent_provider,
-      container_config: g.container_config ? JSON.parse(g.container_config) : null,
       sessionCount: sessions.length,
       runningSessions: running.length,
       wirings,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration
- [ ] **Utility skill** - adds a standalone tool
- [ ] **Operational/container skill** - adds a workflow or agent skill
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The `/add-dashboard` skill is broken on current `main` (v2.0.15). Following the SKILL.md install steps, `pnpm run build` fails on the copied `src/dashboard-pusher.ts` with two distinct compile errors.

### Issue 1: Imports point at non-existent paths (TS2307)

```
src/dashboard-pusher.ts: Cannot find module './db/agent-destinations.js'
src/dashboard-pusher.ts: Cannot find module './db/agent-group-members.js'
src/dashboard-pusher.ts: Cannot find module './db/users.js'
src/dashboard-pusher.ts: Cannot find module './db/user-roles.js'
src/dashboard-pusher.ts: Cannot find module './db/user-dms.js'
```

These modules existed flat under `src/db/` when the skill was added (commit e9a427a, Apr 15). They were since refactored into `src/modules/permissions/db/` (users, user_roles, user_dms, agent_group_members) and `src/modules/agent-to-agent/db/` (agent_destinations).

### Issue 2: `agent_groups.container_config` no longer exists (TS2339)

```
src/dashboard-pusher.ts(160,27): Property 'container_config' does not exist on type 'AgentGroup'
```

The pusher reads `g.container_config` from the AgentGroup row and JSON-parses it. That column was removed when container config moved to per-group on-disk JSON at `groups/<folder>/container.json`, loaded via the new `src/container-config.ts` module.

## Fix

One file changed: `.claude/skills/add-dashboard/resources/dashboard-pusher.ts`.

1. Update the five import paths to the new module locations. All seven required exports (`getDestinations`, `getMembers`, `getAllUsers`, `getUser`, `getUserRoles`, `getAdminsOfAgentGroup`, `getUserDmsForUser`) verified present at the new paths.
2. **Drop the `container_config` field from the per-group JSON snapshot** rather than wiring in `loadContainerConfig(folder)` from `src/container-config.ts`.

### Why drop rather than rewire `container_config`?

Wiring the field correctly means deciding what the dashboard should show now that container config lives on disk per-group: the raw JSON, a presence flag, the resolved-with-defaults config, the path, etc. That's a design call best made by a maintainer with context on what the dashboard UI surfaces, not by a drive-by fix. Dropping the broken field is the smallest change that gets the install compiling and running today; if the dashboard renders this field anywhere, that section will show "missing" gracefully. Happy to follow up with a separate PR that wires `loadContainerConfig` in once the desired shape is clear.

## Verification

After this fix on a fresh clone of v2.0.15:

1. `pnpm install @nanoco/nanoclaw-dashboard`
2. Copy `dashboard-pusher.ts` resource into `src/`
3. Add env vars and the wiring block in `src/index.ts` per SKILL.md
4. `pnpm run build` succeeds (no TS2307, no TS2339)
5. `curl http://localhost:3100/api/status` returns 200 after restart

## Note (out of scope)

SKILL.md step 3 ("Add exports to `src/db/index.ts`") instructs adding re-exports from `./agent-destinations.js` — also a stale path. The current pusher imports directly from module files and doesn't consume these re-exports, so step 3 looks like dead instruction left from an earlier pusher revision. Leaving untouched here per "one thing per PR."

## For Skills

- [x] SKILL.md contains instructions, not inline code
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone (v2.0.15)