### PR TITLE
fix(container): pin host.docker.internal to OneCLI's bridge IP in rootless Docker

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -20,7 +20,13 @@ import {
   TIMEZONE,
 } from './config.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  getOnecliBridgeIp,
+  hostGatewayArgs,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -460,8 +466,15 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
-  // Host gateway
-  args.push(...hostGatewayArgs());
+  // Host gateway. Pin host.docker.internal to OneCLI's bridge IP when we can
+  // resolve it — bypasses rootless Docker's flaky bridge-gateway → loopback
+  // forward (the silent ConnectionRefused trigger). Falls back to host-gateway
+  // when OneCLI isn't on the bridge.
+  const onecliBridgeIp = getOnecliBridgeIp();
+  if (onecliBridgeIp) {
+    log.info('Pinning host.docker.internal to OneCLI bridge IP', { containerName, onecliBridgeIp });
+  }
+  args.push(...hostGatewayArgs({ onecliBridgeIp }));
 
   // User mapping
   const hostUid = process.getuid?.();

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -17,18 +17,32 @@ vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
+// Mock os.platform so we can exercise both Linux and non-Linux branches.
+const mockPlatform: () => NodeJS.Platform = vi.fn(() => 'linux' as NodeJS.Platform);
+vi.mock('os', () => ({
+  default: {
+    get platform() {
+      return mockPlatform;
+    },
+  },
+  platform: () => mockPlatform(),
+}));
+
 import {
   CONTAINER_RUNTIME_BIN,
   readonlyMountArgs,
   stopContainer,
   ensureContainerRuntimeRunning,
   cleanupOrphans,
+  hostGatewayArgs,
+  getOnecliBridgeIp,
 } from './container-runtime.js';
 import { CONTAINER_INSTALL_LABEL } from './config.js';
 import { log } from './log.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(mockPlatform).mockReturnValue('linux');
 });
 
 // --- Pure functions ---
@@ -156,5 +170,51 @@ describe('cleanupOrphans', () => {
       count: 2,
       names: ['nanoclaw-a-1', 'nanoclaw-b-2'],
     });
+  });
+});
+
+describe('hostGatewayArgs', () => {
+  it('returns empty on non-Linux platforms (host.docker.internal is built-in)', () => {
+    vi.mocked(mockPlatform).mockReturnValue('darwin');
+    expect(hostGatewayArgs()).toEqual([]);
+    expect(hostGatewayArgs({ onecliBridgeIp: '172.17.0.2' })).toEqual([]);
+  });
+
+  it('falls back to host-gateway on Linux when no OneCLI IP is provided', () => {
+    expect(hostGatewayArgs()).toEqual(['--add-host=host.docker.internal:host-gateway']);
+    expect(hostGatewayArgs({ onecliBridgeIp: null })).toEqual(['--add-host=host.docker.internal:host-gateway']);
+  });
+
+  it('pins host.docker.internal to the OneCLI bridge IP when provided', () => {
+    expect(hostGatewayArgs({ onecliBridgeIp: '172.17.0.2' })).toEqual(['--add-host=host.docker.internal:172.17.0.2']);
+  });
+});
+
+describe('getOnecliBridgeIp', () => {
+  it('returns the IPv4 address when docker inspect prints one', () => {
+    mockExecSync.mockReturnValueOnce('172.17.0.2\n');
+    expect(getOnecliBridgeIp()).toBe('172.17.0.2');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('inspect onecli'),
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' }),
+    );
+  });
+
+  it('returns null when OneCLI is not on the bridge network (empty inspect output)', () => {
+    mockExecSync.mockReturnValueOnce('\n');
+    expect(getOnecliBridgeIp()).toBeNull();
+  });
+
+  it('returns null when docker inspect emits the literal "<no value>"', () => {
+    // Go template prints "<no value>" when the indexed key is missing.
+    mockExecSync.mockReturnValueOnce('<no value>\n');
+    expect(getOnecliBridgeIp()).toBeNull();
+  });
+
+  it('returns null when docker inspect throws (OneCLI not running)', () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error('No such container: onecli');
+    });
+    expect(getOnecliBridgeIp()).toBeNull();
   });
 });

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -11,13 +11,53 @@ import { log } from './log.js';
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';
 
-/** CLI args needed for the container to resolve the host gateway. */
-export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
-  if (os.platform() === 'linux') {
-    return ['--add-host=host.docker.internal:host-gateway'];
+/**
+ * CLI args mapping `host.docker.internal` for the agent container.
+ *
+ * The default `host-gateway` resolves to the bridge gateway on Linux
+ * (172.17.0.1) and relies on the host's port-forward path back into the
+ * loopback namespace. In rootless Docker setups that path is brittle —
+ * OneCLI binds 127.0.0.1:10255 inside rootlesskit and the bridge gateway
+ * routinely loses its forward across host restarts, leaving the agent
+ * container unable to reach the proxy and the SDK call dies with
+ * ConnectionRefused (the silent-task-failure trigger we shipped runner-
+ * side detection for).
+ *
+ * When OneCLI's own bridge IP is known, pin host.docker.internal to it
+ * directly — the agent container reaches OneCLI as a direct container-
+ * to-container hop on the shared bridge, no rootlesskit involved.
+ *
+ * Falls back to `host-gateway` when OneCLI isn't on the bridge or the
+ * lookup fails (rootful Docker, OneCLI not installed, etc.) so the
+ * default behaviour is unchanged.
+ */
+export function hostGatewayArgs(opts: { onecliBridgeIp?: string | null } = {}): string[] {
+  if (os.platform() !== 'linux') return [];
+  const target = opts.onecliBridgeIp ?? 'host-gateway';
+  return [`--add-host=host.docker.internal:${target}`];
+}
+
+/**
+ * Resolve OneCLI's IP on the default `bridge` Docker network.
+ *
+ * Returns null when:
+ *   - OneCLI isn't running,
+ *   - it's not attached to the bridge network (e.g. only on a
+ *     compose-private network), or
+ *   - `docker inspect` fails for any reason.
+ *
+ * Cheap (<10 ms) and called once per container spawn.
+ */
+export function getOnecliBridgeIp(): string | null {
+  try {
+    const out = execSync(
+      `${CONTAINER_RUNTIME_BIN} inspect onecli --format '{{ index .NetworkSettings.Networks "bridge" "IPAddress" }}'`,
+      { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+    return /^\d+\.\d+\.\d+\.\d+$/.test(out) ? out : null;
+  } catch {
+    return null;
   }
-  return [];
 }
 
 /** Returns CLI args for a readonly bind mount. */


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** When OneCLI is on the default `bridge` Docker network, pin the agent container's `host.docker.internal` mapping to OneCLI's bridge IP at spawn time instead of relying on `host-gateway`. Falls back to `host-gateway` when OneCLI isn't on the bridge, so the default behaviour for rootful Docker / non-OneCLI installs is unchanged.

**Why.** In rootless Docker, OneCLI's gateway port (`10255`) is bound to `127.0.0.1` inside rootlesskit. The agent container reaches it via `HTTPS_PROXY=http://...@host.docker.internal:10255`, which on Linux resolves to the bridge gateway (`host-gateway`). Whether the gateway forwards back into rootlesskit's loopback is brittle — it silently breaks across host restarts, leaving the next agent container unable to reach the proxy. The SDK call dies with `ConnectionRefused` and (pre-#2167) the runner used to ack the message as `completed`, producing a silent task day. The systemd-unit hint `ExecStartPre=-/usr/bin/docker network connect bridge onecli` is a no-op when OneCLI is already on the bridge — it doesn't fix the actual routing flake.

OneCLI is on `bridge` alongside every spawned agent container, and container-to-container traffic on a shared bridge always works. Pinning `host.docker.internal` to OneCLI's bridge IP turns the proxy lookup into a direct bridge hop with no rootlesskit involvement — same hostname, different IP, no other agent code changes.

**How it works.**

- `src/container-runtime.ts` — adds `getOnecliBridgeIp()` (a 5 s cap'd `docker inspect onecli --format '{{ index .NetworkSettings.Networks "bridge" "IPAddress" }}'`, returns `null` on any failure / non-IPv4 output / Go template's `<no value>` literal). `hostGatewayArgs(opts?)` accepts an `onecliBridgeIp` and returns `--add-host=host.docker.internal:<ip>` when it's a valid IP, otherwise the existing `host-gateway` value.
- `src/container-runner.ts` — calls `getOnecliBridgeIp()` once per spawn, passes the result into `hostGatewayArgs`, logs a single line when it pins.

**How it was tested.**

- 7 new unit tests in `src/container-runtime.test.ts` covering: non-Linux returns empty (host.docker.internal is built-in on macOS/Windows); Linux + no IP falls back to `host-gateway`; Linux + IP pins to that IP; `getOnecliBridgeIp` happy path; OneCLI not on bridge (empty output); Go template `<no value>` literal; `docker inspect` throws.
- Verified on a real install: before the patch, a fresh agent container's curl to `host.docker.internal:10255` was \`Failed to connect (Couldn't connect to server)\` while curl to OneCLI's bridge IP \`172.17.0.2:10255\` succeeded — confirming the rootless-loopback gap. After deploying, the new log line \`Pinning host.docker.internal to OneCLI bridge IP onecliBridgeIp="172.17.0.2"\` fires at every spawn, the agent container's `host.docker.internal` resolves to `172.17.0.2`, and an end-to-end SDK call through the proxy succeeds.