### PR TITLE
setup: fix Photon homepage URL in iMessage card

### DIFF
--- a/setup/channels/imessage.ts
+++ b/setup/channels/imessage.ts
@@ -247,7 +247,7 @@ async function collectRemoteCreds(): Promise<RemoteCreds> {
       "Photon is a separate service that owns an iMessage account and",
       "exposes it over HTTP. NanoClaw will talk to it via its API.",
       '',
-      '  1. Set up a Photon server: https://photon.im',
+      '  1. Set up a Photon server: https://photon.codes',
       '  2. Copy the server URL and API key from your Photon dashboard',
     ].join('\n'),
     'Remote iMessage via Photon',


### PR DESCRIPTION
## Why

The iMessage remote-mode card points users at \`https://photon.im\`, which resolves to a Dynadot for-sale page (not the Photon project).

## What

Swap the URL to the real Photon homepage: **\`https://photon.codes\`**.

Verified via the \`chat-adapter-imessage\` npm package's repo (\`github.com/photon-hq\`); the org's listed blog URL is \`photon.codes\`, which resolves to a real Photon site.

## Test plan

- [ ] Run setup → iMessage → "Remote (Photon API)". Confirm the card lists \`photon.codes\`.
- [ ] Click/curl the URL and confirm it loads.