### PR TITLE
feat: per-group model override + AGENT_MODEL env passthrough

### DIFF
--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -47,6 +47,8 @@ export interface ContainerConfig {
   agentGroupId?: string;
   /** Max messages per prompt. Falls back to code default if unset. */
   maxMessagesPerPrompt?: number;
+  /** Claude model override for this group (e.g. "claude-haiku-4-5"). Passed as AGENT_MODEL env var. */
+  model?: string;
 }
 
 function emptyConfig(): ContainerConfig {
@@ -87,6 +89,7 @@ export function readContainerConfig(folder: string): ContainerConfig {
       assistantName: raw.assistantName,
       agentGroupId: raw.agentGroupId,
       maxMessagesPerPrompt: raw.maxMessagesPerPrompt,
+      model: typeof raw.model === 'string' && raw.model.trim() ? raw.model.trim() : undefined,
     };
   } catch (err) {
     console.error(`[container-config] failed to parse ${p}: ${String(err)}`);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -446,6 +446,15 @@ async function buildContainerArgs(
     }
   }
 
+  // AGENT_MODEL override — per-group containerConfig.model takes priority
+  // over the host AGENT_MODEL env var. Only injected when set; absent means
+  // SDK default. Lets each group run a different Claude model (e.g. Haiku
+  // for lightweight chats) without juggling host env vars.
+  const agentModel = containerConfig.model?.trim() || process.env.AGENT_MODEL?.trim();
+  if (agentModel) {
+    args.push('-e', `AGENT_MODEL=${agentModel}`);
+  }
+
   // OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
   // are routed through the agent vault for credential injection. Treated as
   // a transient hard failure: if we can't wire the gateway, we don't spawn.


### PR DESCRIPTION
## Summary
Two related changes shipped together because the override is useless without the passthrough:

### 1. AGENT_MODEL env passthrough (prerequisite)
The host \`container-runner\` now forwards \`AGENT_MODEL\` into the spawned agent container so the SDK picks up the override. Without it, the host's setting never reached the SDK subprocess.

### 2. Per-group model override (the feature)
\`ContainerConfig\` grows a \`model?: string\` field. When set on a group's \`container.json\`, it takes priority over the host \`AGENT_MODEL\` env var. Lets each group run a different Claude model (e.g. Haiku for lightweight chats, Sonnet for general work) without juggling host env vars. Groups without the field are unaffected.

## Files
- \`src/container-config.ts\` — add \`model\` field + parse with trim/empty handling.
- \`src/container-runner.ts\` — \`-e AGENT_MODEL=...\` injection in \`buildContainerArgs\`, with per-group override taking priority.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test\` — all pass
- [ ] Manual: set \`"model": "claude-haiku-4-5"\` in one group's container.json → confirm spawned container has \`AGENT_MODEL=claude-haiku-4-5\`
- [ ] Manual: omit \`model\` field with \`AGENT_MODEL=claude-sonnet-4-6\` set in env → confirm host env propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)