### PR TITLE
setup: tidy Slack app-creation card

### DIFF
--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -27,7 +27,7 @@ import k from 'kleur';
 import * as setupLog from '../logs.js';
 import { BACK_TO_CHANNEL_SELECTION, type ChannelFlowResult } from '../lib/back-nav.js';
 import { brightSelect } from '../lib/bright-select.js';
-import { formatNoteLink, openUrl } from '../lib/browser.js';
+import { openUrl } from '../lib/browser.js';
 import { isHeadless } from '../platform.js';
 import { askOperatorRole } from '../lib/role-prompt.js';
 import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
@@ -126,22 +126,31 @@ export async function runSlackChannel(displayName: string): Promise<ChannelFlowR
 }
 
 async function walkThroughAppCreation(): Promise<'continue' | 'back'> {
+  // Bright-white ANSI overrides the surrounding brand-cyan from `note()`'s
+  // per-line formatter so the URL stands out against the rest of the body.
+  const linkBlock = isHeadless()
+    ? [`\x1b[97mGet started: ${SLACK_APPS_URL}\x1b[39m`, '']
+    : [];
+
   note(
     [
       "You'll create a Slack app that the assistant talks through.",
       "Free and stays inside the workspaces you pick.",
       '',
+      ...linkBlock,
       '  1. Create a new app "From scratch", name it, pick a workspace',
       '  2. OAuth & Permissions → add Bot Token Scopes:',
-      '     chat:write, im:write, channels:history, groups:history,',
-      '     im:history, channels:read, groups:read, users:read,',
-      '     reactions:write',
+      '     • im:write, im:history',
+      '     • channels:read, channels:history',
+      '     • groups:read, groups:history',
+      '     • chat:write',
+      '     • users:read',
+      '     • reactions:write',
       '  3. App Home → enable "Messages Tab" and "Allow users to send',
       '     slash commands and messages from the messages tab"',
       '  4. Basic Information → copy the "Signing Secret"',
       '  5. Install to Workspace → copy the "Bot User OAuth Token" (xoxb-…)',
-      formatNoteLink(SLACK_APPS_URL),
-    ].filter((line): line is string => line !== null).join('\n'),
+    ].join('\n'),
     'Create a Slack app',
   );
 


### PR DESCRIPTION
## Why

The first Slack setup card buried the "Get started" link under five numbered steps and rendered the OAuth scope list as a wrapped wall of commas, making both the link and the scopes hard to scan at a glance.

## What

In `walkThroughAppCreation()` (the "Create a Slack app" card body):

- Move `Get started: https://api.slack.com/apps` above the numbered instructions, and render it in bright white so it stands out against the body's brand-cyan. Headless-only — interactive runs still auto-open the URL in a browser and don't print this line.
- Group the OAuth scope list vertically by family:
  - `im:write, im:history`
  - `channels:read, channels:history`
  - `groups:read, groups:history`
  - `chat:write`
  - `users:read`
  - `reactions:write`

No behavior changes outside the card body.

## Test plan

- [ ] `bash nanoclaw.sh` → click through to "Yes, connect Slack", confirm the URL appears between the welcome text and step 1, in bright white, and the scope bullets render as above.
- [ ] On a non-headless machine (with `DISPLAY` set), confirm the URL line is not printed inside the card and the browser still opens.