### PR TITLE
fix(tests): satisfy tightened RoutableAgentMessage and Session types

### DIFF
--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -838,7 +838,6 @@ describe('agent-shared session resolution', () => {
     const { session } = resolveSession('ag-1', null, null, 'agent-shared');
     expect(session.messaging_group_id).toBeNull();
   });
-
 });
 
 describe('agent-to-agent routing', () => {

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -885,7 +885,12 @@ describe('agent-to-agent routing', () => {
     const { session: paSlackSession } = resolveSession('ag-pa', 'mg-slack', null, 'shared');
 
     await routeAgentMessage(
-      { id: 'out-a2a-1', platform_id: 'ag-researcher', content: JSON.stringify({ text: 'research this' }) },
+      {
+        id: 'out-a2a-1',
+        platform_id: 'ag-researcher',
+        content: JSON.stringify({ text: 'research this' }),
+        in_reply_to: null,
+      },
       paSlackSession,
     );
 
@@ -928,7 +933,12 @@ describe('agent-to-agent routing', () => {
 
     // PA sends from Slack
     await routeAgentMessage(
-      { id: 'out-fwd', platform_id: 'ag-researcher', content: JSON.stringify({ text: 'research' }) },
+      {
+        id: 'out-fwd',
+        platform_id: 'ag-researcher',
+        content: JSON.stringify({ text: 'research' }),
+        in_reply_to: null,
+      },
       paSlackSession,
     );
 
@@ -937,7 +947,12 @@ describe('agent-to-agent routing', () => {
     const researcherSession = getSessionsByAgentGroup('ag-researcher')[0];
 
     await routeAgentMessage(
-      { id: 'out-reply', platform_id: 'ag-pa', content: JSON.stringify({ text: 'found it' }) },
+      {
+        id: 'out-reply',
+        platform_id: 'ag-pa',
+        content: JSON.stringify({ text: 'found it' }),
+        in_reply_to: null,
+      },
       researcherSession,
     );
 
@@ -961,7 +976,12 @@ describe('agent-to-agent routing', () => {
 
     const { session: paSession } = resolveSession('ag-pa', 'mg-slack', null, 'shared');
     await routeAgentMessage(
-      { id: 'out-1', platform_id: 'ag-researcher', content: JSON.stringify({ text: 'go' }) },
+      {
+        id: 'out-1',
+        platform_id: 'ag-researcher',
+        content: JSON.stringify({ text: 'go' }),
+        in_reply_to: null,
+      },
       paSession,
     );
 

--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -328,7 +328,12 @@ describe('routeAgentMessage return-path', () => {
     // B replies to A, but in_reply_to references the C-originated row.
     // Guard rejects (SC belongs to C, not A) → falls through to newest of A.
     await routeAgentMessage(
-      { id: 'msg-reply-tamper', platform_id: A, content: JSON.stringify({ text: 'misdirected' }), in_reply_to: cInboundId },
+      {
+        id: 'msg-reply-tamper',
+        platform_id: A,
+        content: JSON.stringify({ text: 'misdirected' }),
+        in_reply_to: cInboundId,
+      },
       SB,
     );
 
@@ -353,7 +358,12 @@ describe('routeAgentMessage return-path', () => {
     // B replies to A with in_reply_to pointing to the channel message.
     // source_session_id is null → peer-affinity finds nothing → newest of A.
     await routeAgentMessage(
-      { id: 'msg-reply-channel', platform_id: A, content: JSON.stringify({ text: 'response' }), in_reply_to: 'channel-msg-1' },
+      {
+        id: 'msg-reply-channel',
+        platform_id: A,
+        content: JSON.stringify({ text: 'response' }),
+        in_reply_to: 'channel-msg-1',
+      },
       SB,
     );
 

--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -284,8 +284,8 @@ describe('routeAgentMessage return-path', () => {
     const bRows = readInbound(B, SB.id);
     const inboundId = bRows[0].id;
 
-    // Archive S1 — simulates session cleanup or channel disconnect.
-    updateSession(S1.id, { status: 'archived' });
+    // Close S1 — simulates session cleanup or channel disconnect.
+    updateSession(S1.id, { status: 'closed' });
 
     // B replies. origin points to S1 (archived), should fall through to S2.
     await routeAgentMessage(


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`pnpm run build` is currently failing on `main` with five test-only \`tsc\` errors. Two batches of changes landed on the same day and didn't cross-check:

- 9db39b2 made \`RoutableAgentMessage.in_reply_to\` required
- 684a98d / 107945f added new tests in \`src/host-core.test.ts\` that don't pass it (lines 887, 930, 939, 963)
- \`src/modules/agent-to-agent/agent-route.test.ts:288\` uses a stale literal \`updateSession(..., { status: 'archived' })\` — \`Session.status\` is \`'closed' | 'active' | undefined\`. The test's intent ("simulate session cleanup or channel disconnect") matches \`'closed'\`.

## What this PR does

- Adds \`in_reply_to: null\` to the four affected \`routeAgentMessage\` call sites in \`host-core.test.ts\`.
- Switches the archive test to \`status: 'closed'\` and updates the comment.

Test-only — no runtime behavior change.

## Verification

- \`pnpm run build\` ✓
- \`pnpm test\` ✓ (all suites pass)

## Why merge soon

Build is broken on main right now, so any PR that runs \`pnpm run build\` in CI will fail until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)