### PR TITLE
feat: forward AGENT_AUTO_COMPACT_WINDOW to spawned containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -446,6 +446,14 @@ async function buildContainerArgs(
     }
   }
 
+  // Operator-tunable auto-compact threshold for the Claude Agent SDK.
+  // Pass through when set so the container's provider can override the SDK
+  // default. Absent = SDK default (currently 9_000_000 tokens).
+  const autoCompactWindow = process.env.AGENT_AUTO_COMPACT_WINDOW?.trim();
+  if (autoCompactWindow) {
+    args.push('-e', `AGENT_AUTO_COMPACT_WINDOW=${autoCompactWindow}`);
+  }
+
   // OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
   // are routed through the agent vault for credential injection. Treated as
   // a transient hard failure: if we can't wire the gateway, we don't spawn.


### PR DESCRIPTION
## Summary
The Claude Agent SDK reads \`AGENT_AUTO_COMPACT_WINDOW\` from \`process.env\` to override its auto-compact threshold (default ~9M tokens). Today the **host** process picks it up but it never reaches the **agent container** — the runner only forwards a hand-picked allowlist of vars via \`-e\` flags, and this one wasn't on the list.

## Why
Setting \`AGENT_AUTO_COMPACT_WINDOW=800000\` in \`.env\` (a perfectly reasonable operator move when running on a 200k context model and wanting earlier compaction) silently does nothing — the agent's SDK in the container falls back to the default. Caught this in production today after watching long sessions blow past where compaction should've fired.

## Fix
Mirror the existing \`AGENT_MODEL\` passthrough pattern in \`buildContainerArgs\`: when the host has \`AGENT_AUTO_COMPACT_WINDOW\` set, inject it into the container env. Absent = SDK default (no change).

## Files
- \`src/container-runner.ts\` — 7-line block next to the existing TZ / provider env passthrough.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] Manual: set \`AGENT_AUTO_COMPACT_WINDOW=800000\` in \`.env\`, restart host, recycle containers, \`docker exec <name> sh -c 'echo \$AGENT_AUTO_COMPACT_WINDOW'\` → confirms value visible inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)