### PR TITLE
fix(channels/telegram): wire maxTextLength to engage splitter from #1900

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -210,6 +210,7 @@ registerChannelAdapter('telegram', {
       extractReplyContext,
       supportsThreads: false,
       transformOutboundText: sanitizeTelegramLegacyMarkdown,
+      maxTextLength: 4000,
     });
 
     const botUsernamePromise = fetchBotUsername(token);


### PR DESCRIPTION
PR #1900 added the `splitForLimit` helper and `maxTextLength` config option to `chat-sdk-bridge`, but explicitly noted that channel-adapter wiring would need a follow-up:

> "This PR only adds the maxTextLength config option and the splitter — it does not wire any specific adapter to use it... Without that wiring, this PR is infra-only and changes nothing for existing installs."

The author flagged the follow-up but it was never opened. This PR completes the wiring for Telegram on the `channels` branch.

## Change

Single line addition in `src/channels/telegram.ts` `createChatSdkBridge` call:

```ts
maxTextLength: 4000,  // Telegram hard-limit is 4096; buffer for sanitizer escapes
```

Same pattern + value the author of #1900 explicitly suggested in their PR description.

## Why this matters

Without the wiring, the telegram adapter silently truncates outbound messages >4096 chars via `truncateMessage()` legacy behavior. With this fix, the `splitForLimit` helper engages and posts chunks sequentially. The returned id is the first chunk's id so edits/reactions still target the reply head.

This is a real-world pain: I (as a heavy nanoclaw user) repeatedly experienced agent responses arriving truncated (or missing entirely) at 4096+ chars. Multiple times today silent-fail wasted ~15 minutes wondering "did the message arrive at all?" before realizing telegram dropped it.

## Testing

- Local install: applied the same 1-line edit on my own v2.0.14 deployment, rebuilt, restarted. Long agent responses (5000+ chars) now arrive as 2-3 chunks instead of being silently cut off.
- No new tests needed — `splitForLimit` already has unit-test coverage from #1900 (paragraph/line/hard-cut paths).

## Notes for maintainer

- Targeting `channels` branch since `src/channels/telegram.ts` lives there per the skills-as-branches model.
- Per CONTRIBUTING.md: also happy to retarget to `main` if preferred — let me know.
- If `skill/telegram` branch gets created later, this wiring should propagate via the merge-forward CI.
