### PR TITLE
fix(opencode): kill server process group + configurable IDLE_TIMEOUT_MS

### DIFF
--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -17,6 +17,19 @@ const SESSION_STATUS_RETRY_ERROR_AFTER = 3;
 const STALE_SESSION_RE =
   /no conversation found|ENOENT.*\.jsonl|session.*not found|NotFoundError|connection reset|ECONNRESET|404|event timeout/i;
 
+function killProcessTree(proc: ChildProcess): void {
+  if (!proc.pid) return;
+  try {
+    process.kill(-proc.pid, 'SIGKILL');
+  } catch {
+    try {
+      proc.kill('SIGKILL');
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000): Promise<{ url: string; proc: ChildProcess }> {
   return new Promise((resolve, reject) => {
     const hostname = '127.0.0.1';
@@ -26,10 +39,11 @@ function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000
         ...process.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
       },
+      detached: true,
     });
 
     const id = setTimeout(() => {
-      proc.kill('SIGKILL');
+      killProcessTree(proc);
       reject(new Error(`Timeout waiting for OpenCode server to start after ${timeoutMs}ms`));
     }, timeoutMs);
 
@@ -189,11 +203,7 @@ export function destroySharedRuntime(): void {
     } catch {
       /* ignore */
     }
-    try {
-      sharedRuntime.proc.kill('SIGKILL');
-    } catch {
-      /* ignore */
-    }
+    killProcessTree(sharedRuntime.proc);
     sharedRuntime = null;
     sharedConfigKey = null;
   }
@@ -243,7 +253,7 @@ export class OpenCodeProvider implements AgentProvider {
     };
 
     const self = this;
-    const IDLE_TIMEOUT_MS = 90_000;
+    const IDLE_TIMEOUT_MS = Number(process.env.OPENCODE_IDLE_TIMEOUT_MS) || 300_000;
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
       let initYielded = false;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2148. Closes #2149.

Two related bugs in the OpenCode provider that fire together when a local backend (Ollama, llama.cpp) is slower than the hardcoded 90 s event timeout. Bundled into a single PR because they share `container/agent-runner/src/providers/opencode.ts` and a small helper.

### #2148 — `proc.kill('SIGKILL')` leaks the underlying binary, holding port 4096

`spawn('opencode', ...)` runs the npm `opencode-ai` wrapper script that `exec`s the platform binary `opencode-linux-*/bin/opencode` — which is the actual port listener on `127.0.0.1:4096`. SIGKILL on the wrapper PID either races with the exec or the listener has already detached; the binary survives and the port stays bound. Next `spawnOpencodeServer` call fails with `Failed to start server on port 4096` / EADDRINUSE.

**Fix:** spawn detached and signal the whole process group via a new `killProcessTree(proc)` helper that calls `process.kill(-pid, 'SIGKILL')` (with a fallback to plain `proc.kill('SIGKILL')` if the negative-PID call throws — covers the case where the spawn never made it into a process group).

Both call sites updated:
- startup-timeout cleanup in `spawnOpencodeServer`
- `destroySharedRuntime`

### #2149 — Configurable idle timeout

`IDLE_TIMEOUT_MS = 90_000` was hardcoded. Used as a between-events watchdog, but on a freshly-prompted session it acts as a TTFT ceiling — fine for cloud APIs (sub-second TTFT), too tight for local 30B+ inference on cold start.

**Fix:** read `OPENCODE_IDLE_TIMEOUT_MS` from env, default to `300_000` (5 min). Generous for cloud, just enough for slow local. Per-group override via `container.json` `env`, e.g. `"OPENCODE_IDLE_TIMEOUT_MS": "600000"` — no rebuild needed since `src/` is bind-mounted.

### Tests

No behavior-changing additions. Manually verified:
- Process group kill: `docker exec <container> pgrep -af opencode` no longer shows orphan `[opencode] <defunct>` after a forced timeout; `127.0.0.1:4096` is free immediately.
- Configurable timeout: env override applied; default 300 s confirmed when var unset.

### Compounding behavior

Without #2148 fixed, every timeout from the 90 s ceiling (or any idle ceiling) leaks a process and renders the agent container unusable until restarted. Fixing one without the other is half a fix — that's why they're filed together.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

_Not a skill PR — section N/A._
