### PR TITLE
fix: pin thinking.display='summarized' for Opus 4.7

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -284,6 +284,10 @@ export class ClaudeProvider implements AgentProvider {
         allowDangerouslySkipPermissions: true,
         settingSources: ['project', 'user'],
         mcpServers: this.mcpServers,
+        // Opus 4.7 flipped the thinking display default to 'omitted', silencing
+        // thinking blocks in the transcript and observer output. Pin to
+        // 'summarized' so thinking is always visible when the model uses it.
+        thinking: { type: 'adaptive', display: 'summarized' },
         hooks: {
           PreToolUse: [{ hooks: [preToolUseHook] }],
           PostToolUse: [{ hooks: [postToolUseHook] }],


### PR DESCRIPTION
## Summary
The Claude Agent SDK default for \`thinking.display\` flipped to \`'omitted'\` in Opus 4.7, which silences thinking blocks in transcripts and observer output. Pin to \`'summarized'\` so the SDK's thinking summary remains visible when the model uses extended thinking, regardless of which Claude model is in flight.

## Files
- \`container/agent-runner/src/providers/claude.ts\` — 4-line addition to the \`query\` options.

## Test plan
- [x] \`pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit\` clean
- [ ] Manual: run an Opus 4.7 turn that uses extended thinking → confirm summarized thinking appears in transcript / observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)