### PR TITLE
feat: add knowledge/raw/ ingest directory for LLM wiki compilation

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -239,6 +239,54 @@ function resolveProviderContribution(
   return { provider, contribution };
 }
 
+const KNOWLEDGE_RAW_README = `# Knowledge Ingest — \`raw/\`
+
+Drop source material here for compilation into the structured wiki.
+
+## Supported file types
+
+| Extension | Contents |
+|-----------|----------|
+| \`.url\`    | A single URL per file. The compiler fetches and summarises the page. |
+| \`.md\`     | Raw markdown or plain prose — structured into wiki articles. |
+| \`.txt\`    | Plain text (transcripts, notes, paste-ins). |
+| \`.json\`   | Structured data (Granola transcripts, CRM exports, etc.). |
+
+## Naming convention
+
+Use a descriptive, date-prefixed name so files sort chronologically and their
+purpose is obvious without opening them:
+
+\`\`\`
+YYYY-MM-DD_<topic-slug>.<ext>
+\`\`\`
+
+## After compilation
+
+Compiled files are moved to \`processed/\` by the compiler. Do not delete or
+modify files in \`processed/\` — they are the audit trail.
+
+## How to add material
+
+Any agent can write files here directly:
+
+\`\`\`bash
+echo "https://example.com/article" > /workspace/global/knowledge/raw/2026-04-28_article.url
+cp /tmp/transcript.txt /workspace/global/knowledge/raw/2026-04-28_call-transcript.txt
+\`\`\`
+
+The compiler scans this directory periodically and processes any unhandled
+files.
+`;
+
+function initKnowledgeDir(knowledgeDir: string): void {
+  const rawDir = path.join(knowledgeDir, 'raw');
+  const processedDir = path.join(rawDir, 'processed');
+  if (!fs.existsSync(processedDir)) fs.mkdirSync(processedDir, { recursive: true });
+  const readme = path.join(rawDir, 'README.md');
+  if (!fs.existsSync(readme)) fs.writeFileSync(readme, KNOWLEDGE_RAW_README);
+}
+
 function buildMounts(
   agentGroup: AgentGroup,
   session: Session,
@@ -297,6 +345,14 @@ function buildMounts(
   const globalDir = path.join(GROUPS_DIR, 'global');
   if (fs.existsSync(globalDir)) {
     mounts.push({ hostPath: globalDir, containerPath: '/workspace/global', readonly: true });
+
+    // Knowledge ingest — writable nested mount on top of the RO global dir.
+    // Agents drop raw source material here; a downstream compiler (separate
+    // process) picks it up, compiles it into the wiki, then moves files to
+    // raw/processed/.
+    const knowledgeDir = path.join(globalDir, 'knowledge');
+    initKnowledgeDir(knowledgeDir);
+    mounts.push({ hostPath: knowledgeDir, containerPath: '/workspace/global/knowledge', readonly: false });
   }
 
   // Shared CLAUDE.md — read-only, imported by the composed entry point via


### PR DESCRIPTION
## Summary
First piece of a knowledge-base / wiki feature: scaffold a writable \`knowledge/raw/\` ingest directory inside the existing read-only global mount so any agent can drop source material (URLs, markdown, transcripts, JSON exports) for downstream compilation into a structured wiki.

## What's in this PR
- \`initKnowledgeDir(knowledgeDir)\` creates \`raw/processed/\` and writes \`raw/README.md\` (naming conventions, supported file types, usage examples) on first spawn.
- Adds a writable nested mount at \`/workspace/global/knowledge/\` overlaying the read-only \`/workspace/global\` mount.

## What's NOT in this PR
- The compilation engine (LLM-driven raw → wiki articles) — separate follow-up PR
- Session-start briefing injection — separate follow-up PR

Splitting lets the directory scaffold land first; the compiler can then be wired against a stable filesystem contract.

## Files
- \`src/container-runner.ts\` — \`KNOWLEDGE_RAW_README\` constant, \`initKnowledgeDir()\` helper, mount addition.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [ ] Manual: spawn a container → confirm \`/workspace/global/knowledge/raw/README.md\` exists and is writable
- [ ] Manual: \`echo "https://x" > /workspace/global/knowledge/raw/2026-04-28_test.url\` from inside container → confirm host file lands in \`groups/global/knowledge/raw/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)