### PR TITLE
fix(claude-provider): respect operator-set CLAUDE_CODE_AUTO_COMPACT_WINDOW (closes #1820)

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -226,8 +226,12 @@ function createPreCompactHook(assistantName?: string): HookCallback {
 /**
  * Claude Code auto-compacts context at this window (tokens). Kept here so
  * the generic bootstrap doesn't need to know about Claude-specific env vars.
+ *
+ * Operator override: set CLAUDE_CODE_AUTO_COMPACT_WINDOW in the host env to
+ * raise or lower the threshold without editing source — useful when running
+ * with a 1M-context model variant or when emergency-tuning a deployment.
  */
-const CLAUDE_CODE_AUTO_COMPACT_WINDOW = '165000';
+const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '165000';
 
 /**
  * Stale-session detection. Matches Claude Code's error text when a


### PR DESCRIPTION
Closes #1820.

## Summary

`CLAUDE_CODE_AUTO_COMPACT_WINDOW` is set unconditionally on the container's process env, even when the host (or an operator) has already set it for experiments or emergency tuning. There's no way to override the auto-compact threshold per-deployment without editing source.

## Fix

`container/agent-runner/src/providers/claude.ts` — the module-level default now reads from `process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW` first, falling back to the existing `'165000'` literal when unset.

```ts
const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '165000';
```

The `ClaudeProvider` constructor still spreads this into `this.env` exactly as before — no other behavior changes. Operators who don't set the env var see the same `165000` they always saw.

## Why this approach (vs. the issue's suggested patch)

Issue #1820 suggests adding the `if (!env.X) env.X = ...` guard in `container/agent-runner/src/index.ts` around the bootstrap step. The constant has since been moved into the provider module — so the equivalent fix is simply to read it once at import time. Same outcome, smaller diff, no need to refactor the bootstrap path.

## Test plan

- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- [x] Verified `CLAUDE_CODE_AUTO_COMPACT_WINDOW=900000 bun src/index.ts` propagates into the SDK env (not the original `165000`)
- [x] Verified unset env still defaults to `165000` (no behavior change for existing installs)

## Risk

Minimal. One-line change, additive (new behavior only triggers when the env var is set), default unchanged.

## Note on default value

This PR intentionally does **not** raise the default beyond `165000`. The 1M-context Opus 4.7 variant benefits from a larger window (compaction at 16.5% full wastes most of the headroom), but raising the global default is a separate decision tied to the default model choice. Operators who want a different window can now simply set the env var. Happy to file a follow-up issue/PR to discuss raising the default if upstream prefers.
