### PR TITLE
fix(opencode): use native instructions config to load CLAUDE.md and fragments

### DIFF
--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import { spawn, type ChildProcess } from 'child_process';
 
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk';
@@ -62,29 +61,10 @@ function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000
   });
 }
 
-function readClaudeMdForPrompt(): string | undefined {
-  const groupPath = '/workspace/agent/CLAUDE.md';
-  const globalPath = '/workspace/global/CLAUDE.md';
-  let content = '';
-  if (fs.existsSync(groupPath)) {
-    content += fs.readFileSync(groupPath, 'utf-8');
-  }
-  const isMain = process.env.NANOCLAW_IS_MAIN === '1';
-  if (!isMain && fs.existsSync(globalPath)) {
-    if (content) content += '\n\n---\n\n';
-    content += fs.readFileSync(globalPath, 'utf-8');
-  }
-  return content || undefined;
-}
-
 function wrapPromptWithContext(text: string, systemInstructions?: string): string {
   let out = text;
   if (systemInstructions) {
     out = `<system>\n${systemInstructions}\n</system>\n\n${out}`;
-  }
-  const claudeMd = readClaudeMdForPrompt();
-  if (claudeMd) {
-    out = `<system>\n${claudeMd}\n</system>\n\n${out}`;
   }
   return out;
 }
@@ -119,6 +99,19 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
 
   const mcp = mcpServersToOpenCodeConfig(options.mcpServers);
 
+  // Load shared base + per-group fragments + per-group memory through OpenCode's
+  // native instructions pipeline (session/instruction.ts). Absolute paths with
+  // globs are supported. Files are read raw — `@./...` includes are NOT expanded
+  // by OpenCode, so point at the concrete files, not at composed CLAUDE.md.
+  const instructions = [
+    '/app/CLAUDE.md',
+    '/workspace/agent/.claude-fragments/*.md',
+    '/workspace/agent/CLAUDE.local.md',
+  ];
+  if (process.env.NANOCLAW_IS_MAIN !== '1') {
+    instructions.push('/workspace/global/CLAUDE.md');
+  }
+
   return {
     ...(model ? { model } : {}),
     ...(smallModel ? { small_model: smallModel } : {}),
@@ -127,6 +120,7 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
     autoupdate: false,
     snapshot: false,
     provider: providerOptions,
+    instructions,
     mcp,
   };
 }

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -108,9 +108,6 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
     '/workspace/agent/.claude-fragments/*.md',
     '/workspace/agent/CLAUDE.local.md',
   ];
-  if (process.env.NANOCLAW_IS_MAIN !== '1') {
-    instructions.push('/workspace/global/CLAUDE.md');
-  }
 
   return {
     ...(model ? { model } : {}),


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2150.

`wrapPromptWithContext` previously concatenated `/workspace/agent/CLAUDE.md` verbatim into a `<system>...</system>` block in the user-message text. That file is the host-composed entry point that contains only `@./...` includes (the `.claude-shared.md` symlink to `/app/CLAUDE.md`, plus the module fragments). OpenCode does not expand `@` in instruction files — the syntax is a Claude Code convention for the model's own Read tool to lazy-load. Result: the model received the literal lines `@./.claude-shared.md\n@./.claude-fragments/module-...md` as text and saw none of the actual fragment content (workspace, memory, conversation history, agents/core/interactive/scheduling/self-mod modules, OneCLI, etc.). Strong-prior models (Claude, GPT-4) masked the gap; weaker local models visibly lacked NanoClaw conventions.

This PR routes the concrete files through OpenCode's native `instructions` config field. Per `packages/opencode/src/session/instruction.ts` on the upstream `dev` branch (already shipped in `@opencode-ai/sdk@1.4.17`, the version pinned by `/add-opencode`), absolute paths and globs are resolved with `fs.glob(basename, { cwd: dirname, absolute: true, include: 'file' })`, files are read raw, and the resulting strings are concatenated into the LLM's system prompt at `packages/opencode/src/session/prompt.ts:1442`. That is the canonical channel — same one OpenCode uses for `AGENTS.md` / `CLAUDE.md` auto-discovery.

### Configured set

```ts
const instructions = [
  '/app/CLAUDE.md',                              // shared base
  '/workspace/agent/.claude-fragments/*.md',     // per-skill fragments
  '/workspace/agent/CLAUDE.local.md',            // per-group memory
];
if (process.env.NANOCLAW_IS_MAIN !== '1') {
  instructions.push('/workspace/global/CLAUDE.md');  // cross-group memory (non-main)
}
```

Removed: `readClaudeMdForPrompt`, the manual `<system>` wrap of its output in `wrapPromptWithContext`, and the now-unused `fs` import. The dynamic `systemInstructions` wrap (assistant name + destinations) stays as-is — that's per-call data, not file content.

### Verification

Empirically tested with `gemma4:31b` on local Ollama before the fix: agent replied `"I haven't received instructions"` to "what self-modification tools do you have". Post-fix: agent listed the exact MCP tool names (`install_packages`, `add_mcp_server`) and structured response from `module-self-mod.md` content. Base model has no priors for those tools, so the only place that knowledge can come from is the fragment now reaching the system prompt.

### Note on `composeGroupClaudeMd`

`src/claude-md-compose.ts` still produces `/workspace/agent/CLAUDE.md` with `@./...` includes. That file remains required for the Claude provider (whose SDK does expand `@` correctly) but is now redundant for OpenCode users — OpenCode also auto-discovers it via `findUp` and adds the literal text again, but `instructions` takes precedence for actual content. Cleanup is out of scope for this fix; flagging so future work knows.

### Related

- #1955 raised a perf-driven angle on instructions duplication (*"similar duplication may exist for Claude/OpenCode — worth investigating"*). This PR fixes the inverse symptom (silent context loss); both efforts are complementary.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

_Not a skill PR — section N/A._
