### PR TITLE
fix(host-sweep): inject DbRw opener so in-memory tests don't fail silently

### DIFF
--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -256,7 +256,13 @@ export function _resetStuckProcessingRowsForTesting(
   session: Session,
   reason: string,
 ): void {
-  resetStuckProcessingRows(inDb, outDb, session, reason);
+  // In tests, outDb is an in-memory database with no filesystem path, so the
+  // production-path call to openOutboundDbRw(agent_group_id, session_id) would
+  // fail (the path doesn't exist) and silently swallow the error in the catch
+  // block, leaving the orphan claim in place — which is exactly the behaviour
+  // the regression tests are written to detect. Inject an opener that returns
+  // the same outDb so the delete runs on the caller's handle.
+  resetStuckProcessingRows(inDb, outDb, session, reason, () => outDb);
 }
 
 function resetStuckProcessingRows(
@@ -264,6 +270,7 @@ function resetStuckProcessingRows(
   outDb: Database.Database,
   session: Session,
   reason: string,
+  openRw: (agentGroupId: string, sessionId: string) => Database.Database = openOutboundDbRw,
 ): void {
   const claims = getProcessingClaims(outDb);
   const now = Date.now();
@@ -305,7 +312,7 @@ function resetStuckProcessingRows(
   // outDb was opened readonly for reads above; reopen with write access for this delete.
   let outDbRw: Database.Database | null = null;
   try {
-    outDbRw = openOutboundDbRw(session.agent_group_id, session.id);
+    outDbRw = openRw(session.agent_group_id, session.id);
     const cleared = deleteOrphanProcessingClaims(outDbRw);
     if (cleared > 0) {
       log.info('Cleared orphan processing claims', { sessionId: session.id, cleared, reason });
@@ -313,6 +320,8 @@ function resetStuckProcessingRows(
   } catch (err) {
     log.warn('Failed to clear orphan processing claims', { sessionId: session.id, err });
   } finally {
-    outDbRw?.close();
+    // Don't close the caller-supplied outDb (test path injects it as the rw
+    // handle). Production opens a fresh connection here, which we own + close.
+    if (outDbRw && outDbRw !== outDb) outDbRw.close();
   }
 }


### PR DESCRIPTION
## Summary

`resetStuckProcessingRows()` (called from the regression-protected `claim-stuck` path) reopens `outbound.db` by filesystem path via `openOutboundDbRw(agent_group_id, session_id)` to drop orphan processing claims after killing a stuck container.

The 2 host-sweep regression tests (`should clear orphan claims even when message is past process_after` and `still clears orphan claims even when the inbound message has already been retried (skip path)`, both added in 7ce9922) call `_resetStuckProcessingRowsForTesting` with an in-memory outDb and a `fakeSession()` whose path doesn't exist on disk — the reopen fails, the error is silently caught in the `try/catch`, the orphan claim stays in place, and the assertion `expect(getProcessingClaims(outDb)).toEqual([])` fails on a clean checkout.

The bug is in the test fixture's contract with the function under test, not in the function's runtime behaviour. Production paths exist on disk, so the reopen succeeds there.

## Fix

Make the rw-opener injectable. `_resetStuckProcessingRowsForTesting` passes `() => outDb` so the delete runs on the caller's handle; production keeps `openOutboundDbRw` as the default. Don't close the test-supplied handle in the `finally` — the caller still owns it.

## Verification

```
$ git checkout main
$ pnpm test src/host-sweep.test.ts
 Test Files  1 passed (1)
      Tests  12 passed | 2 failed (14)   ← reproduction

$ git checkout fix/host-sweep-test-fixture
$ pnpm test src/host-sweep.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)              ← fixed
$ pnpm test
      Tests  246 passed (246)            ← full suite green
```

Tested on `upstream/main@953264e0` (v2.0.27).

## Test plan

- [x] Reproduce 2-failing-tests on clean checkout
- [x] Verify fix passes all 14 host-sweep tests
- [x] Verify full suite (246 tests) still green
- [x] Typecheck clean
