### PR TITLE
feat(setup): clarify @BotFather is Telegram's official bot

### DIFF
--- a/setup/channels/telegram.ts
+++ b/setup/channels/telegram.ts
@@ -149,7 +149,7 @@ async function collectTelegramToken(): Promise<string> {
       "Your assistant talks to you through a Telegram bot you create.",
       "Here's how:",
       '',
-      '  1. Open Telegram and message @BotFather',
+      "  1. Open Telegram and message @BotFather — Telegram's official bot for creating and managing bots",
       '  2. Send /newbot and follow the prompts',
       '  3. Copy the token it gives you (it looks like <digits>:<chars>)',
       '',


### PR DESCRIPTION
## Summary

Step 1 of the Telegram channel's BotFather instructions used to read:

> 1. Open Telegram and message @BotFather

Two small UX issues with that:

- **"BotFather" reads slightly sketchy without context** — a first-time user has no way to know it's the official, sanctioned account rather than an impersonator.
- **Typing the username from memory leaves room for picking a typo'd impostor account** (Telegram has many \`@BotF4ther\` / \`@BotFAther\` / etc. look-alikes).

This PR updates the line so the official-bot framing is part of the instruction itself:

> 1. Open Telegram and message @BotFather — Telegram's official bot for creating and managing bots

One-line change in the existing \`note()\` body. No new dependencies, no asset churn, no other behavior change.

A follow-up PR will add a scannable QR code to the same card so users can open BotFather directly without typing — addresses the typo concern more thoroughly.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm test setup/\` — 6 files / 52 tests pass
- [x] Visually confirmed the rendered card on a griffin-fairy VM