### PR TITLE
fix(chat-sdk-bridge): fall back to raw text on invalid_blocks

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -190,6 +190,40 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('retries as raw text when postMessage throws invalid_blocks', async () => {
+    let attempt = 0;
+    const postMessage = async (_threadId: string, message: AdapterPostableMessage): Promise<RawMessage<unknown>> => {
+      attempt++;
+      if (attempt === 1 && typeof message === 'object' && 'markdown' in message) {
+        throw new Error('An API error occurred: invalid_blocks');
+      }
+      return { id: 'msg-fallback', threadId: _threadId, raw: {} };
+    };
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ postMessage }),
+      supportsThreads: false,
+    });
+    const id = await bridge.deliver('slack:chan', null, {
+      kind: 'chat-sdk',
+      content: { text: 'table | content' },
+    });
+    expect(id).toBe('msg-fallback');
+    expect(attempt).toBe(2);
+  });
+
+  it('does not catch non-invalid_blocks errors', async () => {
+    const postMessage = async (): Promise<RawMessage<unknown>> => {
+      throw new Error('An API error occurred: channel_not_found');
+    };
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ postMessage }),
+      supportsThreads: false,
+    });
+    await expect(
+      bridge.deliver('slack:chan', null, { kind: 'chat-sdk', content: { text: 'hello' } }),
+    ).rejects.toThrow('channel_not_found');
+  });
+
   it('falls through to the text branch for non-card chat-sdk payloads (no regression)', async () => {
     const { calls, postMessage } = makePostCapture();
     const bridge = createChatSdkBridge({

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -119,6 +119,31 @@ export function splitForLimit(text: string, limit: number): string[] {
   return chunks;
 }
 
+function isInvalidBlocksError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes('invalid_blocks');
+}
+
+async function postWithFallback(
+  adapter: Adapter,
+  tid: string,
+  markdownMsg: { markdown: string; files?: { data: Buffer; filename: string }[] },
+  rawText: string,
+): Promise<{ id?: string } | undefined> {
+  try {
+    return await adapter.postMessage(tid, markdownMsg);
+  } catch (err) {
+    if (isInvalidBlocksError(err)) {
+      log.warn('postMessage got invalid_blocks, retrying as raw text', { tid });
+      return await adapter.postMessage(
+        tid,
+        markdownMsg.files ? { raw: rawText, files: markdownMsg.files } as never : rawText,
+      );
+    }
+    throw err;
+  }
+}
+
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
   const transformText = (t: string): string => (config.transformOutboundText ? config.transformOutboundText(t) : t);
@@ -357,9 +382,17 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       const content = message.content as Record<string, unknown>;
 
       if (content.operation === 'edit' && content.messageId) {
-        await adapter.editMessage(tid, content.messageId as string, {
-          markdown: transformText((content.text as string) || (content.markdown as string) || ''),
-        });
+        const editText = transformText((content.text as string) || (content.markdown as string) || '');
+        try {
+          await adapter.editMessage(tid, content.messageId as string, { markdown: editText });
+        } catch (err) {
+          if (isInvalidBlocksError(err)) {
+            log.warn('editMessage got invalid_blocks, retrying as raw text', { tid });
+            await adapter.editMessage(tid, content.messageId as string, editText);
+          } else {
+            throw err;
+          }
+        }
         return;
       }
 
@@ -473,10 +506,8 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         for (let i = 0; i < chunks.length; i++) {
           const chunk = chunks[i];
           const attachFiles = i === 0 && fileUploads && fileUploads.length > 0;
-          const result = await adapter.postMessage(
-            tid,
-            attachFiles ? { markdown: chunk, files: fileUploads } : { markdown: chunk },
-          );
+          const markdownMsg = attachFiles ? { markdown: chunk, files: fileUploads } : { markdown: chunk };
+          const result = await postWithFallback(adapter, tid, markdownMsg, chunk);
           if (i === 0) firstId = result?.id;
         }
         return firstId;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

When the Slack adapter converts agent markdown to Block Kit JSON and Slack rejects the result with `invalid_blocks`, the delivery layer retries 3x then permanently drops the message. The agent has no idea the send failed — from its perspective the message was delivered.

Common triggers: markdown tables (Block Kit has no native table element), multiple `---` dividers, text blocks exceeding 3000 characters.

### Fix

Catch `invalid_blocks` errors on both `postMessage` and `editMessage` in the Chat SDK bridge, then retry with raw text (bypasses Block Kit conversion entirely). Other errors propagate unchanged into the normal retry path.

The Chat SDK `Adapter.postMessage()` accepts both `{ markdown: string }` (converted to Block Kit) and a plain `string` (passed through as-is). The fallback uses the raw string path.

### How it was tested

- ✅ `pnpm build` — clean
- ✅ `pnpm test` — 259 tests pass (2 new tests added)
- New test: confirms `invalid_blocks` triggers raw-text fallback and succeeds
- New test: confirms non-`invalid_blocks` errors (e.g. `channel_not_found`) still propagate

### Observed failure

```
[21:52:39] ERROR Message delivery failed permanently, giving up
  messageId="msg-1778032358272-a8nbga" sessionId="sess-1777946235465-syx8wd"
  attempts=3 err="An API error occurred: invalid_blocks"
```

The message contained a markdown table (`| Tool | First-try? | Usable? |`) and 6 `---` separators. All 3 attempts failed identically. A subsequent reaction attempt also failed (`message_not_found`) because no message had been delivered to react to.