### PR TITLE
fix(container): trust OneCLI gateway CA inside agent container

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -20,7 +20,13 @@ import {
   TIMEZONE,
 } from './config.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  onecliCaArgs,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -462,6 +468,12 @@ async function buildContainerArgs(
 
   // Host gateway
   args.push(...hostGatewayArgs());
+
+  // OneCLI gateway CA — if the host has one installed, mount it readonly
+  // and point Node-based tools (claude-code, agent-runner, agent-browser,
+  // vercel) at it via NODE_EXTRA_CA_CERTS so they trust the gateway's
+  // MITM cert. No-op on non-OneCLI installs.
+  args.push(...onecliCaArgs());
 
   // User mapping
   const hostUid = process.getuid?.();

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -3,10 +3,37 @@
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
 import { execSync } from 'child_process';
+import fs from 'fs';
 import os from 'os';
+import path from 'path';
 
 import { CONTAINER_INSTALL_LABEL } from './config.js';
 import { log } from './log.js';
+
+/** Path inside the container where the OneCLI gateway CA is mounted. */
+export const ONECLI_CA_CONTAINER_PATH = '/etc/onecli/gateway-ca.pem';
+
+/** Path on the host where the OneCLI gateway CA cert lives, if installed. */
+export const ONECLI_CA_HOST_PATH = path.join(os.homedir(), '.onecli', 'gateway-ca.pem');
+
+/**
+ * If the OneCLI gateway CA is installed on the host, return the CLI args
+ * needed to bind-mount it readonly into the container and trust it from
+ * Node-based tools (`NODE_EXTRA_CA_CERTS`). Returns `[]` on non-OneCLI
+ * installs so the change is a no-op there.
+ *
+ * The container's HTTPS_PROXY (set by `onecli.applyContainerConfig`) points
+ * at the gateway, which MITMs TLS with this CA. Without this trust wiring,
+ * every credentialed call fails with `SELF_SIGNED_CERT_IN_CHAIN`.
+ */
+export function onecliCaArgs(): string[] {
+  if (!fs.existsSync(ONECLI_CA_HOST_PATH)) return [];
+  return [
+    ...readonlyMountArgs(ONECLI_CA_HOST_PATH, ONECLI_CA_CONTAINER_PATH),
+    '-e',
+    `NODE_EXTRA_CA_CERTS=${ONECLI_CA_CONTAINER_PATH}`,
+  ];
+}
 
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';


### PR DESCRIPTION
## Summary

NanoClaw routes every container's outbound TLS through the OneCLI gateway by calling `onecli.applyContainerConfig()` in `src/container-runner.ts:457`. The gateway MITMs HTTPS to inject credentials, presenting a CA-signed cert.

The OneCLI SDK sets `NODE_EXTRA_CA_CERTS` (alongside `SSL_CERT_FILE` for curl/Python and `DENO_CERT` for Deno) via `applyContainerConfig`. However, Node-based tools (claude-code, agent-runner, agent-browser, vercel) still fail TLS handshake against the gateway with `code: 'SELF_SIGNED_CERT_IN_CHAIN'` — the CA path set by the SDK does not resolve correctly inside the container. Every credentialed call from those tools breaks — including the agent-runner reaching api.anthropic.com.

**This is not Podman-specific.** NanoClaw explicitly wires the proxy on every runtime via `applyContainerConfig`, so Docker users hit the same bug. Podman additionally auto-injects host `HTTPS_PROXY` (its `--http-proxy=true` default), which makes the failure surface even on raw `docker run` outside NanoClaw — but the load-bearing path is NanoClaw's own SDK call, which fires regardless of runtime.

This change adds `onecliCaArgs()` in `src/container-runtime.ts`. If `~/.onecli/gateway-ca.pem` exists on the host, the helper bind-mounts it readonly to `/etc/onecli/gateway-ca.pem` inside the container and sets `NODE_EXTRA_CA_CERTS` to that path. Returns `[]` when the host file is absent — non-OneCLI installs see no behavior change.

## Test plan

- [x] `pnpm test` — 245 passing, 2 unrelated upstream failures in `host-sweep.test.ts`
- [x] `pnpm run build` — clean
- [x] Manual: `node fetch('https://registry.npmjs.org/...')` from inside the agent image, with the new mount + env, returns valid JSON through the gateway (previously failed `SELF_SIGNED_CERT_IN_CHAIN`)
- [x] No-op safety: helper short-circuits via `fs.existsSync` on `~/.onecli/gateway-ca.pem`

## Notes for review

- The OneCLI SDK already mounts the CA at `config.caCertificateContainerPath` and sets `NODE_EXTRA_CA_CERTS` to that path. This PR mounts a second copy at a separate path as a workaround for the CA path not resolving correctly inside the container. A cleaner approach would reuse the SDK's path — happy to refactor if reviewers prefer. Kept it independent here to keep the diff minimal and avoid coupling to SDK internals.
- Only Node-based tools need the workaround. curl/Python/Deno are already covered by `applyContainerConfig` via `SSL_CERT_FILE` and `DENO_CERT`.
- Companion to #2292 (skill adding `/convert-to-podman`).