### PR TITLE
setup: gate Slack post-install card with a back-affording confirm

### DIFF
--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -123,6 +123,18 @@ export async function runSlackChannel(displayName: string): Promise<ChannelFlowR
   }
 
   showPostInstallChecklist(info);
+
+  const next = ensureAnswer(
+    await brightSelect<'continue' | 'back'>({
+      message: 'Got your public URL & Slack reinstalled?',
+      options: [
+        { value: 'continue', label: 'Setup complete!' },
+        { value: 'back', label: '← Back to channel selection' },
+      ],
+      initialValue: 'continue',
+    }),
+  );
+  if (next === 'back') return BACK_TO_CHANNEL_SELECTION;
 }
 
 async function walkThroughAppCreation(): Promise<'continue' | 'back'> {


### PR DESCRIPTION
## Why

The Slack channel option is meant to work for **both technical and non-technical users**, but the post-install card (a.k.a. "stage 2" — public URL, event subscriptions, interactivity, reinstall) is a wall that non-technical users don't see coming. They've spent 5+ minutes pasting tokens, the agent says it's "wired" — and then suddenly four more dense steps land in front of them, half of which require setting up a tunneling tool they've never heard of.

Today, after the card renders, setup just falls through to the verify step which prints "Everything's connected." That's both untrue (without the public URL the agent can't receive replies) and morale-killing — the user either feels overwhelmed and gives up entirely, or thinks they're done when they're not.

We need a graceful out that:
- doesn't kill the whole setup,
- doesn't lie about completion,
- lets the user bail to a different channel without it feeling like failure.

## What

After `showPostInstallChecklist()` renders, gate progression on a small picker:

```
◆  Got your public URL & Slack reinstalled?
│  ● Setup complete!
│    ← Back to channel selection
```

- **Setup complete!** → continues into verify (today's behavior, but now opt-in).
- **← Back to channel selection** → returns `BACK_TO_CHANNEL_SELECTION`. The user lands back at the channel picker and can pick Telegram / Discord / etc. instead, without setup aborting.

The Slack adapter / token / agent stay installed in case the user wants to come back to it later.

## Test plan

- [ ] `bash nanoclaw.sh` → "Yes, connect Slack" → finish through to the post-install card. Confirm the new picker appears.
- [ ] Pick "Setup complete!" and confirm verify runs as before.
- [ ] Pick "← Back to channel selection" and confirm you land back at the channel picker without setup aborting.
