### PR TITLE
setup: clarify Slack picker hint

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1086,7 +1086,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         {
           value: 'slack',
           label: 'Yes, connect Slack (experimental)',
-          hint: 'needs public URL',
+          hint: 'advanced setup with public URL needed',
         },
         { value: 'teams', label: 'Yes, connect Microsoft Teams', hint: 'complex setup' },
         { value: 'other', label: 'Other…', hint: 'install via /add-<name> after setup' },


### PR DESCRIPTION
## Why

The Slack option in the channel picker says "needs public URL" — easy to miss that this is materially harder than the other "experimental" options. New users who pick Slack hit the public-URL requirement after they've already pasted a bot token and signing secret.

## What

Picker hint changes from `needs public URL` → `advanced setup with public URL needed`. One-line copy edit in `setup/auto.ts`.

## Test plan

- [ ] `pnpm exec tsx scripts/preview-picker.ts` (local-only preview script — not in PR) renders the new hint at the expected dim brightness next to "Yes, connect Slack (experimental)".