### PR TITLE
fix(host-sweep): parse SQLite timestamps as UTC, not local time

### DIFF
--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -12,6 +12,7 @@ import {
   CLAIM_STUCK_MS,
   _resetStuckProcessingRowsForTesting,
   decideStuckAction,
+  parseSqliteUtc,
 } from './host-sweep.js';
 import type { Session } from './types.js';
 
@@ -290,5 +291,46 @@ describe('resetStuckProcessingRows — orphan claim cleanup', () => {
     expect(getProcessingClaims(outDb)).toEqual([]);
     const row = inDb.prepare('SELECT tries FROM messages_in WHERE id = ?').get('m-2') as { tries: number };
     expect(row.tries).toBe(1); // not bumped, the skip path held
+  });
+});
+
+describe('parseSqliteUtc', () => {
+  // Regression: SQLite TIMESTAMP strings have no zone marker, but Date.parse
+  // treats those as local time. On non-UTC hosts this made every claim look
+  // (TZ offset) hours stale and tripped kill-claim on freshly-claimed messages.
+  // The helper appends "Z" only when no marker is present, so parsing is
+  // always anchored to UTC regardless of host timezone.
+
+  const utcMs = Date.parse('2026-04-20T12:00:00.000Z');
+
+  it('treats a SQLite-style timestamp (no zone) as UTC', () => {
+    expect(parseSqliteUtc('2026-04-20 12:00:00')).toBe(utcMs);
+    expect(parseSqliteUtc('2026-04-20T12:00:00')).toBe(utcMs);
+    expect(parseSqliteUtc('2026-04-20T12:00:00.000')).toBe(utcMs);
+  });
+
+  it('preserves an explicit Z marker', () => {
+    expect(parseSqliteUtc('2026-04-20T12:00:00.000Z')).toBe(utcMs);
+    expect(parseSqliteUtc('2026-04-20T12:00:00z')).toBe(utcMs);
+  });
+
+  it('preserves an explicit numeric offset', () => {
+    // 14:00+02:00 == 12:00 UTC
+    expect(parseSqliteUtc('2026-04-20T14:00:00+02:00')).toBe(utcMs);
+    expect(parseSqliteUtc('2026-04-20T14:00:00+0200')).toBe(utcMs);
+    // 07:00-05:00 == 12:00 UTC
+    expect(parseSqliteUtc('2026-04-20T07:00:00-05:00')).toBe(utcMs);
+  });
+
+  it('returns NaN for unparseable input', () => {
+    expect(Number.isNaN(parseSqliteUtc('not a date'))).toBe(true);
+  });
+
+  it('does not drift across host timezones for SQLite-style input', () => {
+    // The helper itself is timezone-independent because it forces UTC parsing.
+    // (Verifying the regex branch — without the helper, `Date.parse` of the
+    // bare string returns different values depending on the host TZ.)
+    const bare = '2026-04-20T12:00:00';
+    expect(parseSqliteUtc(bare)).toBe(Date.parse(bare + 'Z'));
   });
 });

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -47,6 +47,17 @@ import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbe
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
+/**
+ * SQLite TIMESTAMP columns store UTC without a timezone marker. Date.parse
+ * treats timezoneless ISO strings as local time, so on non-UTC hosts every
+ * timestamp looks (TZ offset) hours stale — leading to spurious kill-claim
+ * decisions on freshly-claimed messages. Append "Z" when no zone marker is
+ * present so Date.parse interprets the string as UTC.
+ */
+export function parseSqliteUtc(s: string): number {
+  return Date.parse(/[zZ]|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + 'Z');
+}
+
 const SWEEP_INTERVAL_MS = 60_000;
 // Absolute idle ceiling for a running container. If the heartbeat file hasn't
 // been touched in this long, the container is either stuck or doing genuinely
@@ -95,7 +106,7 @@ export function decideStuckAction(args: {
 
   const tolerance = Math.max(CLAIM_STUCK_MS, declaredBashMs ?? 0);
   for (const claim of claims) {
-    const claimedAt = Date.parse(claim.status_changed);
+    const claimedAt = parseSqliteUtc(claim.status_changed);
     if (Number.isNaN(claimedAt)) continue;
     const claimAge = now - claimedAt;
     if (claimAge <= tolerance) continue;
@@ -275,7 +286,7 @@ function resetStuckProcessingRows(
     // Already rescheduled for a future retry — don't bump tries again. The
     // wake path (sweep step 2) will fire when process_after elapses and a
     // fresh container will clean the orphan claim on startup.
-    if (msg.processAfter && Date.parse(msg.processAfter) > now) continue;
+    if (msg.processAfter && parseSqliteUtc(msg.processAfter) > now) continue;
 
     if (msg.tries >= MAX_TRIES) {
       markMessageFailed(inDb, msg.id);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

SQLite TIMESTAMP columns store UTC without a zone marker. `Date.parse` treats timezoneless ISO strings as **local time**, so on any non-UTC host every claim and `processAfter` looks (TZ offset) hours stale. Fresh claims trip the kill-claim path on the first sweep tick — every container gets killed within seconds of spawn.

Two affected sites in `src/host-sweep.ts`:

- **`decideStuckAction`** reads `claim.status_changed` and computes `claimAge`. On a `TZ=Europe/Madrid` host (UTC+2), a claim made 5 s ago looks 7 205 s old and exceeds `CLAIM_STUCK_MS` (60 s).
- **The orphan retry loop** reads `msg.processAfter` and skips messages rescheduled into the future. On the same host, future timestamps look (TZ offset) hours in the past, so the skip is missed and `tries` gets bumped on every tick.

This was the root cause behind a stuck-container postmortem on a v2 install running on `TZ=Europe/Madrid`: every freshly-spawned container was killed within ~60 s, before it could even tick a heartbeat.

### Fix

```ts
export function parseSqliteUtc(s: string): number {
  return Date.parse(/[zZ]|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + 'Z');
}
```

The helper appends `"Z"` only when no zone marker is present, then both call sites use it instead of `Date.parse`. Behavior under `TZ=UTC` is unchanged — `Date.parse('2026-04-20T12:00:00')` and `Date.parse('2026-04-20T12:00:00Z')` return the same value when the host is UTC.

### Scope

I checked the other `Date.parse` / `new Date(string)` sites in `src/`:

- `src/circuit-breaker.ts:54` — reads `prev.timestamp` from `circuit-breaker.json`, which is written by the same module via `now.toISOString()` (always carries `Z`). No bug.
- `src/modules/approvals/onecli-approvals.ts:200` — reads `request.expiresAt` from the OneCLI SDK (`@onecli-sh/sdk`), which is JSON-over-HTTP and follows ISO 8601 with `Z`. No bug.

So this PR stays focused on `host-sweep.ts`, which is the only file where a SQLite TIMESTAMP string is parsed.

### Verified

- **Production**: applied to a v2 install on VM 505 (`TZ=Europe/Madrid`, OneCLI v1.21.0, 11 channels). With the patch, an idle container survived 30+ minutes without being killed; previously, kill-claim fired within ~60 s of every spawn.
- **Unit tests**: 5 new cases on `parseSqliteUtc` covering bare/Z/+offset/inverse-offset/invalid input plus a TZ-independence check. All 19 host-sweep tests pass.
- **Type check**: `tsc --noEmit` clean.
- **Format**: pre-commit `prettier --write` reports all files unchanged.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone