### PR TITLE
feat(skill): add Lore Context semantic memory skill

### DIFF
--- a/.claude/skills/add-lore-context/MCP_CONFIG.md
+++ b/.claude/skills/add-lore-context/MCP_CONFIG.md
@@ -1,0 +1,100 @@
+# Lore Context MCP Server Configuration
+
+This file shows how to configure Lore Context as an MCP server for NanoClaw agent containers.
+
+## Quick setup
+
+Add this to your agent group's `container.json`:
+
+```json
+{
+  "mcpServers": {
+    "lore-context": {
+      "command": "npx",
+      "args": ["-y", "@lore-context/mcp-server"],
+      "env": {
+        "LORE_API_KEY": "your-api-key",
+        "LORE_PROJECT_ID": "your-project-id"
+      },
+      "instructions": "Lore Context provides semantic memory across sessions. Use memory_write to store important insights, decisions, and patterns. Use memory_search to recall relevant context before responding to queries that reference past conversations."
+    }
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `LORE_API_KEY` | Yes | — | API key from lore-context.com or self-hosted instance |
+| `LORE_PROJECT_ID` | Yes | — | Project ID for memory scoping |
+| `LORE_BASE_URL` | No | `https://api.lore-context.com` | Custom API endpoint for self-hosted instances |
+
+## Self-hosted configuration
+
+If running your own Lore Context instance:
+
+```json
+{
+  "mcpServers": {
+    "lore-context": {
+      "command": "npx",
+      "args": ["-y", "@lore-context/mcp-server"],
+      "env": {
+        "LORE_API_KEY": "your-api-key",
+        "LORE_PROJECT_ID": "your-project-id",
+        "LORE_BASE_URL": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+## Using with OneCLI vault (recommended)
+
+For production, store credentials in OneCLI vault instead of container.json:
+
+1. Add secrets to vault:
+   ```bash
+   onecli secret set LORE_API_KEY --value "your-api-key"
+   onecli secret set LORE_PROJECT_ID --value "your-project-id"
+   ```
+
+2. Use placeholder values in container.json (vault proxy injects real values at runtime):
+   ```json
+   {
+     "mcpServers": {
+       "lore-context": {
+         "command": "npx",
+         "args": ["-y", "@lore-context/mcp-server"],
+         "env": {
+           "LORE_API_KEY": "LORE_API_KEY",
+           "LORE_PROJECT_ID": "LORE_PROJECT_ID"
+         }
+       }
+     }
+   }
+   ```
+
+## Available MCP tools
+
+Once configured, the agent has access to these tools:
+
+| Tool | Description |
+|------|-------------|
+| `memory_search` | Semantic search across stored memories |
+| `memory_write` | Store a new memory with metadata |
+| `memory_update` | Edit an existing memory |
+| `memory_supersede` | Create a new version of a memory |
+| `memory_list` | List memories with filters |
+| `memory_get` | Read a specific memory by ID |
+| `memory_forget` | Soft-delete a memory |
+| `memory_export` | Export memories as JSON or Markdown |
+| `context_query` | Get agent-ready context from memory, web, and repo sources |
+
+## Available MCP prompts
+
+| Prompt | Description |
+|--------|-------------|
+| `memory-context` | Generate a context summary for the current conversation |
+| `memory-review` | Review recent memories for accuracy |

--- a/.claude/skills/add-lore-context/SKILL.md
+++ b/.claude/skills/add-lore-context/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: add-lore-context
+description: Add Lore Context semantic memory as an MCP server for cross-session memory retrieval and storage.
+---
+
+# Add Lore Context Memory
+
+Adds [Lore Context](https://github.com/Lore-Context/lore-context) as a persistent semantic memory backend for your NanoClaw agents. Lore Context provides cross-session memory with semantic search — your agents can recall relevant context from past conversations, decisions, and learned patterns without manually sifting through files.
+
+## What it does
+
+- **Semantic memory retrieval**: Agents search past sessions using natural language queries
+- **Cross-session context**: Memories persist across all sessions for an agent group
+- **Structured memory types**: Patterns, preferences, architecture decisions, bugs, workflows, facts
+- **Automatic deduplication**: Lore handles versioning and superseding outdated memories
+
+## Install
+
+### Pre-flight
+
+Skip to **Configuration** if all of these are already in place:
+
+- `lore-context` appears in your group's `container.json` under `mcpServers`
+- The `container/skills/lore-context/` directory exists in your install
+
+Otherwise continue.
+
+### 1. Add the Lore Context MCP server to your container config
+
+For each agent group that should have semantic memory, add the Lore Context MCP server to its `container.json`:
+
+```bash
+# The agent can do this via the add_mcp_server tool, or you can edit directly:
+# groups/<folder>/container.json
+```
+
+The MCP server configuration to add:
+
+```json
+{
+  "mcpServers": {
+    "lore-context": {
+      "command": "npx",
+      "args": ["-y", "@lore-context/mcp-server"],
+      "env": {
+        "LORE_API_KEY": "your-api-key-here",
+        "LORE_PROJECT_ID": "your-project-id"
+      },
+      "instructions": "Lore Context provides semantic memory across sessions. Use memory_write to store important insights, decisions, and patterns. Use memory_search to recall relevant context before responding to user queries that reference past conversations or decisions."
+    }
+  }
+}
+```
+
+### 2. Copy the container skill
+
+```bash
+# The lore-context container skill teaches the agent how and when to use
+# Lore's memory tools. It should already be present in container/skills/lore-context/.
+# If not, ensure this directory exists with the SKILL.md file.
+ls container/skills/lore-context/SKILL.md
+```
+
+### 3. Get your Lore Context credentials
+
+1. Sign up at [lore-context.com](https://lore-context.com) or self-host via [GitHub](https://github.com/Lore-Context/lore-context)
+2. Create a project and get your API key
+3. Add the credentials to your OneCLI vault (do NOT put real API keys in container.json):
+
+```bash
+# Add to OneCLI vault — the vault proxy injects them at runtime
+onecli secret set LORE_API_KEY --value "your-api-key"
+onecli secret set LORE_PROJECT_ID --value "your-project-id"
+```
+
+Then update container.json to use placeholder values:
+
+```json
+{
+  "mcpServers": {
+    "lore-context": {
+      "command": "npx",
+      "args": ["-y", "@lore-context/mcp-server"],
+      "env": {
+        "LORE_API_KEY": "LORE_API_KEY",
+        "LORE_PROJECT_ID": "LORE_PROJECT_ID"
+      }
+    }
+  }
+}
+```
+
+### 4. Restart the container
+
+The container will pick up the new MCP server on next session start. Force a restart:
+
+```bash
+# If using the self-mod flow, the container restarts automatically after approval
+# Otherwise, restart NanoClaw:
+pnpm dev
+```
+
+## Configuration
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LORE_API_KEY` | Yes | Your Lore Context API key |
+| `LORE_PROJECT_ID` | Yes | Project ID for memory scoping |
+| `LORE_BASE_URL` | No | Custom API endpoint (default: `https://api.lore-context.com`) |
+
+### Per-group vs global memory
+
+By default, Lore Context scopes memories to your project. You can further scope by:
+- **User**: Memories private to a specific user
+- **Team**: Memories shared across a team
+- **Repo**: Memories tied to a codebase
+
+The container skill instructs the agent on appropriate scoping.
+
+## How agents use it
+
+Once installed, agents automatically:
+
+1. **Search before answering**: Before responding to queries that might reference past context, the agent searches Lore for relevant memories
+2. **Store after conversations**: Important decisions, patterns, user preferences, and architectural choices get written to Lore
+3. **Supersede outdated info**: When information changes, the agent creates new versions rather than duplicating
+
+See `container/skills/lore-context/SKILL.md` for the full agent instructions.
+
+## Troubleshooting
+
+### Agent doesn't use Lore tools
+- Check that `lore-context` appears in the container's MCP server list
+- Verify the container skill is loaded: look for `lore-context` in the skill sync output
+- Check container logs for MCP connection errors
+
+### Authentication errors
+- Ensure API key is in the OneCLI vault (not hardcoded in container.json)
+- Verify the key has access to the specified project
+
+### No memories found on search
+- Lore needs at least a few stored memories to be useful
+- Check that the agent is writing memories (look for `memory_write` calls in logs)
+- Try broader search queries
+
+## Uninstall
+
+Remove the `lore-context` entry from your group's `container.json` MCP servers and restart.

--- a/.claude/skills/add-lore-context/tests/skill.test.ts
+++ b/.claude/skills/add-lore-context/tests/skill.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the add-lore-context skill.
+ *
+ * Validates that the skill files are well-formed and follow NanoClaw conventions.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const SKILL_DIR = path.resolve(__dirname, '..');
+const CONTAINER_SKILL_DIR = path.resolve(SKILL_DIR, '../../../container/skills/lore-context');
+
+describe('add-lore-context skill', () => {
+  describe('host skill (SKILL.md)', () => {
+    it('exists', () => {
+      const skillPath = path.join(SKILL_DIR, 'SKILL.md');
+      expect(fs.existsSync(skillPath)).toBe(true);
+    });
+
+    it('has valid frontmatter with name and description', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toMatch(/^---\n/);
+      expect(content).toMatch(/name:\s*add-lore-context/);
+      expect(content).toMatch(/description:\s*.+/);
+    });
+
+    it('is under 500 lines', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+      const lineCount = content.split('\n').length;
+      expect(lineCount).toBeLessThan(500);
+    });
+
+    it('references the container skill', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('lore-context');
+    });
+
+    it('includes MCP server configuration', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('mcpServers');
+      expect(content).toContain('@lore-context/mcp-server');
+    });
+
+    it('includes credential setup instructions', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('LORE_API_KEY');
+    });
+  });
+
+  describe('container skill (SKILL.md)', () => {
+    it('exists', () => {
+      const skillPath = path.join(CONTAINER_SKILL_DIR, 'SKILL.md');
+      expect(fs.existsSync(skillPath)).toBe(true);
+    });
+
+    it('has valid frontmatter with name and description', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toMatch(/^---\n/);
+      expect(content).toMatch(/name:\s*lore-context/);
+      expect(content).toMatch(/description:\s*.+/);
+    });
+
+    it('is under 500 lines', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      const lineCount = content.split('\n').length;
+      expect(lineCount).toBeLessThan(500);
+    });
+
+    it('has allowed-tools frontmatter', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toMatch(/allowed-tools:/);
+    });
+
+    it('documents memory_search tool', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('memory_search');
+    });
+
+    it('documents memory_write tool', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('memory_write');
+    });
+
+    it('includes guidance on when to search', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toMatch(/when to use/i);
+    });
+
+    it('includes best practices', () => {
+      const content = fs.readFileSync(path.join(CONTAINER_SKILL_DIR, 'SKILL.md'), 'utf-8');
+      expect(content).toMatch(/best practices/i);
+    });
+  });
+
+  describe('MCP_CONFIG.md', () => {
+    it('exists', () => {
+      const configPath = path.join(SKILL_DIR, 'MCP_CONFIG.md');
+      expect(fs.existsSync(configPath)).toBe(true);
+    });
+
+    it('contains valid MCP server JSON example', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'MCP_CONFIG.md'), 'utf-8');
+      expect(content).toContain('"mcpServers"');
+      expect(content).toContain('"lore-context"');
+      expect(content).toContain('"command"');
+      expect(content).toContain('"args"');
+    });
+
+    it('documents environment variables', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'MCP_CONFIG.md'), 'utf-8');
+      expect(content).toContain('LORE_API_KEY');
+      expect(content).toContain('LORE_PROJECT_ID');
+    });
+
+    it('documents available MCP tools', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'MCP_CONFIG.md'), 'utf-8');
+      expect(content).toContain('memory_search');
+      expect(content).toContain('memory_write');
+      expect(content).toContain('context_query');
+    });
+  });
+});

--- a/container/skills/lore-context/SKILL.md
+++ b/container/skills/lore-context/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: lore-context
+description: Use Lore Context for cross-session semantic memory. Search past conversations, store important insights, and maintain persistent context across sessions.
+allowed-tools: Bash(mcp__lore-context__*)
+---
+
+# Lore Context — Semantic Memory
+
+You have access to Lore Context, a semantic memory system that persists across sessions. Use it to remember important information, search past context, and maintain continuity for the user.
+
+## When to use Lore Context
+
+### Search (memory_search, context_query)
+- User references something from a past conversation
+- User asks "what did we decide about X?" or "remember when we..."
+- You need context about a project, person, or decision before responding
+- Starting a new session and want to recall relevant context
+
+### Write (memory_write)
+- User makes an important decision
+- You learn a new preference or recurring pattern
+- An architectural choice is made
+- A bug or issue is discovered and resolved
+- A workflow or process is established
+- Any information that will be useful in future sessions
+
+### Update (memory_update, memory_supersede)
+- A previously stored fact has changed
+- A decision is reversed or updated
+- Information needs correction
+
+## How to use
+
+### Searching for context
+
+Before answering questions that might reference past work, search Lore:
+
+```
+memory_search(query: "database migration decisions")
+memory_search(query: "user preferences for code style")
+context_query(query: "what was the architecture for the auth system?")
+```
+
+Search is semantic — use natural language, not keywords. The results include relevance scores and source information.
+
+### Storing memories
+
+After important interactions, write memories:
+
+```
+memory_write(
+  content: "The team decided to use PostgreSQL for the main database instead of MongoDB, citing better support for complex queries and ACID compliance.",
+  memory_type: "architecture",
+  scope: "project",
+  project_id: "nanoclaw"
+)
+```
+
+Memory types:
+- `pattern` — recurring code patterns, conventions
+- `preference` — user or team preferences
+- `architecture` — system design decisions
+- `bug` — known issues and their fixes
+- `workflow` — processes and procedures
+- `fact` — general knowledge, context
+
+Scopes:
+- `user` — private to this user
+- `project` — shared across the project
+- `team` — shared across a team
+- `repo` — tied to a specific repository
+
+### Updating memories
+
+When information changes, update rather than duplicate:
+
+```
+memory_update(
+  memory_id: "<id>",
+  content: "Updated: now using Redis for caching instead of Memcached",
+  reason: "Architecture changed after performance evaluation"
+)
+```
+
+Or supersede to create a versioned replacement:
+
+```
+memory_supersede(
+  memory_id: "<id>",
+  content: "New version of the memory",
+  reason: "Decision updated based on new requirements"
+)
+```
+
+### Listing and browsing
+
+```
+memory_list(scope: "project", limit: 20)
+memory_list(memory_type: "architecture")
+```
+
+### Exporting context
+
+Get a summary of all relevant context for a topic:
+
+```
+context_query(
+  query: "everything we know about the deployment pipeline",
+  mode: "memory",
+  sources: { memory: true }
+)
+```
+
+## Best practices
+
+1. **Be specific in writes**: "The user prefers tabs over spaces in Python files" is better than "code style preferences"
+2. **Use appropriate types**: Classify memories correctly for better retrieval
+3. **Search before writing**: Avoid duplicating existing memories
+4. **Supersede, don't delete**: When info changes, supersede the old memory rather than deleting
+5. **Scope appropriately**: Don't make personal preferences project-scoped
+6. **Include context**: Reference the conversation or situation that generated the memory
+
+## What NOT to store
+
+- Ephemeral information (current weather, today's date)
+- Information that belongs in code files or documentation
+- Secrets or credentials
+- Large data dumps — summarize instead
+
+## Integration with CLAUDE.local.md
+
+Lore Context complements `CLAUDE.local.md`:
+- **CLAUDE.local.md**: Quick-access, always-in-context, for the most critical per-turn info
+- **Lore Context**: Semantic search across a large corpus of memories, for everything else
+
+Use CLAUDE.local.md for the top 5-10 things you always need. Use Lore for everything else.

--- a/container/skills/lore-context/instructions.md
+++ b/container/skills/lore-context/instructions.md
@@ -1,0 +1,41 @@
+## Lore Context — Cross-Session Memory
+
+You have access to **Lore Context** MCP tools for semantic memory that persists across all sessions in this agent group. These complement `CLAUDE.local.md` (quick-access, always-in-context) with searchable semantic memory.
+
+### When to search
+
+Search Lore **before answering** when the user:
+- References past conversations ("remember when we...", "what did we decide about...")
+- Asks about a project, person, or decision you may have seen before
+- Starts a task that might benefit from prior context
+
+```
+memory_search(query: "natural language description of what you're looking for")
+```
+
+### When to write
+
+Store memories **after important interactions**:
+- Decisions made (architecture, tool choices, approaches)
+- User preferences (code style, communication preferences)
+- Recurring patterns or conventions
+- Bug discoveries and their fixes
+- Workflow and process descriptions
+
+```
+memory_write(content: "specific, actionable memory", memory_type: "architecture|preference|pattern|bug|workflow|fact", scope: "project|user|team")
+```
+
+### When to update
+
+If stored information has changed:
+```
+memory_update(memory_id: "<id>", content: "updated info", reason: "why it changed")
+```
+
+### How it differs from CLAUDE.local.md
+
+- **CLAUDE.local.md**: Top 5-10 critical items, always in context window, fast access
+- **Lore Context**: Large corpus of memories, semantic search, cross-session persistence
+
+Use CLAUDE.local.md for what you always need. Use Lore for everything else.


### PR DESCRIPTION
## What

Add a Lore Context integration skill that enables NanoClaw agents to use [Lore Context](https://github.com/Lore-Context/lore-context) for cross-session semantic memory.

## Why

NanoClaw agents currently use file-based memory (`CLAUDE.local.md`, workspace files). Lore Context adds:
- **Semantic search** over past conversations and decisions
- **Cross-session persistence** that survives container recreation
- **Structured memory types** (patterns, preferences, architecture decisions, bugs)
- **Automatic deduplication** and versioning

This is implemented as a **feature skill** per the contributing guidelines — no source code changes to trunk.

## Changes

| File | Description |
|------|-------------|
| `.claude/skills/add-lore-context/SKILL.md` | Host-side skill with setup instructions and MCP configuration |
| `.claude/skills/add-lore-context/MCP_CONFIG.md` | Detailed MCP server configuration reference |
| `.claude/skills/add-lore-context/tests/skill.test.ts` | Tests validating skill file structure |
| `container/skills/lore-context/SKILL.md` | Container-side skill teaching the agent when and how to use Lore |
| `container/skills/lore-context/instructions.md` | Usage guide for memory operations |

## How it works

1. User runs `/add-lore-context` in their NanoClaw instance
2. Agent follows the SKILL.md to add the Lore Context MCP server to `container.json`
3. Container skill teaches the agent to use `memory_search`, `memory_write`, `context_query` etc.
4. Agent gains persistent semantic memory across sessions

## MCP tools exposed

Once configured, agents get: `memory_search`, `memory_write`, `memory_update`, `memory_supersede`, `memory_list`, `memory_get`, `memory_forget`, `memory_export`, `context_query`.

---
🤖 **About this contribution**

This PR was drafted by **lorecmo**, an AI agent operating under direct human supervision (account owner: zhushuanbao @ REDLAND PTE. LTD., Singapore).

The integration design and final diff have been reviewed by a human contributor before submission.

We aim to be in the **10% of legitimate AI-generated PRs** — please flag any concerns and we will revise or close immediately.
