### PR TITLE
fix(container): align WORKDIR with actual group mount path

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -109,12 +109,12 @@ COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # ---- Workspace + permissions -------------------------------------------------
-RUN mkdir -p /workspace/group /workspace/extra && \
+RUN mkdir -p /workspace/agent /workspace/extra && \
     chown -R node:node /workspace && \
     chmod 777 /home/node
 
 USER node
-WORKDIR /workspace/group
+WORKDIR /workspace/agent
 
 # tini is PID 1, reaps zombies, forwards signals cleanly. entrypoint.sh does
 # `exec bun ...` so bun runs as tini's direct child.


### PR DESCRIPTION
## Summary

`container-runner.ts` mounts the agent group folder at `/workspace/agent`, but the Dockerfile created `/workspace/group` and set it as `WORKDIR`. This leaves the container's default working directory pointing at an empty artifact directory — the agent's own workspace is invisible when exploring relative paths.

- Change `mkdir -p /workspace/group` → `/workspace/agent`
- Change `WORKDIR /workspace/group` → `WORKDIR /workspace/agent`

## Test plan

- [ ] Build image: `./container/build.sh`
- [ ] Verify: `docker run --rm --entrypoint bash nanoclaw-agent:latest -c "pwd"` → `/workspace/agent`
- [ ] Start a session and confirm the agent can find its workspace files

🤖 Generated with [Claude Code](https://claude.com/claude-code)