### PR TITLE
fix(agent-runner): derive MCP allowedTools from registered mcpServers

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -34,7 +34,11 @@ const SDK_DISALLOWED_TOOLS = [
   'ExitWorktree',
 ];
 
-// Tool allowlist for NanoClaw agent containers
+// Tool allowlist for NanoClaw agent containers. MCP-tool entries are derived
+// at the call site from the registered `mcpServers` map so that any server
+// added via `add_mcp_server` (or wired in container.json directly) is
+// reachable to the agent — without this, the SDK's allowedTools filter
+// silently drops every MCP namespace not listed here.
 const TOOL_ALLOWLIST = [
   'Bash',
   'Read',
@@ -54,8 +58,14 @@ const TOOL_ALLOWLIST = [
   'ToolSearch',
   'Skill',
   'NotebookEdit',
-  'mcp__nanoclaw__*',
 ];
+
+// MCP server names are sanitized by the SDK when forming tool prefixes:
+// any character outside [A-Za-z0-9_-] becomes '_'. Mirror that here so our
+// allowlist patterns match what the SDK actually exposes.
+function mcpAllowPattern(serverName: string): string {
+  return `mcp__${serverName.replace(/[^a-zA-Z0-9_-]/g, '_')}__*`;
+}
 
 interface SDKUserMessage {
   type: 'user';
@@ -277,7 +287,10 @@ export class ClaudeProvider implements AgentProvider {
         resume: input.continuation,
         pathToClaudeCodeExecutable: '/pnpm/claude',
         systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
-        allowedTools: TOOL_ALLOWLIST,
+        allowedTools: [
+          ...TOOL_ALLOWLIST,
+          ...Object.keys(this.mcpServers).map(mcpAllowPattern),
+        ],
         disallowedTools: SDK_DISALLOWED_TOOLS,
         env: this.env,
         permissionMode: 'bypassPermissions',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #2241.

**What.** Replaces the static `'mcp__nanoclaw__*'` entry in `TOOL_ALLOWLIST` with dynamic derivation of `mcp__<sanitized-name>__*` patterns from the registered `mcpServers` map at the SDK call site.

**Why.** Claude Code 2.1.116+ treats `allowedTools` as a hard whitelist — servers whose namespace isn't listed have their tools filtered out before the agent sees them, regardless of `permissionMode: 'bypassPermissions'` or any `permissions.allow` in settings. The previous static list only contained `mcp__nanoclaw__*`, so MCPs registered via `add_mcp_server` (or wired directly in `container.json`) were silently inaccessible. Same regression diagnosed by @jsboige in #2028 (withdrawn, not upstreamed).

**How it works.** Adds `mcpAllowPattern(name)` to mirror the SDK's sanitization (`/[^a-zA-Z0-9_-]/g → '_'`), and at the SDK call site spreads `Object.keys(this.mcpServers).map(mcpAllowPattern)` after `TOOL_ALLOWLIST`. The `mcpServers` map is already aggregated by `container/agent-runner/src/index.ts` (built-in nanoclaw + every `container.json` entry) and passed into `ClaudeProvider`, so this picks up both the built-in and every admin-approved registration with no extra plumbing.

**How it was tested.**
- `bun build src/providers/claude.ts` → parses cleanly.
- `bun test src/providers/factory.test.ts` → 3/3 pass; `ClaudeProvider` constructs with patched code.
- Live: triggered a fresh container spawn for an agent group with four registered MCPs (`chroma-mcp`, `Shopify Dev MCP`, `composio`, `firecrawl-mcp`). Pre-patch the agent saw none of them. Post-patch the agent could call tools across all four namespaces (separate per-server vault/config issues remain but are unrelated to this allowlist filter).