### PR TITLE
fix(delivery): exponential backoff + close leaked DB handle on open error

### DIFF
--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -29,10 +29,19 @@ import type { Session } from './types.js';
 
 const ACTIVE_POLL_MS = 1000;
 const SWEEP_POLL_MS = 60_000;
-const MAX_DELIVERY_ATTEMPTS = 3;
+const MAX_DELIVERY_ATTEMPTS = 6;
 
-/** Track delivery attempt counts. Resets on process restart (gives failed messages a fresh chance). */
-const deliveryAttempts = new Map<string, number>();
+interface RetryState {
+  attempts: number;
+  nextRetryAt: number;
+}
+/** Track delivery attempt counts and per-message backoff. Resets on process restart. */
+const deliveryRetries = new Map<string, RetryState>();
+
+function nextBackoffMs(attemptsSoFar: number): number {
+  const schedule = [5_000, 15_000, 45_000, 120_000, 300_000];
+  return schedule[Math.min(attemptsSoFar - 1, schedule.length - 1)];
+}
 
 /**
  * Sessions whose outbound queue is currently being drained.
@@ -165,13 +174,18 @@ async function drainSession(session: Session): Promise<void> {
   const agentGroup = getAgentGroup(session.agent_group_id);
   if (!agentGroup) return;
 
-  let outDb: Database.Database;
-  let inDb: Database.Database;
+  let outDb: Database.Database | null = null;
+  let inDb: Database.Database | null = null;
   try {
     outDb = openOutboundDb(agentGroup.id, session.id);
     inDb = openInboundDb(agentGroup.id, session.id);
   } catch {
-    return; // DBs might not exist yet
+    // DBs might not exist yet, or one opened and the other failed.
+    // Close whichever did open so the file descriptor doesn't leak across
+    // long-running poll cycles.
+    outDb?.close();
+    inDb?.close();
+    return;
   }
 
   try {
@@ -187,11 +201,17 @@ async function drainSession(session: Session): Promise<void> {
     // Ensure platform_message_id column exists (migration for existing sessions)
     migrateDeliveredTable(inDb);
 
+    const now = Date.now();
     for (const msg of undelivered) {
+      // Skip messages still in their backoff window — the next poll tick
+      // will pick them up once nextRetryAt has elapsed.
+      const retry = deliveryRetries.get(msg.id);
+      if (retry && now < retry.nextRetryAt) continue;
+
       try {
         const platformMsgId = await deliverMessage(msg, session, inDb);
         markDelivered(inDb, msg.id, platformMsgId ?? null);
-        deliveryAttempts.delete(msg.id);
+        deliveryRetries.delete(msg.id);
 
         // Pause the typing indicator after a real user-facing message
         // lands on the user's screen, so the client has time to visually
@@ -203,8 +223,7 @@ async function drainSession(session: Session): Promise<void> {
           pauseTypingRefreshAfterDelivery(session.id);
         }
       } catch (err) {
-        const attempts = (deliveryAttempts.get(msg.id) ?? 0) + 1;
-        deliveryAttempts.set(msg.id, attempts);
+        const attempts = (retry?.attempts ?? 0) + 1;
         if (attempts >= MAX_DELIVERY_ATTEMPTS) {
           log.error('Message delivery failed permanently, giving up', {
             messageId: msg.id,
@@ -213,13 +232,16 @@ async function drainSession(session: Session): Promise<void> {
             err,
           });
           markDeliveryFailed(inDb, msg.id);
-          deliveryAttempts.delete(msg.id);
+          deliveryRetries.delete(msg.id);
         } else {
+          const backoff = nextBackoffMs(attempts);
+          deliveryRetries.set(msg.id, { attempts, nextRetryAt: Date.now() + backoff });
           log.warn('Message delivery failed, will retry', {
             messageId: msg.id,
             sessionId: session.id,
             attempt: attempts,
             maxAttempts: MAX_DELIVERY_ATTEMPTS,
+            retryInMs: backoff,
             err,
           });
         }


### PR DESCRIPTION
## Summary
Two related fixes in `drainSession`:

### 1. Exponential backoff
Failed message deliveries currently retry on every poll tick (every second during active polling), which spams third-party APIs that are flaky/throttled. This switches to a `5/15/45/120/300`s schedule keyed per-message. Bumps `MAX_DELIVERY_ATTEMPTS` from 3 → 6 to match the wider schedule.

### 2. Leaked DB handle on open error
When `openOutboundDb` succeeds but `openInboundDb` throws, the catch block returned without closing the already-opened outbound handle — a file-descriptor leak per failing iteration. Both refs now initialize to `null` and the catch closes whichever opened.

Together these stop the symptom seen under flaky-network conditions: the host accumulating thousands of "delivery failed, will retry" log lines per minute and slowly leaking file descriptors.

## Files
- `src/delivery.ts`

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 215/215 pass
- [ ] Manual: temporarily 503 a channel adapter → confirm retry interval grows on the schedule, not every second

🤖 Generated with [Claude Code](https://claude.com/claude-code)