### PR TITLE
feat(yt-dlp-mcp): in-tree MCP server + /add-ytdlp installer

### DIFF
--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -24,7 +24,7 @@ Tools surfaced as `mcp__yt-dlp__ytdlp_<name>` (8 total — see [README](https://
 | `ytdlp_download_video` | Save video file (480p / 720p / 1080p / best, optional trim) |
 | `ytdlp_download_audio` | Audio only (M4A / MP3) |
 
-Downloads land in `$YTDLP_DOWNLOADS_DIR` (defaults below to `/workspace/agent/tmp`), so the agent can hand the resulting path straight to `mcp__nanoclaw__send_file`.
+Downloads land in `$YTDLP_DOWNLOADS_DIR` (defaults below to `/tmp`), so the agent can hand the resulting path straight to `mcp__nanoclaw__send_file`. `/tmp` is container-internal (not bind-mounted), so files evaporate cleanly on container exit — no host clutter to sweep.
 
 ## Phase 1: Pre-flight
 
@@ -91,7 +91,7 @@ For each group that should get video-download capability, merge into `groups/<fo
       "command": "bun",
       "args": ["run", "/app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs"],
       "env": {
-        "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
+        "YTDLP_DOWNLOADS_DIR": "/tmp",
         "NO_PROXY": "*",
         "no_proxy": "*"
       }
@@ -100,7 +100,7 @@ For each group that should get video-download capability, merge into `groups/<fo
 }
 ```
 
-`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path, swept periodically by `mcp__nanoclaw__send_file` consumers.
+`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to `/tmp`. `/tmp` is container-internal (not bind-mounted from the host), so the session container is the only place these files ever exist — they vanish when the container exits with `--rm`. `send_file` copies the bytes into `/workspace/outbox/<msg-id>/` before delivery, so downloads don't need to outlive the container.
 
 `NO_PROXY=*` makes yt-dlp bypass OneCLI's HTTPS_PROXY for every host. Without it, OneCLI intercepts YouTube traffic with its self-signed CA, and yt-dlp rejects the cert because its standalone PyInstaller binary uses certifi's *bundled* CA store — which lives inside the binary and ignores `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`. There's no env-var path to teach this binary to trust OneCLI's CA; only `--ca-certificate` (CLI flag, which the MCP wrapper doesn't expose) or `--no-check-certificate` would work. Bypassing the proxy is the right call anyway: yt-dlp is fetching public video from YouTube/Vimeo/etc., not a credentialed API, so there's nothing for OneCLI to inject. Both upper and lower case are set because Python's stdlib checks `NO_PROXY` while some libraries check `no_proxy`.
 
@@ -108,7 +108,7 @@ Optional env overrides (see [package config docs](https://github.com/kevinwatt/y
 
 ```jsonc
 "env": {
-  "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
+  "YTDLP_DOWNLOADS_DIR": "/tmp",
   "NO_PROXY": "*",
   "no_proxy": "*",
   "YTDLP_DEFAULT_RESOLUTION": "1080p",      // 480p | 720p | 1080p | best (default 720p)
@@ -140,7 +140,7 @@ Common signals:
 - `command not found: yt-dlp` → image wasn't rebuilt after the Dockerfile patch. Re-run `./container/build.sh`.
 - `Cannot find module '@kevinwatt/yt-dlp-mcp'` → `bun.lock` wasn't updated, or the image was built before the lockfile change. Re-run `bun add` then rebuild.
 - Agent says "I don't have download tools" → group's `container.json` is missing the `mcpServers["yt-dlp"]` entry, or the host wasn't restarted.
-- Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/workspace/agent/tmp` is the safe choice.
+- Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/tmp` is the safe choice (container-internal, auto-cleaned on container exit).
 - `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → `NO_PROXY=*` from Phase 4 isn't in the env. OneCLI's gateway is intercepting HTTPS with its self-signed CA, and the standalone yt-dlp binary uses certifi's bundled CA store (inside the PyInstaller binary, *not* the system store), so it has no way to trust OneCLI's CA. The fix is to bypass the proxy entirely, not to teach yt-dlp the cert. Re-check the `env` block has both `NO_PROXY` and `no_proxy` set to `*`.
 
 ## Removal

--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -1,28 +1,24 @@
 ---
 name: add-ytdlp
-description: Add yt-dlp as an MCP tool so the agent can search, fetch metadata, download subtitles/transcripts, and pull video/audio from YouTube, Vimeo, X, TikTok, and ~1000 other sites. Patches `container/Dockerfile` to install the standalone yt-dlp binary, adds `@kevinwatt/yt-dlp-mcp` as an agent-runner dep, and wires it as a stdio MCP server.
+description: Add yt-dlp as an MCP tool so the agent can search YouTube, fetch metadata, and download video/audio from YouTube, Vimeo, X, TikTok, and ~1000 other sites. Patches `container/Dockerfile` to install the standalone yt-dlp binary and wires the in-tree `yt-dlp-mcp` server into selected agent groups.
 ---
 
-# Add Video Download
+# Add yt-dlp
 
-Patches `container/Dockerfile` to install `yt-dlp` (~30MB), adds the upstream `@kevinwatt/yt-dlp-mcp` npm package as an agent-runner runtime dep, and wires it into selected agent groups as a stdio MCP server. After install the agent can take a URL the user shares and reply with the file via `mcp__nanoclaw__send_file`, or with metadata/transcripts/subtitles inline.
+Patches `container/Dockerfile` to install `yt-dlp` (~30MB) and wires the in-tree MCP server at `container/agent-runner/src/yt-dlp-mcp/` into selected agent groups as a stdio MCP server. After install the agent can take a URL the user shares and reply with the file via `mcp__nanoclaw__send_file`, or with metadata/search results inline.
 
 The trunk container image ships **without** yt-dlp — it's added only when this skill runs. The patch is a real Dockerfile edit so it survives `./container/build.sh` and `pnpm run dev` invocations consistently.
 
-The MCP server itself is the upstream `@kevinwatt/yt-dlp-mcp` package (MIT, Node 18+, single maintainer Dewei Yen). We pin a specific version into `container/agent-runner/package.json` rather than vendoring or wrapping — the package is a thin Zod-validated stdio bridge to the yt-dlp CLI, so its API surface is whatever yt-dlp itself can do.
+The MCP server itself is in-tree (lives in this repo at `container/agent-runner/src/yt-dlp-mcp/`), spawned by Bun directly from the bind-mounted source — no npm dependency, no separate publish step. It's a thin wrapper over the yt-dlp CLI with a curated four-tool surface tuned for chat agents.
 
-Tools surfaced as `mcp__yt-dlp__ytdlp_<name>` (8 total — see [README](https://github.com/kevinwatt/yt-dlp-mcp) for full schemas):
+Tools surfaced as `mcp__yt-dlp__<name>`:
 
 | Tool | What it does |
 |------|---------------|
-| `ytdlp_search_videos` | YouTube search with pagination + date filter (JSON / Markdown) |
-| `ytdlp_get_video_metadata` | Full JSON metadata (title, channel, views, formats, …) |
-| `ytdlp_get_video_metadata_summary` | Human-readable metadata summary |
-| `ytdlp_list_subtitle_languages` | List available subtitle languages for a URL |
-| `ytdlp_download_video_subtitles` | VTT subtitles with timestamps |
-| `ytdlp_download_transcript` | Clean plain-text transcript |
-| `ytdlp_download_video` | Save video file (480p / 720p / 1080p / best, optional trim) |
-| `ytdlp_download_audio` | Audio only (M4A / MP3) |
+| `ytdlp_search` | YouTube search with pagination, filters (`minDuration` / `maxDuration` / `minViews`), sort (`relevance` / `date` / `views`), JSON or markdown output, and a `maxChars` cap. |
+| `ytdlp_get_metadata` | Full yt-dlp JSON for a URL, or a compact human-readable summary if `summary: true`. `maxChars` cap. |
+| `ytdlp_download_video` | Default: mp4 at chosen resolution (`480p`/`720p`/`1080p`/`best`). Fallback on failure: best quality in any container. Optional `trim: { start, end }`. |
+| `ytdlp_download_audio` | Default: mp3 (transcoded — needs ffmpeg on PATH). Fallback on failure: best native audio (no transcoding). |
 
 Downloads land in `$YTDLP_DOWNLOADS_DIR` (defaults below to `/tmp`), so the agent can hand the resulting path straight to `mcp__nanoclaw__send_file`. `/tmp` is container-internal (not bind-mounted), so files evaporate cleanly on container exit — no host clutter to sweep.
 
@@ -30,7 +26,6 @@ Downloads land in `$YTDLP_DOWNLOADS_DIR` (defaults below to `/tmp`), so the agen
 
 ```bash
 grep -q '# ---- yt-dlp' container/Dockerfile && echo "DOCKERFILE ALREADY PATCHED — skip Phase 2"
-grep -q '@kevinwatt/yt-dlp-mcp' container/agent-runner/package.json && echo "AGENT-RUNNER ALREADY HAS DEP — skip Phase 3"
 ```
 
 ## Phase 2: Patch the Dockerfile and rebuild
@@ -40,10 +35,10 @@ Use the Edit tool to insert a new RUN block into `container/Dockerfile` immediat
 ```dockerfile
 # ---- yt-dlp (added by /add-ytdlp) ---------------------------------
 # Standalone PyInstaller-bundled Linux binary from the upstream GitHub release
-# (~30MB). No apt package, no Python on PATH required. Used by the
-# @kevinwatt/yt-dlp-mcp MCP server. The --version smoke-test fails the build
-# if the download is corrupt or the tag was retracted. Bump deliberately.
-# Replace <tag> with the N-1 tag in the releases page
+# (~30MB). No apt package, no Python on PATH required. Used by the in-tree
+# yt-dlp-mcp server at /app/src/yt-dlp-mcp/. The --version smoke-test fails
+# the build if the download is corrupt or the tag was retracted. Bump
+# deliberately. Replace <tag> with the N-1 tag in the releases page.
 ARG YTDLP_VERSION=<tag>
 RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/yt-dlp_linux" \
          -o /usr/local/bin/yt-dlp \
@@ -53,17 +48,6 @@ RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSI
 ```
 
 The leading `# ---- yt-dlp` marker is the idempotency anchor — re-running the skill on a patched Dockerfile is a no-op.
-
-## Phase 3: Add the MCP server as an agent-runner dep
-
-`@kevinwatt/yt-dlp-mcp` is npm-published; pin a specific version so rebuilds are reproducible. The agent-runner tree uses Bun, not pnpm, so the `minimumReleaseAge` policy does not apply here — pick a version deliberately by checking [the npm release history](https://www.npmjs.com/package/@kevinwatt/yt-dlp-mcp?activeTab=versions) and prefer one that's been live for at least a few days.
-
-```bash
-cd container/agent-runner && bun add @kevinwatt/yt-dlp-mcp@0.8.4
-cd ../..
-```
-
-This updates `container/agent-runner/package.json` and `container/agent-runner/bun.lock`. Both must be committed — the Dockerfile copies them in and runs `bun install --frozen-lockfile`.
 
 Then rebuild:
 
@@ -75,21 +59,21 @@ Verify (the image tag is install-slug-derived and printed at the end of `build.s
 
 ```bash
 IMAGE=$(docker images --filter 'reference=nanoclaw-agent*:latest' --format '{{.Repository}}:{{.Tag}}' | head -1)
-docker run --rm --entrypoint sh "$IMAGE" -c 'yt-dlp --version && test -f /app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs && echo OK'
+docker run --rm --entrypoint sh "$IMAGE" -c 'yt-dlp --version && echo OK'
 ```
 
 Expect a yt-dlp date version (e.g. `2026.03.17`) followed by `OK`.
 
-## Phase 4: Wire per-agent-group
+## Phase 3: Wire per-agent-group
 
-For each group that should get video-download capability, merge into `groups/<folder>/container.json`:
+For each group that should get yt-dlp capability, merge into `groups/<folder>/container.json`:
 
 ```jsonc
 {
   "mcpServers": {
     "yt-dlp": {
       "command": "bun",
-      "args": ["run", "/app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs"],
+      "args": ["run", "/app/src/yt-dlp-mcp/server.ts"],
       "env": {
         "YTDLP_DOWNLOADS_DIR": "/tmp",
         "NO_PROXY": "*",
@@ -100,25 +84,13 @@ For each group that should get video-download capability, merge into `groups/<fo
 }
 ```
 
-`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to `/tmp`. `/tmp` is container-internal (not bind-mounted from the host), so the session container is the only place these files ever exist — they vanish when the container exits with `--rm`. `send_file` copies the bytes into `/workspace/outbox/<msg-id>/` before delivery, so downloads don't need to outlive the container.
+`YTDLP_DOWNLOADS_DIR` redirects downloads to `/tmp`, which is container-internal (not bind-mounted from the host), so the session container is the only place these files ever exist — they vanish when the container exits with `--rm`. `send_file` copies the bytes into `/workspace/outbox/<msg-id>/` before delivery, so downloads don't need to outlive the container.
 
-`NO_PROXY=*` makes yt-dlp bypass OneCLI's HTTPS_PROXY for every host. Without it, OneCLI intercepts YouTube traffic with its self-signed CA, and yt-dlp rejects the cert because its standalone PyInstaller binary uses certifi's *bundled* CA store — which lives inside the binary and ignores `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`. There's no env-var path to teach this binary to trust OneCLI's CA; only `--ca-certificate` (CLI flag, which the MCP wrapper doesn't expose) or `--no-check-certificate` would work. Bypassing the proxy is the right call anyway: yt-dlp is fetching public video from YouTube/Vimeo/etc., not a credentialed API, so there's nothing for OneCLI to inject. Both upper and lower case are set because Python's stdlib checks `NO_PROXY` while some libraries check `no_proxy`.
+`NO_PROXY=*` makes yt-dlp bypass OneCLI's HTTPS_PROXY for every host. Without it, OneCLI intercepts YouTube traffic with its self-signed CA, and yt-dlp rejects the cert because its standalone PyInstaller binary uses certifi's *bundled* CA store — which lives inside the binary and ignores `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`. There's no env-var path to teach this binary to trust OneCLI's CA; only `--ca-certificate` (CLI flag) or `--no-check-certificate` would work. Bypassing the proxy is the right call anyway: yt-dlp is fetching public video from YouTube/Vimeo/etc., not a credentialed API, so there's nothing for OneCLI to inject. Both upper and lower case are set because Python's stdlib checks `NO_PROXY` while some libraries check `no_proxy`.
 
-Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)) — keep the proxy-bypass vars from the block above:
+If the group should be allowed to read private / age-gated YouTube content, mount a cookie file and pass `--cookies` via the yt-dlp CLI — that's a separate decision and out of scope for this skill.
 
-```jsonc
-"env": {
-  "YTDLP_DOWNLOADS_DIR": "/tmp",
-  "NO_PROXY": "*",
-  "no_proxy": "*",
-  "YTDLP_DEFAULT_RESOLUTION": "1080p",      // 480p | 720p | 1080p | best (default 720p)
-  "YTDLP_DEFAULT_SUBTITLE_LANG": "en"        // default subtitle language
-}
-```
-
-If the group should be allowed to read private / age-gated YouTube content, see the package's [cookie guide](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/cookies.md) — it's a separate decision and requires mounting a cookie file.
-
-## Phase 5: Restart
+## Phase 4: Restart
 
 ```bash
 pnpm run build
@@ -126,9 +98,9 @@ systemctl --user restart nanoclaw  # Linux
 # launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
 ```
 
-## Phase 6: Verify
+## Phase 5: Verify
 
-In a wired chat, send a YouTube link with **"download this"** — you should get the video file back. Other prompts to try: **"give me the transcript"** (`ytdlp_download_transcript`), **"what's the channel and view count"** (`ytdlp_get_video_metadata_summary`), **"audio only"** (`ytdlp_download_audio`).
+In a wired chat, send a YouTube link with **"download this"** — you should get the video file back as mp4. Other prompts to try: **"summarize the metadata for this video"** (`ytdlp_get_metadata` with `summary: true`), **"search for lofi study mix top 5"** (`ytdlp_search`), **"audio only as mp3"** (`ytdlp_download_audio`).
 
 If something's off:
 
@@ -138,14 +110,16 @@ tail -200 logs/nanoclaw.log logs/nanoclaw.error.log | grep -F 'yt-dlp'
 
 Common signals:
 - `command not found: yt-dlp` → image wasn't rebuilt after the Dockerfile patch. Re-run `./container/build.sh`.
-- `Cannot find module '@kevinwatt/yt-dlp-mcp'` → `bun.lock` wasn't updated, or the image was built before the lockfile change. Re-run `bun add` then rebuild.
+- `Cannot find module '/app/src/yt-dlp-mcp/server.ts'` → the agent-runner source bind mount is missing or the path drifted. Confirm the files exist under `container/agent-runner/src/yt-dlp-mcp/` on the host.
 - Agent says "I don't have download tools" → group's `container.json` is missing the `mcpServers["yt-dlp"]` entry, or the host wasn't restarted.
 - Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/tmp` is the safe choice (container-internal, auto-cleaned on container exit).
-- `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → `NO_PROXY=*` from Phase 4 isn't in the env. OneCLI's gateway is intercepting HTTPS with its self-signed CA, and the standalone yt-dlp binary uses certifi's bundled CA store (inside the PyInstaller binary, *not* the system store), so it has no way to trust OneCLI's CA. The fix is to bypass the proxy entirely, not to teach yt-dlp the cert. Re-check the `env` block has both `NO_PROXY` and `no_proxy` set to `*`.
+- mp3 audio comes back as `.m4a`/`.webm` instead → ffmpeg isn't on PATH inside the container, so `ytdlp_download_audio` took the native fallback. Install ffmpeg in the image to enable transcoding (the tool reports `fallback: true` in its result so the agent knows it happened).
+- `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → `NO_PROXY=*` from Phase 3 isn't in the env. OneCLI's gateway is intercepting HTTPS with its self-signed CA, and the standalone yt-dlp binary uses certifi's bundled CA store (inside the PyInstaller binary, *not* the system store), so it has no way to trust OneCLI's CA. The fix is to bypass the proxy entirely, not to teach yt-dlp the cert. Re-check the `env` block has both `NO_PROXY` and `no_proxy` set to `*`.
 
 ## Removal
 
 1. Delete the `"yt-dlp"` entry from `mcpServers` in each group's `container.json`.
-2. `cd container/agent-runner && bun remove @kevinwatt/yt-dlp-mcp && cd ../..`.
-3. Edit `container/Dockerfile` and remove the `# ---- yt-dlp (added by /add-ytdlp) ---` block (the comment header through the trailing blank line).
-4. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.
+2. Edit `container/Dockerfile` and remove the `# ---- yt-dlp (added by /add-ytdlp) ---` block (the comment header through the trailing blank line).
+3. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.
+
+(The in-tree MCP source under `container/agent-runner/src/yt-dlp-mcp/` is left in place — it's harmless without the binary and the `mcpServers` entry. Delete that directory too if you want a clean tree.)

--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: add-ytdlp
+description: Add yt-dlp as an MCP tool so the agent can search, fetch metadata, download subtitles/transcripts, and pull video/audio from YouTube, Vimeo, X, TikTok, and ~1000 other sites. Patches `container/Dockerfile` to install the standalone yt-dlp binary, adds `@kevinwatt/yt-dlp-mcp` as an agent-runner dep, and wires it as a stdio MCP server. No credentials, no sidecar.
+---
+
+# Add Video Download
+
+Patches `container/Dockerfile` to install `yt-dlp` (~30MB), adds the upstream `@kevinwatt/yt-dlp-mcp` npm package as an agent-runner runtime dep, and wires it into selected agent groups as a stdio MCP server. After install the agent can take a URL the user shares and reply with the file via `mcp__nanoclaw__send_file`, or with metadata/transcripts/subtitles inline.
+
+The trunk container image ships **without** yt-dlp — it's added only when this skill runs. There is no `INSTALL_YTDLP` env flag; the patch is a real Dockerfile edit so it survives `./container/build.sh` and `pnpm run dev` invocations consistently. Same shape as `/add-ffmpeg`.
+
+The MCP server itself is the upstream `@kevinwatt/yt-dlp-mcp` package (MIT, Node 18+, single maintainer Dewei Yen). We pin a specific version into `container/agent-runner/package.json` rather than vendoring or wrapping — the package is a thin Zod-validated stdio bridge to the yt-dlp CLI, so its API surface is whatever yt-dlp itself can do.
+
+Tools surfaced as `mcp__yt-dlp__ytdlp_<name>` (8 total — see [README](https://github.com/kevinwatt/yt-dlp-mcp) for full schemas):
+
+| Tool | What it does |
+|------|---------------|
+| `ytdlp_search_videos` | YouTube search with pagination + date filter (JSON / Markdown) |
+| `ytdlp_get_video_metadata` | Full JSON metadata (title, channel, views, formats, …) |
+| `ytdlp_get_video_metadata_summary` | Human-readable metadata summary |
+| `ytdlp_list_subtitle_languages` | List available subtitle languages for a URL |
+| `ytdlp_download_video_subtitles` | VTT subtitles with timestamps |
+| `ytdlp_download_transcript` | Clean plain-text transcript |
+| `ytdlp_download_video` | Save video file (480p / 720p / 1080p / best, optional trim) |
+| `ytdlp_download_audio` | Audio only (M4A / MP3) |
+
+Downloads land in `$YTDLP_DOWNLOADS_DIR` (defaults below to `/workspace/agent/tmp`), so the agent can hand the resulting path straight to `mcp__nanoclaw__send_file`.
+
+## Phase 1: Pre-flight
+
+```bash
+grep -q '# ---- yt-dlp' container/Dockerfile && echo "DOCKERFILE ALREADY PATCHED — skip Phase 2"
+grep -q '@kevinwatt/yt-dlp-mcp' container/agent-runner/package.json && echo "AGENT-RUNNER ALREADY HAS DEP — skip Phase 3"
+```
+
+## Phase 2: Patch the Dockerfile and rebuild
+
+Use the Edit tool to insert a new RUN block into `container/Dockerfile` immediately before the `# Chromium path for agent-browser ...` ENV line (i.e. right after the system-deps `RUN ... apt-get install ...` block). Insert exactly:
+
+```dockerfile
+# ---- yt-dlp (added by /add-ytdlp) ---------------------------------
+# Standalone PyInstaller-bundled Linux binary from the upstream GitHub release
+# (~30MB). No apt package, no Python on PATH required. Used by the
+# @kevinwatt/yt-dlp-mcp MCP server. The --version smoke-test fails the build
+# if the download is corrupt or the tag was retracted. Bump deliberately.
+ARG YTDLP_VERSION=2026.03.17
+RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/yt-dlp_linux" \
+         -o /usr/local/bin/yt-dlp \
+    && chmod +x /usr/local/bin/yt-dlp \
+    && /usr/local/bin/yt-dlp --version
+
+```
+
+The leading `# ---- yt-dlp` marker is the idempotency anchor — re-running the skill on a patched Dockerfile is a no-op.
+
+## Phase 3: Add the MCP server as an agent-runner dep
+
+`@kevinwatt/yt-dlp-mcp` is npm-published; pin a specific version so rebuilds are reproducible. The agent-runner tree uses Bun, not pnpm, so the `minimumReleaseAge` policy does not apply here — pick a version deliberately by checking [the npm release history](https://www.npmjs.com/package/@kevinwatt/yt-dlp-mcp?activeTab=versions) and prefer one that's been live for at least a few days.
+
+```bash
+cd container/agent-runner && bun add @kevinwatt/yt-dlp-mcp@0.8.4
+cd ../..
+```
+
+This updates `container/agent-runner/package.json` and `container/agent-runner/bun.lock`. Both must be committed — the Dockerfile copies them in and runs `bun install --frozen-lockfile`.
+
+Then rebuild:
+
+```bash
+./container/build.sh
+```
+
+Verify (the image tag is install-slug-derived and printed at the end of `build.sh`; `--entrypoint sh` is required so the agent-runner entrypoint doesn't intercept):
+
+```bash
+IMAGE=$(docker images --filter 'reference=nanoclaw-agent*:latest' --format '{{.Repository}}:{{.Tag}}' | head -1)
+docker run --rm --entrypoint sh "$IMAGE" -c 'yt-dlp --version && test -f /app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs && echo OK'
+```
+
+Expect a yt-dlp date version (e.g. `2026.03.17`) followed by `OK`.
+
+## Phase 4: Wire per-agent-group
+
+For each group that should get video-download capability, merge into `groups/<folder>/container.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "yt-dlp": {
+      "command": "bun",
+      "args": ["run", "/app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs"],
+      "env": {
+        "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp"
+      }
+    }
+  }
+}
+```
+
+`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path — same path the ffmpeg MCP uses, swept periodically by `mcp__nanoclaw__send_file` consumers. No `additionalMounts`, no credentials.
+
+Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)):
+
+```jsonc
+"env": {
+  "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
+  "YTDLP_DEFAULT_RESOLUTION": "1080p",      // 480p | 720p | 1080p | best (default 720p)
+  "YTDLP_DEFAULT_SUBTITLE_LANG": "en"        // default subtitle language
+}
+```
+
+If the group should be allowed to read private / age-gated YouTube content, see the package's [cookie guide](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/cookies.md) — it's a separate decision and requires mounting a cookie file.
+
+## Phase 5: Restart
+
+```bash
+pnpm run build
+systemctl --user restart nanoclaw  # Linux
+# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+```
+
+## Phase 6: Verify
+
+In a wired chat, send a YouTube link with **"download this"** — you should get the video file back. Other prompts to try: **"give me the transcript"** (`ytdlp_download_transcript`), **"what's the channel and view count"** (`ytdlp_get_video_metadata_summary`), **"audio only"** (`ytdlp_download_audio`).
+
+If something's off:
+
+```bash
+tail -200 logs/nanoclaw.log logs/nanoclaw.error.log | grep -F 'yt-dlp'
+```
+
+Common signals:
+- `command not found: yt-dlp` → image wasn't rebuilt after the Dockerfile patch. Re-run `./container/build.sh`.
+- `Cannot find module '@kevinwatt/yt-dlp-mcp'` → `bun.lock` wasn't updated, or the image was built before the lockfile change. Re-run `bun add` then rebuild.
+- Agent says "I don't have download tools" → group's `container.json` is missing the `mcpServers["yt-dlp"]` entry, or the host wasn't restarted.
+- Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/workspace/agent/tmp` is the safe choice.
+
+## Removal
+
+1. Delete the `"yt-dlp"` entry from `mcpServers` in each group's `container.json`.
+2. `cd container/agent-runner && bun remove @kevinwatt/yt-dlp-mcp && cd ../..`.
+3. Edit `container/Dockerfile` and remove the `# ---- yt-dlp (added by /add-ytdlp) ---` block (the comment header through the trailing blank line).
+4. `./container/build.sh && pnpm run build && systemctl --user restart nanoclaw`.

--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-ytdlp
-description: Add yt-dlp as an MCP tool so the agent can search, fetch metadata, download subtitles/transcripts, and pull video/audio from YouTube, Vimeo, X, TikTok, and ~1000 other sites. Patches `container/Dockerfile` to install the standalone yt-dlp binary, adds `@kevinwatt/yt-dlp-mcp` as an agent-runner dep, and wires it as a stdio MCP server. No credentials, no sidecar.
+description: Add yt-dlp as an MCP tool so the agent can search, fetch metadata, download subtitles/transcripts, and pull video/audio from YouTube, Vimeo, X, TikTok, and ~1000 other sites. Patches `container/Dockerfile` to install the standalone yt-dlp binary, adds `@kevinwatt/yt-dlp-mcp` as an agent-runner dep, and wires it as a stdio MCP server.
 ---
 
 # Add Video Download
 
 Patches `container/Dockerfile` to install `yt-dlp` (~30MB), adds the upstream `@kevinwatt/yt-dlp-mcp` npm package as an agent-runner runtime dep, and wires it into selected agent groups as a stdio MCP server. After install the agent can take a URL the user shares and reply with the file via `mcp__nanoclaw__send_file`, or with metadata/transcripts/subtitles inline.
 
-The trunk container image ships **without** yt-dlp — it's added only when this skill runs. There is no `INSTALL_YTDLP` env flag; the patch is a real Dockerfile edit so it survives `./container/build.sh` and `pnpm run dev` invocations consistently. Same shape as `/add-ffmpeg`.
+The trunk container image ships **without** yt-dlp — it's added only when this skill runs. The patch is a real Dockerfile edit so it survives `./container/build.sh` and `pnpm run dev` invocations consistently.
 
 The MCP server itself is the upstream `@kevinwatt/yt-dlp-mcp` package (MIT, Node 18+, single maintainer Dewei Yen). We pin a specific version into `container/agent-runner/package.json` rather than vendoring or wrapping — the package is a thin Zod-validated stdio bridge to the yt-dlp CLI, so its API surface is whatever yt-dlp itself can do.
 
@@ -43,7 +43,8 @@ Use the Edit tool to insert a new RUN block into `container/Dockerfile` immediat
 # (~30MB). No apt package, no Python on PATH required. Used by the
 # @kevinwatt/yt-dlp-mcp MCP server. The --version smoke-test fails the build
 # if the download is corrupt or the tag was retracted. Bump deliberately.
-ARG YTDLP_VERSION=2026.03.17
+# Replace <tag> with the N-1 tag in the releases page
+ARG YTDLP_VERSION=<tag>
 RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/yt-dlp_linux" \
          -o /usr/local/bin/yt-dlp \
     && chmod +x /usr/local/bin/yt-dlp \
@@ -97,7 +98,7 @@ For each group that should get video-download capability, merge into `groups/<fo
 }
 ```
 
-`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path — same path the ffmpeg MCP uses, swept periodically by `mcp__nanoclaw__send_file` consumers. No `additionalMounts`, no credentials.
+`YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path, swept periodically by `mcp__nanoclaw__send_file` consumers.
 
 Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)):
 

--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -91,7 +91,10 @@ For each group that should get video-download capability, merge into `groups/<fo
       "command": "bun",
       "args": ["run", "/app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs"],
       "env": {
-        "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp"
+        "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
+        "SSL_CERT_FILE": "/tmp/onecli-combined-ca.pem",
+        "REQUESTS_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
+        "CURL_CA_BUNDLE": "/tmp/onecli-combined-ca.pem"
       }
     }
   }
@@ -100,11 +103,16 @@ For each group that should get video-download capability, merge into `groups/<fo
 
 `YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path, swept periodically by `mcp__nanoclaw__send_file` consumers.
 
-Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)):
+The three `*_CA_*` vars point yt-dlp at OneCLI's combined CA bundle so it trusts the gateway's self-signed cert when traffic is intercepted. OneCLI sets `SSL_CERT_FILE` at the container level, but the MCP SDK's stdio transport strips most env vars when spawning MCP server children (only `HOME, LOGNAME, PATH, SHELL, TERM, USER` propagate by default) — so we re-inject them explicitly here. Without these, yt-dlp fails with `CERTIFICATE_VERIFY_FAILED` against the OneCLI-injected cert, even on plain YouTube. yt-dlp's network paths look at different vars (`SSL_CERT_FILE` for stdlib `ssl`, `REQUESTS_CA_BUNDLE` for `requests`/urllib3, `CURL_CA_BUNDLE` for any curl fallback), so all three are set. The bundle file is mounted by OneCLI at `/tmp/onecli-combined-ca.pem`.
+
+Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)) — keep the three CA-bundle vars from the block above:
 
 ```jsonc
 "env": {
   "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
+  "SSL_CERT_FILE": "/tmp/onecli-combined-ca.pem",
+  "REQUESTS_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
+  "CURL_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
   "YTDLP_DEFAULT_RESOLUTION": "1080p",      // 480p | 720p | 1080p | best (default 720p)
   "YTDLP_DEFAULT_SUBTITLE_LANG": "en"        // default subtitle language
 }
@@ -135,6 +143,7 @@ Common signals:
 - `Cannot find module '@kevinwatt/yt-dlp-mcp'` → `bun.lock` wasn't updated, or the image was built before the lockfile change. Re-run `bun add` then rebuild.
 - Agent says "I don't have download tools" → group's `container.json` is missing the `mcpServers["yt-dlp"]` entry, or the host wasn't restarted.
 - Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/workspace/agent/tmp` is the safe choice.
+- `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → the three `*_CA_*` env vars in Phase 4 weren't applied. OneCLI's gateway is intercepting HTTPS with its own CA, but the MCP SDK strips `SSL_CERT_FILE` when spawning the MCP child. Re-check the `env` block has all three CA-bundle entries pointing at `/tmp/onecli-combined-ca.pem`.
 
 ## Removal
 

--- a/.claude/skills/add-ytdlp/SKILL.md
+++ b/.claude/skills/add-ytdlp/SKILL.md
@@ -92,9 +92,8 @@ For each group that should get video-download capability, merge into `groups/<fo
       "args": ["run", "/app/node_modules/@kevinwatt/yt-dlp-mcp/lib/index.mjs"],
       "env": {
         "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
-        "SSL_CERT_FILE": "/tmp/onecli-combined-ca.pem",
-        "REQUESTS_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
-        "CURL_CA_BUNDLE": "/tmp/onecli-combined-ca.pem"
+        "NO_PROXY": "*",
+        "no_proxy": "*"
       }
     }
   }
@@ -103,16 +102,15 @@ For each group that should get video-download capability, merge into `groups/<fo
 
 `YTDLP_DOWNLOADS_DIR` redirects downloads from the package's default `~/Downloads` (which doesn't exist in the container) to the existing session tmp path, swept periodically by `mcp__nanoclaw__send_file` consumers.
 
-The three `*_CA_*` vars point yt-dlp at OneCLI's combined CA bundle so it trusts the gateway's self-signed cert when traffic is intercepted. OneCLI sets `SSL_CERT_FILE` at the container level, but the MCP SDK's stdio transport strips most env vars when spawning MCP server children (only `HOME, LOGNAME, PATH, SHELL, TERM, USER` propagate by default) — so we re-inject them explicitly here. Without these, yt-dlp fails with `CERTIFICATE_VERIFY_FAILED` against the OneCLI-injected cert, even on plain YouTube. yt-dlp's network paths look at different vars (`SSL_CERT_FILE` for stdlib `ssl`, `REQUESTS_CA_BUNDLE` for `requests`/urllib3, `CURL_CA_BUNDLE` for any curl fallback), so all three are set. The bundle file is mounted by OneCLI at `/tmp/onecli-combined-ca.pem`.
+`NO_PROXY=*` makes yt-dlp bypass OneCLI's HTTPS_PROXY for every host. Without it, OneCLI intercepts YouTube traffic with its self-signed CA, and yt-dlp rejects the cert because its standalone PyInstaller binary uses certifi's *bundled* CA store — which lives inside the binary and ignores `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`. There's no env-var path to teach this binary to trust OneCLI's CA; only `--ca-certificate` (CLI flag, which the MCP wrapper doesn't expose) or `--no-check-certificate` would work. Bypassing the proxy is the right call anyway: yt-dlp is fetching public video from YouTube/Vimeo/etc., not a credentialed API, so there's nothing for OneCLI to inject. Both upper and lower case are set because Python's stdlib checks `NO_PROXY` while some libraries check `no_proxy`.
 
-Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)) — keep the three CA-bundle vars from the block above:
+Optional env overrides (see [package config docs](https://github.com/kevinwatt/yt-dlp-mcp/blob/main/docs/configuration.md)) — keep the proxy-bypass vars from the block above:
 
 ```jsonc
 "env": {
   "YTDLP_DOWNLOADS_DIR": "/workspace/agent/tmp",
-  "SSL_CERT_FILE": "/tmp/onecli-combined-ca.pem",
-  "REQUESTS_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
-  "CURL_CA_BUNDLE": "/tmp/onecli-combined-ca.pem",
+  "NO_PROXY": "*",
+  "no_proxy": "*",
   "YTDLP_DEFAULT_RESOLUTION": "1080p",      // 480p | 720p | 1080p | best (default 720p)
   "YTDLP_DEFAULT_SUBTITLE_LANG": "en"        // default subtitle language
 }
@@ -143,7 +141,7 @@ Common signals:
 - `Cannot find module '@kevinwatt/yt-dlp-mcp'` → `bun.lock` wasn't updated, or the image was built before the lockfile change. Re-run `bun add` then rebuild.
 - Agent says "I don't have download tools" → group's `container.json` is missing the `mcpServers["yt-dlp"]` entry, or the host wasn't restarted.
 - Download succeeds but `mcp__nanoclaw__send_file` fails to find the file → check `YTDLP_DOWNLOADS_DIR` matches what `send_file` is given. Default `/workspace/agent/tmp` is the safe choice.
-- `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → the three `*_CA_*` env vars in Phase 4 weren't applied. OneCLI's gateway is intercepting HTTPS with its own CA, but the MCP SDK strips `SSL_CERT_FILE` when spawning the MCP child. Re-check the `env` block has all three CA-bundle entries pointing at `/tmp/onecli-combined-ca.pem`.
+- `CERTIFICATE_VERIFY_FAILED` / `SSL: certificate verify failed` (even on plain YouTube URLs) → `NO_PROXY=*` from Phase 4 isn't in the env. OneCLI's gateway is intercepting HTTPS with its self-signed CA, and the standalone yt-dlp binary uses certifi's bundled CA store (inside the PyInstaller binary, *not* the system store), so it has no way to trust OneCLI's CA. The fix is to bypass the proxy entirely, not to teach yt-dlp the cert. Re-check the `env` block has both `NO_PROXY` and `no_proxy` set to `*`.
 
 ## Removal
 

--- a/container/agent-runner/src/yt-dlp-mcp/server.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/server.ts
@@ -1,0 +1,66 @@
+/**
+ * yt-dlp MCP server — wraps the yt-dlp CLI as a stdio MCP server.
+ *
+ * Curated tool surface (search, metadata, video download, audio download).
+ * The yt-dlp binary is installed by the /add-ytdlp skill (Dockerfile patch).
+ *
+ * Per-group opt-in: a group enables this server by adding an
+ * `mcpServers["yt-dlp"]` entry to its container.json with
+ *   command: "bun", args: ["run", "/app/src/yt-dlp-mcp/server.ts"].
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { fail } from './spawn.js';
+import { downloadAudioHandler, downloadAudioTool } from './tools/download-audio.js';
+import { downloadVideoHandler, downloadVideoTool } from './tools/download-video.js';
+import { metadataHandler, metadataTool } from './tools/metadata.js';
+import { searchHandler, searchTool } from './tools/search.js';
+
+const TOOLS: Array<{ tool: Tool; handler: (a: Record<string, unknown>) => Promise<CallToolResult> }> = [
+  { tool: searchTool, handler: searchHandler },
+  { tool: metadataTool, handler: metadataHandler },
+  { tool: downloadVideoTool, handler: downloadVideoHandler },
+  { tool: downloadAudioTool, handler: downloadAudioHandler },
+];
+
+export async function startYtDlpMcpServer(): Promise<void> {
+  const server = new Server(
+    { name: 'yt-dlp', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS.map((t) => t.tool),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const found = TOOLS.find((t) => t.tool.name === name);
+    if (!found) return fail(`Unknown tool: ${name}`);
+    try {
+      return await found.handler(args ?? {});
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return fail(`${name}: unhandled exception: ${msg}`);
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(
+    `[yt-dlp-mcp] started with ${TOOLS.length} tools: ${TOOLS.map((t) => t.tool.name).join(', ')}`,
+  );
+}
+
+if (import.meta.main) {
+  startYtDlpMcpServer().catch((e) => {
+    console.error(`[yt-dlp-mcp] fatal: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  });
+}

--- a/container/agent-runner/src/yt-dlp-mcp/spawn.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/spawn.ts
@@ -1,0 +1,59 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export interface YtDlpResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+  timedOut: boolean;
+}
+
+const DEFAULT_TIMEOUT_SEC = 1200;
+
+export async function runYtDlp(
+  args: string[],
+  opts: { timeoutSec?: number } = {},
+): Promise<YtDlpResult> {
+  const timeoutSec = opts.timeoutSec ?? DEFAULT_TIMEOUT_SEC;
+  const proc = Bun.spawn(['yt-dlp', ...args], {
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try { proc.kill('SIGKILL'); } catch { /* already exited */ }
+  }, timeoutSec * 1000);
+
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  clearTimeout(timer);
+
+  return { stdout, stderr, code, timedOut };
+}
+
+export function ok(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+export function okJson(payload: object): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: true, ...payload }) }] };
+}
+
+export function fail(error: string): CallToolResult {
+  console.error(`[yt-dlp-mcp] ${error}`);
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ ok: false, error }) }],
+    isError: true,
+  };
+}
+
+export function tailStderr(s: string, max = 500): string {
+  const trimmed = s.trim();
+  if (trimmed.length <= max) return trimmed;
+  return '...' + trimmed.slice(-max);
+}

--- a/container/agent-runner/src/yt-dlp-mcp/tools/download-audio.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/tools/download-audio.ts
@@ -1,0 +1,91 @@
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { fail, okJson, runYtDlp, tailStderr } from '../spawn.js';
+
+export const downloadAudioTool: Tool = {
+  name: 'ytdlp_download_audio',
+  description:
+    'Download audio. First attempt (when format=mp3, the default): extract to mp3 (requires ffmpeg on PATH). Fallback on failure: best native audio (no transcoding) — typically m4a/webm/opus. Returns the saved file path; chain with mcp__nanoclaw__send_file to deliver.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Video URL.' },
+      format: {
+        type: 'string',
+        enum: ['mp3', 'best'],
+        description: 'mp3 (transcoded, needs ffmpeg) or best (native, no transcoding). Default mp3.',
+      },
+      outputDir: {
+        type: 'string',
+        description: 'Override output directory. Defaults to $YTDLP_DOWNLOADS_DIR or /tmp.',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+export async function downloadAudioHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const url = String(args.url ?? '').trim();
+  if (!url) return fail('url is required');
+  const format = String(args.format ?? 'mp3');
+  if (format !== 'mp3' && format !== 'best') {
+    return fail(`Unsupported format: ${format}. Use mp3 | best.`);
+  }
+  const outputDir = String(args.outputDir ?? process.env.YTDLP_DOWNLOADS_DIR ?? '/tmp');
+
+  if (format === 'best') {
+    const r = await runDownload(url, outputDir, false);
+    if (r.ok) return okJson({ path: r.path, format: 'native', container: extOf(r.path), fallback: false });
+    return fail(`yt-dlp audio download failed: ${tailStderr(r.stderr)}`);
+  }
+
+  // mp3: try transcoding, fall back to native best on failure.
+  const mp3 = await runDownload(url, outputDir, true);
+  if (mp3.ok) return okJson({ path: mp3.path, format: 'mp3', container: 'mp3', fallback: false });
+
+  const native = await runDownload(url, outputDir, false);
+  if (native.ok) {
+    return okJson({
+      path: native.path,
+      format: 'native',
+      container: extOf(native.path),
+      fallback: true,
+      mp3_failure: tailStderr(mp3.stderr, 200),
+    });
+  }
+  return fail(`yt-dlp audio download failed (mp3 + native both errored): ${tailStderr(native.stderr)}`);
+}
+
+interface RunSuccess { ok: true; path: string; }
+interface RunFailure { ok: false; stderr: string; code: number; }
+
+async function runDownload(
+  url: string,
+  outputDir: string,
+  asMp3: boolean,
+): Promise<RunSuccess | RunFailure> {
+  const args = [
+    '-f', 'bestaudio',
+    '-o', `${outputDir}/yt-%(id)s.%(ext)s`,
+    '--no-progress',
+    '--no-warnings',
+    '--no-playlist',
+    '--print', 'after_move:filepath',
+  ];
+  if (asMp3) args.push('-x', '--audio-format', 'mp3', '--audio-quality', '0');
+  args.push(url);
+
+  const result = await runYtDlp(args, { timeoutSec: 900 });
+  if (result.timedOut) return { ok: false, stderr: 'timed out', code: -1 };
+  if (result.code !== 0) return { ok: false, stderr: result.stderr, code: result.code };
+
+  const lines = result.stdout.trim().split('\n').filter(Boolean);
+  const path = lines[lines.length - 1] ?? '';
+  if (!path) return { ok: false, stderr: 'no output filepath printed', code: 0 };
+  return { ok: true, path };
+}
+
+function extOf(path: string): string {
+  const dot = path.lastIndexOf('.');
+  return dot === -1 ? '' : path.slice(dot + 1);
+}

--- a/container/agent-runner/src/yt-dlp-mcp/tools/download-video.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/tools/download-video.ts
@@ -9,10 +9,18 @@ const RESOLUTION_HEIGHT: Record<string, number | undefined> = {
   best: undefined,
 };
 
+const CODEC_VFILTER: Record<string, string> = {
+  h264: '[vcodec~="^avc1"]',
+  h265: '[vcodec~="^(hev1|hvc1)"]',
+  av1: '[vcodec~="^av01"]',
+  vp9: '[vcodec~="^(vp9|vp09)"]',
+  any: '',
+};
+
 export const downloadVideoTool: Tool = {
   name: 'ytdlp_download_video',
   description:
-    'Download a video. First attempt: mp4 (merged with m4a audio). Fallback on failure: best quality available in any container. Returns the saved file path; chain with mcp__nanoclaw__send_file to deliver.',
+    'Download a video. First attempt: mp4 with the requested codec (default H.264 for broad playback compatibility). Fallback on failure: best quality available in any container/codec. Returns the saved file path; chain with mcp__nanoclaw__send_file to deliver.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -21,6 +29,12 @@ export const downloadVideoTool: Tool = {
         type: 'string',
         enum: ['480p', '720p', '1080p', 'best'],
         description: 'Max height. Default best.',
+      },
+      codec: {
+        type: 'string',
+        enum: ['h264', 'h265', 'av1', 'vp9', 'any'],
+        description:
+          'Preferred video codec. Default h264 (avc1) — widest playback compatibility (QuickTime, iOS, WhatsApp, etc.). Use "any" to skip codec filtering.',
       },
       outputDir: {
         type: 'string',
@@ -47,22 +61,27 @@ export async function downloadVideoHandler(args: Record<string, unknown>): Promi
   if (!(resolution in RESOLUTION_HEIGHT)) {
     return fail(`Unsupported resolution: ${resolution}. Use 480p | 720p | 1080p | best.`);
   }
+  const codec = String(args.codec ?? 'h264');
+  if (!(codec in CODEC_VFILTER)) {
+    return fail(`Unsupported codec: ${codec}. Use h264 | h265 | av1 | vp9 | any.`);
+  }
   const outputDir = String(args.outputDir ?? process.env.YTDLP_DOWNLOADS_DIR ?? '/tmp');
   const trim = parseTrim(args.trim);
   if (trim && 'error' in trim) return fail(trim.error);
 
   const height = RESOLUTION_HEIGHT[resolution];
   const heightFilter = height ? `[height<=${height}]` : '';
-  const mp4Format = `bv*[ext=mp4]${heightFilter}+ba[ext=m4a]/b[ext=mp4]${heightFilter}`;
+  const codecFilter = CODEC_VFILTER[codec];
+  const mp4Format = `bv*[ext=mp4]${codecFilter}${heightFilter}+ba[ext=m4a]/b[ext=mp4]${codecFilter}${heightFilter}`;
   const fallbackFormat = height ? `bv*${heightFilter}+ba/b${heightFilter}` : 'bv*+ba/b';
 
   // First attempt: mp4 container.
   const mp4 = await runDownload(url, mp4Format, outputDir, true, trim ?? undefined);
   if (mp4.ok) {
-    return okJson({ path: mp4.path, format: 'mp4', container: extOf(mp4.path), fallback: false });
+    return okJson({ path: mp4.path, format: 'mp4', codec, container: extOf(mp4.path), fallback: false });
   }
 
-  // Fallback: best quality, any container.
+  // Fallback: best quality, any container/codec.
   const best = await runDownload(url, fallbackFormat, outputDir, false, trim ?? undefined);
   if (best.ok) {
     return okJson({

--- a/container/agent-runner/src/yt-dlp-mcp/tools/download-video.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/tools/download-video.ts
@@ -1,0 +1,125 @@
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { fail, okJson, runYtDlp, tailStderr } from '../spawn.js';
+
+const RESOLUTION_HEIGHT: Record<string, number | undefined> = {
+  '480p': 480,
+  '720p': 720,
+  '1080p': 1080,
+  best: undefined,
+};
+
+export const downloadVideoTool: Tool = {
+  name: 'ytdlp_download_video',
+  description:
+    'Download a video. First attempt: mp4 (merged with m4a audio). Fallback on failure: best quality available in any container. Returns the saved file path; chain with mcp__nanoclaw__send_file to deliver.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Video URL.' },
+      resolution: {
+        type: 'string',
+        enum: ['480p', '720p', '1080p', 'best'],
+        description: 'Max height. Default best.',
+      },
+      outputDir: {
+        type: 'string',
+        description: 'Override output directory. Defaults to $YTDLP_DOWNLOADS_DIR or /tmp.',
+      },
+      trim: {
+        type: 'object',
+        description: 'Optional segment to download.',
+        properties: {
+          start: { type: 'number', description: 'Start in seconds.' },
+          end: { type: 'number', description: 'End in seconds.' },
+        },
+        required: ['start', 'end'],
+      },
+    },
+    required: ['url'],
+  },
+};
+
+export async function downloadVideoHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const url = String(args.url ?? '').trim();
+  if (!url) return fail('url is required');
+  const resolution = String(args.resolution ?? 'best');
+  if (!(resolution in RESOLUTION_HEIGHT)) {
+    return fail(`Unsupported resolution: ${resolution}. Use 480p | 720p | 1080p | best.`);
+  }
+  const outputDir = String(args.outputDir ?? process.env.YTDLP_DOWNLOADS_DIR ?? '/tmp');
+  const trim = parseTrim(args.trim);
+  if (trim && 'error' in trim) return fail(trim.error);
+
+  const height = RESOLUTION_HEIGHT[resolution];
+  const heightFilter = height ? `[height<=${height}]` : '';
+  const mp4Format = `bv*[ext=mp4]${heightFilter}+ba[ext=m4a]/b[ext=mp4]${heightFilter}`;
+  const fallbackFormat = height ? `bv*${heightFilter}+ba/b${heightFilter}` : 'bv*+ba/b';
+
+  // First attempt: mp4 container.
+  const mp4 = await runDownload(url, mp4Format, outputDir, true, trim ?? undefined);
+  if (mp4.ok) {
+    return okJson({ path: mp4.path, format: 'mp4', container: extOf(mp4.path), fallback: false });
+  }
+
+  // Fallback: best quality, any container.
+  const best = await runDownload(url, fallbackFormat, outputDir, false, trim ?? undefined);
+  if (best.ok) {
+    return okJson({
+      path: best.path,
+      format: 'best',
+      container: extOf(best.path),
+      fallback: true,
+      mp4_failure: tailStderr(mp4.stderr, 200),
+    });
+  }
+  return fail(`yt-dlp download failed (mp4 + fallback both errored): ${tailStderr(best.stderr)}`);
+}
+
+interface RunSuccess { ok: true; path: string; }
+interface RunFailure { ok: false; stderr: string; code: number; }
+
+async function runDownload(
+  url: string,
+  format: string,
+  outputDir: string,
+  mergeMp4: boolean,
+  trim: { start: number; end: number } | undefined,
+): Promise<RunSuccess | RunFailure> {
+  const args = [
+    '-f', format,
+    '-o', `${outputDir}/yt-%(id)s.%(ext)s`,
+    '--no-progress',
+    '--no-warnings',
+    '--no-playlist',
+    '--print', 'after_move:filepath',
+  ];
+  if (mergeMp4) args.push('--merge-output-format', 'mp4');
+  if (trim) args.push('--download-sections', `*${trim.start}-${trim.end}`);
+  args.push(url);
+
+  const result = await runYtDlp(args, { timeoutSec: 1800 });
+  if (result.timedOut) return { ok: false, stderr: 'timed out', code: -1 };
+  if (result.code !== 0) return { ok: false, stderr: result.stderr, code: result.code };
+
+  const lines = result.stdout.trim().split('\n').filter(Boolean);
+  const path = lines[lines.length - 1] ?? '';
+  if (!path) return { ok: false, stderr: 'no output filepath printed', code: 0 };
+  return { ok: true, path };
+}
+
+function parseTrim(raw: unknown): { start: number; end: number } | { error: string } | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== 'object') return { error: 'trim must be an object {start, end}' };
+  const t = raw as Record<string, unknown>;
+  const start = Number(t.start);
+  const end = Number(t.end);
+  if (!Number.isFinite(start) || start < 0) return { error: 'trim.start must be >= 0' };
+  if (!Number.isFinite(end) || end <= start) return { error: 'trim.end must be > trim.start' };
+  return { start, end };
+}
+
+function extOf(path: string): string {
+  const dot = path.lastIndexOf('.');
+  return dot === -1 ? '' : path.slice(dot + 1);
+}

--- a/container/agent-runner/src/yt-dlp-mcp/tools/metadata.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/tools/metadata.ts
@@ -1,0 +1,92 @@
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { fail, ok, runYtDlp, tailStderr } from '../spawn.js';
+import { truncateForAi } from '../truncate.js';
+
+interface VideoMetadata {
+  id?: string;
+  title?: string;
+  channel?: string;
+  uploader?: string;
+  duration?: number;
+  view_count?: number;
+  like_count?: number;
+  upload_date?: string;
+  description?: string;
+  webpage_url?: string;
+  thumbnail?: string;
+  tags?: string[];
+}
+
+export const metadataTool: Tool = {
+  name: 'ytdlp_get_metadata',
+  description:
+    'Fetch video metadata for a URL. Returns the full yt-dlp JSON by default, or a compact human-readable block if `summary: true`.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Video URL.' },
+      summary: {
+        type: 'boolean',
+        description: 'Return a compact summary instead of full JSON. Default false.',
+      },
+      maxChars: {
+        type: 'number',
+        description: 'Truncate output above this many characters. Default 8000.',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+export async function metadataHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const url = String(args.url ?? '').trim();
+  if (!url) return fail('url is required');
+  const summary = Boolean(args.summary ?? false);
+  const maxChars = Math.max(500, Math.floor(Number(args.maxChars ?? 8000)));
+
+  const result = await runYtDlp(
+    ['--dump-single-json', '--no-playlist', '--no-warnings', url],
+    { timeoutSec: 60 },
+  );
+
+  if (result.timedOut) return fail('yt-dlp metadata timed out');
+  if (result.code !== 0) {
+    return fail(`yt-dlp metadata failed (exit ${result.code}): ${tailStderr(result.stderr)}`);
+  }
+
+  let meta: VideoMetadata;
+  try {
+    meta = JSON.parse(result.stdout);
+  } catch {
+    return fail('yt-dlp returned invalid JSON');
+  }
+
+  const body = summary ? renderSummary(meta) : JSON.stringify(meta, null, 2);
+  return ok(truncateForAi(body, maxChars));
+}
+
+function renderSummary(m: VideoMetadata): string {
+  const channel = m.channel ?? m.uploader ?? '?';
+  const dur = m.duration !== undefined ? `${Math.floor(m.duration / 60)}m ${Math.floor(m.duration % 60)}s` : '?';
+  const views = m.view_count !== undefined ? m.view_count.toLocaleString('en-US') : '?';
+  const likes = m.like_count !== undefined ? m.like_count.toLocaleString('en-US') : '?';
+  const date = m.upload_date ?? '?';
+  const desc = (m.description ?? '').trim().slice(0, 500);
+
+  const lines = [
+    `**${m.title ?? '(untitled)'}**`,
+    `URL: ${m.webpage_url ?? '?'}`,
+    `Channel: ${channel}`,
+    `Duration: ${dur}`,
+    `Views: ${views}  ·  Likes: ${likes}`,
+    `Upload date: ${date}`,
+  ];
+  if (m.tags && m.tags.length > 0) {
+    lines.push(`Tags: ${m.tags.slice(0, 10).join(', ')}`);
+  }
+  if (desc) {
+    lines.push('', 'Description:', desc + (m.description!.length > 500 ? '…' : ''));
+  }
+  return lines.join('\n');
+}

--- a/container/agent-runner/src/yt-dlp-mcp/tools/search.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/tools/search.ts
@@ -1,0 +1,152 @@
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { fail, ok, runYtDlp, tailStderr } from '../spawn.js';
+import { truncateForAi } from '../truncate.js';
+
+interface SearchEntry {
+  id?: string;
+  title?: string;
+  url?: string;
+  webpage_url?: string;
+  channel?: string;
+  uploader?: string;
+  duration?: number;
+  view_count?: number;
+  upload_date?: string;
+}
+
+export const searchTool: Tool = {
+  name: 'ytdlp_search',
+  description:
+    'Search YouTube with pagination and optional filters. Returns markdown by default; pass `format: "json"` for structured entries.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Search query.' },
+      page: { type: 'number', description: '1-based page number. Default 1.' },
+      pageSize: { type: 'number', description: 'Results per page (max 25). Default 10.' },
+      sortBy: {
+        type: 'string',
+        enum: ['relevance', 'date', 'views'],
+        description: 'Sort order. Default relevance (yt-dlp native order).',
+      },
+      minDuration: { type: 'number', description: 'Minimum duration in seconds.' },
+      maxDuration: { type: 'number', description: 'Maximum duration in seconds.' },
+      minViews: { type: 'number', description: 'Minimum view count.' },
+      format: {
+        type: 'string',
+        enum: ['md', 'json'],
+        description: 'Output format. Default md.',
+      },
+      maxChars: {
+        type: 'number',
+        description: 'Truncate output above this many characters. Default 8000.',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+export async function searchHandler(args: Record<string, unknown>): Promise<CallToolResult> {
+  const query = String(args.query ?? '').trim();
+  if (!query) return fail('query is required');
+
+  const page = Math.max(1, Math.floor(Number(args.page ?? 1)));
+  const pageSize = Math.min(25, Math.max(1, Math.floor(Number(args.pageSize ?? 10))));
+  const sortBy = String(args.sortBy ?? 'relevance');
+  const minDuration = num(args.minDuration);
+  const maxDuration = num(args.maxDuration);
+  const minViews = num(args.minViews);
+  const format = String(args.format ?? 'md');
+  const maxChars = Math.max(500, Math.floor(Number(args.maxChars ?? 8000)));
+
+  // Fetch enough to cover up to and including the requested page, then slice.
+  const fetchN = page * pageSize;
+  const result = await runYtDlp(
+    ['--flat-playlist', '--dump-single-json', `ytsearch${fetchN}:${query}`],
+    { timeoutSec: 60 },
+  );
+
+  if (result.timedOut) return fail('yt-dlp search timed out');
+  if (result.code !== 0) {
+    return fail(`yt-dlp search failed (exit ${result.code}): ${tailStderr(result.stderr)}`);
+  }
+
+  let parsed: { entries?: SearchEntry[] };
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return fail('yt-dlp returned invalid JSON');
+  }
+
+  let entries = parsed.entries ?? [];
+
+  entries = entries.filter((e) => {
+    if (minDuration !== undefined && (e.duration ?? 0) < minDuration) return false;
+    if (maxDuration !== undefined && (e.duration ?? Number.POSITIVE_INFINITY) > maxDuration) return false;
+    if (minViews !== undefined && (e.view_count ?? 0) < minViews) return false;
+    return true;
+  });
+
+  if (sortBy === 'views') {
+    entries = entries.slice().sort((a, b) => (b.view_count ?? 0) - (a.view_count ?? 0));
+  } else if (sortBy === 'date') {
+    entries = entries.slice().sort((a, b) => (b.upload_date ?? '').localeCompare(a.upload_date ?? ''));
+  }
+
+  const start = (page - 1) * pageSize;
+  const sliced = entries.slice(start, start + pageSize);
+
+  const body = format === 'json'
+    ? JSON.stringify({ page, pageSize, total: entries.length, entries: sliced }, null, 2)
+    : renderMd(sliced, page, pageSize, entries.length);
+
+  return ok(truncateForAi(body, maxChars));
+}
+
+function renderMd(entries: SearchEntry[], page: number, pageSize: number, total: number): string {
+  if (entries.length === 0) return '_No results._';
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const lines = [
+    `**Search results — page ${page}/${totalPages} (${total} after filters)**`,
+    '',
+  ];
+  for (const e of entries) {
+    const url = e.webpage_url ?? e.url ?? (e.id ? `https://youtu.be/${e.id}` : '');
+    const dur = e.duration !== undefined ? formatDuration(e.duration) : '?';
+    const views = e.view_count !== undefined ? formatViews(e.view_count) : '?';
+    const date = e.upload_date ? formatDate(e.upload_date) : '?';
+    const channel = e.channel ?? e.uploader ?? '?';
+    lines.push(`- [${e.title ?? '(untitled)'}](${url}) — ${channel} · ${dur} · ${views} views · ${date}`);
+  }
+  return lines.join('\n');
+}
+
+function formatDuration(s: number): string {
+  const total = Math.floor(s);
+  const secs = (total % 60).toString().padStart(2, '0');
+  const mins = Math.floor(total / 60);
+  if (mins >= 60) {
+    const h = Math.floor(mins / 60);
+    const m = (mins % 60).toString().padStart(2, '0');
+    return `${h}:${m}:${secs}`;
+  }
+  return `${mins}:${secs}`;
+}
+
+function formatViews(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
+  return String(v);
+}
+
+function formatDate(yyyymmdd: string): string {
+  if (yyyymmdd.length !== 8) return yyyymmdd;
+  return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+}
+
+function num(v: unknown): number | undefined {
+  if (v === undefined || v === null || v === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}

--- a/container/agent-runner/src/yt-dlp-mcp/truncate.ts
+++ b/container/agent-runner/src/yt-dlp-mcp/truncate.ts
@@ -1,0 +1,6 @@
+export function truncateForAi(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const marker = `\n\n…[truncated ${text.length - maxChars} chars]`;
+  const slice = Math.max(0, maxChars - marker.length);
+  return text.slice(0, slice) + marker;
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
  ## Type of Change

  - [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
  - [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
  - [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
  - [ ] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code
  - [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

  ## Description

  Adds `/add-ytdlp` — installs yt-dlp (search YouTube, fetch metadata, download video/audio from YouTube, Vimeo, X, TikTok, ~1000 other sites) as an MCP tool for agent groups.

  Two pieces:

  1. **Install skill** (`.claude/skills/add-ytdlp/SKILL.md`) — patches `container/Dockerfile` to install the standalone PyInstaller yt-dlp binary (~30MB, no Python on PATH needed, pinned via `YTDLP_VERSION`
  arg), then wires the in-tree MCP server into selected agent groups' `container.json` under `mcpServers`. Idempotent install/removal with anchored Dockerfile blocks.

  2. **In-tree MCP server** (`container/agent-runner/src/yt-dlp-mcp/`) — stdio transport, spawned by Bun directly off the source bind mount,
Curated 4-tool surface tuned for chat agents:
     - `ytdlp_search` — paginated search with sort/duration/views filters, md or json output, `maxChars` cap
     - `ytdlp_get_metadata` — full json or compact summary, `maxChars` cap
     - `ytdlp_download_video` — mp4/H.264 (avc1) default for broad device compatibility, falls back to best-quality on failure
     - `ytdlp_download_audio` — mp3 default via ffmpeg, falls back to native bestaudio if ffmpeg missing or transcode fails

  `YTDLP_DOWNLOADS_DIR` defaults to `/tmp` so downloaded files are ready for `mcp__nanoclaw__send_file`.

  ## For Skills

  - [x] SKILL.md contains instructions, not inline code (code goes in separate files)
  - [x] SKILL.md is under 500 lines
  - [ ] I tested this skill on a fresh clone