### PR TITLE
fix(channels/telegram): fail fast when bot polling session is held by another client

### DIFF
--- a/src/channels/telegram-polling-probe.test.ts
+++ b/src/channels/telegram-polling-probe.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for the Telegram polling-collision probe.
+ *
+ * Covers detection of HTTP 409 from `getUpdates`, the three error-shape
+ * heuristics in `isTelegramPollingCollision`, and the probe's
+ * fail-fast-on-409 / fail-soft-on-network behaviour.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyProbeResponse,
+  isTelegramPollingCollision,
+  probeBotPollingFreedom,
+  TelegramPollingCollisionError,
+  withSetupRetry,
+} from './telegram-polling-probe.js';
+
+function makeResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('classifyProbeResponse', () => {
+  it('returns null for 200 OK', () => {
+    expect(classifyProbeResponse(200, { ok: true, result: [] })).toBeNull();
+  });
+
+  it('returns null for non-409 errors', () => {
+    expect(classifyProbeResponse(401, { ok: false, description: 'Unauthorized' })).toBeNull();
+    expect(classifyProbeResponse(500, { ok: false })).toBeNull();
+  });
+
+  it('returns a TelegramPollingCollisionError for 409 with description', () => {
+    const err = classifyProbeResponse(409, {
+      ok: false,
+      error_code: 409,
+      description: 'Conflict: terminated by other getUpdates request',
+    });
+    expect(err).toBeInstanceOf(TelegramPollingCollisionError);
+    expect(err!.description).toContain('Conflict');
+    expect(err!.message).toMatch(/another client/i);
+  });
+
+  it('returns a TelegramPollingCollisionError for 409 with no body', () => {
+    const err = classifyProbeResponse(409, null);
+    expect(err).toBeInstanceOf(TelegramPollingCollisionError);
+    // Falls back to a generic description so the caller still gets a
+    // meaningful message.
+    expect(err!.description).toMatch(/conflict/i);
+  });
+});
+
+describe('isTelegramPollingCollision', () => {
+  it('recognises our own collision error class', () => {
+    const err = new TelegramPollingCollisionError('Conflict: terminated by other getUpdates request');
+    expect(isTelegramPollingCollision(err)).toBe(true);
+  });
+
+  it('recognises a chat-adapter ValidationError that carries the Telegram description', () => {
+    // Shape mirrors @chat-adapter/shared's ValidationError: a plain Error
+    // with a Telegram-like message.
+    const err = new Error('Conflict: terminated by other getUpdates request');
+    expect(isTelegramPollingCollision(err)).toBe(true);
+  });
+
+  it('recognises a generic error mentioning 409 and telegram', () => {
+    const err = new Error('Telegram API getUpdates failed (status 409, error 409)');
+    expect(isTelegramPollingCollision(err)).toBe(true);
+  });
+
+  it('does NOT match generic transient network errors', () => {
+    const err = new Error('NetworkError: Network error calling Telegram getUpdates');
+    expect(isTelegramPollingCollision(err)).toBe(false);
+  });
+
+  it('does NOT match a non-Telegram conflict (e.g. some other 409)', () => {
+    const err = new Error('Conflict on resource X');
+    expect(isTelegramPollingCollision(err)).toBe(false);
+  });
+
+  it('does NOT match a 401 / auth error', () => {
+    const err = new Error('Telegram API getMe failed (status 401)');
+    expect(isTelegramPollingCollision(err)).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isTelegramPollingCollision(undefined)).toBe(false);
+    expect(isTelegramPollingCollision(null)).toBe(false);
+    expect(isTelegramPollingCollision('Conflict: terminated by other getUpdates request')).toBe(false);
+    expect(isTelegramPollingCollision({ message: 'Conflict' })).toBe(false);
+  });
+});
+
+describe('probeBotPollingFreedom', () => {
+  it('resolves silently when Telegram returns 200 with an empty update list', async () => {
+    const fetchMock = async () => makeResponse(200, { ok: true, result: [] });
+    await expect(probeBotPollingFreedom('test-token', fetchMock as typeof fetch)).resolves.toBeUndefined();
+  });
+
+  it('throws TelegramPollingCollisionError on a 409 response', async () => {
+    const fetchMock = async () =>
+      makeResponse(409, {
+        ok: false,
+        error_code: 409,
+        description: 'Conflict: terminated by other getUpdates request',
+      });
+    await expect(probeBotPollingFreedom('test-token', fetchMock as typeof fetch)).rejects.toThrow(
+      TelegramPollingCollisionError,
+    );
+  });
+
+  it('the thrown error includes the conflict description and a fix hint', async () => {
+    const fetchMock = async () =>
+      makeResponse(409, {
+        ok: false,
+        description: 'Conflict: terminated by other getUpdates request',
+      });
+    let caught: unknown;
+    try {
+      await probeBotPollingFreedom('test-token', fetchMock as typeof fetch);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TelegramPollingCollisionError);
+    const tpe = caught as TelegramPollingCollisionError;
+    expect(tpe.description).toContain('Conflict');
+    expect(tpe.message).toMatch(/duplicate NanoClaw host|another process polling/i);
+  });
+
+  it('handles a 409 with non-JSON body without crashing — still throws collision', async () => {
+    const fetchMock = async () =>
+      new Response('<html>some HTML error page</html>', {
+        status: 409,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    await expect(probeBotPollingFreedom('test-token', fetchMock as typeof fetch)).rejects.toThrow(
+      TelegramPollingCollisionError,
+    );
+  });
+
+  it('does NOT throw on transient network failures — lets bridge.setup handle them', async () => {
+    const fetchMock = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    await expect(probeBotPollingFreedom('test-token', fetchMock as typeof fetch)).resolves.toBeUndefined();
+  });
+
+  it('does NOT throw on non-409 HTTP errors — bridge.setup will surface auth/etc with proper context', async () => {
+    const fetchMock = async () => makeResponse(401, { ok: false, description: 'Unauthorized' });
+    await expect(probeBotPollingFreedom('test-token', fetchMock as typeof fetch)).resolves.toBeUndefined();
+  });
+
+  it('sends getUpdates with timeout=0 and offset=-1 (avoids consuming in-flight updates)', async () => {
+    let capturedBody: unknown;
+    const fetchMock = async (_url: string, init?: RequestInit) => {
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : null;
+      return makeResponse(200, { ok: true, result: [] });
+    };
+    await probeBotPollingFreedom('test-token', fetchMock as typeof fetch);
+    expect(capturedBody).toEqual({ timeout: 0, offset: -1 });
+  });
+
+  it('targets the correct Telegram API URL with the bot token', async () => {
+    let capturedUrl = '';
+    const fetchMock = async (url: string) => {
+      capturedUrl = url;
+      return makeResponse(200, { ok: true, result: [] });
+    };
+    await probeBotPollingFreedom('SECRET-TOKEN', fetchMock as typeof fetch);
+    expect(capturedUrl).toBe('https://api.telegram.org/botSECRET-TOKEN/getUpdates');
+  });
+});
+
+describe('withSetupRetry', () => {
+  // Pass a no-op sleep so the retry tests don't burn real time.
+  const noSleep = async () => {};
+
+  it('returns the value on first-try success', async () => {
+    let calls = 0;
+    const result = await withSetupRetry(
+      async () => {
+        calls++;
+        return 'ok';
+      },
+      'test',
+      { sleep: noSleep },
+    );
+    expect(result).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries on transient errors and eventually succeeds', async () => {
+    let calls = 0;
+    const result = await withSetupRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error('transient blip');
+        return 'recovered';
+      },
+      'test',
+      { sleep: noSleep },
+    );
+    expect(result).toBe('recovered');
+    expect(calls).toBe(3);
+  });
+
+  it('throws the last error after exhausting retries', async () => {
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await withSetupRetry(
+        async () => {
+          calls++;
+          throw new Error(`attempt ${calls} failed`);
+        },
+        'test',
+        { sleep: noSleep, maxAttempts: 3 },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe('attempt 3 failed');
+    expect(calls).toBe(3);
+  });
+
+  it('fails fast on a polling-collision error — no retry, no backoff', async () => {
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await withSetupRetry(
+        async () => {
+          calls++;
+          throw new TelegramPollingCollisionError('Conflict: terminated by other getUpdates request');
+        },
+        'test',
+        { sleep: noSleep, maxAttempts: 5 },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TelegramPollingCollisionError);
+    // Critical: did NOT retry. A 409 won't recover by waiting.
+    expect(calls).toBe(1);
+  });
+
+  it('also fails fast when the SDK reports a 409 as a generic Conflict error', async () => {
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await withSetupRetry(
+        async () => {
+          calls++;
+          // The chat-adapter SDK's ValidationError on 409 carries this
+          // description from Telegram. We detect by message shape.
+          throw new Error('Conflict: terminated by other getUpdates request');
+        },
+        'test',
+        { sleep: noSleep, maxAttempts: 5 },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(calls).toBe(1);
+  });
+
+  it('uses the provided sleep — confirming exponential backoff is delegated, not hard-coded', async () => {
+    const delays: number[] = [];
+    const recordingSleep = async (ms: number) => {
+      delays.push(ms);
+    };
+    let calls = 0;
+    let caught: unknown;
+    try {
+      await withSetupRetry(
+        async () => {
+          calls++;
+          throw new Error('always fails');
+        },
+        'test',
+        { sleep: recordingSleep, maxAttempts: 4 },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(calls).toBe(4);
+    // 3 sleeps between 4 attempts: 1000, 2000, 4000 (capped at 16000).
+    expect(delays).toEqual([1000, 2000, 4000]);
+  });
+});

--- a/src/channels/telegram-polling-probe.ts
+++ b/src/channels/telegram-polling-probe.ts
@@ -1,0 +1,158 @@
+/**
+ * Telegram polling-collision detection.
+ *
+ * The Telegram Bot API enforces an exclusive polling session per token —
+ * concurrent `getUpdates` calls return HTTP 409 with a
+ * `Conflict: terminated by other getUpdates request` description. The
+ * `@chat-adapter/telegram` SDK reports this as a generic `ValidationError`
+ * (its 400-499 catch-all bucket) or as a `NetworkError` when the failure
+ * is connection-level — both indistinguishable from real transient
+ * issues, which the surrounding `withRetry` then masks by retrying for
+ * 30+ seconds before throwing.
+ *
+ * Detect the collision up-front via a one-shot probe (`getUpdates`
+ * with `timeout=0`) so the adapter setup fails fast with a message that
+ * points at the actual problem: another live client is holding the bot's
+ * polling session. The most common cause is an orphaned dev process
+ * running alongside the systemd-managed host — see the single-instance
+ * lock PR for the upstream root-cause fix.
+ *
+ * `isTelegramPollingCollision(err)` is exported so the `withRetry`
+ * wrapper can also short-circuit if a 409 surfaces from `bridge.setup`
+ * directly (defence-in-depth).
+ */
+import { log } from '../log.js';
+
+const TELEGRAM_API = 'https://api.telegram.org';
+
+export class TelegramPollingCollisionError extends Error {
+  constructor(public readonly description: string) {
+    super(
+      `Telegram bot polling session is already held by another client ` +
+        `(${description}). The most likely cause is a duplicate NanoClaw ` +
+        `host or another process polling the same bot token. Stop the other ` +
+        `client and try again.`,
+    );
+    this.name = 'TelegramPollingCollisionError';
+  }
+}
+
+/**
+ * Heuristic: is this error a Telegram polling-session collision?
+ *
+ * Three shapes we recognise:
+ *
+ * 1. Our own `TelegramPollingCollisionError` (from `probeBotPollingFreedom`).
+ * 2. A chat-adapter error with a `Conflict` description — the SDK's
+ *    `ValidationError` (mapped from 400-499) carrying Telegram's text.
+ * 3. Any error whose message mentions `409` or `Conflict: terminated by
+ *    other getUpdates` — a defensive catch-all in case the SDK changes
+ *    its error class.
+ */
+export function isTelegramPollingCollision(err: unknown): boolean {
+  if (err instanceof TelegramPollingCollisionError) return true;
+  if (!(err instanceof Error)) return false;
+  const message = err.message || '';
+  if (/\bConflict\b/i.test(message) && /getUpdates/i.test(message)) return true;
+  if (/\b409\b/.test(message) && /telegram/i.test(message)) return true;
+  return false;
+}
+
+/**
+ * Internal: parse a probe response. Exposed for tests so we don't need a
+ * fetch mock with full Response semantics.
+ */
+export function classifyProbeResponse(status: number, body: unknown): TelegramPollingCollisionError | null {
+  if (status !== 409) return null;
+  const description =
+    typeof body === 'object' && body !== null && 'description' in body
+      ? String((body as { description: unknown }).description ?? '')
+      : '';
+  return new TelegramPollingCollisionError(description || 'Conflict reported by Telegram');
+}
+
+/**
+ * Retry a one-shot setup operation that can fail on transient network
+ * errors at cold-start (DNS hiccups, brief upstream outages). Exponential
+ * backoff capped at `maxAttempts` (default 5) — if the network is truly
+ * down we surface the error instead of hanging the service indefinitely.
+ *
+ * Polling-collision errors (HTTP 409 from `getUpdates`) skip the retry
+ * loop entirely. Retrying a 409 just stretches a deterministic failure
+ * across 30+ seconds for no benefit; whoever is holding the bot's polling
+ * session will keep holding it.
+ */
+export async function withSetupRetry<T>(
+  fn: () => Promise<T>,
+  label: string,
+  options: { maxAttempts?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 5;
+  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (isTelegramPollingCollision(err)) {
+        log.error('Telegram bot polling session is held by another client — failing fast', {
+          label,
+          err,
+        });
+        break;
+      }
+      if (attempt === maxAttempts) break;
+      const delay = Math.min(16000, 1000 * 2 ** (attempt - 1));
+      log.warn('Telegram setup failed, retrying', { label, attempt, delayMs: delay, err });
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * One-shot probe of the bot's polling session.
+ *
+ * Calls `getUpdates` with `timeout=0` and `offset=-1`. Telegram answers
+ * immediately with either:
+ *   - 200 OK + `[]`        — nobody else is polling, safe to start
+ *   - 409 Conflict + body  — another client is polling
+ *   - network-level error  — best-effort: log and continue (the real setup
+ *                            will retry properly; we don't want a transient
+ *                            DNS hiccup to block startup)
+ *
+ * `offset=-1` discards any pending updates (we'd rather drop a few than
+ * accidentally consume the in-flight ones from the running adapter).
+ *
+ * @throws {TelegramPollingCollisionError} when Telegram returns 409.
+ */
+export async function probeBotPollingFreedom(token: string, fetchImpl: typeof fetch = fetch): Promise<void> {
+  const url = `${TELEGRAM_API}/bot${token}/getUpdates`;
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ timeout: 0, offset: -1 }),
+    });
+  } catch (err) {
+    // Network-level failure on the probe itself — don't block startup.
+    // The actual bridge.setup will retry with proper backoff.
+    log.warn('Telegram polling probe network error — proceeding to bridge.setup', { err });
+    return;
+  }
+
+  if (response.status === 409) {
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      // Body wasn't JSON — fall through with an empty description.
+    }
+    const collision = classifyProbeResponse(response.status, body);
+    if (collision) throw collision;
+  }
+  // Other non-200s aren't our concern — bridge.setup will surface real
+  // problems (auth, etc.) with proper context.
+}

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -15,28 +15,7 @@ import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js'
 import { registerChannelAdapter } from './channel-registry.js';
 import type { ChannelAdapter, ChannelSetup, InboundMessage } from './adapter.js';
 import { tryConsume } from './telegram-pairing.js';
-
-/**
- * Retry a one-shot operation that can fail on transient network errors at
- * cold-start (DNS hiccups, brief upstream outages). Exponential backoff capped
- * at 5 attempts — if the network is truly down we surface it instead of
- * hanging the service indefinitely.
- */
-async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5): Promise<T> {
-  let lastErr: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastErr = err;
-      if (attempt === maxAttempts) break;
-      const delay = Math.min(16000, 1000 * 2 ** (attempt - 1));
-      log.warn('Telegram setup failed, retrying', { label, attempt, delayMs: delay, err });
-      await new Promise((r) => setTimeout(r, delay));
-    }
-  }
-  throw lastErr;
-}
+import { probeBotPollingFreedom, withSetupRetry } from './telegram-polling-probe.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
@@ -233,11 +212,18 @@ registerChannelAdapter('telegram', {
         }
       },
       async setup(hostConfig: ChannelSetup) {
+        // Pre-flight: probe the bot's polling session before doing any
+        // real setup work. If another client is holding it (HTTP 409), no
+        // amount of retry will recover — fail fast with a clear error so
+        // the operator knows to find the orphan instead of seeing the
+        // adapter silently miss its registration.
+        await probeBotPollingFreedom(token);
+
         const intercepted: ChannelSetup = {
           ...hostConfig,
           onInbound: createPairingInterceptor(botUsernamePromise, hostConfig.onInbound, token),
         };
-        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+        return withSetupRetry(() => bridge.setup(intercepted), 'bridge.setup');
       },
     };
     return wrapped;


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Detect HTTP 409 *Conflict: terminated by other getUpdates request* from the Telegram Bot API and surface it as a clear, actionable error instead of letting the SDK report it as a generic `NetworkError` that `withRetry` masks for 30+ seconds before giving up silently.

**Why.** The Telegram Bot API enforces an exclusive polling session per bot token. When two clients call `getUpdates` concurrently, Telegram returns `409`. The `@chat-adapter/telegram` SDK maps that into its 400-499 catch-all (`ValidationError`) or, when the underlying `fetch` fails, into `NetworkError`. Both are indistinguishable from real transient issues, so the existing `withRetry` retries 5x with exponential backoff (~31s) and finally throws.

The throw aborts `setup()` before `registerChannelAdapter` resolves, leaving the host with only the `cli` adapter registered — visible only as the *absence* of `Channel adapter started channel="telegram"` in the log. Every outbound row to telegram then hits the host's `'No adapter for channel type'` warn and is dropped with `platform_message_id=NULL`, even though `delivery.ts` marks the row `delivered` (the host-side bug for that is in a separate PR against `main`).

This was the user-visible failure mode in a recent post-mortem: a duplicate `pnpm dev` process running alongside the systemd-managed host caused exactly this pattern. The single-instance host lock (sibling PR against `main`) addresses the root cause; this PR makes the symptom diagnosable when something else creates a polling collision (crashed-but-not-released SDK client, second NanoClaw install on the same token, etc.).

**How it works.** Two layers of defence:

1. **Pre-flight probe** in `src/channels/telegram-polling-probe.ts` — `probeBotPollingFreedom(token)` calls `getUpdates` with `timeout=0` and `offset=-1` once before `bridge.setup`. On `409` it throws `TelegramPollingCollisionError` with a message that points at the cause (*"most likely cause is a duplicate NanoClaw host or another process polling the same bot token"*). On network-level errors the probe is permissive — it logs and returns so a transient DNS hiccup doesn't block startup; the real `bridge.setup` will retry properly.
2. **`withSetupRetry`** replaces the old `withRetry`. Same exponential-backoff semantics for transient errors, but `isTelegramPollingCollision(err)` is checked first — on a polling collision (our own error class, or any error whose message matches Telegram's *Conflict* description), the loop breaks immediately. Sleep is also injectable so tests don't burn real time.

The detection heuristic recognises three error shapes: our own collision class, a chat-adapter `ValidationError` carrying Telegram's description, and any error whose message mentions both `409`/`Conflict` and `getUpdates`/`telegram`.

`offset=-1` is important: it discards any pending updates instead of consuming them, so the probe doesn't accidentally swallow in-flight messages from a healthy adapter that's about to start.

**How it was tested.**

25 unit tests in `src/channels/telegram-polling-probe.test.ts`:

- `classifyProbeResponse`: returns null for 200/non-409; returns `TelegramPollingCollisionError` for 409 with description; falls back to a generic description for 409 with no body.
- `isTelegramPollingCollision`: matches our own error class, chat-adapter-shaped *Conflict* descriptions, and 409+telegram messages; rejects generic `NetworkError`s, non-Telegram conflicts, auth errors, and non-Error values.
- `probeBotPollingFreedom`: resolves on 200 + `[]`; throws on 409 (with description, with no body, with non-JSON body); permissive on network failure (`ECONNREFUSED`); permissive on non-409 HTTP errors; sends `{timeout: 0, offset: -1}`; targets the correct URL.
- `withSetupRetry`: first-try success; transient retry-then-recover; throws last error after exhausting retries; **fails fast on `TelegramPollingCollisionError` (1 call, no backoff)**; also fails fast on a generic *Conflict* Error; exponential backoff sequence verified via injected sleep.

No external behavioural change for healthy installs — the probe is one extra `getUpdates` call at adapter setup time, which is also what the polling loop would do milliseconds later anyway.