### PR TITLE
feat(setup): add "Other…" option to channel picker

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -60,7 +60,7 @@ import { isValidTimezone } from '../src/timezone.js';
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
 
-type ChannelChoice = 'telegram' | 'discord' | 'whatsapp' | 'signal' | 'teams' | 'slack' | 'imessage' | 'skip';
+type ChannelChoice = 'telegram' | 'discord' | 'whatsapp' | 'signal' | 'teams' | 'slack' | 'imessage' | 'other' | 'skip';
 
 async function main(): Promise<void> {
   // Make sure ~/.local/bin is on PATH for every child process we spawn.
@@ -441,7 +441,7 @@ async function main(): Promise<void> {
 
   if (!skip.has('channel')) {
     channelChoice = await askChannelChoice();
-    if (channelChoice !== 'skip') {
+    if (channelChoice !== 'skip' && channelChoice !== 'other') {
       await resolveDisplayName();
     }
     if (channelChoice === 'telegram') {
@@ -458,6 +458,8 @@ async function main(): Promise<void> {
       await runSlackChannel(displayName!);
     } else if (channelChoice === 'imessage') {
       await runIMessageChannel(displayName!);
+    } else if (channelChoice === 'other') {
+      await askOtherChannelName();
     } else {
       p.log.info(
         brandBody(
@@ -1076,6 +1078,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
           hint: 'needs public URL',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
+        { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },
         { value: 'skip', label: 'Skip for now', hint: "I'll just use the terminal" },
       ],
     }),
@@ -1083,6 +1086,26 @@ async function askChannelChoice(): Promise<ChannelChoice> {
   setupLog.userInput('channel_choice', String(choice));
   phEmit('channel_chosen', { channel: String(choice) });
   return choice;
+}
+
+async function askOtherChannelName(): Promise<void> {
+  const answer = ensureAnswer(
+    await p.text({
+      message: 'Which channel would you like to install?',
+      placeholder: 'e.g. matrix, github, linear, webex',
+    }),
+  );
+  const name = (answer as string).trim().toLowerCase().replace(/^\/?(add-)?/, '');
+  setupLog.userInput('other_channel', name);
+  phEmit('channel_other_named', { channel: name });
+  p.log.info(
+    brandBody(
+      wrapForGutter(
+        `No bash installer for ${k.bold(name)} — open Claude Code after setup and run ${k.bold(`/add-${name}`)} to install it.`,
+        4,
+      ),
+    ),
+  );
 }
 
 // ─── interactive / env helpers ─────────────────────────────────────────


### PR DESCRIPTION
The first-time setup picker only listed seven channels with bash installers. Users wanting to install one of the other channels (matrix, github, linear, webex, etc.) had no entry point from the picker and had to know to run /add-<name> from Claude Code afterwards.

Add an "Other…" option that prompts for a free-text name, normalizes it (accepts "matrix", "add-matrix", or "/add-matrix"), and prints a hint telling the user to run /add-<name> from Claude Code after setup finishes. The verify step's "What's left" panel already covers the empty-channels case, so the user is not left thinking the channel was wired.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [X] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Summary
                                                                                                                                            
  Adds an "Other…" option to the first-time setup channel picker so users can install channels that don't have a bash installer (matrix,
  github, linear, webex, gchat, resend, whatsapp-cloud, wechat, deltachat, etc.) without having to know to run /add-<name> from Claude Code 
  unprompted.

  In my case, I would like to be able to install my "webchat" channel. (until it gets merged, of course :) )
                                                                                                                                            
  Motivation                                                                                                                                
   
  Today the picker in setup/auto.ts lists 7 channels with interactive bash installers (telegram, discord, whatsapp, signal, imessage, slack,
   teams) plus Skip for now. The other ~10 channels on the channels branch have no entry point from setup at all — a new user finishing
  setup with one of those in mind has to either pick "skip" and figure out /add-<name> on their own, or back out and re-run later.          
                 
 Behavior

  When the user picks "Other…":

  1. A free-text prompt asks which channel to install (placeholder shows e.g. matrix, github, linear, webex).                               
  2. Input is normalized — matrix, add-matrix, and /add-matrix all resolve to matrix.
  3. The choice is recorded in setupLog (other_channel) and PostHog (channel_other_named) so install funnels are still observable.          
  4. Setup prints a hint: "No bash installer for <name> — open Claude Code after setup and run /add-<name> to install it."                  
  5. The rest of setup runs normally. Since no channel got wired, the existing What's left panel at the verify step already nudges the user 
  with /add-<channel> — they aren't left thinking the install completed.                                                                    
                                                                                                                                            
  displayName resolution is skipped for other (nothing to wire), and channelDmLabel('other') returns null so the "Check your  — your        
  assistant is saying hi" banner is correctly suppressed at the end.
                                                                                                                                            
  What this is not                                          

  - It does not attempt to install the channel from bash. Per the existing v2 design, channels outside the seven bash-installable ones are  
  installed via Claude Code skills.
  - It does not validate that the typed name exists as a real /add-* skill — the user finds out when they run it. Validation would couple   
  setup/auto.ts to the channels branch's skill list, which we don't want.   
