### PR TITLE
feat(setup): warn when running on a Google Compute Engine VM

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -200,6 +200,33 @@ if [ "$LOW_MEM" = true ] || [ "$LOW_DISK" = true ]; then
   esac
 fi
 
+# ─── pre-flight: Google Cloud VM warning (Linux) ──────────────────────
+# NanoClaw is known to not run reliably on Google Compute Engine instances.
+# Warn early — before the root check or bootstrap spinner — so users can
+# switch providers before sinking time into setup. Detection uses DMI
+# (no network round-trip), which on GCE reports "Google" / "Google
+# Compute Engine".
+if [ "$(uname -s)" = "Linux" ] \
+  && { grep -qi 'Google' /sys/class/dmi/id/product_name 2>/dev/null \
+    || grep -qi 'Google' /sys/class/dmi/id/sys_vendor   2>/dev/null; }; then
+  printf '  %s\n' "$(red 'Warning: Google Cloud VM detected.')"
+  printf '  %s\n' "$(dim 'Google blocks sudo commands, so NanoClaw is unlikely to run successfully on this VM.')"
+  printf '  %s\n\n' "$(dim 'If you want to run NanoClaw successfully, switch to a different provider (Hetzner, Hostinger, exe.dev and others..).')"
+  read -r -p "  $(bold 'Try anyway?') [y/N] " GCE_ANS </dev/tty
+
+  case "${GCE_ANS:-N}" in
+    [Yy]*)
+      ph_event setup_gce_continued
+      printf '\n'
+      ;;
+    *)
+      ph_event setup_gce_aborted
+      printf '\n  %s\n\n' "$(dim 'Aborted. Re-run on a non-GCE host to continue.')"
+      exit 1
+      ;;
+  esac
+fi
+
 # ─── pre-flight: root user warning (Linux) ────────────────────────────
 if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -eq 0 ]; then
   printf '  %s\n' \


### PR DESCRIPTION
## Summary
- NanoClaw doesn't run reliably on GCE (Google blocks sudo, which the host + container setup depends on).
- Add a pre-flight DMI check (no network round-trip) that fires between the existing spec check and root check, so users can bail out before the bootstrap spinner instead of hitting cryptic failures later.
- Mirrors the existing low-specs and root prompts: warning text, `Try anyway? [y/N]` (default N), `ph_event setup_gce_continued` / `setup_gce_aborted` on each branch.

## Test plan
- [x] `bash -n nanoclaw.sh` — clean.
- [x] On a Hetzner VM (`product_name=vServer`, `sys_vendor=Hetzner`) — DMI condition is false, warning is skipped.
- [x] With a simulated `Google Compute Engine` DMI file — DMI condition is true, warning + prompt fire.
- [ ] Smoke-test on an actual GCE instance (deferred — change is text + prompt, no behavioral risk on non-GCE hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)