### PR TITLE
fix(channels): URL fallback in bridge when adapter omits fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, enrichAttachments, splitForLimit } from './chat-sdk-bridge.js';
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
@@ -76,5 +76,90 @@ describe('createChatSdkBridge', () => {
       supportsThreads: true,
     });
     expect(typeof bridge.subscribe).toBe('function');
+  });
+});
+
+describe('enrichAttachments', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses fetchData when the adapter provides it', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await enrichAttachments([
+      {
+        type: 'image',
+        name: 'pic.png',
+        mimeType: 'image/png',
+        size: 3,
+        url: 'https://example.com/pic.png',
+        fetchData: async () => Buffer.from([1, 2, 3]),
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].data).toBe(Buffer.from([1, 2, 3]).toString('base64'));
+    // fetchData wins → no URL fallback
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to fetch(url) when fetchData is missing (Discord case)', async () => {
+    const url = 'https://cdn.discord.com/attachments/1/2/v.mp4?ex=a&is=b&hm=c';
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(new Uint8Array([9, 8, 7, 6]), { status: 200 }));
+    const result = await enrichAttachments([
+      { type: 'video', name: 'v.mp4', mimeType: 'video/mp4', size: 4, url },
+    ]);
+    expect(fetchSpy).toHaveBeenCalledWith(url);
+    expect(result[0].data).toBe(Buffer.from([9, 8, 7, 6]).toString('base64'));
+  });
+
+  it('skips data (but keeps the entry) when both fetchData and url are missing', async () => {
+    const result = await enrichAttachments([
+      { type: 'file', name: 'no-source.bin', size: 0 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].data).toBeUndefined();
+    expect(result[0].name).toBe('no-source.bin');
+  });
+
+  it('logs and continues when the URL fallback returns a non-2xx', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(null, { status: 404, statusText: 'Not Found' }),
+    );
+    const result = await enrichAttachments([
+      { type: 'image', name: 'gone.png', size: 0, url: 'https://example.com/gone.png' },
+    ]);
+    expect(result[0].data).toBeUndefined();
+    expect(result[0].name).toBe('gone.png');
+  });
+
+  it('logs and continues when the URL fallback throws (network error)', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await enrichAttachments([
+      { type: 'image', name: 'down.png', size: 0, url: 'https://example.com/down.png' },
+    ]);
+    expect(result[0].data).toBeUndefined();
+  });
+
+  it('logs and continues when fetchData itself throws (does not fall through to URL)', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await enrichAttachments([
+      {
+        type: 'audio',
+        name: 'voice.ogg',
+        size: 0,
+        url: 'https://example.com/voice.ogg',
+        fetchData: async () => {
+          throw new Error('auth expired');
+        },
+      },
+    ]);
+    expect(result[0].data).toBeUndefined();
+    // fetchData was attempted; URL fallback is NOT taken — that branch is
+    // only for adapters that omit fetchData entirely. An adapter that has
+    // fetchData but throws is signaling "I tried and failed", not "I have
+    // no idea how to fetch this."
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -101,6 +101,68 @@ function resolveSelectedOption(
   return candidate;
 }
 
+/**
+ * Download bytes for each inbound attachment and return entries the host's
+ * `extractAttachmentFiles` will stage to `inbox/<messageId>/<filename>`.
+ *
+ * Two paths:
+ *   1. `att.fetchData` — preferred. Adapters that need auth (Slack private
+ *      files, Telegram bot file API) wire this themselves.
+ *   2. `att.url` fallback — for adapters that ship URLs but no fetchData.
+ *      Notably `@chat-adapter/discord` (≤4.27.0): inbound attachments come
+ *      with a signed CDN URL but no fetchData callback, so without this
+ *      fallback Discord media never reaches the agent's inbox. A plain
+ *      `fetch(url)` works because Discord CDN URLs carry their own
+ *      signature query params and don't require an Authorization header.
+ *
+ * Failures are logged and skipped — the attachment entry still ships (with
+ * url/name/mime/size) so the agent at least knows something was attached
+ * and can decide what to do.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function enrichAttachments(attachments: any[]): Promise<any[]> {
+  const enriched: Record<string, unknown>[] = [];
+  for (const att of attachments) {
+    const entry: Record<string, unknown> = {
+      type: att.type,
+      name: att.name,
+      mimeType: att.mimeType,
+      size: att.size,
+      width: att.width,
+      height: att.height,
+    };
+    if (typeof att.fetchData === 'function') {
+      try {
+        const buffer: Buffer = await att.fetchData();
+        entry.data = buffer.toString('base64');
+      } catch (err) {
+        log.warn('Failed to download attachment', { type: att.type, err });
+      }
+    } else if (typeof att.url === 'string' && att.url.length > 0) {
+      try {
+        const res = await fetch(att.url);
+        if (res.ok) {
+          const buf = Buffer.from(await res.arrayBuffer());
+          entry.data = buf.toString('base64');
+        } else {
+          log.warn('Failed to download attachment via URL fallback', {
+            type: att.type,
+            status: res.status,
+            url: att.url,
+          });
+        }
+      } catch (err) {
+        log.warn('Failed to download attachment via URL fallback', {
+          type: att.type,
+          err,
+        });
+      }
+    }
+    enriched.push(entry);
+  }
+  return enriched;
+}
+
 export function splitForLimit(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];
@@ -135,28 +197,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
 
     // Download attachment data before serialization loses fetchData()
     if (message.attachments && message.attachments.length > 0) {
-      const enriched = [];
-      for (const att of message.attachments) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entry: Record<string, any> = {
-          type: att.type,
-          name: att.name,
-          mimeType: att.mimeType,
-          size: att.size,
-          width: (att as unknown as Record<string, unknown>).width,
-          height: (att as unknown as Record<string, unknown>).height,
-        };
-        if (att.fetchData) {
-          try {
-            const buffer = await att.fetchData();
-            entry.data = buffer.toString('base64');
-          } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
-          }
-        }
-        enriched.push(entry);
-      }
-      serialized.attachments = enriched;
+      serialized.attachments = await enrichAttachments(message.attachments);
     }
 
     // Extract reply context via platform-specific hook


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
The Chat SDK bridge enriched inbound attachments only when the adapter set `att.fetchData()`. Slack/Telegram/Teams/GChat/WhatsApp all do this, but `@chat-adapter/discord` (≤4.27.0) ships URL-only attachments — no fetchData callback. The bridge then handed the entry to the host with no `data` field, so `extractAttachmentFiles` had nothing to stage and the agent saw `[video: name.mp4 (https://cdn.discord.com/...)]` with no localPath. Net effect: any "operate on the inbound file" flow worked on every other channel and silently failed on Discord.

Adds a URL-based fallback path: when `fetchData` is missing but `att.url` is set, do a plain `fetch(url)` and base64 the bytes into `entry.data`. Discord CDN URLs carry their own signature query params (`?ex=...&is=...&hm=...`) so an Authorization header isn't needed; adapters whose URLs require auth (e.g. Slack private files) already implement fetchData and continue to take the original branch.

Failure modes (non-2xx, network error, fetchData itself throwing) all log and ship the bare attachment entry — the agent still sees that something was attached and can decide what to do — instead of taking down the whole inbound message.

Refactors the inline loop into an exported `enrichAttachments` helper so the behavior is unit-testable without standing up a full Chat instance. Six new tests cover: fetchData wins when present, URL fallback succeeds for Discord-style signed URLs, missing both → entry preserved with no data, URL fallback 404 / network error / fetchData throw → log and continue.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
