### PR TITLE
Clear password field after validation error

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -706,6 +706,7 @@ async function runPasteAuth(method: 'oauth' | 'api'): Promise<void> {
   const answer = ensureAnswer(
     await p.password({
       message: `Paste your ${label}`,
+      clearOnError: true,
       validate: (v) => {
         if (!v || !v.trim()) return 'Required';
         if (!v.trim().startsWith(prefix)) {

--- a/setup/channels/discord.ts
+++ b/setup/channels/discord.ts
@@ -242,6 +242,7 @@ async function collectDiscordToken(): Promise<string> {
   const answer = ensureAnswer(
     await p.password({
       message: 'Paste your bot token',
+      clearOnError: true,
       validate: (v) => {
         const t = (v ?? '').trim();
         if (!t) return 'Token is required';

--- a/setup/channels/imessage.ts
+++ b/setup/channels/imessage.ts
@@ -250,6 +250,7 @@ async function collectRemoteCreds(): Promise<RemoteCreds> {
   const keyAnswer = ensureAnswer(
     await p.password({
       message: 'Photon API key',
+      clearOnError: true,
       validate: (v) => ((v ?? '').trim() ? undefined : 'API key is required'),
     }),
   );

--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -154,6 +154,7 @@ async function collectBotToken(): Promise<string> {
   const answer = ensureAnswer(
     await p.password({
       message: 'Paste your Slack bot token',
+      clearOnError: true,
       validate: (v) => {
         const t = (v ?? '').trim();
         if (!t) return 'Token is required';
@@ -175,6 +176,7 @@ async function collectSigningSecret(): Promise<string> {
   const answer = ensureAnswer(
     await p.password({
       message: 'Paste your Slack signing secret',
+      clearOnError: true,
       validate: (v) => {
         const t = (v ?? '').trim();
         if (!t) return 'Signing secret is required';

--- a/setup/channels/teams.ts
+++ b/setup/channels/teams.ts
@@ -276,6 +276,7 @@ async function stepClientSecret(args: {
     const answer = ensureAnswer(
       await p.password({
         message: 'Paste the client secret Value',
+        clearOnError: true,
         validate: validateWithHelpEscape((v) => {
           const t = (v ?? '').trim();
           if (!t) return 'Required';

--- a/setup/channels/telegram.ts
+++ b/setup/channels/telegram.ts
@@ -150,6 +150,7 @@ async function collectTelegramToken(): Promise<string> {
   const answer = ensureAnswer(
     await p.password({
       message: 'Paste your bot token',
+      clearOnError: true,
       validate: (v) => {
         if (!v || !v.trim()) return "Token is required";
         if (!/^[0-9]+:[A-Za-z0-9_-]{35,}$/.test(v.trim())) {

--- a/setup/lib/setup-config-screen.ts
+++ b/setup/lib/setup-config-screen.ts
@@ -115,7 +115,7 @@ async function promptOne(e: Entry, values: ConfigValues): Promise<void> {
   };
   const ans = ensureAnswer(
     e.secret
-      ? await p.password({ message: e.label, validate })
+      ? await p.password({ message: e.label, clearOnError: true, validate })
       : await p.text({
           message: e.label,
           placeholder: e.placeholder ?? e.default,


### PR DESCRIPTION
## Summary

- Add `clearOnError: true` to all 8 `p.password()` prompts across setup
- When a pasted token fails validation, the input field now clears so the user can paste a fresh value without it appending to the old one

## Test plan

- [ ] Paste an invalid token (e.g. wrong prefix) at any channel setup prompt
- [ ] Confirm the field clears after the error message
- [ ] Paste the correct token — should validate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)