### PR TITLE
setup: correct Slack member-ID card directions

### DIFF
--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -308,9 +308,9 @@ async function collectSlackUserId(): Promise<string> {
     [
       "To get your Slack member ID:",
       '',
-      '  1. In Slack, click your profile picture (top right)',
+      '  1. In Slack, click your profile picture (bottom left)',
       '  2. Click "Profile"',
-      '  3. Click the three dots (⋯) → "Copy member ID"',
+      '  3. Click the three dots (⋮) → "Copy member ID"',
     ].join('\n'),
     'Find your Slack user ID',
   );


### PR DESCRIPTION
## Why

The card walking the user through "Copy member ID" pointed at the wrong place: it said the profile button is top-right (it's bottom-left in the desktop sidebar), and used the horizontal-ellipsis glyph `⋯` for an icon Slack actually renders as a vertical kebab `⋮`.

## What

Two-character/word fix in `collectSlackUserId()`:

- `(top right)` → `(bottom left)`
- `⋯` → `⋮`

## Test plan

- [ ] `bash nanoclaw.sh` → click through to "Yes, connect Slack", continue past the install. The "Find your Slack user ID" card should match the layout the user sees in their Slack desktop client.