### PR TITLE
setup: add "Skip — I'll connect later" option to Claude auth picker

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -740,11 +740,37 @@ async function runAuthStep(): Promise<void> {
           label: 'Paste an Anthropic API key',
           hint: 'pay-per-use via console.anthropic.com',
         },
+        {
+          value: 'skip',
+          label: "Skip — I'll connect later",
+          hint: 'not recommended — Claude helps debug setup issues',
+        },
       ],
     }),
-  ) as 'subscription' | 'oauth' | 'api';
+  ) as 'subscription' | 'oauth' | 'api' | 'skip';
   setupLog.userInput('auth_method', method);
   phEmit('auth_method_chosen', { method });
+
+  if (method === 'skip') {
+    const confirmed = ensureAnswer(
+      await p.confirm({
+        message:
+          "Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.",
+        initialValue: false,
+      }),
+    );
+    if (!confirmed) {
+      // Loop back to the auth picker so they can choose a real method.
+      return runAuthStep();
+    }
+    setupLog.step('auth', 'skipped', 0, { REASON: 'user-skipped' });
+    p.log.warn(
+      brandBody(
+        'Claude sign-in skipped. Re-run setup or run `bash nanoclaw.sh` to finish later.',
+      ),
+    );
+    return;
+  }
 
   if (method === 'subscription') {
     await runSubscriptionAuth();


### PR DESCRIPTION
## Why

The Claude auth picker has three real-auth options today (subscription / OAuth / API key) and no graceful escape. Anyone without one of those — most non-technical users when they first land in setup — gets stuck: Ctrl-C kills the whole flow, and the dev-only \`NANOCLAW_SKIP=auth\` env hatch isn't surfaced.

## What

Add a fourth option that's gated by an explicit confirm:

```
◆  How would you like to connect to Claude?
│  ● Sign in with my Claude subscription   recommended if you have Pro or Max
│    Paste an OAuth token I already have   sk-ant-oat…
│    Paste an Anthropic API key            pay-per-use via console.anthropic.com
│    Skip — I'll connect later             not recommended — Claude helps debug setup issues
```

If the user picks Skip, a confirm fires (default = No):
> Skip Claude sign-in? The agent won't be able to run until you connect, and we won't be able to help debug setup errors.

- **Yes** → log \`auth: skipped\`, warn, continue setup. The verify step already prints "Your Claude account isn't connected" so the success card is honest.
- **No** → loop back to the auth picker.

The hint flags it's not recommended, and the confirm spells out both consequences (agent can't run, no Claude-assisted debugging).

## Test plan

- [ ] Run setup → auth picker → Skip → No: confirm picker re-renders.
- [ ] Run setup → auth picker → Skip → Yes: confirm setup continues and verify-step note flags missing credentials.