### PR TITLE
feat(setup): headless-aware Claude sign-in pre-message

### DIFF
--- a/setup/register-claude-token.sh
+++ b/setup/register-claude-token.sh
@@ -51,13 +51,34 @@ command -v script >/dev/null \
 tmpfile=$(mktemp -t claude-setup-token.XXXXXX)
 trap 'rm -f "$tmpfile"' EXIT
 
-cat <<'EOF'
+# Detect headless. Mirrors `isHeadless()` in setup/platform.ts: on Linux
+# with neither DISPLAY nor WAYLAND_DISPLAY set, no graphical session
+# exists, so `claude setup-token` won't be able to auto-open a browser
+# and the user will need to copy the printed sign-in URL by hand. The
+# pre-message copy below is swapped accordingly so we don't promise a
+# browser pop that will never happen.
+is_headless=0
+if [ "$(uname -s)" = "Linux" ] && [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+  is_headless=1
+fi
+
+if [ "$is_headless" = "1" ]; then
+  cat <<'EOF'
+A sign-in link will appear for you to sign in with your Claude account.
+When you finish, we'll save the token to your OneCLI vault automatically.
+
+Press Enter to continue, or edit the command first.
+
+EOF
+else
+  cat <<'EOF'
 A browser window will open for you to sign in with your Claude account.
 When you finish, we'll save the token to your OneCLI vault automatically.
 
 Press Enter to continue, or edit the command first.
 
 EOF
+fi
 
 cmd="claude setup-token"
 if [ "${BASH_VERSINFO[0]:-0}" -ge 4 ]; then


### PR DESCRIPTION
## Summary

The pre-message printed by `setup/register-claude-token.sh` used to say:

> A browser window will open for you to sign in with your Claude account.

Accurate on a laptop or desktop, but **a lie on headless devices** (Raspberry Pi, SSH'd-into Linux server, CI) where the browser auto-open never lands and the user actually has to copy the URL `claude setup-token` prints to another device.

This PR adds a small bash `is_headless` check (mirrors `isHeadless()` in `setup/platform.ts`: Linux without `DISPLAY` / `WAYLAND_DISPLAY`) and swaps the heredoc accordingly:

**Headless copy:**
> A sign-in link will appear for you to sign in with your Claude account. When you finish, we'll save the token to your OneCLI vault automatically.
>
> Press Enter to continue, or edit the command first.

**GUI copy (unchanged):**
> A browser window will open for you to sign in with your Claude account. When you finish, we'll save the token to your OneCLI vault automatically.
>
> Press Enter to continue, or edit the command first.

The actual `claude setup-token` invocation, the OneCLI token capture, and the rest of the flow are all untouched — only the leading sentence flips based on environment.

## Why bash and not the existing TS helper

The existing `isHeadless()` in `setup/platform.ts` is a TypeScript function. The auth pre-message lives in a bash script that runs before any TS code. Calling TS from bash isn't easy, but the detection itself is 3 lines of identical logic in either language. Inlined the bash equivalent rather than introducing a TS round-trip.

## Test plan

- `pnpm exec tsc --noEmit` — clean (no TS changes)
- `pnpm test setup/` — 5 files / 43 tests pass
- `bash -n setup/register-claude-token.sh` — syntax OK
- Ran `bash nanoclaw.sh` on a headless griffin-fairy VM (Linux, no `DISPLAY`), forced through the auth step (deleted Anthropic OneCLI secret first), confirmed the new headless copy appears