### PR TITLE
fix(repo-tokens): show badge percentage

### DIFF
--- a/repo-tokens/action.yml
+++ b/repo-tokens/action.yml
@@ -128,7 +128,7 @@ runs:
         # Generate SVG badge
         if badge_path:
             label_text = "tokens"
-            value_text = display
+            value_text = f"{display} \u00b7 {pct}%"
             full_desc = f"{display} tokens, {pct}% of context window"
 
             cw = 7.0

--- a/repo-tokens/badge.svg
+++ b/repo-tokens/badge.svg
@@ -1,22 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20" role="img" aria-label="140k tokens, 70% of context window">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="132" height="20" role="img" aria-label="140k tokens, 70% of context window">
   <title>140k tokens, 70% of context window</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <clipPath id="r">
-    <rect width="90" height="20" rx="3" fill="#fff"/>
+    <rect width="132" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <a xlink:href="https://github.com/qwibitai/nanoclaw/tree/main/repo-tokens">
     <g clip-path="url(#r)">
       <rect width="52" height="20" fill="#555"/>
-      <rect x="52" width="38" height="20" fill="#e05d44"/>
-      <rect width="90" height="20" fill="url(#s)"/>
+      <rect x="52" width="80" height="20" fill="#e05d44"/>
+      <rect width="132" height="20" fill="url(#s)"/>
       <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
         <text aria-hidden="true" x="26" y="15" fill="#010101" fill-opacity=".3">tokens</text>
         <text x="26" y="14">tokens</text>
-        <text aria-hidden="true" x="71" y="15" fill="#010101" fill-opacity=".3">140k</text>
-        <text x="71" y="14">140k</text>
+        <text aria-hidden="true" x="92" y="15" fill="#010101" fill-opacity=".3">140k · 70%</text>
+        <text x="92" y="14">140k · 70%</text>
       </g>
     </g>
   </a>


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #1017.

What changed:
- Show the context-window percentage in the visible repo-tokens SVG badge value.
- Regenerate the checked-in badge with the updated display.

How it works:
- Reuse the existing `pct` value when building the SVG badge text.

How it was tested:
- Ran a focused repo-tokens badge generation check.
- Ran the repo-tokens action with the workflow inputs and confirmed `badge=140k tokens · 70% of context window`.
