### PR TITLE
fix: default reply destination to message origin in multi-destination groups

### DIFF
--- a/container/agent-runner/src/destinations.test.ts
+++ b/container/agent-runner/src/destinations.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { closeSessionDb, getInboundDb, initTestSessionDb } from './db/connection.js';
+import { buildSystemPromptAddendum } from './destinations.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+function seedDestination(name: string, displayName: string, channelType: string, platformId: string): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+       VALUES (?, ?, 'channel', ?, ?, NULL)`,
+    )
+    .run(name, displayName, channelType, platformId);
+}
+
+describe('buildSystemPromptAddendum — multi-destination routing guidance', () => {
+  it('includes default-routing nudge when there are >1 destinations', () => {
+    seedDestination('casa', 'Casa', 'whatsapp', 'group-1@g.us');
+    seedDestination('whatsapp-mg-17780', 'whatsapp-mg-17780', 'whatsapp', 'phone-2@s.whatsapp.net');
+
+    const prompt = buildSystemPromptAddendum('Casa');
+
+    expect(prompt).toContain('Default routing');
+    expect(prompt).toContain('from="name"');
+    expect(prompt).toContain('`casa`');
+    expect(prompt).toContain('`whatsapp-mg-17780`');
+  });
+
+  it('omits the default-routing nudge for a single destination (short-circuited)', () => {
+    seedDestination('casa', 'Casa', 'whatsapp', 'group-1@g.us');
+
+    const prompt = buildSystemPromptAddendum('Casa');
+
+    // Single-destination path uses the simpler "no special wrapping needed" copy
+    expect(prompt).toContain('no special wrapping needed');
+    expect(prompt).not.toContain('Default routing');
+  });
+
+  it('handles the no-destination case without crashing', () => {
+    const prompt = buildSystemPromptAddendum('Casa');
+
+    expect(prompt).toContain('no configured destinations');
+    expect(prompt).not.toContain('Default routing');
+  });
+});

--- a/container/agent-runner/src/destinations.ts
+++ b/container/agent-runner/src/destinations.ts
@@ -129,6 +129,10 @@ function buildDestinationsSection(): string {
   lines.push('Use `<internal>...</internal>` to make scratchpad intent explicit.');
   lines.push('');
   lines.push(
+    '**Default routing**: when replying to an incoming message, address the same destination the message came `from` — every inbound `<message>` tag carries a `from="name"` attribute that names the origin destination. Only address a different destination when the request itself asks you to (e.g., "tell Laura that…").',
+  );
+  lines.push('');
+  lines.push(
     'To send a message mid-response (e.g., an acknowledgment before a long task), call the `send_message` MCP tool with the `to` parameter set to a destination name.',
   );
   return lines.join('\n');


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Discovered while production-validating #2325.

In multi-destination groups, an agent receiving a message had no explicit guidance about which destination to reply to. The system prompt listed all destinations and explained the `<message to="name">` syntax, but didn't state the obvious default: reply to whoever sent the message. In practice this caused agents to occasionally address the wrong destination, or default to the first destination listed, when the expected behavior is to mirror the `from=` attribute of the inbound `<message>` tag.

**What this does:**

Adds one line to `buildDestinationsSection()` in `destinations.ts`:

> **Default routing**: when replying to an incoming message, address the same destination the message came `from` — every inbound `<message>` tag carries a `from="name"` attribute that names the origin destination. Only address a different destination when the request itself asks you to (e.g., "tell Laura that…").

Single-destination groups are unaffected — they take a separate short-circuit path that doesn't include this section.

**Tests:** `destinations.test.ts` (new file) covers three cases: multi-destination (nudge present, both destination names listed), single-destination (nudge absent, simpler copy shown), and no-destination (no crash, no nudge).

**Production note:** Validated in Casa group after deploy + `/clear`. A `/clear` is needed to reset sessions that were initialized before this change — existing sessions anchor their system prompt at start and won't pick up the new copy until cleared.

Commit: `57dad14a0100e51be0b6397dc5c9eb42300780c0`