### PR TITLE
fix(migrate-v2): probe correct OneCLI health endpoint

### DIFF
--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -450,7 +450,7 @@ ONECLI_OK=false
 ONECLI_URL_FROM_ENV=$(grep '^ONECLI_URL=' .env 2>/dev/null | head -1 | sed 's/^ONECLI_URL=//')
 ONECLI_URL_CHECK="${ONECLI_URL_FROM_ENV:-http://127.0.0.1:10254}"
 
-if curl -sf "${ONECLI_URL_CHECK}/health" >/dev/null 2>&1; then
+if curl -sf "${ONECLI_URL_CHECK}/api/health" >/dev/null 2>&1; then
   step_ok "OneCLI running at $(dim "$ONECLI_URL_CHECK")"
   ONECLI_OK=true
   log "OneCLI: running at $ONECLI_URL_CHECK"


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2285.

`migrate-v2.sh:453` probes `${ONECLI_URL_CHECK}/health` to detect an already-running OneCLI. `ONECLI_URL_CHECK` defaults to `http://127.0.0.1:10254` (the OneCLI web port), but that port has never exposed `/health` — the web app's health endpoint is `/api/health`, defined in `apps/web/src/app/api/health/route.ts` and present in OneCLI since the initial public commit. The probe therefore always 404s, the conditional fails, and the script falls through to the install path even when OneCLI is already running.

This PR is a one-line fix:

```diff
- if curl -sf "${ONECLI_URL_CHECK}/health" >/dev/null 2>&1; then
+ if curl -sf "${ONECLI_URL_CHECK}/api/health" >/dev/null 2>&1; then
```

I considered a defensive cascade (`/api/health || /health`) but `/health` was never reachable in any released OneCLI version: it's the only health route file in the entire history of `onecli/onecli`, there's no rewrite in `next.config.js`, no `pages/api/health.*` ever existed, and the Rust gateway uses `/healthz` on a separate port (`:10255`) that this script doesn't probe.

Verified against a running OneCLI v1.21.0 on the host this script targets:

```
GET :10254/api/health  -> 200 {"status":"ok","version":"1.21.0",...}
GET :10254/health      -> 404 (Next.js fallback HTML)
GET :10255/healthz     -> 200
GET :10255/health      -> 400 (gateway parses non-/healthz as CONNECT proxy)
```

`curl -sf` treats any 4xx as failure, so `/health` could never have matched on either port. Full root cause, reproduction, and the original observation (during a v1→v2 migration on a production instance) in #2285.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone