### PR TITLE
fix: don't resume SDK session for scheduled task batches

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -160,9 +160,15 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
+    // Scheduled-task batches must not resume a prior SDK session. The SDK
+    // surfaces the previous turn's terminal message into the new turn's stream
+    // when a session is resumed, so task B would capture task A's result text
+    // as its own output. Starting a fresh session for every task batch prevents
+    // this cross-attribution without affecting interactive chat continuity.
+    const isTaskBatch = keep.some((m) => m.kind === 'task');
     const query = config.provider.query({
       prompt,
-      continuation,
+      continuation: isTaskBatch ? undefined : continuation,
       cwd: config.cwd,
       systemContext: config.systemContext,
     });


### PR DESCRIPTION
## Summary
Scheduled tasks share a maintenance session. When the Claude Agent SDK resumes a session across runs, the next turn's stream sometimes includes the previous task's terminal Result event. The poll-loop captures that replayed text as the current task's output — task B silently appears to produce task A's result.

## Fix
Detect task batches (any message with \`kind='task'\`) and pass \`continuation=undefined\` to the provider, forcing a fresh SDK session for every task run. Interactive chat batches still resume as before.

## Files
- \`container/agent-runner/src/poll-loop.ts\` — 8 lines (one comment + one ternary).

## Test plan
- [x] \`cd container/agent-runner && bun test\` — all pass
- [ ] Manual: configure two scheduled tasks 60s apart on the same session → confirm task B's last_result reflects its own work, not task A's

🤖 Generated with [Claude Code](https://claude.com/claude-code)