### PR TITLE
Recognize ANTHROPIC_AUTH_TOKEN in setup verification

### DIFF
--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -84,21 +84,28 @@ describe('credentials detection', () => {
     const content =
       'SOME_KEY=value\nANTHROPIC_API_KEY=sk-ant-test123\nOTHER=foo';
     const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
     expect(hasCredentials).toBe(true);
   });
 
   it('detects CLAUDE_CODE_OAUTH_TOKEN in env content', () => {
     const content = 'CLAUDE_CODE_OAUTH_TOKEN=token123';
     const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
+    expect(hasCredentials).toBe(true);
+  });
+
+  it('detects ANTHROPIC_AUTH_TOKEN in env content', () => {
+    const content = 'ANTHROPIC_AUTH_TOKEN=token123\nANTHROPIC_BASE_URL=http://localhost:8080';
+    const hasCredentials =
+      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
     expect(hasCredentials).toBe(true);
   });
 
   it('returns false when no credentials', () => {
     const content = 'ASSISTANT_NAME="Andy"\nOTHER=foo';
     const hasCredentials =
-      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(content);
+      /^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(content);
     expect(hasCredentials).toBe(false);
   });
 });

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -139,7 +139,7 @@ export async function run(_args: string[]): Promise<void> {
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ONECLI_URL)=/m.test(envContent)) {
+    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|ONECLI_URL)=/m.test(envContent)) {
       credentials = 'configured';
     }
   }


### PR DESCRIPTION
## Summary

Recognize `ANTHROPIC_AUTH_TOKEN` as a valid credential in setup verification.

## Problem

The credential proxy (`src/credential-proxy.ts` line 33) already reads `ANTHROPIC_AUTH_TOKEN` and uses it for OAuth-mode authentication (line 39). However, `setup/verify.ts` only checks for `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` in the `.env` file, causing users with `ANTHROPIC_AUTH_TOKEN` to see `CREDENTIALS: missing` even though their credentials work at runtime.

This affects users who authenticate via LLM gateways, proxies (LiteLLM, Portkey, OpenRouter), or Anthropic-compatible endpoints that use Bearer token auth.

## Prior PRs

#854 and #856 address the same issue but are based on an older `main` and will conflict with the `ONECLI_URL` addition that has since landed. This PR is rebased on current `main` and includes `ONECLI_URL` in the regex.

## Changes

- `setup/verify.ts`: Add `ANTHROPIC_AUTH_TOKEN` to the credential-detection regex
- `setup/environment.test.ts`: Update existing tests to match the new regex and add a test case for `ANTHROPIC_AUTH_TOKEN`

## Validation

Full test suite passes (236 tests, 18 files):

```
npx vitest run
```

Closes #853