### PR TITLE
fix(update-nanoclaw): guard merge state to prevent silent single-parent commits

### DIFF
--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -132,8 +132,14 @@ If Full update or Rebase:
 - If no conflicts: tell user it is clean and proceed.
 
 # Step 4A: Full update (MERGE, default)
+
+Capture the upstream SHA being merged (used by the safety guards below):
+- `UPSTREAM_SHA=$(git rev-parse upstream/$UPSTREAM_BRANCH)`
+
 Run:
 - `git merge upstream/$UPSTREAM_BRANCH --no-edit`
+
+**Critical — do NOT run `git stash`, `git reset`, or `git checkout` while in merge state** (i.e. while `.git/MERGE_HEAD` exists). All three discard `MERGE_HEAD` silently, after which the next `git commit` produces a single-parent commit instead of a merge. The upstream commits then remain orphaned from your ancestry: GitHub's compare API and any `git rev-list origin..upstream` check will keep reporting the fork as "behind upstream" even though the file content was integrated.
 
 If conflicts occur:
 - Run `git status` and identify conflicted files.
@@ -145,7 +151,26 @@ If conflicts occur:
   - Do not refactor surrounding code.
   - `git add <file>`
 - When all resolved:
+  - **Pre-commit guard** — verify `.git/MERGE_HEAD` still exists. If something cleared it during conflict resolution, restore it from the SHA captured above so the next commit becomes a proper merge:
+    ```bash
+    if [ ! -f .git/MERGE_HEAD ]; then
+      echo "$UPSTREAM_SHA" > .git/MERGE_HEAD
+    fi
+    ```
   - If merge did not auto-commit: `git commit --no-edit`
+
+**Post-commit verification** — confirm the resulting commit has 2 parents:
+```bash
+PARENT_COUNT=$(git rev-list --parents -1 HEAD | awk '{print NF-1}')
+if [ "$PARENT_COUNT" != "2" ]; then
+  echo "ERROR: merge produced a $PARENT_COUNT-parent commit (expected 2)."
+  echo "Upstream commits are NOT in your ancestry — the fork will keep reporting 'behind upstream'."
+  echo "Recover with: git reset --hard <backup-tag-from-step-1> and re-run /update-nanoclaw."
+  echo "Avoid 'git stash', 'git reset', 'git checkout' during conflict resolution."
+  exit 1
+fi
+```
+If this fails, abort the skill — do not proceed to Step 5. The user must reset to the backup tag and retry.
 
 # Step 4B: Selective update (CHERRY-PICK)
 If user chose Selective:


### PR DESCRIPTION
## Problem

When `/update-nanoclaw` is run on a customized fork, the result of Step 4A (`git merge upstream/$UPSTREAM_BRANCH --no-edit`) can silently turn into a **single-parent commit** instead of a real merge. The user ends up with a HEAD whose subject reads `"Merge upstream/main into nanoclaw fork"` but `git rev-list --parents -1 HEAD` shows only one parent. The upstream commits remain orphaned from the fork's ancestry, even though their file content was integrated. From that point on, GitHub's compare API and any `git rev-list origin..upstream` check report the fork as "behind by N" forever.

## Reproduction in the wild

I hit this on a customized fork. Forensic evidence from `git reflog`:

```
b407a10 HEAD@{2026-05-01 14:07:36}: commit: Merge upstream/main into nanoclaw fork
6ef203c HEAD@{2026-05-01 14:05:01}: reset: moving to HEAD     ← MERGE_HEAD cleared
6ef203c HEAD@{2026-05-01 13:45:08}: reset: moving to HEAD
6ef203c HEAD@{2026-05-01 13:42:55}: commit: chore(message-archive): drop trailing blank line
```

`git fsck --lost-found` surfaces a dangling 2-parent commit at exactly 14:05:01 with the `WIP on main:` prefix — the signature of `git stash`. `git stash push` calls `git reset --hard HEAD` internally, which clears `.git/MERGE_HEAD`. After that, `git commit` produces a regular single-parent commit even when the working tree contains the merged content.

A daily upstream-drift check that uses `gh api compare ${FORK_SHA}...${UPSTREAM_SHA}` then keeps reporting "148 commits behind" indefinitely — because compare-by-ancestry sees those 148 SHAs as missing from the fork, even though their content is merged in.

## Root cause

The skill's Step 4A is technically correct (`git merge upstream/$UPSTREAM_BRANCH --no-edit` does the right thing), but it has no guard rails. During multi-conflict resolution sessions, an agent or operator may run `git stash`, `git reset`, or `git checkout` to "save progress" or "unstage something" — all three discard `MERGE_HEAD` silently. The next `git commit` then produces a single-parent commit, and the skill's flow continues to Step 5 (validation), Step 6 (audit), Step 7 (breaking changes), and the final restart, all on top of a broken merge.

## Fix

Three changes to Step 4A in `.claude/skills/update-nanoclaw/SKILL.md`:

1. **Capture the upstream SHA at the top of the step**, so it's available for recovery:
   \`UPSTREAM_SHA=\$(git rev-parse upstream/\$UPSTREAM_BRANCH)\`

2. **Explicit warning** that \`git stash\`, \`git reset\`, and \`git checkout\` are forbidden while \`.git/MERGE_HEAD\` exists, with a one-line explanation of why.

3. **Pre-commit guard**: right before \`git commit\`, check whether \`.git/MERGE_HEAD\` still exists. If something cleared it during conflict resolution, restore it from \`\$UPSTREAM_SHA\`. The resolved files are still in the index, so the next commit becomes a proper 2-parent merge. This is mechanical and safe.

4. **Post-commit verification**: assert HEAD has 2 parents. If not, abort the skill with a recovery recipe (reset to backup tag, retry). Don't continue to Step 5 — accumulating build/test side-effects on top of a broken merge makes recovery messier.

The asymmetry between guards 3 and 4 is intentional: pre-commit auto-recovers because the state is well-defined and confined; post-commit aborts because downstream side-effects may have accumulated and silently amending HEAD is riskier than asking the user to reset and retry.

## Test plan

- [ ] Manual repro: simulate the failure mode by running \`git stash && git stash pop\` mid-merge, then \`git commit\`. Verify the post-commit verification trips.
- [ ] Manual repro of the auto-recovery: delete \`.git/MERGE_HEAD\` mid-merge with files staged, run the pre-commit guard snippet, verify the resulting commit has 2 parents.
- [ ] No-op path: a clean merge with no conflicts continues to produce a 2-parent merge commit (no behavior change).