### PR TITLE
fix(chat-sdk-bridge): fall back to URL fetch for adapters without fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -137,21 +137,47 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     if (message.attachments && message.attachments.length > 0) {
       const enriched = [];
       for (const att of message.attachments) {
+        const attAny = att as unknown as Record<string, unknown>;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const entry: Record<string, any> = {
           type: att.type,
           name: att.name,
           mimeType: att.mimeType,
           size: att.size,
-          width: (att as unknown as Record<string, unknown>).width,
-          height: (att as unknown as Record<string, unknown>).height,
+          url: attAny.url,
+          width: attAny.width,
+          height: attAny.height,
         };
         if (att.fetchData) {
           try {
             const buffer = await att.fetchData();
             entry.data = buffer.toString('base64');
           } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
+            log.warn('Failed to download attachment via fetchData', { type: att.type, err });
+          }
+        } else if (typeof entry.url === 'string') {
+          // Fallback for adapters that expose only a URL on attachments and
+          // don't implement fetchData. Best-effort: HTTP errors and non-2xx
+          // responses log a warning and skip data; the URL field remains so
+          // callers can still attempt their own download.
+          try {
+            const res = await fetch(entry.url as string);
+            if (res.ok) {
+              const buffer = Buffer.from(await res.arrayBuffer());
+              entry.data = buffer.toString('base64');
+            } else {
+              log.warn('Attachment URL fetch returned non-OK', {
+                status: res.status,
+                type: att.type,
+                url: entry.url,
+              });
+            }
+          } catch (err) {
+            log.warn('Failed to download attachment via URL', {
+              type: att.type,
+              url: entry.url,
+              err,
+            });
           }
         }
         enriched.push(entry);


### PR DESCRIPTION
## Type of Change                                                                                                                                                                              
- [x] **Fix** - bug fix or security fix to source code
                                                        
## Description
The current attachment loop in `chat-sdk-bridge.messageToInbound` calls `att.fetchData()` and falls through if the method is absent. Adapters that don't implement `fetchData` (the Discord chat-adapter is one example) leave the attachment entry without binary data — the host inbox stores only the URL string and the agent gets no `localPath`.                                       

When `fetchData` is absent but `att.url` is a string, fetch the URL via the runtime's global `fetch` and base64-encode the body. Best-effort: HTTP errors and non-2xx responses log a warning and skip data; the URL field is preserved on the entry so downstream callers can still attempt their own download.                                                                                  
                                                                                                                 
Also: include `url` on the enriched entry unconditionally (it's needed by the fallback path and useful as metadata even when `fetchData` succeeds).