### PR TITLE
fix(manage-channels): include canonical SQL queries in SKILL.md

### DIFF
--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -11,7 +11,16 @@ Privilege is a **user-level** concept, not a channel-level one (see `src/db/user
 
 ## Assess Current State
 
-Read the central DB (`data/v2.db`) — query `agent_groups`, `messaging_groups`, `messaging_group_agents`, `users`, and `user_roles` tables. Also check `.env` for channel tokens and `src/channels/index.ts` for uncommented imports.
+Read the central DB (`data/v2.db`) using these canonical queries (column names match the schema, not the CLI flags — the `register` command's `--assistant-name` is stored in `agent_groups.name`):
+
+```sql
+SELECT id, name AS assistant_name, folder, agent_provider FROM agent_groups;
+SELECT id, channel_type, platform_id, name, unknown_sender_policy FROM messaging_groups;
+SELECT messaging_group_id, agent_group_id, session_mode, priority FROM messaging_group_agents;
+SELECT user_id, role, agent_group_id FROM user_roles ORDER BY role='owner' DESC;
+```
+
+Also check `.env` for channel tokens and `src/channels/index.ts` for uncommented imports.
 
 Categorize channels as: **wired** (has DB entities + messaging_group_agents row), **configured but unwired** (has credentials + barrel import, no DB entities), or **not configured**.
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2289.

The `/manage-channels` skill's "Assess Current State" step pointed at the DB tables in prose only — *"query `agent_groups`, `messaging_groups`, `messaging_group_agents`, `users`, and `user_roles`"* — without specifying columns. The same SKILL.md mentions the `register` CLI flag `--assistant-name "<name>"` three times, but never says that flag is stored in the `name` column of `agent_groups`.

When the agent had to compose a `SELECT` against `agent_groups` from the SKILL.md vocabulary alone, it extrapolated the flag name into a column name and produced:

```sql
SELECT id, folder, assistant_name FROM agent_groups;
-- Error: in prepare, no such column: assistant_name
```

This PR replaces the prose pointer with canonical SQL queries that match the real schema, plus a one-line note clarifying the CLI ↔ schema mapping. The `name AS assistant_name` alias preserves the familiar term in the agent's output without changing the schema.

```diff
-Read the central DB (`data/v2.db`) — query `agent_groups`, `messaging_groups`, `messaging_group_agents`, `users`, and `user_roles` tables. Also check `.env` for channel tokens and `src/channels/index.ts` for uncommented imports.
+Read the central DB (`data/v2.db`) using these canonical queries (column names match the schema, not the CLI flags — the `register` command's `--assistant-name` is stored in `agent_groups.name`):
+
+```sql
+SELECT id, name AS assistant_name, folder, agent_provider FROM agent_groups;
+SELECT id, channel_type, platform_id, name, unknown_sender_policy FROM messaging_groups;
+SELECT messaging_group_id, agent_group_id, session_mode, priority FROM messaging_group_agents;
+SELECT user_id, role, agent_group_id FROM user_roles ORDER BY role='owner' DESC;
+```
+
+Also check `.env` for channel tokens and `src/channels/index.ts` for uncommented imports.
```

## Verified

Applied as a drop-in to a v2 install; `/manage-channels` runs clean from end to end with no further inference. Reproduction without the fix produces the exact error in the issue.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone