### PR TITLE
fix(container): make axios MCP servers work through OneCLI's proxy

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -104,6 +104,23 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
+# ---- Vendored axios proxy patch ----------------------------------------------
+# OneCLI's gateway (port 10255) only accepts CONNECT-tunneled HTTPS. axios's
+# built-in HTTPS_PROXY support sends absolute-form HTTP that OneCLI rejects
+# with 400, blocking auth injection for axios-based MCP servers (e.g. the
+# official @notionhq/notion-mcp-server). The preload below monkey-patches
+# axios.defaults.httpsAgent with HttpsProxyAgent at startup, restoring proper
+# CONNECT tunneling. Activated per-MCP-server via
+#   "env": { "NODE_OPTIONS": "--require /app/vendor/axios-onecli-proxy.cjs" }
+# in container.json. Pin exactly — supply-chain policy.
+RUN mkdir -p /app/vendor && cd /app/vendor && \
+    echo '{"private":true,"dependencies":{"https-proxy-agent":"7.0.6"}}' > package.json && \
+    npm install --no-audit --no-fund --silent && \
+    chmod -R a+rX /app/vendor
+
+COPY axios-onecli-proxy.cjs /app/vendor/axios-onecli-proxy.cjs
+RUN chmod a+r /app/vendor/axios-onecli-proxy.cjs
+
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/container/axios-onecli-proxy.cjs
+++ b/container/axios-onecli-proxy.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+// OneCLI's gateway is CONNECT-only. axios's built-in HTTPS_PROXY support sends
+// absolute-form HTTP that the gateway rejects with 400. Patch axios.defaults
+// to use https-proxy-agent (correct CONNECT tunneling) instead.
+
+(() => {
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (!proxyUrl) return;
+
+  let HttpsProxyAgent;
+  try {
+    ({ HttpsProxyAgent } = require(`${__dirname}/node_modules/https-proxy-agent`));
+  } catch (err) {
+    console.error('[axios-onecli-proxy] https-proxy-agent not vendored — patch skipped:', err.message);
+    return;
+  }
+  const agent = new HttpsProxyAgent(proxyUrl);
+
+  const Module = require('module');
+  const origRequire = Module.prototype.require;
+  Module.prototype.require = function patched(id) {
+    const m = origRequire.apply(this, arguments);
+    if (id === 'axios' && m && !m.__nanoclaw_proxy_patched && m.defaults) {
+      m.defaults.httpsAgent = agent;
+      m.defaults.proxy = false;
+      m.__nanoclaw_proxy_patched = true;
+    }
+    return m;
+  };
+})();


### PR DESCRIPTION
## Summary

OneCLI's gateway is **CONNECT-only**, but axios v1.x's built-in `HTTPS_PROXY` support sends absolute-form HTTP requests directly to the proxy port, which OneCLI rejects with HTTP 400 and `connection error: serving HTTP connection`. This silently breaks auth injection for any axios-based MCP server — including [`@notionhq/notion-mcp-server`](https://www.npmjs.com/package/@notionhq/notion-mcp-server), which pins `axios@1.8.4`.

`curl` and Node native `fetch()` (undici) work fine. Only axios is affected, because `NODE_USE_ENV_PROXY=1` only configures undici's `EnvHttpProxyAgent` (used by `fetch`), not Node's `http`/`https` core agents (used by axios).

## Fix

Vendor `https-proxy-agent@7.0.6` under `/app/vendor/` and ship a tiny NODE_OPTIONS preload (`container/axios-onecli-proxy.cjs`) that monkey-patches `axios.defaults.httpsAgent` with `HttpsProxyAgent`, restoring proper CONNECT tunneling.

Opt-in per MCP server in `container.json`:

```json
"vigil-notion": {
  "command": "npx",
  "args": ["-y", "@notionhq/notion-mcp-server"],
  "env": {
    "OPENAPI_MCP_HEADERS": "{\"Notion-Version\":\"2022-06-28\"}",
    "NODE_OPTIONS": "--require /app/vendor/axios-onecli-proxy.cjs"
  }
}
```

Servers that don't set `NODE_OPTIONS` get no behaviour change.

## Verification

End-to-end traced from inside a live container:

- axios via the patched preload → `200 OK` with `x-notion-request-id` from real Notion
- OneCLI gateway log shows `CONNECT host=api.notion.com:443 mode=mitm` followed by `MITM ... injections_applied=1`
- Without the preload (control): same axios call returns `HTTP 400` with empty body, OneCLI logs `connection error: serving HTTP connection`

## Test plan

- [x] Build container image with `./container/build.sh`
- [x] Wire `NODE_OPTIONS=--require /app/vendor/axios-onecli-proxy.cjs` into a Notion MCP server's env block
- [x] From inside the running container: `axios.get('https://api.notion.com/v1/users/me', { headers: { 'Notion-Version': '2022-06-28' } })` → 200 with real Notion response
- [x] Confirm OneCLI gateway log shows `injections_applied=1` for the call
- [x] Confirm MCP servers without the NODE_OPTIONS opt-in are unaffected (control: vanilla axios still 400s, but that's the existing pre-PR behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)