### PR TITLE
feat(setup): support MacPorts as macOS package manager

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -170,15 +170,17 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
   esac
 fi
 
-# ─── pre-flight: Homebrew on macOS ─────────────────────────────────────
-# setup/install-node.sh and setup/install-docker.sh both require `brew` on
-# macOS. On a factory Mac there's no brew, and those helpers would fail
-# later inside the bootstrap spinner with a cryptic error. Prompt here,
-# before the spinner starts, so the user knows what's about to happen and
-# brew's own interactive sudo/CLT prompts stay readable.
-if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
+# ─── pre-flight: macOS package manager ─────────────────────────────────
+# setup/install-node.sh and setup/install-docker.sh need a macOS package
+# manager. Homebrew is the default; MacPorts is also accepted (Node only —
+# Docker Desktop is not packaged by MacPorts and must be installed manually).
+# On a factory Mac with neither, prompt to install Homebrew before the
+# spinner starts so brew's own interactive sudo/CLT prompts stay readable.
+if [ "$(uname -s)" = "Darwin" ] \
+   && ! command -v brew >/dev/null 2>&1 \
+   && ! command -v port >/dev/null 2>&1; then
   printf '  %s\n' \
-    "$(dim "Homebrew isn't installed. NanoClaw uses it to install Node and Docker on your Mac.")"
+    "$(dim "No macOS package manager found. NanoClaw uses Homebrew (or MacPorts) to install Node and Docker.")"
   printf '  %s\n\n' \
     "$(dim "This also installs Apple's Command Line Tools, which can take 5-10 minutes.")"
   read -r -p "  $(bold 'Install Homebrew now?') [Y/n] " BREW_ANS </dev/tty
@@ -205,14 +207,14 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
       if ! command -v brew >/dev/null 2>&1; then
         printf '\n  %s %s\n' "$(red '✗')" "Homebrew install didn't complete."
         printf '  %s\n\n' \
-          "$(dim 'Install manually from https://brew.sh and re-run: bash nanoclaw.sh')"
+          "$(dim 'Install manually from https://brew.sh (or MacPorts from https://macports.org) and re-run: bash nanoclaw.sh')"
         exit 1
       fi
       printf '\n'
       ;;
     *)
       printf '\n  %s\n\n' \
-        "$(dim 'NanoClaw needs Homebrew. Install it from https://brew.sh and re-run.')"
+        "$(dim 'NanoClaw needs Homebrew or MacPorts. Install one (https://brew.sh or https://macports.org) and re-run.')"
       exit 1
       ;;
   esac

--- a/setup/channels/signal.ts
+++ b/setup/channels/signal.ts
@@ -140,13 +140,23 @@ async function ensureSignalCli(): Promise<void> {
   if (!probe.error && probe.status === 0) return;
 
   if (process.platform === 'darwin') {
+    const hasBrew =
+      spawnSync('command', ['-v', 'brew'], { shell: true, stdio: 'ignore' })
+        .status === 0;
+    const hasPort =
+      spawnSync('command', ['-v', 'port'], { shell: true, stdio: 'ignore' })
+        .status === 0;
+    const installLine =
+      !hasBrew && hasPort
+        ? { cmd: '  sudo port install signal-cli', label: 'MacPorts' }
+        : { cmd: '  brew install signal-cli', label: 'Homebrew' };
     note(
       [
         "NanoClaw talks to Signal through signal-cli, which isn't installed yet.",
         '',
-        'The quickest way on macOS is Homebrew:',
+        `The quickest way on macOS is ${installLine.label}:`,
         '',
-        k.cyan('  brew install signal-cli'),
+        k.cyan(installLine.cmd),
         '',
         "Install it in another terminal, then re-run setup.",
       ].join('\n'),

--- a/setup/install-docker.sh
+++ b/setup/install-docker.sh
@@ -20,14 +20,20 @@ fi
 
 case "$(uname -s)" in
   Darwin)
-    echo "STEP: brew-install-docker"
-    if ! command -v brew >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1; then
+      echo "STEP: brew-install-docker"
+      brew install --cask docker
+    elif command -v port >/dev/null 2>&1; then
       echo "STATUS: failed"
-      echo "ERROR: Homebrew not installed. Install brew first (https://brew.sh) then re-run."
+      echo "ERROR: MacPorts detected but Docker Desktop isn't packaged by MacPorts. Install Docker Desktop manually from https://www.docker.com/products/docker-desktop and re-run."
+      echo "=== END ==="
+      exit 1
+    else
+      echo "STATUS: failed"
+      echo "ERROR: No macOS package manager found. Install Homebrew (https://brew.sh) and re-run, or install Docker Desktop manually from https://www.docker.com/products/docker-desktop."
       echo "=== END ==="
       exit 1
     fi
-    brew install --cask docker
     ;;
   Linux)
     echo "STEP: docker-get-script"

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -19,14 +19,18 @@ fi
 
 case "$(uname -s)" in
   Darwin)
-    echo "STEP: brew-install-node"
-    if ! command -v brew >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1; then
+      echo "STEP: brew-install-node"
+      brew install node@22
+    elif command -v port >/dev/null 2>&1; then
+      echo "STEP: port-install-node"
+      sudo port install nodejs22 npm10
+    else
       echo "STATUS: failed"
-      echo "ERROR: Homebrew not installed. Install brew first (https://brew.sh) then re-run."
+      echo "ERROR: No macOS package manager found. Install Homebrew (https://brew.sh) or MacPorts (https://macports.org) and re-run."
       echo "=== END ==="
       exit 1
     fi
-    brew install node@22
     ;;
   Linux)
     echo "STEP: nodesource-setup"


### PR DESCRIPTION
Accept MacPorts alongside Homebrew for installing Node and signal-cli on
macOS. Docker Desktop isn't packaged by MacPorts, so the Docker installer
errors with a clear pointer to the manual download when only `port` is
available.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [X] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
Accept MacPorts alongside Homebrew for installing Node and signal-cli on
macOS. Docker Desktop isn't packaged by MacPorts, so the Docker installer
errors with a clear pointer to the manual download when only `port` is
available.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
