### PR TITLE
fix: prevent telegram pairing spinner from flooding terminal

### DIFF
--- a/setup/channels/telegram.ts
+++ b/setup/channels/telegram.ts
@@ -33,7 +33,7 @@ import {
   spawnStep,
   writeStepEntry,
 } from '../lib/runner.js';
-import { accentGreen, brandBold, note } from '../lib/theme.js';
+import { accentGreen, brandBold, fitToWidth, note } from '../lib/theme.js';
 
 const DEFAULT_AGENT_NAME = 'Nano';
 
@@ -254,11 +254,11 @@ async function runPairTelegram(): Promise<
           stopSpinner("Old code expired. Here's a fresh one.");
         }
         note(formatCodeCard(block.fields.CODE ?? '????'), 'Secret code');
-        s.start('Waiting for you to send the code from Telegram…');
+        s.start(fitToWidth('Waiting for you to send the code from Telegram…', ''));
         spinnerActive = true;
       } else if (block.type === 'PAIR_TELEGRAM_ATTEMPT') {
         stopSpinner(`Got "${block.fields.CANDIDATE ?? '?'}", not a match.`);
-        s.start('Waiting for the correct code…');
+        s.start(fitToWidth('Waiting for the correct code…', ''));
         spinnerActive = true;
       } else if (block.type === 'PAIR_TELEGRAM') {
         if (block.fields.STATUS === 'success') {


### PR DESCRIPTION
## Summary
- Telegram pairing spinner label exceeded terminal width, causing clack's cursor-up redraw to break — each animation tick printed a new line instead of updating in-place, pushing the secret code off-screen
- Wrapped the two pairing spinner labels with `fitToWidth()`, the same utility the rest of the setup flow already uses for this exact problem

## Test plan
- [ ] Run setup with Telegram pairing on a narrow terminal and confirm the spinner updates in-place
- [ ] Verify the secret code stays visible while the spinner runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)