### PR TITLE
feat(setup): label headless URL fallback with "Get started:"

### DIFF
--- a/setup/channels/discord.ts
+++ b/setup/channels/discord.ts
@@ -28,7 +28,7 @@ import k from 'kleur';
 
 import * as setupLog from '../logs.js';
 import { brightSelect } from '../lib/bright-select.js';
-import { confirmThenOpen } from '../lib/browser.js';
+import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { accentGreen, brandBody, fmtDuration, note } from '../lib/theme.js';
@@ -165,7 +165,7 @@ async function walkThroughBotCreation(): Promise<void> {
       '  3. On the same tab, enable "Message Content Intent"',
       '     (under Privileged Gateway Intents)',
       '',
-      k.dim(url),
+      formatNoteLink(url),
     ].join('\n'),
     'Create a Discord bot',
   );
@@ -225,7 +225,7 @@ async function walkThroughServerCreation(): Promise<void> {
       '  2. Choose "Create My Own" → "For me and my friends"',
       '  3. Give it any name (e.g. "NanoClaw")',
       '',
-      k.dim(url),
+      formatNoteLink(url),
     ].join('\n'),
     'Create a Discord server',
   );
@@ -447,7 +447,7 @@ async function promptInviteBot(
       '  1. Pick any server you\'re in (a personal one is fine)',
       '  2. Click "Authorize"',
       '',
-      k.dim(url),
+      formatNoteLink(url),
     ].join('\n'),
     'Add bot to a server',
   );

--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -25,7 +25,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
-import { confirmThenOpen } from '../lib/browser.js';
+import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { accentGreen, fmtDuration, note, wrapForGutter } from '../lib/theme.js';
@@ -136,7 +136,7 @@ async function walkThroughAppCreation(): Promise<void> {
       '  4. Basic Information → copy the "Signing Secret"',
       '  5. Install to Workspace → copy the "Bot User OAuth Token" (xoxb-…)',
       '',
-      k.dim(SLACK_APPS_URL),
+      formatNoteLink(SLACK_APPS_URL),
     ].join('\n'),
     'Create a Slack app',
   );

--- a/setup/channels/telegram.ts
+++ b/setup/channels/telegram.ts
@@ -21,7 +21,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
-import { confirmThenOpen } from '../lib/browser.js';
+import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import {
   type Block,
@@ -51,7 +51,7 @@ export async function runTelegramChannel(displayName: string): Promise<void> {
     [
       `Opening @${botUsername} in Telegram so it's ready when the pairing code shows up.`,
       '',
-      k.dim(botUrl),
+      formatNoteLink(botUrl),
     ].join('\n'),
     'Open Telegram',
   );

--- a/setup/lib/browser.ts
+++ b/setup/lib/browser.ts
@@ -19,6 +19,7 @@
 import { spawn } from 'child_process';
 
 import * as p from '@clack/prompts';
+import k from 'kleur';
 
 import { isHeadless } from '../platform.js';
 import { ensureAnswer } from './runner.js';
@@ -36,6 +37,21 @@ export function openUrl(url: string): void {
   } catch {
     // swallow — URL is visible in the note.
   }
+}
+
+/**
+ * Format a URL for display inside a setup `note(...)` card. On
+ * GUI devices the URL renders dim — it's a fallback in case the
+ * auto-open misses, and `confirmThenOpen` is doing the heavy
+ * lifting of getting the user there. On headless devices the
+ * URL becomes the user's only path forward, so we surface it
+ * with a "Get started:" label and full-strength text — copy-
+ * pasting onto another device is the actual action, not an
+ * incidental reference.
+ */
+export function formatNoteLink(url: string): string {
+  if (isHeadless()) return `Get started: ${url}`;
+  return k.dim(url);
 }
 
 /**


### PR DESCRIPTION
> **Stacked on #2101, #2102, #2103, #2104, #2106, #2108, #2145** — current diff includes their commits. Once those merge, this PR's diff collapses to the `formatNoteLink` helper and the five one-line call-site swaps.

## Summary

When a card's auto-open is gated on `confirmThenOpen`, the URL also appears inside the surrounding `note(...)` as a copy-paste fallback — rendered dim because on a GUI device the auto-open is doing the heavy lifting and the printed URL is just an incidental backup.

On headless devices the auto-open doesn't run (per #2145), so the URL inside the note is the user's *only* path forward. A dim URL reads as "incidental reference" exactly when it should be reading as "this is the action."

Adds `formatNoteLink(url)` to `setup/lib/browser.ts`:

- GUI device → `k.dim(url)` (unchanged from today)
- Headless device → `Get started: <url>` at full strength

Replaces five call sites (Discord ×3, Slack ×1, Telegram ×1). Single helper, atomic switch via the same `isHeadless()` plumbing introduced in #2145, so the headless behavior across all five flows stays in sync.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test setup/` — 5 files / 43 tests pass
- [x] Visually previewed all five cards on a headless griffin-fairy VM via `node /tmp/headless-cards-demo.mjs`; "Get started: <url>" line renders at full strength inside each