### PR TITLE
fix(container): repair claude-code install for pnpm v11

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -84,25 +84,37 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 # Most stable first, most frequently bumped last. Bumping claude-code
 # (the most common change) only invalidates one layer.
 #
-# only-built-dependencies gates pnpm's supply-chain policy:
-#   - agent-browser has a postinstall build step.
-#   - @anthropic-ai/claude-code's postinstall downloads the native Claude
-#     binary (linux-arm64 variant on our image). Without the allowlist
-#     the SDK fails at spawn time with "native binary not found".
+# .npmrc settings:
+#   only-built-dependencies — supply-chain allowlist for postinstall scripts.
+#   link-mode=copy          — pnpm v11 default symlinks the global package
+#                              dir back into the read-only CAS store, which
+#                              breaks claude-code's install.cjs (it tries to
+#                              unlinkSync the placeholder bin/claude.exe and
+#                              hits EACCES). Copy mode makes the global tree
+#                              independently writable.
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
 RUN corepack enable
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     echo "only-built-dependencies[]=agent-browser" > /root/.npmrc && \
     echo "only-built-dependencies[]=@anthropic-ai/claude-code" >> /root/.npmrc && \
+    echo "link-mode=copy" >> /root/.npmrc && \
     pnpm install -g "vercel@${VERCEL_VERSION}"
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "agent-browser@${AGENT_BROWSER_VERSION}"
 
+# pnpm v11 does not run postinstall scripts on `install -g` even with the
+# only-built-dependencies allowlist, so claude-code's bin/claude.exe stays
+# as the placeholder stub. Run install.cjs manually to swap in the real
+# native binary, then sanity-check with --version so a broken image fails
+# the build instead of failing at agent runtime.
 RUN --mount=type=cache,target=/root/.cache/pnpm \
-    pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+    pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && \
+    CC_DIR=$(dirname "$(find -L /pnpm/global/v11 -name install.cjs -path '*@anthropic-ai/claude-code/install.cjs' | head -1)") && \
+    cd "$CC_DIR" && node install.cjs && \
+    /pnpm/bin/claude --version
 
 # ---- Entrypoint --------------------------------------------------------------
 COPY entrypoint.sh /app/entrypoint.sh

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -285,7 +285,7 @@ export class ClaudeProvider implements AgentProvider {
         cwd: input.cwd,
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,
-        pathToClaudeCodeExecutable: '/pnpm/claude',
+        pathToClaudeCodeExecutable: '/pnpm/bin/claude',
         systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
         allowedTools: [
           ...TOOL_ALLOWLIST,


### PR DESCRIPTION
## Summary

- A freshly built agent image's `claude` binary was a 500-byte placeholder stub that printed *"native binary not installed"* and exited 1, surfacing to users as `Error: Claude Code process exited with code 1` on the first message to any agent.
- Two compounding root causes in pnpm v11: (1) global installs no longer run postinstall scripts even with the `only-built-dependencies` allowlist, so `@anthropic-ai/claude-code`'s `install.cjs` (which swaps the placeholder for the platform-specific native binary) never runs; (2) the global package dir is symlinked into the read-only content-addressable store, so even a manual `install.cjs` fails with `EACCES` on `unlinkSync` of the placeholder.
- Fix in two files: `container/Dockerfile` adds `link-mode=copy` to .npmrc (makes the global tree independently writable), runs `install.cjs` explicitly after the global install, and smoke-tests with `claude --version` so a broken image fails the build instead of failing silently at agent runtime. `container/agent-runner/src/providers/claude.ts` updates `pathToClaudeCodeExecutable` from `/pnpm/claude` to `/pnpm/bin/claude` to match pnpm v11's bin shim layout.

## Test plan

- [x] Reproduced: bare `pnpm install -g @anthropic-ai/claude-code@2.1.116` in a fresh `node:22-slim` leaves `bin/claude.exe` as the 500-byte placeholder stub
- [x] Fix verified: with `link-mode=copy` + explicit `install.cjs`, `bin/claude.exe` becomes the 237MB native binary and `claude --version` returns `2.1.116 (Claude Code)`
- [x] End-to-end: rebuilt the agent image with the fix, restarted host, sent Discord DM to a wired agent — got a real reply in ~6s, no errors in `logs/nanoclaw.error.log`
- [ ] Cross-arch: only verified on `linux/arm64` (Apple Silicon host). The fix logic is platform-agnostic (find-by-glob covers any `claude-code-*` optional dep), but worth a CI check on `linux/amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)