### PR TITLE
fix(add-karpathy-llm-wiki): v2 compatibility — schedule_task MCP + remove build step

### DIFF
--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -71,7 +71,7 @@ AskUserQuestion: "Want periodic wiki health checks?"
 2. **Monthly**
 3. **Skip** — lint manually
 
-If yes, ask the agent to schedule the lint task using the `schedule_task` MCP tool in conversation. No direct DB insertion needed.
+If yes, ask the agent to schedule the lint task using the `schedule_task` MCP tool in conversation.
 
 ## Step 6: Restart
 

--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -71,38 +71,11 @@ AskUserQuestion: "Want periodic wiki health checks?"
 2. **Monthly**
 3. **Skip** — lint manually
 
-If yes, create a NanoClaw scheduled task that runs in the wiki group. This is NOT a Claude Code cron job — it's a NanoClaw group task that runs in the agent container. Insert it into the SQLite database:
+If yes, ask the agent to schedule the lint task using the `schedule_task` MCP tool in conversation. No direct DB insertion needed.
+
+## Step 6: Restart
 
 ```bash
-pnpm exec tsx -e "
-const Database = require('better-sqlite3');
-const { CronExpressionParser } = require('cron-parser');
-const db = new Database('store/messages.db');
-const interval = CronExpressionParser.parse('<cron-expr>', { tz: process.env.TZ || 'UTC' });
-const nextRun = interval.next().toISOString();
-db.prepare('INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').run(
-  'wiki-lint',
-  '<group_folder>',
-  '<chat_jid>',
-  'Run a wiki lint pass per the wiki container skill. Check for contradictions, orphan pages, stale content, missing cross-references, and gaps. Report findings and offer to fix issues.',
-  'cron',
-  '<cron-expr>',
-  'group',
-  nextRun,
-  'active',
-  new Date().toISOString()
-);
-db.close();
-"
-```
-
-Use the group's `folder` and `chat_jid` from the registered groups table. Cron expressions: `0 10 * * 0` (weekly Sunday 10am) or `0 10 1 * *` (monthly 1st at 10am).
-
-## Step 6: Build and restart
-
-```bash
-pnpm run build
-./container/build.sh
 launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
 # Linux: systemctl --user restart nanoclaw
 ```


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Two v2-breaking steps in `/add-karpathy-llm-wiki`:

**Step 5 — SQLite insertion into non-existent table**
The skill writes directly into `store/messages.db` → `scheduled_tasks`. That table doesn't exist in v2 — scheduled tasks are stored as `messages_in` rows in per-session inbound DBs. Replaced the raw SQL block with an instruction to use the `schedule_task` MCP tool, which is the correct v2 path.

**Step 6 — Unnecessary build commands**
The skill ran `pnpm run build` and `./container/build.sh` before restarting. These aren't needed for a skill/config change and fail on most user setups. Kept only the service restart.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone