### PR TITLE
fix: add admin cancel commands for active agent runs

### DIFF
--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -11,7 +11,16 @@ import { TIMEZONE, formatLocalTime } from './timezone.js';
  */
 export type CommandCategory = 'admin' | 'filtered' | 'passthrough' | 'none';
 
-const ADMIN_COMMANDS = new Set(['/remote-control', '/clear', '/compact', '/context', '/cost', '/files']);
+const ADMIN_COMMANDS = new Set([
+  '/remote-control',
+  '/clear',
+  '/compact',
+  '/context',
+  '/cost',
+  '/files',
+  '/cancel',
+  '/stop',
+]);
 const FILTERED_COMMANDS = new Set(['/help', '/login', '/logout', '/doctor', '/config', '/start']);
 
 export interface CommandInfo {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -870,6 +870,7 @@ Messages starting with `/` are checked against three lists:
 - `/remote-control` — remote control session
 - `/clear` — clear session context
 - `/compact` — force context compaction
+- `/cancel`, `/stop` — stop the active container for the session
 - If sent by a non-admin user, the command is rejected with an error message. Not forwarded to the agent.
 
 **Filtered commands (dropped entirely):**

--- a/src/command-gate.ts
+++ b/src/command-gate.ts
@@ -4,7 +4,7 @@
  *
  * - Filtered commands: dropped silently (never reach the container)
  * - Admin commands: checked against user_roles; denied senders get a
- *   "Permission denied" response written directly to messages_out
+ *   "Permission denied" response
  * - Normal messages: pass through unchanged
  */
 import { getDb, hasTable } from './db/connection.js';
@@ -12,7 +12,19 @@ import { getDb, hasTable } from './db/connection.js';
 export type GateResult = { action: 'pass' } | { action: 'filter' } | { action: 'deny'; command: string };
 
 const FILTERED_COMMANDS = new Set(['/help', '/login', '/logout', '/doctor', '/config', '/remote-control']);
-const ADMIN_COMMANDS = new Set(['/clear', '/compact', '/context', '/cost', '/files']);
+const CANCEL_COMMANDS = new Set(['/cancel', '/stop']);
+const ADMIN_COMMANDS = new Set(['/clear', '/compact', '/context', '/cost', '/files', ...CANCEL_COMMANDS]);
+
+export function slashCommand(content: string): string | null {
+  const text = commandText(content);
+  if (!text.startsWith('/')) return null;
+  return text.split(/\s/)[0].toLowerCase();
+}
+
+export function cancelCommand(content: string): string | null {
+  const command = slashCommand(content);
+  return command && CANCEL_COMMANDS.has(command) ? command : null;
+}
 
 /**
  * Classify a message and decide whether it should reach the container.
@@ -21,17 +33,8 @@ const ADMIN_COMMANDS = new Set(['/clear', '/compact', '/context', '/cost', '/fil
  * admin commands.
  */
 export function gateCommand(content: string, userId: string | null, agentGroupId: string): GateResult {
-  let text: string;
-  try {
-    const parsed = JSON.parse(content);
-    text = (parsed.text || '').trim();
-  } catch {
-    text = content.trim();
-  }
-
-  if (!text.startsWith('/')) return { action: 'pass' };
-
-  const command = text.split(/\s/)[0].toLowerCase();
+  const command = slashCommand(content);
+  if (!command) return { action: 'pass' };
 
   if (FILTERED_COMMANDS.has(command)) return { action: 'filter' };
 
@@ -44,6 +47,17 @@ export function gateCommand(content: string, userId: string | null, agentGroupId
 
   // Unknown slash commands pass through (the agent/SDK handles them)
   return { action: 'pass' };
+}
+
+function commandText(content: string): string {
+  let text: string;
+  try {
+    const parsed = JSON.parse(content);
+    text = (parsed.text || '').trim();
+  } catch {
+    text = content.trim();
+  }
+  return text;
 }
 
 function isAdmin(userId: string | null, agentGroupId: string): boolean {

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -47,6 +47,13 @@ function now() {
 
 const TEST_DIR = '/tmp/nanoclaw-test-host';
 
+async function installDeliverySpy() {
+  const { setDeliveryAdapter } = await import('./delivery.js');
+  const deliver = vi.fn().mockResolvedValue(undefined);
+  setDeliveryAdapter({ deliver });
+  return deliver;
+}
+
 beforeEach(() => {
   // Clean test directory
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
@@ -449,6 +456,204 @@ describe('router', () => {
     expect(wakeContainer).not.toHaveBeenCalled();
     // No session should have been created for this agent.
     expect(findSession('mg-1', null)).toBeUndefined();
+  });
+
+  it('cancels an active run without enqueueing the cancel command', async () => {
+    const { routeInbound, setSenderResolver } = await import('./router.js');
+    const { wakeContainer, killContainer, isContainerRunning } = await import('./container-runner.js');
+    const { createUser } = await import('./modules/permissions/db/users.js');
+    const { grantRole } = await import('./modules/permissions/db/user-roles.js');
+    const deliver = await installDeliverySpy();
+
+    setSenderResolver((event) => {
+      const content = JSON.parse(event.message.content) as { senderId?: string };
+      return content.senderId ? `${event.channelType}:${content.senderId}` : null;
+    });
+    createUser({ id: 'discord:owner', kind: 'discord', display_name: 'Owner', created_at: now() });
+    grantRole({ user_id: 'discord:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-running',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'Owner', senderId: 'owner', text: 'start work' }),
+        timestamp: now(),
+      },
+    });
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeDefined();
+    const inDb = new Database(inboundDbPath('ag-1', session!.id));
+    const runningRow = inDb.prepare('SELECT id FROM messages_in').get() as { id: string };
+    inDb.close();
+
+    const outDb = new Database(outboundDbPath('ag-1', session!.id));
+    outDb
+      .prepare(
+        "INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, 'processing', datetime('now'))",
+      )
+      .run(runningRow.id);
+    outDb.close();
+
+    (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (killContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (isContainerRunning as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-cancel',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'Owner', senderId: 'owner', text: '/cancel' }),
+        timestamp: now(),
+      },
+    });
+
+    expect(killContainer).toHaveBeenCalledWith(session!.id, 'user cancel: /cancel');
+    expect(wakeContainer).not.toHaveBeenCalled();
+
+    const verifyDb = new Database(inboundDbPath('ag-1', session!.id));
+    const rows = verifyDb.prepare('SELECT id, status, content FROM messages_in ORDER BY seq').all() as Array<{
+      id: string;
+      status: string;
+      content: string;
+    }>;
+    verifyDb.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(runningRow.id);
+    expect(rows[0].status).toBe('completed');
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      'discord',
+      'chan-123',
+      null,
+      'chat',
+      JSON.stringify({ text: 'Cancelled current run.' }),
+    );
+
+    const verifyOutDb = new Database(outboundDbPath('ag-1', session!.id));
+    const outboundRows = verifyOutDb.prepare('SELECT content FROM messages_out').all();
+    verifyOutDb.close();
+    expect(outboundRows).toHaveLength(0);
+  });
+
+  it('denies cancel aliases from non-admin senders without waking the agent', async () => {
+    const { routeInbound, setSenderResolver } = await import('./router.js');
+    const { wakeContainer, killContainer, isContainerRunning } = await import('./container-runner.js');
+    const deliver = await installDeliverySpy();
+
+    setSenderResolver((event) => {
+      const content = JSON.parse(event.message.content) as { senderId?: string };
+      return content.senderId ? `${event.channelType}:${content.senderId}` : null;
+    });
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-running',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'User', senderId: 'user', text: 'start work' }),
+        timestamp: now(),
+      },
+    });
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeDefined();
+
+    (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (killContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (isContainerRunning as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-stop',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'User', senderId: 'user', text: '/stop' }),
+        timestamp: now(),
+      },
+    });
+
+    expect(killContainer).not.toHaveBeenCalled();
+    expect(wakeContainer).not.toHaveBeenCalled();
+
+    const inDb = new Database(inboundDbPath('ag-1', session!.id));
+    const inboundRows = inDb.prepare('SELECT content FROM messages_in ORDER BY seq').all() as Array<{
+      content: string;
+    }>;
+    inDb.close();
+    expect(inboundRows).toHaveLength(1);
+    expect(JSON.parse(inboundRows[0].content).text).toBe('start work');
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      'discord',
+      'chan-123',
+      null,
+      'chat',
+      JSON.stringify({ text: 'Permission denied: /stop requires admin access.' }),
+    );
+
+    const outDb = new Database(outboundDbPath('ag-1', session!.id));
+    const outboundRows = outDb.prepare('SELECT content FROM messages_out').all();
+    outDb.close();
+    expect(outboundRows).toHaveLength(0);
+  });
+
+  it('handles admin cancel without an active session without waking the agent', async () => {
+    const { routeInbound, setSenderResolver } = await import('./router.js');
+    const { wakeContainer, killContainer, isContainerRunning } = await import('./container-runner.js');
+    const { createUser } = await import('./modules/permissions/db/users.js');
+    const { grantRole } = await import('./modules/permissions/db/user-roles.js');
+    const deliver = await installDeliverySpy();
+
+    setSenderResolver((event) => {
+      const content = JSON.parse(event.message.content) as { senderId?: string };
+      return content.senderId ? `${event.channelType}:${content.senderId}` : null;
+    });
+    createUser({ id: 'discord:owner', kind: 'discord', display_name: 'Owner', created_at: now() });
+    grantRole({ user_id: 'discord:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+
+    (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (killContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (isContainerRunning as unknown as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-cancel',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'Owner', senderId: 'owner', text: '/cancel' }),
+        timestamp: now(),
+      },
+    });
+
+    expect(killContainer).not.toHaveBeenCalled();
+    expect(wakeContainer).not.toHaveBeenCalled();
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeUndefined();
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      'discord',
+      'chan-123',
+      null,
+      'chat',
+      JSON.stringify({ text: 'No active run to cancel.' }),
+    );
   });
 });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,7 +18,8 @@
  * for policy refusals.
  */
 import { getChannelAdapter } from './channels/channel-registry.js';
-import { gateCommand } from './command-gate.js';
+import { cancelCommand, gateCommand } from './command-gate.js';
+import { getDeliveryAdapter } from './delivery.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { recordDroppedMessage } from './db/dropped-messages.js';
 import {
@@ -26,14 +27,18 @@ import {
   getMessagingGroupAgents,
   getMessagingGroupWithAgentCount,
 } from './db/messaging-groups.js';
-import { findSessionForAgent } from './db/sessions.js';
+import { findSessionByAgentGroup, findSessionForAgent, getSession } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
-import { wakeContainer } from './container-runner.js';
-import { getSession } from './db/sessions.js';
-import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
-import type { InboundEvent } from './channels/adapter.js';
+import {
+  completeProcessingMessages,
+  resolveSession,
+  writeSessionMessage,
+  writeOutboundDirect,
+} from './session-manager.js';
+import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import type { AgentGroup, MessagingGroup, MessagingGroupAgent, Session } from './types.js';
+import type { DeliveryAddress, InboundEvent } from './channels/adapter.js';
 
 function generateId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -251,6 +256,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   //    avoids the extra await).
   const parsed = safeParseContent(event.message.content);
   const messageText = parsed.text ?? '';
+  const cancel = cancelCommand(event.message.content);
 
   let engagedCount = 0;
   let accumulatedCount = 0;
@@ -259,6 +265,13 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   for (const agent of agents) {
     const agentGroup = getAgentGroup(agent.agent_group_id);
     if (!agentGroup) continue;
+
+    if (cancel) {
+      if (await handleCancelCommand(agent, agentGroup, mg, event, userId, adapter?.supportsThreads === true, cancel)) {
+        engagedCount++;
+      }
+      continue;
+    }
 
     const engages = evaluateEngage(agent, messageText, isMention, mg, event.threadId);
 
@@ -389,10 +402,7 @@ async function deliverToAgent(
   // per-thread session regardless of wiring. agent-shared preserved (it's
   // a cross-channel directive the adapter doesn't know about). DMs collapse
   // sub-threads to one session (is_group=0 short-circuit).
-  let effectiveSessionMode = agent.session_mode;
-  if (adapterSupportsThreads && effectiveSessionMode !== 'agent-shared' && mg.is_group !== 0) {
-    effectiveSessionMode = 'per-thread';
-  }
+  const effectiveSessionMode = effectiveSessionModeFor(agent, mg, adapterSupportsThreads);
 
   const { session, created } = resolveSession(agent.agent_group_id, mg.id, event.threadId, effectiveSessionMode);
 
@@ -463,6 +473,98 @@ async function deliverToAgent(
       // started so it doesn't leak; the inbound row stays pending.
       if (!woke) stopTypingRefresh(freshSession.id);
     }
+  }
+}
+
+async function handleCancelCommand(
+  agent: MessagingGroupAgent,
+  agentGroup: AgentGroup,
+  mg: MessagingGroup,
+  event: InboundEvent,
+  userId: string | null,
+  adapterSupportsThreads: boolean,
+  command: string,
+): Promise<boolean> {
+  const deliveryAddr = event.replyTo ?? {
+    channelType: event.channelType,
+    platformId: event.platformId,
+    threadId: event.threadId,
+  };
+
+  const gate = gateCommand(event.message.content, userId, agent.agent_group_id);
+  if (gate.action === 'deny') {
+    await deliverCommandResponse(deliveryAddr, `Permission denied: ${gate.command} requires admin access.`);
+    log.info('Cancel command denied by gate', { command: gate.command, userId, agentGroupId: agent.agent_group_id });
+    return true;
+  }
+  if (gate.action === 'filter') return true;
+
+  const session = findExistingSessionForAgent(agent, mg, event.threadId, adapterSupportsThreads);
+  if (!session || !isContainerRunning(session.id)) {
+    await deliverCommandResponse(deliveryAddr, 'No active run to cancel.');
+    log.info('Cancel command received with no active container', {
+      command,
+      sessionId: session?.id ?? null,
+      agentGroupId: agent.agent_group_id,
+    });
+    return true;
+  }
+
+  killContainer(session.id, `user cancel: ${command}`);
+  const completedMessages = completeProcessingMessages(session.agent_group_id, session.id);
+  await deliverCommandResponse(deliveryAddr, 'Cancelled current run.');
+  log.info('Active container cancelled by user command', {
+    command,
+    sessionId: session.id,
+    agentGroupId: agent.agent_group_id,
+    agentGroupName: agentGroup.name,
+    completedMessages,
+  });
+  return true;
+}
+
+function effectiveSessionModeFor(
+  agent: MessagingGroupAgent,
+  mg: MessagingGroup,
+  adapterSupportsThreads: boolean,
+): 'shared' | 'per-thread' | 'agent-shared' {
+  let effectiveSessionMode = agent.session_mode;
+  if (adapterSupportsThreads && effectiveSessionMode !== 'agent-shared' && mg.is_group !== 0) {
+    effectiveSessionMode = 'per-thread';
+  }
+  return effectiveSessionMode;
+}
+
+function findExistingSessionForAgent(
+  agent: MessagingGroupAgent,
+  mg: MessagingGroup,
+  threadId: string | null,
+  adapterSupportsThreads: boolean,
+): Session | undefined {
+  const effectiveSessionMode = effectiveSessionModeFor(agent, mg, adapterSupportsThreads);
+  if (effectiveSessionMode === 'agent-shared') {
+    return findSessionByAgentGroup(agent.agent_group_id);
+  }
+  return findSessionForAgent(agent.agent_group_id, mg.id, effectiveSessionMode === 'shared' ? null : threadId);
+}
+
+async function deliverCommandResponse(deliveryAddr: DeliveryAddress, text: string): Promise<void> {
+  const adapter = getDeliveryAdapter();
+  if (!adapter) {
+    log.warn('No delivery adapter configured for command response', { deliveryAddr, text });
+    return;
+  }
+
+  try {
+    await adapter.deliver(
+      deliveryAddr.channelType,
+      deliveryAddr.platformId,
+      deliveryAddr.threadId,
+      'chat',
+      JSON.stringify({ text }),
+    );
+  } catch (err) {
+    log.warn('Command response delivery failed', { deliveryAddr, text, err });
   }
 }
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -20,7 +20,6 @@ import { DATA_DIR } from './config.js';
 import { getMessagingGroup } from './db/messaging-groups.js';
 import {
   createSession,
-  findSession,
   findSessionByAgentGroup,
   findSessionForAgent,
   getSession,
@@ -33,6 +32,7 @@ import {
   upsertSessionRouting,
   insertMessage,
   migrateMessagesInTable,
+  getProcessingClaims,
 } from './db/session-db.js';
 import { log } from './log.js';
 import type { Session } from './types.js';
@@ -293,6 +293,32 @@ export function openInboundDb(agentGroupId: string, sessionId: string): Database
 /** Open the outbound DB for a session (host reads only). */
 export function openOutboundDb(agentGroupId: string, sessionId: string): Database.Database {
   return openOutboundDbRaw(outboundDbPath(agentGroupId, sessionId));
+}
+
+/**
+ * Mark messages currently claimed by the killed container as completed so a
+ * user-triggered cancel does not replay the same in-flight request.
+ */
+export function completeProcessingMessages(agentGroupId: string, sessionId: string): number {
+  const inDb = openInboundDb(agentGroupId, sessionId);
+  let outDb: Database.Database | null = null;
+  try {
+    outDb = openOutboundDb(agentGroupId, sessionId);
+    const claims = getProcessingClaims(outDb);
+    if (claims.length === 0) return 0;
+
+    let completed = 0;
+    const stmt = inDb.prepare("UPDATE messages_in SET status = 'completed' WHERE id = ? AND status != 'completed'");
+    inDb.transaction(() => {
+      for (const { message_id } of claims) {
+        completed += stmt.run(message_id).changes;
+      }
+    })();
+    return completed;
+  } finally {
+    outDb?.close();
+    inDb.close();
+  }
 }
 
 /**


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #554.

Adds host-side support for `/cancel` and `/stop` so admins can cancel an in-flight agent run from chat without enqueueing the command for the agent to process.

Root cause: slash commands were only filtered or passed through to the container. There was no host-routed command path that could interrupt an already-running session, so users had no in-channel way to stop long-running work.

What changed:

- Classify `/cancel` and `/stop` as admin-only commands in the host command gate and agent-runner formatter.
- Route cancel commands before normal agent delivery, resolve the existing target session, and kill the active container when one is running.
- Mark messages claimed as `processing` by the killed container as completed so the canceled request does not replay.
- Send cancel acknowledgements directly through the host delivery adapter instead of writing to the container-owned outbound database.
- Document the new admin commands.

Validation:

- `pnpm test src/host-core.test.ts`
- `pnpm test src/host-core.test.ts src/container-runner.test.ts src/container-runtime.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run format:check`
- `pnpm exec eslint src/router.ts src/session-manager.ts src/command-gate.ts src/host-core.test.ts` (warnings only)
- `git diff --check`

Known existing local failures:

- `pnpm test` still fails in `setup/platform.test.ts` because local Node version detection returns `null`.
- `pnpm run lint` still reports pre-existing repo lint errors outside this change.
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` still fails because local `bun` type definitions are unavailable.

## For Skills

N/A - this is not a skill PR.

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
