### PR TITLE
feat: support remote HTTP/SSE MCP servers in container.json schema

### DIFF
--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -15,8 +15,12 @@ export interface RunnerConfig {
   groupName: string;
   agentGroupId: string;
   maxMessagesPerPrompt: number;
-  mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  mcpServers: Record<string, McpServerConfig>;
 }
+
+export type McpServerConfig =
+  | { command: string; args: string[]; env: Record<string, string>; url?: never; type?: 'stdio' }
+  | { url: string; type: 'http' | 'sse'; headers?: Record<string, string>; command?: never };
 
 const DEFAULT_MAX_MESSAGES = 10;
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -25,7 +25,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { loadConfig } from './config.js';
+import { loadConfig, type McpServerConfig } from './config.js';
 import { buildSystemPromptAddendum } from './destinations.js';
 // Providers barrel — each enabled provider self-registers on import.
 // Provider skills append imports to providers/index.ts.
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
   const mcpServerPath = path.join(__dirname, 'mcp-tools', 'index.ts');
 
   // Build MCP servers config: nanoclaw built-in + any from container.json
-  const mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {
+  const mcpServers: Record<string, McpServerConfig> = {
     nanoclaw: {
       command: 'bun',
       args: ['run', mcpServerPath],
@@ -83,7 +83,11 @@ async function main(): Promise<void> {
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
     mcpServers[name] = serverConfig;
-    log(`Additional MCP server: ${name} (${serverConfig.command})`);
+    if ('url' in serverConfig && serverConfig.url) {
+      log(`Additional MCP server: ${name} (${serverConfig.type} ${serverConfig.url})`);
+    } else if ('command' in serverConfig && serverConfig.command) {
+      log(`Additional MCP server: ${name} (${serverConfig.command})`);
+    }
   }
 
   const provider = createProvider(providerName, {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -49,11 +49,9 @@ export interface QueryInput {
   };
 }
 
-export interface McpServerConfig {
-  command: string;
-  args: string[];
-  env: Record<string, string>;
-}
+export type McpServerConfig =
+  | { command: string; args: string[]; env: Record<string, string>; url?: never }
+  | { url: string; type: 'http' | 'sse'; headers?: Record<string, string>; command?: never };
 
 export interface AgentQuery {
   /** Push a follow-up message into the active query. */

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -14,15 +14,30 @@ import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
 
-export interface McpServerConfig {
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-  // Optional always-in-context guidance. When set, the host writes the
-  // content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
-  // into the composed CLAUDE.md.
-  instructions?: string;
-}
+export type McpServerConfig =
+  | {
+      // stdio transport (local process)
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      url?: never;
+      headers?: never;
+      type?: 'stdio';
+      // Optional always-in-context guidance. When set, the host writes the
+      // content to `.claude-fragments/mcp-<name>.md` at spawn and imports it
+      // into the composed CLAUDE.md.
+      instructions?: string;
+    }
+  | {
+      // HTTP (Streamable HTTP) or SSE transport (remote server)
+      url: string;
+      type: 'http' | 'sse';
+      headers?: Record<string, string>;
+      command?: never;
+      args?: never;
+      env?: never;
+      instructions?: string;
+    };
 
 export interface AdditionalMountConfig {
   hostPath: string;


### PR DESCRIPTION
## Summary
Extends \`McpServerConfig\` to a discriminated union: stdio (existing \`command\`/\`args\`/\`env\` shape) or url-based (Streamable HTTP / SSE transport). Auth headers can be passed via \`headers\`. Existing stdio servers continue to validate without changes — \`type\` defaults to \`'stdio'\`.

## Why
Lots of useful MCP servers (Granola, Composio, Linear, etc.) ship as remote HTTP/SSE endpoints with bearer-token auth. Today's stdio-only schema forces users to wrap each one in a local process. Adding the url variant lets container.json reference them directly.

## Scope
This is the **schema-only piece** so it can land independently. Subsequent PRs will wire:
- \`add_mcp_server\` MCP tool params (url/type/headers)
- host-side self-mod approval validation + write
- container-side MCP factory branching on transport

## Files
- \`src/container-config.ts\` — host-side type schema.
- \`container/agent-runner/src/config.ts\` — runtime schema mirror.
- \`container/agent-runner/src/index.ts\` — log line branches on transport.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit\` clean
- [ ] Manual: add an \`url\`-based entry to a group's \`container.json\`, restart container → confirm log line shows the URL+type and the SDK loads the remote server

🤖 Generated with [Claude Code](https://claude.com/claude-code)