### PR TITLE
fix: suppress duplicate text when send_message fires

### DIFF
--- a/container/agent-runner/src/db/session-state.ts
+++ b/container/agent-runner/src/db/session-state.ts
@@ -77,3 +77,24 @@ export function setContinuation(providerName: string, id: string): void {
 export function clearContinuation(providerName: string): void {
   deleteValue(continuationKey(providerName));
 }
+
+const TURN_SEND_INVOKED_KEY = 'turn_send_invoked';
+
+/**
+ * Mark that a user-facing send tool (send_message, send_file) fired during
+ * the current turn. The poll-loop reads this at result time to suppress the
+ * SDK's closing text echo — otherwise the user sees two messages.
+ * Cleared by the poll-loop at the start of each new turn.
+ * NOT set by add_reaction: reaction + closing summary is a valid reply path.
+ */
+export function setTurnSendInvoked(): void {
+  setValue(TURN_SEND_INVOKED_KEY, '1');
+}
+
+export function getTurnSendInvoked(): boolean {
+  return getValue(TURN_SEND_INVOKED_KEY) === '1';
+}
+
+export function clearTurnSendInvoked(): void {
+  deleteValue(TURN_SEND_INVOKED_KEY);
+}

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import { findByName, getAllDestinations } from '../destinations.js';
 import { getMessageIdBySeq, getRoutingBySeq, writeMessageOut } from '../db/messages-out.js';
 import { getSessionRouting } from '../db/session-routing.js';
+import { setTurnSendInvoked } from '../db/session-state.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
 
@@ -126,6 +127,7 @@ export const sendMessage: McpToolDefinition = {
       content: JSON.stringify({ text }),
     });
 
+    setTurnSendInvoked();
     log(`send_message: #${seq} → ${routing.resolvedName}`);
     return ok(`Message sent to ${routing.resolvedName} (id: ${seq})`);
   },
@@ -172,6 +174,7 @@ export const sendFile: McpToolDefinition = {
       content: JSON.stringify({ text: (args.text as string) || '', files: [filename] }),
     });
 
+    setTurnSendInvoked();
     log(`send_file: ${id} → ${routing.resolvedName} (${filename})`);
     return ok(`File sent to ${routing.resolvedName} (id: ${id}, filename: ${filename})`);
   },

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -6,6 +6,8 @@ import {
   clearContinuation,
   migrateLegacyContinuation,
   setContinuation,
+  getTurnSendInvoked,
+  clearTurnSendInvoked,
 } from './db/session-state.js';
 import { formatMessages, extractRouting, categorizeMessage, isClearCommand, stripInternalTags, type RoutingContext } from './formatter.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
@@ -92,6 +94,9 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     const ids = messages.map((m) => m.id);
     markProcessing(ids);
+
+    // Reset the per-turn send flag so a fresh turn starts clean.
+    clearTurnSendInvoked();
 
     const routing = extractRouting(messages);
 
@@ -309,8 +314,17 @@ async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        // Duplicate suppression: if send_message or send_file already delivered
+        // a reply this turn, the SDK still surfaces the agent's closing text as
+        // a Result. Sending it would produce a second message. Log it but skip
+        // delivery. add_reaction does NOT set this flag — reaction + closing
+        // summary is a valid reply path.
         if (event.text) {
-          dispatchResultText(event.text, routing);
+          if (getTurnSendInvoked()) {
+            log(`Suppressing result text (send already fired this turn): ${event.text.slice(0, 200)}`);
+          } else {
+            dispatchResultText(event.text, routing);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
When an agent calls `send_message` or `send_file`, the SDK's closing turn-result text is *also* delivered to the channel — the user sees their reply twice.

## Fix
Track a per-turn `turn_send_invoked` flag in `session_state` (outbound.db):
- `setTurnSendInvoked()` is called inside `sendMessage` and `sendFile` MCP handlers (`container/agent-runner/src/mcp-tools/core.ts`).
- At result time, `runPollLoop` checks `getTurnSendInvoked()`. If set, the closing text is logged-but-not-dispatched (`container/agent-runner/src/poll-loop.ts`).
- The flag is cleared at the start of each new turn.

`add_reaction` deliberately does NOT set the flag — reaction + closing summary is a valid reply path.

## Files
- `container/agent-runner/src/db/session-state.ts` — new `TURN_SEND_INVOKED_KEY` + 3 getter/setter/clear functions.
- `container/agent-runner/src/mcp-tools/core.ts` — call `setTurnSendInvoked()` from `sendMessage` + `sendFile`.
- `container/agent-runner/src/poll-loop.ts` — `clearTurnSendInvoked()` at turn start; gate `dispatchResultText` on `!getTurnSendInvoked()`.

## Test plan
- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean
- [x] `cd container/agent-runner && bun test` — 59/59 pass
- [ ] Manual: agent calls `send_message` → result text is suppressed, only one message lands in chat
- [ ] Manual: agent only calls `add_reaction` → result text still delivered (reaction + summary path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)