### PR TITLE
fix(host-sweep): reopen outbound DB as writable for orphan claim cleanup

### DIFF
--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -32,6 +32,14 @@ export function openOutboundDb(dbPath: string): Database.Database {
   return db;
 }
 
+/** Open the outbound DB for a session with write access. Only safe to call when no container is running. */
+export function openOutboundDbRw(dbPath: string): Database.Database {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = DELETE');
+  db.pragma('busy_timeout = 5000');
+  return db;
+}
+
 export function upsertSessionRouting(
   db: Database.Database,
   routing: { channel_type: string | null; platform_id: string | null; thread_id: string | null },

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -43,7 +43,7 @@ import {
   type ContainerState,
 } from './db/session-db.js';
 import { log } from './log.js';
-import { openInboundDb, openOutboundDb, inboundDbPath, heartbeatPath } from './session-manager.js';
+import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbeatPath } from './session-manager.js';
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
@@ -302,8 +302,17 @@ function resetStuckProcessingRows(
   // agent-runner has a chance to run clearStaleProcessingAcks() on startup.
   // We're safe to write outbound.db here because we just killed the container
   // that owned it (or it crashed and left no writer behind).
-  const cleared = deleteOrphanProcessingClaims(outDb);
-  if (cleared > 0) {
-    log.info('Cleared orphan processing claims', { sessionId: session.id, cleared, reason });
+  // outDb was opened readonly for reads above; reopen with write access for this delete.
+  let outDbRw: Database.Database | null = null;
+  try {
+    outDbRw = openOutboundDbRw(session.agent_group_id, session.id);
+    const cleared = deleteOrphanProcessingClaims(outDbRw);
+    if (cleared > 0) {
+      log.info('Cleared orphan processing claims', { sessionId: session.id, cleared, reason });
+    }
+  } catch (err) {
+    log.warn('Failed to clear orphan processing claims', { sessionId: session.id, err });
+  } finally {
+    outDbRw?.close();
   }
 }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -30,6 +30,7 @@ import {
   ensureSchema,
   openInboundDb as openInboundDbRaw,
   openOutboundDb as openOutboundDbRaw,
+  openOutboundDbRw as openOutboundDbRwRaw,
   upsertSessionRouting,
   insertMessage,
   migrateMessagesInTable,
@@ -353,6 +354,11 @@ export function openInboundDb(agentGroupId: string, sessionId: string): Database
 /** Open the outbound DB for a session (host reads only). */
 export function openOutboundDb(agentGroupId: string, sessionId: string): Database.Database {
   return openOutboundDbRaw(outboundDbPath(agentGroupId, sessionId));
+}
+
+/** Open the outbound DB for a session with write access. Only safe to call when no container is running. */
+export function openOutboundDbRw(agentGroupId: string, sessionId: string): Database.Database {
+  return openOutboundDbRwRaw(outboundDbPath(agentGroupId, sessionId));
 }
 
 /**


### PR DESCRIPTION
## Problem

PR #2151 added `deleteOrphanProcessingClaims()` to `resetStuckProcessingRows()` in `host-sweep.ts`, but `outDb` is always opened readonly (`immutable: true` via `openOutboundDb`). The write silently fails, leaving orphan `processing_ack` rows that block future message delivery for the session.

## Fix

Add `openOutboundDbRw()` alongside the existing readonly opener in `session-db.ts` and re-export it from `session-manager.ts`. In `resetStuckProcessingRows()`, open a short-lived writable handle just for the delete, then close it immediately. The readonly handle is still used for all reads above.

This is safe because `resetStuckProcessingRows()` is only called after the container has been killed or confirmed not running, so there is no concurrent writer.

## Changes

- `src/db/session-db.ts` — add `openOutboundDbRw(dbPath)`
- `src/session-manager.ts` — re-export as `openOutboundDbRw(agentGroupId, sessionId)`
- `src/host-sweep.ts` — use writable handle for the delete in `resetStuckProcessingRows()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)