### PR TITLE
fix(container-runner): map host user via keep-id on rootless podman

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -23,9 +23,14 @@ import {
   TIMEZONE,
 } from './config.js';
 import { materializeContainerJson } from './container-config.js';
-import { getContainerConfig } from './db/container-configs.js';
-import { updateContainerConfigScalars } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import { getContainerConfig, updateContainerConfigScalars } from './db/container-configs.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  isRootlessPodman,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from './egress-lockdown.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -469,10 +474,28 @@ async function buildContainerArgs(
     args.push(...hostGatewayArgs());
   }
 
-  // User mapping
+  // User mapping. Two regimes:
+  //
+  // 1. Rootless podman → map the image's USER directive (node, uid 1000)
+  //    to the host running user via `--userns=keep-id:uid=1000,gid=1000`.
+  //    Container processes run as `node` and writes show up as owned by
+  //    whoever invoked podman, regardless of whether their host uid is
+  //    1000 or not. Without this flag podman's default rootless mapping
+  //    puts the host running user at container uid 0 and the image's
+  //    `node` user (uid 1000) lands in subuid range, unable to write
+  //    host files (symptom: EACCES / "readonly database" inside the
+  //    container despite the host user owning the bind-mounted files).
+  //
+  // 2. Rootful Docker → no user namespace exists. A container process
+  //    running as `node` (uid 1000) writes files owned by host uid 1000.
+  //    Force `--user $hostUid:$hostGid` when the operator's host uid
+  //    isn't 1000 (and isn't root) to make writes show up as the host
+  //    user.
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
-  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+  if (isRootlessPodman()) {
+    args.push('--userns=keep-id:uid=1000,gid=1000');
+  } else if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
     args.push('--user', `${hostUid}:${hostGid}`);
     args.push('-e', 'HOME=/home/node');
   }

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -25,6 +25,38 @@ export function readonlyMountArgs(hostPath: string, containerPath: string): stri
   return ['-v', `${hostPath}:${containerPath}:ro`];
 }
 
+/**
+ * True iff the container runtime is rootless podman. Cached — `info` is
+ * non-trivial. Safe against real Docker: the `Host.Security.Rootless`
+ * template field is podman-only, so `docker info` returns an empty string
+ * and the helper returns false.
+ *
+ * Used to decide whether the spawn args need an explicit `--user` flag.
+ * Rootful Docker has no user namespace mapping, so files written by a
+ * container process are owned by whatever uid that process runs as on
+ * the host — passing `--user $hostUid:$hostGid` is the only way to make
+ * the container's writes show up as the host user. Rootless podman has
+ * its own user-namespace mapping that maps the image's USER directive
+ * to the host running user automatically; passing `--user` there breaks
+ * that mapping and routes writes through subuids, which don't own host
+ * files.
+ */
+let cachedRootlessPodman: boolean | undefined;
+export function isRootlessPodman(): boolean {
+  if (cachedRootlessPodman !== undefined) return cachedRootlessPodman;
+  try {
+    const out = execSync(`${CONTAINER_RUNTIME_BIN} info --format '{{.Host.Security.Rootless}}'`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    cachedRootlessPodman = out.trim() === 'true';
+  } catch {
+    cachedRootlessPodman = false;
+  }
+  return cachedRootlessPodman;
+}
+
 /** Stop a container by name. Uses execFileSync to avoid shell injection. */
 export function stopContainer(name: string): void {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name)) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The user-mapping block in `container-runner.ts` forces the container to run as the host's uid:gid when the host uid is neither 0 nor 1000:

```ts
if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
  args.push('--user', `${hostUid}:${hostGid}`);
  args.push('-e', 'HOME=/home/node');
}
```

That's correct for **rootful Docker** — no user namespace, so a container process running as the image's `node` user (uid 1000) writes files owned by host uid 1000, wrong if the operator's host uid isn't 1000. Forcing `--user` makes writes show up as the host user.

It's broken for **rootless podman** with operators whose host uid isn't 1000:

- Podman's default rootless mapping is `host_running_uid → container uid 0`. The image's `USER node` (uid 1000) is processed inside that user namespace, so it lands in subuid range — not on the host running user's uid.
- Files owned by the operator on the host therefore can't be written from inside the container.
- Symptom: EACCES / SQLite `SQLITE_READONLY` despite the operator owning the bind-mounted files at the FS level.

(Operators with host uid 1000 don't see the failure: by coincidence the running-uid 1000 happens to equal the image's USER uid 1000, so the mapping aligns. Operators on multi-user hosts where their uid is 1001+ hit the bug immediately.)

## Fix

Add a cached `isRootlessPodman()` helper that calls `<runtime> info --format '{{.Host.Security.Rootless}}'`. The template field is podman-only; on Docker the call returns an empty string and the helper returns `false` — Docker users see no behavior change.

Then split the user-mapping logic by regime:

```ts
if (isRootlessPodman()) {
  // Map the image's USER (node, uid 1000) to the host running user.
  args.push('--userns=keep-id:uid=1000,gid=1000');
} else if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
  // Rootful Docker: existing behavior.
  args.push('--user', `${hostUid}:${hostGid}`);
  args.push('-e', 'HOME=/home/node');
}
```

`--userns=keep-id:uid=1000,gid=1000` tells podman to map the host running user to container uid 1000 (the image's `node` user). Container runs as `node` (Claude Code happy, not root) and writes show up as owned by the host running user — works for any host uid.

## Empirical verification

Tested on rootless podman 5.8.2 with two operators on the same host: one with host uid 1000 (matches image USER), one with host uid 1001 (doesn't match).

| Operator | Without flag (current code) | With flag (this PR) |
|---|---|---|
| host uid 1000 | container uid 1000 → host uid 1000 ✓ (works by coincidence) | container uid 1000 → host uid 1000 ✓ (now intentional) |
| host uid 1001 | container uid 1000 → subuid range (~590823) ✗ writes fail | container uid 1000 → host uid 1001 ✓ writes succeed |

`/proc/<pid>/uid_map` confirms the mapping in each case. File writes from inside the container land with the operator's ownership on the host.

## Files

- `src/container-runtime.ts` — add cached `isRootlessPodman()` helper.
- `src/container-runner.ts` — split user-mapping logic by runtime regime.

## Note

Eliminates the need for elaborate workarounds (setpriv wrappers, `chmod 0777` on session directories, `--user 0:0` + post-spawn privilege drop) on rootless multi-user hosts where operators have non-1000 uids — a common situation on shared servers and second-user accounts.