### PR TITLE
feat(signal): inbound + outbound reaction support

### DIFF
--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -262,8 +262,9 @@ Otherwise, run `/init-first-agent` to create an agent and wire it to your Signal
 - Echo suppression — outbound messages matched on `(platformId, text)` within a 10 s TTL to avoid syncMessage loops
 - Note to Self — messages you send to your own account from another device route to the agent as inbound with `isFromMe: true`
 - Voice attachments — detected but not transcribed by default; the agent receives `[Voice Message]` placeholder text. Run `/add-voice-transcription` for local transcription via parakeet-mlx
+- Reactions (inbound + outbound) — agents can call `add_reaction({ messageId, emoji })` and the emoji is applied as a Signal reaction on the target message. Inbound reactions arrive as a `chat` message with structured `content.reaction` and a `[reacted ➕ 👍 to message]` text fallback the formatter renders without changes. Emoji input accepts either a shortcode (`thumbs_up`, `:heart:`, `white_check_mark`) or the literal unicode character (`👍`); unknown shortcodes log a warning and fall back to 👍.
 
-Not supported yet: outbound file attachments (logged and dropped), edit/delete messages, reactions.
+Not supported yet: outbound file attachments (logged and dropped), edit/delete messages.
 
 ## Troubleshooting
 

--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -202,7 +202,7 @@ describe('SignalAdapter', () => {
         '+15555550123',
         null,
         expect.objectContaining({
-          id: '1700000000000',
+          id: '1700000000000:+15555550123',
           kind: 'chat',
           content: expect.objectContaining({
             text: 'Hello from Signal',
@@ -1124,6 +1124,34 @@ describe('SignalAdapter', () => {
       await adapter.teardown();
     });
 
+    it('extracts targetAuthor from router-suffixed `<ts>:<author>:<ag-id>` ids', async () => {
+      // After the router's `messageIdForAgent` (src/router.ts:511) suffixes
+      // `:<agent-group-id>` to the inbound message id, the agent's
+      // add_reaction tool sees an id like `1700000111111:+15555550123:ag-xxx`.
+      // sendReaction must drop the trailing agent-group segment and send the
+      // real Signal author to signal-cli.
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000111111:+15555550123:ag-1776971233072-qyooix',
+          emoji: '👍',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      const params = calls[0].params as Record<string, unknown>;
+      expect(params.targetAuthor).toBe('+15555550123');
+      expect(params.targetTimestamp).toBe(1700000111111);
+
+      await adapter.teardown();
+    });
+
     it('does not invoke send for reaction-only payloads', async () => {
       const adapter = createAdapter();
       await adapter.setup(createMockSetup());
@@ -1209,9 +1237,10 @@ describe('SignalAdapter', () => {
       expect(platformId).toBe('+15555550123');
       expect(threadId).toBeNull();
       expect(msg.kind).toBe('chat');
-      // id is the reaction's own timestamp so it doesn't collide with the
-      // original message in messages_in
-      expect(msg.id).toBe('1700000999999');
+      // id is the reaction's own timestamp PLUS the sender — see the encoding
+      // explanation in handleEnvelope. The router will further suffix
+      // `:<agent-group-id>` for fan-out uniqueness.
+      expect(msg.id).toBe('1700000999999:+15555550123');
       const content = msg.content as Record<string, unknown>;
       expect(content.text).toBe('[reacted ➕ 👍 to message]');
       expect(content.sender).toBe('+15555550123');

--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -126,6 +126,7 @@ describe('SignalAdapter', () => {
     tcpRef.fakeSocket = null;
     tcpRef.rpcResponses.set('send', { timestamp: 1234567890 });
     tcpRef.rpcResponses.set('sendTyping', {});
+    tcpRef.rpcResponses.set('sendReaction', { timestamp: 1234567890 });
   });
 
   afterEach(() => {
@@ -956,6 +957,403 @@ describe('SignalAdapter', () => {
     it('does not support threads', () => {
       const adapter = createAdapter();
       expect(adapter.supportsThreads).toBe(false);
+    });
+  });
+
+  // --- Reactions ---
+
+  describe('outbound reactions', () => {
+    it('issues sendReaction with targetAuthor and targetTimestamp parsed from messageId', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: '👍',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      const params = calls[0].params as Record<string, unknown>;
+      expect(params.recipient).toEqual(['+15555550123']);
+      expect(params.account).toBe('+15551234567');
+      expect(params.targetAuthor).toBe('+15555550123');
+      expect(params.targetTimestamp).toBe(1700000000000);
+      expect(params.emoji).toBe('👍');
+      expect(params.remove).toBeUndefined();
+
+      await adapter.teardown();
+    });
+
+    it('uses groupId for group destinations', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('group:abc123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: '❤️',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      const params = calls[0].params as Record<string, unknown>;
+      expect(params.groupId).toBe('abc123');
+      expect(params.recipient).toBeUndefined();
+      expect(params.targetAuthor).toBe('+15555550123');
+
+      await adapter.teardown();
+    });
+
+    it('converts shortcode emoji names to unicode', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: 'thumbs_up',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      expect((calls[0].params as Record<string, unknown>).emoji).toBe('👍');
+
+      await adapter.teardown();
+    });
+
+    it('passes literal unicode emoji through unchanged', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: '🎉',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect((calls[0].params as Record<string, unknown>).emoji).toBe('🎉');
+
+      await adapter.teardown();
+    });
+
+    it('falls back to a default emoji when the shortcode is unknown', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: 'totally_made_up_shortcode',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      // Fallback character must be a real emoji, not the original shortcode
+      expect((calls[0].params as Record<string, unknown>).emoji).toBe('👍');
+
+      await adapter.teardown();
+    });
+
+    it('propagates remove=true to sendReaction', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: '👍',
+          remove: true,
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect((calls[0].params as Record<string, unknown>).remove).toBe(true);
+
+      await adapter.teardown();
+    });
+
+    it('targets self-account when messageId has no author suffix (own outbound)', async () => {
+      // Legacy / self-message: messageId is just the timestamp string. Target
+      // author defaults to the bot account so reactions on the agent's own
+      // sends still resolve.
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000',
+          emoji: '👀',
+        },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls).toHaveLength(1);
+      const params = calls[0].params as Record<string, unknown>;
+      expect(params.targetAuthor).toBe('+15551234567');
+      expect(params.targetTimestamp).toBe(1700000000000);
+
+      await adapter.teardown();
+    });
+
+    it('does not invoke send for reaction-only payloads', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000000000:+15555550123',
+          emoji: '👍',
+        },
+      });
+
+      expect(getRpcCallsForMethod('send')).toHaveLength(0);
+
+      await adapter.teardown();
+    });
+  });
+
+  describe('outbound text returns platform message id', () => {
+    it('returns "<timestamp>:<account>" so the host can target it later', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+      tcpRef.rpcResponses.set('send', { timestamp: 1700000111111 });
+
+      const id = await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: { text: 'hello' },
+      });
+
+      expect(id).toBe('1700000111111:+15551234567');
+
+      await adapter.teardown();
+    });
+
+    it('returns the first chunk timestamp when chunking', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+      tcpRef.fakeSocket.write.mockClear();
+
+      // Each send returns the same timestamp from the test mock; we just want
+      // the deliver() return to be the first chunk's timestamp, not undefined.
+      tcpRef.rpcResponses.set('send', { timestamp: 1700000222222 });
+
+      const id = await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: { text: 'x'.repeat(8500) },
+      });
+
+      expect(id).toBe('1700000222222:+15551234567');
+
+      await adapter.teardown();
+    });
+  });
+
+  describe('inbound reactions', () => {
+    it('emits a chat InboundMessage with structured reaction object for a DM reaction', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        sourceUuid: 'uuid-alice',
+        dataMessage: {
+          timestamp: 1700000999999,
+          reaction: {
+            emoji: '👍',
+            targetAuthor: '+15551234567',
+            targetSentTimestamp: 1700000111111,
+            isRemove: false,
+          },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(cfg.onInbound).toHaveBeenCalledTimes(1);
+      const [platformId, threadId, msg] = (cfg.onInbound as any).mock.calls[0];
+      expect(platformId).toBe('+15555550123');
+      expect(threadId).toBeNull();
+      expect(msg.kind).toBe('chat');
+      // id is the reaction's own timestamp so it doesn't collide with the
+      // original message in messages_in
+      expect(msg.id).toBe('1700000999999');
+      const content = msg.content as Record<string, unknown>;
+      expect(content.text).toBe('[reacted ➕ 👍 to message]');
+      expect(content.sender).toBe('+15555550123');
+      expect(content.senderName).toBe('Alice');
+      const reaction = content.reaction as Record<string, unknown>;
+      expect(reaction.emoji).toBe('👍');
+      expect(reaction.isAdded).toBe(true);
+      expect(reaction.targetMessageId).toBe('1700000111111:+15551234567');
+
+      await adapter.teardown();
+    });
+
+    it('marks remove reactions with isAdded=false and a ➖ marker', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000999999,
+          reaction: {
+            emoji: '❤️',
+            targetAuthor: '+15551234567',
+            targetSentTimestamp: 1700000111111,
+            isRemove: true,
+          },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const msg = (cfg.onInbound as any).mock.calls[0][2];
+      const content = msg.content as Record<string, unknown>;
+      expect(content.text).toBe('[reacted ➖ ❤️ to message]');
+      const reaction = content.reaction as Record<string, unknown>;
+      expect(reaction.isAdded).toBe(false);
+
+      await adapter.teardown();
+    });
+
+    it('routes group reactions to group:<id> platformId', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000999999,
+          groupV2: { id: 'group-id-xyz' },
+          reaction: {
+            emoji: '🎉',
+            targetAuthor: '+15551234567',
+            targetSentTimestamp: 1700000111111,
+            isRemove: false,
+          },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [platformId] = (cfg.onInbound as any).mock.calls[0];
+      expect(platformId).toBe('group:group-id-xyz');
+
+      await adapter.teardown();
+    });
+
+    it('suppresses echo of our own outbound reaction', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      // Bot sends a reaction first
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: {
+          operation: 'reaction',
+          messageId: '1700000111111:+15555550123',
+          emoji: '👍',
+        },
+      });
+
+      // signal-cli echoes it back via syncMessage. The adapter must not
+      // forward this round-trip to the agent.
+      pushEvent({
+        sourceNumber: '+15551234567',
+        syncMessage: {
+          sentMessage: {
+            timestamp: 1700000222222,
+            destinationNumber: '+15555550123',
+            reaction: {
+              emoji: '👍',
+              targetAuthor: '+15555550123',
+              targetSentTimestamp: 1700000111111,
+              isRemove: false,
+            },
+          },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cfg.onInbound).not.toHaveBeenCalled();
+
+      await adapter.teardown();
+    });
+
+    it('treats reaction envelope as reaction even when alongside other dataMessage fields', async () => {
+      // signal-cli normally sends reactions in their own dataMessage, but if
+      // a message arrives with both `reaction` and `message` populated we
+      // should treat it as a reaction (don't double-emit a text inbound).
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000999999,
+          message: 'should not surface as text',
+          reaction: {
+            emoji: '🔥',
+            targetAuthor: '+15551234567',
+            targetSentTimestamp: 1700000111111,
+            isRemove: false,
+          },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(cfg.onInbound).toHaveBeenCalledTimes(1);
+      const msg = (cfg.onInbound as any).mock.calls[0][2];
+      const content = msg.content as Record<string, unknown>;
+      expect(content.text).toBe('[reacted ➕ 🔥 to message]');
+      // No raw text leaked through
+      expect(content.text).not.toContain('should not surface as text');
+
+      await adapter.teardown();
     });
   });
 });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -267,6 +267,32 @@ class EchoCache {
     return true;
   }
 
+  /**
+   * Reaction-shaped echo entries. Keyed on `(platformId, emoji,
+   * targetSentTimestamp)` rather than text — text-keying would either collide
+   * with a real message or never match because reactions have no text body.
+   */
+  private reactionKey(platformId: string, emoji: string, targetTimestamp: number): string {
+    return `${platformId}\x00reaction\x00${emoji}\x00${targetTimestamp}`;
+  }
+
+  rememberReaction(platformId: string, emoji: string, targetTimestamp: number): void {
+    this.entries.set(this.reactionKey(platformId, emoji, targetTimestamp), Date.now());
+    this.cleanup();
+  }
+
+  isEchoReaction(platformId: string, emoji: string, targetTimestamp: number): boolean {
+    const key = this.reactionKey(platformId, emoji, targetTimestamp);
+    const ts = this.entries.get(key);
+    if (!ts) return false;
+    if (Date.now() - ts > ECHO_TTL_MS) {
+      this.entries.delete(key);
+      return false;
+    }
+    this.entries.delete(key);
+    return true;
+  }
+
   private cleanup(): void {
     const now = Date.now();
     for (const [key, ts] of this.entries) {
@@ -296,6 +322,15 @@ interface SignalMention {
   name?: string;
 }
 
+interface SignalReaction {
+  emoji?: string;
+  targetAuthor?: string;
+  targetAuthorNumber?: string;
+  targetAuthorUuid?: string;
+  targetSentTimestamp?: number;
+  isRemove?: boolean;
+}
+
 interface SignalDataMessage {
   timestamp?: number;
   message?: string;
@@ -303,6 +338,7 @@ interface SignalDataMessage {
   groupInfo?: { groupId?: string; groupName?: string; type?: string };
   groupV2?: { id?: string };
   quote?: SignalQuote;
+  reaction?: SignalReaction;
   attachments?: Array<{
     id?: string;
     contentType?: string;
@@ -434,6 +470,109 @@ function chunkText(text: string, limit: number): string[] {
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 // ---------------------------------------------------------------------------
+// Emoji shortcode → unicode
+//
+// The agent-runner's `add_reaction` MCP tool documents emoji as shortcode
+// names (`thumbs_up`, `heart`, `white_check_mark`). signal-cli's sendReaction
+// expects the literal unicode character. Chat SDK handles this internally for
+// chat-sdk channels; native adapters need to do it themselves.
+//
+// Coverage focuses on the shortcodes the tool's instructions mention plus the
+// most commonly-used reactions. Unknown shortcodes fall back to 👍 with a
+// warning so the agent's intent ("react to acknowledge") still goes through
+// rather than the call quietly dropping.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EMOJI = '👍';
+
+const EMOJI_SHORTCODES: Record<string, string> = {
+  thumbs_up: '👍',
+  '+1': '👍',
+  thumbsup: '👍',
+  thumbs_down: '👎',
+  '-1': '👎',
+  thumbsdown: '👎',
+  heart: '❤️',
+  red_heart: '❤️',
+  white_check_mark: '✅',
+  check: '✅',
+  check_mark: '✅',
+  x: '❌',
+  cross_mark: '❌',
+  no_entry: '⛔',
+  warning: '⚠️',
+  eyes: '👀',
+  fire: '🔥',
+  hundred: '💯',
+  '100': '💯',
+  pray: '🙏',
+  raised_hands: '🙌',
+  clap: '👏',
+  ok_hand: '👌',
+  joy: '😂',
+  laughing: '😂',
+  smile: '😄',
+  smiley: '😃',
+  grin: '😁',
+  wink: '😉',
+  thinking: '🤔',
+  thinking_face: '🤔',
+  cry: '😢',
+  sob: '😭',
+  rage: '😡',
+  angry: '😠',
+  sweat_smile: '😅',
+  shrug: '🤷',
+  party: '🎉',
+  tada: '🎉',
+  rocket: '🚀',
+  star: '⭐',
+  sparkles: '✨',
+  bulb: '💡',
+  zap: '⚡',
+  bell: '🔔',
+  question: '❓',
+  exclamation: '❗',
+  wave: '👋',
+  point_up: '☝️',
+  point_right: '👉',
+  muscle: '💪',
+  brain: '🧠',
+  robot: '🤖',
+  see_no_evil: '🙈',
+  hear_no_evil: '🙉',
+  speak_no_evil: '🙊',
+};
+
+/**
+ * Resolve an agent-supplied emoji argument to a single unicode emoji.
+ *
+ * Inputs in priority order:
+ *   1. Already-unicode (anything that doesn't match `[a-z0-9_+-]+` ASCII) → pass through
+ *   2. Known shortcode in EMOJI_SHORTCODES → mapped unicode
+ *   3. Anything else → DEFAULT_EMOJI + warning
+ *
+ * Strips a leading/trailing colon so `:thumbs_up:` works alongside `thumbs_up`.
+ */
+function emojiToUnicode(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return DEFAULT_EMOJI;
+  const stripped = trimmed.replace(/^:|:$/g, '');
+  // ASCII-only shortcode pattern — anything containing non-ASCII is assumed
+  // to already be a unicode emoji (or grapheme cluster).
+  if (/^[a-z0-9_+-]+$/i.test(stripped)) {
+    const mapped = EMOJI_SHORTCODES[stripped.toLowerCase()];
+    if (mapped) return mapped;
+    log.warn('Signal: unknown emoji shortcode, falling back to default', {
+      shortcode: stripped,
+      fallback: DEFAULT_EMOJI,
+    });
+    return DEFAULT_EMOJI;
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
 // Signal text styles — convert Markdown to Signal's offset-based formatting
 // ---------------------------------------------------------------------------
 
@@ -551,6 +690,25 @@ export function createSignalAdapter(config: {
     // Sync messages (sent from another device)
     const syncSent = envelope.syncMessage?.sentMessage;
     if (syncSent) {
+      // Reaction sync — drop if it's our own outbound reaction echoing back.
+      // (Reactions sent from another linked device with a non-self destination
+      // are also our outbound and likewise skipped — they aren't a separate
+      // user event the agent needs to see.)
+      if (syncSent.reaction) {
+        const groupId = syncSent.groupV2?.id ?? syncSent.groupInfo?.groupId;
+        const dest = (syncSent.destinationNumber ?? syncSent.destination ?? '').trim();
+        const platformId = groupId ? `group:${groupId}` : dest;
+        const r = syncSent.reaction;
+        if (
+          platformId &&
+          r.emoji &&
+          r.targetSentTimestamp &&
+          echoCache.isEchoReaction(platformId, r.emoji, r.targetSentTimestamp)
+        ) {
+          log.debug('Signal: skipping echoed reaction', { platformId, emoji: r.emoji });
+        }
+        return;
+      }
       const dest = (syncSent.destinationNumber ?? syncSent.destination ?? '').trim();
       // "Note to Self" — destination is our own account
       if (dest === config.account) {
@@ -584,6 +742,14 @@ export function createSignalAdapter(config: {
 
     const dataMessage = envelope.dataMessage;
     if (!dataMessage) return;
+
+    // Reaction event — handle before text/voice/attachment processing so a
+    // dataMessage that carries both `reaction` and `message` (rare) is treated
+    // as the reaction it is, not as a text message from the same envelope.
+    if (dataMessage.reaction) {
+      await handleInboundReaction(envelope, dataMessage.reaction);
+      return;
+    }
 
     const rawText = (dataMessage.message ?? '').trim();
     const text = rawText ? resolveMentions(rawText, dataMessage.mentions) : '';
@@ -678,6 +844,74 @@ export function createSignalAdapter(config: {
   }
 
   /**
+   * Translate a Signal reaction event into an InboundMessage. The structured
+   * `reaction` object mirrors Chat SDK's `ReactionEvent` shape (emoji,
+   * isAdded, targetMessageId) so the eventual chat-sdk-bridge implementation
+   * can reuse the same `messages_in.content` schema. The synthesized `text`
+   * field keeps the existing agent-runner formatter rendering something
+   * meaningful with no formatter changes.
+   */
+  async function handleInboundReaction(envelope: SignalEnvelope, reaction: SignalReaction): Promise<void> {
+    if (!setup) return;
+    if (!reaction.emoji || !reaction.targetSentTimestamp) {
+      log.debug('Signal: ignoring reaction with missing emoji or targetSentTimestamp', { reaction });
+      return;
+    }
+
+    const sender = (envelope.sourceNumber ?? envelope.sourceUuid ?? envelope.source ?? '').trim();
+    if (!sender) return;
+    const senderName = (envelope.sourceName?.trim() || sender).trim();
+
+    const dataMessage = envelope.dataMessage!;
+    const groupInfo = dataMessage.groupInfo;
+    const groupId = dataMessage.groupV2?.id ?? groupInfo?.groupId;
+    const isGroup = Boolean(groupId);
+    const platformId = isGroup ? `group:${groupId}` : sender;
+
+    if (echoCache.isEchoReaction(platformId, reaction.emoji, reaction.targetSentTimestamp)) {
+      log.debug('Signal: skipping echoed reaction', { platformId, emoji: reaction.emoji });
+      return;
+    }
+
+    const isAdded = !reaction.isRemove;
+    const targetAuthor =
+      reaction.targetAuthor || reaction.targetAuthorUuid || reaction.targetAuthorNumber || '';
+    const targetMessageId = `${reaction.targetSentTimestamp}:${targetAuthor}`;
+    const marker = isAdded ? '➕' : '➖';
+    const text = `[reacted ${marker} ${reaction.emoji} to message]`;
+    const timestamp = dataMessage.timestamp
+      ? new Date(dataMessage.timestamp).toISOString()
+      : new Date().toISOString();
+
+    const chatName = groupInfo?.groupName ?? (isGroup ? `Group ${groupId?.slice(0, 8)}` : senderName);
+    setup.onMetadata(platformId, chatName, isGroup);
+
+    const msg: InboundMessage = {
+      id: String(dataMessage.timestamp ?? Date.now()),
+      kind: 'chat',
+      content: {
+        text,
+        sender,
+        senderId: `signal:${sender}`,
+        senderName,
+        reaction: {
+          emoji: reaction.emoji,
+          isAdded,
+          targetMessageId,
+        },
+      },
+      timestamp,
+    };
+    await setup.onInbound(platformId, null, msg);
+    log.info('Signal reaction received', {
+      platformId,
+      sender: senderName,
+      emoji: reaction.emoji,
+      isAdded,
+    });
+  }
+
+  /**
    * Build the `replyTo` object the agent-runner formatter expects (see
    * `container/agent-runner/src/formatter.ts:formatReplyContext`). The
    * formatter requires both `sender` and `text` to render the
@@ -701,13 +935,21 @@ export function createSignalAdapter(config: {
 
   // -- send helpers --
 
-  async function sendText(platformId: string, text: string): Promise<void> {
-    if (!connected || !tcp) return;
+  /**
+   * Send `text` as one or more Signal messages, returning the timestamp of
+   * the first chunk's send response (so callers can record it as the
+   * platform message id). The first chunk is the head of the reply, which
+   * is what later edits / reactions / replies want to target.
+   */
+  async function sendText(platformId: string, text: string): Promise<number | null> {
+    if (!connected || !tcp) return null;
 
     echoCache.remember(platformId, text);
 
     const MAX_CHUNK = 4000;
     const chunks = text.length <= MAX_CHUNK ? [text] : chunkText(text, MAX_CHUNK);
+
+    let firstTimestamp: number | null = null;
 
     for (const chunk of chunks) {
       try {
@@ -724,17 +966,22 @@ export function createSignalAdapter(config: {
           params.recipient = [platformId];
         }
 
+        let result: unknown;
         try {
-          await tcp.rpc('send', params);
+          result = await tcp.rpc('send', params);
         } catch (styledErr) {
           if (textStyles.length > 0) {
             log.debug('Signal: textStyle rejected, retrying with markup');
             delete params.textStyle;
             params.message = chunk;
-            await tcp.rpc('send', params);
+            result = await tcp.rpc('send', params);
           } else {
             throw styledErr;
           }
+        }
+        if (firstTimestamp === null && result && typeof result === 'object') {
+          const ts = (result as Record<string, unknown>).timestamp;
+          if (typeof ts === 'number') firstTimestamp = ts;
         }
       } catch (err) {
         log.error('Signal: send failed', { platformId, err });
@@ -742,6 +989,7 @@ export function createSignalAdapter(config: {
     }
 
     log.info('Signal message sent', { platformId, length: text.length });
+    return firstTimestamp;
   }
 
   /**
@@ -786,6 +1034,66 @@ export function createSignalAdapter(config: {
           /* best-effort cleanup */
         }
       }
+    }
+  }
+
+  /**
+   * Send a reaction via signal-cli's `sendReaction` JSON-RPC. The encoded
+   * `messageId` carries both the target timestamp and the target author —
+   * see the inbound `id` and outbound `deliver()` return value, both of which
+   * use the same `<timestamp>:<authorIdent>` format. Legacy ids without a
+   * suffix default targetAuthor to our own account (covers reactions on the
+   * agent's own outbound from before this encoding was introduced).
+   */
+  async function sendReaction(
+    platformId: string,
+    encodedMessageId: string,
+    rawEmoji: string,
+    remove: boolean,
+  ): Promise<string | undefined> {
+    if (!connected || !tcp) return undefined;
+
+    const sepIdx = encodedMessageId.indexOf(':');
+    const tsRaw = sepIdx === -1 ? encodedMessageId : encodedMessageId.slice(0, sepIdx);
+    const targetAuthor = sepIdx === -1 ? config.account : encodedMessageId.slice(sepIdx + 1);
+    const targetTimestamp = Number(tsRaw);
+    if (!Number.isFinite(targetTimestamp) || targetTimestamp <= 0) {
+      log.error('Signal: sendReaction got unparseable messageId', { encodedMessageId });
+      return undefined;
+    }
+    if (!targetAuthor) {
+      log.error('Signal: sendReaction missing targetAuthor', { encodedMessageId });
+      return undefined;
+    }
+
+    const emoji = emojiToUnicode(rawEmoji);
+
+    const params: Record<string, unknown> = {
+      emoji,
+      targetAuthor,
+      targetTimestamp,
+    };
+    if (config.account) params.account = config.account;
+    if (remove) params.remove = true;
+    if (platformId.startsWith('group:')) {
+      params.groupId = platformId.slice('group:'.length);
+    } else {
+      params.recipient = [platformId];
+    }
+
+    echoCache.rememberReaction(platformId, emoji, targetTimestamp);
+
+    try {
+      const result = await tcp.rpc('sendReaction', params);
+      log.info('Signal reaction sent', { platformId, emoji, targetTimestamp, remove });
+      if (result && typeof result === 'object') {
+        const ts = (result as Record<string, unknown>).timestamp;
+        if (typeof ts === 'number') return `${ts}:${config.account}`;
+      }
+      return undefined;
+    } catch (err) {
+      log.error('Signal: sendReaction failed', { platformId, emoji, targetTimestamp, err });
+      return undefined;
     }
   }
 
@@ -893,6 +1201,19 @@ export function createSignalAdapter(config: {
 
     async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
       const content = message.content as Record<string, unknown> | string | undefined;
+
+      // Reaction operation — mirrors the chat-sdk-bridge contour so an agent
+      // calling `add_reaction` works the same on Signal as on Discord/Slack.
+      if (
+        content &&
+        typeof content === 'object' &&
+        content.operation === 'reaction' &&
+        typeof content.messageId === 'string' &&
+        typeof content.emoji === 'string'
+      ) {
+        return await sendReaction(platformId, content.messageId, content.emoji, content.remove === true);
+      }
+
       let text: string | null = null;
       if (typeof content === 'string') {
         text = content;
@@ -905,8 +1226,15 @@ export function createSignalAdapter(config: {
       // Send accompanying text first so it lands above the attachment(s) in
       // the recipient's chat. Both branches no-op cleanly if their input is
       // empty, so any combination of (text, files) works.
-      if (text) await sendText(platformId, text);
+      let sentTimestamp: number | null = null;
+      if (text) sentTimestamp = await sendText(platformId, text);
       if (files.length > 0) await sendAttachments(platformId, files);
+      // Return the head-of-reply id so the host can record it in
+      // delivered.platform_message_id. The encoded form `<ts>:<account>`
+      // round-trips through `add_reaction` / future edit support to the
+      // sendReaction helper, which decodes it back into targetTimestamp +
+      // targetAuthor.
+      if (sentTimestamp !== null) return `${sentTimestamp}:${config.account}`;
       return undefined;
     },
 

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -721,7 +721,10 @@ export function createSignalAdapter(config: {
         setup.onMetadata(platformId, 'Note to Self', false);
 
         const msg: InboundMessage = {
-          id: String(syncSent.timestamp ?? Date.now()),
+          // Encode the sender into the id so a later add_reaction can recover
+          // the targetAuthor. The router suffixes `:<agent-group-id>` for
+          // fan-out uniqueness; sendReaction takes the second `:`-component.
+          id: `${syncSent.timestamp ?? Date.now()}:${config.account}`,
           kind: 'chat',
           content: {
             text,
@@ -826,7 +829,9 @@ export function createSignalAdapter(config: {
     }
 
     const msg: InboundMessage = {
-      id: String(dataMessage.timestamp ?? Date.now()),
+      // Encode the sender so sendReaction can recover targetAuthor — see
+      // syncSent path above for the full rationale.
+      id: `${dataMessage.timestamp ?? Date.now()}:${sender}`,
       kind: 'chat',
       content: {
         text: content,
@@ -887,7 +892,10 @@ export function createSignalAdapter(config: {
     setup.onMetadata(platformId, chatName, isGroup);
 
     const msg: InboundMessage = {
-      id: String(dataMessage.timestamp ?? Date.now()),
+      // Encode sender so reactions stay reactable — same rationale as the
+      // text path. The reaction's own timestamp keeps the row distinct from
+      // the original message it reacted to.
+      id: `${dataMessage.timestamp ?? Date.now()}:${sender}`,
       kind: 'chat',
       content: {
         text,
@@ -1053,9 +1061,19 @@ export function createSignalAdapter(config: {
   ): Promise<string | undefined> {
     if (!connected || !tcp) return undefined;
 
-    const sepIdx = encodedMessageId.indexOf(':');
-    const tsRaw = sepIdx === -1 ? encodedMessageId : encodedMessageId.slice(0, sepIdx);
-    const targetAuthor = sepIdx === -1 ? config.account : encodedMessageId.slice(sepIdx + 1);
+    // messageId encoding (see handleEnvelope and deliver):
+    //   - `<ts>`                      — legacy / no-author fallback
+    //   - `<ts>:<author>`             — outbound reply (deliver())
+    //   - `<ts>:<author>:<ag-id>`     — inbound message after the router's
+    //                                   per-agent fan-out suffix in router.ts
+    //                                   `messageIdForAgent`
+    // Author is always the SECOND `:`-segment when present; trailing
+    // segments (e.g. agent-group id) are dropped. Without an author segment,
+    // fall back to our own account so reactions on the agent's own outbound
+    // still resolve.
+    const parts = encodedMessageId.split(':');
+    const tsRaw = parts[0];
+    const targetAuthor = parts[1] && parts[1].length > 0 ? parts[1] : config.account;
     const targetTimestamp = Number(tsRaw);
     if (!Number.isFinite(targetTimestamp) || targetTimestamp <= 0) {
       log.error('Signal: sendReaction got unparseable messageId', { encodedMessageId });


### PR DESCRIPTION
## Summary

- Adds Signal reaction support — both directions — mirroring the chat-sdk-bridge contour (`content.operation === 'reaction' && content.messageId && content.emoji`).
- Outbound: agents can call the existing `add_reaction` MCP tool and the emoji lands as a Signal reaction on the target message via signal-cli's `sendReaction` JSON-RPC.
- Inbound: `dataMessage.reaction` envelopes parse into a `chat`-kind `InboundMessage` carrying a structured `reaction` object (emoji / isAdded / targetMessageId — Chat SDK `ReactionEvent` shape) plus a `[reacted ➕ 👍 to message]` text fallback so the existing formatter renders something useful with no formatter changes.
- `sendText` now returns the first chunk's signal-cli timestamp and `deliver` returns `<ts>:<account>` so the host's `delivered.platform_message_id` tracks the head of every reply — prerequisite for reactions on the agent's own outbound to resolve.
- Inbound message ids encode the sender (`<ts>:<sender>`) so after the router's `messageIdForAgent` suffixes `:<agent-group-id>` for fan-out uniqueness, `sendReaction` can still recover `targetAuthor` by taking the second `:`-segment. Without this, signal-cli silently drops reactions targeted at an agent-group id.
- Inline shortcode→unicode map covers the names the `add_reaction` tool documents (`thumbs_up`, `heart`, `white_check_mark`, `eyes`, …) plus common reactions; unknown shortcodes warn and fall back to 👍 so the agent's intent still reaches Signal.
- 13 new tests (53 total in `signal.test.ts`).

Smoke-tested live against signal-cli. Inbound reactions arrive at the agent and surface as `[reacted ➕ 👍 to message]`; outbound reactions land on the right message in Signal.

## Test plan

- [x] `pnpm test src/channels/signal.test.ts` — all green
- [x] `pnpm test` — full host suite green (only pre-existing host-sweep flakes)
- [x] Live smoke test: agent reacts ✅ on user's text via `add_reaction`; user reacts 👍 on agent's reply and the agent sees it
- [ ] Reviewer to spot-check: shortcode mapping, group reactions, sync echo suppression