### PR TITLE
fix(setup): include Apple Silicon + Colima env vars in launchd plist

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -84,6 +84,67 @@ export async function run(_args: string[]): Promise<void> {
   }
 }
 
+/**
+ * Build the launchd `EnvironmentVariables` block for the host service plist.
+ *
+ * launchd-spawned processes do NOT inherit the user's shell environment, so
+ * any env vars the host process needs at runtime must be set explicitly here.
+ *
+ * Three platform-specific gaps were silently breaking macOS Apple Silicon +
+ * Colima installs out of the box, all surfaced here:
+ *
+ *   1. PATH — Apple Silicon Homebrew installs to /opt/homebrew/bin, which
+ *      isn't on the launchd default PATH. Without it, the host can't exec
+ *      `docker` and crash-loops with `docker: command not found`.
+ *
+ *   2. DOCKER_HOST — Colima writes its socket at
+ *      ~/.colima/default/docker.sock and relies on the user's shell to
+ *      DOCKER_HOST it. The launchd-spawned host doesn't see that, so
+ *      `docker info` falls through to the default socket and errors.
+ *
+ *   3. TMPDIR — the OneCLI SDK writes its self-signed gateway CA to
+ *      `os.tmpdir()` and bind-mounts it into agent containers. macOS's
+ *      default tmpdir (/var/folders/<salt>/T/) is outside Colima's
+ *      shared paths, so the bind mount silently degrades to an empty
+ *      directory inside the container and the agent can't complete TLS
+ *      to the OneCLI proxy. Pointing TMPDIR at a directory under /Users
+ *      (which Colima shares by default) routes the CA somewhere visible.
+ *
+ * The Colima entries are emitted only when ~/.colima/default/docker.sock
+ * exists, so users on Docker Desktop or Apple Container don't get a stale
+ * DOCKER_HOST that points at a missing socket.
+ */
+function buildLaunchdEnvironment(homeDir: string): string {
+  const entries: Array<[string, string]> = [];
+
+  // PATH — prepend /opt/homebrew/bin on Apple Silicon so Homebrew binaries
+  // (docker, onecli, etc.) are discoverable.
+  const pathDirs = ['/usr/local/bin', '/usr/bin', '/bin', `${homeDir}/.local/bin`];
+  if (os.arch() === 'arm64') {
+    pathDirs.unshift('/opt/homebrew/bin');
+  }
+  entries.push(['PATH', pathDirs.join(':')]);
+  entries.push(['HOME', homeDir]);
+
+  // Colima — detect via socket existence, then set the env vars launchd
+  // would otherwise miss.
+  const colimaSocket = path.join(homeDir, '.colima', 'default', 'docker.sock');
+  if (fs.existsSync(colimaSocket)) {
+    entries.push(['DOCKER_HOST', `unix://${colimaSocket}`]);
+
+    // Override TMPDIR to a Colima-shared path. Create the directory now so
+    // the OneCLI SDK's first writeFileSync doesn't fail on the nonexistent
+    // parent.
+    const tmpDir = path.join(homeDir, '.cache', 'nanoclaw-tmp');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    entries.push(['TMPDIR', `${tmpDir}/`]);
+  }
+
+  return entries
+    .map(([k, v]) => `        <key>${k}</key>\n        <string>${v}</string>`)
+    .join('\n');
+}
+
 function setupLaunchd(
   projectRoot: string,
   nodePath: string,
@@ -99,6 +160,8 @@ function setupLaunchd(
     `${label}.plist`,
   );
   fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+
+  const envBlock = buildLaunchdEnvironment(homeDir);
 
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -119,10 +182,7 @@ function setupLaunchd(
     <true/>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
-        <key>HOME</key>
-        <string>${homeDir}</string>
+${envBlock}
     </dict>
     <key>StandardOutPath</key>
     <string>${projectRoot}/logs/nanoclaw.log</string>


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [X] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
### What
Fix nanoclaw install on Apple Silicon + Colima

### Why
Fix failing install on this system type

### How
The plist generated by setup omits three env vars that are inherited from the user's shell on most setups but absent under launchd on Apple Silicon + Colima. This PR has no effect on other systems (e.g. Docker Desktop / Apple Container / non-macOS).

 * PATH missing /opt/homebrew/bin → host crashes with "docker: command not found" because Apple Silicon's Homebrew prefix isn't on launchd's default PATH.
 * DOCKER_HOST unset → docker info hits the platform-default /var/run/docker.sock which Colima doesn't create.
 * TMPDIR inherited from launchd → OneCLI SDK writes its self-signed CA to /var/folders/<salt>/T/ which is outside Colima's shared paths; bind-mounting that file into an agent container silently degrades to an empty directory, the container's TLS to the proxy fails, and the poll-loop sits idle on retries.

### How tested
Clean install now works on this system

