### PR TITLE
setup: update WhatsApp link instructions to "You / Settings"

### DIFF
--- a/setup/channels/whatsapp.ts
+++ b/setup/channels/whatsapp.ts
@@ -312,7 +312,7 @@ async function renderQr(qr: string): Promise<string[]> {
     const QRCode = await import('qrcode');
     const qrText = await QRCode.toString(qr, { type: 'terminal', small: true });
     const caption = k.dim(
-      '   Open WhatsApp → Settings → Linked Devices → Link a Device → scan.',
+      '   Open WhatsApp → You / Settings → Linked Devices → Link a Device → scan.',
     );
     return [...qrText.trimEnd().split('\n'), '', caption];
   } catch {
@@ -328,7 +328,7 @@ function formatPairingCard(code: string): string {
     '',
     `   ${brandBold(spaced)}`,
     '',
-    k.dim('   Open WhatsApp → Settings → Linked Devices → Link a Device'),
+    k.dim('   Open WhatsApp → You / Settings → Linked Devices → Link a Device'),
     k.dim('   → "Link with phone number instead" → enter this code.'),
     k.dim('   It expires in ~60 seconds.'),
   ].join('\n');


### PR DESCRIPTION
## Why

WhatsApp's mobile UI calls the menu "You" on iOS and "Settings" on Android (depending on platform/version). Our QR-scan and pairing-code captions only mentioned "Settings", so iOS users had to figure out the iOS-specific path themselves.

## What's in this PR

Two one-line copy edits in `setup/channels/whatsapp.ts`:
- QR-scan caption (under the QR code in the terminal)
- Pairing-code caption (under the 8-character pairing code)

Both now read **"Open WhatsApp → You / Settings → Linked Devices → Link a Device → scan."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)