### PR TITLE
fix(setup): pin Baileys to 7.0.0-rc.9 in install-whatsapp scripts

### DIFF
--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -57,7 +57,7 @@ groups: () => import('./groups.js'),
 ### 5. Install the adapter packages (pinned)
 
 ```bash
-pnpm install @whiskeysockets/baileys@6.17.16 qrcode@1.5.4 @types/qrcode@1.5.6 pino@9.6.0
+pnpm install @whiskeysockets/baileys@7.0.0-rc.9 qrcode@1.5.4 @types/qrcode@1.5.6 pino@9.6.0
 ```
 
 ### 6. Build

--- a/setup/add-whatsapp.sh
+++ b/setup/add-whatsapp.sh
@@ -16,7 +16,7 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Keep in sync with .claude/skills/add-whatsapp/SKILL.md.
-BAILEYS_VERSION="@whiskeysockets/baileys@6.17.16"
+BAILEYS_VERSION="@whiskeysockets/baileys@7.0.0-rc.9"
 QRCODE_VERSION="qrcode@1.5.4"
 QRCODE_TYPES_VERSION="@types/qrcode@1.5.6"
 PINO_VERSION="pino@9.6.0"

--- a/setup/install-whatsapp.sh
+++ b/setup/install-whatsapp.sh
@@ -66,7 +66,7 @@ if ! grep -q "'whatsapp-auth':" setup/index.ts; then
 fi
 
 echo "STEP: pnpm-install"
-pnpm install @whiskeysockets/baileys@6.17.16 qrcode@1.5.4 @types/qrcode@1.5.6 pino@9.6.0
+pnpm install @whiskeysockets/baileys@7.0.0-rc.9 qrcode@1.5.4 @types/qrcode@1.5.6 pino@9.6.0
 
 echo "STEP: pnpm-build"
 pnpm run build


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2283.

PR #2259 ("upgrade Baileys v6→v7 for proper LID handling") was merged into the `channels` branch on 2026-05-05. PR #2260 ("drop WhatsApp LID dual-row migration step") was merged into `main` 28 seconds later, assuming v7 was already there — its added comment explicitly says *"With Baileys v7, the adapter resolves LIDs via extractAddressingContext"*. But #2259 never reached `main`, so the v6 pin survived in three places while the WhatsApp adapter source the install script copies from `origin/channels` was already on the v7 LID API.

Result: every fresh `bash migrate-v2.sh` run against a v1 install fails deterministically at `2c-install-whatsapp` with TS errors on `msg.key.remoteJidAlt`, `msg.key.participantAlt`, and the `lid-mapping.update` event payload. Reproduction, full root cause, and environment details in #2283.

This PR bumps the three pin sites to `7.0.0-rc.9` (the same version v1 has been running on for months):

- `setup/install-whatsapp.sh:69`
- `setup/add-whatsapp.sh:19`
- `.claude/skills/add-whatsapp/SKILL.md:60`

`package.json` and `pnpm-lock.yaml` aren't touched — `install-whatsapp.sh` mutates those at runtime via `pnpm install @whiskeysockets/baileys@<version>`. Once the script's pin is correct, those files reach the right state on the next install.

Verified end-to-end on VM 505 against a v1.2.53 install with 11 channels (9 WhatsApp, 1 Matrix, 1 Discord): with this fix applied, `2c-install-whatsapp` succeeds and `tsc` clears against the resulting tree. Migrate then proceeds to subsequent steps (a separate `3b-onecli` failure unrelated to this fix will be filed in its own issue).