### PR TITLE
fix(host): throw on missing channel adapter instead of silently dropping the message

### DIFF
--- a/src/channels/delivery-adapter.test.ts
+++ b/src/channels/delivery-adapter.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the delivery-adapter bridge.
+ *
+ * Verifies:
+ *   - deliver() throws MissingChannelAdapterError when no adapter is
+ *     registered (instead of silently returning undefined and letting
+ *     the caller markDelivered with platform_message_id=NULL).
+ *   - deliver() forwards to the resolved adapter and returns its
+ *     platform message id on the happy path.
+ *   - deliver() parses the JSON content string before handing it to the
+ *     adapter (preserves the existing contract).
+ *   - deliver() propagates real adapter errors as-is (so the retry loop
+ *     in delivery.ts handles them the way it always has).
+ *   - setTyping() is tolerant of missing adapters (no throw, no-op).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDeliveryAdapter, MissingChannelAdapterError } from './delivery-adapter.js';
+import type { ChannelAdapter, OutboundFile } from './adapter.js';
+
+function makeStubAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
+  return {
+    name: 'stub',
+    channelType: 'stub',
+    supportsThreads: false,
+    deliver: vi.fn().mockResolvedValue('stub-platform-id'),
+    ...overrides,
+  } as ChannelAdapter;
+}
+
+describe('createDeliveryAdapter — deliver()', () => {
+  it('throws MissingChannelAdapterError when no adapter is registered', async () => {
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => null });
+
+    let caught: unknown;
+    try {
+      await bridge.deliver('telegram', 'telegram:123', null, 'chat', '{"text":"hi"}');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MissingChannelAdapterError);
+    expect((caught as MissingChannelAdapterError).channelType).toBe('telegram');
+    expect((caught as Error).message).toMatch(/No adapter registered/i);
+    expect((caught as Error).message).toMatch(/telegram/);
+  });
+
+  it('also throws when the registry returns undefined', async () => {
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => undefined });
+    await expect(bridge.deliver('telegram', 'telegram:123', null, 'chat', '{"text":"hi"}')).rejects.toBeInstanceOf(
+      MissingChannelAdapterError,
+    );
+  });
+
+  it('forwards to the resolved adapter and returns its platform message id', async () => {
+    const adapter = makeStubAdapter({
+      deliver: vi.fn().mockResolvedValue('1805102895:42'),
+    });
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+
+    const result = await bridge.deliver('telegram', 'telegram:123', 'thread-1', 'chat', '{"text":"hello"}');
+
+    expect(result).toBe('1805102895:42');
+    expect(adapter.deliver).toHaveBeenCalledTimes(1);
+    expect(adapter.deliver).toHaveBeenCalledWith('telegram:123', 'thread-1', {
+      kind: 'chat',
+      content: { text: 'hello' },
+      files: undefined,
+    });
+  });
+
+  it('passes file attachments through to the adapter unchanged', async () => {
+    const adapter = makeStubAdapter();
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+    const files: OutboundFile[] = [{ filename: 'a.png', data: Buffer.from('x') }];
+
+    await bridge.deliver('telegram', 'telegram:123', null, 'chat', '{"text":"with file"}', files);
+
+    expect(adapter.deliver).toHaveBeenCalledWith('telegram:123', null, {
+      kind: 'chat',
+      content: { text: 'with file' },
+      files,
+    });
+  });
+
+  it('parses the JSON content string before handing it to the adapter', async () => {
+    const adapter = makeStubAdapter();
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+
+    await bridge.deliver('telegram', 'telegram:123', null, 'chat', '{"nested":{"a":1},"arr":[2,3]}');
+
+    const call = (adapter.deliver as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2].content).toEqual({ nested: { a: 1 }, arr: [2, 3] });
+  });
+
+  it('propagates real adapter errors as-is (so delivery.ts retry path runs)', async () => {
+    const realErr = new Error('Telegram API getMe failed (status 401)');
+    const adapter = makeStubAdapter({
+      deliver: vi.fn().mockRejectedValue(realErr),
+    });
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+
+    await expect(bridge.deliver('telegram', 'telegram:123', null, 'chat', '{"text":"hi"}')).rejects.toBe(realErr);
+  });
+
+  it('resolves the adapter via the channelType argument, not a static reference', async () => {
+    // Two adapters, one per channelType. The bridge should pick by argument,
+    // not by closure capture — tests the DI seam.
+    const tg = makeStubAdapter({ name: 'tg', channelType: 'telegram' });
+    const slk = makeStubAdapter({ name: 'slk', channelType: 'slack' });
+    const registry: Record<string, ChannelAdapter> = { telegram: tg, slack: slk };
+    const bridge = createDeliveryAdapter({
+      getChannelAdapter: (ct) => registry[ct] ?? null,
+    });
+
+    await bridge.deliver('slack', 'slack:C123', null, 'chat', '{"text":"hi"}');
+
+    expect(slk.deliver).toHaveBeenCalledTimes(1);
+    expect(tg.deliver).not.toHaveBeenCalled();
+  });
+});
+
+describe('createDeliveryAdapter — setTyping()', () => {
+  it('does not throw when no adapter is registered (typing is advisory)', async () => {
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => null });
+    await expect(bridge.setTyping!('telegram', 'telegram:123', null)).resolves.toBeUndefined();
+  });
+
+  it('forwards to adapter.setTyping when present', async () => {
+    const setTyping = vi.fn().mockResolvedValue(undefined);
+    const adapter = makeStubAdapter({ setTyping });
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+
+    await bridge.setTyping!('telegram', 'telegram:123', 'thread-1');
+
+    expect(setTyping).toHaveBeenCalledWith('telegram:123', 'thread-1');
+  });
+
+  it('is a no-op when adapter exists but does not implement setTyping', async () => {
+    const adapter = makeStubAdapter({ setTyping: undefined });
+    const bridge = createDeliveryAdapter({ getChannelAdapter: () => adapter });
+    await expect(bridge.setTyping!('telegram', 'telegram:123', null)).resolves.toBeUndefined();
+  });
+});
+
+describe('MissingChannelAdapterError', () => {
+  it('carries the channelType and a useful message', () => {
+    const err = new MissingChannelAdapterError('telegram');
+    expect(err.channelType).toBe('telegram');
+    expect(err.message).toContain('telegram');
+    expect(err.name).toBe('MissingChannelAdapterError');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/src/channels/delivery-adapter.ts
+++ b/src/channels/delivery-adapter.ts
@@ -1,0 +1,87 @@
+/**
+ * Delivery adapter bridge — dispatches outbound messages to whichever
+ * channel adapter owns the target `channelType`.
+ *
+ * The bug this module's behaviour fixes: previously this lambda lived
+ * inline in `src/index.ts` and silently returned `undefined` when no
+ * adapter was registered for a channel. The caller in `src/delivery.ts`
+ * then wrote `markDelivered(msg.id, undefined)` — a row with
+ * `status='delivered'` and `platform_message_id=NULL`. Net result: a
+ * message that never left the host was indistinguishable in the DB from
+ * one that was successfully sent. Operators saw `delivered: delivered`
+ * for a row that had in fact been dropped.
+ *
+ * The pattern is the delivery-side cousin of the silent-task-failure bug
+ * fixed in PR #2167. Same shape: a code path that should propagate
+ * "I didn't do the thing" instead collapses it to "I did the thing".
+ *
+ * The fix: throw `MissingChannelAdapterError` instead of returning
+ * undefined. The retry loop in `deliverSessionMessages` (delivery.ts)
+ * already has the right shape — three attempts then `markDeliveryFailed`
+ * — so the row ends as `status='failed'` and is visible to operators.
+ *
+ * `setTyping` keeps its tolerant behaviour: a missing adapter shouldn't
+ * block typing-indicator suppression, and there's no persistent state
+ * for it to corrupt.
+ */
+import type { ChannelDeliveryAdapter } from '../delivery.js';
+import type { ChannelAdapter, OutboundFile } from './adapter.js';
+
+export class MissingChannelAdapterError extends Error {
+  constructor(public readonly channelType: string) {
+    super(
+      `No adapter registered for channel type '${channelType}'. ` +
+        `The message cannot be delivered — verify the channel adapter started successfully ` +
+        `at host startup (search the log for "Channel adapter started channel=\\"${channelType}\\"").`,
+    );
+    this.name = 'MissingChannelAdapterError';
+  }
+}
+
+export interface CreateDeliveryAdapterDeps {
+  /**
+   * Resolves a channel adapter by channelType. Returns null/undefined when
+   * no adapter is registered.
+   *
+   * Injected so tests can drive the factory without spinning up the full
+   * channel registry.
+   */
+  getChannelAdapter: (channelType: string) => ChannelAdapter | null | undefined;
+}
+
+/**
+ * Build the delivery adapter bridge passed to `setDeliveryAdapter`.
+ *
+ * On `deliver`: if no channel adapter is registered for `channelType`,
+ * throw `MissingChannelAdapterError`. The exception propagates up to
+ * `deliverSessionMessages` in delivery.ts, which retries up to three
+ * times then calls `markDeliveryFailed` — the row ends as
+ * `status='failed'` instead of being silently marked delivered with a
+ * NULL platform message id.
+ *
+ * On `setTyping`: tolerant of a missing adapter. Typing indicators are
+ * advisory; not having an adapter to send the indicator to isn't a
+ * delivery failure and we have no persistent state to corrupt.
+ */
+export function createDeliveryAdapter(deps: CreateDeliveryAdapterDeps): ChannelDeliveryAdapter {
+  return {
+    async deliver(
+      channelType: string,
+      platformId: string,
+      threadId: string | null,
+      kind: string,
+      content: string,
+      files?: OutboundFile[],
+    ): Promise<string | undefined> {
+      const adapter = deps.getChannelAdapter(channelType);
+      if (!adapter) {
+        throw new MissingChannelAdapterError(channelType);
+      }
+      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
+    },
+    async setTyping(channelType: string, platformId: string, threadId: string | null): Promise<void> {
+      const adapter = deps.getChannelAdapter(channelType);
+      await adapter?.setTyping?.(platformId, threadId);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import './modules/index.js';
 
 import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
 import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from './channels/channel-registry.js';
+import { createDeliveryAdapter } from './channels/delivery-adapter.js';
 
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
@@ -130,29 +131,11 @@ async function main(): Promise<void> {
     };
   });
 
-  // 4. Delivery adapter bridge — dispatches to channel adapters
-  const deliveryAdapter = {
-    async deliver(
-      channelType: string,
-      platformId: string,
-      threadId: string | null,
-      kind: string,
-      content: string,
-      files?: import('./channels/adapter.js').OutboundFile[],
-    ): Promise<string | undefined> {
-      const adapter = getChannelAdapter(channelType);
-      if (!adapter) {
-        log.warn('No adapter for channel type', { channelType });
-        return;
-      }
-      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
-    },
-    async setTyping(channelType: string, platformId: string, threadId: string | null): Promise<void> {
-      const adapter = getChannelAdapter(channelType);
-      await adapter?.setTyping?.(platformId, threadId);
-    },
-  };
-  setDeliveryAdapter(deliveryAdapter);
+  // 4. Delivery adapter bridge — dispatches to channel adapters.
+  //    See src/channels/delivery-adapter.ts for the no-adapter-throws
+  //    rationale (silent NULL-platform-id deliveries are a delivery-side
+  //    cousin of PR #2167's silent-task-failure bug).
+  setDeliveryAdapter(createDeliveryAdapter({ getChannelAdapter }));
 
   // 5. Start delivery polls
   startActiveDeliveryPoll();


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Make `deliveryAdapter.deliver` throw `MissingChannelAdapterError` when no adapter is registered for a `channelType`, so the retry loop in `deliverSessionMessages` runs and the row is eventually marked `status='failed'` instead of being silently marked `delivered` with `platform_message_id=NULL`.

**Why.** The pre-fix code in `src/index.ts:144-147` was:

```ts
const adapter = getChannelAdapter(channelType);
if (!adapter) {
  log.warn('No adapter for channel type', { channelType });
  return;
}
```

`return` resolves the promise to `undefined`, which is *also* what the caller in `delivery.ts` would see on a successful adapter that didn't return a message id (some adapters legitimately do that). The caller then runs:

```ts
markDelivered(inDb, msg.id, platformMsgId ?? null);
```

Net effect: the row is recorded as `status='delivered'` with `platform_message_id=NULL` even though no API call was made. The operator looking at the DB sees `delivered` and assumes the user got the message. They didn't.

This is the delivery-side cousin of the silent-task-failure bug fixed in #2167. Same shape: a code path that should propagate *"I didn't do the thing"* instead collapses it to *"I did the thing"*.

The trigger pattern observed in the wild: an adapter's `setup` throws silently (e.g. Telegram bot polling collision — see the sibling PR on the `channels` branch), so `registerChannelAdapter` never resolves, the adapter is missing from the registry, and every outbound message to that channel gets marked `delivered`/NULL. The user sees nothing; the operator sees a healthy delivery log. Verified in real data: today's morning briefing produced 6 outbound rows across two cycles, all with empty `platform_message_id`s in `delivered`, all sat in the bot's outbox without ever being sent.

**How it works.**

1. **`src/channels/delivery-adapter.ts`** — new module. `createDeliveryAdapter({ getChannelAdapter })` returns the bridge. `deliver` throws `MissingChannelAdapterError(channelType)` (carries the channelType + a hint pointing operators at the missing `Channel adapter started` log line). `setTyping` keeps its tolerant behaviour (typing indicators are advisory; not having an adapter to suppress the indicator on isn't a delivery failure and we have no persistent state to corrupt).
2. **`src/index.ts`** — switches from the inline lambda to `setDeliveryAdapter(createDeliveryAdapter({ getChannelAdapter }))`.

The retry path in `delivery.ts` already handles thrown errors correctly: 3 attempts via `MAX_DELIVERY_ATTEMPTS`, then `markDeliveryFailed` writes `status='failed'`. No change needed there. After the third attempt, the row is visible to operators as a real failure instead of a phantom delivery.

**How it was tested.**

11 unit tests in `src/channels/delivery-adapter.test.ts`:

- Throws `MissingChannelAdapterError` when registry returns `null`; same when it returns `undefined`.
- Forwards to the resolved adapter and returns its platform message id.
- Passes file attachments through unchanged.
- Parses the JSON `content` string before handing it to the adapter (preserves the existing contract).
- Propagates real adapter errors as-is so `delivery.ts` retry path runs.
- Resolves the adapter via the `channelType` argument (DI seam, not closure capture).
- `setTyping`: no-throw when adapter missing; forwards when present; no-op when adapter exists but doesn't implement `setTyping`.
- `MissingChannelAdapterError` carries `channelType`, has the right `name`, and is an `Error` instance.

No DB writes were affected — only what `markDelivered` ends up persisting. After this fix, a missing-adapter delivery ends as `status='failed'` (visible to anyone scanning for delivery failures), not as `status='delivered'` with NULL ids (invisible).