### PR TITLE
fix(setup): add /opt/homebrew/bin to launchd plist PATH

### DIFF
--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -37,7 +37,7 @@ function generatePlist(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -120,7 +120,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>


### PR DESCRIPTION
### Problem
On Apple Silicon Macs with docker installed from brew the host process crash-loops at startup with `/bin/sh: docker: command not found`, eventually hitting the circuit breaker and stalling setup. Affected: anyone whose `docker`/`podman` CLI comes from Homebrew (e.g. users following `/convert-to-podman`, brew-installed Docker without Desktop, or Apple Container).

### Root cause
`setup/service.ts` writes a hardcoded `PATH=/usr/local/bin:/usr/bin:/bin:~/.local/bin` into the generated plist. On Apple Silicon, Homebrew lives at `/opt/homebrew/bin` — that's where brew-installed `podman` (and any `docker` symlink pointing at it) live. launchd jobs don't inherit the user's interactive shell PATH, so those binaries are invisible to the host process.

This has gone unnoticed because most Mac users run **Docker Desktop**, which installs `docker` at `/usr/local/bin/docker` regardless of CPU arch — already on the plist PATH. The bug only bites the smaller cohort of Apple Silicon users whose container runtime comes from brew. As Podman + Apple Container adoption grows, more users will hit this.

### Fix
Prepend `/opt/homebrew/bin` to the macOS plist PATH. Harmless on Intel Macs (the directory doesn't exist; brew there uses `/usr/local`). Linux systemd unit unchanged.

### Validation
- 10/10 `setup/service.test.ts` tests pass with updated expectation
- Live plist patched + `launchctl bootout`/`bootstrap` cycle: clean start, host stays up, no error log entries
- End-to-end `pnpm run chat hi` returns a real reply from the agent (validates host process → CLI socket → container spawn → Claude API via OneCLI gateway)
