### PR TITLE
fix(channels): exponential backoff for gateway listener restarts

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -305,8 +305,14 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         // Start local HTTP server to receive forwarded Gateway events (including interactions)
         const webhookUrl = await startLocalWebhookServer(gatewayAdapter, setupConfig, config.botToken);
 
+        // Exponential backoff capped at 1h. Without this, an unrecoverable
+        // failure (e.g., TokenInvalid) restarts ~10×/sec and Discord's
+        // Cloudflare layer issues a multi-hour IP block. A run that lasts
+        // longer than 5 minutes counts as healthy and resets the counter.
+        let consecutiveFailures = 0;
         const startGateway = () => {
           if (gatewayAbort?.signal.aborted) return;
+          const startedAt = Date.now();
           // Capture the long-running listener promise via waitUntil
           let listenerPromise: Promise<unknown> | undefined;
           gatewayAdapter.startGatewayListener!(
@@ -321,21 +327,30 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           ).then(() => {
             // startGatewayListener resolves immediately with a Response;
             // the actual work is in the listenerPromise passed to waitUntil
-            if (listenerPromise) {
-              listenerPromise
-                .then(() => {
-                  if (!gatewayAbort?.signal.aborted) {
-                    log.info('Gateway listener expired, restarting', { adapter: adapter.name });
-                    startGateway();
-                  }
-                })
-                .catch((err) => {
-                  if (!gatewayAbort?.signal.aborted) {
-                    log.error('Gateway listener error, restarting in 5s', { adapter: adapter.name, err });
-                    setTimeout(startGateway, 5000);
-                  }
+            if (!listenerPromise) return;
+            const reschedule = (err?: unknown) => {
+              if (gatewayAbort?.signal.aborted) return;
+              const ranForMs = Date.now() - startedAt;
+              if (ranForMs > 5 * 60 * 1000) consecutiveFailures = 0;
+              else consecutiveFailures++;
+              const delayMs = Math.min(60 * 60 * 1000, 2 ** consecutiveFailures * 1000);
+              if (err) {
+                log.error('Gateway listener error, retrying', {
+                  adapter: adapter.name,
+                  err,
+                  consecutiveFailures,
+                  delayMs,
                 });
-            }
+              } else {
+                log.info('Gateway listener expired, restarting', {
+                  adapter: adapter.name,
+                  consecutiveFailures,
+                  delayMs,
+                });
+              }
+              setTimeout(startGateway, delayMs);
+            };
+            listenerPromise.then(() => reschedule()).catch(reschedule);
           });
         };
         startGateway();


### PR DESCRIPTION
## Summary

  The chat-sdk-bridge gateway restart loop has no backoff. When the listener
  resolves cleanly (`.then` path) it restarts immediately, and on error (`.catch`)
  it waits a fixed 5s. For an unrecoverable failure like `TokenInvalid` the
  listener resolves cleanly almost instantly, so the restart loop runs roughly
  10×/sec. Discord's Cloudflare edge treats this as abuse and answers with a
  ~24h IP block on REST and gateway alike.

  ## Repro

  1. Misconfigure `DISCORD_BOT_TOKEN` (rotate at the dev portal without updating
     `.env`, or paste from a stale clipboard).
  2. Start nanoclaw. The Discord adapter will log `TokenInvalid` and then loop:
     [chat-sdk:discord] Discord Gateway listener stopped
     INFO Gateway listener expired, restarting   adapter="discord"
  …with timestamps ~100ms apart.
  3. Within seconds, the host's IP is Cloudflare-blocked. Verified
  `retry-after: 86245` on `https://discord.com/api/v10/users/@me` after the
  loop, plus failed gateway WS handshakes.

  ## Fix

  `src/channels/chat-sdk-bridge.ts` — both the clean-expiry and error paths share
  a single `reschedule()` helper:

  - Increments `consecutiveFailures` on every restart.
  - Resets the counter to 0 if the listener stayed up > 5 min (healthy expiry —
    e.g., the normal 24h `durationMs` re-handshake).
  - Sleeps `Math.min(60*60*1000, 2**consecutiveFailures * 1000)` before the next
    attempt — exponential up to a 1h cap.
  - Logs `consecutiveFailures` and `delayMs` as structured fields.

  Backoff ladder (seconds): 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 3600
  (cap). For a permanent failure that's ~36,000× lower retry rate than today.

  ## Test plan

  - [ ] Invalid token: log shows `consecutiveFailures` incrementing and `delayMs`
     doubling, capped at `3600000`. No more 10/sec spam.
  - [ ] Valid token: gateway connects, listener runs > 5 min, counter resets;
     next normal expiry restarts immediately with `consecutiveFailures=0`.
  - [ ] Service restart with a working token: initial-connect latency unchanged.

  ## Related

  - #1289 — pre-flight credential validation on startup. Different angle
    (validate before starting), but the same crash-loop is covered there for
    *missing* creds. This PR is complementary: an *invalid* (stale, rotated)
    token is only knowable after attempting connect, so backoff still matters
    even with pre-flight checks.