### PR TITLE
feat: /add-ffmpeg-tool — ffmpeg/ffprobe MCP server for media transformation

### DIFF
--- a/.claude/skills/add-ffmpeg-tool/SKILL.md
+++ b/.claude/skills/add-ffmpeg-tool/SKILL.md
@@ -37,10 +37,11 @@ grep -q '^INSTALL_FFMPEG=' .env \
 ./container/build.sh
 ```
 
-Adds ~80 MB to the image. Verify:
+Adds ~80 MB to the image. Verify (the image tag is install-slug-derived and printed at the end of `build.sh` — substitute it below; `--entrypoint sh` is required so the agent-runner entrypoint doesn't intercept):
 
 ```bash
-docker run --rm nanoclaw-agent:latest which ffmpeg ffprobe
+IMAGE=$(docker images --filter 'reference=nanoclaw-agent*:latest' --format '{{.Repository}}:{{.Tag}}' | head -1)
+docker run --rm --entrypoint sh "$IMAGE" -c 'which ffmpeg && ffmpeg -version | head -1'
 ```
 
 ## Phase 3: Wire per-agent-group

--- a/.claude/skills/add-ffmpeg-tool/SKILL.md
+++ b/.claude/skills/add-ffmpeg-tool/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: add-ffmpeg-tool
+description: Add ffmpeg as an MCP tool so the agent can convert, trim, extract audio from, and compress media files (mp4, mp3, wav, mov, webm, etc.) and send the result back to the channel. Wraps the ffmpeg/ffprobe binaries as a stdio MCP server; no third-party npm package, no credentials, no sidecar.
+---
+
+# Add ffmpeg Tool
+
+Wires the in-repo `container/agent-runner/src/ffmpeg-mcp/server.ts` stdio MCP server into selected agent groups and adds the `ffmpeg` + `ffprobe` binaries to the container image. After this skill runs, the agent can take an inbound media attachment, transform it, and reply with the result via the existing `mcp__nanoclaw__send_file` tool.
+
+Tools exposed (surfaced to the agent as `mcp__ffmpeg__<name>`):
+
+| Tool | What it does |
+|------|---------------|
+| `probe` | ffprobe metadata: duration, format, per-stream codec/size info |
+| `convert` | Change format/container (mp4 ↔ mp3 ↔ wav ↔ mov ↔ webm, etc.) |
+| `trim` | Cut a `[start, start+duration)` segment |
+| `extract_audio` | Strip the audio track from a video |
+| `compress` | Re-encode for size, by CRF or rough target MB |
+
+Streaming, complex filtergraphs, watermark/overlay, and DRM are intentionally out of scope — keeps the surface auditable.
+
+**Why this pattern:** ffmpeg is a CLI binary already on `$PATH` once installed, so no separate npm package or OAuth flow is needed. The MCP server lives inside the agent-runner source tree (mounted RO at `/app/src` at runtime) and is invoked per-group via `bun run`. The tool-allowlist pattern (`mcp__ffmpeg__*`) is auto-derived from the group's `mcpServers` map by `providers/claude.ts` — no manual allowlist edit.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+```bash
+grep -q 'INSTALL_FFMPEG' container/Dockerfile && \
+grep -q '^INSTALL_FFMPEG=true' .env 2>/dev/null && \
+echo "ALREADY APPLIED — skip to Phase 3"
+```
+
+### Confirm the .env file exists
+
+```bash
+ls .env 2>&1
+```
+
+If absent, you're on a fresh checkout — run `/setup` first or `touch .env`.
+
+## Phase 2: Apply Code Changes
+
+### Enable the build flag
+
+Upsert `INSTALL_FFMPEG=true` into `.env` (mirrors `INSTALL_CJK_FONTS`):
+
+```bash
+grep -q '^INSTALL_FFMPEG=' .env \
+  && sed -i.bak 's/^INSTALL_FFMPEG=.*/INSTALL_FFMPEG=true/' .env && rm -f .env.bak \
+  || echo 'INSTALL_FFMPEG=true' >> .env
+```
+
+`./container/build.sh` and `setup/container.ts` both read this var and pass `--build-arg INSTALL_FFMPEG=true` to docker, so the conditional `apt-get install ffmpeg` block in the Dockerfile fires.
+
+### Rebuild the container image
+
+```bash
+./container/build.sh
+```
+
+ffmpeg (+ ffprobe + libs) adds ~80 MB. Verify the binaries landed:
+
+```bash
+docker run --rm "$(./container/build.sh --print-image 2>/dev/null || echo nanoclaw-agent:latest)" which ffmpeg ffprobe
+```
+
+(If `--print-image` isn't supported, just `docker images | head` to find the right tag.)
+
+## Phase 3: Wire Per-Agent-Group
+
+For each agent group that should be able to transform media (typically the user's personal DM agent — anywhere they routinely send video/audio attachments), edit `groups/<folder>/container.json` and merge in:
+
+```jsonc
+{
+  "mcpServers": {
+    "ffmpeg": {
+      "command": "bun",
+      "args": ["run", "/app/src/ffmpeg-mcp/server.ts"],
+      "env": {}
+    }
+  }
+}
+```
+
+That's it — no `additionalMounts`, no env vars, no credentials. The MCP server reads input files from `/workspace/inbox/...` (already mounted as part of the session DB layout) and writes outputs to `/workspace/agent/tmp/`, which is the existing RW per-group workspace.
+
+If the group should **not** have ffmpeg (e.g. a shared/scoped agent the user doesn't want producing media), leave its `container.json` untouched.
+
+### Optional: extend the per-tool timeout
+
+The default is 5 minutes per ffmpeg invocation. For groups that handle very long videos, override via env in the same `mcpServers.ffmpeg` block:
+
+```jsonc
+"env": { "NANOCLAW_FFMPEG_TIMEOUT_SEC": "900" }
+```
+
+## Phase 4: Build and Restart
+
+```bash
+pnpm run build
+systemctl --user restart nanoclaw  # Linux
+# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+```
+
+## Phase 5: Verify
+
+### Test from the wired agent
+
+Tell the user:
+
+> Send a short `.mp4` to your `<agent-name>` chat with the message **"convert to mp3"**. The agent should call `mcp__ffmpeg__convert`, then `mcp__nanoclaw__send_file`, and you should receive the `.mp3` back in the same chat. Other things to try:
+> - Send a video and ask **"what's the duration"** → uses `probe`, no file delivered.
+> - Send a video and ask **"give me seconds 5–15 as a clip"** → uses `trim`.
+> - Send a video and ask **"strip the audio out"** → uses `extract_audio`.
+
+### Check logs if it's not working
+
+```bash
+tail -200 logs/nanoclaw.log logs/nanoclaw.error.log | grep -iE 'ffmpeg|mcp'
+```
+
+Every failure path inside the MCP server emits a `[ffmpeg-mcp]` line on stderr — the host pipes container stderr into the normal log stream, so `grep ffmpeg-mcp` is the fastest signal.
+
+Common signals:
+- `command not found: ffmpeg` → `INSTALL_FFMPEG=true` wasn't in `.env` at build time, or the image wasn't rebuilt. Re-run `./container/build.sh`.
+- `Input path must live under /workspace` → the agent passed a path it shouldn't have. Tell it to operate on the attachment under `/workspace/inbox/...` (already in the system prompt context).
+- `Unsupported output_format` → check the whitelist in `server.ts` (`OUTPUT_EXT_WHITELIST`); add the extension if it's a legitimate media format you trust.
+- `ffmpeg failed: ...` → the line includes the last 200 chars of ffmpeg's stderr. Common cause: the input file isn't actually media (corrupted upload, wrong MIME).
+- Agent says "I don't have ffmpeg tools" → the group's `container.json` is missing the `mcpServers.ffmpeg` entry, or the host wasn't restarted.
+
+## Removal
+
+1. Delete the `"ffmpeg"` entry from `mcpServers` in each group's `container.json`.
+2. Set `INSTALL_FFMPEG=false` in `.env` (or remove the line) — frees ~80 MB on the next image build.
+3. Optional: delete `container/agent-runner/src/ffmpeg-mcp/` if no group still uses it. Removing it doesn't break anything else; the file is only loaded when explicitly wired.
+4. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.
+
+## Notes
+
+- **No credentials, no sidecar.** Unlike `/add-gmail-tool` (OAuth + OneCLI) or `/add-local-whisper` (Python sidecar), ffmpeg is a static binary — the MCP server is a thin wrapper that spawns it via `Bun.spawn` with array-form argv. No shell, no string interpolation, no privileged mounts.
+- **Per-group opt-in.** Wiring is per-`container.json`, matching the `/add-gmail-tool` and `/add-ollama-tool` precedent. A group without the entry simply doesn't see the tools.
+- **Output staging.** Tools write to `/workspace/agent/tmp/ffmpeg-<uuid>.<ext>`. The agent then chains `mcp__nanoclaw__send_file` to deliver. `/workspace/agent` is already RW-mounted; nothing new is needed.
+- **Failure logging.** Every failure path (path traversal, extension whitelist, timeout, non-zero exit, missing binary) writes a `[ffmpeg-mcp] <tool>: <reason>` line to the container's stderr, which surfaces in `logs/nanoclaw.log` for operator triage. The user-facing error returned to the agent stays brief; the log line carries the full detail (exit code, stderr tail).
+
+## Credits & references
+
+- **Skill pattern:** modeled on [`add-gmail-tool`](../add-gmail-tool/SKILL.md) (per-group `container.json` wiring) and [`add-local-whisper`](../add-local-whisper/SKILL.md) (`.env`-driven build flag).
+- **MCP server SDK:** [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk).
+- **ffmpeg:** [ffmpeg.org](https://ffmpeg.org/), LGPL/GPL.

--- a/.claude/skills/add-ffmpeg-tool/SKILL.md
+++ b/.claude/skills/add-ffmpeg-tool/SKILL.md
@@ -5,9 +5,9 @@ description: Add ffmpeg as an MCP tool so the agent can convert, trim, extract a
 
 # Add ffmpeg Tool
 
-Wires the in-repo `container/agent-runner/src/ffmpeg-mcp/server.ts` stdio MCP server into selected agent groups and adds the `ffmpeg` + `ffprobe` binaries to the container image. After this skill runs, the agent can take an inbound media attachment, transform it, and reply with the result via the existing `mcp__nanoclaw__send_file` tool.
+Wires the in-repo `container/agent-runner/src/ffmpeg-mcp/server.ts` MCP server into selected agent groups and adds the `ffmpeg` + `ffprobe` binaries to the container image. After install, the agent can transform an inbound media attachment and reply with the result via `mcp__nanoclaw__send_file`.
 
-Tools exposed (surfaced to the agent as `mcp__ffmpeg__<name>`):
+Tools surfaced as `mcp__ffmpeg__<name>`:
 
 | Tool | What it does |
 |------|---------------|
@@ -17,13 +17,7 @@ Tools exposed (surfaced to the agent as `mcp__ffmpeg__<name>`):
 | `extract_audio` | Strip the audio track from a video |
 | `compress` | Re-encode for size, by CRF or rough target MB |
 
-Streaming, complex filtergraphs, watermark/overlay, and DRM are intentionally out of scope — keeps the surface auditable.
-
-**Why this pattern:** ffmpeg is a CLI binary already on `$PATH` once installed, so no separate npm package or OAuth flow is needed. The MCP server lives inside the agent-runner source tree (mounted RO at `/app/src` at runtime) and is invoked per-group via `bun run`. The tool-allowlist pattern (`mcp__ffmpeg__*`) is auto-derived from the group's `mcpServers` map by `providers/claude.ts` — no manual allowlist edit.
-
 ## Phase 1: Pre-flight
-
-### Check if already applied
 
 ```bash
 grep -q 'INSTALL_FFMPEG' container/Dockerfile && \
@@ -31,45 +25,27 @@ grep -q '^INSTALL_FFMPEG=true' .env 2>/dev/null && \
 echo "ALREADY APPLIED — skip to Phase 3"
 ```
 
-### Confirm the .env file exists
+Confirm `.env` exists (`ls .env`); if absent, run `/setup` first or `touch .env`.
 
-```bash
-ls .env 2>&1
-```
-
-If absent, you're on a fresh checkout — run `/setup` first or `touch .env`.
-
-## Phase 2: Apply Code Changes
-
-### Enable the build flag
-
-Upsert `INSTALL_FFMPEG=true` into `.env` (mirrors `INSTALL_CJK_FONTS`):
+## Phase 2: Enable the build flag and rebuild
 
 ```bash
 grep -q '^INSTALL_FFMPEG=' .env \
   && sed -i.bak 's/^INSTALL_FFMPEG=.*/INSTALL_FFMPEG=true/' .env && rm -f .env.bak \
   || echo 'INSTALL_FFMPEG=true' >> .env
-```
 
-`./container/build.sh` and `setup/container.ts` both read this var and pass `--build-arg INSTALL_FFMPEG=true` to docker, so the conditional `apt-get install ffmpeg` block in the Dockerfile fires.
-
-### Rebuild the container image
-
-```bash
 ./container/build.sh
 ```
 
-ffmpeg (+ ffprobe + libs) adds ~80 MB. Verify the binaries landed:
+Adds ~80 MB to the image. Verify:
 
 ```bash
-docker run --rm "$(./container/build.sh --print-image 2>/dev/null || echo nanoclaw-agent:latest)" which ffmpeg ffprobe
+docker run --rm nanoclaw-agent:latest which ffmpeg ffprobe
 ```
 
-(If `--print-image` isn't supported, just `docker images | head` to find the right tag.)
+## Phase 3: Wire per-agent-group
 
-## Phase 3: Wire Per-Agent-Group
-
-For each agent group that should be able to transform media (typically the user's personal DM agent — anywhere they routinely send video/audio attachments), edit `groups/<folder>/container.json` and merge in:
+For each group that should be able to transform media, merge into `groups/<folder>/container.json`:
 
 ```jsonc
 {
@@ -83,19 +59,15 @@ For each agent group that should be able to transform media (typically the user'
 }
 ```
 
-That's it — no `additionalMounts`, no env vars, no credentials. The MCP server reads input files from `/workspace/inbox/...` (already mounted as part of the session DB layout) and writes outputs to `/workspace/agent/tmp/`, which is the existing RW per-group workspace.
+No `additionalMounts`, no credentials. Inputs are read from `/workspace/inbox/...` (already mounted), outputs go to `/workspace/agent/tmp/`.
 
-If the group should **not** have ffmpeg (e.g. a shared/scoped agent the user doesn't want producing media), leave its `container.json` untouched.
-
-### Optional: extend the per-tool timeout
-
-The default is 5 minutes per ffmpeg invocation. For groups that handle very long videos, override via env in the same `mcpServers.ffmpeg` block:
+Optional: extend the per-tool timeout (default 5 min) for groups that handle very long media:
 
 ```jsonc
 "env": { "NANOCLAW_FFMPEG_TIMEOUT_SEC": "900" }
 ```
 
-## Phase 4: Build and Restart
+## Phase 4: Restart
 
 ```bash
 pnpm run build
@@ -105,46 +77,25 @@ systemctl --user restart nanoclaw  # Linux
 
 ## Phase 5: Verify
 
-### Test from the wired agent
+In a wired chat, send a short `.mp4` with **"convert to mp3"** — you should receive an `.mp3` back. Other prompts to try: **"what's the duration"** (probe), **"give me seconds 5–15"** (trim), **"strip the audio"** (extract_audio).
 
-Tell the user:
-
-> Send a short `.mp4` to your `<agent-name>` chat with the message **"convert to mp3"**. The agent should call `mcp__ffmpeg__convert`, then `mcp__nanoclaw__send_file`, and you should receive the `.mp3` back in the same chat. Other things to try:
-> - Send a video and ask **"what's the duration"** → uses `probe`, no file delivered.
-> - Send a video and ask **"give me seconds 5–15 as a clip"** → uses `trim`.
-> - Send a video and ask **"strip the audio out"** → uses `extract_audio`.
-
-### Check logs if it's not working
+If something's off:
 
 ```bash
-tail -200 logs/nanoclaw.log logs/nanoclaw.error.log | grep -iE 'ffmpeg|mcp'
+tail -200 logs/nanoclaw.log logs/nanoclaw.error.log | grep -F '[ffmpeg-mcp]'
 ```
 
-Every failure path inside the MCP server emits a `[ffmpeg-mcp]` line on stderr — the host pipes container stderr into the normal log stream, so `grep ffmpeg-mcp` is the fastest signal.
+Every failure path emits a `[ffmpeg-mcp]` line on the container's stderr, captured by the host into `logs/nanoclaw.log`.
 
 Common signals:
-- `command not found: ffmpeg` → `INSTALL_FFMPEG=true` wasn't in `.env` at build time, or the image wasn't rebuilt. Re-run `./container/build.sh`.
-- `Input path must live under /workspace` → the agent passed a path it shouldn't have. Tell it to operate on the attachment under `/workspace/inbox/...` (already in the system prompt context).
-- `Unsupported output_format` → check the whitelist in `server.ts` (`OUTPUT_EXT_WHITELIST`); add the extension if it's a legitimate media format you trust.
-- `ffmpeg failed: ...` → the line includes the last 200 chars of ffmpeg's stderr. Common cause: the input file isn't actually media (corrupted upload, wrong MIME).
-- Agent says "I don't have ffmpeg tools" → the group's `container.json` is missing the `mcpServers.ffmpeg` entry, or the host wasn't restarted.
+- `command not found: ffmpeg` → image wasn't rebuilt with `INSTALL_FFMPEG=true`. Re-run `./container/build.sh`.
+- `Input path must live under /workspace` → tell the agent to operate on `/workspace/inbox/...`.
+- `Unsupported output_format` → check `OUTPUT_EXT_WHITELIST` in `server.ts`.
+- `ffmpeg failed: ...` → the line includes the last 200 chars of ffmpeg's stderr; usually the input isn't valid media.
+- Agent says "I don't have ffmpeg tools" → group's `container.json` is missing the `mcpServers.ffmpeg` entry, or the host wasn't restarted.
 
 ## Removal
 
 1. Delete the `"ffmpeg"` entry from `mcpServers` in each group's `container.json`.
-2. Set `INSTALL_FFMPEG=false` in `.env` (or remove the line) — frees ~80 MB on the next image build.
-3. Optional: delete `container/agent-runner/src/ffmpeg-mcp/` if no group still uses it. Removing it doesn't break anything else; the file is only loaded when explicitly wired.
-4. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.
-
-## Notes
-
-- **No credentials, no sidecar.** Unlike `/add-gmail-tool` (OAuth + OneCLI) or `/add-local-whisper` (Python sidecar), ffmpeg is a static binary — the MCP server is a thin wrapper that spawns it via `Bun.spawn` with array-form argv. No shell, no string interpolation, no privileged mounts.
-- **Per-group opt-in.** Wiring is per-`container.json`, matching the `/add-gmail-tool` and `/add-ollama-tool` precedent. A group without the entry simply doesn't see the tools.
-- **Output staging.** Tools write to `/workspace/agent/tmp/ffmpeg-<uuid>.<ext>`. The agent then chains `mcp__nanoclaw__send_file` to deliver. `/workspace/agent` is already RW-mounted; nothing new is needed.
-- **Failure logging.** Every failure path (path traversal, extension whitelist, timeout, non-zero exit, missing binary) writes a `[ffmpeg-mcp] <tool>: <reason>` line to the container's stderr, which surfaces in `logs/nanoclaw.log` for operator triage. The user-facing error returned to the agent stays brief; the log line carries the full detail (exit code, stderr tail).
-
-## Credits & references
-
-- **Skill pattern:** modeled on [`add-gmail-tool`](../add-gmail-tool/SKILL.md) (per-group `container.json` wiring) and [`add-local-whisper`](../add-local-whisper/SKILL.md) (`.env`-driven build flag).
-- **MCP server SDK:** [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk).
-- **ffmpeg:** [ffmpeg.org](https://ffmpeg.org/), LGPL/GPL.
+2. Set `INSTALL_FFMPEG=false` in `.env`.
+3. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -16,6 +16,10 @@ FROM node:22-slim
 # CJK fonts add ~200MB. Opt in only if you render Chinese/Japanese/Korean text.
 ARG INSTALL_CJK_FONTS=false
 
+# ffmpeg + ffprobe add ~80MB. Opt in if the agent transforms media via the
+# /add-ffmpeg-tool MCP server (cut/convert/extract audio/etc.).
+ARG INSTALL_FFMPEG=false
+
 # Pin CLI versions for reproducibility. Bump deliberately — unpinned installs
 # mean every rebuild silently picks up the latest and can break in lockstep
 # across all users.
@@ -53,6 +57,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         unzip \
     && if [ "$INSTALL_CJK_FONTS" = "true" ]; then \
         apt-get install -y --no-install-recommends fonts-noto-cjk; \
+       fi \
+    && if [ "$INSTALL_FFMPEG" = "true" ]; then \
+        apt-get install -y --no-install-recommends ffmpeg; \
        fi \
     && rm -rf /var/lib/apt/lists/*
 

--- a/container/agent-runner/src/ffmpeg-mcp/server.test.ts
+++ b/container/agent-runner/src/ffmpeg-mcp/server.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for the ffmpeg MCP server.
+ *
+ * The spawn layer is swapped out via `__setSpawnForTesting` so we never
+ * actually exec ffmpeg/ffprobe — we assert on the argv we would have run
+ * and on how the server packages spawn results into MCP responses.
+ *
+ * The workspace root is overridden to a tmp dir via the
+ * NANOCLAW_FFMPEG_WORKSPACE_ROOT env var so tests can stage real fixture
+ * files without needing /workspace to exist.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const TEST_WORKSPACE = fs.mkdtempSync(path.join(os.tmpdir(), 'ffmpeg-mcp-test-'));
+process.env.NANOCLAW_FFMPEG_WORKSPACE_ROOT = TEST_WORKSPACE;
+
+const FIXTURE_DIR = path.join(TEST_WORKSPACE, 'agent', 'test-fixtures');
+fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { __setSpawnForTesting, __test__ } from './server.js';
+import type { RunResult, SpawnFn } from './server.js';
+
+const {
+  resolveInputPath,
+  validateOutputExt,
+  mimeFor,
+  probeHandler,
+  convertHandler,
+  trimHandler,
+  extractAudioHandler,
+  compressHandler,
+} = __test__;
+
+function stageFixture(name: string, contents = 'fake media bytes'): string {
+  const p = path.join(FIXTURE_DIR, name);
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+function makeOutputFile(spawnedArgs: string[], bytes = 'OUT'): void {
+  // Handlers expect the output file to exist after a successful spawn.
+  // Our argv shape always puts the output path last.
+  const out = spawnedArgs[spawnedArgs.length - 1];
+  if (out && out.startsWith(path.join(TEST_WORKSPACE, 'agent', 'tmp'))) {
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, bytes);
+  }
+}
+
+interface SpawnCall { cmd: string; args: string[] }
+
+function recordingSpawn(result: RunResult): { calls: SpawnCall[]; spawn: SpawnFn } {
+  const calls: SpawnCall[] = [];
+  const spawn: SpawnFn = async (cmd, args) => {
+    calls.push({ cmd, args });
+    if (cmd === 'ffmpeg' && result.exitCode === 0) makeOutputFile(args);
+    return result;
+  };
+  return { calls, spawn };
+}
+
+const SUCCESS: RunResult = { exitCode: 0, stderr: '', stdout: '', timedOut: false };
+const FAIL: RunResult = { exitCode: 1, stderr: 'Invalid data', stdout: '', timedOut: false };
+const TIMEOUT: RunResult = { exitCode: 137, stderr: '', stdout: '', timedOut: true };
+
+afterEach(() => {
+  __setSpawnForTesting(null);
+});
+
+describe('validateOutputExt', () => {
+  it('accepts whitelisted extensions case-insensitively', () => {
+    expect(validateOutputExt('mp4')).toBe('mp4');
+    expect(validateOutputExt('MP3')).toBe('mp3');
+    expect(validateOutputExt('.WAV')).toBe('wav');
+  });
+  it('rejects unknown extensions', () => {
+    expect(validateOutputExt('exe')).toBeNull();
+    expect(validateOutputExt('sh')).toBeNull();
+    expect(validateOutputExt('')).toBeNull();
+  });
+});
+
+describe('mimeFor', () => {
+  it('returns standard MIME types for known extensions', () => {
+    expect(mimeFor('mp3')).toBe('audio/mpeg');
+    expect(mimeFor('mp4')).toBe('video/mp4');
+    expect(mimeFor('webm')).toBe('video/webm');
+  });
+  it('falls back to octet-stream for unknown', () => {
+    expect(mimeFor('xyz')).toBe('application/octet-stream');
+  });
+});
+
+describe('resolveInputPath', () => {
+  it('rejects empty input', () => {
+    expect(resolveInputPath('')).toEqual({ error: 'input path is required' });
+  });
+  it('rejects paths outside the workspace', () => {
+    const r = resolveInputPath('/etc/passwd');
+    expect('error' in r).toBe(true);
+  });
+  it('rejects ../ traversal escaping the workspace', () => {
+    stageFixture('traversal.txt');
+    const r = resolveInputPath(path.join(FIXTURE_DIR, '..', '..', '..', '..', 'etc', 'hostname'));
+    expect('error' in r).toBe(true);
+  });
+  it('accepts valid in-workspace paths', () => {
+    const p = stageFixture('clip.mp4');
+    const r = resolveInputPath(p);
+    expect('path' in r ? r.path : null).toBe(p);
+  });
+  it('rejects directories', () => {
+    const r = resolveInputPath(FIXTURE_DIR);
+    expect('error' in r).toBe(true);
+  });
+});
+
+describe('convert handler', () => {
+  it('builds expected ffmpeg argv', async () => {
+    const input = stageFixture('a.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await convertHandler({ input, output_format: 'mp3' });
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe('ffmpeg');
+    expect(calls[0].args).toContain('-i');
+    expect(calls[0].args).toContain(input);
+    const outArg = calls[0].args[calls[0].args.length - 1];
+    expect(outArg.endsWith('.mp3')).toBe(true);
+  });
+
+  it('rejects disallowed output extensions', async () => {
+    const input = stageFixture('b.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await convertHandler({ input, output_format: 'exe' });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('threads audio_bitrate_kbps as -b:a flag', async () => {
+    const input = stageFixture('c.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    await convertHandler({ input, output_format: 'mp3', audio_bitrate_kbps: 192 });
+    expect(calls[0].args).toContain('-b:a');
+    expect(calls[0].args).toContain('192k');
+  });
+
+  it('rejects negative bitrate', async () => {
+    const input = stageFixture('d.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await convertHandler({ input, output_format: 'mp3', audio_bitrate_kbps: -1 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('surfaces ffmpeg failure with stderr', async () => {
+    const input = stageFixture('e.mp4');
+    const { spawn } = recordingSpawn(FAIL);
+    __setSpawnForTesting(spawn);
+
+    const res = await convertHandler({ input, output_format: 'mp3' });
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('ffmpeg failed');
+    expect(text).toContain('Invalid data');
+  });
+
+  it('reports timeouts distinctly', async () => {
+    const input = stageFixture('f.mp4');
+    const { spawn } = recordingSpawn(TIMEOUT);
+    __setSpawnForTesting(spawn);
+
+    const res = await convertHandler({ input, output_format: 'mp3' });
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('timed out');
+  });
+});
+
+describe('trim handler', () => {
+  it('threads start and duration as ffmpeg flags', async () => {
+    const input = stageFixture('t.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    await trimHandler({ input, start_seconds: 5, duration_seconds: 10 });
+    expect(calls[0].args).toContain('-ss');
+    expect(calls[0].args).toContain('5');
+    expect(calls[0].args).toContain('-t');
+    expect(calls[0].args).toContain('10');
+  });
+
+  it('rejects negative start', async () => {
+    const input = stageFixture('t2.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await trimHandler({ input, start_seconds: -1, duration_seconds: 5 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects zero duration', async () => {
+    const input = stageFixture('t3.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await trimHandler({ input, start_seconds: 0, duration_seconds: 0 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('defaults output_format to source extension', async () => {
+    const input = stageFixture('keep.webm');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    await trimHandler({ input, start_seconds: 0, duration_seconds: 1 });
+    const out = calls[0].args[calls[0].args.length - 1];
+    expect(out.endsWith('.webm')).toBe(true);
+  });
+});
+
+describe('extract_audio handler', () => {
+  it('passes -vn to drop video', async () => {
+    const input = stageFixture('movie.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    await extractAudioHandler({ input });
+    expect(calls[0].args).toContain('-vn');
+    const out = calls[0].args[calls[0].args.length - 1];
+    expect(out.endsWith('.mp3')).toBe(true);
+  });
+
+  it('rejects video output formats', async () => {
+    const input = stageFixture('movie2.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await extractAudioHandler({ input, output_format: 'mp4' });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('compress handler', () => {
+  it('requires exactly one of crf or target_size_mb', async () => {
+    const input = stageFixture('big.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const neither = await compressHandler({ input });
+    expect(neither.isError).toBe(true);
+
+    const both = await compressHandler({ input, crf: 28, target_size_mb: 5 });
+    expect(both.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('threads crf flag when provided', async () => {
+    const input = stageFixture('big2.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    await compressHandler({ input, crf: 24 });
+    expect(calls[0].args).toContain('-crf');
+    expect(calls[0].args).toContain('24');
+  });
+
+  it('rejects out-of-range crf', async () => {
+    const input = stageFixture('big3.mp4');
+    const { calls, spawn } = recordingSpawn(SUCCESS);
+    __setSpawnForTesting(spawn);
+
+    const res = await compressHandler({ input, crf: 99 });
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('probe handler', () => {
+  it('parses ffprobe JSON into a structured response', async () => {
+    const input = stageFixture('p.mp4');
+    const probeJson = JSON.stringify({
+      format: { duration: '12.34', size: '4096', format_name: 'mov,mp4,m4a' },
+      streams: [
+        { codec_type: 'video', codec_name: 'h264', width: 1280, height: 720 },
+        { codec_type: 'audio', codec_name: 'aac', sample_rate: '48000', channels: 2 },
+      ],
+    });
+    const { spawn } = recordingSpawn({ exitCode: 0, stderr: '', stdout: probeJson, timedOut: false });
+    __setSpawnForTesting(spawn);
+
+    const res = await probeHandler({ path: input });
+    expect(res.isError).toBeFalsy();
+    const parsed = JSON.parse((res.content[0] as { text: string }).text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.duration_s).toBe(12.34);
+    expect(parsed.streams).toHaveLength(2);
+    expect(parsed.streams[0].codec).toBe('h264');
+  });
+
+  it('reports invalid JSON cleanly', async () => {
+    const input = stageFixture('p2.mp4');
+    const { spawn } = recordingSpawn({ exitCode: 0, stderr: '', stdout: 'not json', timedOut: false });
+    __setSpawnForTesting(spawn);
+
+    const res = await probeHandler({ path: input });
+    expect(res.isError).toBe(true);
+  });
+});

--- a/container/agent-runner/src/ffmpeg-mcp/server.ts
+++ b/container/agent-runner/src/ffmpeg-mcp/server.ts
@@ -1,0 +1,549 @@
+/**
+ * ffmpeg MCP server — wraps `ffmpeg` and `ffprobe` as a stdio MCP server.
+ *
+ * Lives outside the built-in `nanoclaw` MCP server so it follows the same
+ * per-group opt-in pattern as gmail/ollama: a group enables ffmpeg by adding
+ * an `mcpServers.ffmpeg` entry to its `container.json`. The tool-allowlist
+ * pattern (`mcp__ffmpeg__*`) is auto-derived from that map by `claude.ts`.
+ *
+ * Tool surface (curated, not a 1:1 ffmpeg wrapper):
+ *   probe          — ffprobe metadata
+ *   convert        — change container/codec format
+ *   trim           — extract a [start, start+duration) segment
+ *   extract_audio  — strip audio track from a video
+ *   compress       — re-encode for size (CRF or target MB)
+ *
+ * Streaming, filtergraphs, watermark/overlay, and DRM are intentionally
+ * out of scope. The agent chains tool output → mcp__nanoclaw__send_file
+ * to deliver results back to the channel.
+ */
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+// Workspace root is hardcoded for the container; tests can override via
+// NANOCLAW_FFMPEG_WORKSPACE_ROOT to stage fixtures in a tmp dir instead.
+function workspaceRoot(): string {
+  return process.env.NANOCLAW_FFMPEG_WORKSPACE_ROOT || '/workspace';
+}
+function tmpDir(): string {
+  return path.join(workspaceRoot(), 'agent', 'tmp');
+}
+const DEFAULT_TIMEOUT_SEC = Number(process.env.NANOCLAW_FFMPEG_TIMEOUT_SEC) || 300;
+const STDERR_TAIL_BYTES = 2048;
+
+const OUTPUT_EXT_WHITELIST = new Set([
+  'mp4', 'mov', 'webm', 'mkv', 'avi',
+  'mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac', 'opus',
+  'gif', 'jpg', 'jpeg', 'png',
+]);
+
+const MIME_BY_EXT: Record<string, string> = {
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  webm: 'video/webm',
+  mkv: 'video/x-matroska',
+  avi: 'video/x-msvideo',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+  opus: 'audio/opus',
+  gif: 'image/gif',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+};
+
+// ---- Logging ----------------------------------------------------------------
+
+/**
+ * Operator-facing log line. Captured via the container's stderr pipe and
+ * surfaced in `logs/nanoclaw.log` alongside the rest of the agent runtime
+ * output. The user-facing error returned to the agent is intentionally
+ * shorter — this line carries the debugging detail.
+ */
+function logErr(tool: string, reason: string, extra?: Record<string, unknown>): void {
+  const detail = extra ? ' ' + JSON.stringify(extra) : '';
+  console.error(`[ffmpeg-mcp] ${tool}: ${reason}${detail}`);
+}
+
+function logInfo(msg: string): void {
+  console.error(`[ffmpeg-mcp] ${msg}`);
+}
+
+// ---- MCP response helpers ---------------------------------------------------
+
+function ok(payload: object): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: true, ...payload }) }] };
+}
+
+function fail(tool: string, error: string, logExtra?: Record<string, unknown>): CallToolResult {
+  logErr(tool, error, logExtra);
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ ok: false, error }) }],
+    isError: true,
+  };
+}
+
+// ---- Path + extension validation -------------------------------------------
+
+/**
+ * Resolve and validate an input path.
+ *
+ * Accepts absolute paths under /workspace or relative paths (resolved
+ * against /workspace/agent). Rejects anything that escapes /workspace via
+ * `..` or symlink — `realpath` is the source of truth.
+ */
+function resolveInputPath(input: string): { path: string } | { error: string } {
+  if (!input || typeof input !== 'string') return { error: 'input path is required' };
+  const candidate = path.isAbsolute(input) ? input : path.resolve('/workspace/agent', input);
+  let real: string;
+  try {
+    real = fs.realpathSync(candidate);
+  } catch {
+    return { error: `Input not found: ${input}` };
+  }
+  const root = workspaceRoot();
+  if (real !== root && !real.startsWith(root + path.sep)) {
+    return { error: 'Input path must live under /workspace' };
+  }
+  if (!fs.statSync(real).isFile()) {
+    return { error: 'Input path is not a regular file' };
+  }
+  return { path: real };
+}
+
+function validateOutputExt(ext: string): string | null {
+  const clean = ext.toLowerCase().replace(/^\./, '');
+  if (!OUTPUT_EXT_WHITELIST.has(clean)) return null;
+  return clean;
+}
+
+function mimeFor(ext: string): string {
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream';
+}
+
+function makeOutputPath(ext: string): string {
+  const dir = tmpDir();
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, `ffmpeg-${randomUUID()}.${ext}`);
+}
+
+// ---- Spawn layer (injectable for tests) -------------------------------------
+
+export interface RunResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+  timedOut: boolean;
+}
+
+export type SpawnFn = (cmd: string, args: string[], timeoutSec: number) => Promise<RunResult>;
+
+async function defaultSpawn(cmd: string, args: string[], timeoutSec: number): Promise<RunResult> {
+  const proc = Bun.spawn([cmd, ...args], {
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try { proc.kill('SIGKILL'); } catch { /* already exited */ }
+  }, timeoutSec * 1000);
+
+  const [stdout, stderrFull, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  clearTimeout(timer);
+
+  const stderr = stderrFull.length > STDERR_TAIL_BYTES
+    ? '...' + stderrFull.slice(-STDERR_TAIL_BYTES)
+    : stderrFull;
+
+  return { exitCode, stderr, stdout, timedOut };
+}
+
+let _spawn: SpawnFn = defaultSpawn;
+
+/** Test-only: swap the spawn implementation. */
+export function __setSpawnForTesting(fn: SpawnFn | null): void {
+  _spawn = fn ?? defaultSpawn;
+}
+
+async function runFfmpeg(args: string[]): Promise<RunResult> {
+  return _spawn('ffmpeg', ['-hide_banner', '-loglevel', 'error', '-y', ...args], DEFAULT_TIMEOUT_SEC);
+}
+
+async function runFfprobe(args: string[]): Promise<RunResult> {
+  return _spawn('ffprobe', ['-hide_banner', '-loglevel', 'error', ...args], DEFAULT_TIMEOUT_SEC);
+}
+
+// ---- Tool: probe ------------------------------------------------------------
+
+const probeTool: Tool = {
+  name: 'probe',
+  description:
+    'Inspect a media file with ffprobe and return its duration, format, and per-stream codec info. Use this before convert/trim to confirm the file is what the agent expects.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Path to the media file (absolute under /workspace, or relative to /workspace/agent).' },
+    },
+    required: ['path'],
+  },
+};
+
+async function probeHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const resolved = resolveInputPath(args.path as string);
+  if ('error' in resolved) return fail('probe', resolved.error, { path: basename(args.path) });
+
+  const result = await runFfprobe([
+    '-print_format', 'json',
+    '-show_format',
+    '-show_streams',
+    resolved.path,
+  ]);
+
+  if (result.timedOut) return fail('probe', 'ffprobe timed out', { path: path.basename(resolved.path) });
+  if (result.exitCode !== 0) {
+    return fail('probe', 'ffprobe failed', {
+      path: path.basename(resolved.path),
+      exitCode: result.exitCode,
+      stderr: result.stderr,
+    });
+  }
+
+  let parsed: { format?: { duration?: string; size?: string; format_name?: string }; streams?: Array<Record<string, unknown>> };
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return fail('probe', 'ffprobe returned invalid JSON', { path: path.basename(resolved.path) });
+  }
+
+  const streams = (parsed.streams ?? []).map((s) => ({
+    type: s.codec_type as string | undefined,
+    codec: s.codec_name as string | undefined,
+    width: s.width as number | undefined,
+    height: s.height as number | undefined,
+    sample_rate: s.sample_rate ? Number(s.sample_rate) : undefined,
+    channels: s.channels as number | undefined,
+  }));
+
+  return ok({
+    duration_s: parsed.format?.duration ? Number(parsed.format.duration) : null,
+    size_bytes: parsed.format?.size ? Number(parsed.format.size) : null,
+    format: parsed.format?.format_name ?? null,
+    streams,
+  });
+}
+
+// ---- Tool: convert ----------------------------------------------------------
+
+const convertTool: Tool = {
+  name: 'convert',
+  description:
+    'Convert a media file to a different format (e.g. mp4 → mp3, mov → mp4, wav → ogg). Returns the path to the new file; chain with mcp__nanoclaw__send_file to deliver.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      input: { type: 'string', description: 'Path to the source file.' },
+      output_format: {
+        type: 'string',
+        description: `Target format extension (without the dot). Allowed: ${[...OUTPUT_EXT_WHITELIST].sort().join(', ')}.`,
+      },
+      audio_bitrate_kbps: { type: 'number', description: 'Optional audio bitrate in kbps (e.g. 128, 192, 320).' },
+      video_crf: { type: 'number', description: 'Optional H.264/H.265 CRF (lower = higher quality, 18–28 typical).' },
+    },
+    required: ['input', 'output_format'],
+  },
+};
+
+async function convertHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const resolved = resolveInputPath(args.input as string);
+  if ('error' in resolved) return fail('convert', resolved.error, { input: basename(args.input) });
+
+  const ext = validateOutputExt(String(args.output_format ?? ''));
+  if (!ext) return fail('convert', 'Unsupported output_format', { requested: args.output_format });
+
+  const out = makeOutputPath(ext);
+  const ffArgs: string[] = ['-i', resolved.path];
+
+  if (args.audio_bitrate_kbps !== undefined) {
+    const br = Number(args.audio_bitrate_kbps);
+    if (!Number.isFinite(br) || br <= 0) return fail('convert', 'audio_bitrate_kbps must be a positive number');
+    ffArgs.push('-b:a', `${Math.round(br)}k`);
+  }
+  if (args.video_crf !== undefined) {
+    const crf = Number(args.video_crf);
+    if (!Number.isFinite(crf) || crf < 0 || crf > 51) return fail('convert', 'video_crf must be in [0, 51]');
+    ffArgs.push('-crf', String(Math.round(crf)));
+  }
+
+  ffArgs.push(out);
+  return await runAndPackage('convert', ffArgs, out, ext);
+}
+
+// ---- Tool: trim -------------------------------------------------------------
+
+const trimTool: Tool = {
+  name: 'trim',
+  description:
+    'Cut a [start, start+duration) segment out of a media file. By default keeps the source format; pass output_format to also convert.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      input: { type: 'string', description: 'Path to the source file.' },
+      start_seconds: { type: 'number', description: 'Segment start in seconds (>= 0).' },
+      duration_seconds: { type: 'number', description: 'Segment length in seconds (> 0).' },
+      output_format: {
+        type: 'string',
+        description: 'Optional output format extension (defaults to the source extension).',
+      },
+    },
+    required: ['input', 'start_seconds', 'duration_seconds'],
+  },
+};
+
+async function trimHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const resolved = resolveInputPath(args.input as string);
+  if ('error' in resolved) return fail('trim', resolved.error, { input: basename(args.input) });
+
+  const start = Number(args.start_seconds);
+  const dur = Number(args.duration_seconds);
+  if (!Number.isFinite(start) || start < 0) return fail('trim', 'start_seconds must be >= 0');
+  if (!Number.isFinite(dur) || dur <= 0) return fail('trim', 'duration_seconds must be > 0');
+
+  const sourceExt = path.extname(resolved.path).slice(1).toLowerCase();
+  const requested = args.output_format ? String(args.output_format) : sourceExt;
+  const ext = validateOutputExt(requested);
+  if (!ext) return fail('trim', 'Unsupported output_format', { requested });
+
+  const out = makeOutputPath(ext);
+  // Place -ss before -i for fast seek (keyframe-snapped, accurate enough for most cuts).
+  const ffArgs = ['-ss', String(start), '-i', resolved.path, '-t', String(dur), out];
+  return await runAndPackage('trim', ffArgs, out, ext);
+}
+
+// ---- Tool: extract_audio ----------------------------------------------------
+
+const extractAudioTool: Tool = {
+  name: 'extract_audio',
+  description:
+    'Strip the audio track from a video and save it as a standalone audio file. Defaults to mp3.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      input: { type: 'string', description: 'Path to the source file.' },
+      output_format: {
+        type: 'string',
+        description: 'Audio format extension. Allowed: mp3, wav, ogg, flac, m4a, aac, opus. Default: mp3.',
+      },
+    },
+    required: ['input'],
+  },
+};
+
+const AUDIO_ONLY_EXTS = new Set(['mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac', 'opus']);
+
+async function extractAudioHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const resolved = resolveInputPath(args.input as string);
+  if ('error' in resolved) return fail('extract_audio', resolved.error, { input: basename(args.input) });
+
+  const requested = String(args.output_format ?? 'mp3').toLowerCase().replace(/^\./, '');
+  if (!AUDIO_ONLY_EXTS.has(requested)) {
+    return fail('extract_audio', 'Unsupported audio format', { requested });
+  }
+
+  const out = makeOutputPath(requested);
+  // -vn drops the video stream; let ffmpeg pick the default codec for the container.
+  const ffArgs = ['-i', resolved.path, '-vn', out];
+  return await runAndPackage('extract_audio', ffArgs, out, requested);
+}
+
+// ---- Tool: compress ---------------------------------------------------------
+
+const compressTool: Tool = {
+  name: 'compress',
+  description:
+    'Re-encode a media file to reduce size. Pass either `crf` (constant quality, 18–35 typical, lower = bigger) or `target_size_mb` (rough average bitrate for that size). One of the two is required.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      input: { type: 'string', description: 'Path to the source file.' },
+      crf: { type: 'number', description: 'H.264/H.265 CRF in [0, 51]. Mutually exclusive with target_size_mb.' },
+      target_size_mb: { type: 'number', description: 'Approx target size in MB. Mutually exclusive with crf.' },
+    },
+    required: ['input'],
+  },
+};
+
+async function compressHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const resolved = resolveInputPath(args.input as string);
+  if ('error' in resolved) return fail('compress', resolved.error, { input: basename(args.input) });
+
+  const hasCrf = args.crf !== undefined;
+  const hasTarget = args.target_size_mb !== undefined;
+  if (hasCrf === hasTarget) {
+    return fail('compress', 'Pass exactly one of `crf` or `target_size_mb`');
+  }
+
+  const sourceExt = path.extname(resolved.path).slice(1).toLowerCase();
+  const ext = validateOutputExt(sourceExt) ?? 'mp4';
+  const out = makeOutputPath(ext);
+  const ffArgs: string[] = ['-i', resolved.path];
+
+  if (hasCrf) {
+    const crf = Number(args.crf);
+    if (!Number.isFinite(crf) || crf < 0 || crf > 51) return fail('compress', 'crf must be in [0, 51]');
+    ffArgs.push('-crf', String(Math.round(crf)));
+  } else {
+    const targetMb = Number(args.target_size_mb);
+    if (!Number.isFinite(targetMb) || targetMb <= 0) return fail('compress', 'target_size_mb must be > 0');
+    // Probe duration to compute bitrate. Failure here is non-fatal — we fall
+    // back to a fixed mid-quality CRF.
+    const dur = await probeDurationSec(resolved.path);
+    if (dur && dur > 0) {
+      const bitrateKbps = Math.max(64, Math.floor((targetMb * 8 * 1024) / dur));
+      ffArgs.push('-b:v', `${bitrateKbps}k`);
+    } else {
+      ffArgs.push('-crf', '28');
+    }
+  }
+
+  ffArgs.push(out);
+  return await runAndPackage('compress', ffArgs, out, ext);
+}
+
+async function probeDurationSec(filePath: string): Promise<number | null> {
+  const result = await runFfprobe([
+    '-print_format', 'json',
+    '-show_format',
+    filePath,
+  ]);
+  if (result.exitCode !== 0) return null;
+  try {
+    const parsed = JSON.parse(result.stdout) as { format?: { duration?: string } };
+    const d = parsed.format?.duration ? Number(parsed.format.duration) : NaN;
+    return Number.isFinite(d) ? d : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---- Shared run-and-package -------------------------------------------------
+
+async function runAndPackage(
+  tool: string,
+  ffArgs: string[],
+  outPath: string,
+  ext: string,
+): Promise<CallToolResult> {
+  const result = await runFfmpeg(ffArgs);
+
+  if (result.timedOut) {
+    safeUnlink(outPath);
+    return fail(tool, 'ffmpeg timed out', { timeout_sec: DEFAULT_TIMEOUT_SEC });
+  }
+  if (result.exitCode !== 0) {
+    safeUnlink(outPath);
+    return fail(tool, `ffmpeg failed: ${truncStderr(result.stderr)}`, {
+      exitCode: result.exitCode,
+      stderr: result.stderr,
+    });
+  }
+  if (!fs.existsSync(outPath)) {
+    return fail(tool, 'ffmpeg reported success but no output file was written');
+  }
+
+  const stat = fs.statSync(outPath);
+  logInfo(`${tool}: wrote ${path.basename(outPath)} (${stat.size} bytes)`);
+  return ok({
+    path: outPath,
+    size_bytes: stat.size,
+    mime_type: mimeFor(ext),
+  });
+}
+
+function safeUnlink(p: string): void {
+  try { fs.unlinkSync(p); } catch { /* nothing to clean up */ }
+}
+
+function truncStderr(s: string): string {
+  const trimmed = s.trim();
+  if (trimmed.length <= 200) return trimmed;
+  return trimmed.slice(0, 200) + '...';
+}
+
+function basename(input: unknown): string {
+  if (typeof input !== 'string') return '<non-string>';
+  try { return path.basename(input); } catch { return '<unparseable>'; }
+}
+
+// ---- Server bootstrap -------------------------------------------------------
+
+const TOOLS: Array<{ tool: Tool; handler: (a: Record<string, unknown>) => Promise<CallToolResult> }> = [
+  { tool: probeTool, handler: probeHandler },
+  { tool: convertTool, handler: convertHandler },
+  { tool: trimTool, handler: trimHandler },
+  { tool: extractAudioTool, handler: extractAudioHandler },
+  { tool: compressTool, handler: compressHandler },
+];
+
+export async function startFfmpegMcpServer(): Promise<void> {
+  const server = new Server({ name: 'ffmpeg', version: '1.0.0' }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS.map((t) => t.tool),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const found = TOOLS.find((t) => t.tool.name === name);
+    if (!found) {
+      return fail('dispatch', `Unknown tool: ${name}`);
+    }
+    try {
+      return await found.handler(args ?? {});
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return fail(name, 'Unhandled exception', { error: msg });
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logInfo(`ffmpeg MCP server started with ${TOOLS.length} tools: ${TOOLS.map((t) => t.tool.name).join(', ')}`);
+}
+
+// Run when invoked as a script (the only way `bun run server.ts` enters here).
+// Skip when imported by tests.
+if (import.meta.main) {
+  startFfmpegMcpServer().catch((e) => {
+    console.error(`[ffmpeg-mcp] fatal: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  });
+}
+
+// Test-only exports.
+export const __test__ = {
+  resolveInputPath,
+  validateOutputExt,
+  mimeFor,
+  probeHandler,
+  convertHandler,
+  trimHandler,
+  extractAudioHandler,
+  compressHandler,
+};

--- a/container/build.sh
+++ b/container/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Build the NanoClaw agent container image.
 #
-# Reads one optional build flag from ../.env:
+# Reads optional build flags from ../.env:
 #   INSTALL_CJK_FONTS=true   — add Chinese/Japanese/Korean fonts (~200MB)
+#   INSTALL_FFMPEG=true      — add ffmpeg + ffprobe (~80MB) for /add-ffmpeg-tool
 # setup/container.ts reads the same file, so both build paths stay in sync.
-# Callers can also override by exporting INSTALL_CJK_FONTS directly.
+# Callers can also override by exporting either var directly.
 
 set -e
 
@@ -25,11 +26,18 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 if [ -z "${INSTALL_CJK_FONTS:-}" ] && [ -f "../.env" ]; then
     INSTALL_CJK_FONTS="$(grep '^INSTALL_CJK_FONTS=' ../.env | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]')"
 fi
+if [ -z "${INSTALL_FFMPEG:-}" ] && [ -f "../.env" ]; then
+    INSTALL_FFMPEG="$(grep '^INSTALL_FFMPEG=' ../.env | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]')"
+fi
 
 BUILD_ARGS=()
 if [ "${INSTALL_CJK_FONTS:-false}" = "true" ]; then
     echo "CJK fonts: enabled (adds ~200MB)"
     BUILD_ARGS+=(--build-arg INSTALL_CJK_FONTS=true)
+fi
+if [ "${INSTALL_FFMPEG:-false}" = "true" ]; then
+    echo "ffmpeg: enabled (adds ~80MB)"
+    BUILD_ARGS+=(--build-arg INSTALL_FFMPEG=true)
 fi
 
 echo "Building NanoClaw agent container image..."

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -171,16 +171,21 @@ export async function run(args: string[]): Promise<void> {
   const buildCmd = 'docker build';
   const runCmd = 'docker';
 
-  // Build-args from .env. Only INSTALL_CJK_FONTS is passed through today.
-  // Keeps /setup and ./container/build.sh in sync — both read the same source.
+  // Build-args from .env. Keeps /setup and ./container/build.sh in sync —
+  // both read the same source.
   const buildArgs: string[] = [];
   try {
     const fs = await import('fs');
     const envPath = path.join(projectRoot, '.env');
     if (fs.existsSync(envPath)) {
-      const match = fs.readFileSync(envPath, 'utf-8').match(/^INSTALL_CJK_FONTS=(.+)$/m);
-      const val = match?.[1].trim().replace(/^["']|["']$/g, '').toLowerCase();
-      if (val === 'true') buildArgs.push('--build-arg INSTALL_CJK_FONTS=true');
+      const envText = fs.readFileSync(envPath, 'utf-8');
+      const readFlag = (key: string): boolean => {
+        const match = envText.match(new RegExp(`^${key}=(.+)$`, 'm'));
+        const val = match?.[1].trim().replace(/^["']|["']$/g, '').toLowerCase();
+        return val === 'true';
+      };
+      if (readFlag('INSTALL_CJK_FONTS')) buildArgs.push('--build-arg INSTALL_CJK_FONTS=true');
+      if (readFlag('INSTALL_FFMPEG')) buildArgs.push('--build-arg INSTALL_FFMPEG=true');
     }
   } catch {
     // .env is optional; absence is normal on a fresh checkout


### PR DESCRIPTION
  <!-- contributing-guide: v1 -->
  ## Type of Change

  - [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
  - [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
  - [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
  - [ ] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code
  - [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

  ## Description

  Adds an in-repo ffmpeg MCP server so an agent can transform a media attachment a user sent (mp4, mov, webm, mp3, wav, etc.) and reply with the result via the existing `mcp__nanoclaw__send_file` tool.
  Concrete flow this unlocks: user sends `clip.mp4` with *"convert to mp3"*, agent calls `mcp__ffmpeg__convert`, then `send_file` — user gets `clip.mp3` back in the same channel.

  **Tools (surfaced as `mcp__ffmpeg__<name>`):**

  | Tool | What it does |
  |------|---------------|
  | `probe` | ffprobe metadata: duration, format, per-stream codec/size info |
  | `convert` | Change format/container (mp4 ↔ mp3 ↔ wav ↔ mov ↔ webm, etc.) |
  | `trim` | Cut a `[start, start+duration)` segment |
  | `extract_audio` | Strip the audio track from a video |
  | `compress` | Re-encode for size, by CRF or rough target MB |

  **How it's wired:**
  - The MCP server is a standalone Bun script at `container/agent-runner/src/ffmpeg-mcp/server.ts`, run per-group via `bun run /app/src/ffmpeg-mcp/server.ts` from a `mcpServers.ffmpeg` entry in the group's
  `container.json`. The `mcp__ffmpeg__*` allowlist pattern is already auto-derived from that map by `providers/claude.ts` — no `TOOL_ALLOWLIST` edit needed.
  - The ffmpeg/ffprobe binaries are added to the image only when `INSTALL_FFMPEG=true` is set in `.env`. `container/build.sh` and `setup/container.ts` both
  read the flag, so `/setup` and `./container/build.sh` stay in sync.
  - The `/add-ffmpeg-tool` skill walks the operator through flipping the flag, rebuilding, wiring per-group, and verifying with a real round-trip.

  **Safety:**
  - `Bun.spawn([...args])` array form, never `shell:true`.
  - `realpath`-based workspace containment on every input path (rejects `/etc/passwd`, traversal via `..`, symlink escape).
  - Output-extension whitelist (`.exe`, `.sh` etc. rejected).
  - 5-minute hard timeout per invocation, tunable via `NANOCLAW_FFMPEG_TIMEOUT_SEC` env in the per-group `mcpServers.ffmpeg` block.
  - Every failure path emits a `[ffmpeg-mcp]` log line on the container's stderr.

  **Testing:** 26 unit tests in `container/agent-runner/src/ffmpeg-mcp/server.test.ts` cover argv shape per tool, path-traversal rejection, extension whitelist, timeout/failure surfacing, and ffprobe JSON
  parsing. Spawn layer is injectable (`__setSpawnForTesting`) so tests never exec the real binary. End-to-end verified locally with a Telegram round-trip: `.mp4` → "convert to mp3" → `.mp3` delivered.

  ## For Skills

  - [x] SKILL.md contains instructions, not inline code (code goes in separate files)
  - [x] SKILL.md is under 500 lines (101 lines)
  - [ ] I tested this skill on a fresh clone