### PR TITLE
fix(agent-runner): refresh routing on follow-up messages mid-query

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
-import { formatMessages, stripInternalTags } from './formatter.js';
+import { formatMessages, stripInternalTags, mergeRouting, type RoutingContext } from './formatter.js';
 import { TIMEZONE } from './timezone.js';
 
 beforeEach(() => {
@@ -163,5 +163,50 @@ describe('stripInternalTags', () => {
     expect(stripInternalTags('<internal>thinking</internal>The answer is 42')).toBe(
       'The answer is 42',
     );
+  });
+});
+
+describe('mergeRouting', () => {
+  const empty: RoutingContext = { platformId: null, channelType: null, threadId: null, inReplyTo: null };
+
+  it('overlays non-null fields onto null current', () => {
+    const incoming: RoutingContext = {
+      platformId: 'platform-1',
+      channelType: 'signal',
+      threadId: 'thr-1',
+      inReplyTo: 'm1',
+    };
+    expect(mergeRouting(empty, incoming)).toEqual(incoming);
+  });
+
+  it('preserves prior values when incoming is null (task follow-up after chat)', () => {
+    const current: RoutingContext = {
+      platformId: 'platform-1',
+      channelType: 'signal',
+      threadId: 'thr-1',
+      inReplyTo: 'm1',
+    };
+    expect(mergeRouting(current, empty)).toEqual(current);
+  });
+
+  it('merges field-by-field — incoming partial overlays only its non-null fields', () => {
+    const current: RoutingContext = {
+      platformId: 'old-platform',
+      channelType: 'old-channel',
+      threadId: 'old-thread',
+      inReplyTo: 'old-reply',
+    };
+    const incoming: RoutingContext = {
+      platformId: 'new-platform',
+      channelType: null,
+      threadId: null,
+      inReplyTo: 'new-reply',
+    };
+    expect(mergeRouting(current, incoming)).toEqual({
+      platformId: 'new-platform',
+      channelType: 'old-channel',
+      threadId: 'old-thread',
+      inReplyTo: 'new-reply',
+    });
   });
 });

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -115,6 +115,26 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
 }
 
 /**
+ * Overlay non-null fields from `incoming` onto `current`. Latest non-null wins;
+ * a null in `incoming` preserves the prior value.
+ *
+ * Used by the poll loop when follow-ups arrive mid-query: a chat follow-up
+ * should override routing seeded by a null-routed task batch, but a later task
+ * follow-up must NOT clobber the chat's routing back to null. Without this,
+ * `dispatchResultText`'s scratchpad fallback can't recover when the initial
+ * batch was a cron task and the user later sends a chat — the agent reply is
+ * dropped to scratchpad and never delivered.
+ */
+export function mergeRouting(current: RoutingContext, incoming: RoutingContext): RoutingContext {
+  return {
+    platformId: incoming.platformId ?? current.platformId,
+    channelType: incoming.channelType ?? current.channelType,
+    threadId: incoming.threadId ?? current.threadId,
+    inReplyTo: incoming.inReplyTo ?? current.inReplyTo,
+  };
+}
+
+/**
  * Format a batch of messages_in rows into a prompt string.
  *
  * Prepends a `<context timezone="<IANA>" />` header so the agent always knows

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -7,7 +7,7 @@ import {
   migrateLegacyContinuation,
   setContinuation,
 } from './db/session-state.js';
-import { formatMessages, extractRouting, categorizeMessage, isClearCommand, isRunnerCommand, stripInternalTags, type RoutingContext } from './formatter.js';
+import { formatMessages, extractRouting, mergeRouting, categorizeMessage, isClearCommand, isRunnerCommand, stripInternalTags, type RoutingContext } from './formatter.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
 
 const POLL_INTERVAL_MS = 1000;
@@ -322,6 +322,22 @@ async function processQuery(
         // was awaited. Pushing into a closed stream is wasted work; the
         // claimed messages get released by the host's processing-claim sweep.
         if (done) return;
+
+        // Refresh in-flight routing from the follow-up batch. Without this,
+        // the outer `routing` stays frozen on whatever the initial batch had
+        // — and when the initial batch was a null-routed cron task, the agent
+        // reply hits dispatchResultText with all-null routing and the
+        // single-destination scratchpad fallback can't reply on the channel
+        // the follow-up came from. mergeRouting overlays non-null fields so a
+        // later task follow-up doesn't clobber routing seeded by an earlier
+        // chat. Mutating the existing object propagates by reference to the
+        // dispatchResultText/sendToDestination call sites without changing
+        // their signatures.
+        const merged = mergeRouting(routing, extractRouting(keep));
+        routing.platformId = merged.platformId;
+        routing.channelType = merged.channelType;
+        routing.threadId = merged.threadId;
+        routing.inReplyTo = merged.inReplyTo;
 
         const keptIds = keep.map((m) => m.id);
         const prompt = formatMessages(keep);


### PR DESCRIPTION
## Summary

The poll loop extracts `RoutingContext` once from the initial batch (`extractRouting(messages[0])`) and freezes it for the rest of the query. When the initial batch is a null-routed cron task and a real chat then arrives as a follow-up via `query.push`, the agent reply runs through `dispatchResultText` with the original (all-null) routing — so the single-destination scratchpad fallback (`poll-loop.ts:443`, `routing.channelType && routing.platformId`) can't reply on the channel the message came from, and the second fallback ("exactly one destination overall?") misses too in any multi-destination session. Result: bare-text replies get logged as `[scratchpad]` and the user receives nothing.

This was reproducible in production: a session woke at a recurring cron task, responded silently (no user-facing message), then absorbed chat follow-ups whose replies hit the WARNING and never reached the channel.

## Approach

- Add `mergeRouting(current, incoming)` to `formatter.ts` with "latest non-null wins" semantics. A chat follow-up updates routing seeded by a task batch, but a later task follow-up does NOT clobber the chat's routing back to null.
- In the follow-up pump in `processQuery` (after pre-task-script gating, before `query.push`), patch the in-flight `routing` object in place. Mutation propagates by reference to `dispatchResultText` and `sendToDestination` without signature changes.

## Test plan

- [x] `cd container/agent-runner && bun test` — three new \`mergeRouting\` unit tests pass (overlay onto null current, preserve prior on null incoming, partial field-by-field merge).
- [x] \`pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit\` — clean.
- [x] End-to-end production verification: cold-spawned a session with a null-routed task as initial batch, sent a chat as follow-up. Container log shows \`Processing 1 message(s), kinds: task\` → \`Pushing 1 follow-up message(s) into active query\` → \`Result: <bare text>\` → host log shows the message sent and delivered. No \`WARNING: agent output had no <message to=...>\` for the follow-up.

## Notes

\`RoutingContext\` fields are not declared \`readonly\`, so in-place mutation is type-clean. The follow-up pump's \`pollInFlight\` flag plus the SDK's request-response semantics ensure the merge happens between turns, not during a result dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)