### PR TITLE
fix(container): pin pnpm to 10.33.0 to match host

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -91,7 +91,13 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 #     the SDK fails at spawn time with "native binary not found".
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+# Pin pnpm to match the host (package.json packageManager). pnpm 11 stopped
+# honoring `only-built-dependencies[]=` in .npmrc for global installs, which
+# silently skips claude-code's native-binary postinstall and agent-browser's
+# bin chmod — the agent then crashes at runtime with "native binary not
+# installed". Keep this in lockstep with package.json's `packageManager`.
+ARG PNPM_VERSION=10.33.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     echo "only-built-dependencies[]=agent-browser" > /root/.npmrc && \


### PR DESCRIPTION
## Summary

- Pin the container's pnpm to `10.33.0` (matching the host's `package.json` `packageManager` field) so corepack stops pulling pnpm 11.
- pnpm 11 silently stops honoring `only-built-dependencies[]=` in `.npmrc` for global installs, which means `@anthropic-ai/claude-code`'s native-binary postinstall and `agent-browser`'s bin-chmod postinstall both get skipped during image build.

## Symptoms before the fix

After a clean rebuild against current `main`, the agent crashes the first time a session is spawned:

```
Error: claude native binary not installed.

Either postinstall did not run (--ignore-scripts, some pnpm configs)
or the platform-native optional dependency was not downloaded
(--omit=optional).
```

`agent-browser` fails the same way:

```
Error: Cannot make binary executable: EPERM: operation not permitted,
chmod '/pnpm/store/v11/links/.../agent-browser-linux-arm64'
```

In a chat-channel install (e.g. iMessage), the bot replies with the crash error to its own DM, which can produce a fast loop if the messaging-group config is broken — but the crash itself is the root cause.

## How to verify

```bash
docker builder prune -af
./container/build.sh
docker run --rm --entrypoint sh nanoclaw-agent:latest -c '/pnpm/claude --version'
# expected: 2.1.116 (Claude Code)
```

Without this PR, the same command prints "claude native binary not installed".

## Test plan

- [ ] Clean rebuild succeeds: `docker builder prune -af && ./container/build.sh`
- [ ] `/pnpm/claude --version` prints `2.1.116 (Claude Code)` in the resulting image
- [ ] `/pnpm/agent-browser --version` runs without an EPERM chmod error
- [ ] Live: send a message to a wired agent, get a non-error reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)