### PR TITLE
fix(whatsapp): allow self-chat messages through fromMe filter

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -197,6 +197,7 @@ registerChannelAdapter('whatsapp', {
     // LID → phone JID mapping (WhatsApp's new ID system)
     const lidToPhoneMap: Record<string, string> = {};
     let botLidUser: string | undefined;
+    let botPhoneJid: string | undefined;
 
     // Outgoing queue for messages sent while disconnected
     const outgoingQueue: Array<{ jid: string; text: string }> = [];
@@ -496,8 +497,9 @@ registerChannelAdapter('whatsapp', {
           if (sock.user) {
             const phoneUser = sock.user.id.split(':')[0];
             const lidUser = sock.user.lid?.split(':')[0];
+            botPhoneJid = `${phoneUser}@s.whatsapp.net`;
             if (lidUser && phoneUser) {
-              setLidPhoneMapping(lidUser, `${phoneUser}@s.whatsapp.net`);
+              setLidPhoneMapping(lidUser, botPhoneJid);
               botLidUser = lidUser;
             }
           }
@@ -579,9 +581,16 @@ registerChannelAdapter('whatsapp', {
             const senderName = msg.pushName || sender.split('@')[0];
             const fromMe = msg.key.fromMe || false;
             // Filter bot's own messages to prevent echo loops.
-            // fromMe is always true for messages sent from this linked device,
-            // regardless of ASSISTANT_HAS_OWN_NUMBER mode.
-            if (fromMe) continue;
+            // In self-chat (user messaging their own number), all messages have
+            // fromMe=true — use sentMessageCache to distinguish bot echoes from
+            // user-typed messages. For all other chats, the blanket fromMe
+            // filter is correct since the user's phone messages shouldn't wake
+            // the agent in third-party conversations.
+            if (fromMe) {
+              const isSelfChat = botPhoneJid && chatJid === botPhoneJid;
+              if (!isSelfChat) continue;
+              if (sentMessageCache.has(msg.key.id || '')) continue;
+            }
 
             const isBotMessage = ASSISTANT_HAS_OWN_NUMBER ? false : content.startsWith(`${ASSISTANT_NAME}:`);
 


### PR DESCRIPTION
## Summary

- The blanket `if (fromMe) continue` echo filter drops **all** messages from the linked device, including user-typed messages in WhatsApp self-chat (messaging your own number)
- For self-chat, uses the existing `sentMessageCache` to distinguish bot echoes from user messages instead of the blanket `fromMe` check
- No behavioral change for DMs with others, groups, or `ASSISTANT_HAS_OWN_NUMBER` mode — only self-chat is affected

## Details

Introduced in c02ac06 (Apr 14 2026) — "feat(v2): add formatting, approvals, and echo filter to WhatsApp adapter". The original adapter (c303b6e) passed `fromMe` as a soft `isBotMessage` flag without dropping messages.

The fix detects self-chat by comparing `chatJid` to the bot's own phone JID (`botPhoneJid`). For self-chat, echo detection falls back to `sentMessageCache.has(msg.key.id)` — messages the bot sent are in the cache and get filtered; user-typed messages are not and pass through.

## Test plan

- [ ] Send a message in WhatsApp self-chat → agent receives and responds
- [ ] Send a message in a DM with another person → behavior unchanged (their messages route, your phone messages are still filtered)
- [ ] Agent sends a reply in self-chat → no echo loop (reply is in sentMessageCache)
- [ ] Group chat behavior unchanged (group JIDs never match botPhoneJid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)