### PR TITLE
feat: implement resolveChannelName for Slack and Telegram

### DIFF
--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -16,6 +16,15 @@ registerChannelAdapter('slack', {
       botToken: env.SLACK_BOT_TOKEN,
       signingSecret: env.SLACK_SIGNING_SECRET,
     });
-    return createChatSdkBridge({ adapter: slackAdapter, concurrency: 'concurrent', supportsThreads: true });
+    const bridge = createChatSdkBridge({ adapter: slackAdapter, concurrency: 'concurrent', supportsThreads: true });
+    bridge.resolveChannelName = async (platformId: string) => {
+      try {
+        const info = await slackAdapter.fetchThread(platformId);
+        return (info as { channelName?: string }).channelName ?? null;
+      } catch {
+        return null;
+      }
+    };
+    return bridge;
   },
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -216,6 +216,21 @@ registerChannelAdapter('telegram', {
 
     const wrapped: ChannelAdapter = {
       ...bridge,
+      resolveChannelName: async (platformId: string) => {
+        const chatId = platformId.split(':').slice(1).join(':');
+        if (!chatId) return null;
+        try {
+          const res = await fetch(`https://api.telegram.org/bot${token}/getChat`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ chat_id: chatId }),
+          });
+          const data = (await res.json()) as { ok?: boolean; result?: { title?: string } };
+          return data.ok ? (data.result?.title ?? null) : null;
+        } catch {
+          return null;
+        }
+      },
       async setup(hostConfig: ChannelSetup) {
         const intercepted: ChannelSetup = {
           ...hostConfig,


### PR DESCRIPTION
## Summary

- Implement `resolveChannelName` on the Slack adapter using `fetchThread` → `conversations.info`
- Implement `resolveChannelName` on the Telegram adapter using Telegram's `getChat` API
- Enables the channel-approval flow to show the actual channel/group name in the approval card

## Depends on

- #2105 (adds `resolveChannelName` optional method to `ChannelAdapter` interface)

## Test plan

- [x] Mention bot in unwired Telegram group → approval card shows group name
- [ ] Mention bot in unwired Slack channel → approval card shows channel name
- [ ] Channel name is persisted to the messaging group for future use

🤖 Generated with [Claude Code](https://claude.com/claude-code)