### PR TITLE
feat(claude-md-compose): auto-import per-group CLAUDE.role.md if present

### DIFF
--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for composeGroupClaudeMd — verifies the composed CLAUDE.md
+ * imports the right things, and notably auto-imports per-group
+ * `CLAUDE.role.md` when the operator (or a port skill) has written one.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import type { AgentGroup } from './types.js';
+
+const TEST_ROOT = path.join(os.tmpdir(), 'nanoclaw-test-compose');
+const TEST_GROUPS_DIR = path.join(TEST_ROOT, 'groups');
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, GROUPS_DIR: TEST_GROUPS_DIR };
+});
+
+vi.mock('./db/container-configs.js', () => ({
+  getContainerConfig: () => ({ mcp_servers: '{}', cli_scope: 'group' }),
+}));
+
+const { composeGroupClaudeMd } = await import('./claude-md-compose.js');
+
+const GROUP: AgentGroup = {
+  id: 'ag-test',
+  name: 'Test',
+  folder: 'test-group',
+  agent_provider: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(TEST_GROUPS_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+function readComposed(): string {
+  return fs.readFileSync(path.join(TEST_GROUPS_DIR, GROUP.folder, 'CLAUDE.md'), 'utf-8');
+}
+
+describe('composeGroupClaudeMd CLAUDE.role.md auto-import', () => {
+  it('does NOT add @./CLAUDE.role.md when the file is missing', () => {
+    composeGroupClaudeMd(GROUP);
+    expect(readComposed()).not.toContain('@./CLAUDE.role.md');
+  });
+
+  it('adds @./CLAUDE.role.md when the file exists', () => {
+    const groupDir = path.join(TEST_GROUPS_DIR, GROUP.folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(path.join(groupDir, 'CLAUDE.role.md'), '# Role\nYou are Test.\n');
+
+    composeGroupClaudeMd(GROUP);
+    expect(readComposed()).toContain('@./CLAUDE.role.md');
+  });
+
+  it('imports role.md after the shared base and after fragments', () => {
+    const groupDir = path.join(TEST_GROUPS_DIR, GROUP.folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(path.join(groupDir, 'CLAUDE.role.md'), '# Role\n');
+
+    composeGroupClaudeMd(GROUP);
+    const body = readComposed();
+    const sharedIdx = body.indexOf('@./.claude-shared.md');
+    const roleIdx = body.indexOf('@./CLAUDE.role.md');
+    expect(sharedIdx).toBeGreaterThanOrEqual(0);
+    expect(roleIdx).toBeGreaterThan(sharedIdx);
+  });
+
+  it('is idempotent — re-running with role.md already present produces the same body', () => {
+    const groupDir = path.join(TEST_GROUPS_DIR, GROUP.folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(path.join(groupDir, 'CLAUDE.role.md'), '# Role\n');
+
+    composeGroupClaudeMd(GROUP);
+    const first = readComposed();
+    composeGroupClaudeMd(GROUP);
+    const second = readComposed();
+    expect(second).toBe(first);
+  });
+});

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -126,6 +126,13 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   for (const name of [...desired.keys()].sort()) {
     imports.push(`@./.claude-fragments/${name}`);
   }
+  // Per-group role spec — auto-imported when the operator (or a port skill
+  // like `/migrate-team-from-v1`) has written one. Loads after framework
+  // base + fragments so the role can override defaults. Absent file → no
+  // import; never write a dangling reference.
+  if (fs.existsSync(path.join(groupDir, 'CLAUDE.role.md'))) {
+    imports.push('@./CLAUDE.role.md');
+  }
   const body = [COMPOSED_HEADER, ...imports, ''].join('\n');
   writeAtomic(path.join(groupDir, 'CLAUDE.md'), body);
 


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

(Borderline — see "Why source change" below. Happy to convert to skill-only if maintainers prefer.)

## Description

The composed \`groups/<folder>/CLAUDE.md\` already imports the shared base and module/skill fragments. This PR adds a conditional \`@./CLAUDE.role.md\` import when the file exists in the group dir.

## Why

Per-group role specs are already a known convention in trunk:

- \`scripts/init-group-agent.ts\` documents \`--instructions\` as **\"seed text for CLAUDE.role.md\"** (lines 33, 77 — though the current code seeds \`CLAUDE.local.md\`; that's a separate doc/code drift worth a follow-up).
- \`scripts/init-lane-agent.ts\` instructs operators to \`Edit groups/<folder>/CLAUDE.role.md with the lane's role spec\`.
- Port skills (e.g. \`/migrate-team-from-v1\`) write the team's identity / voice / rules to \`CLAUDE.role.md\` during the v1→v2 port.

Without this auto-import, operators have to also touch \`CLAUDE.local.md\` to add an \`@./CLAUDE.role.md\` line, or the role spec they wrote is invisible to the agent. That manual step is easy to miss and produces a confusing failure mode (the agent operates from the generic NanoClaw base only — no team-specific behavior — without any obvious error).

## Behavior

- **Absent file** → no import emitted. Backwards-compatible; never writes a dangling \`@./\` reference.
- **Present file** → imported after \`.claude-shared.md\` and after fragments, so the role spec can override framework defaults.
- **Idempotent** — re-running \`composeGroupClaudeMd\` produces the same body.

## Tests

New file \`src/claude-md-compose.test.ts\` covers all four cases (4 tests, all passing):

1. No \`CLAUDE.role.md\` → import is absent.
2. \`CLAUDE.role.md\` present → import is added.
3. Role import comes after the shared base.
4. Re-running produces identical output.

## Verification

- \`pnpm test src/claude-md-compose.test.ts\` ✓ 4/4
- Local install with \`migrate-team-from-v1\` flow confirms agents now load their role spec without the manual \`CLAUDE.local.md\` step.

## CI note

This PR's CI will fail until #2344 (test-only \`tsc\` fixes) lands — the failures aren't from this change. After #2344 merges, I'll rebase/repush to retrigger CI.

## Why source change rather than skill

The change is 3 LOC in one function. There's no clean way to express \"add an import line to the composed CLAUDE.md\" through the skill mechanism without monkey-patching \`claude-md-compose.ts\` from a skill, which feels worse than a small principled change to trunk. Happy to revisit if maintainers see a skill-shaped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)