### PR TITLE
feat: add OpenAI and Codex agent providers

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -20,6 +20,7 @@ ARG INSTALL_CJK_FONTS=false
 # mean every rebuild silently picks up the latest and can break in lockstep
 # across all users.
 ARG CLAUDE_CODE_VERSION=2.1.116
+ARG CODEX_VERSION=0.124.0
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=latest
 ARG BUN_VERSION=1.3.12
@@ -103,6 +104,9 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "@openai/codex@${CODEX_VERSION}"
 
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -1,0 +1,393 @@
+/**
+ * Codex app-server JSON-RPC transport primitives.
+ *
+ * Communicates with `codex app-server` over stdio. This module is just the
+ * plumbing — spawn the process, send requests, dispatch responses and
+ * notifications. Higher-level semantics (threads, turns, event translation)
+ * live in codex.ts.
+ *
+ * Kept separate so the transport can be unit-tested without pulling in the
+ * full provider and so any future Codex tooling (e.g. a CLI for manual
+ * debugging) can reuse the same primitives.
+ */
+import fs from 'fs';
+import path from 'path';
+import { spawn, type ChildProcess } from 'child_process';
+import { createInterface, type Interface as ReadlineInterface } from 'readline';
+
+function log(msg: string): void {
+  console.error(`[codex-app-server] ${msg}`);
+}
+
+const INIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Errors from `thread/resume` that indicate the thread ID is unusable —
+ * typically because the app-server has no memory of it (thread transcript
+ * was deleted, server was wiped, ID is from a different codex version).
+ * Only errors matching this pattern trigger silent fallback to a fresh
+ * thread; everything else bubbles up so the caller can decide what to do.
+ *
+ * Shared with `codex.ts`'s `isSessionInvalid` to keep the two detection
+ * paths in sync.
+ */
+export const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
+
+/**
+ * Escape a string for emission inside a TOML basic string (double-quoted).
+ * Handles `"` and `\`. Rejects newlines: basic strings can't contain raw
+ * newlines, and silently converting them to `\n` would mask misconfiguration
+ * (e.g. a secret pasted with a trailing newline). Multiline strings are
+ * unsupported for `config.toml` use here.
+ */
+export function tomlBasicString(value: string): string {
+  if (value.includes('\n') || value.includes('\r')) {
+    throw new Error(
+      `MCP config value contains newline (not supported in config.toml): ${JSON.stringify(value.slice(0, 40))}${value.length > 40 ? '…' : ''}`,
+    );
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+let nextRequestId = 1;
+
+interface JsonRpcRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcServerRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+type JsonRpcMessage = JsonRpcResponse | JsonRpcNotification | JsonRpcServerRequest;
+
+function makeRequest(method: string, params: Record<string, unknown>): JsonRpcRequest {
+  return { id: nextRequestId++, method, params };
+}
+
+function isResponse(msg: JsonRpcMessage): msg is JsonRpcResponse {
+  return 'id' in msg && ('result' in msg || 'error' in msg) && !('method' in msg);
+}
+
+function isServerRequest(msg: JsonRpcMessage): msg is JsonRpcServerRequest {
+  return 'id' in msg && 'method' in msg;
+}
+
+// ── App-server handle ───────────────────────────────────────────────────────
+
+export interface AppServer {
+  process: ChildProcess;
+  readline: ReadlineInterface;
+  pending: Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>;
+  notificationHandlers: ((n: JsonRpcNotification) => void)[];
+  serverRequestHandlers: ((r: JsonRpcServerRequest) => void)[];
+}
+
+export function spawnCodexAppServer(configOverrides: string[] = []): AppServer {
+  const args = ['app-server', '--listen', 'stdio://'];
+  for (const override of configOverrides) args.push('-c', override);
+
+  log(`Spawning: codex ${args.join(' ')}`);
+  const proc = spawn('codex', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  const rl = createInterface({ input: proc.stdout! });
+
+  const server: AppServer = {
+    process: proc,
+    readline: rl,
+    pending: new Map(),
+    notificationHandlers: [],
+    serverRequestHandlers: [],
+  };
+
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString().trim();
+    if (text) log(`[stderr] ${text}`);
+  });
+
+  rl.on('line', (line: string) => {
+    if (!line.trim()) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      log(`[parse-error] ${line.slice(0, 200)}`);
+      return;
+    }
+
+    if (isResponse(msg)) {
+      const handler = server.pending.get(msg.id);
+      if (handler) {
+        server.pending.delete(msg.id);
+        handler.resolve(msg);
+      }
+    } else if (isServerRequest(msg)) {
+      for (const h of server.serverRequestHandlers) h(msg);
+    } else if ('method' in msg) {
+      for (const h of server.notificationHandlers) h(msg as JsonRpcNotification);
+    }
+  });
+
+  proc.on('error', (err) => {
+    log(`[process-error] ${err.message}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  proc.on('exit', (code, signal) => {
+    log(`[exit] code=${code} signal=${signal}`);
+    const err = new Error(`Codex app-server exited: code=${code} signal=${signal}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  return server;
+}
+
+export function sendCodexRequest(
+  server: AppServer,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs = 60_000,
+): Promise<JsonRpcResponse> {
+  const req = makeRequest(method, params);
+  const line = JSON.stringify(req) + '\n';
+
+  return new Promise<JsonRpcResponse>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.pending.delete(req.id);
+      reject(new Error(`Timeout waiting for ${method} response (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    server.pending.set(req.id, {
+      resolve: (r) => {
+        clearTimeout(timer);
+        resolve(r);
+      },
+      reject: (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    });
+
+    try {
+      server.process.stdin!.write(line);
+    } catch (err) {
+      clearTimeout(timer);
+      server.pending.delete(req.id);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+export function sendCodexResponse(server: AppServer, id: number, result: unknown): void {
+  const line = JSON.stringify({ id, result }) + '\n';
+  try {
+    server.process.stdin!.write(line);
+  } catch (err) {
+    log(`[send-error] Failed to send response for id=${id}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function killCodexAppServer(server: AppServer): void {
+  try {
+    server.readline.close();
+    server.process.kill('SIGTERM');
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── Auto-approval ───────────────────────────────────────────────────────────
+// The container sandbox is already the security boundary; inside it, Codex's
+// own approval prompts would just block every tool call on a user that isn't
+// watching. Accept everything and let sandbox limits do the enforcement.
+
+export function attachCodexAutoApproval(server: AppServer): void {
+  server.serverRequestHandlers.push((req) => {
+    const method = req.method;
+    log(`[approval] ${method}`);
+
+    switch (method) {
+      case 'item/commandExecution/requestApproval':
+      case 'item/fileChange/requestApproval':
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+      case 'item/permissions/requestApproval':
+        sendCodexResponse(server, req.id, {
+          permissions: { fileSystem: { read: ['/'], write: ['/'] }, network: { enabled: true } },
+          scope: 'session',
+        });
+        break;
+      case 'applyPatchApproval':
+      case 'execCommandApproval':
+        sendCodexResponse(server, req.id, { decision: 'approved' });
+        break;
+      case 'item/tool/call': {
+        const toolName = (req.params as { tool?: string }).tool || 'unknown';
+        log(`[approval] Unexpected dynamic tool call: ${toolName}`);
+        sendCodexResponse(server, req.id, {
+          success: false,
+          contentItems: [{ type: 'inputText', text: `Tool "${toolName}" is not available. Use MCP tools instead.` }],
+        });
+        break;
+      }
+      case 'item/tool/requestUserInput':
+      case 'mcpServer/elicitation/request':
+        sendCodexResponse(server, req.id, { input: null });
+        break;
+      default:
+        log(`[approval] Unknown method ${method}, generic accept`);
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+    }
+  });
+}
+
+// ── High-level helpers ──────────────────────────────────────────────────────
+
+export async function initializeCodexAppServer(server: AppServer): Promise<void> {
+  log('Sending initialize…');
+  const resp = await sendCodexRequest(
+    server,
+    'initialize',
+    {
+      clientInfo: { name: 'nanoclaw', version: '1.0.0' },
+      capabilities: { experimentalApi: false },
+    },
+    INIT_TIMEOUT_MS,
+  );
+  if (resp.error) throw new Error(`Initialize failed: ${resp.error.message}`);
+  log('Initialize successful');
+}
+
+export interface ThreadParams {
+  model: string;
+  cwd: string;
+  sandbox?: string;
+  approvalPolicy?: string;
+  personality?: string;
+  baseInstructions?: string;
+}
+
+/**
+ * Start or resume a Codex thread. If `threadId` is provided, attempts
+ * `thread/resume` first and falls back to a fresh `thread/start` on failure
+ * (stale thread IDs commonly outlive containers). Returns the active thread
+ * ID either way.
+ */
+export async function startOrResumeCodexThread(
+  server: AppServer,
+  threadId: string | undefined,
+  params: ThreadParams,
+): Promise<string> {
+  if (threadId) {
+    log(`Resuming thread: ${threadId}`);
+    const resp = await sendCodexRequest(server, 'thread/resume', {
+      threadId,
+      ...(params as unknown as Record<string, unknown>),
+    });
+    if (!resp.error) {
+      log(`Thread resumed: ${threadId}`);
+      return threadId;
+    }
+    // Only fall through to fresh-thread on recognized stale-thread errors.
+    // Auth, version, or transient failures would otherwise silently discard
+    // session state — fail loud instead so the caller can retry or surface.
+    if (!STALE_THREAD_RE.test(resp.error.message)) {
+      throw new Error(`thread/resume failed: ${resp.error.message}`);
+    }
+    log(`Stale thread ${threadId}; starting fresh thread.`);
+  }
+
+  log('Starting new thread…');
+  const resp = await sendCodexRequest(server, 'thread/start', {
+    ...(params as unknown as Record<string, unknown>),
+  });
+  if (resp.error) throw new Error(`thread/start failed: ${resp.error.message}`);
+
+  const result = resp.result as { thread?: { id?: string } } | undefined;
+  const newThreadId = result?.thread?.id;
+  if (!newThreadId) throw new Error('thread/start response missing thread ID');
+  log(`New thread: ${newThreadId}`);
+  return newThreadId;
+}
+
+export interface TurnParams {
+  threadId: string;
+  inputText: string;
+  model?: string;
+  cwd?: string;
+}
+
+export async function startCodexTurn(server: AppServer, params: TurnParams): Promise<void> {
+  const resp = await sendCodexRequest(server, 'turn/start', {
+    threadId: params.threadId,
+    input: [{ type: 'text', text: params.inputText }],
+    model: params.model,
+    cwd: params.cwd,
+  });
+  if (resp.error) throw new Error(`turn/start failed: ${resp.error.message}`);
+}
+
+// ── MCP config.toml ─────────────────────────────────────────────────────────
+// Codex discovers MCP servers by reading ~/.codex/config.toml at startup.
+// We rewrite it on every spawn from whatever mcpServers the agent-runner
+// passes in, so the container's config reflects the current host wiring.
+
+export interface CodexMcpServer {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>): void {
+  const codexConfigDir = path.join(process.env.HOME || '/home/node', '.codex');
+  fs.mkdirSync(codexConfigDir, { recursive: true });
+  const configTomlPath = path.join(codexConfigDir, 'config.toml');
+
+  const lines: string[] = [];
+  for (const [name, config] of Object.entries(servers)) {
+    lines.push(`[mcp_servers.${name}]`);
+    lines.push('type = "stdio"');
+    lines.push(`command = ${tomlBasicString(config.command)}`);
+    if (config.args && config.args.length > 0) {
+      const argsStr = config.args.map(tomlBasicString).join(', ');
+      lines.push(`args = [${argsStr}]`);
+    }
+    if (config.env && Object.keys(config.env).length > 0) {
+      lines.push(`[mcp_servers.${name}.env]`);
+      for (const [key, value] of Object.entries(config.env)) {
+        lines.push(`${key} = ${tomlBasicString(value)}`);
+      }
+    }
+    lines.push('');
+  }
+
+  fs.writeFileSync(configTomlPath, lines.join('\n'));
+  log(`Wrote MCP config.toml (${Object.keys(servers).length} server(s))`);
+}
+
+export function createCodexConfigOverrides(): string[] {
+  return ['features.use_linux_sandbox_bwrap=false'];
+}

--- a/container/agent-runner/src/providers/codex.factory.test.ts
+++ b/container/agent-runner/src/providers/codex.factory.test.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect } from 'bun:test';
+
+import { createProvider } from './factory.js';
+import { CodexProvider, resolveClaudeImports } from './codex.js';
+
+describe('createProvider (codex)', () => {
+  it('returns CodexProvider for codex', () => {
+    expect(createProvider('codex')).toBeInstanceOf(CodexProvider);
+  });
+
+  it('flags stale thread errors as session-invalid', () => {
+    const p = new CodexProvider();
+    expect(p.isSessionInvalid(new Error('thread not found'))).toBe(true);
+    expect(p.isSessionInvalid(new Error('unknown thread 123'))).toBe(true);
+    expect(p.isSessionInvalid(new Error('No such thread: abc'))).toBe(true);
+  });
+
+  it('does not flag unrelated errors as session-invalid', () => {
+    const p = new CodexProvider();
+    expect(p.isSessionInvalid(new Error('rate limit exceeded'))).toBe(false);
+    expect(p.isSessionInvalid(new Error('connection reset'))).toBe(false);
+    expect(p.isSessionInvalid(new Error('codex app-server exited: code=1'))).toBe(false);
+  });
+
+  it('declares no native slash command support', () => {
+    const p = new CodexProvider();
+    expect(p.supportsNativeSlashCommands).toBe(false);
+  });
+});
+
+describe('resolveClaudeImports', () => {
+  function scratchDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'codex-imports-'));
+  }
+
+  it('inlines a single relative import', () => {
+    const dir = scratchDir();
+    fs.writeFileSync(path.join(dir, 'fragment.md'), 'FRAGMENT CONTENT');
+    const resolved = resolveClaudeImports('before\n@./fragment.md\nafter', dir);
+    expect(resolved).toContain('FRAGMENT CONTENT');
+    expect(resolved).not.toContain('@./fragment.md');
+    expect(resolved).toMatch(/before[\s\S]*FRAGMENT CONTENT[\s\S]*after/);
+  });
+
+  it('expands nested imports relative to the parent file', () => {
+    const dir = scratchDir();
+    fs.mkdirSync(path.join(dir, 'sub'));
+    fs.writeFileSync(path.join(dir, 'sub', 'inner.md'), 'INNER');
+    fs.writeFileSync(path.join(dir, 'sub', 'outer.md'), '@./inner.md');
+    const resolved = resolveClaudeImports('@./sub/outer.md', dir);
+    expect(resolved).toBe('INNER');
+  });
+
+  it('drops missing imports to empty text rather than leaving raw @path', () => {
+    const dir = scratchDir();
+    const resolved = resolveClaudeImports('before\n@./does-not-exist.md\nafter', dir);
+    expect(resolved).not.toContain('@./does-not-exist.md');
+    expect(resolved).toContain('before');
+    expect(resolved).toContain('after');
+  });
+
+  it('breaks cycles', () => {
+    const dir = scratchDir();
+    fs.writeFileSync(path.join(dir, 'a.md'), '@./b.md');
+    fs.writeFileSync(path.join(dir, 'b.md'), '@./a.md');
+    // Just needs to terminate without a stack overflow.
+    const resolved = resolveClaudeImports('@./a.md', dir);
+    expect(typeof resolved).toBe('string');
+  });
+
+  it('leaves non-import @ mentions alone (only line-anchored @<path> is imported)', () => {
+    const dir = scratchDir();
+    const resolved = resolveClaudeImports('email @someone for details', dir);
+    expect(resolved).toBe('email @someone for details');
+  });
+});

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -1,0 +1,332 @@
+/**
+ * OpenAI Codex provider — wraps `codex app-server` via JSON-RPC.
+ *
+ * Unlike the (deprecated) @openai/codex-sdk approach, the app-server
+ * protocol exposes proper session/stream semantics, native compaction, and
+ * stable MCP config via ~/.codex/config.toml — which is the same mechanism
+ * the standalone codex CLI uses, so the container and host share one
+ * provider-integration story.
+ *
+ * Codex turns don't accept mid-turn input. Follow-up `push()` messages are
+ * queued and drained after the current turn completes (same pattern as the
+ * opencode provider — see poll-loop for why that's correct: the poll-loop
+ * only pushes once it has new pending messages, and we only drain between
+ * turns, so no message is dropped).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import {
+  type AppServer,
+  type JsonRpcNotification,
+  STALE_THREAD_RE,
+  attachCodexAutoApproval,
+  createCodexConfigOverrides,
+  initializeCodexAppServer,
+  killCodexAppServer,
+  spawnCodexAppServer,
+  startCodexTurn,
+  startOrResumeCodexThread,
+  writeCodexMcpConfigToml,
+} from './codex-app-server.js';
+
+/** Hard ceiling for a single turn. Guards against app-server wedging. */
+const TURN_TIMEOUT_MS = 5 * 60 * 1000;
+
+// ── System-prompt assembly ──────────────────────────────────────────────────
+// Codex's app-server doesn't expand Claude Code's `@-import` syntax in
+// CLAUDE.md, and doesn't auto-load CLAUDE.local.md from the working dir the
+// way Claude Code does. Left alone, the agent sees only the raw import
+// directives as literal text and none of the composed content — no shared
+// CLAUDE.md, no module fragments, no per-group memory. We resolve both here
+// so Codex (and any other non-Claude provider) gets the same effective
+// system prompt the Claude provider gets natively.
+
+/**
+ * Inline `@<path>` import directives (line-anchored) with the contents of
+ * the referenced file, resolved relative to `baseDir`. Recurses so imports
+ * within imported files expand too. Cycles and missing files are silently
+ * dropped (replaced with empty text) rather than left as raw `@path` lines,
+ * which would confuse the model.
+ */
+export function resolveClaudeImports(content: string, baseDir: string, seen: Set<string> = new Set()): string {
+  return content.replace(/^@(\S+)\s*$/gm, (_match, importPath: string) => {
+    try {
+      const resolved = path.resolve(baseDir, importPath);
+      if (seen.has(resolved)) return '';
+      if (!fs.existsSync(resolved)) return '';
+      const nextSeen = new Set(seen);
+      nextSeen.add(resolved);
+      const imported = fs.readFileSync(resolved, 'utf-8');
+      return resolveClaudeImports(imported, path.dirname(resolved), nextSeen);
+    } catch {
+      return '';
+    }
+  });
+}
+
+function readAgentAndGlobalClaudeMd(): string | undefined {
+  // Per-group CLAUDE.md is responsible for pulling in the global instructions
+  // if the group wants them (the default scaffold starts with
+  // `@./.claude-global.md` which resolveClaudeImports inlines). Appending
+  // `/workspace/global/CLAUDE.md` explicitly here would double-inline the
+  // global content for any non-main group, wasting context tokens and
+  // risking contradictory instructions. Groups that don't import global
+  // intentionally don't get it — same as Claude-backed agents.
+  const groupDir = '/workspace/agent';
+  const groupPath = `${groupDir}/CLAUDE.md`;
+  const localPath = `${groupDir}/CLAUDE.local.md`;
+  const parts: string[] = [];
+
+  if (fs.existsSync(groupPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(groupPath, 'utf-8'), groupDir));
+  }
+  if (fs.existsSync(localPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(localPath, 'utf-8'), groupDir));
+  }
+
+  return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
+}
+
+function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
+  const claudeMd = readAgentAndGlobalClaudeMd();
+  const pieces = [claudeMd, promptAddendum].filter((s): s is string => Boolean(s));
+  return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class CodexProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private readonly mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  private readonly model: string;
+
+  constructor(options: ProviderOptions = {}) {
+    this.mcpServers = options.mcpServers ?? {};
+    this.model = (options.env?.CODEX_MODEL as string | undefined) ?? 'gpt-5.4-mini';
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return STALE_THREAD_RE.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let ended = false;
+    let aborted = false;
+    const kick = (): void => {
+      waiting?.();
+    };
+
+    pending.push(input.prompt);
+
+    const self = this;
+
+    async function* gen(): AsyncGenerator<ProviderEvent> {
+      // One app-server per query invocation. The poll-loop keeps a single
+      // query active per batch of pending messages and ends it on idle, so
+      // spawn-per-query matches that cadence naturally.
+      writeCodexMcpConfigToml(self.mcpServers);
+      const server = spawnCodexAppServer(createCodexConfigOverrides());
+      attachCodexAutoApproval(server);
+
+      let threadId: string | undefined = input.continuation;
+      let initYielded = false;
+
+      try {
+        await initializeCodexAppServer(server);
+
+        const threadParams = {
+          model: self.model,
+          cwd: input.cwd,
+          sandbox: 'danger-full-access',
+          approvalPolicy: 'never',
+          personality: 'friendly',
+          baseInstructions: composeBaseInstructions(input.systemContext?.instructions),
+        };
+
+        threadId = await startOrResumeCodexThread(server, threadId, threadParams);
+
+        while (!aborted) {
+          while (pending.length === 0 && !ended && !aborted) {
+            await new Promise<void>((resolve) => {
+              waiting = resolve;
+            });
+            waiting = null;
+          }
+          if (aborted) return;
+          if (pending.length === 0 && ended) return;
+
+          const text = pending.shift()!;
+
+          // One turn = one channel of streaming events. Each notification
+          // from the app-server yields an `activity` first (so the
+          // poll-loop's idle timer stays honest) and then, where relevant,
+          // an init / result / progress event.
+          yield* runOneTurn(
+            server,
+            threadId!,
+            text,
+            self.model,
+            input.cwd,
+            () => initYielded,
+            () => {
+              initYielded = true;
+            },
+          );
+        }
+      } finally {
+        killCodexAppServer(server);
+      }
+    }
+
+    return {
+      push: (message: string) => {
+        pending.push(message);
+        kick();
+      },
+      end: () => {
+        ended = true;
+        kick();
+      },
+      abort: () => {
+        aborted = true;
+        kick();
+      },
+      events: gen(),
+    };
+  }
+}
+
+// ── Per-turn event pump ─────────────────────────────────────────────────────
+// Pulled out because the gen() loop above reads cleaner with it extracted,
+// and because it's a natural seam for future unit tests that drive it with
+// a fake notification stream.
+
+async function* runOneTurn(
+  server: AppServer,
+  threadId: string,
+  inputText: string,
+  model: string,
+  cwd: string,
+  hasInit: () => boolean,
+  markInit: () => void,
+): AsyncGenerator<ProviderEvent> {
+  // Mutable refs via object properties — TS can't track closure assignments
+  // for narrowing, but property access keeps the declared type visible.
+  const turnState: { error: Error | null } = { error: null };
+  let resultText = '';
+  let turnDone = false;
+
+  // Buffered event queue so we can `yield` across the async notification
+  // callback. Each notification pushes zero or more ProviderEvents; the
+  // generator drains the buffer.
+  const buffer: ProviderEvent[] = [];
+  let waker: (() => void) | null = null;
+  const kick = (): void => {
+    waker?.();
+    waker = null;
+  };
+
+  const handler = (n: JsonRpcNotification): void => {
+    const method = n.method;
+    const params = n.params;
+
+    // Every inbound notification counts as activity for the poll-loop's
+    // idle timer — yield before any event-specific translation so even
+    // long tool executions keep the loop awake.
+    buffer.push({ type: 'activity' });
+
+    switch (method) {
+      case 'thread/started': {
+        const thread = params.thread as { id?: string } | undefined;
+        if (thread?.id && !hasInit()) {
+          markInit();
+          buffer.push({ type: 'init', continuation: thread.id });
+        }
+        break;
+      }
+      case 'item/agentMessage/delta': {
+        const delta = params.delta as string;
+        if (delta) resultText += delta;
+        break;
+      }
+      case 'item/completed': {
+        const item = params.item as { type?: string; text?: string } | undefined;
+        if (item?.type === 'agentMessage' && item.text) resultText = item.text;
+        break;
+      }
+      case 'turn/completed':
+        turnDone = true;
+        break;
+      case 'turn/failed': {
+        const e = params.error as { message?: string } | undefined;
+        turnState.error = new Error(e?.message || 'Turn failed');
+        turnDone = true;
+        break;
+      }
+      case 'thread/status/changed': {
+        const status = params.status as string | undefined;
+        if (status) buffer.push({ type: 'progress', message: `status: ${status}` });
+        break;
+      }
+      default:
+        // Silently handle the many item/* notifications — they already
+        // contributed an activity event above.
+        break;
+    }
+
+    kick();
+  };
+
+  server.notificationHandlers.push(handler);
+
+  const timer = setTimeout(() => {
+    turnState.error = new Error(`Turn timed out after ${TURN_TIMEOUT_MS}ms`);
+    turnDone = true;
+    kick();
+  }, TURN_TIMEOUT_MS);
+
+  try {
+    // If we yield init before turn/start, the poll-loop stores
+    // continuation early and survives a mid-turn crash.
+    if (!hasInit()) {
+      markInit();
+      buffer.push({ type: 'init', continuation: threadId });
+    }
+
+    await startCodexTurn(server, { threadId, inputText, model, cwd });
+
+    while (true) {
+      while (buffer.length > 0) {
+        const ev = buffer.shift()!;
+        yield ev;
+      }
+      if (turnDone) break;
+      await new Promise<void>((resolve) => {
+        waker = resolve;
+      });
+      waker = null;
+    }
+
+    while (buffer.length > 0) yield buffer.shift()!;
+
+    if (turnState.error) {
+      yield { type: 'error', message: turnState.error.message, retryable: false };
+      return;
+    }
+
+    yield { type: 'result', text: resultText || null };
+  } finally {
+    clearTimeout(timer);
+    const idx = server.notificationHandlers.indexOf(handler);
+    if (idx >= 0) server.notificationHandlers.splice(idx, 1);
+  }
+}
+
+registerProvider('codex', (opts) => new CodexProvider(opts));

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -4,3 +4,5 @@
 
 import './claude.js';
 import './mock.js';
+import './codex.js';
+import './openai.js';

--- a/container/agent-runner/src/providers/openai.test.ts
+++ b/container/agent-runner/src/providers/openai.test.ts
@@ -1,0 +1,771 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+
+// Prevent MCP SDK from spawning real child processes in provider-level tests.
+// Bun hoists mock.module() above all imports, so openai.js sees the mocks.
+mock.module('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    connect() { return Promise.resolve(); }
+    listTools() { return Promise.resolve({ tools: [] }); }
+    close() { return Promise.resolve(); }
+  },
+}));
+mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class {},
+}));
+
+import {
+  resolveOpenAIChatCompletionsUrl,
+  resolveOpenAIRequestTimeoutMs,
+  resolveOpenAIStreamEnabled,
+  resolveClaudeImports,
+  OpenAIHttpError,
+  ProviderRuntimeError,
+  toProviderError,
+  parseToolArguments,
+  createOpenAIToolName,
+  truncateToolResult,
+  normalizeToolParameters,
+  parseOpenAIChatResponse,
+  parseRetryAfterSeconds,
+  shouldRetryOpenAIError,
+  getOpenAIRetryDelayMs,
+  sleepOpenAIRetryDelay,
+  parseOpenAISseDataLine,
+  parseOpenAIStreamingChunk,
+  createOpenAIStreamingAccumulator,
+  applyOpenAIStreamingChunk,
+  assembleOpenAIStreamingResponse,
+  OpenAIProvider,
+} from './openai.js';
+
+describe('resolveOpenAIChatCompletionsUrl', () => {
+  it('returns default URL when no baseUrl', () => {
+    expect(resolveOpenAIChatCompletionsUrl()).toBe('https://api.openai.com/v1/chat/completions');
+    expect(resolveOpenAIChatCompletionsUrl(undefined)).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  it('uses as-is when ending with /chat/completions', () => {
+    expect(resolveOpenAIChatCompletionsUrl('https://custom.api/v1/chat/completions'))
+      .toBe('https://custom.api/v1/chat/completions');
+  });
+
+  it('appends /chat/completions when ending with /v1', () => {
+    expect(resolveOpenAIChatCompletionsUrl('https://custom.api/v1'))
+      .toBe('https://custom.api/v1/chat/completions');
+  });
+
+  it('appends /v1/chat/completions for bare base URL', () => {
+    expect(resolveOpenAIChatCompletionsUrl('https://custom.api'))
+      .toBe('https://custom.api/v1/chat/completions');
+  });
+
+  it('trims whitespace from baseUrl', () => {
+    expect(resolveOpenAIChatCompletionsUrl('  https://custom.api/v1  '))
+      .toBe('https://custom.api/v1/chat/completions');
+  });
+});
+
+describe('resolveOpenAIRequestTimeoutMs', () => {
+  it('returns 120000 for undefined', () => {
+    expect(resolveOpenAIRequestTimeoutMs()).toBe(120000);
+    expect(resolveOpenAIRequestTimeoutMs(undefined)).toBe(120000);
+  });
+
+  it('returns 120000 for empty string', () => {
+    expect(resolveOpenAIRequestTimeoutMs('')).toBe(120000);
+    expect(resolveOpenAIRequestTimeoutMs('   ')).toBe(120000);
+  });
+
+  it('parses valid integer', () => {
+    expect(resolveOpenAIRequestTimeoutMs('30000')).toBe(30000);
+    expect(resolveOpenAIRequestTimeoutMs(' 60000 ')).toBe(60000);
+  });
+
+  it('returns default for invalid non-numeric strings', () => {
+    expect(resolveOpenAIRequestTimeoutMs('abc')).toBe(120000);
+    expect(resolveOpenAIRequestTimeoutMs('12.5')).toBe(120000);
+    expect(resolveOpenAIRequestTimeoutMs('-100')).toBe(120000);
+    expect(resolveOpenAIRequestTimeoutMs('0')).toBe(120000);
+  });
+});
+
+describe('resolveOpenAIStreamEnabled', () => {
+  it('returns true when undefined', () => {
+    expect(resolveOpenAIStreamEnabled()).toBe(true);
+    expect(resolveOpenAIStreamEnabled(undefined)).toBe(true);
+  });
+
+  it('returns false for "false", "0", "no"', () => {
+    expect(resolveOpenAIStreamEnabled('false')).toBe(false);
+    expect(resolveOpenAIStreamEnabled('FALSE')).toBe(false);
+    expect(resolveOpenAIStreamEnabled('0')).toBe(false);
+    expect(resolveOpenAIStreamEnabled('no')).toBe(false);
+    expect(resolveOpenAIStreamEnabled('NO')).toBe(false);
+  });
+
+  it('returns true for other truthy values', () => {
+    expect(resolveOpenAIStreamEnabled('true')).toBe(true);
+    expect(resolveOpenAIStreamEnabled('1')).toBe(true);
+    expect(resolveOpenAIStreamEnabled('yes')).toBe(true);
+  });
+});
+
+describe('resolveClaudeImports (openai)', () => {
+  function scratchDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'openai-imports-'));
+  }
+
+  it('inlines a single relative import', () => {
+    const dir = scratchDir();
+    fs.writeFileSync(path.join(dir, 'frag.md'), 'FRAG CONTENT');
+    const result = resolveClaudeImports('before\n@./frag.md\nafter', dir);
+    expect(result).toContain('FRAG CONTENT');
+    expect(result).not.toContain('@./frag.md');
+  });
+
+  it('expands nested imports relative to parent directory', () => {
+    const dir = scratchDir();
+    fs.mkdirSync(path.join(dir, 'sub'));
+    fs.writeFileSync(path.join(dir, 'sub', 'inner.md'), 'INNER');
+    fs.writeFileSync(path.join(dir, 'sub', 'outer.md'), '@./inner.md');
+    const result = resolveClaudeImports('@./sub/outer.md', dir);
+    expect(result).toBe('INNER');
+  });
+
+  it('drops missing imports silently', () => {
+    const dir = scratchDir();
+    const result = resolveClaudeImports('A\n@./no-such-file.md\nB', dir);
+    expect(result).not.toContain('@./no-such-file.md');
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+
+  it('breaks circular imports without stack overflow', () => {
+    const dir = scratchDir();
+    fs.writeFileSync(path.join(dir, 'a.md'), '@./b.md');
+    fs.writeFileSync(path.join(dir, 'b.md'), '@./a.md');
+    const result = resolveClaudeImports('@./a.md', dir);
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('toProviderError', () => {
+  it('classifies 401 as auth/non-retryable', () => {
+    const err = new OpenAIHttpError(401, 'unauthorized');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'unauthorized', retryable: false, classification: 'auth' });
+  });
+
+  it('classifies 403 as auth/non-retryable', () => {
+    const err = new OpenAIHttpError(403, 'forbidden');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'forbidden', retryable: false, classification: 'auth' });
+  });
+
+  it('classifies 429 as retryable', () => {
+    const err = new OpenAIHttpError(429, 'rate limited');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'rate limited', retryable: true });
+  });
+
+  it('classifies 500 as retryable', () => {
+    const err = new OpenAIHttpError(500, 'server error');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'server error', retryable: true });
+  });
+
+  it('classifies 400 as non-retryable', () => {
+    const err = new OpenAIHttpError(400, 'bad request');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'bad request', retryable: false });
+  });
+
+  it('classifies AbortError as retryable', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'aborted', retryable: true });
+  });
+
+  it('classifies TypeError as retryable', () => {
+    const evt = toProviderError(new TypeError('network fetch failed'));
+    expect(evt).toEqual({ type: 'error', message: 'network fetch failed', retryable: true });
+  });
+
+  it('passes through ProviderRuntimeError', () => {
+    const err = new ProviderRuntimeError('custom', true, 'custom-class');
+    const evt = toProviderError(err);
+    expect(evt).toEqual({ type: 'error', message: 'custom', retryable: true, classification: 'custom-class' });
+  });
+
+  it('classifies unknown error as non-retryable', () => {
+    const evt = toProviderError('some string error');
+    expect(evt).toEqual({ type: 'error', message: 'some string error', retryable: false });
+  });
+});
+
+describe('parseToolArguments', () => {
+  it('parses valid JSON object', () => {
+    const result = parseToolArguments('{"key":"value"}');
+    expect(result).toEqual({ ok: true, value: { key: 'value' } });
+  });
+
+  it('returns empty object for empty string', () => {
+    expect(parseToolArguments('')).toEqual({ ok: true, value: {} });
+    expect(parseToolArguments('  ')).toEqual({ ok: true, value: {} });
+  });
+
+  it('returns error for invalid JSON', () => {
+    const result = parseToolArguments('{invalid}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('invalid JSON');
+    }
+  });
+
+  it('returns error for non-object JSON (array)', () => {
+    const result = parseToolArguments('[1,2,3]');
+    expect(result).toEqual({ ok: false, error: 'Error: tool arguments must be a JSON object' });
+  });
+
+  it('returns error for non-object JSON (string)', () => {
+    const result = parseToolArguments('"hello"');
+    expect(result).toEqual({ ok: false, error: 'Error: tool arguments must be a JSON object' });
+  });
+});
+
+describe('createOpenAIToolName', () => {
+  it('sanitizes special characters', () => {
+    const used = new Set<string>();
+    expect(createOpenAIToolName('my.tool/name', used)).toBe('my_tool_name');
+  });
+
+  it('collapses multiple underscores from __', () => {
+    const used = new Set<string>();
+    expect(createOpenAIToolName('my__tool', used)).toBe('my_tool');
+  });
+
+  it('adds suffix for duplicates', () => {
+    const used = new Set<string>();
+    const first = createOpenAIToolName('tool', used);
+    const second = createOpenAIToolName('tool', used);
+    expect(first).toBe('tool');
+    expect(second).toBe('tool_2');
+    expect(used.has('tool')).toBe(true);
+    expect(used.has('tool_2')).toBe(true);
+  });
+
+  it('enforces 64-char limit', () => {
+    const used = new Set<string>();
+    const longName = 'a'.repeat(100);
+    const result = createOpenAIToolName(longName, used);
+    expect(result.length).toBeLessThanOrEqual(64);
+  });
+
+  it('handles empty name', () => {
+    const used = new Set<string>();
+    const result = createOpenAIToolName('', used);
+    expect(result).toBe('tool');
+  });
+
+  it('allows hyphens and underscores', () => {
+    const used = new Set<string>();
+    expect(createOpenAIToolName('my-tool_name', used)).toBe('my-tool_name');
+  });
+});
+
+describe('truncateToolResult', () => {
+  it('returns text unchanged when under limit', () => {
+    const text = 'short result';
+    expect(truncateToolResult(text)).toBe(text);
+  });
+
+  it('truncates and adds marker when over limit', () => {
+    const limit = 50 * 1024;
+    const text = 'x'.repeat(limit + 1000);
+    const result = truncateToolResult(text);
+    expect(result.length).toBeLessThan(text.length);
+    expect(result).toContain('[truncated 1000 characters from MCP tool result]');
+    expect(result.startsWith('x'.repeat(limit))).toBe(true);
+  });
+
+  it('returns text at exactly limit unchanged', () => {
+    const limit = 50 * 1024;
+    const text = 'x'.repeat(limit);
+    expect(truncateToolResult(text)).toBe(text);
+  });
+});
+
+describe('normalizeToolParameters', () => {
+  it('adds type:object and properties when missing', () => {
+    const result = normalizeToolParameters(undefined);
+    expect(result).toEqual({ type: 'object', properties: {} });
+  });
+
+  it('adds type:object when schema has properties but no type', () => {
+    const result = normalizeToolParameters({ properties: { foo: { type: 'string' } } } as any);
+    expect(result.type).toBe('object');
+    expect(result.properties).toEqual({ foo: { type: 'string' } });
+  });
+
+  it('preserves existing object schema', () => {
+    const schema = { type: 'object', properties: { bar: { type: 'number' } }, required: ['bar'] };
+    const result = normalizeToolParameters(schema as any);
+    expect(result.type).toBe('object');
+    expect(result.properties).toEqual({ bar: { type: 'number' } });
+    expect(result.required).toEqual(['bar']);
+  });
+
+  it('handles empty object schema', () => {
+    const result = normalizeToolParameters({} as any);
+    expect(result.type).toBe('object');
+    expect(result.properties).toEqual({});
+  });
+});
+
+describe('parseOpenAIChatResponse', () => {
+  it('parses a minimal valid response', () => {
+    const payload = {
+      choices: [{
+        index: 0,
+        finish_reason: 'stop',
+        message: { role: 'assistant', content: 'Hello' },
+      }],
+    };
+    const result = parseOpenAIChatResponse(payload);
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices[0].message.content).toBe('Hello');
+    expect(result.choices[0].finish_reason).toBe('stop');
+  });
+
+  it('throws when choices missing', () => {
+    expect(() => parseOpenAIChatResponse({})).toThrow('did not include choices');
+  });
+
+  it('parses response with tool_calls', () => {
+    const payload = {
+      choices: [{
+        index: 0,
+        finish_reason: 'tool_calls',
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'my_tool', arguments: '{"a":1}' },
+          }],
+        },
+      }],
+    };
+    const result = parseOpenAIChatResponse(payload);
+    expect(result.choices[0].message.tool_calls).toHaveLength(1);
+    expect(result.choices[0].message.tool_calls![0].function.name).toBe('my_tool');
+  });
+});
+
+describe('shouldRetryOpenAIError', () => {
+  it('retries 429', () => {
+    expect(shouldRetryOpenAIError(new OpenAIHttpError(429, 'rate limited'))).toBe(true);
+  });
+
+  it('retries 500-599', () => {
+    expect(shouldRetryOpenAIError(new OpenAIHttpError(500, 'server error'))).toBe(true);
+    expect(shouldRetryOpenAIError(new OpenAIHttpError(503, 'unavailable'))).toBe(true);
+  });
+
+  it('does not retry 400', () => {
+    expect(shouldRetryOpenAIError(new OpenAIHttpError(400, 'bad request'))).toBe(false);
+  });
+
+  it('does not retry 401', () => {
+    expect(shouldRetryOpenAIError(new OpenAIHttpError(401, 'unauthorized'))).toBe(false);
+  });
+
+  it('retries AbortError', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(shouldRetryOpenAIError(err)).toBe(true);
+  });
+
+  it('retries TypeError (network)', () => {
+    expect(shouldRetryOpenAIError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('respects ProviderRuntimeError.retryable', () => {
+    expect(shouldRetryOpenAIError(new ProviderRuntimeError('err', true))).toBe(true);
+    expect(shouldRetryOpenAIError(new ProviderRuntimeError('err', false))).toBe(false);
+  });
+});
+
+describe('parseRetryAfterSeconds', () => {
+  it('parses numeric retry-after header', () => {
+    const headers = new Headers({ 'retry-after': '5' });
+    expect(parseRetryAfterSeconds(headers)).toBe(5);
+  });
+
+  it('returns undefined when header missing', () => {
+    expect(parseRetryAfterSeconds(new Headers())).toBeUndefined();
+  });
+
+  it('returns undefined for non-numeric value', () => {
+    const headers = new Headers({ 'retry-after': 'Wed, 21 Oct 2015 07:28:00 GMT' });
+    expect(parseRetryAfterSeconds(headers)).toBeUndefined();
+  });
+
+  it('returns undefined for zero or negative', () => {
+    expect(parseRetryAfterSeconds(new Headers({ 'retry-after': '0' }))).toBeUndefined();
+    expect(parseRetryAfterSeconds(new Headers({ 'retry-after': '-1' }))).toBeUndefined();
+  });
+});
+
+describe('getOpenAIRetryDelayMs', () => {
+  it('uses retry-after header from OpenAIHttpError when present', () => {
+    const headers = new Headers({ 'retry-after': '3' });
+    const err = new OpenAIHttpError(429, 'rate limited', headers);
+    expect(getOpenAIRetryDelayMs(err, 1)).toBe(3000);
+  });
+
+  it('uses exponential backoff when no retry-after', () => {
+    const err = new OpenAIHttpError(500, 'server error');
+    // base(1000) * 2^(attempt-1) + floor(random * 500)
+    expect(getOpenAIRetryDelayMs(err, 1, () => 0)).toBe(1000);
+    expect(getOpenAIRetryDelayMs(err, 2, () => 0)).toBe(2000);
+  });
+
+  it('adds jitter based on random function', () => {
+    const err = new OpenAIHttpError(500, 'error');
+    // 1000 * 2^0 + floor(1.0 * 500) = 1500
+    expect(getOpenAIRetryDelayMs(err, 1, () => 1)).toBe(1500);
+  });
+
+  it('clamps jitter random to [0, 1]', () => {
+    const err = new TypeError('fetch failed');
+    const delay = getOpenAIRetryDelayMs(err, 1, () => -0.5);
+    // 1000 * 2^0 + floor(0 * 500) = 1000
+    expect(delay).toBe(1000);
+  });
+});
+
+describe('sleepOpenAIRetryDelay', () => {
+  it('resolves after delay', async () => {
+    await sleepOpenAIRetryDelay(0);
+  });
+});
+
+describe('parseOpenAISseDataLine', () => {
+  it('parses "data:" prefixed line', () => {
+    const chunk = parseOpenAISseDataLine('data:{"choices":[{"index":0,"delta":{"content":"hi"}}]}');
+    expect(chunk).not.toBe('done');
+    expect(chunk).not.toBeUndefined();
+    if (chunk && chunk !== 'done') {
+      expect(chunk.choices[0].delta?.content).toBe('hi');
+    }
+  });
+
+  it('parses "data: " with space', () => {
+    const chunk = parseOpenAISseDataLine('data: {"choices":[{"index":0,"delta":{"content":"x"}}]}');
+    expect(chunk).not.toBe('done');
+    expect(chunk).not.toBeUndefined();
+    if (chunk && chunk !== 'done') {
+      expect(chunk.choices[0].delta?.content).toBe('x');
+    }
+  });
+
+  it('returns undefined for blank lines', () => {
+    expect(parseOpenAISseDataLine('')).toBeUndefined();
+    expect(parseOpenAISseDataLine('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for comment lines', () => {
+    expect(parseOpenAISseDataLine(': keep-alive')).toBeUndefined();
+  });
+
+  it('returns "done" for [DONE]', () => {
+    expect(parseOpenAISseDataLine('data: [DONE]')).toBe('done');
+    expect(parseOpenAISseDataLine('data:[DONE]')).toBe('done');
+  });
+
+  it('returns undefined for non-data lines', () => {
+    expect(parseOpenAISseDataLine('event: ping')).toBeUndefined();
+  });
+});
+
+describe('parseOpenAIStreamingChunk', () => {
+  it('parses a chunk with empty choices (usage-only)', () => {
+    const result = parseOpenAIStreamingChunk({ choices: [] });
+    expect(result.choices).toHaveLength(0);
+  });
+
+  it('throws for non-object payload', () => {
+    expect(() => parseOpenAIStreamingChunk('not an object')).toThrow('did not include choices');
+  });
+
+  it('throws for missing choices array', () => {
+    expect(() => parseOpenAIStreamingChunk({ id: 'x' })).toThrow('did not include choices');
+  });
+});
+
+describe('streaming accumulation', () => {
+  it('accumulates text content across chunks', () => {
+    const acc = createOpenAIStreamingAccumulator();
+
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'Hello' } }],
+    });
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{ index: 0, delta: { content: ' world' } }],
+    });
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{ index: 0, finish_reason: 'stop' }],
+    });
+
+    const response = assembleOpenAIStreamingResponse(acc);
+    expect(response.choices).toHaveLength(1);
+    expect(response.choices[0].message.content).toBe('Hello world');
+    expect(response.choices[0].finish_reason).toBe('stop');
+    expect(response.choices[0].message.role).toBe('assistant');
+  });
+
+  it('accumulates tool call arguments across fragmented deltas', () => {
+    const acc = createOpenAIStreamingAccumulator();
+
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{
+        index: 0,
+        delta: {
+          role: 'assistant',
+          tool_calls: [{
+            index: 0,
+            id: 'call_abc',
+            type: 'function',
+            function: { name: 'my_tool', arguments: '{"ke' },
+          }],
+        },
+      }],
+    });
+
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: 0,
+            function: { arguments: 'y":"val' },
+          }],
+        },
+      }],
+    });
+
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: 0,
+            function: { arguments: 'ue"}' },
+          }],
+        },
+      }],
+    });
+
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{ index: 0, finish_reason: 'tool_calls' }],
+    });
+
+    const response = assembleOpenAIStreamingResponse(acc);
+    expect(response.choices[0].message.tool_calls).toHaveLength(1);
+    expect(response.choices[0].message.tool_calls![0].id).toBe('call_abc');
+    expect(response.choices[0].message.tool_calls![0].function.name).toBe('my_tool');
+    expect(response.choices[0].message.tool_calls![0].function.arguments).toBe('{"key":"value"}');
+  });
+
+  it('handles usage-only chunk with empty choices', () => {
+    const acc = createOpenAIStreamingAccumulator();
+    applyOpenAIStreamingChunk(acc, { choices: [] });
+    const response = assembleOpenAIStreamingResponse(acc);
+    expect(response.choices).toHaveLength(0);
+  });
+
+  it('assembles empty content when no text and no tool calls', () => {
+    const acc = createOpenAIStreamingAccumulator();
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: 'stop' }],
+    });
+    const response = assembleOpenAIStreamingResponse(acc);
+    expect(response.choices[0].message.content).toBe('');
+  });
+
+  it('sets content to null when tool_calls present but no text', () => {
+    const acc = createOpenAIStreamingAccumulator();
+    applyOpenAIStreamingChunk(acc, {
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: 0,
+            id: 'call_x',
+            type: 'function',
+            function: { name: 'fn', arguments: '{}' },
+          }],
+        },
+        finish_reason: 'tool_calls',
+      }],
+    });
+    const response = assembleOpenAIStreamingResponse(acc);
+    expect(response.choices[0].message.content).toBeNull();
+    expect(response.choices[0].message.tool_calls).toHaveLength(1);
+  });
+});
+
+describe('OpenAIProvider', () => {
+  it('reports supportsNativeSlashCommands as false', () => {
+    const provider = new OpenAIProvider();
+    expect(provider.supportsNativeSlashCommands).toBe(false);
+  });
+
+  it('isSessionInvalid always returns false', () => {
+    const provider = new OpenAIProvider();
+    expect(provider.isSessionInvalid(new Error('anything'))).toBe(false);
+    expect(provider.isSessionInvalid(null)).toBe(false);
+  });
+});
+
+describe('error classes', () => {
+  it('OpenAIHttpError stores status and headers', () => {
+    const headers = new Headers({ 'x-test': '1' });
+    const err = new OpenAIHttpError(429, 'rate limited', headers);
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('rate limited');
+    expect(err.headers?.get('x-test')).toBe('1');
+    expect(err.name).toBe('OpenAIHttpError');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('ProviderRuntimeError stores retryable and classification', () => {
+    const err = new ProviderRuntimeError('fail', false, 'auth');
+    expect(err.retryable).toBe(false);
+    expect(err.classification).toBe('auth');
+    expect(err.name).toBe('ProviderRuntimeError');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('OpenAIProvider fetch integration', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  type Event = { type: string; message?: string; text?: string | null; retryable?: boolean };
+
+  async function drain(events: AsyncIterable<unknown>, max = 60): Promise<Event[]> {
+    const out: Event[] = [];
+    for await (const ev of events) {
+      const e = ev as Event;
+      out.push(e);
+      if (e.type === 'result' || e.type === 'error') break;
+      if (out.length >= max) break;
+    }
+    return out;
+  }
+
+  function jsonResponse(body: object, status = 200, headers: Record<string, string> = {}): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json', ...headers },
+    });
+  }
+
+  function okBody(content: string) {
+    return { choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }] };
+  }
+
+  const baseEnv = { OPENAI_API_KEY: 'test-key', OPENAI_MODEL: 'gpt-4', OPENAI_STREAM: 'false' };
+
+  it('sends fetch to resolved OPENAI_BASE_URL', async () => {
+    let fetchedUrl = '';
+    globalThis.fetch = mock((url: string) => {
+      fetchedUrl = url;
+      return Promise.resolve(jsonResponse(okBody('hi')));
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider({
+      env: { ...baseEnv, OPENAI_BASE_URL: 'https://custom.example.com/v1' },
+    });
+
+    const q = provider.query({ prompt: 'ping', cwd: '/tmp' });
+    await drain(q.events);
+
+    expect(fetchedUrl).toBe('https://custom.example.com/v1/chat/completions');
+  });
+
+  it('sends stream: false in request body when OPENAI_STREAM=false', async () => {
+    let fetchedBody = '';
+    globalThis.fetch = mock((_url: string, init: { body: string }) => {
+      fetchedBody = init.body;
+      return Promise.resolve(jsonResponse(okBody('ok')));
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider({ env: baseEnv });
+    const q = provider.query({ prompt: 'ping', cwd: '/tmp' });
+    await drain(q.events);
+
+    expect(JSON.parse(fetchedBody).stream).toBe(false);
+  });
+
+  it('emits retry progress on 429', async () => {
+    let fetchCount = 0;
+    globalThis.fetch = mock(() => {
+      fetchCount++;
+      return Promise.resolve(
+        new Response('rate limited', { status: 429, headers: { 'Retry-After': '0' } }),
+      );
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider({ env: baseEnv });
+    const q = provider.query({ prompt: 'test', cwd: '/tmp' });
+
+    const events: Event[] = [];
+    for await (const ev of q.events) {
+      const e = ev as Event;
+      events.push(e);
+      if (e.type === 'progress' && e.message?.includes('retrying in')) {
+        q.abort();
+        break;
+      }
+      if (e.type === 'result' || e.type === 'error') break;
+      if (events.length >= 60) break;
+    }
+
+    expect(fetchCount).toBe(1);
+    const retryProgress = events.find((e) => e.type === 'progress' && e.message?.includes('retrying in'));
+    expect(retryProgress).toBeDefined();
+    expect(retryProgress!.message).toContain('HTTP 429');
+  });
+
+  it('yields non-retryable error on content_filter finish_reason', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        jsonResponse({
+          choices: [{ message: { role: 'assistant', content: null }, finish_reason: 'content_filter' }],
+        }),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider({ env: baseEnv });
+    const q = provider.query({ prompt: 'test', cwd: '/tmp' });
+    const events = await drain(q.events);
+
+    const err = events.find((e) => e.type === 'error');
+    expect(err).toBeDefined();
+    expect(err!.message).toContain('content filter');
+    expect(err!.retryable).toBe(false);
+  });
+});

--- a/container/agent-runner/src/providers/openai.ts
+++ b/container/agent-runner/src/providers/openai.ts
@@ -1,0 +1,1251 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+const OPENAI_CONTINUATION = JSON.stringify({ provider: 'openai', v: 1 });
+const MAX_TOOL_STEPS = 12;
+const MAX_TOOL_RESULT_CHARS = 50 * 1024;
+const OPENAI_MAX_ATTEMPTS = 3;
+const OPENAI_RETRY_BASE_DELAY_MS = 1000;
+const OPENAI_RETRY_MAX_JITTER_MS = 500;
+
+/**
+ * Resolves the OpenAI chat completions endpoint URL.
+ * - If baseUrl is not provided, returns the default OpenAI URL.
+ * - If baseUrl ends with `/chat/completions`, uses it as-is.
+ * - If baseUrl ends with `/v1`, appends `/chat/completions`.
+ * - Otherwise, appends `/v1/chat/completions`.
+ */
+export function resolveOpenAIChatCompletionsUrl(baseUrl?: string): string {
+  if (!baseUrl) {
+    return OPENAI_CHAT_COMPLETIONS_URL;
+  }
+
+  const trimmed = baseUrl.trim();
+  if (trimmed.endsWith('/chat/completions')) {
+    return trimmed;
+  }
+  if (trimmed.endsWith('/v1')) {
+    return `${trimmed}/chat/completions`;
+  }
+  return `${trimmed}/v1/chat/completions`;
+}
+
+/**
+ * Resolves the OpenAI request timeout in milliseconds.
+ * - If raw is not provided or invalid, returns the default 120000 ms.
+ * - Parses raw as an integer and returns it if valid and positive.
+ * - Returns default if parsing fails or value is non-positive.
+ */
+export function resolveOpenAIRequestTimeoutMs(raw?: string): number {
+  const DEFAULT_TIMEOUT_MS = 120000;
+
+  if (!raw) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+
+  // Strict validation: only accept strings that are purely digits
+  if (!/^\d+$/.test(trimmed)) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+
+  const parsed = Number(trimmed);
+  if (parsed <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+
+  return parsed;
+}
+
+export function resolveOpenAIStreamEnabled(raw?: string): boolean {
+  if (!raw) {
+    return true;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  return normalized !== 'false' && normalized !== '0' && normalized !== 'no';
+}
+
+type JsonObject = Record<string, unknown>;
+
+interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+type OpenAIChatMessage =
+  | { role: 'system'; content: string }
+  | { role: 'user'; content: string }
+  | { role: 'assistant'; content?: string | null; tool_calls?: OpenAIToolCall[] }
+  | { role: 'tool'; tool_call_id: string; content: string };
+
+interface OpenAIChatTool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters: JsonObject;
+  };
+}
+
+interface OpenAIChatRequest {
+  model: string;
+  messages: OpenAIChatMessage[];
+  stream: boolean;
+  tools?: OpenAIChatTool[];
+  tool_choice?: 'auto';
+}
+
+interface OpenAIChatResponse {
+  choices: Array<{
+    index: number;
+    finish_reason?: string;
+    message: Extract<OpenAIChatMessage, { role: 'assistant' }>;
+  }>;
+}
+
+export interface OpenAIStreamingToolCallDelta {
+  index?: number;
+  id?: string;
+  type?: string;
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+export interface OpenAIStreamingChoiceDelta {
+  role?: string;
+  content?: string | null;
+  tool_calls?: OpenAIStreamingToolCallDelta[];
+}
+
+export interface OpenAIStreamingChoice {
+  index: number;
+  delta?: OpenAIStreamingChoiceDelta;
+  finish_reason?: string | null;
+}
+
+export interface OpenAIStreamingChatChunk {
+  choices: OpenAIStreamingChoice[];
+}
+
+export interface OpenAIStreamingToolCallState {
+  id?: string;
+  type?: string;
+  name: string;
+  arguments: string;
+}
+
+export interface OpenAIStreamingChoiceState {
+  index: number;
+  content: string;
+  finishReason?: string;
+  toolCalls: Map<number, OpenAIStreamingToolCallState>;
+}
+
+export interface OpenAIStreamingAccumulator {
+  choices: Map<number, OpenAIStreamingChoiceState>;
+}
+
+type McpCallResult = Awaited<ReturnType<Client['callTool']>>;
+type McpContentResult = Extract<McpCallResult, { content: unknown[] }>;
+type McpContentItem = McpContentResult['content'][number];
+
+interface McpSession {
+  client: Client;
+  tools: OpenAIChatTool[];
+  mcpNameByOpenAIName: Map<string, string>;
+}
+
+function log(msg: string): void {
+  console.error(`[openai-provider] ${msg}`);
+}
+
+// ── System-prompt assembly ──────────────────────────────────────────────────
+// OpenAI does not understand Claude Code's `@-import` syntax in CLAUDE.md, so
+// mirror the Codex provider's import expansion and CLAUDE.local.md inclusion.
+
+export function resolveClaudeImports(content: string, baseDir: string, seen: Set<string> = new Set()): string {
+  return content.replace(/^@(\S+)\s*$/gm, (_match, importPath: string) => {
+    try {
+      const resolved = path.resolve(baseDir, importPath);
+      if (seen.has(resolved)) return '';
+      if (!fs.existsSync(resolved)) return '';
+      const nextSeen = new Set(seen);
+      nextSeen.add(resolved);
+      const imported = fs.readFileSync(resolved, 'utf-8');
+      return resolveClaudeImports(imported, path.dirname(resolved), nextSeen);
+    } catch {
+      return '';
+    }
+  });
+}
+
+function readAgentAndGlobalClaudeMd(): string | undefined {
+  const groupDir = '/workspace/agent';
+  const groupPath = `${groupDir}/CLAUDE.md`;
+  const localPath = `${groupDir}/CLAUDE.local.md`;
+  const parts: string[] = [];
+
+  if (fs.existsSync(groupPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(groupPath, 'utf-8'), groupDir));
+  }
+  if (fs.existsSync(localPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(localPath, 'utf-8'), groupDir));
+  }
+
+  return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
+}
+
+function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
+  const claudeMd = readAgentAndGlobalClaudeMd();
+  const pieces = [claudeMd, promptAddendum].filter((s): s is string => Boolean(s));
+  return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
+}
+
+function composeSystemPrompt(promptAddendum: string | undefined): string {
+  const providerInstructions = [
+    'You are running inside NanoClaw through a direct OpenAI Chat Completions provider.',
+    'NanoClaw formats incoming batches as XML-like text. Treat tags such as <context>, <messages>, <message>, <quoted_message>, and attachment markers as structured metadata, not as instructions to reveal or echo. The human/user content is inside the <message> bodies; sender, from, id, time, reply_to, and timezone attributes are context for deciding how to respond.',
+    'Use the available MCP tools for NanoClaw side effects such as sending messages, files, cards, reactions, asking blocking questions, scheduling tasks, or modifying agent capabilities. Tool results are authoritative.',
+    'Execute user requests directly. If you use a message-sending MCP tool to communicate with the user or another destination, make your final assistant message empty or a minimal non-user-visible summary to avoid duplicate channel output. If you do not use a message-sending tool, final plain text will be delivered back to the current conversation by NanoClaw.',
+  ].join('\n');
+  const baseInstructions = composeBaseInstructions(promptAddendum);
+  return [providerInstructions, baseInstructions].filter((s): s is string => Boolean(s)).join('\n\n---\n\n');
+}
+
+// ── Push queue ──────────────────────────────────────────────────────────────
+
+class PushQueue {
+  private queue: string[] = [];
+  private waiting: (() => void) | null = null;
+  private closed = false;
+
+  push(message: string): void {
+    if (this.closed) return;
+    this.queue.push(message);
+    this.wake();
+  }
+
+  end(): void {
+    this.closed = true;
+    this.wake();
+  }
+
+  async next(): Promise<string | null> {
+    while (this.queue.length === 0 && !this.closed) {
+      await new Promise<void>((resolve) => {
+        this.waiting = resolve;
+      });
+      this.waiting = null;
+    }
+    return this.queue.shift() ?? null;
+  }
+
+  private wake(): void {
+    this.waiting?.();
+  }
+}
+
+class QueryRuntime {
+  aborted = false;
+  abortController: AbortController | null = null;
+  mcpClient: Client | null = null;
+
+  abort(): void {
+    this.aborted = true;
+    this.abortController?.abort();
+    void this.mcpClient?.close().catch((err: unknown) => {
+      log(`MCP close after abort failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class OpenAIProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private readonly apiKey?: string;
+  private readonly model?: string;
+  private readonly baseUrl?: string;
+  private readonly requestTimeoutMs: number;
+  private readonly streamEnabled: boolean;
+
+  constructor(options: ProviderOptions = {}) {
+    this.apiKey = getEnv(options.env, 'OPENAI_API_KEY');
+    this.model = getEnv(options.env, 'OPENAI_MODEL');
+    this.baseUrl = getEnv(options.env, 'OPENAI_BASE_URL');
+    this.requestTimeoutMs = resolveOpenAIRequestTimeoutMs(getEnv(options.env, 'OPENAI_REQUEST_TIMEOUT_MS'));
+    this.streamEnabled = resolveOpenAIStreamEnabled(getEnv(options.env, 'OPENAI_STREAM'));
+    log(`Chat completions URL: ${resolveOpenAIChatCompletionsUrl(this.baseUrl)}`);
+  }
+
+  /**
+   * OpenAI Chat Completions API is stateless; there is no server-side session or thread.
+   * OPENAI_CONTINUATION is just a static marker { provider: 'openai', v: 1 } for continuation
+   * tracking, not a session token. Always returns false.
+   */
+  isSessionInvalid(_err: unknown): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const queue = new PushQueue();
+    const runtime = new QueryRuntime();
+    const apiKey = this.apiKey;
+    const model = this.model;
+    const baseUrl = this.baseUrl;
+    const requestTimeoutMs = this.requestTimeoutMs;
+    const streamEnabled = this.streamEnabled;
+
+    queue.push(input.prompt);
+
+    async function* gen(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'activity' };
+      yield { type: 'init', continuation: OPENAI_CONTINUATION };
+
+      if (!apiKey) {
+        yield { type: 'error', message: 'OPENAI_API_KEY is required for the OpenAI provider', retryable: false, classification: 'auth' };
+        return;
+      }
+      if (!model) {
+        yield { type: 'error', message: 'OPENAI_MODEL is required for the OpenAI provider', retryable: false };
+        return;
+      }
+
+      let mcpSession: McpSession | null = null;
+      const messages: OpenAIChatMessage[] = [{ role: 'system', content: composeSystemPrompt(input.systemContext?.instructions) }];
+
+      try {
+        yield { type: 'progress', message: 'Starting NanoClaw MCP tools' };
+        mcpSession = await startMcpSession();
+        runtime.mcpClient = mcpSession.client;
+        yield { type: 'activity' };
+        yield { type: 'progress', message: `Discovered ${mcpSession.tools.length} MCP tools` };
+
+        while (!runtime.aborted) {
+          const prompt = await queue.next();
+          if (prompt === null || runtime.aborted) return;
+
+          messages.push({ role: 'user', content: prompt });
+          yield* runOneTurn(messages, mcpSession, apiKey, model, baseUrl, requestTimeoutMs, streamEnabled, runtime);
+        }
+      } catch (err) {
+        if (!runtime.aborted) {
+          yield toProviderError(err);
+        }
+      } finally {
+        if (mcpSession) {
+          runtime.mcpClient = null;
+          await mcpSession.client.close().catch((err: unknown) => {
+            log(`MCP close failed: ${err instanceof Error ? err.message : String(err)}`);
+          });
+        }
+      }
+    }
+
+    return {
+      push: (message: string) => queue.push(message),
+      end: () => queue.end(),
+      abort: () => {
+        runtime.abort();
+        queue.end();
+      },
+      events: gen(),
+    };
+  }
+}
+
+// ── Turn loop ───────────────────────────────────────────────────────────────
+
+async function* runOneTurn(
+  messages: OpenAIChatMessage[],
+  mcpSession: McpSession,
+  apiKey: string,
+  model: string,
+  baseUrl: string | undefined,
+  requestTimeoutMs: number,
+  streamEnabled: boolean,
+  runtime: QueryRuntime,
+): AsyncGenerator<ProviderEvent> {
+  for (let step = 1; step <= MAX_TOOL_STEPS; step++) {
+    if (runtime.aborted) return;
+
+    let response: OpenAIChatResponse | undefined;
+
+    for (let attempt = 1; attempt <= OPENAI_MAX_ATTEMPTS; attempt++) {
+      if (runtime.aborted) return;
+
+      yield { type: 'activity' };
+      yield {
+        type: 'progress',
+        message:
+          attempt === 1
+            ? step === 1
+              ? 'Calling OpenAI'
+              : `Calling OpenAI after tool step ${step - 1}`
+            : `Retrying OpenAI request (attempt ${attempt} of ${OPENAI_MAX_ATTEMPTS})`,
+      };
+
+      try {
+        if (streamEnabled) {
+          response = yield* createStreamingChatCompletion(apiKey, model, messages, mcpSession.tools, baseUrl, requestTimeoutMs, runtime);
+        } else {
+          response = await createChatCompletion(apiKey, model, messages, mcpSession.tools, baseUrl, requestTimeoutMs, runtime);
+        }
+        break;
+      } catch (err) {
+        if (runtime.aborted) return;
+        if (attempt >= OPENAI_MAX_ATTEMPTS || !shouldRetryOpenAIError(err)) {
+          throw err;
+        }
+
+        const delayMs = getOpenAIRetryDelayMs(err, attempt);
+        yield { type: 'activity' };
+        yield {
+          type: 'progress',
+          message: `OpenAI request failed transiently (${describeOpenAIError(err)}); retrying in ${delayMs}ms`,
+        };
+
+        if (runtime.aborted) return;
+        await sleepOpenAIRetryDelay(delayMs);
+        if (runtime.aborted) return;
+      }
+    }
+
+    if (runtime.aborted) return;
+    if (!response) {
+      throw new ProviderRuntimeError('OpenAI request did not return a response', true);
+    }
+
+    const choice = response.choices[0];
+    if (!choice) {
+      throw new ProviderRuntimeError('OpenAI returned no choices', true);
+    }
+
+    const assistantMessage = choice.message;
+    messages.push(assistantMessage);
+    yield { type: 'activity' };
+
+    // Handle finish_reason before processing tool calls or result
+    if (choice.finish_reason === 'content_filter') {
+      throw new ProviderRuntimeError('Response blocked by content filter', false);
+    }
+
+    if (choice.finish_reason === 'length') {
+      yield { type: 'progress', message: 'Response truncated due to length limit' };
+    }
+
+    const toolCalls = assistantMessage.tool_calls ?? [];
+    if (toolCalls.length === 0) {
+      const text = assistantMessage.content?.trim() ? assistantMessage.content : null;
+      yield { type: 'result', text };
+      return;
+    }
+
+    yield { type: 'progress', message: `OpenAI requested ${toolCalls.length} tool call${toolCalls.length === 1 ? '' : 's'}` };
+
+    if (toolCalls.length === 1) {
+      if (runtime.aborted) return;
+      const tc = toolCalls[0];
+      const mcpName = mcpSession.mcpNameByOpenAIName.get(tc.function.name);
+      yield { type: 'activity' };
+      yield { type: 'progress', message: `Running MCP tool: ${mcpName ?? tc.function.name}` };
+      const toolMessage = await callMcpToolAsMessage(tc, mcpSession);
+      messages.push(toolMessage);
+      yield { type: 'activity' };
+    } else {
+      // OpenAI's tool calls within a single assistant response are independent: the model
+      // has not seen any tool result yet when it generates multiple calls, so their execution
+      // order cannot affect each other's semantics. We launch them concurrently and collect
+      // results with Promise.allSettled to ensure one failure does not drop other results.
+      // Messages are appended in the original toolCalls order for deterministic history.
+      if (runtime.aborted) return;
+      for (const tc of toolCalls) {
+        const mcpName = mcpSession.mcpNameByOpenAIName.get(tc.function.name);
+        yield { type: 'activity' };
+        yield { type: 'progress', message: `Running MCP tool: ${mcpName ?? tc.function.name}` };
+      }
+
+      const settled = await Promise.allSettled(
+        toolCalls.map((tc) => callMcpToolAsMessage(tc, mcpSession)),
+      );
+
+      for (let i = 0; i < toolCalls.length; i++) {
+        const result = settled[i];
+        if (result.status === 'fulfilled') {
+          messages.push(result.value);
+        } else {
+          const errMsg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolCalls[i].id,
+            content: `Error: ${errMsg}`,
+          });
+        }
+      }
+      yield { type: 'activity' };
+    }
+  }
+
+  throw new ProviderRuntimeError(`OpenAI tool loop exceeded ${MAX_TOOL_STEPS} steps`, false);
+}
+
+async function callMcpToolAsMessage(
+  toolCall: OpenAIToolCall,
+  mcpSession: McpSession,
+): Promise<Extract<OpenAIChatMessage, { role: 'tool' }>> {
+  const openAIName = toolCall.function.name;
+  const mcpName = mcpSession.mcpNameByOpenAIName.get(openAIName);
+
+  if (!mcpName) {
+    return {
+      role: 'tool',
+      tool_call_id: toolCall.id,
+      content: `Error: unknown MCP tool mapped from OpenAI tool name "${openAIName}"`,
+    };
+  }
+
+  const parsedArgs = parseToolArguments(toolCall.function.arguments);
+  if (!parsedArgs.ok) {
+    return { role: 'tool', tool_call_id: toolCall.id, content: parsedArgs.error };
+  }
+
+  try {
+    const result = await mcpSession.client.callTool({ name: mcpName, arguments: parsedArgs.value });
+    const text = truncateToolResult(formatMcpResult(result));
+    return { role: 'tool', tool_call_id: toolCall.id, content: text };
+  } catch (err) {
+    const errMessage = err instanceof Error ? err.message : String(err);
+    return { role: 'tool', tool_call_id: toolCall.id, content: `Error while running ${mcpName}: ${errMessage}` };
+  }
+}
+
+async function createChatCompletion(
+  apiKey: string,
+  model: string,
+  messages: OpenAIChatMessage[],
+  tools: OpenAIChatTool[],
+  baseUrl: string | undefined,
+  requestTimeoutMs: number,
+  runtime: QueryRuntime,
+): Promise<OpenAIChatResponse> {
+  const request: OpenAIChatRequest = {
+    model,
+    messages,
+    stream: false,
+  };
+
+  if (tools.length > 0) {
+    request.tools = tools;
+    request.tool_choice = 'auto';
+  }
+
+  const controller = new AbortController();
+  runtime.abortController = controller;
+
+  const url = resolveOpenAIChatCompletionsUrl(baseUrl);
+
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    timeoutTimer = setTimeout(() => {
+      controller.abort();
+    }, requestTimeoutMs);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new OpenAIHttpError(response.status, await readOpenAIError(response), response.headers);
+    }
+
+    const payload: unknown = await response.json();
+    return parseOpenAIChatResponse(payload);
+  } finally {
+    if (timeoutTimer !== null) {
+      clearTimeout(timeoutTimer);
+    }
+    if (runtime.abortController === controller) {
+      runtime.abortController = null;
+    }
+  }
+}
+
+async function* createStreamingChatCompletion(
+  apiKey: string,
+  model: string,
+  messages: OpenAIChatMessage[],
+  tools: OpenAIChatTool[],
+  baseUrl: string | undefined,
+  requestTimeoutMs: number,
+  runtime: QueryRuntime,
+): AsyncGenerator<ProviderEvent, OpenAIChatResponse, void> {
+  const request: OpenAIChatRequest = {
+    model,
+    messages,
+    stream: true,
+  };
+
+  if (tools.length > 0) {
+    request.tools = tools;
+    request.tool_choice = 'auto';
+  }
+
+  const controller = new AbortController();
+  runtime.abortController = controller;
+
+  const url = resolveOpenAIChatCompletionsUrl(baseUrl);
+  const accumulator = createOpenAIStreamingAccumulator();
+
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    timeoutTimer = setTimeout(() => {
+      controller.abort();
+    }, requestTimeoutMs);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new OpenAIHttpError(response.status, await readOpenAIError(response), response.headers);
+    }
+
+    if (!response.body) {
+      throw new ProviderRuntimeError('OpenAI streaming response did not include a body', true);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let done = false;
+
+    while (!done) {
+      const read = await reader.read();
+      if (read.done) break;
+
+      buffer += decoder.decode(read.value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const parsed = parseOpenAISseDataLine(line);
+        if (parsed === 'done') {
+          done = true;
+          break;
+        }
+        if (parsed === undefined) continue;
+
+        applyOpenAIStreamingChunk(accumulator, parsed);
+        yield { type: 'activity' };
+      }
+    }
+
+    buffer += decoder.decode();
+    if (!done && buffer.length > 0) {
+      const parsed = parseOpenAISseDataLine(buffer);
+      if (parsed !== undefined && parsed !== 'done') {
+        applyOpenAIStreamingChunk(accumulator, parsed);
+        yield { type: 'activity' };
+      }
+    }
+
+    return assembleOpenAIStreamingResponse(accumulator);
+  } catch (err) {
+    if (err instanceof OpenAIHttpError || err instanceof ProviderRuntimeError || err instanceof TypeError || (err instanceof Error && err.name === 'AbortError')) {
+      throw err;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ProviderRuntimeError(`OpenAI streaming response failed before completion: ${message}`, true);
+  } finally {
+    if (timeoutTimer !== null) {
+      clearTimeout(timeoutTimer);
+    }
+    if (runtime.abortController === controller) {
+      runtime.abortController = null;
+    }
+  }
+}
+
+export function createOpenAIStreamingAccumulator(): OpenAIStreamingAccumulator {
+  return { choices: new Map() };
+}
+
+export function parseOpenAISseDataLine(line: string): OpenAIStreamingChatChunk | 'done' | undefined {
+  const normalized = line.endsWith('\r') ? line.slice(0, -1) : line;
+  if (!normalized.trim() || normalized.startsWith(':')) {
+    return undefined;
+  }
+  if (!normalized.startsWith('data:')) {
+    return undefined;
+  }
+
+  const rawData = normalized.slice(5);
+  const data = rawData.startsWith(' ') ? rawData.slice(1) : rawData;
+  if (data.trim() === '[DONE]') {
+    return 'done';
+  }
+
+  const payload = JSON.parse(data) as unknown;
+  return parseOpenAIStreamingChunk(payload);
+}
+
+export function parseOpenAIStreamingChunk(payload: unknown): OpenAIStreamingChatChunk {
+  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+    throw new Error('OpenAI streaming chunk did not include choices');
+  }
+
+  return {
+    choices: payload.choices.map(parseOpenAIStreamingChoice),
+  };
+}
+
+function parseOpenAIStreamingChoice(payload: unknown, fallbackIndex: number): OpenAIStreamingChoice {
+  if (!isRecord(payload)) {
+    throw new Error('OpenAI streaming choice was not an object');
+  }
+
+  return {
+    index: typeof payload.index === 'number' ? payload.index : fallbackIndex,
+    delta: parseOpenAIStreamingDelta(payload.delta),
+    finish_reason:
+      typeof payload.finish_reason === 'string' || payload.finish_reason === null ? payload.finish_reason : undefined,
+  };
+}
+
+function parseOpenAIStreamingDelta(payload: unknown): OpenAIStreamingChoiceDelta | undefined {
+  if (payload === undefined || payload === null) {
+    return undefined;
+  }
+  if (!isRecord(payload)) {
+    throw new Error('OpenAI streaming delta was not an object');
+  }
+
+  const delta: OpenAIStreamingChoiceDelta = {};
+  if (typeof payload.role === 'string') {
+    delta.role = payload.role;
+  }
+  if (typeof payload.content === 'string' || payload.content === null) {
+    delta.content = payload.content;
+  }
+  if (payload.tool_calls !== undefined) {
+    if (!Array.isArray(payload.tool_calls)) {
+      throw new Error('OpenAI streaming tool_calls delta was not an array');
+    }
+    delta.tool_calls = payload.tool_calls.map(parseOpenAIStreamingToolCallDelta);
+  }
+
+  return delta;
+}
+
+function parseOpenAIStreamingToolCallDelta(payload: unknown): OpenAIStreamingToolCallDelta {
+  if (!isRecord(payload)) {
+    throw new Error('OpenAI streaming tool call delta was not an object');
+  }
+
+  const delta: OpenAIStreamingToolCallDelta = {};
+  if (typeof payload.index === 'number') {
+    delta.index = payload.index;
+  }
+  if (typeof payload.id === 'string') {
+    delta.id = payload.id;
+  }
+  if (typeof payload.type === 'string') {
+    delta.type = payload.type;
+  }
+  if (payload.function !== undefined) {
+    if (!isRecord(payload.function)) {
+      throw new Error('OpenAI streaming tool call function delta was not an object');
+    }
+    delta.function = {};
+    if (typeof payload.function.name === 'string') {
+      delta.function.name = payload.function.name;
+    }
+    if (typeof payload.function.arguments === 'string') {
+      delta.function.arguments = payload.function.arguments;
+    }
+  }
+
+  return delta;
+}
+
+export function applyOpenAIStreamingChunk(accumulator: OpenAIStreamingAccumulator, chunk: OpenAIStreamingChatChunk): void {
+  for (const choice of chunk.choices) {
+    let state = accumulator.choices.get(choice.index);
+    if (!state) {
+      state = { index: choice.index, content: '', toolCalls: new Map() };
+      accumulator.choices.set(choice.index, state);
+    }
+
+    if (typeof choice.finish_reason === 'string') {
+      state.finishReason = choice.finish_reason;
+    }
+
+    const delta = choice.delta;
+    if (!delta) continue;
+
+    if (typeof delta.content === 'string') {
+      state.content += delta.content;
+    }
+
+    if (!delta.tool_calls) continue;
+
+    for (const toolCallDelta of delta.tool_calls) {
+      if (typeof toolCallDelta.index !== 'number') {
+        throw new Error('OpenAI streaming tool call delta was missing index');
+      }
+
+      let toolCall = state.toolCalls.get(toolCallDelta.index);
+      if (!toolCall) {
+        toolCall = { name: '', arguments: '' };
+        state.toolCalls.set(toolCallDelta.index, toolCall);
+      }
+
+      if (typeof toolCallDelta.id === 'string' && !toolCall.id) {
+        toolCall.id = toolCallDelta.id;
+      }
+      if (typeof toolCallDelta.type === 'string' && !toolCall.type) {
+        toolCall.type = toolCallDelta.type;
+      }
+      if (toolCallDelta.function) {
+        if (typeof toolCallDelta.function.name === 'string') {
+          toolCall.name += toolCallDelta.function.name;
+        }
+        if (typeof toolCallDelta.function.arguments === 'string') {
+          toolCall.arguments += toolCallDelta.function.arguments;
+        }
+      }
+    }
+  }
+}
+
+export function assembleOpenAIStreamingResponse(accumulator: OpenAIStreamingAccumulator): OpenAIChatResponse {
+  return {
+    choices: [...accumulator.choices.values()]
+      .sort((a, b) => a.index - b.index)
+      .map((choice) => ({
+        index: choice.index,
+        finish_reason: choice.finishReason,
+        message: assembleOpenAIStreamingMessage(choice),
+      })),
+  };
+}
+
+function assembleOpenAIStreamingMessage(choice: OpenAIStreamingChoiceState): Extract<OpenAIChatMessage, { role: 'assistant' }> {
+  const toolCalls = [...choice.toolCalls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([_index, toolCall]) => assembleOpenAIStreamingToolCall(toolCall));
+
+  const message: Extract<OpenAIChatMessage, { role: 'assistant' }> = { role: 'assistant' };
+  if (choice.content.length > 0) {
+    message.content = choice.content;
+  } else if (toolCalls.length > 0) {
+    message.content = null;
+  } else {
+    message.content = '';
+  }
+
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+
+  return message;
+}
+
+function assembleOpenAIStreamingToolCall(toolCall: OpenAIStreamingToolCallState): OpenAIToolCall {
+  if (!toolCall.id) {
+    throw new Error('OpenAI streaming tool call was missing id');
+  }
+  if (!toolCall.name) {
+    throw new Error('OpenAI streaming tool call was missing function name');
+  }
+
+  return {
+    id: toolCall.id,
+    type: 'function',
+    function: {
+      name: toolCall.name,
+      arguments: toolCall.arguments,
+    },
+  };
+}
+
+// ── MCP integration ─────────────────────────────────────────────────────────
+
+async function startMcpSession(): Promise<McpSession> {
+  const client = new Client({ name: 'nanoclaw-openai-provider', version: '1.0.0' }, { capabilities: {} });
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: ['run', '/app/src/mcp-tools/index.ts'],
+  });
+
+  await client.connect(transport);
+  const mcpTools = await listAllMcpTools(client);
+  const catalog = buildToolCatalog(mcpTools);
+  return { client, ...catalog };
+}
+
+async function listAllMcpTools(client: Client): Promise<Tool[]> {
+  const tools: Tool[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const result = await client.listTools(cursor ? { cursor } : undefined);
+    tools.push(...result.tools);
+    cursor = result.nextCursor;
+  } while (cursor);
+
+  return tools;
+}
+
+function buildToolCatalog(mcpTools: Tool[]): Pick<McpSession, 'tools' | 'mcpNameByOpenAIName'> {
+  const used = new Set<string>();
+  const mcpNameByOpenAIName = new Map<string, string>();
+  const tools = mcpTools.map((tool): OpenAIChatTool => {
+    const openAIName = createOpenAIToolName(tool.name, used);
+    mcpNameByOpenAIName.set(openAIName, tool.name);
+    return {
+      type: 'function',
+      function: {
+        name: openAIName,
+        description: tool.description,
+        parameters: normalizeToolParameters(tool.inputSchema),
+      },
+    };
+  });
+
+  return { tools, mcpNameByOpenAIName };
+}
+
+export function createOpenAIToolName(mcpName: string, used: Set<string>): string {
+  const sanitized = mcpName.replace(/__+/g, '_').replace(/[^A-Za-z0-9_-]/g, '_');
+  const base = (sanitized || 'tool').slice(0, 64);
+
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+
+  for (let i = 2; ; i++) {
+    const suffix = `_${i}`;
+    const candidate = `${base.slice(0, 64 - suffix.length)}${suffix}`;
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+}
+
+export function normalizeToolParameters(schema: Tool['inputSchema'] | undefined): JsonObject {
+  const params: JsonObject = isRecord(schema) ? { ...schema } : {};
+  if (params.type !== 'object') {
+    params.type = 'object';
+  }
+  if (!isRecord(params.properties)) {
+    params.properties = {};
+  }
+  return params;
+}
+
+export function parseToolArguments(raw: string): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: true, value: {} };
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!isRecord(parsed)) {
+      return { ok: false, error: 'Error: tool arguments must be a JSON object' };
+    }
+    return { ok: true, value: parsed };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Error: invalid JSON tool arguments: ${message}` };
+  }
+}
+
+function formatMcpResult(result: McpCallResult): string {
+  if ('content' in result && Array.isArray(result.content)) {
+    const text = result.content.map(formatMcpContentItem).join('\n');
+    return 'isError' in result && result.isError ? `Tool returned an error:\n${text}` : text;
+  }
+  if ('toolResult' in result) {
+    return stringifyUnknown(result.toolResult);
+  }
+  return stringifyUnknown(result);
+}
+
+function formatMcpContentItem(item: McpContentItem): string {
+  switch (item.type) {
+    case 'text':
+      return item.text;
+    case 'image':
+      return `[image: ${item.mimeType}, ${item.data.length} base64 chars]`;
+    case 'audio':
+      return `[audio: ${item.mimeType}, ${item.data.length} base64 chars]`;
+    case 'resource':
+      return stringifyUnknown(item.resource);
+    case 'resource_link':
+      return `[resource: ${item.name} at ${item.uri}]`;
+    default:
+      return stringifyUnknown(item);
+  }
+}
+
+export function truncateToolResult(text: string): string {
+  if (text.length <= MAX_TOOL_RESULT_CHARS) return text;
+  return `${text.slice(0, MAX_TOOL_RESULT_CHARS)}\n\n[truncated ${text.length - MAX_TOOL_RESULT_CHARS} characters from MCP tool result]`;
+}
+
+// ── OpenAI response parsing and errors ──────────────────────────────────────
+
+export class OpenAIHttpError extends Error {
+  readonly status: number;
+  readonly headers?: Headers;
+
+  constructor(status: number, message: string, headers?: Headers) {
+    super(message);
+    this.name = 'OpenAIHttpError';
+    this.status = status;
+    this.headers = headers;
+  }
+}
+
+export class ProviderRuntimeError extends Error {
+  readonly retryable: boolean;
+  readonly classification?: string;
+
+  constructor(message: string, retryable: boolean, classification?: string) {
+    super(message);
+    this.name = 'ProviderRuntimeError';
+    this.retryable = retryable;
+    this.classification = classification;
+  }
+}
+
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
+  const raw = headers.get('retry-after')?.trim();
+  if (!raw) return undefined;
+
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+}
+
+export function shouldRetryOpenAIError(err: unknown): boolean {
+  if (err instanceof ProviderRuntimeError) {
+    return err.retryable;
+  }
+
+  if (err instanceof OpenAIHttpError) {
+    return err.status === 429 || (err.status >= 500 && err.status <= 599);
+  }
+
+  if (err instanceof Error && err.name === 'AbortError') {
+    return true;
+  }
+
+  return err instanceof TypeError;
+}
+
+export function getOpenAIRetryDelayMs(err: unknown, retryAttempt: number, random: () => number = Math.random): number {
+  if (err instanceof OpenAIHttpError && err.headers) {
+    const retryAfterSeconds = parseRetryAfterSeconds(err.headers);
+    if (retryAfterSeconds !== undefined) {
+      return Math.round(retryAfterSeconds * 1000);
+    }
+  }
+
+  const exponentialDelayMs = OPENAI_RETRY_BASE_DELAY_MS * 2 ** Math.max(0, retryAttempt - 1);
+  const jitterRatio = Math.max(0, Math.min(random(), 1));
+  const jitterMs = Math.floor(jitterRatio * OPENAI_RETRY_MAX_JITTER_MS);
+  return exponentialDelayMs + jitterMs;
+}
+
+export async function sleepOpenAIRetryDelay(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+}
+
+function describeOpenAIError(err: unknown): string {
+  if (err instanceof OpenAIHttpError) {
+    return `HTTP ${err.status}`;
+  }
+  if (err instanceof Error) {
+    return err.name || err.message;
+  }
+  return String(err);
+}
+
+async function readOpenAIError(response: Response): Promise<string> {
+  const fallback = `OpenAI request failed with HTTP ${response.status}`;
+  const text = await response.text();
+  if (!text.trim()) return fallback;
+
+  const parsed = safeJsonParse(text);
+  if (isRecord(parsed)) {
+    const error = parsed.error;
+    if (isRecord(error) && typeof error.message === 'string') {
+      return `${fallback}: ${error.message}`;
+    }
+  }
+
+  return `${fallback}: ${text.slice(0, 500)}`;
+}
+
+export function parseOpenAIChatResponse(payload: unknown): OpenAIChatResponse {
+  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+    throw new Error('OpenAI response did not include choices');
+  }
+
+  return {
+    choices: payload.choices.map((choice, index) => parseOpenAIChoice(choice, index)),
+  };
+}
+
+function parseOpenAIChoice(payload: unknown, fallbackIndex: number): OpenAIChatResponse['choices'][number] {
+  if (!isRecord(payload)) {
+    throw new Error('OpenAI choice was not an object');
+  }
+  return {
+    index: typeof payload.index === 'number' ? payload.index : fallbackIndex,
+    finish_reason: typeof payload.finish_reason === 'string' ? payload.finish_reason : undefined,
+    message: parseAssistantMessage(payload.message),
+  };
+}
+
+function parseAssistantMessage(payload: unknown): Extract<OpenAIChatMessage, { role: 'assistant' }> {
+  if (!isRecord(payload) || payload.role !== 'assistant') {
+    throw new Error('OpenAI choice did not include an assistant message');
+  }
+
+  const message: Extract<OpenAIChatMessage, { role: 'assistant' }> = { role: 'assistant' };
+  if (typeof payload.content === 'string' || payload.content === null) {
+    message.content = payload.content;
+  }
+
+  const toolCalls = parseOpenAIToolCalls(payload.tool_calls);
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+
+  return message;
+}
+
+function parseOpenAIToolCalls(payload: unknown): OpenAIToolCall[] {
+  if (payload === undefined || payload === null) return [];
+  if (!Array.isArray(payload)) {
+    throw new Error('OpenAI tool_calls was not an array');
+  }
+  return payload.map(parseOpenAIToolCall);
+}
+
+function parseOpenAIToolCall(payload: unknown): OpenAIToolCall {
+  if (!isRecord(payload) || payload.type !== 'function' || typeof payload.id !== 'string' || !isRecord(payload.function)) {
+    throw new Error('OpenAI tool call was malformed');
+  }
+
+  const fn = payload.function;
+  if (typeof fn.name !== 'string') {
+    throw new Error('OpenAI tool call function name was missing');
+  }
+
+  return {
+    id: payload.id,
+    type: 'function',
+    function: {
+      name: fn.name,
+      arguments: typeof fn.arguments === 'string' ? fn.arguments : '{}',
+    },
+  };
+}
+
+export function toProviderError(err: unknown): ProviderEvent {
+  if (err instanceof ProviderRuntimeError) {
+    return { type: 'error', message: err.message, retryable: err.retryable, classification: err.classification };
+  }
+
+  if (err instanceof OpenAIHttpError) {
+    if (err.status === 401 || err.status === 403) {
+      return { type: 'error', message: err.message, retryable: false, classification: 'auth' };
+    }
+    if (err.status === 429) {
+      return { type: 'error', message: err.message, retryable: true };
+    }
+    if (err.status >= 500 && err.status <= 599) {
+      return { type: 'error', message: err.message, retryable: true };
+    }
+    return { type: 'error', message: err.message, retryable: false };
+  }
+
+  if (err instanceof Error && err.name === 'AbortError') {
+    return { type: 'error', message: err.message, retryable: true };
+  }
+
+  if (err instanceof TypeError) {
+    return { type: 'error', message: err.message, retryable: true };
+  }
+
+  return { type: 'error', message: err instanceof Error ? err.message : String(err), retryable: false };
+}
+
+function getEnv(env: Record<string, string | undefined> | undefined, key: string): string | undefined {
+  const value = env?.[key] ?? process.env[key];
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    const json = JSON.stringify(value, null, 2);
+    return json ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+registerProvider('openai', (opts) => new OpenAIProvider(opts));

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,0 +1,51 @@
+/**
+ * Host-side container config for the `codex` provider.
+ *
+ * Codex reads auth and MCP config from ~/.codex. We give each session its
+ * own private copy of that directory so:
+ *
+ * - The user's host ~/.codex/auth.json reaches the container without us
+ *   touching their host config.toml (which the host's own `codex` CLI
+ *   might be using).
+ * - The in-container provider can rewrite config.toml freely on every
+ *   wake with container-appropriate MCP server paths, without racing
+ *   other sessions or leaking per-session paths back to the host.
+ *
+ * Env passthrough covers the two knobs that are read at runtime:
+ *   OPENAI_API_KEY  — fallback auth when auth.json isn't a subscription token
+ *   CODEX_MODEL     — model override if the user wants something other than the default
+ *   OPENAI_BASE_URL — rare, but supports API-compatible alternates
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { readEnvFile } from '../env.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+registerProviderContainerConfig('codex', (ctx) => {
+  const codexDir = path.join(ctx.sessionDir, 'codex');
+  fs.mkdirSync(codexDir, { recursive: true });
+
+  // Copy the host's auth.json into the per-session dir if it exists.
+  // We only copy auth.json, not the full ~/.codex — config.toml would
+  // get clobbered by the container on every wake anyway.
+  const hostHome = ctx.hostEnv.HOME;
+  if (hostHome) {
+    const hostAuth = path.join(hostHome, '.codex', 'auth.json');
+    if (fs.existsSync(hostAuth)) {
+      fs.copyFileSync(hostAuth, path.join(codexDir, 'auth.json'));
+    }
+  }
+
+  const dotenv = readEnvFile(['OPENAI_API_KEY', 'CODEX_MODEL', 'OPENAI_BASE_URL']);
+  const env: Record<string, string> = {};
+  for (const key of ['OPENAI_API_KEY', 'CODEX_MODEL', 'OPENAI_BASE_URL'] as const) {
+    const value = ctx.hostEnv[key] || dotenv[key];
+    if (value) env[key] = value;
+  }
+
+  return {
+    mounts: [{ hostPath: codexDir, containerPath: '/home/node/.codex', readonly: false }],
+    env,
+  };
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,3 +4,6 @@
 // needs (claude, mock) don't appear here.
 //
 // Skills add a new provider by appending one import line below.
+
+import './codex.js';
+import './openai.js';

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,20 @@
+/**
+ * Host-side container config for the `openai` provider.
+ *
+ * Minimal: just forward API key, model, and optional base URL from .env
+ * into the container environment. No mounts needed — the OpenAI provider
+ * talks to the API directly via fetch().
+ */
+import { readEnvFile } from '../env.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+registerProviderContainerConfig('openai', (ctx) => {
+  const dotenv = readEnvFile(['OPENAI_API_KEY', 'OPENAI_MODEL', 'OPENAI_BASE_URL']);
+  const env: Record<string, string> = {};
+  for (const key of ['OPENAI_API_KEY', 'OPENAI_MODEL', 'OPENAI_BASE_URL'] as const) {
+    const value = ctx.hostEnv[key] || dotenv[key];
+    if (value) env[key] = value;
+  }
+
+  return { env };
+});


### PR DESCRIPTION
## Summary

Add two new agent providers to enable OpenAI-powered agents alongside Claude:

- **OpenAI provider**: Direct Chat Completions API with full MCP tool integration, streaming SSE support, retry with exponential backoff + jitter, and tool name sanitization for OpenAI's 64-char constraint
- **Codex provider**: Wraps `codex app-server` via JSON-RPC with thread start/resume, auto-approval for sandboxed containers, and TOML-based MCP config generation

## Architecture

Both providers follow the existing host/container split pattern:

| Layer | OpenAI | Codex |
|-------|--------|-------|
| **Host-side** (`src/providers/`) | Env passthrough: `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_BASE_URL` | Env passthrough + `~/.codex/auth.json` mount into per-session dir |
| **Container-side** (`container/agent-runner/src/providers/`) | Full `AgentProvider` implementation with MCP tool loop | `codex app-server` JSON-RPC wrapper with notification-driven event pump |

### OpenAI Provider Highlights
- Streaming and non-streaming Chat Completions support
- SSE parser with accumulator pattern for fragmented tool call arguments
- MCP tool discovery via `@modelcontextprotocol/sdk` with tool name sanitization
- Concurrent tool execution via `Promise.allSettled` (matches OpenAI's `parallel_tool_calls` semantics)
- Retry logic: exponential backoff + jitter + `Retry-After` header support
- System prompt composed from `CLAUDE.md` + `CLAUDE.local.md` with `@-import` expansion
- 50KB tool result truncation, 12-step tool loop ceiling, 120s default request timeout

### Codex Provider Highlights
- Spawns `codex app-server` per query with stdio JSON-RPC transport
- Thread start/resume with stale-thread detection and automatic fallback
- Auto-approval handler (container sandbox is the security boundary)
- MCP config written to `~/.codex/config.toml` on each spawn
- 5-minute per-turn timeout guard

### Dockerfile
- Adds `@openai/codex@0.124.0` global install (pinned version)

## Tests

93 new tests across two test files:

- `openai.test.ts` (84 tests): URL resolution, timeout parsing, stream toggle, `@-import` expansion, error classification, tool argument parsing, tool name sanitization, truncation, schema normalization, response parsing, retry logic, SSE parsing, streaming accumulation, provider construction, fetch integration with mocked responses
- `codex.factory.test.ts` (9 tests): Provider factory wiring, stale thread detection, slash command support flag, `@-import` expansion

## Verification

- ✅ TypeScript build: clean
- ✅ ESLint: clean
- ✅ Container tests (bun): 68 pass, 0 fail
- ✅ Host-side tests (vitest): 197 pass, 0 fail

## Notes

- `resolveClaudeImports` and `readAgentAndGlobalClaudeMd` are duplicated between `openai.ts` and `codex.ts` — intentional for now to keep providers self-contained; should extract to shared utility once behavior stabilizes
- Codex default model is `gpt-5.4-mini` (hardcoded); OpenAI provider requires explicit `OPENAI_MODEL` env var
- Removed unrelated Slack channel adapter that was accidentally mixed into the branch