### PR TITLE
feat(setup): paint "you" green in the display-name prompt

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -52,7 +52,7 @@ import { claudeCliAvailable, resolveTimezoneViaClaude } from './lib/tz-from-clau
 import * as setupLog from './logs.js';
 import { ensureAnswer, fail, runQuietChild, runQuietStep } from './lib/runner.js';
 import { emit as phEmit } from './lib/diagnostics.js';
-import { brandBody, brandBold, brandChip, dimWrap, fitToWidth, note, wrapForGutter } from './lib/theme.js';
+import { accentGreen, brandBody, brandBold, brandChip, dimWrap, fitToWidth, note, wrapForGutter } from './lib/theme.js';
 import { isValidTimezone } from '../src/timezone.js';
 
 const CLI_AGENT_NAME = 'Terminal Agent';
@@ -976,7 +976,7 @@ async function runTimezoneStep(): Promise<void> {
 async function askDisplayName(fallback: string): Promise<string> {
   const answer = ensureAnswer(
     await p.text({
-      message: 'What should your assistant call you?',
+      message: `What should your assistant call ${accentGreen('you')}?`,
       placeholder: fallback,
       defaultValue: fallback,
     }),

--- a/setup/lib/theme.ts
+++ b/setup/lib/theme.ts
@@ -40,6 +40,18 @@ export function brandChip(s: string): string {
 }
 
 /**
+ * Accent green (#3fba50) for emphasizing a single word inside prompt
+ * messages — currently the "you" in "What should your assistant call
+ * you?" so the operator parses at a glance who the question is about.
+ * Same TTY/NO_COLOR/truecolor gating as the rest of the palette.
+ */
+export function accentGreen(s: string): string {
+  if (!USE_ANSI) return s;
+  if (TRUECOLOR) return `\x1b[38;2;63;186;80m${s}\x1b[39m`;
+  return k.green(s);
+}
+
+/**
  * Brand body color for setup-flow prose. Used for card bodies (via the
  * `note()` formatter) and `p.log.*` body arguments — anywhere the
  * previous "dim" treatment was making prose hard to read or washing


### PR DESCRIPTION
> **Stacked on #2101 and #2102** — the diff currently includes their commits. Once those merge, this PR's diff will collapse to just the `accentGreen` helper and the one-line prompt change.

## Summary

Adds an `accentGreen` helper (`#3fba50`) in `setup/lib/theme.ts` with the same TTY / `NO_COLOR` / truecolor gating used by `brand`/`brandBold`/`brandChip`/`brandBody`, then wraps the word "you" in the `askDisplayName` prompt so the operator can parse at a glance who the question is about — the user, not the assistant.

> What should your assistant call **you**?

The mirror prompt that asks for the assistant's name ("What should your assistant be called?") is left as a follow-up so the green-word treatment can be reviewed independently first.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test setup/` — 5 files / 43 tests pass
- [x] Ran `bash nanoclaw.sh`; verified "you" renders in green at the display-name prompt; nothing else changed