### PR TITLE
fix: migration UX improvements + legacy OneCLI container cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This is NanoClaw v2, a ground-up rewrite with breaking changes throughout. It ca
 
 **Do this instead:**
 1. Abort the merge: `git merge --abort` (or `git reset --hard ORIG_HEAD` if the merge already completed).
-2. Tell the user, verbatim: *"This is the v2 rewrite — it can't be merged into your existing install. Run `bash migrate-v2.sh` to migrate instead."*
-3. Wait for the user to confirm before doing anything else. Do not attempt the migration yourself.
+2. Tell the user, verbatim: *"This is the v2 rewrite — it can't be merged into your existing install. Run `! bash migrate-v2.sh` to migrate instead."*
+3. Wait for the user to confirm before doing anything else. Do not run the migration script yourself — it requires an interactive terminal and must be run by the user with the `!` prefix.
 
 If you are a fresh install (you ran `git clone`, not `git pull`) and there are no conflicts, ignore this banner and continue below.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This is NanoClaw v2, a ground-up rewrite with breaking changes throughout. It ca
 
 **Do this instead:**
 1. Abort the merge: `git merge --abort` (or `git reset --hard ORIG_HEAD` if the merge already completed).
-2. Tell the user, verbatim: *"This is the v2 rewrite — it can't be merged into your existing install. Run `! bash migrate-v2.sh` to migrate instead."*
-3. Wait for the user to confirm before doing anything else. Do not run the migration script yourself — it requires an interactive terminal and must be run by the user with the `!` prefix.
+2. Tell the user, verbatim: *"This is the v2 rewrite — it can't be merged into your existing install. Exit Claude Code (or open a separate terminal) and run `bash migrate-v2.sh` from the shell."*
+3. Wait for the user to confirm before doing anything else. Do not run the migration script yourself — it requires an interactive terminal and cannot be run from within Claude Code.
 
 If you are a fresh install (you ran `git clone`, not `git pull`) and there are no conflicts, ignore this banner and continue below.
 

--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -563,47 +563,22 @@ echo
 echo "$(bold 'Service switchover')"
 echo
 
-# Retire the legacy v1 service file and alias it to the v2 unit.
-# Called after the user confirms "keep v2", or when v1 wasn't running.
+# Disable the v1 service so it doesn't auto-start, but leave the unit file
+# on disk so the user can rollback with: systemctl --user start nanoclaw
 # Idempotent — safe to call multiple times.
-retire_v1_service() {
-  if [ -z "$V2_SERVICE" ]; then
-    return
-  fi
-
+disable_v1_service() {
   if [ "$PLATFORM_SERVICE" = "systemd" ]; then
-    local unit_dir="$HOME/.config/systemd/user"
-    local v1_file="$unit_dir/${V1_SERVICE}.service"
-    local v2_file="${V2_SERVICE}.service"
-
-    # Already a correct symlink — nothing to do
-    if [ -L "$v1_file" ] && [ "$(readlink "$v1_file")" = "$v2_file" ]; then
-      return
-    fi
-
-    # Only retire if the file exists (as a regular file or stale symlink)
+    local v1_file="$HOME/.config/systemd/user/${V1_SERVICE}.service"
     if [ -f "$v1_file" ] || [ -L "$v1_file" ]; then
       systemctl --user stop "$V1_SERVICE" 2>/dev/null || true
       systemctl --user disable "$V1_SERVICE" 2>/dev/null || true
-      rm -f "$v1_file"
-      ln -s "$v2_file" "$v1_file"
-      systemctl --user daemon-reload 2>/dev/null || true
-      step_ok "Aliased $V1_SERVICE → $V2_SERVICE"
+      step_ok "Disabled $V1_SERVICE (unit file kept for rollback)"
     fi
-
   elif [ "$PLATFORM_SERVICE" = "launchd" ]; then
     local v1_plist="$HOME/Library/LaunchAgents/${V1_SERVICE}.plist"
-    local v2_plist="${V2_SERVICE}.plist"
-
-    if [ -L "$v1_plist" ] && [ "$(readlink "$v1_plist")" = "$v2_plist" ]; then
-      return
-    fi
-
     if [ -f "$v1_plist" ] || [ -L "$v1_plist" ]; then
       launchctl unload "$v1_plist" 2>/dev/null || true
-      rm -f "$v1_plist"
-      ln -s "$v2_plist" "$v1_plist"
-      step_ok "Aliased $V1_SERVICE → $V2_SERVICE"
+      step_ok "Unloaded $V1_SERVICE (plist kept for rollback)"
     fi
   fi
 }
@@ -696,14 +671,14 @@ if [ "$V1_RUNNING" = "true" ]; then
       SERVICE_SWITCHED=false
     else
       step_ok "Keeping v2 service"
-      retire_v1_service
+      disable_v1_service
     fi
   else
     step_skip "Service switchover skipped"
   fi
 else
   step_skip "v1 service not running — nothing to switch"
-  retire_v1_service
+  disable_v1_service
 fi
 
 echo
@@ -735,6 +710,16 @@ echo "    $(green '✓')  Channels installed: ${SELECTED_CHANNELS[*]}"
 fi
 echo "    $(green '✓')  Container skills copied"
 echo "    $(green '✓')  Container image built"
+if [ "$SERVICE_SWITCHED" = "true" ] && [ -n "$V2_SERVICE" ]; then
+echo "    $(green '✓')  Service switched to v2 $(dim "($V2_SERVICE)")"
+echo
+echo "  $(bold 'Rollback to v1:')"
+if [ "$PLATFORM_SERVICE" = "systemd" ]; then
+echo "    $(dim '$') systemctl --user stop $V2_SERVICE && systemctl --user start $V1_SERVICE"
+elif [ "$PLATFORM_SERVICE" = "launchd" ]; then
+echo "    $(dim '$') launchctl unload ~/Library/LaunchAgents/${V2_SERVICE}.plist && launchctl load ~/Library/LaunchAgents/${V1_SERVICE}.plist"
+fi
+fi
 echo
 echo "  $(bold 'What still needs a human:')"
 if [ "$ONECLI_OK" = "false" ]; then

--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -5,6 +5,9 @@
 # Run from the v2 directory:
 #   bash migrate-v2.sh
 #
+# From Claude Code, use the ! prefix so it runs in your terminal:
+#   ! bash migrate-v2.sh
+#
 # Finds v1 automatically (sibling directory, or $NANOCLAW_V1_PATH).
 # Installs prerequisites (Node, pnpm, deps) via the existing setup.sh
 # bootstrap, then runs the migration steps.
@@ -16,6 +19,19 @@ set -uo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
+
+# This script has interactive prompts (channel selection, service switchover)
+# and streams progress output — it must run in a real terminal, not inside
+# a tool subprocess (e.g. Claude Code's Bash tool, which collapses output).
+if ! [ -t 0 ] || ! [ -t 1 ]; then
+  echo "This script requires an interactive terminal."
+  echo ""
+  echo "If you're in Claude Code, run it directly with the ! prefix:"
+  echo "  ! bash migrate-v2.sh"
+  echo ""
+  echo "Or run it in a separate terminal session."
+  exit 1
+fi
 
 LOGS_DIR="$PROJECT_ROOT/logs"
 STEPS_DIR="$LOGS_DIR/migrate-steps"

--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -563,6 +563,51 @@ echo
 echo "$(bold 'Service switchover')"
 echo
 
+# Retire the legacy v1 service file and alias it to the v2 unit.
+# Called after the user confirms "keep v2", or when v1 wasn't running.
+# Idempotent — safe to call multiple times.
+retire_v1_service() {
+  if [ -z "$V2_SERVICE" ]; then
+    return
+  fi
+
+  if [ "$PLATFORM_SERVICE" = "systemd" ]; then
+    local unit_dir="$HOME/.config/systemd/user"
+    local v1_file="$unit_dir/${V1_SERVICE}.service"
+    local v2_file="${V2_SERVICE}.service"
+
+    # Already a correct symlink — nothing to do
+    if [ -L "$v1_file" ] && [ "$(readlink "$v1_file")" = "$v2_file" ]; then
+      return
+    fi
+
+    # Only retire if the file exists (as a regular file or stale symlink)
+    if [ -f "$v1_file" ] || [ -L "$v1_file" ]; then
+      systemctl --user stop "$V1_SERVICE" 2>/dev/null || true
+      systemctl --user disable "$V1_SERVICE" 2>/dev/null || true
+      rm -f "$v1_file"
+      ln -s "$v2_file" "$v1_file"
+      systemctl --user daemon-reload 2>/dev/null || true
+      step_ok "Aliased $V1_SERVICE → $V2_SERVICE"
+    fi
+
+  elif [ "$PLATFORM_SERVICE" = "launchd" ]; then
+    local v1_plist="$HOME/Library/LaunchAgents/${V1_SERVICE}.plist"
+    local v2_plist="${V2_SERVICE}.plist"
+
+    if [ -L "$v1_plist" ] && [ "$(readlink "$v1_plist")" = "$v2_plist" ]; then
+      return
+    fi
+
+    if [ -f "$v1_plist" ] || [ -L "$v1_plist" ]; then
+      launchctl unload "$v1_plist" 2>/dev/null || true
+      rm -f "$v1_plist"
+      ln -s "$v2_plist" "$v1_plist"
+      step_ok "Aliased $V1_SERVICE → $V2_SERVICE"
+    fi
+  fi
+}
+
 # Detect platform and service names
 V1_SERVICE=""
 V2_SERVICE=""
@@ -651,16 +696,14 @@ if [ "$V1_RUNNING" = "true" ]; then
       SERVICE_SWITCHED=false
     else
       step_ok "Keeping v2 service"
-      # Disable v1 from auto-starting
-      if [ "$PLATFORM_SERVICE" = "systemd" ]; then
-        systemctl --user disable "$V1_SERVICE" 2>/dev/null || true
-      fi
+      retire_v1_service
     fi
   else
     step_skip "Service switchover skipped"
   fi
 else
   step_skip "v1 service not running — nothing to switch"
+  retire_v1_service
 fi
 
 echo

--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -5,8 +5,7 @@
 # Run from the v2 directory:
 #   bash migrate-v2.sh
 #
-# From Claude Code, use the ! prefix so it runs in your terminal:
-#   ! bash migrate-v2.sh
+# If you're in Claude Code, exit first or open a separate terminal.
 #
 # Finds v1 automatically (sibling directory, or $NANOCLAW_V1_PATH).
 # Installs prerequisites (Node, pnpm, deps) via the existing setup.sh
@@ -26,10 +25,10 @@ cd "$PROJECT_ROOT"
 if ! [ -t 0 ] || ! [ -t 1 ]; then
   echo "This script requires an interactive terminal."
   echo ""
-  echo "If you're in Claude Code, run it directly with the ! prefix:"
-  echo "  ! bash migrate-v2.sh"
+  echo "If you're in Claude Code, exit first or open a separate terminal,"
+  echo "then run:"
+  echo "  bash migrate-v2.sh"
   echo ""
-  echo "Or run it in a separate terminal session."
   exit 1
 fi
 

--- a/setup/migrate-v2/select-channels.ts
+++ b/setup/migrate-v2/select-channels.ts
@@ -12,6 +12,7 @@
 import fs from 'fs';
 
 import * as p from '@clack/prompts';
+import { styleText } from 'node:util';
 
 const CHANNELS = [
   { value: 'telegram',       label: 'Telegram' },
@@ -47,7 +48,7 @@ async function main(): Promise<void> {
   }
 
   const selected = await p.multiselect({
-    message: 'Which channels do you want to set up?',
+    message: 'Which channels do you want to set up?\n' + styleText('dim', '  space to select, enter to confirm') + '\n',
     options: CHANNELS,
     required: false,
   });

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -115,8 +115,42 @@ function installOnecliCliOnly(): { stdout: string; ok: boolean } {
   return { stdout: upstream.stdout + (upstream.stderr ?? '') + '\n' + fallback.stdout, ok: fallback.ok };
 }
 
+// Remove containers in the "onecli" compose project whose service name isn't
+// in the v2 set. Pre-v2 OneCLI used service "app" (container onecli-app-1);
+// v2 uses "onecli". Compose flags the old container as an orphan but won't
+// stop it without --remove-orphans, leaving port 10254 bound and crashing
+// the new bring-up. Filed upstream; this is the downstream workaround.
+function removeLegacyOnecliContainers(): string {
+  const out: string[] = [];
+  let list = '';
+  try {
+    list = execSync(
+      `docker ps -a --filter "label=com.docker.compose.project=onecli" --format '{{.Names}}|{{.Label "com.docker.compose.service"}}'`,
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+    ).trim();
+  } catch {
+    return '';
+  }
+  if (!list) return '';
+  const v2Services = new Set(['onecli', 'postgres']);
+  for (const line of list.split('\n')) {
+    const [name, service] = line.split('|');
+    if (!name || !service || v2Services.has(service)) continue;
+    out.push(`Removing legacy OneCLI container: ${name} (service=${service})`);
+    try {
+      execSync(`docker rm -f ${JSON.stringify(name)}`, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      out.push(`  rm failed (continuing): ${(err as Error).message}`);
+    }
+  }
+  return out.join('\n');
+}
+
 function installOnecli(): { stdout: string; ok: boolean } {
   let stdout = '';
+
+  const cleanup = removeLegacyOnecliContainers();
+  if (cleanup) stdout += cleanup + '\n';
 
   // Gateway install (docker-compose based, no rate-limit concerns).
   const gw = runInstall('curl -fsSL onecli.sh/install | sh');


### PR DESCRIPTION
## Summary

Supersedes #2216, bundling its migration UX fixes with an additional OneCLI installer fix into a single branch.

**Migration script UX (originally in #2216):**
- Require interactive terminal for `migrate-v2.sh` — TTY guard exits early with instructions when run inside Claude Code's Bash tool (no TTY).
- Update CLAUDE.md banner to direct users to exit Claude Code (or open a separate terminal) before running the migration, matching the new TTY guard.
- Retire legacy v1 service unit file after switchover so `systemctl --user restart nanoclaw` (or `launchctl kickstart` on macOS) starts v2 instead of v1.
- Preserve the v1 service file for rollback rather than symlinking — keeps a single-command rollback path and adds rollback instructions to the migration summary.
- Add a hint to the channel multiselect prompt during migration.

**OneCLI installer (new):**
- Clean up legacy OneCLI containers before the installer runs, so first-time setup on a host with stale containers from earlier installs doesn't fail.

## Test plan

- [ ] `bash migrate-v2.sh` from a real shell runs to completion on a v1 install (Linux/systemd and macOS/launchd).
- [ ] Running `bash migrate-v2.sh` from inside Claude Code's Bash tool exits early with the TTY guidance.
- [ ] After migration, `systemctl --user restart nanoclaw` (Linux) / `launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) starts the v2 service.
- [ ] Rollback path: the v1 unit file is still on disk and re-enabling it brings v1 back.
- [ ] On a host with a stale OneCLI container, `setup/onecli.ts` removes it before the installer runs.