### PR TITLE
fix(setup): use fmtDuration in the container-build spinner

### DIFF
--- a/setup/lib/windowed-runner.ts
+++ b/setup/lib/windowed-runner.ts
@@ -23,7 +23,7 @@ import { emit as phEmit } from './diagnostics.js';
 import type { StepResult, SpinnerLabels } from './runner.js';
 import { dumpTranscriptOnFailure, spawnStep, writeStepEntry } from './runner.js';
 import * as setupLog from '../logs.js';
-import { brandBody, fitToWidth } from './theme.js';
+import { brandBody, fitToWidth, fmtDuration } from './theme.js';
 
 const WINDOW_SIZE = 3;
 const SPINNER_FRAMES = ['◒', '◐', '◓', '◑'];
@@ -85,9 +85,8 @@ async function runUnderWindow(
   const redraw = (): void => {
     if (stallPromptActive) return;
     out.write(`\x1b[${WINDOW_SIZE + 1}A`);
-    const elapsed = Math.round((Date.now() - start) / 1000);
     const icon = SPINNER_FRAMES[frameIdx % SPINNER_FRAMES.length];
-    const suffix = ` (${elapsed}s)`;
+    const suffix = ` (${fmtDuration(Date.now() - start)})`;
     const header = fitToWidth(labels.running, suffix);
     out.write(`\x1b[2K${k.cyan(icon)}  ${header}${k.dim(suffix)}\n`);
 
@@ -164,8 +163,7 @@ async function runUnderWindow(
   out.write(SHOW_CURSOR);
   process.off('exit', restoreCursorOnExit);
 
-  const elapsed = Math.round((Date.now() - start) / 1000);
-  const suffix = ` (${elapsed}s)`;
+  const suffix = ` (${fmtDuration(Date.now() - start)})`;
   if (result.ok) {
     const isSkipped = result.terminal?.fields.STATUS === 'skipped';
     const msg = isSkipped && labels.skipped ? labels.skipped : labels.done;


### PR DESCRIPTION
> **Heads-up — completing a previous fix.** PR #2108 introduced the `fmtDuration` helper and applied minute-aware time formatting everywhere across the setup flow. This one file was deliberately skipped at the time because another PR (now closed) was supposed to remove the timer here entirely, making the format change moot. With that other PR closed, this spot was left as the only place still printing raw seconds (`170s` instead of `2m 50s`). This PR closes that gap.

## Summary

`setup/lib/windowed-runner.ts` is the file that drives the container-build spinner ("Preparing your assistant's sandbox…"). It had two spots still printing elapsed time as raw seconds:

- The live spinner suffix that ticks during the build (line 90)
- The success / error completion suffix (line 167)

This PR routes both through the existing `fmtDuration` helper from #2108, so anything past 60 seconds renders as `Xm Ys` (e.g. `2m 50s`) — matching every other timer in the setup flow.

## Implementation

- Add `fmtDuration` to the imports from `./theme.js`.
- Replace `Math.round((Date.now() - start) / 1000)` + `(${elapsed}s)` with a single `(${fmtDuration(Date.now() - start)})` call at both sites.
- The helper itself is unchanged from #2108. Behavior under 60s is identical (`Xs`); behavior past 60s now matches everywhere else.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test setup/` — 6 files / 52 tests pass
- [x] Visually previewed via mock spinner that ticks elapsed time at 60× speed; confirmed `0s → 59s → 1m 0s → 1m 30s → 2m 50s → 5m+` flips at the right thresholds