### PR TITLE
fix(host): single-instance lock to prevent duplicate hosts racing on shared state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import path from 'path';
 
 import { DATA_DIR } from './config.js';
 import { enforceStartupBackoff, resetCircuitBreaker } from './circuit-breaker.js';
+import { acquireSingleInstanceLock, SingleInstanceError, type SingleInstanceHandle } from './single-instance.js';
 import { migrateGroupsToClaudeLocal } from './claude-md-compose.js';
 import { initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
@@ -56,10 +57,31 @@ import './modules/index.js';
 import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
 import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from './channels/channel-registry.js';
 
+// Held for the lifetime of the process. Released on graceful shutdown so the
+// next start doesn't have to wait for the stale-reclaim path.
+let singleInstanceHandle: SingleInstanceHandle | null = null;
+
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
 
-  // 0. Circuit breaker — backoff on rapid restarts
+  // 0a. Single-instance lock — runs before everything else so a duplicate
+  //     host aborts before it can race for the CLI socket, the Telegram bot
+  //     polling session, or the per-session DBs. See src/single-instance.ts.
+  try {
+    singleInstanceHandle = acquireSingleInstanceLock();
+    log.info('Acquired host lock', { lockFile: singleInstanceHandle.lockFile, pid: process.pid });
+  } catch (err) {
+    if (err instanceof SingleInstanceError) {
+      log.fatal('Another NanoClaw host is already running — exiting', {
+        holderPid: err.holderPid,
+        lockFile: err.lockFile,
+      });
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  // 0b. Circuit breaker — backoff on rapid restarts
   await enforceStartupBackoff();
 
   // 1. Init central DB
@@ -185,6 +207,9 @@ async function shutdown(signal: string): Promise<void> {
     // via SIGTERM/SIGINT, not a crash, so the next start shouldn't be counted
     // as one.
     resetCircuitBreaker();
+    // Release the host lock so the next start doesn't have to reclaim a
+    // stale file. Best-effort — even if this throws, exit(0) still runs.
+    singleInstanceHandle?.release();
     process.exit(0);
   }
 }

--- a/src/single-instance.test.ts
+++ b/src/single-instance.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the single-instance host lock.
+ *
+ * Each test runs in its own tmp directory to avoid cross-test interference.
+ * Liveness is probed via real `process.kill(pid, 0)`, so the test that
+ * simulates a dead holder uses a never-allocated PID (PID 1 is always
+ * alive on Linux/macOS — `init` — so we use a definitely-dead PID instead).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { acquireSingleInstanceLock, SingleInstanceError } from './single-instance.js';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-si-test-'));
+}
+
+function findDeadPid(): number {
+  // Probe upward until we find one that's not running. PID 1 is always
+  // alive (init), so start high and work up. Caps at 10000 attempts to
+  // avoid spinning if the OS happens to be very full.
+  for (let pid = 99999; pid < 99999 + 10000; pid++) {
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return pid;
+    }
+  }
+  throw new Error('Could not find a dead PID for the test');
+}
+
+describe('single-instance lock', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('acquires the lock when no holder exists, writing the current pid', () => {
+    const handle = acquireSingleInstanceLock(tmpDir);
+    expect(handle.lockFile).toBe(path.join(tmpDir, 'host.lock'));
+    expect(fs.existsSync(handle.lockFile)).toBe(true);
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('release() removes the lock file when this process owns it', () => {
+    const handle = acquireSingleInstanceLock(tmpDir);
+    expect(fs.existsSync(handle.lockFile)).toBe(true);
+    handle.release();
+    expect(fs.existsSync(handle.lockFile)).toBe(false);
+  });
+
+  it('release() is idempotent — second call is a no-op', () => {
+    const handle = acquireSingleInstanceLock(tmpDir);
+    handle.release();
+    expect(() => handle.release()).not.toThrow();
+  });
+
+  it('after release, the lock can be re-acquired in the same process', () => {
+    const first = acquireSingleInstanceLock(tmpDir);
+    first.release();
+    const second = acquireSingleInstanceLock(tmpDir);
+    expect(fs.existsSync(second.lockFile)).toBe(true);
+    second.release();
+  });
+
+  it('throws SingleInstanceError when a live process holds the lock', () => {
+    // Simulate a live holder by writing our own PID to the lock file
+    // without acquiring through the API. process.kill(self, 0) returns true,
+    // so the lock looks live to the second caller.
+    const lockFile = path.join(tmpDir, 'host.lock');
+    fs.writeFileSync(lockFile, String(process.pid));
+
+    let caught: unknown;
+    try {
+      acquireSingleInstanceLock(tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SingleInstanceError);
+    const sie = caught as SingleInstanceError;
+    expect(sie.holderPid).toBe(process.pid);
+    expect(sie.lockFile).toBe(lockFile);
+    // File must NOT have been disturbed — still owned by the "holder".
+    expect(fs.readFileSync(lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a stale lock whose holder PID is no longer running', () => {
+    const lockFile = path.join(tmpDir, 'host.lock');
+    const deadPid = findDeadPid();
+    fs.writeFileSync(lockFile, String(deadPid));
+
+    const handle = acquireSingleInstanceLock(tmpDir);
+    // The reclaim path unlinks then re-creates with our PID.
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a lock file with non-numeric garbage as content', () => {
+    const lockFile = path.join(tmpDir, 'host.lock');
+    fs.writeFileSync(lockFile, 'not-a-pid');
+
+    const handle = acquireSingleInstanceLock(tmpDir);
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a lock file with PID 0 (invalid)', () => {
+    const lockFile = path.join(tmpDir, 'host.lock');
+    fs.writeFileSync(lockFile, '0');
+
+    const handle = acquireSingleInstanceLock(tmpDir);
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a lock file with negative PID (invalid)', () => {
+    const lockFile = path.join(tmpDir, 'host.lock');
+    fs.writeFileSync(lockFile, '-42');
+
+    const handle = acquireSingleInstanceLock(tmpDir);
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('release() is a no-op when this process no longer owns the lock', () => {
+    // Acquire, then have someone else "take over" by overwriting the file.
+    // Our release() should detect the PID mismatch and leave the file alone.
+    const handle = acquireSingleInstanceLock(tmpDir);
+    fs.writeFileSync(handle.lockFile, '99999999'); // pretend another process took over
+    handle.release();
+    // File must still be there — we didn't own it anymore.
+    expect(fs.existsSync(handle.lockFile)).toBe(true);
+    expect(fs.readFileSync(handle.lockFile, 'utf8').trim()).toBe('99999999');
+  });
+
+  it('creates the data directory if it does not exist yet (fresh install)', () => {
+    const fresh = path.join(tmpDir, 'nested', 'data');
+    expect(fs.existsSync(fresh)).toBe(false);
+    const handle = acquireSingleInstanceLock(fresh);
+    expect(fs.existsSync(fresh)).toBe(true);
+    expect(fs.existsSync(handle.lockFile)).toBe(true);
+  });
+});

--- a/src/single-instance.ts
+++ b/src/single-instance.ts
@@ -1,0 +1,147 @@
+/**
+ * Single-instance host lock.
+ *
+ * Held for the lifetime of a NanoClaw host process via a PID file at
+ * `data/host.lock`. Acquired before DB open, migrations, and adapter setup —
+ * so a duplicate process aborts before it can race for cli.sock, the
+ * Telegram bot polling session, or the per-session DBs.
+ *
+ * The bug this fixes: nothing in the host process previously enforced
+ * singleton-ness. The CLI socket adapter unlinks-and-rebinds on startup
+ * (so a second instance silently steals the socket from the first), the
+ * webhook port collision is avoidable via env-var divergence, SQLite WAL
+ * tolerates concurrent writers, and the systemd unit has no PIDFile=. A
+ * `pnpm dev` started under a login shell could therefore run alongside a
+ * systemd-managed host and race it on every outbound delivery — see the
+ * post-mortem in PR #2167's sibling investigation.
+ *
+ * This is an advisory lock — `O_EXCL` create on a regular file. Sufficient
+ * on local filesystems (NFS not supported, but NanoClaw's data dir is
+ * always local). On EEXIST we read the holder PID and check liveness via
+ * `kill(pid, 0)`. If the holder is dead, we reclaim; if alive, we throw a
+ * `SingleInstanceError` carrying the live PID so the caller can log it
+ * before exiting.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+
+const LOCK_FILENAME = 'host.lock';
+
+/** Maximum stale-cleanup retries — bounds worst-case loop if two processes
+ *  race on reclaim. Each iteration is one stat/read/unlink, so 5 is plenty. */
+const MAX_RECLAIM_ATTEMPTS = 5;
+
+export class SingleInstanceError extends Error {
+  constructor(
+    public readonly holderPid: number,
+    public readonly lockFile: string,
+  ) {
+    super(
+      `Another NanoClaw host is already running (pid ${holderPid}). ` +
+        `Lock file: ${lockFile}. If that process is gone, remove the file manually.`,
+    );
+    this.name = 'SingleInstanceError';
+  }
+}
+
+/** Probe liveness via signal 0. ESRCH = not running; EPERM = exists but
+ *  owned by another user (still alive); anything else, assume alive to err
+ *  on the side of refusing to start. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+function readHolderPid(lockFile: string): number | null {
+  try {
+    const text = fs.readFileSync(lockFile, 'utf8').trim();
+    const pid = Number.parseInt(text, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+export interface SingleInstanceHandle {
+  /** Path to the lock file held by this process. */
+  readonly lockFile: string;
+  /** Best-effort release. Idempotent. Logs nothing — let the caller decide. */
+  release(): void;
+}
+
+/**
+ * Acquire the host lock. Throws `SingleInstanceError` if another live
+ * process holds it. A stale lock (holder is gone) is reclaimed
+ * automatically.
+ *
+ * Override the data directory via `dataDir` for tests.
+ */
+export function acquireSingleInstanceLock(dataDir: string = DATA_DIR): SingleInstanceHandle {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const lockFile = path.join(dataDir, LOCK_FILENAME);
+
+  for (let attempt = 0; attempt < MAX_RECLAIM_ATTEMPTS; attempt++) {
+    try {
+      // 'wx' = O_WRONLY | O_CREAT | O_EXCL — atomic create-or-fail.
+      const fd = fs.openSync(lockFile, 'wx');
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } finally {
+        fs.closeSync(fd);
+      }
+      return makeHandle(lockFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+
+    // EEXIST — someone holds it (or it's stale). Check.
+    const holderPid = readHolderPid(lockFile);
+    if (holderPid !== null && isProcessAlive(holderPid)) {
+      throw new SingleInstanceError(holderPid, lockFile);
+    }
+
+    // Stale (or unreadable garbage). Try to remove it. ENOENT means another
+    // process beat us to the cleanup — loop and retry the create.
+    try {
+      fs.unlinkSync(lockFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+
+  // Should be unreachable under normal contention. If we get here, two
+  // processes are aggressively racing reclaim — surface as if the other
+  // wins, so this one exits.
+  const holderPid = readHolderPid(lockFile) ?? 0;
+  throw new SingleInstanceError(holderPid, lockFile);
+}
+
+function makeHandle(lockFile: string): SingleInstanceHandle {
+  let released = false;
+  return {
+    lockFile,
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        // Re-check ownership before unlinking — a stale-reclaim from another
+        // process could have replaced our file with theirs. If the PID
+        // doesn't match, the lock isn't ours anymore; leave it alone.
+        const holderPid = readHolderPid(lockFile);
+        if (holderPid === process.pid) {
+          fs.unlinkSync(lockFile);
+        }
+      } catch {
+        // Best-effort. A failed release just leaves a stale file that the
+        // next start will reclaim.
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Adds a PID-file advisory lock at `data/host.lock` acquired before DB open, migrations, and adapter setup. A duplicate host process aborts with a clear error pointing at the live holder PID, instead of silently racing the running host on every outbound delivery.

**Why.** Nothing previously enforced singleton-ness:

- The CLI socket adapter unlinks-and-rebinds on startup (`src/channels/cli.ts:65-72`), so a second instance silently steals the socket from the first.
- Webhook port collisions are avoidable via env-var divergence (the systemd unit pins `WEBHOOK_PORT=3002`; ad-hoc `pnpm dev` defaults to `3000`).
- SQLite WAL mode tolerates concurrent multi-process writers — `data/v2.db` and the per-session `inbound.db`/`outbound.db` are all happy to be opened twice.
- The systemd unit has no `PIDFile=` and uses `Type=simple`.

A `pnpm dev` started under a login shell can run alongside a systemd-managed host. Both poll `outbound.db` every 1s and call `deliveryAdapter.deliver` concurrently. Whichever calls `markDelivered` first wins the `INSERT OR IGNORE` — losing the real `platform_message_id` from the slower (network-bound) call. In the case where the broken instance has no Telegram adapter registered (a known failure mode — see the sibling PR on the `channels` branch for the trigger and #2167 for the same bug class on the task-ack side), the row is silently marked `delivered` with `platform_message_id=NULL` even though no API call was made.

CLAUDE.md's *"exactly one writer per file — no cross-mount lock contention"* invariant is enforced only by the host-vs-container split, not against a sibling host process. The design assumed singleton-by-convention; this change makes it singleton-by-construction.

**How it works.**

1. **`src/single-instance.ts`** — new module. `acquireSingleInstanceLock(dataDir)` opens `host.lock` with `'wx'` (`O_WRONLY | O_CREAT | O_EXCL`) and writes `process.pid`. On `EEXIST` it reads the holder PID, probes liveness via `process.kill(pid, 0)` (`ESRCH` = dead), and either throws `SingleInstanceError(holderPid, lockFile)` or unlinks the stale file and retries the create. The handle's `release()` re-checks ownership before unlinking so a stale-reclaim by a peer doesn't make us delete their file. Bounded reclaim retries (default 5) prevent an infinite loop under aggressive contention.
2. **`src/index.ts`** — wired in as step `0a`, before `enforceStartupBackoff`. On `SingleInstanceError`, logs the holder PID and `process.exit(1)`. The handle is held in module scope and `release()`d in `shutdown()` so the next start doesn't pay the stale-reclaim cost.

The lock is advisory (`O_EXCL` create on a regular file). Sufficient on local filesystems; NFS not supported, but NanoClaw's data dir is always local.

**How it was tested.**

- 11 unit tests in `src/single-instance.test.ts` cover:
  - Acquire when no holder exists, with PID written.
  - `release()` removes the file; idempotent; re-acquirable in same process.
  - Throws `SingleInstanceError` with the live holder PID when held.
  - Reclaims a stale lock (dead PID), garbage non-numeric content, `0`, and negative PIDs.
  - `release()` is a no-op when this process no longer owns the lock (PID mismatch).
  - Creates the data directory if it doesn't exist (fresh-install case).
- Verified on a real install (Pi5 rootless Docker, single systemd-managed host) that the lock acquires cleanly, releases on `SIGTERM`, and a second `pnpm dev` aborts with a `SingleInstanceError` pointing at PID 2277554.