### PR TITLE
setup: add back-to-channels exit to "Other…" channel prompt

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -468,7 +468,7 @@ async function main(): Promise<void> {
       } else if (channelChoice === 'imessage') {
         result = await runIMessageChannel(displayName!);
       } else if (channelChoice === 'other') {
-        await askOtherChannelName();
+        result = await askOtherChannelName();
       } else {
         p.log.info(
           brandBody(
@@ -1099,10 +1099,26 @@ async function askChannelChoice(): Promise<ChannelChoice> {
   return choice;
 }
 
-async function askOtherChannelName(): Promise<void> {
+async function askOtherChannelName(): Promise<void | typeof BACK_TO_CHANNEL_SELECTION> {
+  const action = ensureAnswer(
+    await brightSelect<'type' | 'back'>({
+      message: 'Which channel would you like to install?',
+      options: [
+        {
+          value: 'type',
+          label: 'Type the channel name',
+          hint: 'e.g. matrix, github, linear, webex',
+        },
+        { value: 'back', label: '← Back to channel selection' },
+      ],
+      initialValue: 'type',
+    }),
+  );
+  if (action === 'back') return BACK_TO_CHANNEL_SELECTION;
+
   const answer = ensureAnswer(
     await p.text({
-      message: 'Which channel would you like to install?',
+      message: 'Channel name',
       placeholder: 'e.g. matrix, github, linear, webex',
     }),
   );


### PR DESCRIPTION
## Why

After picking "Other…" from the channel picker, today's flow drops the user into a free-text prompt with no way back. If they realize they meant something on the original list (or just want to bail), Ctrl-C is the only option — and that ends setup entirely.

## What

Replace the bare text input with a brightSelect that mirrors the back-affording pattern used in the channel sub-flows:

```
◆  Which channel would you like to install?
│  ● Type the channel name      e.g. matrix, github, linear, webex
│    ← Back to channel selection
```

Picking "Type" shows the existing text input; picking "Back" returns \`BACK_TO_CHANNEL_SELECTION\` so the user lands at the channel picker without setup aborting.

## Test plan

- [ ] Run setup → pick "Other…" → confirm the new picker appears.
- [ ] Pick "Type the channel name" → enter \`matrix\` → confirm the existing post-install hint renders.
- [ ] Pick "← Back to channel selection" → confirm you land back at the channel picker.