### PR TITLE
setup: add ← Back option to Slack channel flow

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -29,6 +29,7 @@ import path from 'path';
 import * as p from '@clack/prompts';
 import k from 'kleur';
 
+import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runDiscordChannel } from './channels/discord.js';
 import { runIMessageChannel } from './channels/imessage.js';
 import { runSignalChannel } from './channels/signal.js';
@@ -440,35 +441,45 @@ async function main(): Promise<void> {
   let channelChoice: ChannelChoice = 'skip';
 
   if (!skip.has('channel')) {
-    channelChoice = await askChannelChoice();
-    if (channelChoice !== 'skip' && channelChoice !== 'other') {
-      await resolveDisplayName();
-    }
-    if (channelChoice === 'telegram') {
-      await runTelegramChannel(displayName!);
-    } else if (channelChoice === 'discord') {
-      await runDiscordChannel(displayName!);
-    } else if (channelChoice === 'whatsapp') {
-      await runWhatsAppChannel(displayName!);
-    } else if (channelChoice === 'signal') {
-      await runSignalChannel(displayName!);
-    } else if (channelChoice === 'teams') {
-      await runTeamsChannel(displayName!);
-    } else if (channelChoice === 'slack') {
-      await runSlackChannel(displayName!);
-    } else if (channelChoice === 'imessage') {
-      await runIMessageChannel(displayName!);
-    } else if (channelChoice === 'other') {
-      await askOtherChannelName();
-    } else {
-      p.log.info(
-        brandBody(
-          wrapForGutter(
-            'No messaging app for now. You can add one later (like Telegram, Discord, WhatsApp, Teams, Slack, or iMessage).',
-            4,
+    // Loop so a channel sub-flow can return BACK_TO_CHANNEL_SELECTION on
+    // its first prompt and bounce the user back to the chooser without
+    // restarting setup. Channels not yet wired with the back option just
+    // return void and the loop exits after one pass.
+    let backed = true;
+    while (backed) {
+      backed = false;
+      channelChoice = await askChannelChoice();
+      if (channelChoice !== 'skip' && channelChoice !== 'other') {
+        await resolveDisplayName();
+      }
+      let result: void | typeof BACK_TO_CHANNEL_SELECTION;
+      if (channelChoice === 'telegram') {
+        await runTelegramChannel(displayName!);
+      } else if (channelChoice === 'discord') {
+        result = await runDiscordChannel(displayName!);
+      } else if (channelChoice === 'whatsapp') {
+        result = await runWhatsAppChannel(displayName!);
+      } else if (channelChoice === 'signal') {
+        await runSignalChannel(displayName!);
+      } else if (channelChoice === 'teams') {
+        await runTeamsChannel(displayName!);
+      } else if (channelChoice === 'slack') {
+        await runSlackChannel(displayName!);
+      } else if (channelChoice === 'imessage') {
+        result = await runIMessageChannel(displayName!);
+      } else if (channelChoice === 'other') {
+        await askOtherChannelName();
+      } else {
+        p.log.info(
+          brandBody(
+            wrapForGutter(
+              'No messaging app for now. You can add one later (like Telegram, Discord, WhatsApp, Teams, Slack, or iMessage).',
+              4,
+            ),
           ),
-        ),
-      );
+        );
+      }
+      if (result === BACK_TO_CHANNEL_SELECTION) backed = true;
     }
   }
 

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -464,7 +464,7 @@ async function main(): Promise<void> {
       } else if (channelChoice === 'teams') {
         await runTeamsChannel(displayName!);
       } else if (channelChoice === 'slack') {
-        await runSlackChannel(displayName!);
+        result = await runSlackChannel(displayName!);
       } else if (channelChoice === 'imessage') {
         result = await runIMessageChannel(displayName!);
       } else if (channelChoice === 'other') {

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -454,7 +454,7 @@ async function main(): Promise<void> {
       }
       let result: void | typeof BACK_TO_CHANNEL_SELECTION;
       if (channelChoice === 'telegram') {
-        await runTelegramChannel(displayName!);
+        result = await runTelegramChannel(displayName!);
       } else if (channelChoice === 'discord') {
         result = await runDiscordChannel(displayName!);
       } else if (channelChoice === 'whatsapp') {

--- a/setup/channels/discord.ts
+++ b/setup/channels/discord.ts
@@ -27,6 +27,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
+import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
 import { brightSelect } from '../lib/bright-select.js';
 import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
@@ -48,8 +49,10 @@ interface AppInfo {
   owner: { id: string; username: string } | null;
 }
 
-export async function runDiscordChannel(displayName: string): Promise<void> {
-  const hasBot = await askHasBotToken();
+export async function runDiscordChannel(displayName: string): Promise<ChannelFlowResult> {
+  const choice = await askHasBotToken();
+  if (choice === 'back') return BACK_TO_CHANNEL_SELECTION;
+  const hasBot = choice === 'yes';
   if (!hasBot) {
     await walkThroughBotCreation();
   }
@@ -142,17 +145,18 @@ export async function runDiscordChannel(displayName: string): Promise<void> {
   }
 }
 
-async function askHasBotToken(): Promise<boolean> {
+async function askHasBotToken(): Promise<'yes' | 'no' | 'back'> {
   const answer = ensureAnswer(
     await brightSelect({
       message: 'Do you already have a Discord bot?',
       options: [
         { value: 'yes', label: 'Yes, I have a bot token ready' },
         { value: 'no', label: "No, walk me through creating one" },
+        { value: 'back', label: '← Back to channel selection' },
       ],
     }),
   );
-  return answer === 'yes';
+  return answer as 'yes' | 'no' | 'back';
 }
 
 async function walkThroughBotCreation(): Promise<void> {

--- a/setup/channels/imessage.ts
+++ b/setup/channels/imessage.ts
@@ -33,6 +33,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
+import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
 import { brightSelect } from '../lib/bright-select.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
@@ -48,10 +49,11 @@ interface RemoteCreds {
   apiKey: string;
 }
 
-export async function runIMessageChannel(displayName: string): Promise<void> {
+export async function runIMessageChannel(displayName: string): Promise<ChannelFlowResult> {
   const isMac = os.platform() === 'darwin';
 
   const mode = await askMode(isMac);
+  if (mode === 'back') return BACK_TO_CHANNEL_SELECTION;
   let remoteCreds: RemoteCreds | null = null;
 
   if (mode === 'local') {
@@ -139,34 +141,38 @@ export async function runIMessageChannel(displayName: string): Promise<void> {
   }
 }
 
-async function askMode(isMac: boolean): Promise<Mode> {
+async function askMode(isMac: boolean): Promise<Mode | 'back'> {
+  const baseOptions = isMac
+    ? [
+        {
+          value: 'local' as const,
+          label: 'Local (this Mac)',
+          hint: "uses this machine's iMessage account",
+        },
+        {
+          value: 'remote' as const,
+          label: 'Remote (Photon API)',
+          hint: 'the bot lives on another server',
+        },
+      ]
+    : [
+        {
+          value: 'remote' as const,
+          label: 'Remote (Photon API)',
+          hint: 'only option off macOS',
+        },
+      ];
   const choice = ensureAnswer(
-    await brightSelect<Mode>({
+    await brightSelect<Mode | 'back'>({
       message: 'How should iMessage run?',
       initialValue: isMac ? 'local' : 'remote',
-      options: isMac
-        ? [
-            {
-              value: 'local',
-              label: 'Local (this Mac)',
-              hint: "uses this machine's iMessage account",
-            },
-            {
-              value: 'remote',
-              label: 'Remote (Photon API)',
-              hint: 'the bot lives on another server',
-            },
-          ]
-        : [
-            {
-              value: 'remote',
-              label: 'Remote (Photon API)',
-              hint: 'only option off macOS',
-            },
-          ],
+      options: [
+        ...baseOptions,
+        { value: 'back', label: '← Back to channel selection' },
+      ],
     }),
   );
-  setupLog.userInput('imessage_mode', String(choice));
+  if (choice !== 'back') setupLog.userInput('imessage_mode', String(choice));
   return choice;
 }
 

--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -25,7 +25,10 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
-import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
+import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
+import { brightSelect } from '../lib/bright-select.js';
+import { formatNoteLink, openUrl } from '../lib/browser.js';
+import { isHeadless } from '../platform.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
 import { readEnvKey } from '../environment.js';
@@ -42,8 +45,9 @@ interface WorkspaceInfo {
   botUserId: string;
 }
 
-export async function runSlackChannel(displayName: string): Promise<void> {
-  await walkThroughAppCreation();
+export async function runSlackChannel(displayName: string): Promise<ChannelFlowResult> {
+  const intro = await walkThroughAppCreation();
+  if (intro === 'back') return BACK_TO_CHANNEL_SELECTION;
 
   const token = await collectBotToken();
   const signingSecret = await collectSigningSecret();
@@ -121,7 +125,7 @@ export async function runSlackChannel(displayName: string): Promise<void> {
   showPostInstallChecklist(info);
 }
 
-async function walkThroughAppCreation(): Promise<void> {
+async function walkThroughAppCreation(): Promise<'continue' | 'back'> {
   note(
     [
       "You'll create a Slack app that the assistant talks through.",
@@ -140,7 +144,20 @@ async function walkThroughAppCreation(): Promise<void> {
     ].filter((line): line is string => line !== null).join('\n'),
     'Create a Slack app',
   );
-  await confirmThenOpen(SLACK_APPS_URL, 'Press Enter to open Slack app settings');
+
+  // Back-aware gate replacing the old `confirmThenOpen` "Press Enter to open
+  // Slack app settings" so users can bail out of Slack before we open the
+  // browser or ask for tokens.
+  const choice = ensureAnswer(await brightSelect<'open' | 'back'>({
+    message: 'Open Slack app settings in your browser?',
+    options: [
+      { value: 'open', label: 'Open Slack app settings' },
+      { value: 'back', label: '← Back to channel selection' },
+    ],
+    initialValue: 'open',
+  }));
+  if (choice === 'back') return 'back';
+  if (!isHeadless()) openUrl(SLACK_APPS_URL);
 
   ensureAnswer(
     await p.confirm({
@@ -148,6 +165,7 @@ async function walkThroughAppCreation(): Promise<void> {
       initialValue: true,
     }),
   );
+  return 'continue';
 }
 
 async function collectBotToken(): Promise<string> {

--- a/setup/channels/telegram.ts
+++ b/setup/channels/telegram.ts
@@ -21,7 +21,9 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
+import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
 import { confirmThenOpen, formatNoteLink } from '../lib/browser.js';
+import { brightSelect } from '../lib/bright-select.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import {
   type Block,
@@ -38,8 +40,10 @@ import { accentGreen, brandBold, fitToWidth, fmtDuration, note } from '../lib/th
 
 const DEFAULT_AGENT_NAME = 'Nano';
 
-export async function runTelegramChannel(displayName: string): Promise<void> {
-  const token = await collectTelegramToken();
+export async function runTelegramChannel(displayName: string): Promise<ChannelFlowResult> {
+  const tokenOrBack = await collectTelegramToken();
+  if (tokenOrBack === 'back') return BACK_TO_CHANNEL_SELECTION;
+  const token = tokenOrBack;
   const botUsername = await validateTelegramToken(token);
 
   // Deep-link the user into the bot's chat so they're on the right screen
@@ -131,17 +135,24 @@ export async function runTelegramChannel(displayName: string): Promise<void> {
   }
 }
 
-async function collectTelegramToken(): Promise<string> {
+async function collectTelegramToken(): Promise<string | 'back'> {
   const existing = readEnvKey('TELEGRAM_BOT_TOKEN');
   if (existing && /^[0-9]+:[A-Za-z0-9_-]{35,}$/.test(existing)) {
-    const reuse = ensureAnswer(await p.confirm({
+    const choice = ensureAnswer(await brightSelect<'yes' | 'no' | 'back'>({
       message: `Found an existing Telegram bot token (${existing.slice(0, 8)}…). Use it?`,
-      initialValue: true,
+      options: [
+        { value: 'yes', label: 'Yes, use the existing token' },
+        { value: 'no', label: 'No, paste a new one' },
+        { value: 'back', label: '← Back to channel selection' },
+      ],
+      initialValue: 'yes',
     }));
-    if (reuse) {
+    if (choice === 'back') return 'back';
+    if (choice === 'yes') {
       setupLog.userInput('telegram_token', 'reused-existing');
       return existing;
     }
+    // 'no' falls through to the paste flow below
   }
 
   note(
@@ -158,6 +169,19 @@ async function collectTelegramToken(): Promise<string> {
     ].join('\n'),
     'Set up your Telegram bot',
   );
+
+  // Back-aware gate before the password prompt — `p.password` doesn't
+  // accept extra options, so we offer Back as a separate brightSelect
+  // immediately after the BotFather instructions and before the paste.
+  const proceed = ensureAnswer(await brightSelect<'continue' | 'back'>({
+    message: 'Ready to paste your bot token?',
+    options: [
+      { value: 'continue', label: 'Yes, paste it on the next prompt' },
+      { value: 'back', label: '← Back to channel selection' },
+    ],
+    initialValue: 'continue',
+  }));
+  if (proceed === 'back') return 'back';
 
   const answer = ensureAnswer(
     await p.password({

--- a/setup/channels/whatsapp.ts
+++ b/setup/channels/whatsapp.ts
@@ -33,6 +33,7 @@ import * as p from '@clack/prompts';
 import k from 'kleur';
 
 import * as setupLog from '../logs.js';
+import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
 import { brightSelect } from '../lib/bright-select.js';
 import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
 import {
@@ -53,8 +54,9 @@ const AUTH_CREDS_PATH = path.join(process.cwd(), 'store', 'auth', 'creds.json');
 
 type AuthMethod = 'qr' | 'pairing-code';
 
-export async function runWhatsAppChannel(displayName: string): Promise<void> {
+export async function runWhatsAppChannel(displayName: string): Promise<ChannelFlowResult> {
   const method = await askAuthMethod();
+  if (method === 'back') return BACK_TO_CHANNEL_SELECTION;
   const phone = method === 'pairing-code' ? await askPhoneNumber() : undefined;
 
   const install = await runQuietChild(
@@ -148,7 +150,7 @@ export async function runWhatsAppChannel(displayName: string): Promise<void> {
   }
 }
 
-async function askAuthMethod(): Promise<AuthMethod> {
+async function askAuthMethod(): Promise<AuthMethod | 'back'> {
   const choice = ensureAnswer(
     await brightSelect({
       message: 'How would you like to authenticate with WhatsApp?',
@@ -163,10 +165,14 @@ async function askAuthMethod(): Promise<AuthMethod> {
           label: 'Enter a pairing code on your phone',
           hint: 'no camera needed',
         },
+        {
+          value: 'back',
+          label: '← Back to channel selection',
+        },
       ],
     }),
-  ) as AuthMethod;
-  setupLog.userInput('whatsapp_auth_method', choice);
+  ) as AuthMethod | 'back';
+  if (choice !== 'back') setupLog.userInput('whatsapp_auth_method', choice);
   return choice;
 }
 

--- a/setup/lib/back-nav.ts
+++ b/setup/lib/back-nav.ts
@@ -1,0 +1,17 @@
+/**
+ * Channel-flow back-navigation sentinel.
+ *
+ * Each `runXxxChannel(displayName)` in `setup/channels/` may return either
+ * `void` (sub-flow completed normally) or `BACK_TO_CHANNEL_SELECTION` to
+ * signal "the user picked '← Back to channel selection' on my first
+ * prompt; please re-run the channel chooser." `setup/auto.ts` catches
+ * that signal and loops back to `askChannelChoice()`.
+ *
+ * Back is only offered on the *first* interactive prompt of each channel
+ * sub-flow — once the user has answered something, they're committed
+ * (subsequent steps may have side effects like opening browsers, hitting
+ * APIs, or installing adapter packages, none of which are easily undone).
+ */
+export const BACK_TO_CHANNEL_SELECTION = Symbol('BACK_TO_CHANNEL_SELECTION');
+
+export type ChannelFlowResult = void | typeof BACK_TO_CHANNEL_SELECTION;


### PR DESCRIPTION
Stacked on #2269 (back-nav scaffolding) and #2271 (Telegram).

## Why

Same problem as #2269: pick Slack by mistake and there's no way out short of killing setup. This adds a `← Back to channel selection` option before any browser opens or tokens are requested.

## The tradeoff: actually one *fewer* prompt

Unlike Telegram (which had to add a prompt because Clack's password input doesn't take menu options), Slack's first prompt was an existing "Press Enter to open Slack app settings" confirm — a single-purpose Yes/No that always opens the browser.

We replace it with a 2-option `brightSelect` ("Open Slack app settings" / "← Back to channel selection") that serves both purposes. Net: same number of screens as before, just with a Back option folded in. No extra noise.

## What's in this PR

- `setup/channels/slack.ts` — first interactive becomes a brightSelect with Open / ← Back; openUrl is called inline (skipping the redundant `confirmThenOpen` Press-Enter step)
- `setup/auto.ts` — propagates the back-nav return value (one-line change)

## Test plan

- [ ] Pick Slack → see "Open Slack app settings in your browser?" with Open / ← Back
- [ ] Pick ← Back → returns to channel chooser
- [ ] Pick Open → browser opens to api.slack.com/apps, flow continues to "Got your bot token and signing secret?"
- [ ] Headless (no DISPLAY) → no browser-open attempt, flow continues directly to token prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)