### PR TITLE
fix: detect thinking-only end_turn and clear continuation

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -309,6 +309,14 @@ async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        // Thinking-only end_turn: model produced reasoning but no text. Clear
+        // the continuation so the next turn starts fresh — resuming an empty-
+        // reply session loops on more empty replies.
+        if (event.thinkingOnly) {
+          log('Thinking-only result: clearing continuation anchor');
+          clearContinuation(providerName);
+          queryContinuation = undefined;
+        }
         if (event.text) {
           dispatchResultText(event.text, routing);
         }

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -221,6 +221,26 @@ function createPreCompactHook(assistantName?: string): HookCallback {
   };
 }
 
+// ── Thinking-only end_turn detection ──
+
+/**
+ * Returns true when the SDK result message represents a thinking-only end_turn:
+ * the model produced thinking blocks but no text output. The caller should
+ * clear the continuation anchor so the next turn starts fresh instead of
+ * resuming a session that will loop on empty replies.
+ */
+export function isThinkingOnlyEndTurn(message: unknown): boolean {
+  if (typeof message !== 'object' || message === null) return false;
+  const m = message as Record<string, unknown>;
+  return (
+    m.type === 'result' &&
+    m.subtype === 'success' &&
+    m.stop_reason === 'end_turn' &&
+    typeof m.result === 'string' &&
+    (m.result as string).trim() === ''
+  );
+}
+
 // ── Provider ──
 
 /**
@@ -308,7 +328,11 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
           const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
-          yield { type: 'result', text };
+          const thinkingOnly = isThinkingOnlyEndTurn(message);
+          if (thinkingOnly) {
+            log('Thinking-only end_turn detected — caller will clear continuation anchor');
+          }
+          yield { type: 'result', text, thinkingOnly };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -71,7 +71,7 @@ export interface AgentQuery {
 
 export type ProviderEvent =
   | { type: 'init'; continuation: string }
-  | { type: 'result'; text: string | null }
+  | { type: 'result'; text: string | null; thinkingOnly?: boolean }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }
   | { type: 'progress'; message: string }
   /**


### PR DESCRIPTION
## Summary
When the SDK produces a Result with stop_reason='end_turn' but an empty result string (only thinking blocks, no text output), resuming that session on the next turn often loops — the model picks up where it left off and emits another empty reply.

## Fix
- Add \`isThinkingOnlyEndTurn(message)\` in \`providers/claude.ts\` that detects the pattern from the SDK message shape: \`type='result'\`, \`subtype='success'\`, \`stop_reason='end_turn'\`, empty \`result\` string.
- Propagate a \`thinkingOnly\` flag on \`ProviderEvent\` of type \`result\`.
- In \`poll-loop.ts\`, when a result event has \`thinkingOnly=true\`, call \`clearContinuation(providerName)\` and reset \`queryContinuation\`. The next turn starts fresh.

## Files
- \`container/agent-runner/src/providers/claude.ts\` — add helper, set flag.
- \`container/agent-runner/src/providers/types.ts\` — extend ProviderEvent shape.
- \`container/agent-runner/src/poll-loop.ts\` — handle thinkingOnly.

## Test plan
- [x] \`bun test\` — 44/44 pass (1 unrelated DB-lock error from concurrent test run)
- [ ] Manual: trigger a thinking-only end_turn → confirm continuation cleared in session_state and next turn doesn't loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)