### PR TITLE
fix(telegram): escape stray * and _ instead of stripping (URLs with _ get mangled)

### DIFF
--- a/src/channels/telegram-markdown-sanitize.test.ts
+++ b/src/channels/telegram-markdown-sanitize.test.ts
@@ -24,12 +24,19 @@ describe('sanitizeTelegramLegacyMarkdown', () => {
     expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
   });
 
-  it('strips formatting chars on odd delimiter count (unbalanced *)', () => {
-    expect(sanitizeTelegramLegacyMarkdown('a * b *c*')).toBe('a  b c');
+  it('escapes formatting chars on odd delimiter count (unbalanced *)', () => {
+    expect(sanitizeTelegramLegacyMarkdown('a * b *c*')).toBe('a \\* b \\*c\\*');
   });
 
-  it('strips formatting chars on odd delimiter count (unbalanced _)', () => {
-    expect(sanitizeTelegramLegacyMarkdown('file_name has _one italic_')).toBe('filename has one italic');
+  it('escapes formatting chars on odd delimiter count (unbalanced _)', () => {
+    expect(sanitizeTelegramLegacyMarkdown('file_name has _one italic_')).toBe('file\\_name has \\_one italic\\_');
+  });
+
+  it('preserves underscores in URL slugs (regression: `group_name` was being stripped to `groupname`)', () => {
+    const input = '**http://example.com/group_name/page/**';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).toContain('group\\_name');
+    expect(out).not.toContain('groupname');
   });
 
   it('strips brackets when unbalanced', () => {

--- a/src/channels/telegram-markdown-sanitize.ts
+++ b/src/channels/telegram-markdown-sanitize.ts
@@ -36,11 +36,15 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
   text = text.replace(/\*\*([^*\n]+?)\*\*/g, '*$1*');
   text = text.replace(/__([^_\n]+?)__/g, '_$1_');
 
+  // When delimiters are unbalanced, Telegram's legacy parser would reject the
+  // message. Escape stray chars rather than stripping them — stripping silently
+  // mangles URLs that contain `_` (e.g. a path like `/group_name/site/` becomes
+  // `/groupname/site/` after delivery, which 404s when the user clicks).
+  // `\_` and `\*` render as literal in Telegram's legacy Markdown.
   const starCount = (text.match(/\*/g) ?? []).length;
   const underCount = (text.match(/_/g) ?? []).length;
-  if (starCount % 2 !== 0 || underCount % 2 !== 0) {
-    text = text.replace(/[*_]/g, '');
-  }
+  if (starCount % 2 !== 0) text = text.replace(/\*/g, '\\*');
+  if (underCount % 2 !== 0) text = text.replace(/_/g, '\\_');
 
   const openBrackets = (text.match(/\[/g) ?? []).length;
   const closeBrackets = (text.match(/\]/g) ?? []).length;


### PR DESCRIPTION
## Summary

When an outbound message has an **odd** count of `*` or `_`, the legacy-Markdown sanitizer in `src/channels/telegram-markdown-sanitize.ts` removes every occurrence of those characters to make Telegram's parser happy. This silently corrupts URLs whose path contains an underscore.

Concrete repro (caught in the wild):
- Agent posts `http://host/group_name/page/`
- Outgoing text has 1 underscore (odd) → sanitizer strips it
- Telegram delivers `http://host/groupname/page/`
- User clicks the link, gets a 404, blames the agent

This bites any deployment whose group folder convention uses underscores (`student_01`, `team_alpha`, etc.) — exactly the shape `/add-classroom` already encourages.

## Fix

Backslash-escape stray `*` / `_` instead of stripping them. Telegram's legacy Markdown renders `\_` and `\*` as literal characters, so URLs survive verbatim. Even-balanced messages still pass through untouched, so legitimate `_italic_` and `*bold*` rendering is preserved.

```diff
- if (starCount % 2 !== 0 || underCount % 2 !== 0) {
-   text = text.replace(/[*_]/g, '');
- }
+ if (starCount % 2 !== 0) text = text.replace(/\*/g, '\\*');
+ if (underCount % 2 !== 0) text = text.replace(/_/g, '\\_');
```

Three-line code change in the sanitizer plus tests:
- Two existing tests (`strips formatting chars on odd delimiter count …`) updated to `escapes formatting chars …` with the new expected output.
- One new regression test for the URL-with-underscore case.

## Test plan

- [x] `pnpm exec vitest run src/channels/telegram-markdown-sanitize.test.ts` — 16/16 pass.
- [x] Even-balanced inputs (`'a *b* c _d_ e'`, links like `[docs](https://example.com)`) still untouched.
- [x] Code-block handling (` ```...``` ` and `` `inline` ``) still untouched — those segments are placeholdered before delimiter counting and restored after.
- [x] Pre-existing tests for bracket balancing, list-bullet rewriting, horizontal-rule flattening, code preservation all pass unchanged.

## Risk

Behaviour change is small and intentional: messages that previously had stray formatting chars silently removed will now show those chars literally (with a leading backslash). For human-readable text the result is more honest (you see the `*` or `_` you wrote). For URLs the result is correct (they work). I don't think this breaks any existing user expectation, but flagging in case a maintainer disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)