### PR TITLE
feat(mcp): support http and sse MCP server transports

### DIFF
--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -7,6 +7,8 @@
  */
 import fs from 'fs';
 
+import type { McpServerConfig } from './providers/types.js';
+
 const CONFIG_PATH = '/workspace/agent/container.json';
 
 export interface RunnerConfig {
@@ -15,7 +17,7 @@ export interface RunnerConfig {
   groupName: string;
   agentGroupId: string;
   maxMessagesPerPrompt: number;
-  mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  mcpServers: Record<string, McpServerConfig>;
   model?: string;
   effort?: string;
 }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -34,6 +34,7 @@ import { MEMORY_SESSION_HOOK } from './memory/session-hook.js';
 // Provider skills append imports to providers/index.ts.
 import './providers/index.js';
 import { createProvider, type ProviderName } from './providers/factory.js';
+import type { McpServerConfig } from './providers/types.js';
 import { runPollLoop } from './poll-loop.js';
 
 function log(msg: string): void {
@@ -84,7 +85,7 @@ async function main(): Promise<void> {
   const mcpServerPath = path.join(__dirname, 'mcp-tools', 'index.ts');
 
   // Build MCP servers config: nanoclaw built-in + any from container.json
-  const mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {
+  const mcpServers: Record<string, McpServerConfig> = {
     nanoclaw: {
       command: 'bun',
       args: ['run', mcpServerPath],
@@ -94,7 +95,10 @@ async function main(): Promise<void> {
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
     mcpServers[name] = serverConfig;
-    log(`Additional MCP server: ${name} (${serverConfig.command})`);
+    const transport = serverConfig.type === 'http' || serverConfig.type === 'sse'
+      ? `${serverConfig.type}: ${serverConfig.url}`
+      : `stdio: ${serverConfig.command}`;
+    log(`Additional MCP server: ${name} (${transport})`);
   }
 
   const provider = createProvider(providerName, {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -100,10 +100,36 @@ export interface QueryInput {
   };
 }
 
-export interface McpServerConfig {
+/**
+ * MCP server configuration.
+ *
+ * Mirrors the transports the Claude Agent SDK supports:
+ *   - stdio: spawn an in-container subprocess and pipe stdio (default).
+ *   - http:  connect to an external Streamable-HTTP MCP server by URL.
+ *   - sse:   connect to an external Server-Sent-Events MCP server by URL.
+ *
+ * `type` is optional only for stdio for back-compat with existing
+ * container.json files that omit it.
+ */
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig | McpSseServerConfig;
+
+export interface McpStdioServerConfig {
+  type?: 'stdio';
   command: string;
-  args: string[];
-  env: Record<string, string>;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpHttpServerConfig {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface McpSseServerConfig {
+  type: 'sse';
+  url: string;
+  headers?: Record<string, string>;
 }
 
 export interface AgentQuery {

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -16,10 +16,36 @@ import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
-export interface McpServerConfig {
+/**
+ * MCP server configuration. Mirrors the transports the Claude Agent SDK
+ * supports — stdio (default, in-container subprocess), http and sse
+ * (external server reached by URL).
+ *
+ * `instructions` is host-side only; the host writes it to
+ * `.claude-fragments/mcp-<name>.md` at spawn and imports it into the
+ * composed CLAUDE.md (see `claude-md-compose.ts`).
+ */
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig | McpSseServerConfig;
+
+export interface McpStdioServerConfig {
+  type?: 'stdio';
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  instructions?: string;
+}
+
+export interface McpHttpServerConfig {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+  instructions?: string;
+}
+
+export interface McpSseServerConfig {
+  type: 'sse';
+  url: string;
+  headers?: Record<string, string>;
   instructions?: string;
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

> None of the checkbox categories fit cleanly. This is a small source-only change that adds capability (HTTP/SSE MCP transports), not a bug fix and not a skill. CONTRIBUTING.md says features should be skills — but this isn't skill-able, since the type definition lives in the agent-runner and gates what *every* skill can configure. Happy to discuss whether this belongs in source or whether you'd prefer a different shape; in the meantime, no box ticked since none apply.

## Description

Widens `McpServerConfig` from a stdio-only shape to a discriminated union that mirrors the transports the Claude Agent SDK already supports:

- `type: 'stdio'` (default) — `{ command, args?, env? }` (existing behavior, unchanged)
- `type: 'http'` — `{ url, headers? }` (Streamable HTTP)
- `type: 'sse'`  — `{ url, headers? }` (Server-Sent Events)

Stdio entries without an explicit `type` continue to work — no existing `container.json` files need to change.

For HTTP and SSE the agent-runner hands the config straight through to the SDK; the SDK handles the transport. No host-orchestrator change, no Dockerfile change, no new dependencies.

### Motivation

Today every MCP server is a subprocess of the agent container. That's fine for servers whose runtime fits cleanly in-container, but it ties some configurations to the agent's namespace that don't need to be there. The HTTP/SSE transports let an MCP server live outside the agent container — on the host, in a sidecar container, or as a hosted service — addressed by URL.

The concrete near-term use case is MCP servers that talk raw TCP+TLS protocols (IMAP, SMTP, Postgres, Redis, etc.) where credentials must be injected at the protocol layer (HTTPS-proxy approaches like OneCLI don't help). Running such a server out-of-container keeps the credentials out of the agent's environment without requiring NanoClaw to grow protocol-specific proxying.

### Files

- `src/container-config.ts` — host type widened. `instructions?` kept on every variant; `claude-md-compose.ts` already reads it from any MCP entry.
- `container/agent-runner/src/providers/types.ts` — provider-side type widened to match.
- `container/agent-runner/src/config.ts` — `RunnerConfig.mcpServers` references the union type instead of an inline stdio shape.
- `container/agent-runner/src/index.ts` — startup log line handles all three variants (stdio prints command, http/sse print URL).

### Possible follow-up

This PR only widens the type so externally-hosted MCP servers can be addressed. If there's interest, I can follow up with a separate PR that also lets `container.json` declare *how* a sidecar MCP server is launched and managed (a sidecars block: image, env, lifecycle, networking) so NanoClaw can spawn and reap them alongside the agent container, instead of leaving that to the operator.

### Note on CI failure

The two failing tests in `src/host-sweep.test.ts` (`resetStuckProcessingRows — orphan claim cleanup`) are not caused by this PR. Verified by running them against pristine `upstream/main` code with none of this PR's changes applied — both fail identically. They're a regression from #2183 (the `openOutboundDbRw` reopen path doesn't match the in-memory test DB) that I will fix in a different PR.