### PR TITLE
feat: add tool-visibility skill for live tool-call previews

### DIFF
--- a/.claude/skills/add-tool-visibility/REMOVE.md
+++ b/.claude/skills/add-tool-visibility/REMOVE.md
@@ -1,0 +1,63 @@
+# Remove Tool Visibility
+
+Idempotent — safe to run even if some steps were never applied. Reverses the
+copied hook module, both tests, and the provider wiring.
+
+## 1. Delete the copied files
+
+```bash
+rm -f container/agent-runner/src/hooks/tool-visibility.ts
+rm -f container/agent-runner/src/hooks/tool-visibility.test.ts
+rm -f container/agent-runner/src/hooks/tool-visibility-wiring.test.ts
+rmdir container/agent-runner/src/hooks 2>/dev/null || true   # only if now empty
+```
+
+## 2. Revert the provider wiring
+
+In `container/agent-runner/src/providers/claude.ts`:
+
+- DELETE the import line
+  `import { postToolUseVisibility, preToolUseVisibility } from '../hooks/tool-visibility.js';`
+  (delete, don't comment out). Skip if already gone.
+- In the `hooks:` options object inside `ClaudeProvider.query()`, remove the
+  two visibility entries so the three arrays read:
+
+```typescript
+        hooks: {
+          PreToolUse: [{ hooks: [preToolUseHook] }],
+          PostToolUse: [{ hooks: [postToolUseHook] }],
+          PostToolUseFailure: [{ hooks: [postToolUseHook] }],
+          PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+        },
+```
+
+Leave `PreCompact` and everything else untouched.
+
+## 3. Dependencies
+
+None to uninstall — the skill adds no packages; it uses the SDK and DB layer
+the agent-runner already ships.
+
+## 4. Rebuild and restart
+
+Run from your NanoClaw project root:
+
+```bash
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+cd container/agent-runner && bun test; cd ../..
+./container/build.sh
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
+# or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+```
+
+## Verification
+
+Confirm it is fully unwired:
+
+```bash
+ls container/agent-runner/src/hooks/tool-visibility.ts 2>/dev/null   # no such file
+grep -n "ToolUseVisibility" container/agent-runner/src/providers/claude.ts   # no output
+```
+
+New containers spawned after the restart no longer send tool-call previews.

--- a/.claude/skills/add-tool-visibility/REMOVE.md
+++ b/.claude/skills/add-tool-visibility/REMOVE.md
@@ -36,7 +36,9 @@ Leave `PreCompact` and everything else untouched.
 ## 3. Dependencies
 
 None to uninstall — the skill adds no packages; it uses the SDK and DB layer
-the agent-runner already ships.
+the agent-runner already ships (`writeMessageOut`, `getSessionRouting`,
+`getInboundDb`, `getOutboundDb` for task-session classification via
+`processing_ack`).
 
 ## 4. Rebuild and restart
 

--- a/.claude/skills/add-tool-visibility/SKILL.md
+++ b/.claude/skills/add-tool-visibility/SKILL.md
@@ -1,32 +1,56 @@
 ---
 name: add-tool-visibility
-description: Add live chat-side visibility for agent tool calls — shows "🖥️ bash: <cmd>" before each tool call, failure markers, and duration markers after slow Bash. Surfaces what the agent is doing in real time during long multi-step runs. Triggers on "tool visibility", "live tool use", "show tool calls", "tool preview".
+description: Add live chat-side visibility for agent tool calls — shows tool previews before each call, failure markers, and duration markers after slow Bash. Surfaces what the agent is doing in real time during long multi-step runs. Triggers on "tool visibility", "live tool use", "show tool calls", "tool preview".
 ---
 
 # Add Tool Visibility
 
 Adds live tool-call previews to chat. When the agent runs Bash, Read, Write,
-Edit, WebFetch, or sub-agent (Task/Agent) tools, a short message describing
-the call is written to the session's outbound DB and delivered into the same
-chat thread the user is conversing in. Slow Bash calls (> 3s) get a completion
-marker; failed calls get a ❌ marker with the reason; long-running Agent/Task
-calls get a "still working — Xs elapsed" tick every 30s. Scheduled-task
-sessions are suppressed entirely (no orphan previews from silent checks).
+Edit, WebFetch, Skill, or sub-agent (Task/Agent) tools, a short message
+describing the call is written to the session's outbound DB and delivered
+into the same chat thread the user is conversing in.
 
-This is a utility skill: it ships its code in this folder and copies it into
-the project. All logic lives in one skill-owned file; the single reach-in into
-core is appending two callbacks to the hook arrays the Claude provider already
-passes to the SDK.
+Behavior (what the hook actually does):
+
+- **Pre-call** — emoji + (for non-Bash tools) a verb-aligned label + a short
+  input summary. Bash prefers the tool's human `description` when present;
+  otherwise it summarizes the command (skips pure assignment prefixes, unwraps
+  common `ssh` / `$VAR`-as-ssh patterns, collapses heredocs, shortens
+  `bash script.sh` to the script basename). Paths are ellipsis-shortened;
+  URLs show domain only. Values that look like paths/commands/queries are
+  wrapped in backticks.
+- **Debounce** — Read / Write / Edit / MultiEdit / WebFetch within 300ms are
+  coalesced into one line with `×N`.
+- **Skip** — WebSearch, Glob, Grep (too noisy). Subagent transcripts under
+  `/subagents/` are skipped so only the top-level agent appears.
+- **Empty TodoWrite** — `todos: []` emits nothing.
+- **Failures** — `PostToolUseFailure` or heuristic error payloads emit
+  `❌  <intent>  · <reason>` (reason capped at 80 chars, surrogate-safe).
+- **Slow Bash** — after > 3s success, emits `✓  Xs` optionally with a result
+  shape (`N lines → first-line peek`, or size for other tools).
+- **Agent/Task progress** — after 30s, then every 30s: `⏳ still working — …`.
+- **Task sessions** — when the in-flight `processing_ack` batch is non-empty
+  and contains no chat-kind message, all emits are suppressed (scheduled-task
+  silent-on-OK). Classification uses the current turn's batch, not the
+  global-latest inbound row, so a mid-turn cron insert cannot silence a chat.
+- **`_toolVis: true`** — set on outbound content JSON so a host delivery
+  bridge can accumulate lines into one edited bubble if it supports that.
+  Bridges without that support ignore the flag and send normally.
+- **Truncation** — previews use `safeSlice` so a cut never leaves a lone
+  UTF-16 surrogate (half-emoji), which some backends reject as invalid UTF-8.
+- Failures inside the hook are swallowed; the agent turn always continues.
 
 | Tool | Pre-call message | Post-call message |
 |------|------------------|-------------------|
-| `Bash` | `🖥️ bash: <cmd-summary>` | `🖥️ bash: done in Xs` (only if > 3s) |
-| `Read` / `Write` / `Edit` / `MultiEdit` | `📖 read: <path>` (debounced ×N) | — |
-| `WebFetch` | `🌐 fetch: <domain>` (debounced ×N) | — |
+| `Bash` | `🖥️  <description or cmd-summary>` | `✓  Xs · <shape>` (only if > 3s) |
+| `Read` / `Write` / `Edit` / `MultiEdit` | `📖 read  <path>` (debounced ×N) | — |
+| `WebFetch` | `🌐 fetch  <domain>` (debounced ×N) | — |
+| `Skill` | `📚 skill  <name>` | — |
+| `TodoWrite` (non-empty) | `📝 todo  N tasks` | — |
 | `WebSearch` / `Glob` / `Grep` | (skipped — too noisy) | — |
-| `Task` / `Agent` (sub-agents) | `🤖 task: <description>` + 30s progress ticks | — |
-| any failed tool | — | `❌ <label>: ✗ <reason>` |
-| other / MCP tools | `🔧 <label>: <input-summary>` | — |
+| `Task` / `Agent` | `🤖 task  <description>` + 30s progress ticks | — |
+| any failed tool | — | `❌  <intent>  · <reason>` |
+| other / MCP tools | `🔧 <label>  <input-summary>` | — |
 
 ## Install
 
@@ -54,19 +78,18 @@ cp .claude/skills/add-tool-visibility/resources/tool-visibility-wiring.test.ts c
 ```
 
 - `tool-visibility.ts` — the hook implementations (`preToolUseVisibility`,
-  `postToolUseVisibility`) plus input summarizers, debouncing, and failure
-  detection. Writes through core's `writeMessageOut()` with routing from
-  `session_routing`; any failure inside the hook is swallowed so it can never
-  kill an agent turn.
-- `tool-visibility.test.ts` — behavior: drives the real hook callbacks against
-  the real in-memory session DBs and asserts a deliverable chat row lands in
-  `messages_out`. This is the guard for the hook's runtime consumption of core
-  DB state (outbound schema, `session_routing`, `messages_in.kind`).
-- `tool-visibility-wiring.test.ts` — the code edit in step 2: asserts (via the
-  TS AST) that `claude.ts` imports both visibility hooks from
+  `postToolUseVisibility`) plus input summarizers, debouncing, failure
+  detection, task-session classification, and surrogate-safe truncation.
+  Writes through core's `writeMessageOut()` with routing from
+  `session_routing`.
+- `tool-visibility.test.ts` — pure summarizer cases plus hook behavior
+  against the real in-memory session DBs (outbound schema, `session_routing`,
+  `messages_in.kind`, `processing_ack`).
+- `tool-visibility-wiring.test.ts` — asserts (via the TS AST) that
+  `claude.ts` imports both visibility hooks from
   `../hooks/tool-visibility.js` and that each is an element of the right hook
   array (`PreToolUse` / `PostToolUse` / `PostToolUseFailure`), placed after
-  the core hook in each array. Delete or misplace the edit and this goes red.
+  the core hook in each array.
 
 ### 2. Wire into the Claude provider
 
@@ -128,15 +151,15 @@ respawn; they pick up the visibility hooks on the next spawn.
 
 None. No environment variables, no credentials, no per-group setup. The hooks
 activate for every Claude-provider session that has a reply lane
-(`session_routing`); agent-shared/internal sessions and scheduled-task
-sessions stay silent by design.
+(`session_routing`); agent-shared/internal sessions and scheduled-task-only
+processing batches stay silent by design.
 
 ## Next steps
 
 In a wired chat, send a message that triggers a tool call (e.g. "list the
-files in /etc"). The chat shows `🖥️ bash: ls /etc` before the agent's
-final answer. Bash calls under 3 seconds produce no completion marker —
-that's the spam guard, not a bug.
+files in /etc"). The chat shows a Bash preview line before the agent's final
+answer. Bash calls under 3 seconds produce no completion marker — that is the
+spam guard, not a bug.
 
 ## Recipe entry
 

--- a/.claude/skills/add-tool-visibility/SKILL.md
+++ b/.claude/skills/add-tool-visibility/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: add-tool-visibility
+description: Add live chat-side visibility for agent tool calls — shows "🖥️ bash: <cmd>" before each tool call, failure markers, and duration markers after slow Bash. Surfaces what the agent is doing in real time during long multi-step runs. Triggers on "tool visibility", "live tool use", "show tool calls", "tool preview".
+---
+
+# Add Tool Visibility
+
+Adds live tool-call previews to chat. When the agent runs Bash, Read, Write,
+Edit, WebFetch, or sub-agent (Task/Agent) tools, a short message describing
+the call is written to the session's outbound DB and delivered into the same
+chat thread the user is conversing in. Slow Bash calls (> 3s) get a completion
+marker; failed calls get a ❌ marker with the reason; long-running Agent/Task
+calls get a "still working — Xs elapsed" tick every 30s. Scheduled-task
+sessions are suppressed entirely (no orphan previews from silent checks).
+
+This is a utility skill: it ships its code in this folder and copies it into
+the project. All logic lives in one skill-owned file; the single reach-in into
+core is appending two callbacks to the hook arrays the Claude provider already
+passes to the SDK.
+
+| Tool | Pre-call message | Post-call message |
+|------|------------------|-------------------|
+| `Bash` | `🖥️ bash: <cmd-summary>` | `🖥️ bash: done in Xs` (only if > 3s) |
+| `Read` / `Write` / `Edit` / `MultiEdit` | `📖 read: <path>` (debounced ×N) | — |
+| `WebFetch` | `🌐 fetch: <domain>` (debounced ×N) | — |
+| `WebSearch` / `Glob` / `Grep` | (skipped — too noisy) | — |
+| `Task` / `Agent` (sub-agents) | `🤖 task: <description>` + 30s progress ticks | — |
+| any failed tool | — | `❌ <label>: ✗ <reason>` |
+| other / MCP tools | `🔧 <label>: <input-summary>` | — |
+
+## Install
+
+### Pre-flight
+
+If all of the following are already present, skip to **Validate**:
+
+- `container/agent-runner/src/hooks/tool-visibility.ts`
+- `container/agent-runner/src/hooks/tool-visibility.test.ts`
+- `container/agent-runner/src/hooks/tool-visibility-wiring.test.ts`
+- an import of `preToolUseVisibility` in `container/agent-runner/src/providers/claude.ts`
+
+Missing pieces — continue below. All steps are idempotent; re-running is safe.
+
+### 1. Copy the hook module and its tests
+
+Wholesale copies (owned entirely by this skill — user edits to these files
+won't survive a re-run, as designed):
+
+```bash
+mkdir -p container/agent-runner/src/hooks
+cp .claude/skills/add-tool-visibility/resources/tool-visibility.ts             container/agent-runner/src/hooks/tool-visibility.ts
+cp .claude/skills/add-tool-visibility/resources/tool-visibility.test.ts        container/agent-runner/src/hooks/tool-visibility.test.ts
+cp .claude/skills/add-tool-visibility/resources/tool-visibility-wiring.test.ts container/agent-runner/src/hooks/tool-visibility-wiring.test.ts
+```
+
+- `tool-visibility.ts` — the hook implementations (`preToolUseVisibility`,
+  `postToolUseVisibility`) plus input summarizers, debouncing, and failure
+  detection. Writes through core's `writeMessageOut()` with routing from
+  `session_routing`; any failure inside the hook is swallowed so it can never
+  kill an agent turn.
+- `tool-visibility.test.ts` — behavior: drives the real hook callbacks against
+  the real in-memory session DBs and asserts a deliverable chat row lands in
+  `messages_out`. This is the guard for the hook's runtime consumption of core
+  DB state (outbound schema, `session_routing`, `messages_in.kind`).
+- `tool-visibility-wiring.test.ts` — the code edit in step 2: asserts (via the
+  TS AST) that `claude.ts` imports both visibility hooks from
+  `../hooks/tool-visibility.js` and that each is an element of the right hook
+  array (`PreToolUse` / `PostToolUse` / `PostToolUseFailure`), placed after
+  the core hook in each array. Delete or misplace the edit and this goes red.
+
+### 2. Wire into the Claude provider
+
+This is the skill's one integration point, in
+`container/agent-runner/src/providers/claude.ts`. It is two appends: one
+import line, and the two hook names appended to the three existing hook
+arrays. All logic stays in the skill's own file.
+
+**Re-run check:** if `preToolUseVisibility` already appears in the file, this
+step is done — do not append a second time.
+
+Add the import below the existing `../db/connection.js` import:
+
+```typescript
+import { postToolUseVisibility, preToolUseVisibility } from '../hooks/tool-visibility.js';
+```
+
+In the `hooks:` options object inside `ClaudeProvider.query()`, append the
+visibility hooks to the three arrays — **after** the existing core hooks, so
+`container_state` recording always runs first:
+
+```typescript
+        hooks: {
+          PreToolUse: [{ hooks: [preToolUseHook, preToolUseVisibility] }],
+          PostToolUse: [{ hooks: [postToolUseHook, postToolUseVisibility] }],
+          PostToolUseFailure: [{ hooks: [postToolUseHook, postToolUseVisibility] }],
+          PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+        },
+```
+
+(`PreCompact` is unchanged — shown only to anchor the block.)
+
+### 3. Validate
+
+Run from your NanoClaw project root:
+
+```bash
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit   # container typecheck — guards symbol/path drift
+cd container/agent-runner
+bun install                                                       # only needed if node_modules is missing
+bun test src/hooks/                                               # behavior + wiring guards
+cd ../..
+```
+
+All must be green before proceeding. Then rebuild the agent image and restart
+so new sessions pick up the hooks:
+
+```bash
+./container/build.sh
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
+# or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+```
+
+Already-running container sessions keep their old image until they exit and
+respawn; they pick up the visibility hooks on the next spawn.
+
+## Configuration
+
+None. No environment variables, no credentials, no per-group setup. The hooks
+activate for every Claude-provider session that has a reply lane
+(`session_routing`); agent-shared/internal sessions and scheduled-task
+sessions stay silent by design.
+
+## Next steps
+
+In a wired chat, send a message that triggers a tool call (e.g. "list the
+files in /etc"). The chat shows `🖥️ bash: ls /etc` before the agent's
+final answer. Bash calls under 3 seconds produce no completion marker —
+that's the spam guard, not a bug.
+
+## Recipe entry
+
+Independent — no dependency on other skills and no ordering constraint.
+Applies to the Claude provider only; groups running another provider
+(`agent_provider` ≠ claude) are unaffected. Needs the agent-image rebuild
+(step 3) after apply; when composing several image-touching skills in one
+recipe run, one rebuild at the end covers them all.
+
+To back this skill out, follow [REMOVE.md](REMOVE.md).

--- a/.claude/skills/add-tool-visibility/resources/tool-visibility-wiring.test.ts
+++ b/.claude/skills/add-tool-visibility/resources/tool-visibility-wiring.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Wiring test for the add-tool-visibility skill's code-edit integration point.
+ *
+ * The skill appends two hook callbacks to the hook arrays the Claude provider
+ * passes to the SDK in `ClaudeProvider.query()` (src/providers/claude.ts).
+ * That edit is not invocable hermetically — calling `query()` spawns the real
+ * Claude Code SDK subprocess, and the hooks config is an options literal with
+ * no runtime registry to inspect — so this asserts the edit *structurally*,
+ * via the TypeScript AST. It verifies not just that the symbols appear, but
+ * that:
+ *   - claude.ts statically imports `preToolUseVisibility` and
+ *     `postToolUseVisibility` from '../hooks/tool-visibility.js',
+ *   - `preToolUseVisibility` is an element of the inner `hooks` array of the
+ *     PreToolUse matcher,
+ *   - `postToolUseVisibility` is an element of the inner `hooks` arrays of
+ *     BOTH the PostToolUse and PostToolUseFailure matchers,
+ *   - each visibility hook comes AFTER the core hook in its array
+ *     (`preToolUseHook` / `postToolUseHook`), so container_state recording
+ *     still runs first even if visibility throws.
+ *
+ * Delete the import, drop a hook from an array, or flip the ordering and this
+ * goes red. Combined with the behavior test (tool-visibility.test.ts, the
+ * hook's consumption of the real session DBs) and the container typecheck
+ * (drifted symbols/paths), the three legs cover deletion, misplacement,
+ * drift, and core consumption.
+ *
+ * Ships with the skill; apply copies it to container/agent-runner/src/hooks/.
+ */
+import { describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+
+import ts from 'typescript';
+
+const claudePath = path.resolve(import.meta.dir, '../providers/claude.ts');
+const source = fs.readFileSync(claudePath, 'utf8');
+const sf = ts.createSourceFile('claude.ts', source, ts.ScriptTarget.Latest, true);
+
+/** Named imports from '../hooks/tool-visibility.js', or null if absent. */
+function visibilityImportNames(): string[] | null {
+  let names: string[] | null = null;
+  sf.forEachChild((n) => {
+    if (
+      ts.isImportDeclaration(n) &&
+      ts.isStringLiteral(n.moduleSpecifier) &&
+      n.moduleSpecifier.text === '../hooks/tool-visibility.js'
+    ) {
+      const bindings = n.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        names = bindings.elements.map((e) => e.name.text);
+      }
+    }
+  });
+  return names;
+}
+
+/**
+ * Find the `hooks:` options property (the object literal keyed by hook event
+ * names) and return, per event, the identifier names listed in the inner
+ * `hooks: [...]` arrays of its matchers, in source order.
+ */
+function hookIdentifiersByEvent(): Map<string, string[]> {
+  const events = new Map<string, string[]>();
+
+  function innerHookNames(matcherArray: ts.ArrayLiteralExpression): string[] {
+    const names: string[] = [];
+    for (const matcher of matcherArray.elements) {
+      if (!ts.isObjectLiteralExpression(matcher)) continue;
+      for (const prop of matcher.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          ts.isIdentifier(prop.name) &&
+          prop.name.text === 'hooks' &&
+          ts.isArrayLiteralExpression(prop.initializer)
+        ) {
+          for (const el of prop.initializer.elements) {
+            if (ts.isIdentifier(el)) names.push(el.text);
+            else names.push(el.getText(sf)); // e.g. createPreCompactHook(...)
+          }
+        }
+      }
+    }
+    return names;
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'hooks' &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      // The hooks *options* object is keyed by hook event names; a matcher's
+      // inner `hooks` array holds callbacks, not an object literal — that's
+      // how we tell the two apart.
+      for (const prop of node.initializer.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          ts.isIdentifier(prop.name) &&
+          ts.isArrayLiteralExpression(prop.initializer)
+        ) {
+          events.set(prop.name.text, innerHookNames(prop.initializer));
+        }
+      }
+    }
+    node.forEachChild(visit);
+  }
+  visit(sf);
+  return events;
+}
+
+describe('add-tool-visibility wiring in src/providers/claude.ts', () => {
+  it("imports both visibility hooks from '../hooks/tool-visibility.js'", () => {
+    const names = visibilityImportNames();
+    expect(names, "static import from '../hooks/tool-visibility.js' must exist").not.toBeNull();
+    expect(names).toContain('preToolUseVisibility');
+    expect(names).toContain('postToolUseVisibility');
+  });
+
+  it('appends preToolUseVisibility to the PreToolUse hook array, after the core hook', () => {
+    const pre = hookIdentifiersByEvent().get('PreToolUse') ?? [];
+    const coreIdx = pre.indexOf('preToolUseHook');
+    const visIdx = pre.indexOf('preToolUseVisibility');
+    expect(coreIdx, 'core preToolUseHook anchor not found in PreToolUse').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'preToolUseVisibility must be wired into PreToolUse').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'visibility must run after the core hook (container_state first)').toBeGreaterThan(coreIdx);
+  });
+
+  it('appends postToolUseVisibility to the PostToolUse hook array, after the core hook', () => {
+    const post = hookIdentifiersByEvent().get('PostToolUse') ?? [];
+    const coreIdx = post.indexOf('postToolUseHook');
+    const visIdx = post.indexOf('postToolUseVisibility');
+    expect(coreIdx, 'core postToolUseHook anchor not found in PostToolUse').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'postToolUseVisibility must be wired into PostToolUse').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'visibility must run after the core hook (container_state first)').toBeGreaterThan(coreIdx);
+  });
+
+  it('appends postToolUseVisibility to the PostToolUseFailure hook array, after the core hook', () => {
+    const fail = hookIdentifiersByEvent().get('PostToolUseFailure') ?? [];
+    const coreIdx = fail.indexOf('postToolUseHook');
+    const visIdx = fail.indexOf('postToolUseVisibility');
+    expect(coreIdx, 'core postToolUseHook anchor not found in PostToolUseFailure').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'postToolUseVisibility must be wired into PostToolUseFailure').toBeGreaterThanOrEqual(0);
+    expect(visIdx, 'visibility must run after the core hook (container_state first)').toBeGreaterThan(coreIdx);
+  });
+});

--- a/.claude/skills/add-tool-visibility/resources/tool-visibility.test.ts
+++ b/.claude/skills/add-tool-visibility/resources/tool-visibility.test.ts
@@ -1,32 +1,44 @@
 /**
- * Behavior test for how the tool-visibility hooks consume core: the
- * session-DB layer (`writeMessageOut` into outbound.db, `session_routing`
- * and `messages_in` reads from inbound.db).
+ * Behavior tests for the tool-visibility hooks: pure input summarizers and
+ * the session-DB layer (`writeMessageOut` into outbound.db, `session_routing`
+ * and `messages_in` / `processing_ack` reads).
  *
  * The wiring into the Claude provider is guarded separately by the
  * structural test (tool-visibility-wiring.test.ts); this test drives the
  * real hook callbacks against the real in-memory session DBs from
  * `initTestSessionDb()` and asserts a deliverable chat row lands in
  * messages_out. It goes red when core's outbound schema, the
- * session_routing shape, or the messages_in `kind` column drift away from
- * what the hook assumes.
+ * session_routing shape, or the messages_in / processing_ack contract
+ * drifts away from what the hook assumes.
  *
- * Note on ordering: tool-visibility.ts caches its task-session check
- * (latest messages_in.kind) once per process, so the first test seeds a
- * 'chat' message before any hook runs and the suite relies on that cached
- * non-task verdict throughout.
+ * Task-session suppression classifies on the in-flight processing_ack
+ * batch (not a process-global cache of the latest messages_in.kind).
+ * Tests that need tool-vis on seed a chat message + matching processing
+ * ack; task-only wakes seed a task message + ack.
  *
  * Ships with the skill; apply copies it to container/agent-runner/src/hooks/.
  */
 import { beforeEach, describe, expect, test } from 'bun:test';
 
-import { getOutboundDb, initTestSessionDb } from '../db/connection.js';
-import { postToolUseVisibility, preToolUseVisibility } from './tool-visibility.js';
+import { getInboundDb, getOutboundDb, initTestSessionDb } from '../db/connection.js';
+import {
+  describeToolInput,
+  postToolUseVisibility,
+  preToolUseVisibility,
+  safeSlice,
+  summarizeBash,
+  summarizeHeredoc,
+} from './tool-visibility.js';
 
 const hookOptions = { signal: new AbortController().signal };
 
-function seedInbound(opts: { routing: boolean }): void {
-  const { inbound } = initTestSessionDb();
+function seedInbound(opts: {
+  routing: boolean;
+  kind?: 'chat' | 'task';
+  messageId?: string;
+  processing?: boolean;
+}): void {
+  const { inbound, outbound } = initTestSessionDb();
   // The shipped test schema has no session_routing table (the host creates
   // it at spawn); add it here to mirror the real inbound.db.
   if (opts.routing) {
@@ -42,12 +54,25 @@ function seedInbound(opts: { routing: boolean }): void {
       .prepare('INSERT INTO session_routing (id, channel_type, platform_id, thread_id) VALUES (1, ?, ?, ?)')
       .run('telegram', 'tg-12345', null);
   }
+  const messageId = opts.messageId ?? 'm-1';
+  const kind = opts.kind ?? 'chat';
   inbound
     .prepare(
       `INSERT INTO messages_in (id, seq, kind, timestamp, content)
-       VALUES ('m-1', 2, 'chat', ?, '{"text":"hi"}')`,
+       VALUES (?, 2, ?, ?, '{"text":"hi"}')`,
     )
-    .run(new Date().toISOString());
+    .run(messageId, kind, new Date().toISOString());
+
+  // isTaskSession() reads processing_ack for the in-flight batch. Seed a
+  // matching ack so chat turns show tool-vis and task-only turns suppress.
+  if (opts.processing !== false) {
+    outbound
+      .prepare(
+        `INSERT INTO processing_ack (message_id, status, status_changed)
+         VALUES (?, 'processing', ?)`,
+      )
+      .run(messageId, new Date().toISOString());
+  }
 }
 
 function outboundRows(): Array<{ kind: string; platform_id: string | null; channel_type: string | null; content: string }> {
@@ -56,9 +81,69 @@ function outboundRows(): Array<{ kind: string; platform_id: string | null; chann
     .all() as Array<{ kind: string; platform_id: string | null; channel_type: string | null; content: string }>;
 }
 
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = s.charCodeAt(i + 1);
+      if (!(n >= 0xdc00 && n <= 0xdfff)) return true;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) return true;
+  }
+  return false;
+}
+
+describe('tool-visibility pure summarizers', () => {
+  test('safeSlice never leaves a lone UTF-16 high surrogate', () => {
+    const line = 'x'.repeat(149) + '📊 rest';
+    const cut = safeSlice(line, 150);
+    expect(hasLoneSurrogate(cut)).toBe(false);
+    expect(cut.length).toBe(149);
+    expect(safeSlice('hello world', 5)).toBe('hello');
+    expect(safeSlice('a📊b', 3)).toBe('a📊');
+  });
+
+  test('describeToolInput prefers Bash description over command', () => {
+    expect(
+      describeToolInput('Bash', {
+        description: 'Inspect the merge conflict',
+        command: 'git status',
+      }),
+    ).toBe('Inspect the merge conflict');
+    expect(describeToolInput('Bash', { description: 'x'.repeat(81), command: 'git status' })).toBe(
+      `${'x'.repeat(80)}…`,
+    );
+  });
+
+  test('describeToolInput falls back to summarized command without description', () => {
+    expect(describeToolInput('Bash', { command: 'git status' })).toBe('`git status`');
+  });
+
+  test('summarizeBash skips pure assignment segments before the real command', () => {
+    // Generic wrapper pattern: assign a launcher, then invoke it.
+    const cmd = 'SSH_CMD="ssh -i /keys/id_ed25519" && $SSH_CMD root@host.example "df -h"';
+    expect(summarizeBash(cmd)).toBe('ssh root@host.example: df -h');
+  });
+
+  test('summarizeBash collapses heredocs and bare bash scripts', () => {
+    const heredoc = `python3 <<"PY"
+import re
+print("done")
+PY`;
+    expect(summarizeHeredoc(heredoc)).toBe('python3 «PY» import re…');
+    expect(summarizeBash('bash /tmp/scripts/deploy.sh')).toBe('deploy.sh');
+  });
+
+  test('describeToolInput renders Skill and non-Bash tools', () => {
+    expect(describeToolInput('Skill', { skill: 'add-discord' })).toBe('`add-discord`');
+    expect(describeToolInput('Read', { file_path: '/tmp/example.ts' })).toBe('`/tmp/example.ts`');
+    expect(describeToolInput('TodoWrite', { todos: [{}, {}] })).toBe('2 tasks');
+  });
+});
+
 describe('tool-visibility hooks against the real session DBs', () => {
   beforeEach(() => {
-    seedInbound({ routing: true });
+    seedInbound({ routing: true, kind: 'chat' });
   });
 
   test('PreToolUse(Bash) writes a deliverable chat preview into messages_out', async () => {
@@ -74,9 +159,24 @@ describe('tool-visibility hooks against the real session DBs', () => {
     expect(rows[0].kind).toBe('chat');
     expect(rows[0].platform_id).toBe('tg-12345');
     expect(rows[0].channel_type).toBe('telegram');
-    const content = JSON.parse(rows[0].content) as { text: string };
+    const content = JSON.parse(rows[0].content) as { text: string; _toolVis?: boolean };
     expect(content.text).toContain('git status');
     expect(content.text).toContain('🖥️');
+    expect(content._toolVis).toBe(true);
+  });
+
+  test('PreToolUse(Bash) prefers description in the preview line', async () => {
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { description: 'Check git status', command: 'git status --short' },
+    };
+    await preToolUseVisibility(input as never, 'tu-desc', hookOptions);
+    const content = JSON.parse(outboundRows()[0].content) as { text: string };
+    expect(content.text).toContain('Check git status');
+    // Description-first: no redundant "bash" verb label, no backtick-wrapped command.
+    expect(content.text).not.toMatch(/bash\s/);
+    expect(content.text).not.toContain('git status --short');
   });
 
   test('PostToolUseFailure emits a failure marker with the error reason', async () => {
@@ -93,6 +193,7 @@ describe('tool-visibility hooks against the real session DBs', () => {
     const content = JSON.parse(rows[0].content) as { text: string };
     expect(content.text).toContain('❌');
     expect(content.text).toContain('exit code 1');
+    expect(content.text).toContain('·');
   });
 
   test('a session without a reply lane stays silent (no messages_out row)', async () => {
@@ -104,5 +205,59 @@ describe('tool-visibility hooks against the real session DBs', () => {
     };
     await preToolUseVisibility(input as never, 'tu-3', hookOptions);
     expect(outboundRows().length).toBe(0);
+  });
+
+  test('empty TodoWrite is suppressed', async () => {
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [] },
+    };
+    await preToolUseVisibility(input as never, 'tu-todo0', hookOptions);
+    expect(outboundRows().length).toBe(0);
+  });
+
+  test('non-empty TodoWrite still emits', async () => {
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ content: 'a' }, { content: 'b' }] },
+    };
+    await preToolUseVisibility(input as never, 'tu-todo2', hookOptions);
+    const content = JSON.parse(outboundRows()[0].content) as { text: string };
+    expect(content.text).toContain('2 tasks');
+    expect(content.text).toContain('📝');
+  });
+
+  test('task-only processing batch suppresses tool-vis', async () => {
+    seedInbound({ routing: true, kind: 'task', messageId: 'task-1' });
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'df -h' },
+    };
+    await preToolUseVisibility(input as never, 'tu-task', hookOptions);
+    expect(outboundRows().length).toBe(0);
+  });
+
+  test('mid-turn task row that is not in processing_ack does not silence a chat turn', async () => {
+    // Interactive chat is the processing batch; a later cron task is only
+    // pending in messages_in and must not flip tool-vis off.
+    seedInbound({ routing: true, kind: 'chat', messageId: 'chat-1' });
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, seq, kind, timestamp, content)
+         VALUES ('cron-mid', 3, 'task', ?, '{"text":"monitor"}')`,
+      )
+      .run(new Date().toISOString());
+    // No processing_ack for cron-mid — it is still pending.
+
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo ok' },
+    };
+    await preToolUseVisibility(input as never, 'tu-chat', hookOptions);
+    expect(outboundRows().length).toBe(1);
   });
 });

--- a/.claude/skills/add-tool-visibility/resources/tool-visibility.test.ts
+++ b/.claude/skills/add-tool-visibility/resources/tool-visibility.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Behavior test for how the tool-visibility hooks consume core: the
+ * session-DB layer (`writeMessageOut` into outbound.db, `session_routing`
+ * and `messages_in` reads from inbound.db).
+ *
+ * The wiring into the Claude provider is guarded separately by the
+ * structural test (tool-visibility-wiring.test.ts); this test drives the
+ * real hook callbacks against the real in-memory session DBs from
+ * `initTestSessionDb()` and asserts a deliverable chat row lands in
+ * messages_out. It goes red when core's outbound schema, the
+ * session_routing shape, or the messages_in `kind` column drift away from
+ * what the hook assumes.
+ *
+ * Note on ordering: tool-visibility.ts caches its task-session check
+ * (latest messages_in.kind) once per process, so the first test seeds a
+ * 'chat' message before any hook runs and the suite relies on that cached
+ * non-task verdict throughout.
+ *
+ * Ships with the skill; apply copies it to container/agent-runner/src/hooks/.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { getOutboundDb, initTestSessionDb } from '../db/connection.js';
+import { postToolUseVisibility, preToolUseVisibility } from './tool-visibility.js';
+
+const hookOptions = { signal: new AbortController().signal };
+
+function seedInbound(opts: { routing: boolean }): void {
+  const { inbound } = initTestSessionDb();
+  // The shipped test schema has no session_routing table (the host creates
+  // it at spawn); add it here to mirror the real inbound.db.
+  if (opts.routing) {
+    inbound.exec(`
+      CREATE TABLE IF NOT EXISTS session_routing (
+        id           INTEGER PRIMARY KEY CHECK (id = 1),
+        channel_type TEXT,
+        platform_id  TEXT,
+        thread_id    TEXT
+      );
+    `);
+    inbound
+      .prepare('INSERT INTO session_routing (id, channel_type, platform_id, thread_id) VALUES (1, ?, ?, ?)')
+      .run('telegram', 'tg-12345', null);
+  }
+  inbound
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, content)
+       VALUES ('m-1', 2, 'chat', ?, '{"text":"hi"}')`,
+    )
+    .run(new Date().toISOString());
+}
+
+function outboundRows(): Array<{ kind: string; platform_id: string | null; channel_type: string | null; content: string }> {
+  return getOutboundDb()
+    .prepare('SELECT kind, platform_id, channel_type, content FROM messages_out ORDER BY seq')
+    .all() as Array<{ kind: string; platform_id: string | null; channel_type: string | null; content: string }>;
+}
+
+describe('tool-visibility hooks against the real session DBs', () => {
+  beforeEach(() => {
+    seedInbound({ routing: true });
+  });
+
+  test('PreToolUse(Bash) writes a deliverable chat preview into messages_out', async () => {
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+    };
+    await preToolUseVisibility(input as never, 'tu-1', hookOptions);
+
+    const rows = outboundRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].kind).toBe('chat');
+    expect(rows[0].platform_id).toBe('tg-12345');
+    expect(rows[0].channel_type).toBe('telegram');
+    const content = JSON.parse(rows[0].content) as { text: string };
+    expect(content.text).toContain('git status');
+    expect(content.text).toContain('🖥️');
+  });
+
+  test('PostToolUseFailure emits a failure marker with the error reason', async () => {
+    const input = {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash',
+      tool_input: { command: 'false' },
+      error: 'exit code 1',
+    };
+    await postToolUseVisibility(input as never, 'tu-2', hookOptions);
+
+    const rows = outboundRows();
+    expect(rows.length).toBe(1);
+    const content = JSON.parse(rows[0].content) as { text: string };
+    expect(content.text).toContain('❌');
+    expect(content.text).toContain('exit code 1');
+  });
+
+  test('a session without a reply lane stays silent (no messages_out row)', async () => {
+    seedInbound({ routing: false });
+    const input = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+    };
+    await preToolUseVisibility(input as never, 'tu-3', hookOptions);
+    expect(outboundRows().length).toBe(0);
+  });
+});

--- a/.claude/skills/add-tool-visibility/resources/tool-visibility.ts
+++ b/.claude/skills/add-tool-visibility/resources/tool-visibility.ts
@@ -1,0 +1,478 @@
+/**
+ * Live tool-use visibility — emits chat messages describing each tool
+ * call as the agent runs. Ported from v1 (`container/agent-runner/src/index.ts`
+ * tool-hooks block) onto v2's outbound DB + Bun runtime.
+ *
+ * Strategy:
+ *   PreToolUse  → "🔧 label: short description"
+ *   PostToolUse → "✅ label: Xs" (only for slow Bash, > 3s)
+ *
+ * Rapid file I/O (Read/Write/Edit/WebFetch) is debounced 300ms and coalesced
+ * into a single "×N" message to prevent chat spam. Noisy tools (WebSearch,
+ * Glob, Grep) are skipped entirely.
+ *
+ * Messages are written to outbound.db via writeMessageOut() with routing
+ * pulled from session_routing (default reply lane). The host's delivery
+ * loop picks them up and sends them through the same channel adapter the
+ * rest of the chat goes through.
+ */
+import path from 'path';
+
+import type { HookCallback } from '@anthropic-ai/claude-agent-sdk';
+
+import { writeMessageOut } from '../db/messages-out.js';
+import { getSessionRouting } from '../db/session-routing.js';
+import { getInboundDb } from '../db/connection.js';
+
+// Detect whether this agent turn was triggered by a scheduled-task wake-up
+// (vs. an interactive chat message). Scheduled tasks often run with explicit
+// silent-on-OK behavior — leaking tool-call previews to chat creates orphan-
+// notification noise without context. We cache per-process so the first turn
+// after spawn determines the policy.
+let _isTaskSession: boolean | null = null;
+function isTaskSession(): boolean {
+  if (_isTaskSession !== null) return _isTaskSession;
+  try {
+    const db = getInboundDb();
+    const row = db.prepare("SELECT kind FROM messages_in ORDER BY seq DESC LIMIT 1").get() as { kind?: string } | undefined;
+    _isTaskSession = row?.kind === 'task';
+  } catch { _isTaskSession = false; }
+  return _isTaskSession;
+}
+
+const SKIP_TOOLS = new Set(['WebSearch', 'Glob', 'Grep']);
+
+const MAX_INPUT_PREVIEW = 120;
+const LONG_CALL_THRESHOLD_MS = 3000;
+const PROGRESS_FIRST_DELAY_MS = 30000;  // first progress msg at 30s
+const PROGRESS_INTERVAL_MS = 30000;     // then every 30s
+
+const TOOL_EMOJI: Record<string, string> = {
+  Bash: '🖥️',
+  Read: '📖',
+  Write: '✍️',
+  Edit: '✏️',
+  MultiEdit: '✏️',
+  WebFetch: '🌐',
+  WebSearch: '🌐',
+  Agent: '🤖',
+  Task: '🤖',
+  TodoWrite: '📝',
+};
+
+const TOOL_LABEL: Record<string, string> = {
+  Bash: 'bash',
+  Read: 'read',
+  Write: 'write',
+  Edit: 'edit',
+  MultiEdit: 'edit',
+  WebFetch: 'fetch',
+  WebSearch: 'search',
+  Agent: 'agent',
+  Task: 'task',
+  TodoWrite: 'todo',
+};
+
+const BATCH_TOOLS = new Set(['Read', 'Write', 'Edit', 'MultiEdit', 'WebFetch']);
+
+const BASH_WITH_SUBCOMMAND = new Set([
+  'git', 'npm', 'pnpm', 'bun', 'apt', 'apt-get', 'pip', 'pip3',
+  'systemctl', 'docker', 'yarn', 'uv', 'gh', 'ssh',
+]);
+
+function log(msg: string): void {
+  console.error(`[tool-visibility] ${msg}`);
+}
+
+function truncate(s: string): string {
+  return s.length > MAX_INPUT_PREVIEW ? s.slice(0, MAX_INPUT_PREVIEW) + '…' : s;
+}
+
+/** Extract domain from URL — keeps preview compact ("github.com" not full URL). */
+function domainOf(url: string): string {
+  return url.replace(/^https?:\/\//, '').split('/')[0];
+}
+
+/** Shorten long file paths from the start with an ellipsis prefix. */
+function shortPath(p: string, maxLen = 35): string {
+  if (p.length <= maxLen) return p;
+  return '…' + p.slice(-(maxLen - 1));
+}
+
+/** Format a tool message with verb-aligned label for easier scanning. */
+function formatToolLine(emoji: string, label: string, desc: string, count = 0): string {
+  const countStr = count > 1 ? ` ×${count}` : '';
+  // Pad label so descriptions align vertically across tool calls.
+  const paddedLabel = label.padEnd(8);
+  return desc ? `${emoji} ${paddedLabel}${countStr} ${desc}`.trimEnd()
+              : `${emoji} ${paddedLabel.trimEnd()}${countStr}`;
+}
+
+/**
+ * Try to extract a string output from a tool_response of unknown shape.
+ * Returns null if nothing string-y is found.
+ */
+function extractResponseText(toolResponse: unknown): string | null {
+  if (toolResponse == null) return null;
+  if (typeof toolResponse === 'string') return toolResponse;
+  if (typeof toolResponse === 'object') {
+    const r = toolResponse as Record<string, unknown>;
+    if (typeof r.output === 'string') return r.output;
+    if (typeof r.text === 'string') return r.text;
+    if (typeof r.content === 'string') return r.content;
+    if (typeof r.stdout === 'string') return r.stdout;
+  }
+  return null;
+}
+
+/**
+ * Compact post-completion result hint — line counts, response sizes, exit codes.
+ * Returns null when there's nothing interesting to add (avoids chat spam).
+ */
+function resultShape(toolName: string, toolResponse: unknown): string | null {
+  const text = extractResponseText(toolResponse);
+  if (toolName === 'Read' && text) {
+    const lines = text.split('\n').length;
+    return `${lines} lines`;
+  }
+  if (toolName === 'Bash' && text) {
+    const allLines = text.split('\n');
+    const nonEmpty = allLines.filter((l) => l.trim()).length;
+    if (nonEmpty < 1) return null;
+    // Show first non-empty line as a sneak-peek; useful confirmation that
+    // the command actually produced what was expected. Trim to keep the
+    // chat-line compact.
+    const firstLine = allLines.find((l) => l.trim()) || '';
+    const peek = firstLine.replace(/\s+/g, ' ').trim().slice(0, 60);
+    if (nonEmpty >= 5) {
+      return peek ? `${nonEmpty} lines  → \`${peek}\`` : `${nonEmpty} lines`;
+    }
+    if (peek) return `→ \`${peek}\``;
+    return null;
+  }
+  if (toolName === 'WebFetch' && text) {
+    const kb = Math.round(text.length / 1024);
+    if (kb >= 1) return `${kb}KB`;
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Heuristic failure detection from a normal PostToolUse response. Some tools
+ * report errors via the response payload rather than throwing — this catches
+ * those so we still emit the ❌ marker.
+ */
+function detectFailureFromResponse(_toolName: string, toolResponse: unknown): string | null {
+  if (toolResponse == null) return null;
+  if (typeof toolResponse === 'object') {
+    const r = toolResponse as Record<string, unknown>;
+    if (r.is_error === true || r.success === false) {
+      const explicit = typeof r.error === 'string' ? r.error
+        : typeof r.message === 'string' ? r.message
+        : 'failed';
+      return explicit.replace(/\s+/g, ' ').trim().slice(0, 80);
+    }
+    if (typeof r.error === 'string' && r.error.trim()) {
+      return r.error.replace(/\s+/g, ' ').trim().slice(0, 80);
+    }
+  }
+  const text = extractResponseText(toolResponse);
+  if (!text) return null;
+  // Pattern-based fallback. Conservative — only flag clear failures.
+  const patterns: RegExp[] = [
+    /^(Error|ERROR): (.+)$/m,
+    /(permission denied)/i,
+    /(no such file or directory)/i,
+    /(command not found)/i,
+    /(Traceback \(most recent call last\))/,
+  ];
+  for (const p of patterns) {
+    const m = text.match(p);
+    if (m) return m[0].replace(/\s+/g, ' ').trim().slice(0, 80);
+  }
+  return null;
+}
+
+/** Extract the meaningful part of a bash command for the preview. */
+function summarizeBash(raw: string): string {
+  const cmd = raw.replace(/\s+/g, ' ').trim();
+
+  // Split into segments by command connectors and skip ones that are pure
+  // variable-assignment blocks (e.g. `SSHK="ssh -i ..."` before `&& $SSHK ...`).
+  // Without this, long ssh-wrapper assignments at the start eat the whole preview.
+  const segments = cmd.split(/\s*(?:&&|\|\||;|\|)\s*/).map(s => s.trim()).filter(Boolean);
+  const isPureAssignment = (s: string) =>
+    /^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s*)+$/.test(s);
+  let first = segments[0] ?? '';
+  for (const seg of segments) {
+    if (isPureAssignment(seg)) continue;
+    // Also strip leading inline `VAR=value VAR2=value cmd ...` assignments
+    first = seg.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
+    break;
+  }
+
+  const stripped = first.replace(/^sudo\s+/, '');
+  const words = stripped.split(' ');
+  const bin = path.basename(words[0] ?? '');
+  const sub = words[1] ?? '';
+
+  // Treat `$VAR root@host …` as ssh-like — common pattern for SSH-key-bundle aliases.
+  const isSshLike = bin === 'ssh' || /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(words[0] ?? '');
+  if (isSshLike) {
+    // Skip leading flags so we don't mistake `-i` / `-o` / etc. for the host.
+    // Flags that take an argument consume the next word too.
+    const sshFlagsWithArg = new Set(['-i', '-o', '-p', '-J', '-F', '-L', '-R', '-D', '-l', '-c', '-m', '-b', '-B', '-e', '-I', '-Q', '-S', '-W', '-w']);
+    const sshArgs = words.slice(1);
+    let idx = 0;
+    while (idx < sshArgs.length) {
+      const a = sshArgs[idx];
+      if (sshFlagsWithArg.has(a)) {
+        idx += 2;
+        continue;
+      }
+      if (a.startsWith('-')) {
+        idx += 1;
+        continue;
+      }
+      break;
+    }
+    const host = sshArgs[idx];
+    if (host) {
+      const afterHost = sshArgs.slice(idx + 1).join(' ');
+      const remoteCmd = afterHost.replace(/^["']|["']$/g, '').trim();
+      return truncate(remoteCmd ? `ssh ${host}: ${remoteCmd}` : `ssh ${host}`);
+    }
+    return truncate(first);
+  }
+  if (BASH_WITH_SUBCOMMAND.has(bin) && sub && !sub.startsWith('-')) {
+    return truncate(`${bin} ${sub}`);
+  }
+  return truncate(first);
+}
+
+/** Human-readable summary of a tool's input. */
+function describeToolInput(toolName: string, toolInput: unknown): string {
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  const input = toolInput as Record<string, unknown>;
+
+  if (toolName === 'Bash' && typeof input.command === 'string') {
+    return `\`${summarizeBash(input.command)}\``;
+  }
+  if ((toolName === 'Read' || toolName === 'Write' || toolName === 'Edit' || toolName === 'MultiEdit') && typeof input.file_path === 'string') {
+    return `\`${shortPath(input.file_path)}\``;
+  }
+  if (toolName === 'Glob' && typeof input.pattern === 'string') {
+    return `\`${input.pattern}\``;
+  }
+  if (toolName === 'Grep' && typeof input.pattern === 'string') {
+    return `\`${input.pattern}\``;
+  }
+  if (toolName === 'WebFetch' && typeof input.url === 'string') {
+    return `\`${domainOf(input.url)}\``;
+  }
+  if (toolName === 'WebSearch' && typeof input.query === 'string') {
+    return `\`${truncate(input.query)}\``;
+  }
+  if (toolName === 'Task' && typeof input.description === 'string') {
+    return truncate(input.description);
+  }
+  if (toolName === 'TodoWrite' && Array.isArray(input.todos)) {
+    const n = input.todos.length;
+    return `${n} task${n === 1 ? '' : 's'}`;
+  }
+
+  for (const val of Object.values(input)) {
+    if (typeof val === 'string' && val.length > 0) {
+      return truncate(val.replace(/\s+/g, ' ').trim());
+    }
+  }
+  return '';
+}
+
+/**
+ * Write a chat message through the outbound DB. Non-blocking — any failure
+ * is swallowed so a broken hook can never kill the agent turn.
+ */
+function emit(text: string): void {
+  // Scheduled-task sessions: suppress tool-vis entirely. Orphan tool-call
+  // previews leak into chat without context when the agent stays silent
+  // on a successful "all OK" check — pure noise to the user.
+  if (isTaskSession()) return;
+  try {
+    const routing = getSessionRouting();
+    if (!routing.channel_type || !routing.platform_id) {
+      // Agent-shared or internal session with no reply lane — nothing to do.
+      return;
+    }
+    writeMessageOut({
+      id: `tv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'chat',
+      platform_id: routing.platform_id,
+      channel_type: routing.channel_type,
+      thread_id: routing.thread_id,
+      // Mark as tool-visibility so the chat-sdk-bridge accumulates these
+      // into a single edited message-bubble per thread (Telegram-style),
+      // rather than sending a new notification per tool call.
+      content: JSON.stringify({ text, _toolVis: true }),
+    });
+  } catch (err) {
+    log(`emit failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// ── Batching for rapid file I/O ──────────────────────────────────────
+
+interface BatchEntry {
+  emoji: string;
+  label: string;
+  lastDesc: string;
+  count: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+const toolBatch = new Map<string, BatchEntry>();
+
+function flushBatch(toolName: string): void {
+  const entry = toolBatch.get(toolName);
+  if (!entry) return;
+  toolBatch.delete(toolName);
+  emit(formatToolLine(entry.emoji, entry.label, entry.lastDesc, entry.count));
+}
+
+function sendBatched(toolName: string, emoji: string, label: string, desc: string): void {
+  const existing = toolBatch.get(toolName);
+  if (existing) {
+    clearTimeout(existing.timer);
+    existing.count++;
+    existing.lastDesc = desc;
+    existing.timer = setTimeout(() => flushBatch(toolName), 300);
+  } else {
+    const timer = setTimeout(() => flushBatch(toolName), 300);
+    toolBatch.set(toolName, { emoji, label, lastDesc: desc, count: 1, timer });
+  }
+}
+
+// ── Duration tracking for slow Bash ──────────────────────────────────
+
+const toolStartTimes: Record<string, number> = {};
+const progressTimers: Record<string, ReturnType<typeof setInterval>> = {};
+
+// ── Hook implementations ─────────────────────────────────────────────
+
+/**
+ * Augment the existing v2 PreToolUse hook with chat visibility.
+ * Call this AFTER the existing `preToolUseHook` runs (so container_state
+ * still gets recorded even if visibility errors).
+ */
+export const preToolUseVisibility: HookCallback = async (input, toolUseId) => {
+  if (isTaskSession()) return { continue: true };
+  const i = input as { tool_name?: string; tool_input?: unknown; tool_use_id?: string; transcript_path?: string };
+  // Skip subagent (Task/Agent) tool calls — user wants only the top-level
+  // agent's activity in chat. Subagent transcripts live under `/subagents/`.
+  if (typeof i.transcript_path === 'string' && i.transcript_path.includes('/subagents/')) {
+    return { continue: true };
+  }
+  const toolName = i.tool_name ?? '';
+
+  if (SKIP_TOOLS.has(toolName)) return { continue: true };
+
+  const id = toolUseId || i.tool_use_id;
+  if (id) toolStartTimes[id] = Date.now();
+
+  const desc = describeToolInput(toolName, i.tool_input);
+  const emoji = TOOL_EMOJI[toolName] ?? '🔧';
+  const label = TOOL_LABEL[toolName] ?? toolName.toLowerCase();
+
+  if (BATCH_TOOLS.has(toolName)) {
+    sendBatched(toolName, emoji, label, desc);
+  } else {
+    emit(formatToolLine(emoji, label, desc));
+  }
+
+  // Progress emitter for long-running Agent/Task calls — sends a
+  // "still working — Xs elapsed" message every 30s while the call hasn't
+  // returned. Cleared in the post-tool hook.
+  if ((toolName === 'Agent' || toolName === 'Task') && id) {
+    const startedAt = toolStartTimes[id] ?? Date.now();
+    const tick = () => {
+      const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+      const elapsedStr = elapsedSec >= 60
+        ? `${Math.floor(elapsedSec / 60)}m ${elapsedSec % 60}s`
+        : `${elapsedSec}s`;
+      emit(formatToolLine('⏳', label, `still working — ${elapsedStr} elapsed`));
+    };
+    progressTimers[id] = setInterval(tick, PROGRESS_INTERVAL_MS);
+    // First tick after 30s (don't fire immediately — pre-hook line already shown)
+    setTimeout(tick, PROGRESS_FIRST_DELAY_MS);
+  }
+
+  return { continue: true };
+};
+
+/**
+ * Post-tool hook: only emits a completion marker for Bash calls that ran
+ * longer than LONG_CALL_THRESHOLD_MS. Other tools stay silent on the way
+ * out — the pre-hook message is enough signal.
+ */
+export const postToolUseVisibility: HookCallback = async (input, toolUseId) => {
+  if (isTaskSession()) return { continue: true };
+  const i = input as {
+    hook_event_name?: string;
+    tool_name?: string;
+    tool_input?: unknown;
+    tool_response?: unknown;
+    error?: string;
+    tool_use_id?: string;
+    transcript_path?: string;
+  };
+  if (typeof i.transcript_path === 'string' && i.transcript_path.includes('/subagents/')) {
+    return { continue: true };
+  }
+  const toolName = i.tool_name ?? '';
+
+  if (SKIP_TOOLS.has(toolName)) return { continue: true };
+
+  const id = toolUseId || i.tool_use_id;
+  const startTime = id ? toolStartTimes[id] : undefined;
+  if (id) delete toolStartTimes[id];
+
+  // Clear any progress timer for Agent/Task — call is done, no more ticks.
+  if (id && progressTimers[id]) {
+    clearInterval(progressTimers[id]);
+    delete progressTimers[id];
+  }
+
+  const label = TOOL_LABEL[toolName] ?? toolName.toLowerCase();
+  const desc = describeToolInput(toolName, i.tool_input);
+
+  // FAILURE PATH 1 — explicit PostToolUseFailure event with `error` field.
+  if (i.hook_event_name === 'PostToolUseFailure') {
+    const reason = (i.error ?? 'failed').replace(/\s+/g, ' ').trim().slice(0, 80);
+    const merged = desc ? `${desc}  ✗ ${reason}` : `✗ ${reason}`;
+    emit(formatToolLine('❌', label, merged));
+    return { continue: true };
+  }
+
+  // FAILURE PATH 2 — heuristic detection from tool_response (some tools
+  // report errors in their normal response payload).
+  const inferred = detectFailureFromResponse(toolName, i.tool_response);
+  if (inferred) {
+    const merged = desc ? `${desc}  ✗ ${inferred}` : `✗ ${inferred}`;
+    emit(formatToolLine('❌', label, merged));
+    return { continue: true };
+  }
+
+  // SUCCESS PATH — emit done-marker for slow Bash, optionally enriched
+  // with a result-shape hint (line count, response size).
+  if (toolName === 'Bash' && startTime) {
+    const elapsed = Date.now() - startTime;
+    if (elapsed > LONG_CALL_THRESHOLD_MS) {
+      const shape = resultShape(toolName, i.tool_response);
+      const elapsedStr = `done in ${(elapsed / 1000).toFixed(1)}s`;
+      const finalDesc = shape ? `${elapsedStr}  ${shape}` : elapsedStr;
+      emit(formatToolLine('🖥️', 'bash', finalDesc));
+    }
+  }
+
+  return { continue: true };
+};

--- a/.claude/skills/add-tool-visibility/resources/tool-visibility.ts
+++ b/.claude/skills/add-tool-visibility/resources/tool-visibility.ts
@@ -5,7 +5,7 @@
  *
  * Strategy:
  *   PreToolUse  → "🔧 label: short description"
- *   PostToolUse → "✅ label: Xs" (only for slow Bash, > 3s)
+ *   PostToolUse → "✓ Xs" (only for slow Bash, > 3s)
  *
  * Rapid file I/O (Read/Write/Edit/WebFetch) is debounced 300ms and coalesced
  * into a single "×N" message to prevent chat spam. Noisy tools (WebSearch,
@@ -14,7 +14,9 @@
  * Messages are written to outbound.db via writeMessageOut() with routing
  * pulled from session_routing (default reply lane). The host's delivery
  * loop picks them up and sends them through the same channel adapter the
- * rest of the chat goes through.
+ * rest of the chat goes through. Content is marked `_toolVis: true` so a
+ * host bridge that supports edit-in-place can accumulate lines into one
+ * bubble (optional; without that support each line is a normal chat send).
  */
 import path from 'path';
 
@@ -22,27 +24,45 @@ import type { HookCallback } from '@anthropic-ai/claude-agent-sdk';
 
 import { writeMessageOut } from '../db/messages-out.js';
 import { getSessionRouting } from '../db/session-routing.js';
-import { getInboundDb } from '../db/connection.js';
+import { getInboundDb, getOutboundDb } from '../db/connection.js';
 
 // Detect whether this agent turn was triggered by a scheduled-task wake-up
 // (vs. an interactive chat message). Scheduled tasks often run with explicit
 // silent-on-OK behavior — leaking tool-call previews to chat creates orphan-
-// notification noise without context. We cache per-process so the first turn
-// after spawn determines the policy.
-let _isTaskSession: boolean | null = null;
+// notification noise without context.
+//
+// Classify on THIS turn's batch, not the global-latest inbound row. The old
+// `ORDER BY seq DESC LIMIT 1` flipped an in-progress *chat* turn to silent
+// whenever a cron task happened to land in inbound mid-turn — suppressing all
+// tool-vis for that reply. The current turn's messages are recorded in
+// outbound.db's `processing_ack` (status='processing') by markProcessing(); a
+// freshly-inserted cron task is still 'pending' (next poll) and is NOT in this
+// batch. We suppress only when the in-flight batch is non-empty and contains
+// NO interactive chat message — i.e. a genuine task-only wake. Re-queried
+// every call (no cache): a single container handles both chat and task wakes.
 function isTaskSession(): boolean {
-  if (_isTaskSession !== null) return _isTaskSession;
   try {
-    const db = getInboundDb();
-    const row = db.prepare("SELECT kind FROM messages_in ORDER BY seq DESC LIMIT 1").get() as { kind?: string } | undefined;
-    _isTaskSession = row?.kind === 'task';
-  } catch { _isTaskSession = false; }
-  return _isTaskSession;
+    const acks = getOutboundDb()
+      .prepare("SELECT message_id FROM processing_ack WHERE status = 'processing'")
+      .all() as Array<{ message_id: string }>;
+    if (acks.length === 0) return false; // nothing in-flight → treat as interactive
+    const ids = acks.map((a) => a.message_id);
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = getInboundDb()
+      .prepare(`SELECT kind FROM messages_in WHERE id IN (${placeholders})`)
+      .all(...ids) as Array<{ kind?: string }>;
+    if (rows.length === 0) return false;
+    // Any non-task (chat) message in the batch → interactive turn → show tool-vis.
+    const hasChat = rows.some((r) => r.kind && r.kind !== 'task');
+    return !hasChat;
+  } catch {
+    return false;
+  }
 }
 
 const SKIP_TOOLS = new Set(['WebSearch', 'Glob', 'Grep']);
 
-const MAX_INPUT_PREVIEW = 120;
+const MAX_INPUT_PREVIEW = 80;
 const LONG_CALL_THRESHOLD_MS = 3000;
 const PROGRESS_FIRST_DELAY_MS = 30000;  // first progress msg at 30s
 const PROGRESS_INTERVAL_MS = 30000;     // then every 30s
@@ -58,6 +78,7 @@ const TOOL_EMOJI: Record<string, string> = {
   Agent: '🤖',
   Task: '🤖',
   TodoWrite: '📝',
+  Skill: '📚',
 };
 
 const TOOL_LABEL: Record<string, string> = {
@@ -71,6 +92,7 @@ const TOOL_LABEL: Record<string, string> = {
   Agent: 'agent',
   Task: 'task',
   TodoWrite: 'todo',
+  Skill: 'skill',
 };
 
 const BATCH_TOOLS = new Set(['Read', 'Write', 'Edit', 'MultiEdit', 'WebFetch']);
@@ -84,8 +106,18 @@ function log(msg: string): void {
   console.error(`[tool-visibility] ${msg}`);
 }
 
+// Never cut inside a UTF-16 surrogate pair — a preview ending in half an
+// emoji is invalid UTF-8 and makes some chat backends reject the whole
+// tool-vis bubble (and, via a pre-send flush, every later real message on
+// that chat).
+export function safeSlice(s: string, n: number): string {
+  const cut = s.slice(0, n);
+  const last = cut.charCodeAt(cut.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
+}
+
 function truncate(s: string): string {
-  return s.length > MAX_INPUT_PREVIEW ? s.slice(0, MAX_INPUT_PREVIEW) + '…' : s;
+  return s.length > MAX_INPUT_PREVIEW ? safeSlice(s, MAX_INPUT_PREVIEW) + '…' : s;
 }
 
 /** Extract domain from URL — keeps preview compact ("github.com" not full URL). */
@@ -102,6 +134,9 @@ function shortPath(p: string, maxLen = 35): string {
 /** Format a tool message with verb-aligned label for easier scanning. */
 function formatToolLine(emoji: string, label: string, desc: string, count = 0): string {
   const countStr = count > 1 ? ` ×${count}` : '';
+  if (!label) {
+    return desc ? `${emoji}${countStr}  ${desc}` : `${emoji}${countStr}`;
+  }
   // Pad label so descriptions align vertically across tool calls.
   const paddedLabel = label.padEnd(8);
   return desc ? `${emoji} ${paddedLabel}${countStr} ${desc}`.trimEnd()
@@ -143,11 +178,11 @@ function resultShape(toolName: string, toolResponse: unknown): string | null {
     // the command actually produced what was expected. Trim to keep the
     // chat-line compact.
     const firstLine = allLines.find((l) => l.trim()) || '';
-    const peek = firstLine.replace(/\s+/g, ' ').trim().slice(0, 60);
+    const peek = safeSlice(firstLine.replace(/\s+/g, ' ').trim(), 60);
     if (nonEmpty >= 5) {
-      return peek ? `${nonEmpty} lines  → \`${peek}\`` : `${nonEmpty} lines`;
+      return peek ? `${nonEmpty} lines → ${peek}` : `${nonEmpty} lines`;
     }
-    if (peek) return `→ \`${peek}\``;
+    if (peek) return `→ ${peek}`;
     return null;
   }
   if (toolName === 'WebFetch' && text) {
@@ -171,10 +206,10 @@ function detectFailureFromResponse(_toolName: string, toolResponse: unknown): st
       const explicit = typeof r.error === 'string' ? r.error
         : typeof r.message === 'string' ? r.message
         : 'failed';
-      return explicit.replace(/\s+/g, ' ').trim().slice(0, 80);
+      return safeSlice(explicit.replace(/\s+/g, ' ').trim(), 80);
     }
     if (typeof r.error === 'string' && r.error.trim()) {
-      return r.error.replace(/\s+/g, ' ').trim().slice(0, 80);
+      return safeSlice(r.error.replace(/\s+/g, ' ').trim(), 80);
     }
   }
   const text = extractResponseText(toolResponse);
@@ -189,18 +224,35 @@ function detectFailureFromResponse(_toolName: string, toolResponse: unknown): st
   ];
   for (const p of patterns) {
     const m = text.match(p);
-    if (m) return m[0].replace(/\s+/g, ' ').trim().slice(0, 80);
+    if (m) return safeSlice(m[0].replace(/\s+/g, ' ').trim(), 80);
   }
   return null;
 }
 
+/** Collapse a heredoc into its interpreter, marker, and first useful line. */
+export function summarizeHeredoc(cmd: string): string {
+  const match = cmd.match(/((?:[\w./-]+\s+)*)((?:python3?|bash|sh|node|ruby|perl)\S*)\s+<<-?\s*['"]?(\w+)['"]?/i);
+  if (!match) return cmd;
+  const interpreter = path.basename(match[2]);
+  const tag = match[3];
+  const body = cmd.slice(match[0].length);
+  const firstUseful =
+    body
+      .split(/\n|;/)
+      .map((line) => line.trim())
+      .find((line) => line && !line.startsWith('#') && line !== tag) ?? '';
+  const hint = firstUseful ? safeSlice(firstUseful.replace(/\s+/g, ' '), 40) : tag;
+  return `${interpreter} «${tag}» ${hint}…`;
+}
+
 /** Extract the meaningful part of a bash command for the preview. */
-function summarizeBash(raw: string): string {
-  const cmd = raw.replace(/\s+/g, ' ').trim();
+export function summarizeBash(raw: string): string {
+  const cmd = summarizeHeredoc(raw.trim()).replace(/\s+/g, ' ').trim();
 
   // Split into segments by command connectors and skip ones that are pure
-  // variable-assignment blocks (e.g. `SSHK="ssh -i ..."` before `&& $SSHK ...`).
-  // Without this, long ssh-wrapper assignments at the start eat the whole preview.
+  // variable-assignment blocks (e.g. `SSH_CMD="ssh -i key"` before
+  // `&& $SSH_CMD host "ls"`). Without this, long wrapper assignments at the
+  // start eat the whole preview.
   const segments = cmd.split(/\s*(?:&&|\|\||;|\|)\s*/).map(s => s.trim()).filter(Boolean);
   const isPureAssignment = (s: string) =>
     /^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s*)+$/.test(s);
@@ -248,16 +300,25 @@ function summarizeBash(raw: string): string {
   if (BASH_WITH_SUBCOMMAND.has(bin) && sub && !sub.startsWith('-')) {
     return truncate(`${bin} ${sub}`);
   }
+  if ((bin === 'bash' || bin === 'sh') && sub) {
+    return truncate(path.basename(sub));
+  }
   return truncate(first);
 }
 
 /** Human-readable summary of a tool's input. */
-function describeToolInput(toolName: string, toolInput: unknown): string {
+export function describeToolInput(toolName: string, toolInput: unknown): string {
   if (!toolInput || typeof toolInput !== 'object') return '';
   const input = toolInput as Record<string, unknown>;
 
-  if (toolName === 'Bash' && typeof input.command === 'string') {
-    return `\`${summarizeBash(input.command)}\``;
+  if (toolName === 'Bash') {
+    // Prefer the human description when the SDK/tool supplies one — glances
+    // better than raw launcher syntax. Fall back to command summary.
+    if (typeof input.description === 'string' && input.description.trim()) {
+      return truncate(input.description.replace(/\s+/g, ' ').trim());
+    }
+    if (typeof input.command === 'string') return `\`${summarizeBash(input.command)}\``;
+    return '';
   }
   if ((toolName === 'Read' || toolName === 'Write' || toolName === 'Edit' || toolName === 'MultiEdit') && typeof input.file_path === 'string') {
     return `\`${shortPath(input.file_path)}\``;
@@ -280,6 +341,9 @@ function describeToolInput(toolName: string, toolInput: unknown): string {
   if (toolName === 'TodoWrite' && Array.isArray(input.todos)) {
     const n = input.todos.length;
     return `${n} task${n === 1 ? '' : 's'}`;
+  }
+  if (toolName === 'Skill' && typeof input.skill === 'string') {
+    return `\`${input.skill}\``;
   }
 
   for (const val of Object.values(input)) {
@@ -311,9 +375,10 @@ function emit(text: string): void {
       platform_id: routing.platform_id,
       channel_type: routing.channel_type,
       thread_id: routing.thread_id,
-      // Mark as tool-visibility so the chat-sdk-bridge accumulates these
-      // into a single edited message-bubble per thread (Telegram-style),
-      // rather than sending a new notification per tool call.
+      // Mark as tool-visibility so a host bridge can accumulate these into
+      // a single edited message-bubble per thread (Telegram-style), rather
+      // than sending a new notification per tool call. Bridges without
+      // that support ignore the flag and deliver normally.
       content: JSON.stringify({ text, _toolVis: true }),
     });
   } catch (err) {
@@ -381,7 +446,15 @@ export const preToolUseVisibility: HookCallback = async (input, toolUseId) => {
 
   const desc = describeToolInput(toolName, i.tool_input);
   const emoji = TOOL_EMOJI[toolName] ?? '🔧';
-  const label = TOOL_LABEL[toolName] ?? toolName.toLowerCase();
+  // Bash rows omit the redundant "bash" label — description/command carries intent.
+  const label = toolName === 'Bash' ? '' : (TOOL_LABEL[toolName] ?? toolName.toLowerCase());
+
+  // Suppress empty TodoWrite calls (e.g. clearing stale todos).
+  // `📝 todo  0 tasks` is pure noise; conveys no semantic information.
+  if (toolName === 'TodoWrite') {
+    const todos = (i.tool_input as { todos?: unknown[] } | undefined)?.todos;
+    if (Array.isArray(todos) && todos.length === 0) return { continue: true };
+  }
 
   if (BATCH_TOOLS.has(toolName)) {
     sendBatched(toolName, emoji, label, desc);
@@ -442,14 +515,12 @@ export const postToolUseVisibility: HookCallback = async (input, toolUseId) => {
     delete progressTimers[id];
   }
 
-  const label = TOOL_LABEL[toolName] ?? toolName.toLowerCase();
   const desc = describeToolInput(toolName, i.tool_input);
 
   // FAILURE PATH 1 — explicit PostToolUseFailure event with `error` field.
   if (i.hook_event_name === 'PostToolUseFailure') {
-    const reason = (i.error ?? 'failed').replace(/\s+/g, ' ').trim().slice(0, 80);
-    const merged = desc ? `${desc}  ✗ ${reason}` : `✗ ${reason}`;
-    emit(formatToolLine('❌', label, merged));
+    const reason = safeSlice((i.error ?? 'failed').replace(/\s+/g, ' ').trim(), 80);
+    emit(desc ? `❌  ${desc}  · ${reason}` : `❌  ${reason}`);
     return { continue: true };
   }
 
@@ -457,20 +528,17 @@ export const postToolUseVisibility: HookCallback = async (input, toolUseId) => {
   // report errors in their normal response payload).
   const inferred = detectFailureFromResponse(toolName, i.tool_response);
   if (inferred) {
-    const merged = desc ? `${desc}  ✗ ${inferred}` : `✗ ${inferred}`;
-    emit(formatToolLine('❌', label, merged));
+    emit(desc ? `❌  ${desc}  · ${inferred}` : `❌  ${inferred}`);
     return { continue: true };
   }
 
   // SUCCESS PATH — emit done-marker for slow Bash, optionally enriched
-  // with a result-shape hint (line count, response size).
+  // with a result-shape hint (line count, first-line peek).
   if (toolName === 'Bash' && startTime) {
     const elapsed = Date.now() - startTime;
     if (elapsed > LONG_CALL_THRESHOLD_MS) {
       const shape = resultShape(toolName, i.tool_response);
-      const elapsedStr = `done in ${(elapsed / 1000).toFixed(1)}s`;
-      const finalDesc = shape ? `${elapsedStr}  ${shape}` : elapsedStr;
-      emit(formatToolLine('🖥️', 'bash', finalDesc));
+      emit(`✓  ${(elapsed / 1000).toFixed(1)}s` + (shape ? ` · ${shape}` : ''));
     }
   }
 


### PR DESCRIPTION
## What

Adds **tool-visibility** — live tool-call previews surfaced into the chat as the agent runs (PreToolUse/PostToolUse/PostToolUseFailure hooks).

## Update 2026-07-25 — resynced with three months of production use

This branch has been running as a patch on a fork since May. The skill's copy of the hook had drifted behind the version actually in use, so it has been brought back in line: `resources/tool-visibility.ts` goes from 478 to 603 lines, with tests and docs updated alongside.

The largest visible change is that **previews are now description-first**. When a tool call carries a `description`, that is what the user sees; the command summary is the fallback rather than the headline. In practice this is the difference between a chat line that reads `🖥️ bash \`cd /srv/app && node --check src/index.js\`` and one that reads `Check the parser for syntax errors`. On a phone, where most of these previews are actually read, it is the whole difference between signal and scroll.

Everything ported, with why:

- **Description-first previews** — prefer `tool_input.description`; the redundant `bash` label is gone.
- **Compact post markers** — failures render as `❌ … · reason`, slow Bash as `✓ Xs · shape`, dropping the repeated `done in` / `bash` noise.
- **Bash peek without inline code** — `N lines → peek` instead of backticks, which survives long multi-line commands intact.
- **`MAX_INPUT_PREVIEW` 80** — tuned down for narrow screens.
- **Heredoc summarizing and `bash script.sh` → basename** — a heredoc no longer floods the preview with its body.
- **Assignment-prefix handling** — a command of the shape `VAR="…" && $VAR host …` previewed only the assignment, hiding the actual command. It now skips the prefix and summarizes what runs.
- **Empty `TodoWrite` suppressed** — `todos: []` emits nothing instead of an empty bullet.
- **UTF-16-safe truncation** — previews never cut inside a surrogate pair, so an emoji cannot end up as half a character in the chat.
- **Task-session detection reads the processing batch** — `isTaskSession()` consults `processing_ack` plus `messages_in.kind` and suppresses only genuine task-only wakes. The earlier heuristic could silence a real chat turn that happened to overlap a scheduled task.

Deliberately **not** ported, because it is specific to the fork's environment rather than to the feature:

- An agent-name allowlist read from a container-local config file.
- An SSH-wrapper unwrapper tied to a local launcher and workspace paths. The generic assignment-prefix handling above covers the same class of case without hardcoding anything.
- Host-side edit coalescing, which lives in `chat-sdk-bridge.ts`. The skill ships the container hook and the `_toolVis` flag; coalescing stays out of scope.

## Conformance to the skills model

Rebuilt as a self-contained skill per `docs/skill-guidelines.md` (was previously branch-merge based):
- Self-contained `.claude/skills/add-tool-visibility/`; apply **copies files in** + makes one minimal reach-in — no branch, no `git merge`.
- **Integration point** = the `claude.ts` provider reach-in: 1 import + appending the visibility hooks to the existing PreToolUse / PostToolUse / PostToolUseFailure arrays. All logic lives in the skill's own `tool-visibility.ts`; the core edit is just the wiring.
- **Two test legs** (`bun:test`, container side, shipped with the skill):
  - *AST wiring test* — asserts the import + all three hook-array memberships + ordering (visibility hook after the core hook). Goes red if the reach-in is deleted or drifts.
  - *Behavior test* — drives the real hooks against real in-memory session DBs (the hooks do raw SQL against inbound/outbound), catching core-consumption drift a typecheck can't.
- **REMOVE.md** reverses everything (hook file, test, import line, the three array appends). Apply is idempotent (re-run guarded). No VERIFY.md.

## Test evidence

Current run, after the resync: **18/18 tests pass across the two skill test files** (`45 expect() calls`, 694 ms), and `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` exits 0. New coverage added for the description-first path, the empty-`TodoWrite` suppression, and the task-only batch — including the case that previously misfired, where a mid-turn task row that is not in `processing_ack` must **not** silence a chat turn.

Earlier evidence from the original submission still holds: apply on clean `main` → `bun test` 108/108, container `tsc` clean; negative-probe verified (removing the hooks → 3 tests red; removing the import → wiring test + `tsc` red; restore → green); REMOVE → `git status` clean; apply twice → exactly one import and one set of hook entries.
