### PR TITLE
fix: surface silent task failures instead of acking them as completed

### DIFF
--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -101,13 +101,17 @@ export function markCompleted(ids: string[]): void {
   })();
 }
 
-/** Mark a single message as failed — writes to processing_ack in outbound.db. */
-export function markFailed(id: string): void {
-  getOutboundDb()
-    .prepare(
-      "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', datetime('now'))",
-    )
-    .run(id);
+/** Mark messages as failed — updates processing_ack in outbound.db. */
+export function markFailed(ids: string[] | string): void {
+  const list = typeof ids === 'string' ? [ids] : ids;
+  if (list.length === 0) return;
+  const db = getOutboundDb();
+  const stmt = db.prepare(
+    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', datetime('now'))",
+  );
+  db.transaction(() => {
+    for (const id of list) stmt.run(id);
+  })();
 }
 
 /** Get a message by ID (read from inbound.db). */

--- a/container/agent-runner/src/poll-loop-failure.test.ts
+++ b/container/agent-runner/src/poll-loop-failure.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Targeted tests for the silent-task / lie-by-omission fix.
+ *
+ * Scenarios:
+ *   1. SDK terminal result with subtype='error_*' → markFailed + DM the
+ *      originating channel.
+ *   2. SDK stream ends without any terminal result → markFailed + DM.
+ *   3. SDK terminal result with subtype='success' but empty text →
+ *      markCompleted (legitimate "no chat reply needed" turn). No DM.
+ *   4. Synthetic mid-turn result (subtype undefined) followed by terminal
+ *      success → text dispatched, terminal success acks the turn. No DM.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
+import { getUndeliveredMessages } from './db/messages-out.js';
+import { runPollLoop } from './poll-loop.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, QueryInput } from './providers/types.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+function insertChat(id: string, text: string): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+       VALUES (?, 'chat', datetime('now'), 'pending', 'chan-1', 'discord', 'thread-1', ?)`,
+    )
+    .run(id, JSON.stringify({ sender: 'Tester', text }));
+}
+
+function getAckStatus(messageId: string): string | undefined {
+  const row = getOutboundDb()
+    .prepare("SELECT status FROM processing_ack WHERE message_id = ?")
+    .get(messageId) as { status: string } | undefined;
+  return row?.status;
+}
+
+/** Programmable provider — yields a sequence of events then closes the stream. */
+class ScriptedProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  constructor(private events: ProviderEvent[]) {}
+  isSessionInvalid(): boolean { return false; }
+  query(_input: QueryInput): AgentQuery {
+    const events = this.events;
+    const iter: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        for (const ev of events) yield ev;
+      },
+    };
+    return {
+      push() {},
+      end() {},
+      events: iter,
+      abort() {},
+    };
+  }
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/**
+ * Runs the poll loop in the background and returns a controller. Tests
+ * must call `controller.stop()` after assertions to prevent the loop
+ * from cross-contaminating the next test's DB (the connection module's
+ * DB singleton is reset in beforeEach, so a still-running loop would
+ * point at the next test's DB).
+ */
+function startLoop(provider: AgentProvider): { stop: () => Promise<void> } {
+  const controller = new AbortController();
+  const promise = runPollLoop({
+    provider,
+    providerName: 'mock',
+    cwd: '/tmp',
+    stopSignal: controller.signal,
+  }).catch(() => {});
+  return {
+    stop: async () => {
+      controller.abort();
+      await promise;
+    },
+  };
+}
+
+describe('silent-failure detection in processQuery', () => {
+  it('marks message FAILED and DMs the channel when SDK returns an error subtype', async () => {
+    insertChat('m1', 'hello');
+    const loop = startLoop(new ScriptedProvider([
+      { type: 'init', continuation: 'sess-1' },
+      { type: 'result', text: null, subtype: 'error_during_execution' },
+    ]));
+
+    await waitFor(() => getAckStatus('m1') !== undefined);
+    await loop.stop();
+
+    expect(getAckStatus('m1')).toBe('failed');
+    const out = getUndeliveredMessages();
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    const failureNote = out.find((m) => JSON.parse(m.content).text?.includes('did not complete'));
+    expect(failureNote).toBeTruthy();
+    expect(JSON.parse(failureNote!.content).text).toContain('error_during_execution');
+    expect(failureNote!.platform_id).toBe('chan-1');
+    expect(failureNote!.channel_type).toBe('discord');
+  });
+
+  it('marks message FAILED and DMs the channel when stream ends with no terminal result', async () => {
+    insertChat('m1', 'hello');
+    const loop = startLoop(new ScriptedProvider([
+      { type: 'init', continuation: 'sess-1' },
+      { type: 'activity' },
+      // No 'result' event — stream just ends.
+    ]));
+
+    await waitFor(() => getAckStatus('m1') !== undefined);
+    await loop.stop();
+
+    expect(getAckStatus('m1')).toBe('failed');
+    const out = getUndeliveredMessages();
+    const failureNote = out.find((m) => JSON.parse(m.content).text?.includes('did not complete'));
+    expect(failureNote).toBeTruthy();
+    expect(JSON.parse(failureNote!.content).text).toContain('SDK stream ended without terminal result');
+  });
+
+  it('captures last in-stream error event and surfaces it in the failure DM', async () => {
+    insertChat('m1', 'hello');
+    const loop = startLoop(new ScriptedProvider([
+      { type: 'init', continuation: 'sess-1' },
+      { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' },
+      // Stream ends without terminal result after the error.
+    ]));
+
+    await waitFor(() => getAckStatus('m1') !== undefined);
+    await loop.stop();
+
+    expect(getAckStatus('m1')).toBe('failed');
+    const out = getUndeliveredMessages();
+    const failureNote = out.find((m) => JSON.parse(m.content).text?.includes('did not complete'));
+    expect(failureNote).toBeTruthy();
+    expect(JSON.parse(failureNote!.content).text).toContain('Rate limit');
+    expect(JSON.parse(failureNote!.content).text).toContain('quota');
+  });
+
+  it('marks COMPLETED for a clean success terminal even when text is empty (no chat reply needed)', async () => {
+    insertChat('m1', 'hello');
+    const loop = startLoop(new ScriptedProvider([
+      { type: 'init', continuation: 'sess-1' },
+      { type: 'result', text: null, subtype: 'success' },
+    ]));
+
+    await waitFor(() => getAckStatus('m1') !== undefined);
+    await loop.stop();
+
+    expect(getAckStatus('m1')).toBe('completed');
+    const out = getUndeliveredMessages();
+    // No failure DM should have been written.
+    const failureNote = out.find((m) => JSON.parse(m.content).text?.includes('did not complete'));
+    expect(failureNote).toBeUndefined();
+  });
+
+  it('treats subtype-undefined result as synthetic mid-turn (compact_boundary): dispatches text without acking the turn', async () => {
+    insertChat('m1', 'hello');
+    const loop = startLoop(new ScriptedProvider([
+      { type: 'init', continuation: 'sess-1' },
+      // Synthetic mid-turn signal — text gets dispatched, turn not acked yet.
+      { type: 'result', text: 'Context compacted.' },
+      // Real terminal result follows.
+      { type: 'result', text: '<message to="x">all done</message>', subtype: 'success' },
+    ]));
+
+    await waitFor(() => getAckStatus('m1') === 'completed');
+    await loop.stop();
+
+    expect(getAckStatus('m1')).toBe('completed');
+    const out = getUndeliveredMessages();
+    // The compact-boundary text was dispatched mid-turn via the single-channel
+    // shortcut to the originating chan-1/discord.
+    const compactNote = out.find((m) => JSON.parse(m.content).text === 'Context compacted.');
+    expect(compactNote).toBeTruthy();
+    // No failure DM should be present.
+    const failureNote = out.find((m) => JSON.parse(m.content).text?.includes('did not complete'));
+    expect(failureNote).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,5 +1,5 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
-import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
+import { getPendingMessages, markProcessing, markCompleted, markFailed, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import {
@@ -33,6 +33,13 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * Optional stop signal. When the signal aborts, the loop exits at the
+   * next iteration boundary. Used by tests to halt the loop deterministically
+   * after assertions complete; production callers omit this and let the
+   * container process lifecycle stop the loop.
+   */
+  stopSignal?: AbortSignal;
 }
 
 /**
@@ -63,6 +70,10 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
   let pollCount = 0;
   while (true) {
+    if (config.stopSignal?.aborted) {
+      log('Stop signal received — exiting poll loop');
+      return;
+    }
     // Skip system messages — they're responses for MCP tools (e.g., ask_user_question)
     const messages = getPendingMessages().filter((m) => m.kind !== 'system');
     pollCount++;
@@ -170,13 +181,16 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Process the query while concurrently polling for new messages
     const skippedSet = new Set(skipped);
     const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
+    let outcome: QueryResult | null = null;
+    let threwException = false;
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
-      if (result.continuation && result.continuation !== continuation) {
-        continuation = result.continuation;
+      outcome = await processQuery(query, routing, processingIds, config.providerName);
+      if (outcome.continuation && outcome.continuation !== continuation) {
+        continuation = outcome.continuation;
         setContinuation(config.providerName, continuation);
       }
     } catch (err) {
+      threwException = true;
       const errMsg = err instanceof Error ? err.message : String(err);
       log(`Query error: ${errMsg}`);
 
@@ -198,12 +212,32 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         thread_id: routing.threadId,
         content: JSON.stringify({ text: `Error: ${errMsg}` }),
       });
+      markFailed(processingIds);
+      log(`Failed ${processingIds.length} message(s) — threw: ${errMsg}`);
+      continue;
     }
 
-    // Ensure completed even if processQuery ended without a result event
-    // (e.g. stream closed unexpectedly).
-    markCompleted(processingIds);
-    log(`Completed ${ids.length} message(s)`);
+    // No throw: did the SDK actually report a success result, or did the
+    // stream end silently (the v2 lie-by-omission bug — task ack 'completed'
+    // with zero output)? processQuery already handled the in-stream
+    // success/error-subtype branch (markCompleted vs markFailed). Here we
+    // catch the "no terminal result event ever arrived" case.
+    if (!outcome.sawTerminalResult) {
+      const reason = outcome.lastErrorMessage
+        ? `SDK stream ended without terminal result (last signal: ${outcome.lastErrorMessage})`
+        : 'SDK stream ended without terminal result';
+      log(`Failing ${processingIds.length} message(s): ${reason}`);
+      writeMessageOut({
+        id: generateId(),
+        kind: 'chat',
+        platform_id: routing.platformId,
+        channel_type: routing.channelType,
+        thread_id: routing.threadId,
+        content: JSON.stringify({ text: `⚠️ Task did not complete: ${reason}.` }),
+      });
+      markFailed(processingIds);
+    }
+    log(`Turn done — ${ids.length} message(s) ${threwException ? 'failed' : outcome.sawTerminalResult ? 'completed' : 'failed-silent'}`);
   }
 }
 
@@ -243,6 +277,31 @@ function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommand
 
 interface QueryResult {
   continuation?: string;
+  /**
+   * True when the SDK emitted a terminal `result` event whose `subtype`
+   * is treated as success (success | undefined | null). False when the
+   * stream ended without one — i.e. the silent-failure mode where the
+   * v2 runner used to mark tasks `completed` with zero output. The
+   * caller (runPollLoop) writes a user-visible failure DM in that case.
+   */
+  sawTerminalResult: boolean;
+  /** Most recent in-stream error/quota signal (used in the failure DM). */
+  lastErrorMessage?: string;
+}
+
+/**
+ * SDK `result` subtype taxonomy:
+ *   - undefined  → synthetic mid-turn signal (e.g. compact_boundary). NOT
+ *                  terminal; the real terminal result arrives later.
+ *   - 'error_*'  → terminal failure (max turns, execution error, etc.)
+ *   - other      → terminal success ('success', or any future label)
+ *
+ * Treating unknown subtypes as success is fail-open: we'd rather miss a
+ * future error subtype than scream-and-DM-a-channel for every harmless
+ * SDK addition. Failure is the explicit case.
+ */
+function isFailureSubtype(subtype: string | null | undefined): boolean {
+  return typeof subtype === 'string' && subtype.startsWith('error_');
 }
 
 async function processQuery(
@@ -253,6 +312,8 @@ async function processQuery(
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
+  let sawTerminalResult = false;
+  let lastErrorMessage: string | undefined;
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open is
@@ -340,16 +401,46 @@ async function processQuery(
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
       } else if (event.type === 'result') {
-        // A result — with or without text — means the turn is done. Mark
-        // the initial batch completed now so the host sweep doesn't see
-        // stale 'processing' claims while the query stays open for
-        // follow-up pushes. The agent may have responded via MCP
-        // (send_message) mid-turn, or the message may not need a response
-        // at all — either way the turn is finished.
+        // Synthetic mid-turn results (compact_boundary, etc.) have no
+        // subtype — dispatch the text but DO NOT mark the turn done; the
+        // real terminal result event still arrives later.
+        if (event.subtype === undefined) {
+          if (event.text) dispatchResultText(event.text, routing);
+          continue;
+        }
+
+        if (isFailureSubtype(event.subtype)) {
+          // Surface the failure to the user instead of silently marking
+          // the message completed (the v2 lie-by-omission this fix targets).
+          lastErrorMessage = event.subtype ?? undefined;
+          log(`SDK terminal result is failure: ${event.subtype}`);
+          markFailed(initialBatchIds);
+          writeMessageOut({
+            id: generateId(),
+            kind: 'chat',
+            platform_id: routing.platformId,
+            channel_type: routing.channelType,
+            thread_id: routing.threadId,
+            content: JSON.stringify({
+              text: `⚠️ Task did not complete: ${event.subtype}${event.text ? ` — ${event.text}` : ''}.`,
+            }),
+          });
+          sawTerminalResult = true;
+          continue;
+        }
+
+        // Success path — mark the initial batch completed now so the host
+        // sweep doesn't see stale 'processing' claims while the query
+        // stays open for follow-up pushes. The agent may have responded
+        // via MCP mid-turn, or the message may not need a response at all
+        // — either way the turn is finished.
         markCompleted(initialBatchIds);
+        sawTerminalResult = true;
         if (event.text) {
           dispatchResultText(event.text, routing);
         }
+      } else if (event.type === 'error') {
+        lastErrorMessage = `${event.message}${event.classification ? ` (${event.classification})` : ''}`;
       }
     }
   } finally {
@@ -357,7 +448,7 @@ async function processQuery(
     clearInterval(pollHandle);
   }
 
-  return { continuation: queryContinuation };
+  return { continuation: queryContinuation, sawTerminalResult, lastErrorMessage };
 }
 
 function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -308,7 +308,8 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
           const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
-          yield { type: 'result', text };
+          const subtype = (message as { subtype?: string }).subtype ?? null;
+          yield { type: 'result', text, subtype };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -30,15 +30,17 @@ export class MockProvider implements AgentProvider {
         yield { type: 'activity' };
         yield { type: 'init', continuation: `mock-session-${Date.now()}` };
 
-        // Process initial prompt
+        // Process initial prompt — emit a terminal success result so the
+        // poll-loop's silent-failure detector does not treat this as a
+        // dropped turn (subtype undefined would mean synthetic mid-turn).
         yield { type: 'activity' };
-        yield { type: 'result', text: responseFactory(input.prompt) };
+        yield { type: 'result', text: responseFactory(input.prompt), subtype: 'success' };
 
         // Process any pushed follow-ups
         while (!ended && !aborted) {
           if (pending.length > 0) {
             const msg = pending.shift()!;
-            yield { type: 'result', text: responseFactory(msg) };
+            yield { type: 'result', text: responseFactory(msg), subtype: 'success' };
             continue;
           }
           // Wait for push() or end()
@@ -51,7 +53,7 @@ export class MockProvider implements AgentProvider {
         // Drain remaining
         while (pending.length > 0) {
           const msg = pending.shift()!;
-          yield { type: 'result', text: responseFactory(msg) };
+          yield { type: 'result', text: responseFactory(msg), subtype: 'success' };
         }
       },
     };

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -71,7 +71,14 @@ export interface AgentQuery {
 
 export type ProviderEvent =
   | { type: 'init'; continuation: string }
-  | { type: 'result'; text: string | null }
+  /**
+   * `subtype` carries the provider's outcome label: 'success' for a clean
+   * turn, 'error_max_turns' / 'error_during_execution' / etc. for failures.
+   * `undefined` means a synthetic mid-turn signal (e.g. compact_boundary)
+   * that should NOT be treated as the turn's terminal result. The poll-loop
+   * uses this to distinguish a clean completion from a silent SDK failure.
+   */
+  | { type: 'result'; text: string | null; subtype?: string | null }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }
   | { type: 'progress'; message: string }
   /**

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { migrateMessagesInTable } from './session-db.js';
+import { migrateMessagesInTable, syncProcessingAcks } from './session-db.js';
 
 const TEST_DIR = '/tmp/nanoclaw-session-db-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
@@ -54,5 +54,97 @@ describe('migrateMessagesInTable', () => {
     };
     expect(row.series_id).toBe('legacy-1');
     db.close();
+  });
+});
+
+describe('syncProcessingAcks', () => {
+  function makeDbs(): { inDb: Database.Database; outDb: Database.Database } {
+    const inDb = new Database(':memory:');
+    inDb.exec(`
+      CREATE TABLE messages_in (
+        id             TEXT PRIMARY KEY,
+        seq            INTEGER UNIQUE,
+        kind           TEXT NOT NULL,
+        timestamp      TEXT NOT NULL,
+        status         TEXT DEFAULT 'pending',
+        process_after  TEXT,
+        recurrence     TEXT,
+        series_id      TEXT,
+        tries          INTEGER DEFAULT 0,
+        trigger        INTEGER NOT NULL DEFAULT 1,
+        platform_id    TEXT,
+        channel_type   TEXT,
+        thread_id      TEXT,
+        content        TEXT NOT NULL
+      );
+    `);
+    const outDb = new Database(':memory:');
+    outDb.exec(`
+      CREATE TABLE processing_ack (
+        message_id     TEXT PRIMARY KEY,
+        status         TEXT NOT NULL,
+        status_changed TEXT NOT NULL
+      );
+    `);
+    return { inDb, outDb };
+  }
+
+  it("propagates 'failed' processing_ack as 'failed' on messages_in (not 'completed')", () => {
+    const { inDb, outDb } = makeDbs();
+    inDb
+      .prepare(
+        "INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES ('m1','task',datetime('now'),'pending','{}')",
+      )
+      .run();
+    outDb
+      .prepare("INSERT INTO processing_ack (message_id, status, status_changed) VALUES ('m1','failed',datetime('now'))")
+      .run();
+
+    syncProcessingAcks(inDb, outDb);
+
+    const row = inDb.prepare('SELECT status FROM messages_in WHERE id = ?').get('m1') as { status: string };
+    expect(row.status).toBe('failed');
+    inDb.close();
+    outDb.close();
+  });
+
+  it("propagates 'completed' processing_ack as 'completed'", () => {
+    const { inDb, outDb } = makeDbs();
+    inDb
+      .prepare(
+        "INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES ('m1','task',datetime('now'),'pending','{}')",
+      )
+      .run();
+    outDb
+      .prepare(
+        "INSERT INTO processing_ack (message_id, status, status_changed) VALUES ('m1','completed',datetime('now'))",
+      )
+      .run();
+
+    syncProcessingAcks(inDb, outDb);
+
+    const row = inDb.prepare('SELECT status FROM messages_in WHERE id = ?').get('m1') as { status: string };
+    expect(row.status).toBe('completed');
+    inDb.close();
+    outDb.close();
+  });
+
+  it("does not downgrade an already-completed row to 'failed' on a stale ack", () => {
+    const { inDb, outDb } = makeDbs();
+    inDb
+      .prepare(
+        "INSERT INTO messages_in (id, kind, timestamp, status, content) VALUES ('m1','task',datetime('now'),'completed','{}')",
+      )
+      .run();
+    outDb
+      .prepare("INSERT INTO processing_ack (message_id, status, status_changed) VALUES ('m1','failed',datetime('now'))")
+      .run();
+
+    syncProcessingAcks(inDb, outDb);
+
+    const row = inDb.prepare('SELECT status FROM messages_in WHERE id = ?').get('m1') as { status: string };
+    expect(row.status).toBe('completed');
+    inDb.close();
+    outDb.close();
   });
 });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -146,16 +146,24 @@ export function getMessageForRetry(
 }
 
 export function syncProcessingAcks(inDb: Database.Database, outDb: Database.Database): void {
-  const completed = outDb
-    .prepare("SELECT message_id FROM processing_ack WHERE status IN ('completed', 'failed')")
-    .all() as Array<{ message_id: string }>;
+  const acks = outDb
+    .prepare("SELECT message_id, status FROM processing_ack WHERE status IN ('completed', 'failed')")
+    .all() as Array<{ message_id: string; status: 'completed' | 'failed' }>;
 
-  if (completed.length === 0) return;
+  if (acks.length === 0) return;
 
-  const updateStmt = inDb.prepare("UPDATE messages_in SET status = 'completed' WHERE id = ? AND status != 'completed'");
+  // Propagate the actual ack status. Pre-fix this collapsed 'failed' →
+  // 'completed', erasing the runner's signal that a turn errored out and
+  // leaving operators thinking silent-failure days were healthy.
+  const setCompleted = inDb.prepare(
+    "UPDATE messages_in SET status = 'completed' WHERE id = ? AND status NOT IN ('completed','failed')",
+  );
+  const setFailed = inDb.prepare(
+    "UPDATE messages_in SET status = 'failed' WHERE id = ? AND status NOT IN ('completed','failed')",
+  );
   inDb.transaction(() => {
-    for (const { message_id } of completed) {
-      updateStmt.run(message_id);
+    for (const { message_id, status } of acks) {
+      (status === 'failed' ? setFailed : setCompleted).run(message_id);
     }
   })();
 }

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -41,12 +41,25 @@ import {
   syncProcessingAcks,
   type ContainerState,
 } from './db/session-db.js';
+import { getMessagingGroup } from './db/messaging-groups.js';
+import { getDeliveryAdapter } from './delivery.js';
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, inboundDbPath, heartbeatPath } from './session-manager.js';
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
 const SWEEP_INTERVAL_MS = 60_000;
+/**
+ * Look-back window for silent-task detection. A `kind='task'` row that
+ * went to status='completed' inside this window AND wrote zero
+ * messages_out rows in the same window is treated as a silent failure
+ * (the v2 lie-by-omission bug). The runner's own markFailed path
+ * (poll-loop.ts) is the primary fix; this is the host-side belt-and-
+ * braces that catches anything the runner missed.
+ */
+const SILENT_TASK_WINDOW_MIN = 15;
+/** Per-process dedup so we don't DM the same silent-task multiple sweeps in a row. */
+const notifiedSilentTasks = new Set<string>();
 // Absolute idle ceiling for a running container. If the heartbeat file hasn't
 // been touched in this long, the container is either stuck or doing genuinely
 // nothing — kill and restart on the next inbound.
@@ -188,7 +201,17 @@ async function sweepSession(session: Session): Promise<void> {
       resetStuckProcessingRows(inDb, outDb, session, 'container not running');
     }
 
-    // 5. Recurrence fanout for completed recurring tasks.
+    // 5. Silent-task detection. Catches the v2 lie-by-omission failure
+    // mode where a scheduled task was marked completed but produced zero
+    // outputs. The runner-side fix in poll-loop.ts already handles the
+    // common cases (markFailed + write a chat); this scan is the
+    // belt-and-braces that catches anything that bypassed it (e.g. an
+    // SDK event shape we don't yet recognise).
+    if (outDb) {
+      await detectAndNotifySilentTasks(inDb, outDb, session);
+    }
+
+    // 6. Recurrence fanout for completed recurring tasks.
     // MODULE-HOOK:scheduling-recurrence:start
     const { handleRecurrence } = await import('./modules/scheduling/recurrence.js');
     await handleRecurrence(inDb, session);
@@ -285,4 +308,112 @@ function resetStuckProcessingRows(
       });
     }
   }
+}
+
+/**
+ * Scan for `kind='task'` rows that went to status='completed' or 'failed'
+ * inside the look-back window AND produced zero messages_out within that
+ * same window. DM the session's originating channel so an operator can
+ * see the failure. Per-process dedup via `notifiedSilentTasks` so we
+ * don't re-DM on every sweep tick.
+ */
+async function detectAndNotifySilentTasks(
+  inDb: Database.Database,
+  outDb: Database.Database,
+  session: Session,
+): Promise<void> {
+  const cutoff = new Date(Date.now() - SILENT_TASK_WINDOW_MIN * 60_000).toISOString();
+
+  type Row = { id: string; status: string; timestamp: string };
+  const recentTasks = inDb
+    .prepare(
+      `SELECT id, status, timestamp
+         FROM messages_in
+        WHERE kind = 'task'
+          AND status IN ('completed','failed')
+          AND timestamp >= ?`,
+    )
+    .all(cutoff) as Row[];
+
+  if (recentTasks.length === 0) return;
+
+  const countOut = outDb.prepare(
+    `SELECT COUNT(*) AS n
+       FROM messages_out
+      WHERE timestamp >= ?
+        AND timestamp <= datetime(?, '+15 minutes')
+        AND kind != 'system'`,
+  );
+
+  for (const row of recentTasks) {
+    if (notifiedSilentTasks.has(row.id)) continue;
+    const result = countOut.get(row.timestamp, row.timestamp) as { n: number };
+    if (result.n > 0) continue;
+
+    // Silent task confirmed. DM the channel.
+    notifiedSilentTasks.add(row.id);
+    log.warn('Silent task detected — completed/failed with zero output', {
+      sessionId: session.id,
+      messageId: row.id,
+      status: row.status,
+      taskTimestamp: row.timestamp,
+    });
+    await dmChannelForSilentTask(session, row.id, row.status, row.timestamp);
+  }
+
+  // Bound the dedup set: drop ids whose timestamp is older than the window.
+  // Keeps the set from growing unboundedly across host uptime.
+  if (notifiedSilentTasks.size > 1000) {
+    const stillRelevant = new Set<string>(recentTasks.map((r) => r.id));
+    for (const id of notifiedSilentTasks) {
+      if (!stillRelevant.has(id)) notifiedSilentTasks.delete(id);
+    }
+  }
+}
+
+async function dmChannelForSilentTask(
+  session: Session,
+  messageId: string,
+  ackStatus: string,
+  taskTimestamp: string,
+): Promise<void> {
+  const adapter = getDeliveryAdapter();
+  if (!adapter) {
+    log.warn('No delivery adapter — cannot DM silent-task notification', { messageId });
+    return;
+  }
+
+  if (!session.messaging_group_id) {
+    log.warn('Session has no messaging group — cannot DM silent-task notification', {
+      messageId,
+      sessionId: session.id,
+    });
+    return;
+  }
+  const mg = getMessagingGroup(session.messaging_group_id);
+  if (!mg) {
+    log.warn('Session messaging group not found — cannot DM silent-task notification', {
+      messageId,
+      messagingGroupId: session.messaging_group_id,
+    });
+    return;
+  }
+
+  const text =
+    `⚠️ Scheduled task did not produce any output and was marked ${ackStatus}.\n` +
+    `Task: ${messageId}\nFired: ${taskTimestamp}`;
+
+  try {
+    await adapter.deliver(mg.channel_type, mg.platform_id, null, 'chat', JSON.stringify({ text }));
+  } catch (err) {
+    log.error('Failed to deliver silent-task notification', {
+      messageId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Test-only: reset the in-memory dedup set. */
+export function _resetSilentTaskNotifyDedup(): void {
+  notifiedSilentTasks.clear();
 }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Stops the agent-runner from acking scheduled tasks as `completed` when the SDK call actually failed silently — and adds a host-side scan that catches anything that bypasses the runner-side fix.

**Why.** When the Claude SDK terminates with an error subtype (`error_max_turns`, `error_during_execution`, …) or the stream closes without a terminal `result` event, the v2 poll-loop unconditionally called `markCompleted` and produced no user-visible signal. Combined with the host's `syncProcessingAcks` collapsing both `completed` and `failed` `processing_ack` rows into `messages_in.status='completed'`, scheduled tasks could fail every day and look healthy — operators had no way to tell. Reproduced in real data: three consecutive morning-briefing runs marked complete with zero `messages_out`.

**How it works.**

1. **`container/agent-runner/src/providers/types.ts`** — `result` `ProviderEvent` carries the SDK's `subtype`. Three buckets: `undefined` = synthetic mid-turn (e.g. `compact_boundary`, dispatch text, do not ack); `error_*` = terminal failure; otherwise = terminal success.
2. **`container/agent-runner/src/providers/claude.ts`** — yield site reads `(message as { subtype?: string }).subtype` and passes it through.
3. **`container/agent-runner/src/poll-loop.ts`** — `processQuery` tracks `sawTerminalResult` and `lastErrorMessage`. Error subtype → `markFailed(initialBatchIds)` and write a `⚠️ Task did not complete: <subtype>` chat to the originating channel. After the stream ends without a terminal result → same. The outer catch path now calls `markFailed` instead of always `markCompleted`. `markFailed` becomes array-aware to mirror `markCompleted`. `MockProvider` updated to yield `subtype: 'success'`. New `stopSignal: AbortSignal` on `PollLoopConfig` so tests can halt the loop deterministically (production callers omit it).
4. **`src/db/session-db.ts`** — `syncProcessingAcks` propagates `failed` as `failed` instead of collapsing to `completed`, with a guard so an already-completed row isn't downgraded by a stale ack.
5. **`src/host-sweep.ts`** — new `detectAndNotifySilentTasks` step. Scans `kind='task'` rows acked completed/failed in the last 15 min with **zero** `messages_out` in the same window, DMs the session's originating messaging group via `getDeliveryAdapter().deliver(...)`, dedups per-process. Caps the dedup `Set` at 1000 entries.

**How it was tested.**

- 5 new container tests in `container/agent-runner/src/poll-loop-failure.test.ts` covering: error subtype path, stream-closed-without-terminal path, in-stream error captured in DM, empty success result legitimately ack'd, synthetic mid-turn followed by terminal success.
- 3 new host tests in `src/db/session-db.test.ts` covering `syncProcessingAcks` propagating `failed` as `failed`, propagating `completed` as `completed`, and refusing to downgrade an already-completed row.
- Verified on a real install — the day before this fix, three consecutive morning-briefing tasks (`task-1777349525294-capq6s`, `task-1777435932858-rqa22y`, `task-1777522278899-8mqkfc`) each acked `completed` with 0 `messages_out`. With this patch deployed, future failures will `markFailed` and DM `⚠️ Task did not complete: …` to the channel; the host-side scan will catch any path the runner-side missed.