### PR TITLE
feat: per-wiring channel permission (read | write | read+write)

### DIFF
--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -28,7 +28,8 @@ For each unwired channel:
 1. Read its SKILL.md `## Channel Info` for terminology, how-to-find-id, typical-use, and default-isolation
 2. Ask for the platform ID using the platform's terminology
 3. Ask the isolation question (see below)
-4. Register with the appropriate flags
+4. Ask the permission question (see below)
+5. Register with the appropriate flags
 
 ### Isolation Question
 
@@ -40,6 +41,16 @@ Present a multiple-choice with a contextual recommendation. The three options:
 
 Use the channel's `typical-use` and `default-isolation` fields to pick the recommendation. Offer to explain more if the user is unsure — reference `docs/isolation-model.md` for the detailed explanation.
 
+### Permission Question
+
+Channel permission controls which direction a wiring allows. Three values:
+
+- **`read+write`** (default) — agent receives inbound from the channel and may reply. The classic both-ways wiring.
+- **`read`** — *monitor-only*. Agent sees messages but cannot send back. Use for surveillance / digest channels where the agent should observe but never disturb. Pair with a separate `write` channel where it actually responds.
+- **`write`** — *post-only*. Agent can send here but messages from this channel are never delivered to it. Use for the response side of a monitor-only setup, or for one-way notification channels (e.g. an alerts log the agent posts to).
+
+Recommend `read+write` unless the user describes a one-way use case. If they want "monitor in one channel and reply in another," wire the same agent to two messaging groups: the monitor channel as `--permission read` and the response channel as `--permission write` (or `read+write` if they also want the agent to see replies there).
+
 ### Register Command
 
 ```bash
@@ -47,10 +58,11 @@ pnpm exec tsx setup/index.ts --step register -- \
   --platform-id "<id>" --name "<name>" \
   --folder "<folder>" --channel "<type>" \
   --session-mode "<shared|agent-shared|per-thread>" \
+  --permission "<read|write|read+write>" \
   --assistant-name "<name>"
 ```
 
-The `register` step creates the agent group (reusing it if the folder already exists), the messaging group, and the wiring row. `createMessagingGroupAgent` auto-creates the companion `agent_destinations` row so the agent can address the channel by name — no separate destination step needed.
+`--permission` defaults to `read+write` when omitted, so existing setup flows behave exactly as before. The `register` step creates the agent group (reusing it if the folder already exists), the messaging group, and the wiring row. `createMessagingGroupAgent` auto-creates the companion `agent_destinations` row so the agent can address the channel by name — no separate destination step needed. The destinations row is created for `read`-only wirings too (it's used to project the channel name into the container) but the runtime delivery check in `src/delivery.ts` skips the actual write with a `log.warn`.
 
 For separate agents, also ask for a folder name and optionally a different assistant name.
 
@@ -76,6 +88,23 @@ When adding another group/chat on an already-configured platform (e.g. a second 
 2. Ask which channel to move and to which agent group
 3. Delete the old `messaging_group_agents` entry, create a new one
 4. Note: existing sessions stay with the old agent group; new messages route to the new one. The `agent_destinations` row created for the old wiring is NOT automatically removed — if you want the old agent to stop seeing the channel as a named target, delete it from `agent_destinations` manually.
+
+## Change Channel Permission
+
+To flip an existing wiring between `read`, `write`, and `read+write` without re-creating it, update the row in place:
+
+```bash
+# Inspect current permissions
+sqlite3 data/v2.db "SELECT mga.id, mg.channel_type, mg.platform_id, mga.permission \
+                    FROM messaging_group_agents mga \
+                    JOIN messaging_groups mg ON mg.id = mga.messaging_group_id \
+                    WHERE mga.agent_group_id = '<agent-group-id>';"
+
+# Flip to monitor-only on a specific wiring
+sqlite3 data/v2.db "UPDATE messaging_group_agents SET permission='read' WHERE id='<mga-id>';"
+```
+
+The host re-reads the wiring on every inbound and every outbound message, so changes take effect on the next message — no service restart needed.
 
 ## Show Configuration
 

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -22,6 +22,7 @@ import { initGroupFilesystem } from '../src/group-init.js';
 import { log } from '../src/log.js';
 import { namespacedPlatformId } from '../src/platform-id.js';
 import { resolveSession, writeSessionMessage } from '../src/session-manager.js';
+import type { WiringPermission } from '../src/types.js';
 import { emitStatus } from './status.js';
 
 interface RegisterArgs {
@@ -41,6 +42,8 @@ interface RegisterArgs {
   assistantName: string;
   /** Session mode: 'shared' (one session per channel) or 'per-thread' */
   sessionMode: string;
+  /** Channel permission: 'read' (monitor-only), 'write' (post-only), or 'read+write' (default). */
+  permission: WiringPermission;
 }
 
 function parseArgs(args: string[]): RegisterArgs {
@@ -53,6 +56,7 @@ function parseArgs(args: string[]): RegisterArgs {
     requiresTrigger: false,
     assistantName: 'Andy',
     sessionMode: 'shared',
+    permission: 'read+write',
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -81,6 +85,17 @@ function parseArgs(args: string[]): RegisterArgs {
       case '--session-mode':
         result.sessionMode = args[++i] || 'shared';
         break;
+      case '--permission': {
+        const raw = (args[++i] || '').toLowerCase();
+        if (raw !== 'read' && raw !== 'write' && raw !== 'read+write') {
+          // Stay loose at parse time — validation happens in run() so the
+          // failure surfaces through emitStatus like other arg errors.
+          result.permission = raw as WiringPermission;
+        } else {
+          result.permission = raw;
+        }
+        break;
+      }
     }
   }
 
@@ -108,6 +123,15 @@ export async function run(args: string[]): Promise<void> {
     emitStatus('REGISTER_CHANNEL', {
       STATUS: 'failed',
       ERROR: 'invalid_folder',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(4);
+  }
+
+  if (parsed.permission !== 'read' && parsed.permission !== 'write' && parsed.permission !== 'read+write') {
+    emitStatus('REGISTER_CHANNEL', {
+      STATUS: 'failed',
+      ERROR: 'invalid_permission',
       LOG: 'logs/setup.log',
     });
     process.exit(4);
@@ -183,6 +207,7 @@ export async function run(args: string[]): Promise<void> {
       ignored_message_policy: 'drop',
       session_mode: parsed.sessionMode as 'shared' | 'per-thread' | 'agent-shared',
       priority: 0,
+      permission: parsed.permission,
       created_at: new Date().toISOString(),
     });
     log.info('Wired agent to messaging group', {
@@ -253,6 +278,7 @@ export async function run(args: string[]): Promise<void> {
     REQUIRES_TRIGGER: parsed.requiresTrigger,
     ASSISTANT_NAME: parsed.assistantName,
     SESSION_MODE: parsed.sessionMode,
+    PERMISSION: parsed.permission,
     NAME_UPDATED: nameUpdated,
     STATUS: 'success',
     LOG: 'logs/setup.log',

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -1,4 +1,4 @@
-import type { MessagingGroup, MessagingGroupAgent } from '../types.js';
+import type { MessagingGroup, MessagingGroupAgent, WiringPermission } from '../types.js';
 // Transitional tier violation: core imports from optional agent-to-agent module.
 // `createMessagingGroupAgent` auto-creates a destination row on wiring — the
 // two concerns are currently bundled. When agent-to-agent isn't installed,
@@ -129,21 +129,27 @@ export function setMessagingGroupDeniedAt(id: string, deniedAt: string | null): 
  * a numeric suffix to break collisions within the agent's namespace. This
  * mirrors the backfill logic in migration 004.
  */
-export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
+export function createMessagingGroupAgent(
+  mga: Omit<MessagingGroupAgent, 'permission'> & { permission?: WiringPermission },
+): void {
+  // Default the permission column so callers don't have to repeat 'read+write'
+  // at every wiring site. The DB column also has DEFAULT 'read+write' (see
+  // migration 014); we mirror it here for the named-param INSERT below.
+  const row: MessagingGroupAgent = { ...mga, permission: mga.permission ?? 'read+write' };
   getDb()
     .prepare(
       `INSERT INTO messaging_group_agents (
          id, messaging_group_id, agent_group_id,
          engage_mode, engage_pattern, sender_scope, ignored_message_policy,
-         session_mode, priority, created_at
+         session_mode, priority, permission, created_at
        )
        VALUES (
          @id, @messaging_group_id, @agent_group_id,
          @engage_mode, @engage_pattern, @sender_scope, @ignored_message_policy,
-         @session_mode, @priority, @created_at
+         @session_mode, @priority, @permission, @created_at
        )`,
     )
-    .run(mga);
+    .run(row);
 
   // Auto-create an agent_destinations row so delivery's ACL doesn't block
   // outbound messages that target this chat. Guarded: when the agent-to-agent
@@ -216,7 +222,13 @@ export function updateMessagingGroupAgent(
   updates: Partial<
     Pick<
       MessagingGroupAgent,
-      'engage_mode' | 'engage_pattern' | 'sender_scope' | 'ignored_message_policy' | 'session_mode' | 'priority'
+      | 'engage_mode'
+      | 'engage_pattern'
+      | 'sender_scope'
+      | 'ignored_message_policy'
+      | 'session_mode'
+      | 'priority'
+      | 'permission'
     >
   >,
 ): void {

--- a/src/db/migrations/014-wiring-permission.ts
+++ b/src/db/migrations/014-wiring-permission.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-wiring channel permission.
+ *
+ * `read`        — agent receives inbound from this channel; outbound is skipped.
+ * `write`       — agent may send to this channel; inbound is filtered out.
+ * `read+write`  — both directions (current behavior, default for existing rows).
+ *
+ * Enforced in `src/router.ts` (skip inbound on write-only) and
+ * `src/delivery.ts` (skip outbound on read-only). The default keeps every
+ * pre-existing wiring behaving exactly as before.
+ */
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration014: Migration = {
+  version: 14,
+  name: 'wiring-permission',
+  up(db: Database.Database) {
+    db.exec(
+      `ALTER TABLE messaging_group_agents
+         ADD COLUMN permission TEXT NOT NULL DEFAULT 'read+write'
+         CHECK (permission IN ('read', 'write', 'read+write'))`,
+    );
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -10,6 +10,7 @@ import { migration010 } from './010-engage-modes.js';
 import { migration011 } from './011-pending-sender-approvals.js';
 import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
+import { migration014 } from './014-wiring-permission.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -31,6 +32,7 @@ const migrations: Migration[] = [
   migration011,
   migration012,
   migration013,
+  migration014,
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -12,7 +12,7 @@ import type Database from 'better-sqlite3';
 import { getRunningSessions, getActiveSessions, createPendingQuestion } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
-import { getMessagingGroupByPlatform } from './db/messaging-groups.js';
+import { getMessagingGroupByPlatform, getMessagingGroupAgentByPair } from './db/messaging-groups.js';
 import {
   getDueOutboundMessages,
   getDeliveredIds,
@@ -290,6 +290,26 @@ async function deliverMessage(
     if (!mg) {
       throw new Error(`unknown messaging group for ${msg.channel_type}/${msg.platform_id} (message ${msg.id})`);
     }
+
+    // Channel permission: a wiring with permission='read' is monitor-only,
+    // even when this is the session's origin chat (monitor-only channels
+    // still spawn sessions on inbound, but those sessions cannot reply
+    // into them). Mark the outbound row failed and skip — read-only is
+    // deterministic, so the standard retry path is wrong here. The next
+    // poll filters this row out via the `delivered` table.
+    // See migration 014.
+    const wiring = getMessagingGroupAgentByPair(mg.id, session.agent_group_id);
+    if (wiring && wiring.permission === 'read') {
+      log.warn('Skipping read-only wiring on outbound', {
+        messageId: msg.id,
+        sessionId: session.id,
+        agentGroupId: session.agent_group_id,
+        channel: `${mg.channel_type}/${mg.platform_id}`,
+      });
+      markDeliveryFailed(inDb, msg.id);
+      return;
+    }
+
     const isOriginChat = session.messaging_group_id === mg.id;
     // Guarded: without the agent-to-agent module, `agent_destinations`
     // doesn't exist and we permit all non-origin channel sends (the

--- a/src/router.ts
+++ b/src/router.ts
@@ -278,6 +278,19 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     const agentGroup = getAgentGroup(agent.agent_group_id);
     if (!agentGroup) continue;
 
+    // Channel permission: `write` means post-only — the agent posts here
+    // but never receives inbound. Skip silently; the bottom-of-routine
+    // drop record records the no-engaged-agent case as usual. The
+    // companion `read` direction is enforced in delivery.ts.
+    // See migration 014.
+    if (agent.permission === 'write') {
+      log.warn('Skipping write-only wiring on inbound', {
+        agentGroupId: agent.agent_group_id,
+        messagingGroupId: mg.id,
+      });
+      continue;
+    }
+
     const engages = evaluateEngage(agent, messageText, isMention, mg, event.threadId);
 
     const accessOk = engages && (!accessGate || accessGate(event, userId, mg, agent.agent_group_id).allowed);

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,16 @@ export type EngageMode = 'pattern' | 'mention' | 'mention-sticky';
 export type SenderScope = 'all' | 'known';
 export type IgnoredMessagePolicy = 'drop' | 'accumulate';
 
+/**
+ * Per-wiring channel permission. `read` lets the agent monitor a channel
+ * without replying ("monitor-only"); `write` lets the agent post here but
+ * never receive inbound; `read+write` is the default both-ways wiring.
+ *
+ * Enforced in `src/router.ts` (inbound) and `src/delivery.ts` (outbound).
+ * See migration 014.
+ */
+export type WiringPermission = 'read' | 'write' | 'read+write';
+
 export interface MessagingGroupAgent {
   id: string;
   messaging_group_id: string;
@@ -96,6 +106,7 @@ export interface MessagingGroupAgent {
   ignored_message_policy: IgnoredMessagePolicy;
   session_mode: 'shared' | 'per-thread' | 'agent-shared';
   priority: number;
+  permission: WiringPermission;
   created_at: string;
 }
 

--- a/src/wiring-permission.test.ts
+++ b/src/wiring-permission.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Per-wiring channel permission tests — `permission` column on
+ * `messaging_group_agents` (migration 014).
+ *
+ * Inbound (`write` is post-only): router skips the wiring with a log.warn;
+ *   no session is spawned. (See src/router.ts.)
+ * Outbound (`read` is monitor-only): delivery skips with a log.warn and
+ *   marks the row failed; subsequent ticks see the message as already-
+ *   delivered (status='failed' lives in the same `delivered` table that
+ *   `getDeliveredIds` filters on), so the adapter is never re-invoked.
+ *   (See src/delivery.ts.)
+ */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-wiring-permission' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-wiring-permission';
+
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+} from './db/index.js';
+import { findSession } from './db/sessions.js';
+import { resolveSession, inboundDbPath, outboundDbPath } from './session-manager.js';
+import { deliverSessionMessages, setDeliveryAdapter } from './delivery.js';
+import type { InboundEvent } from './channels/adapter.js';
+import type { WiringPermission } from './types.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedAgentAndChannel(permission: WiringPermission): void {
+  createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'discord',
+    platform_id: 'chan-test',
+    name: 'Channel',
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+  });
+  createMessagingGroupAgent({
+    id: 'mga-1',
+    messaging_group_id: 'mg-1',
+    agent_group_id: 'ag-1',
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    permission,
+    created_at: now(),
+  });
+}
+
+function insertOutbound(agentGroupId: string, sessionId: string, msgId: string): void {
+  const db = new Database(outboundDbPath(agentGroupId, sessionId));
+  db.prepare(
+    `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+     VALUES (?, datetime('now'), 'chat', 'chan-test', 'discord', ?)`,
+  ).run(msgId, JSON.stringify({ text: 'agent reply' }));
+  db.close();
+}
+
+function inboundEvent(): InboundEvent {
+  return {
+    channelType: 'discord',
+    platformId: 'chan-test',
+    threadId: null,
+    message: {
+      id: 'msg-in',
+      kind: 'chat',
+      content: JSON.stringify({ sender: 'User', text: 'hello' }),
+      timestamp: now(),
+    },
+  };
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('wiring permission', () => {
+  it('read+write: routes inbound and delivers outbound', async () => {
+    seedAgentAndChannel('read+write');
+
+    // Inbound side: routeInbound creates a session and stores the message.
+    const { routeInbound } = await import('./router.js');
+    await routeInbound(inboundEvent());
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeDefined();
+    const inRows = new Database(inboundDbPath('ag-1', session!.id))
+      .prepare('SELECT id FROM messages_in')
+      .all() as Array<{ id: string }>;
+    expect(inRows).toHaveLength(1);
+
+    // Outbound side: a queued reply hits the adapter exactly once.
+    insertOutbound('ag-1', session!.id, 'out-ok');
+    const calls: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_ct, _pid, _tid, _kind, content) {
+        calls.push(content);
+        return 'plat-1';
+      },
+    });
+    await deliverSessionMessages(session!);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('write-only: router skips the wiring on inbound, no session is spawned', async () => {
+    seedAgentAndChannel('write');
+    const { routeInbound } = await import('./router.js');
+    await routeInbound(inboundEvent());
+
+    expect(findSession('mg-1', null)).toBeUndefined();
+  });
+
+  it('read-only: delivery skips outbound, marks failed, and never retries', async () => {
+    seedAgentAndChannel('read');
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-blocked');
+
+    let adapterCalls = 0;
+    setDeliveryAdapter({
+      async deliver() {
+        adapterCalls++;
+        return 'should-not-be-called';
+      },
+    });
+
+    // Three consecutive ticks: the adapter must never be invoked. The
+    // first tick marks the row failed; subsequent ticks see it as
+    // already-recorded in the `delivered` table and skip.
+    await deliverSessionMessages(session);
+    await deliverSessionMessages(session);
+    await deliverSessionMessages(session);
+    expect(adapterCalls).toBe(0);
+
+    const inDb = new Database(inboundDbPath('ag-1', session.id));
+    const failed = inDb.prepare("SELECT message_out_id FROM delivered WHERE status = 'failed'").all() as Array<{
+      message_out_id: string;
+    }>;
+    inDb.close();
+    expect(failed).toHaveLength(1);
+    expect(failed[0].message_out_id).toBe('out-blocked');
+  });
+});


### PR DESCRIPTION
  <!-- contributing-guide: v1 -->
  ## Type of Change

  - [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
  - [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
  - [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
  - [ ] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code
  - [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

  ## Description

  - Adds a `permission` column on `messaging_group_agents` (migration 014) so each (agent, channel) wiring is independently `read+write` (default), `read` (monitor-only), or `write` (post-only).
  - Inbound: `read` / `read+write` deliver to the agent inbox as before; `write` skips the wiring with a `log.warn` and falls through to the existing `no_agent_engaged` drop. (`src/router.ts`)
  - Outbound: a `read` wiring blocks the write — even back to the session's own origin chat. Inside `deliverMessage`, on hit: `log.warn` + `markDeliveryFailed` + return. The next poll sees the row in the `delivered` table and skips, so retries are deterministic-skipped without a
  special branch in the catch path. No exception class. (`src/delivery.ts`)
  - Default for every pre-existing wiring is `read+write`, so this is a no-op upgrade for current installs.
  - `createMessagingGroupAgent` defaults the column internally — callers (setup, scripts, tests) don't need to repeat `'read+write'` at every wiring site.
  - Tests in `src/wiring-permission.test.ts` cover the three corners: `read+write` round-trips inbound + outbound, `write` blocks inbound (no session spawned), `read` blocks outbound and never re-invokes the adapter across multiple poll ticks.

  ### How to use

  Three modes:

  - **`read+write`** (default) — both directions. Classic wiring.
  - **`read`** — monitor-only. Agent sees the channel but cannot send back. Use for surveillance / digest channels.
  - **`write`** — post-only. Agent can send here but inbound is filtered out. Use for one-way notification channels (alert logs, etc.) or as the response side of a monitor-only setup.

  **Via the `/manage-channels` skill** — the wire flow now asks a Permission Question before creating the wiring. Pick one of the three modes; the skill explains each and recommends `read+write` unless you describe a one-way use case. To run the classic split (monitor in channel
  A, reply in channel B), wire the same agent to both groups: A as `read`, B as `write` (or `read+write` if it should also see replies in B).

  **Via the setup CLI** — pass `--permission` to the `register` step:

  ```bash
  pnpm exec tsx setup/index.ts --step register -- \
    --platform-id "<id>" --name "<name>" \
    --folder "<folder>" --channel "<type>" \
    --session-mode "<shared|agent-shared|per-thread>" \
    --permission "<read|write|read+write>" \
    --assistant-name "<name>"
  ```

  Omitting the flag keeps the previous `read+write` behavior.

  Flipping an existing wiring in place — no re-wire needed:

  ```bash
  # Inspect
  sqlite3 data/v2.db "SELECT mga.id, mg.channel_type, mg.platform_id, mga.permission \
                      FROM messaging_group_agents mga \
                      JOIN messaging_groups mg ON mg.id = mga.messaging_group_id;"

  # Flip to monitor-only
  sqlite3 data/v2.db "UPDATE messaging_group_agents SET permission='read' WHERE id='<mga-id>';"
  ```

  The runtime checks the column on each inbound/outbound — no host restart needed for the change to take effect.