### PR TITLE
fix(platform-id): don't namespace CLI bare platform ids

### DIFF
--- a/src/platform-id.test.ts
+++ b/src/platform-id.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { namespacedPlatformId } from './platform-id.js';
+
+describe('namespacedPlatformId', () => {
+  it('adds the channel prefix for Chat SDK adapters with a bare id', () => {
+    expect(namespacedPlatformId('telegram', '123456')).toBe('telegram:123456');
+    expect(namespacedPlatformId('discord', 'guild:chan')).toBe('discord:guild:chan');
+  });
+
+  it('leaves an already-prefixed id alone', () => {
+    expect(namespacedPlatformId('telegram', 'telegram:123456')).toBe('telegram:123456');
+    expect(namespacedPlatformId('slack', 'slack:T01:C02')).toBe('slack:T01:C02');
+  });
+
+  it('does not prefix native ID shapes (Signal, WhatsApp, iMessage)', () => {
+    expect(namespacedPlatformId('whatsapp', '15551234567@s.whatsapp.net')).toBe('15551234567@s.whatsapp.net');
+    expect(namespacedPlatformId('imessage', 'user@example.com')).toBe('user@example.com');
+    expect(namespacedPlatformId('signal', '+15551234567')).toBe('+15551234567');
+    expect(namespacedPlatformId('signal', 'group:abc123')).toBe('group:abc123');
+  });
+
+  it('does not prefix CLI ids — the adapter emits the bare value', () => {
+    expect(namespacedPlatformId('cli', 'local')).toBe('local');
+  });
+});

--- a/src/platform-id.ts
+++ b/src/platform-id.ts
@@ -15,8 +15,12 @@
  * for DMs and 'group:<id>' for group chats. DeltaChat emits numeric chat IDs
  * ('12'). Prefixing any of these would cause a mismatch with what the adapter
  * later emits.
+ *
+ * The CLI adapter emits a bare 'local' platform_id. It has no recognizable
+ * shape, so it gets a channel-name carve-out.
  */
 export function namespacedPlatformId(channel: string, raw: string): string {
+  if (channel === 'cli') return raw;
   if (raw.startsWith(`${channel}:`)) return raw;
   if (raw.includes('@')) return raw;
   if (raw.startsWith('+') || raw.startsWith('group:')) return raw;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix to source code

## Description

Closes #2186.

**What.** Add a `channel === 'cli'` carve-out to `namespacedPlatformId`, alongside the existing shape-based carve-outs for Signal/WhatsApp/iMessage.

**Why.** The CLI channel adapter emits a bare `platform_id` of `'local'`. `namespacedPlatformId` produced `'cli:local'` for it, so any setup path that wrote a `messaging_groups` row through `register` / `init-first-agent` stored the wrong shape — the router's `(channel_type, platform_id)` lookup never matched inbound CLI events and chat messages were silently dropped.

**How it works.** A single `if (channel === 'cli') return raw;` short-circuit at the top of the function. CLI's bare `'local'` has no recognizable shape, so the channel name is the disambiguator.

**How it was tested.** Added `src/platform-id.test.ts` covering each adapter category (Chat-SDK prefixed/unprefixed, native shapes, CLI). Manually re-ran `pnpm run chat hi` against a freshly registered CLI wiring and got a reply.