### PR TITLE
feat(scheduling): add interval-based recurrence (@every:<ms>)

### DIFF
--- a/container/agent-runner/src/mcp-tools/scheduling.ts
+++ b/container/agent-runner/src/mcp-tools/scheduling.ts
@@ -49,7 +49,7 @@ export const scheduleTask: McpToolDefinition = {
         recurrence: {
           type: 'string',
           description:
-            'Cron expression for recurring tasks (e.g., "0 9 * * 1-5" = weekdays at 9am user-local). Evaluated in the user\'s timezone.',
+            'Recurrence rule for repeating tasks. Two formats: (1) Cron expression (e.g., "0 9 * * 1-5" = weekdays at 9am user-local) — evaluated in the user\'s timezone. (2) Fixed interval: "@every:<ms>" where <ms> is the interval in milliseconds (e.g., "@every:18000000" = every 5 hours). Interval is drift-free: anchored to the last scheduled time, not wall-clock.',
         },
         script: { type: 'string', description: 'Optional pre-agent script to run before processing' },
       },

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -18,18 +18,42 @@ import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { clearRecurrence, getCompletedRecurring, insertRecurrence } from './db.js';
 
+/**
+ * Compute the next run for an `@every:<ms>` interval recurrence.
+ * Anchors to the last scheduled time (process_after) rather than Date.now()
+ * so the interval doesn't drift when a task runs slightly late. Skips any
+ * missed firings (e.g. after downtime) to land in the future.
+ */
+function nextIntervalRun(recurrence: string, lastProcessAfter: string | null): string {
+  const ms = parseInt(recurrence.slice('@every:'.length), 10);
+  if (!ms || ms <= 0) throw new Error(`Invalid interval: ${recurrence}`);
+  const anchor = lastProcessAfter ? new Date(lastProcessAfter).getTime() : Date.now();
+  let next = anchor + ms;
+  const now = Date.now();
+  while (next <= now) next += ms;
+  return new Date(next).toISOString();
+}
+
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
   const recurring = getCompletedRecurring(inDb);
 
   for (const msg of recurring) {
     try {
-      const { CronExpressionParser } = await import('cron-parser');
-      // Interpret the cron expression in the user's timezone. v1 did this
-      // (src/v1/task-scheduler.ts:20-49); without it, a task written "0 9 * * *"
-      // by an agent running in a user's local TZ fires at 09:00 UTC instead of
-      // 09:00 user-local.
-      const interval = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE });
-      const nextRun = interval.next().toISOString();
+      let nextRun: string | null;
+
+      if (msg.recurrence.startsWith('@every:')) {
+        // Interval-based recurrence: @every:<milliseconds>
+        nextRun = nextIntervalRun(msg.recurrence, msg.process_after);
+      } else {
+        const { CronExpressionParser } = await import('cron-parser');
+        // Interpret the cron expression in the user's timezone. v1 did this
+        // (src/v1/task-scheduler.ts:20-49); without it, a task written "0 9 * * *"
+        // by an agent running in a user's local TZ fires at 09:00 UTC instead of
+        // 09:00 user-local.
+        const interval = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE });
+        nextRun = interval.next().toISOString();
+      }
+
       const prefix = msg.kind === 'task' ? 'task' : 'msg';
       const newId = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 


### PR DESCRIPTION
## Summary

- Adds `@every:<ms>` interval recurrence format to the scheduling sweep, complementing existing cron expressions
- Anchors interval to the last `process_after` timestamp to prevent drift when a task runs slightly late
- Skips missed firings after downtime (fast-forwards to next future slot)
- Documents the new format in the `schedule_recurring` MCP tool description

## Motivation

Cron expressions can't express simple "every N hours/minutes" intervals without coupling to wall-clock alignment (e.g. `0 */5 * * *` fires at :00 past the hour, not 5h after task completion). The `@every:<ms>` format is a lightweight addition that keeps the recurrence field a single string and requires no schema change.

## Format

```
@every:<milliseconds>
```

Examples:
- `@every:3600000` — every hour
- `@every:18000000` — every 5 hours
- `@every:86400000` — every 24 hours

## Test plan

- [ ] Create a task with `recurrence = '@every:18000000'` and confirm the sweep inserts a new row with `process_after` ≈ 5 h in the future
- [ ] Simulate downtime by setting `process_after` to the past and confirm the sweep skips to the next future slot rather than inserting an immediate row
- [ ] Confirm existing cron-based recurrence is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)