### PR TITLE
fix: inject destination reminder after SDK auto-compaction

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -91,7 +91,115 @@ describe('poll loop integration', () => {
 
     await loopPromise.catch(() => {});
   });
+
+  it('should inject destination reminder after a compacted event', async () => {
+    // Two destinations — required for the reminder to fire (single-destination
+    // groups have a fallback path that works without <message to="…"> wrapping).
+    getInboundDb()
+      .prepare(
+        `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+         VALUES ('discord-second', 'Discord Second', 'channel', 'discord', 'chan-2', NULL)`,
+      )
+      .run();
+
+    insertMessage('m1', { sender: 'Alice', text: 'First message' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new CompactingProvider();
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider as unknown as MockProvider, controller.signal, 2500);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2500);
+    controller.abort();
+
+    expect(provider.pushes.length).toBeGreaterThanOrEqual(1);
+    const reminder = provider.pushes.find((p) => p.includes('Context was just compacted'));
+    expect(reminder).toBeDefined();
+    expect(reminder).toContain('2 destinations');
+    expect(reminder).toContain('discord-test');
+    expect(reminder).toContain('discord-second');
+    expect(reminder).toContain('<message to="name">');
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('should NOT inject destination reminder with a single destination', async () => {
+    insertMessage('m1', { sender: 'Alice', text: 'First message' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new CompactingProvider();
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider as unknown as MockProvider, controller.signal, 2500);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2500);
+    controller.abort();
+
+    // Only the original prompt push (if any) — no reminder, since beforeEach
+    // seeds exactly one destination.
+    const reminders = provider.pushes.filter((p) => p.includes('Context was just compacted'));
+    expect(reminders).toHaveLength(0);
+
+    await loopPromise.catch(() => {});
+  });
 });
+
+/**
+ * Provider that emits a single compacted event mid-stream, then returns a
+ * result. Captures every push() call so tests can assert on the injected
+ * reminder content.
+ */
+class CompactingProvider {
+  readonly supportsNativeSlashCommands = false;
+  readonly pushes: string[] = [];
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query(_input: { prompt: string; cwd: string }) {
+    const pushes = this.pushes;
+    let ended = false;
+    let aborted = false;
+    let resolveWaiter: (() => void) | null = null;
+
+    async function* events() {
+      yield { type: 'activity' as const };
+      yield { type: 'init' as const, continuation: 'compaction-test-session' };
+      yield { type: 'activity' as const };
+      yield { type: 'compacted' as const, text: 'Context compacted (50,000 tokens compacted).' };
+
+      // Wait for poll-loop to push the reminder (or end / abort)
+      await new Promise<void>((resolve) => {
+        resolveWaiter = resolve;
+        // Belt-and-braces: don't hang forever if the reminder never arrives
+        setTimeout(resolve, 200);
+      });
+
+      yield { type: 'activity' as const };
+      yield { type: 'result' as const, text: '<message to="discord-test">ack</message>' };
+      while (!ended && !aborted) {
+        await new Promise<void>((resolve) => {
+          resolveWaiter = resolve;
+          setTimeout(resolve, 50);
+        });
+      }
+    }
+
+    return {
+      push(message: string) {
+        pushes.push(message);
+        resolveWaiter?.();
+      },
+      end() {
+        ended = true;
+        resolveWaiter?.();
+      },
+      abort() {
+        aborted = true;
+        resolveWaiter?.();
+      },
+      events: events(),
+    };
+  }
+}
 
 // Helper: run poll loop until aborted or timeout
 async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -366,6 +366,23 @@ async function processQuery(
         if (event.text) {
           dispatchResultText(event.text, routing);
         }
+      } else if (event.type === 'compacted') {
+        // The SDK auto-compacted the conversation. After compaction the
+        // model often drops the learned `<message to="…">` wrapping
+        // discipline (the destinations are still in the system prompt,
+        // but the behavioral pattern is summarized away). Inject a
+        // reminder back into the live query so the next turn re-anchors
+        // on the destination model. Only do this when there's >1
+        // destination — single-destination groups have a fallback that
+        // works without wrapping. See qwibitai/nanoclaw#2325.
+        const destinations = getAllDestinations();
+        if (destinations.length > 1) {
+          const names = destinations.map((d) => d.name).join(', ');
+          query.push(
+            `[system] Context was just compacted. Reminder: you have ${destinations.length} destinations (${names}). ` +
+              `Use <message to="name"> blocks to address them. Bare text goes to the scratchpad fallback only.`,
+          );
+        }
       }
     }
   } finally {
@@ -389,6 +406,9 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
       break;
     case 'progress':
       log(`Progress: ${event.message}`);
+      break;
+    case 'compacted':
+      log(`Compacted: ${event.text}`);
       break;
   }
 }

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -329,7 +329,7 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
           const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';
-          yield { type: 'result', text: `Context compacted${detail}.` };
+          yield { type: 'compacted', text: `Context compacted${detail}.` };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
           const tn = message as { summary?: string };
           yield { type: 'progress', message: tn.summary || 'Task notification' };

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -79,4 +79,12 @@ export type ProviderEvent =
    * event (tool call, thinking, partial message, anything) so the
    * poll-loop's idle timer stays honest during long tool runs.
    */
-  | { type: 'activity' };
+  | { type: 'activity' }
+  /**
+   * The provider's underlying SDK auto-compacted the conversation context.
+   * The poll-loop reacts by injecting a destination reminder back into
+   * the live query so the agent doesn't drop `<message to="…">` wrapping
+   * after compaction. Distinct from `result` so it doesn't mark the turn
+   * completed or get dispatched as a chat message. See qwibitai/nanoclaw#2325.
+   */
+  | { type: 'compacted'; text: string };


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2325.

After SDK auto-compaction, agents in multi-destination groups would lose the `<message to="...">` wrapping pattern — the compacted summary preserves the destination list in the system prompt but not the habitual use of blocks. This caused bare-text output to fall through to the scratchpad fallback and get self-routed as A2A.

**What this does:**

1. `providers/types.ts` — adds `{ type: 'compacted'; text: string }` to the `ProviderEvent` union. Keeps the event distinct from `result` so it doesn't mark the turn complete or dispatch a chat message.

2. `providers/claude.ts` — `compact_boundary` SDK events now yield `{ type: 'compacted' }` instead of `{ type: 'result' }`. Previously the compaction notification was treated as a completed turn result.

3. `poll-loop.ts` — handles the new `compacted` event: when the group has >1 destinations, pushes a `[system]`-tagged reminder into the active query — _"Context was just compacted. Reminder: you have N destinations (list). Use `<message to="name">` blocks…"_ Single-destination groups skip the push (the simpler fallback path works without wrapping).

4. `integration.test.ts` — two new integration tests using a `CompactingProvider` helper that emits a `compacted` event mid-stream: one covering the multi-destination reminder path, one confirming single-destination groups are not affected.

**Behavior change to note:** The "Context compacted (N tokens compacted)" string no longer appears as a chat message to the user. It is now logged at `[poll-loop]` level. If you rely on that message surfacing in the conversation, this is a visible change.

Commit: `12719be6e15025a47797dae75d64b999d226707f`