### PR TITLE
setup: label Slack setup cards as parts 1 and 2

### DIFF
--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -142,7 +142,7 @@ async function walkThroughAppCreation(): Promise<'continue' | 'back'> {
       '  5. Install to Workspace → copy the "Bot User OAuth Token" (xoxb-…)',
       formatNoteLink(SLACK_APPS_URL),
     ].filter((line): line is string => line !== null).join('\n'),
-    'Create a Slack app',
+    'Create a Slack app — part 1 of 2',
   );
 
   // Back-aware gate replacing the old `confirmThenOpen` "Press Enter to open
@@ -433,6 +433,6 @@ function showPostInstallChecklist(info: WorkspaceInfo): void {
       ].join('\n'),
       6,
     ),
-    'Finish setting up Slack',
+    'Finish setting up Slack — part 2 of 2',
   );
 }


### PR DESCRIPTION
## Why

Slack setup has two distinct chunks separated by the bot install step: app/token creation up front, public-URL/event-subscription wiring after. Today both cards just say "Create a Slack app" and "Finish setting up Slack" — nothing tells the user there's a second card waiting.

## What

Title changes only:

- `Create a Slack app` → `Create a Slack app — part 1 of 2`
- `Finish setting up Slack` → `Finish setting up Slack — part 2 of 2`

## Test plan

- [ ] Run `bash nanoclaw.sh`, click through to Slack, see "part 1 of 2" on the first card.
- [ ] Run `pnpm exec tsx scripts/preview-slack-cards.ts` (local-only) to render both cards back-to-back without going through the install flow.