### PR TITLE
fix(claude-provider): use [1m] model tag for reliable 1M context

### DIFF
--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -15,6 +15,7 @@ export interface RunnerConfig {
   groupName: string;
   agentGroupId: string;
   maxMessagesPerPrompt: number;
+  model: string | null;
   mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
 }
 
@@ -42,6 +43,7 @@ export function loadConfig(): RunnerConfig {
     groupName: (raw.groupName as string) || '',
     agentGroupId: (raw.agentGroupId as string) || '',
     maxMessagesPerPrompt: (raw.maxMessagesPerPrompt as number) || DEFAULT_MAX_MESSAGES,
+    model: (raw.model as string) || null,
     mcpServers: (raw.mcpServers as RunnerConfig['mcpServers']) || {},
   };
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -88,6 +88,7 @@ async function main(): Promise<void> {
 
   const provider = createProvider(providerName, {
     assistantName: config.assistantName || undefined,
+    model: config.model || undefined,
     mcpServers,
     env: { ...process.env },
     additionalDirectories: additionalDirectories.length > 0 ? additionalDirectories : undefined,

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -233,15 +233,35 @@ function createPreCompactHook(assistantName?: string): HookCallback {
 
 // ── Provider ──
 
-/**
- * Claude Code auto-compacts context at this window (tokens). Kept here so
- * the generic bootstrap doesn't need to know about Claude-specific env vars.
- *
- * Operator override: set CLAUDE_CODE_AUTO_COMPACT_WINDOW in the host env to
- * raise or lower the threshold without editing source — useful when running
- * with a 1M-context model variant or when emergency-tuning a deployment.
- */
-const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '165000';
+// ── Model-aware compaction ──
+
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
+  'claude-haiku-4-5-20251001': 200_000,
+};
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const COMPACT_RATIO = 0.8;
+const MODELS_1M = new Set(['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7']);
+
+function compactWindowForModel(model?: string): string {
+  if (process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW) {
+    return process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+  }
+  const ctx = (model && MODEL_CONTEXT_WINDOWS[model]) || DEFAULT_CONTEXT_WINDOW;
+  return String(Math.round(ctx * COMPACT_RATIO));
+}
+
+// The CLI recognizes `[1m]` in the model name as a direct signal to use 1M
+// context (checked before betas or remote config). It strips the tag before
+// API calls via its internal normalizer. This avoids a race where --betas
+// aren't stored in the CLI's global state before the first compaction check.
+function modelForSdk(model?: string): string | undefined {
+  if (!model) return undefined;
+  if (MODELS_1M.has(model)) return `${model}[1m]`;
+  return model;
+}
 
 /**
  * Stale-session detection. Matches Claude Code's error text when a
@@ -254,17 +274,19 @@ export class ClaudeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = true;
 
   private assistantName?: string;
+  private model?: string;
   private mcpServers: Record<string, McpServerConfig>;
   private env: Record<string, string | undefined>;
   private additionalDirectories?: string[];
 
   constructor(options: ProviderOptions = {}) {
     this.assistantName = options.assistantName;
+    this.model = options.model;
     this.mcpServers = options.mcpServers ?? {};
     this.additionalDirectories = options.additionalDirectories;
     this.env = {
       ...(options.env ?? {}),
-      CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: compactWindowForModel(this.model),
     };
   }
 
@@ -282,6 +304,7 @@ export class ClaudeProvider implements AgentProvider {
     const sdkResult = sdkQuery({
       prompt: stream,
       options: {
+        model: modelForSdk(this.model),
         cwd: input.cwd,
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -22,6 +22,7 @@ export interface AgentProvider {
  */
 export interface ProviderOptions {
   assistantName?: string;
+  model?: string;
   mcpServers?: Record<string, McpServerConfig>;
   env?: Record<string, string | undefined>;
   additionalDirectories?: string[];

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -47,6 +47,8 @@ export interface ContainerConfig {
   agentGroupId?: string;
   /** Max messages per prompt. Falls back to code default if unset. */
   maxMessagesPerPrompt?: number;
+  /** Claude model override (e.g. "claude-sonnet-4-6", "claude-opus-4-6"). */
+  model?: string;
 }
 
 function emptyConfig(): ContainerConfig {
@@ -87,6 +89,7 @@ export function readContainerConfig(folder: string): ContainerConfig {
       assistantName: raw.assistantName,
       agentGroupId: raw.agentGroupId,
       maxMessagesPerPrompt: raw.maxMessagesPerPrompt,
+      model: raw.model,
     };
   } catch (err) {
     console.error(`[container-config] failed to parse ${p}: ${String(err)}`);


### PR DESCRIPTION
## Summary

- Plumb the `model` field from `container.json` through the agent-runner config, provider options, and into the Claude SDK `query()` call
- Use the CLI's `[1m]` model tag (e.g. `claude-sonnet-4-6[1m]`) instead of `--betas` to signal 1M context — the CLI strips the tag before API calls via its internal normalizer
- Compute `CLAUDE_CODE_AUTO_COMPACT_WINDOW` from the model's actual context window (80% of 1M = 800K for Sonnet/Opus) instead of hardcoding 165K
- Allow env var override for `CLAUDE_CODE_AUTO_COMPACT_WINDOW` when explicitly set

### Why `[1m]` instead of `--betas`?

The CLI's context window function checks three paths in order:
1. `[1m]` tag in model name — unconditional, no dependencies
2. `--betas` flag — requires `sdkBetas` to be stored in global state first
3. Remote config lookup — unavailable in headless containers

In headless containers, path 3 is unavailable and path 2 has a race condition: the betas store may not complete before the compaction window is computed. This causes 1M models to compact at ~168K tokens (80% of the 200K default) instead of ~800K.

The `[1m]` tag (path 1) is checked first via a simple regex (`/\[1m\]/i.test(modelName)`) with no async dependencies, making it reliable in all environments.

### Related

- #2116 (merged) — adds `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var, but doesn't help because `Math.min(perceivedContextWindow, envVar)` caps it at 200K when the CLI doesn't know the model is 1M
- #1968 (open) — uses `--betas` approach, which has the same race condition this PR avoids

## Test plan

- [x] Set `"model": "claude-sonnet-4-6"` in a group's `container.json`
- [x] Start a session — verify `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is `800000`
- [ ] Fill context past 168K tokens — verify compaction does NOT trigger until ~800K
- [ ] Verify `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var override still works when explicitly set
- [ ] Verify models not in the 1M set (e.g. Haiku) get 200K default and no `[1m]` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)