### PR TITLE
feat(providers): surface Claude Code skill catalog to non-Claude providers

### DIFF
--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -21,6 +21,7 @@ If all of the following are already present, skip to **Configuration**:
 - `container/agent-runner/src/providers/codex.ts`
 - `container/agent-runner/src/providers/codex-app-server.ts`
 - `container/agent-runner/src/providers/codex.factory.test.ts`
+- `container/agent-runner/src/providers/skill-catalog.ts` (shared with `/add-opencode`)
 - `import './codex.js';` line in `src/providers/index.ts`
 - `import './codex.js';` line in `container/agent-runner/src/providers/index.ts`
 - `ARG CODEX_VERSION` and `"@openai/codex@${CODEX_VERSION}"` in the pnpm global-install block in `container/Dockerfile`
@@ -42,7 +43,11 @@ git show origin/providers:src/providers/codex.ts                                
 git show origin/providers:container/agent-runner/src/providers/codex.ts               > container/agent-runner/src/providers/codex.ts
 git show origin/providers:container/agent-runner/src/providers/codex-app-server.ts    > container/agent-runner/src/providers/codex-app-server.ts
 git show origin/providers:container/agent-runner/src/providers/codex.factory.test.ts  > container/agent-runner/src/providers/codex.factory.test.ts
+git show origin/providers:container/agent-runner/src/providers/skill-catalog.ts       > container/agent-runner/src/providers/skill-catalog.ts
+git show origin/providers:container/agent-runner/src/providers/skill-catalog.test.ts  > container/agent-runner/src/providers/skill-catalog.test.ts
 ```
+
+`skill-catalog.ts` is a small shared helper used by every non-Claude provider (it builds a discovery list of installed Claude Code skills so Codex / OpenCode / etc. can `Read` and follow them). Idempotent — if `/add-opencode` already copied it, this just rewrites the identical bytes.
 
 ### 3. Append the self-registration imports
 

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -17,6 +17,7 @@ If all of the following are already present, skip to **Configuration**:
 
 - `src/providers/opencode.ts`
 - `container/agent-runner/src/providers/opencode.ts`
+- `container/agent-runner/src/providers/skill-catalog.ts` (shared with `/add-codex`)
 - `import './opencode.js';` line in `src/providers/index.ts`
 - `import './opencode.js';` line in `container/agent-runner/src/providers/index.ts`
 - `@opencode-ai/sdk` in `container/agent-runner/package.json`
@@ -40,7 +41,11 @@ git show origin/providers:container/agent-runner/src/providers/opencode.ts      
 git show origin/providers:container/agent-runner/src/providers/mcp-to-opencode.ts      > container/agent-runner/src/providers/mcp-to-opencode.ts
 git show origin/providers:container/agent-runner/src/providers/mcp-to-opencode.test.ts > container/agent-runner/src/providers/mcp-to-opencode.test.ts
 git show origin/providers:container/agent-runner/src/providers/opencode.factory.test.ts > container/agent-runner/src/providers/opencode.factory.test.ts
+git show origin/providers:container/agent-runner/src/providers/skill-catalog.ts        > container/agent-runner/src/providers/skill-catalog.ts
+git show origin/providers:container/agent-runner/src/providers/skill-catalog.test.ts   > container/agent-runner/src/providers/skill-catalog.test.ts
 ```
+
+`skill-catalog.ts` is a small shared helper used by every non-Claude provider (it builds a discovery list of installed Claude Code skills so Codex / OpenCode / etc. can `Read` and follow them). Idempotent — if `/add-codex` already copied it, this just rewrites the identical bytes.
 
 ### 3. Append the self-registration imports
 

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -17,6 +17,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { registerProvider } from './provider-registry.js';
+import { composeAvailableSkills } from './skill-catalog.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 import {
   type AppServer,
@@ -92,7 +93,8 @@ function readAgentAndGlobalClaudeMd(): string | undefined {
 
 function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
   const claudeMd = readAgentAndGlobalClaudeMd();
-  const pieces = [claudeMd, promptAddendum].filter((s): s is string => Boolean(s));
+  const skills = composeAvailableSkills();
+  const pieces = [claudeMd, skills, promptAddendum].filter((s): s is string => Boolean(s));
   return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
 }
 

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -1,10 +1,18 @@
 import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
 
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk';
 
 import { registerProvider } from './provider-registry.js';
+import { composeAvailableSkills } from './skill-catalog.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 import { mcpServersToOpenCodeConfig } from './mcp-to-opencode.js';
+
+// Stable path for the skills-catalog markdown OpenCode reads via `instructions`.
+// Written synchronously at config-build time and re-written on every config
+// rebuild so the catalog tracks any group-level skill add/remove between
+// session restarts. /tmp is per-container, so no cross-session leakage.
+const SKILLS_CATALOG_PATH = '/tmp/nanoclaw-skills-catalog.md';
 
 function log(msg: string): void {
   console.error(`[opencode-provider] ${msg}`);
@@ -122,6 +130,21 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
     '/workspace/agent/.claude-fragments/*.md',
     '/workspace/agent/CLAUDE.local.md',
   ];
+
+  // Skills catalog: OpenCode doesn't have Claude Code's `Skill` tool, so per-
+  // group prompts referencing "use the X skill" would dangle. Materialize the
+  // discovery list to a tmp file and add it to instructions. The agent reads
+  // /app/skills/<name>/SKILL.md on demand for the full body — same lazy-load
+  // model Claude Code uses internally.
+  const skillsCatalog = composeAvailableSkills();
+  if (skillsCatalog) {
+    try {
+      fs.writeFileSync(SKILLS_CATALOG_PATH, skillsCatalog, 'utf-8');
+      instructions.push(SKILLS_CATALOG_PATH);
+    } catch (err) {
+      log(`Failed to write skills catalog (${err instanceof Error ? err.message : err}); proceeding without it.`);
+    }
+  }
 
   return {
     ...(model ? { model } : {}),

--- a/container/agent-runner/src/providers/skill-catalog.test.ts
+++ b/container/agent-runner/src/providers/skill-catalog.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect } from 'bun:test';
+
+import { composeAvailableSkills, listAvailableSkills } from './skill-catalog.js';
+
+function makeSkillsDir(skills: { name: string; frontmatter?: string; body?: string }[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-catalog-'));
+  for (const s of skills) {
+    const skillDir = path.join(dir, s.name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    const body = s.body ?? '# Body';
+    const content = s.frontmatter ? `---\n${s.frontmatter}\n---\n${body}` : body;
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content);
+  }
+  return dir;
+}
+
+describe('listAvailableSkills', () => {
+  it('returns an empty list when the skills dir does not exist', () => {
+    expect(listAvailableSkills(path.join(os.tmpdir(), 'no-such-' + Date.now()))).toEqual([]);
+  });
+
+  it('parses name + description from frontmatter', () => {
+    const dir = makeSkillsDir([
+      { name: 'make-website', frontmatter: 'name: make-website\ndescription: Build and publish a website.' },
+      { name: 'wiki', frontmatter: 'name: wiki\ndescription: Maintain a persistent wiki.' },
+    ]);
+    const out = listAvailableSkills(dir);
+    expect(out).toEqual([
+      { name: 'make-website', description: 'Build and publish a website.' },
+      { name: 'wiki', description: 'Maintain a persistent wiki.' },
+    ]);
+  });
+
+  it('skips skills without a description (frontmatter or none)', () => {
+    const dir = makeSkillsDir([
+      { name: 'good', frontmatter: 'name: good\ndescription: Has one.' },
+      { name: 'no-desc', frontmatter: 'name: no-desc' },
+      { name: 'no-frontmatter' },
+    ]);
+    const out = listAvailableSkills(dir);
+    expect(out.map((e) => e.name)).toEqual(['good']);
+  });
+
+  it('falls back to directory name when frontmatter omits the name field', () => {
+    const dir = makeSkillsDir([{ name: 'fallback', frontmatter: 'description: Has description but no name field.' }]);
+    expect(listAvailableSkills(dir)).toEqual([
+      { name: 'fallback', description: 'Has description but no name field.' },
+    ]);
+  });
+
+  it('strips quoted descriptions', () => {
+    const dir = makeSkillsDir([{ name: 'q', frontmatter: 'description: "A quoted description."' }]);
+    expect(listAvailableSkills(dir)).toEqual([{ name: 'q', description: 'A quoted description.' }]);
+  });
+
+  it('sorts skills deterministically (alphabetical by directory name)', () => {
+    const dir = makeSkillsDir([
+      { name: 'zulu', frontmatter: 'name: zulu\ndescription: Z.' },
+      { name: 'alpha', frontmatter: 'name: alpha\ndescription: A.' },
+      { name: 'mike', frontmatter: 'name: mike\ndescription: M.' },
+    ]);
+    const out = listAvailableSkills(dir).map((e) => e.name);
+    expect(out).toEqual(['alpha', 'mike', 'zulu']);
+  });
+});
+
+describe('composeAvailableSkills', () => {
+  it('returns undefined when no eligible skills exist', () => {
+    const dir = makeSkillsDir([{ name: 'naked', body: '# Just a body, no frontmatter' }]);
+    expect(composeAvailableSkills(dir)).toBeUndefined();
+  });
+
+  it('returns undefined when the dir does not exist', () => {
+    expect(composeAvailableSkills(path.join(os.tmpdir(), 'no-such-' + Date.now()))).toBeUndefined();
+  });
+
+  it('emits a markdown section with discovery instructions and the entry list', () => {
+    const dir = makeSkillsDir([
+      { name: 'make-website', frontmatter: 'name: make-website\ndescription: Build and publish a website.' },
+      { name: 'wiki', frontmatter: 'name: wiki\ndescription: Maintain a persistent wiki.' },
+    ]);
+    const out = composeAvailableSkills(dir)!;
+    expect(out).toContain('# Available skills');
+    expect(out).toContain('Read /app/skills/<name>/SKILL.md');
+    expect(out).toContain('**make-website** — Build and publish a website.');
+    expect(out).toContain('**wiki** — Maintain a persistent wiki.');
+  });
+});

--- a/container/agent-runner/src/providers/skill-catalog.ts
+++ b/container/agent-runner/src/providers/skill-catalog.ts
@@ -1,0 +1,85 @@
+/**
+ * Skill-catalog discovery for non-Claude providers.
+ *
+ * Claude Code natively surfaces skills via its `Skill` tool — the agent
+ * sees a list of (name, description) pairs at runtime and reads the full
+ * SKILL.md body on demand when one matches a request. Other providers
+ * (Codex, OpenCode, future Gemini/Ollama, etc.) don't have this discovery
+ * mechanism, so any per-group prompt that says "use the make-website skill"
+ * dangles — the tool doesn't exist, the body isn't loaded.
+ *
+ * `composeAvailableSkills` builds the same name+description list as a
+ * markdown section that any provider can inject into its system prompt
+ * (Codex appends to baseInstructions; OpenCode writes to a tmp file and
+ * adds it to its `instructions` array). We deliberately don't inline each
+ * SKILL.md's full body — that's tens of KB across the catalog and most
+ * skills won't apply to any given turn. The discovery list directs the
+ * agent to read the full SKILL.md when a description matches, mirroring
+ * Claude Code's lazy-load model and keeping prompt overhead proportional
+ * to skill count rather than skill size.
+ *
+ * The skills directory defaults to `/home/node/.claude/skills` — the
+ * per-group symlinks the host writes from `claude-md-compose.ts`. This
+ * scopes naturally to whichever skills the group's `container.json`
+ * selected; disabled skills aren't symlinked, so they don't appear here.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_SKILLS_DIR = '/home/node/.claude/skills';
+
+export interface SkillCatalogEntry {
+  name: string;
+  description: string;
+}
+
+export function listAvailableSkills(skillsDir = DEFAULT_SKILLS_DIR): SkillCatalogEntry[] {
+  if (!fs.existsSync(skillsDir)) return [];
+  const entries: SkillCatalogEntry[] = [];
+  for (const dirent of fs.readdirSync(skillsDir).sort()) {
+    const skillMdPath = path.join(skillsDir, dirent, 'SKILL.md');
+    if (!fs.existsSync(skillMdPath)) continue;
+    const raw = fs.readFileSync(skillMdPath, 'utf-8');
+    const fm = parseFrontmatter(raw);
+    const description = fm.description?.trim();
+    if (!description) continue;
+    entries.push({ name: fm.name ?? dirent, description });
+  }
+  return entries;
+}
+
+export function composeAvailableSkills(skillsDir = DEFAULT_SKILLS_DIR): string | undefined {
+  const entries = listAvailableSkills(skillsDir);
+  if (entries.length === 0) return undefined;
+
+  const list = entries.map((e) => `- **${e.name}** — ${e.description}`).join('\n');
+  return [
+    '# Available skills',
+    '',
+    "When the user's request matches a skill below, your first action is to `Read /app/skills/<name>/SKILL.md` and follow the recipe inside before doing the work. The skill's instructions take precedence over your defaults for the task it covers.",
+    '',
+    list,
+  ].join('\n');
+}
+
+/**
+ * Minimal YAML frontmatter parser — extracts `key: value` pairs from an
+ * opening `---`/`---` block. Good enough for the SKILL.md schema (flat
+ * scalar fields). Doesn't handle nested objects or multiline strings; if
+ * a skill grows those, expand here.
+ */
+function parseFrontmatter(content: string): Record<string, string> {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) return {};
+  const out: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!m) continue;
+    let value = m[2];
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[m[1]] = value;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

This PR makes Claude Code skills work for non-Claude providers, in two paired commits:

1. **Source-side** — adds `container/agent-runner/src/providers/skill-catalog.ts`, a shared helper (`composeAvailableSkills` / `listAvailableSkills`) that builds a markdown discovery list of skills available to the current group. Wires it into both non-Claude providers shipped on this branch:
   - **Codex** (`codex.ts`) — appended to `baseInstructions` (string-add at thread start).
   - **OpenCode** (`opencode.ts`) — written to `/tmp/nanoclaw-skills-catalog.md` in `buildOpenCodeConfig` and added to the `instructions` array OpenCode natively reads.
2. **Install-side** — updates `.claude/skills/add-codex/SKILL.md` and `.claude/skills/add-opencode/SKILL.md` so the new file is copied into customer installs alongside the provider files. Without this, any merge of commit 1 alone would break `/add-codex` and `/add-opencode` (provider would import a file that wasn't copied → build break).

Both commits ride one branch off `providers` so they merge atomically; neither is safe alone.

## Why

Claude Code natively exposes skills via its `Skill` tool — agents see (name, description) pairs at runtime and `Read` the full SKILL.md body on demand. Non-Claude providers don't have this discovery mechanism, so per-group prompts referencing skills (e.g. "use the make-website skill") — particularly ones authored under Claude and inherited when a group switches providers — currently dangle. The tool doesn't exist, the body isn't loaded, the agent improvises.

This is observable today: any group whose `CLAUDE.local.md` references a skill stops working that recipe the moment the group switches to Codex or OpenCode, even though the SKILL.md is right there at `/app/skills/<name>/SKILL.md`.

## What the discovery list looks like

```
# Available skills

When the user's request matches a skill below, your first action is to `Read /app/skills/<name>/SKILL.md` and follow the recipe inside before doing the work. The skill's instructions take precedence over your defaults for the task it covers.

- **make-website** — Build and publish a website. Use whenever the user asks to make...
- **wiki** — Maintain the persistent course-content wiki for this group...
```

We deliberately don't inline each SKILL.md body — that would be tens of KB of system prompt for a full catalog, most of which won't apply to any given turn. The lazy-load model mirrors what Claude Code does internally and keeps prompt overhead proportional to skill count, not skill size.

## Test plan

- [x] New `skill-catalog.test.ts` covers: empty/missing dir, frontmatter parsing edge cases (no description, no name field, no frontmatter at all, quoted values), deterministic alphabetical sort.
- [x] Existing codex/opencode tests continue to pass.
- [x] Container suite (`bun test` in `container/agent-runner/`) — 86 pass, 0 fail.
- [x] `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean.
- [x] Both install skills updated; running `/add-codex` or `/add-opencode` against the post-merge providers branch will copy the new file. Either skill running second is idempotent (rewrites identical bytes).
- [ ] Manual end-to-end verification on a real Codex agent group (in a downstream fork): the skill catalog appears in the system prompt and the agent invokes the listed skills via `Read`.

## Risk

- **Prompt-size impact:** the discovery list is small (~one line per skill) but it does add to the baseline system prompt for every Codex/OpenCode turn. For a default install with ~10 skills it is well under 1KB.
- **Behavior change:** non-Claude agents that previously ignored skill references will now act on them. If anyone is intentionally relying on those references being ignored, this is a breaking change for them — unlikely but worth flagging.
- **OpenCode tmp-file write:** `/tmp/nanoclaw-skills-catalog.md` is per-container, so no cross-session leakage. Failure to write is logged and falls back gracefully (instructions array just doesn't include it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)