### PR TITLE
fix(setup): hint headless-host fallback in subscription sign-in prompt

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -726,9 +726,17 @@ async function runAuthStep(): Promise<void> {
   }
 }
 
+function isHeadlessLinux(): boolean {
+  return process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
+}
+
 async function runSubscriptionAuth(): Promise<void> {
   p.log.step(brandBody('Opening the Claude sign-in flow…'));
-  console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
+  if (isHeadlessLinux()) {
+    console.log(k.dim('   (headless host — copy the printed URL into a browser on another machine)'));
+  } else {
+    console.log(k.dim('   (a browser will open for sign-in; this part is interactive)'));
+  }
   console.log();
   const start = Date.now();
   const code = await runInheritScript('bash', ['setup/register-claude-token.sh']);


### PR DESCRIPTION
## Summary
On a headless Linux host (no \`DISPLAY\` / \`WAYLAND_DISPLAY\`), the *"a browser will open for sign-in"* hint shown by \`runSubscriptionAuth\` is wrong — the bundled Claude CLI prints a URL that the operator must copy into a browser on another machine. Detect headless Linux and swap to the correct hint.

## Why
Cloud-droplet installs would sit at the auth step waiting for a browser that never opens; first-time users assumed the script had hung.

## Files
- \`setup/auto.ts\` — adds \`isHeadlessLinux()\` helper, branches the dimmed hint string.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [ ] Manual: run setup on a headless Ubuntu droplet → confirm "headless host — copy the printed URL" hint
- [ ] Manual: run setup on a desktop Linux/macOS → confirm original "a browser will open" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)