### PR TITLE
fix(test-infra): openInboundDb honors in-memory test DB

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -27,34 +27,29 @@ const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
 let _inbound: Database | null = null;
 let _outbound: Database | null = null;
 let _heartbeatPath: string = DEFAULT_HEARTBEAT_PATH;
-// True when initTestSessionDb() set _inbound to an in-memory DB. Used by
-// openInboundDb() so tests don't try to open the missing /workspace path.
-let _inboundIsTest = false;
-// Saved real close() for the in-memory inbound singleton. We no-op the
-// public .close() during tests so caller try/finally doesn't tear down
-// the shared DB; closeSessionDb() invokes this to do the real teardown.
-let _inboundOriginalClose: (() => void) | null = null;
+let _testMode = false;
 
 /**
- * Avoid all cached db reads; open inbound.db read-only with mmap and page cache disabled. 
- * 
+ * Avoid all cached db reads; open inbound.db read-only with mmap and page cache disabled.
+ *
  * Use this (not getInboundDb) for readers that need to see host-written rows
  * promptly — e.g. messages_in polling. Caller must .close() the returned
  * connection (try/finally).
  *
  * Needed for mounts where host writes don't reliably invalidate
  * SQLite's caches: virtiofs (Colima, Lima, Podman Machine, Apple
- * Container), NFS. 
- * 
+ * Container), NFS.
+ *
  * Cost is microseconds per query, so safe for universal use.
  */
 export function openInboundDb(): Database {
-  // In test mode the inbound DB is an in-memory singleton — there is no
-  // file at DEFAULT_INBOUND_PATH. Return the singleton directly; its
-  // .close() was no-op'd in initTestSessionDb so caller try/finally
-  // cleanup doesn't tear down the shared DB.
-  if (_inboundIsTest && _inbound) return _inbound;
-
+  // In test mode return a thin wrapper over the in-memory singleton.
+  // Callers do try/finally { db.close() } — the wrapper no-ops close()
+  // so the singleton survives for the rest of the test.
+  if (_testMode && _inbound) {
+    const db = _inbound;
+    return { prepare: (sql: string) => db.prepare(sql), exec: (sql: string) => db.exec(sql), close: () => {} } as unknown as Database;
+  }
   const db = new Database(DEFAULT_INBOUND_PATH, { readonly: true });
   db.exec('PRAGMA busy_timeout = 5000');
   db.exec('PRAGMA mmap_size = 0');
@@ -183,13 +178,8 @@ export function clearStaleProcessingAcks(): void {
 
 /** For tests — creates in-memory DBs with the session schemas. */
 export function initTestSessionDb(): { inbound: Database; outbound: Database } {
+  _testMode = true;
   _inbound = new Database(':memory:');
-  _inboundIsTest = true;
-  // No-op .close() so callers using openInboundDb()'s try/finally pattern
-  // don't tear down our shared singleton. closeSessionDb() does the real
-  // teardown via the saved original.
-  _inboundOriginalClose = _inbound.close.bind(_inbound);
-  _inbound.close = () => {};
   _inbound.exec('PRAGMA foreign_keys = ON');
   _inbound.exec(`
     CREATE TABLE messages_in (
@@ -263,14 +253,9 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
 }
 
 export function closeSessionDb(): void {
-  if (_inboundOriginalClose) {
-    _inboundOriginalClose();
-    _inboundOriginalClose = null;
-  } else {
-    _inbound?.close();
-  }
+  _inbound?.close();
   _inbound = null;
-  _inboundIsTest = false;
+  _testMode = false;
   _outbound?.close();
   _outbound = null;
 }

--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -27,6 +27,13 @@ const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
 let _inbound: Database | null = null;
 let _outbound: Database | null = null;
 let _heartbeatPath: string = DEFAULT_HEARTBEAT_PATH;
+// True when initTestSessionDb() set _inbound to an in-memory DB. Used by
+// openInboundDb() so tests don't try to open the missing /workspace path.
+let _inboundIsTest = false;
+// Saved real close() for the in-memory inbound singleton. We no-op the
+// public .close() during tests so caller try/finally doesn't tear down
+// the shared DB; closeSessionDb() invokes this to do the real teardown.
+let _inboundOriginalClose: (() => void) | null = null;
 
 /**
  * Avoid all cached db reads; open inbound.db read-only with mmap and page cache disabled. 
@@ -42,6 +49,12 @@ let _heartbeatPath: string = DEFAULT_HEARTBEAT_PATH;
  * Cost is microseconds per query, so safe for universal use.
  */
 export function openInboundDb(): Database {
+  // In test mode the inbound DB is an in-memory singleton — there is no
+  // file at DEFAULT_INBOUND_PATH. Return the singleton directly; its
+  // .close() was no-op'd in initTestSessionDb so caller try/finally
+  // cleanup doesn't tear down the shared DB.
+  if (_inboundIsTest && _inbound) return _inbound;
+
   const db = new Database(DEFAULT_INBOUND_PATH, { readonly: true });
   db.exec('PRAGMA busy_timeout = 5000');
   db.exec('PRAGMA mmap_size = 0');
@@ -171,6 +184,12 @@ export function clearStaleProcessingAcks(): void {
 /** For tests — creates in-memory DBs with the session schemas. */
 export function initTestSessionDb(): { inbound: Database; outbound: Database } {
   _inbound = new Database(':memory:');
+  _inboundIsTest = true;
+  // No-op .close() so callers using openInboundDb()'s try/finally pattern
+  // don't tear down our shared singleton. closeSessionDb() does the real
+  // teardown via the saved original.
+  _inboundOriginalClose = _inbound.close.bind(_inbound);
+  _inbound.close = () => {};
   _inbound.exec('PRAGMA foreign_keys = ON');
   _inbound.exec(`
     CREATE TABLE messages_in (
@@ -244,8 +263,14 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
 }
 
 export function closeSessionDb(): void {
-  _inbound?.close();
+  if (_inboundOriginalClose) {
+    _inboundOriginalClose();
+    _inboundOriginalClose = null;
+  } else {
+    _inbound?.close();
+  }
   _inbound = null;
+  _inboundIsTest = false;
   _outbound?.close();
   _outbound = null;
 }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

### What
Make `openInboundDb()` honor the in-memory DB created by `initTestSessionDb()` so the agent-runner test suite actually runs under \`bun test\`.

### Why
\`initTestSessionDb()\` (\`src/db/connection.ts:172\`) creates an in-memory inbound singleton, but \`openInboundDb()\` always opened the hardcoded \`/workspace/inbound.db\` path — which doesn't exist outside a real container. Every test that exercised \`getPendingMessages()\` — directly, or via test fixtures that load data through it (e.g. \`poll-loop.test.ts:29\` loads formatter test rows via \`getPendingMessages\`) — failed with \`SQLITE_CANTOPEN\`.

Baseline on \`main\`:

\`\`\`
$ cd container/agent-runner && bun test
 34 pass
 25 fail
\`\`\`

After this fix:

\`\`\`
 59 pass
 0 fail
\`\`\`

### How it works
In test mode, \`openInboundDb()\` returns the in-memory singleton instead of opening a fresh file connection. To preserve the existing \`open / try { … } finally { db.close() }\` pattern in \`messages-in.ts\` without tearing down the shared singleton on every call, \`initTestSessionDb()\` overrides the singleton's \`.close()\` to a no-op and saves the real close for \`closeSessionDb()\` to invoke during teardown.

Production behavior is unchanged: \`_inboundIsTest\` only flips inside \`initTestSessionDb()\`, which is never called outside the test runner. The mmap-disabled per-call connection semantics (load-bearing for cross-mount visibility — see the comment block on \`openInboundDb\`) are preserved for non-test code.

### How it was tested
\`bun test\` from \`container/agent-runner/\`: 59 pass, 0 fail. \`bun run typecheck\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)