### PR TITLE
fix(agent-runner/formatter): preserve thread context when system message heads the batch

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -13,7 +13,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
-import { formatMessages, stripInternalTags } from './formatter.js';
+import { formatMessages, stripInternalTags, extractRouting } from './formatter.js';
+import type { MessageInRow } from './db/messages-in.js';
 import { TIMEZONE } from './timezone.js';
 
 beforeEach(() => {
@@ -163,5 +164,124 @@ describe('stripInternalTags', () => {
     expect(stripInternalTags('<internal>thinking</internal>The answer is 42')).toBe(
       'The answer is 42',
     );
+  });
+});
+
+// --- extractRouting (Slack thread context preservation) ---
+
+function row(overrides: Partial<MessageInRow>): MessageInRow {
+  return {
+    id: 'm-default',
+    seq: 0,
+    kind: 'chat-sdk',
+    timestamp: '2026-05-08T01:00:00.000Z',
+    status: 'pending',
+    platform_id: null,
+    channel_type: null,
+    thread_id: null,
+    content: '{}',
+    process_after: null,
+    recurrence: null,
+    trigger: 1,
+    tries: 0,
+    ...overrides,
+  };
+}
+
+describe('extractRouting', () => {
+  it('uses messages[0] when first row has full routing', () => {
+    const messages = [
+      row({
+        id: 'm-1',
+        platform_id: 'slack:C06HTHNR3DH',
+        channel_type: 'slack',
+        thread_id: 'slack:C06HTHNR3DH:1778199266.779799',
+      }),
+    ];
+    const r = extractRouting(messages);
+    expect(r.platformId).toBe('slack:C06HTHNR3DH');
+    expect(r.threadId).toBe('slack:C06HTHNR3DH:1778199266.779799');
+    expect(r.inReplyTo).toBe('m-1');
+  });
+
+  it('skips a system "agent" channel row at messages[0] and uses the chat row behind it', () => {
+    // Reproduces incident 2026-05-08 (sess-1778201595257-akx9i0):
+    // an install_packages approval-note (channel_type='agent', no thread)
+    // landed at messages[0] and previously null-ed out the chat reply's
+    // thread context.
+    const messages = [
+      row({
+        id: 'appr-note-1',
+        kind: 'chat',
+        channel_type: 'agent',
+        platform_id: 'ag-1777563454330-or4qfh',
+        thread_id: null,
+      }),
+      row({
+        id: 'm-real-2',
+        platform_id: 'slack:C06HTHNR3DH',
+        channel_type: 'slack',
+        thread_id: 'slack:C06HTHNR3DH:1778201592.978489',
+      }),
+    ];
+    const r = extractRouting(messages);
+    expect(r.platformId).toBe('slack:C06HTHNR3DH');
+    expect(r.channelType).toBe('slack');
+    expect(r.threadId).toBe('slack:C06HTHNR3DH:1778201592.978489');
+    expect(r.inReplyTo).toBe('m-real-2');
+  });
+
+  it('falls back to platform-only row when no row carries thread_id', () => {
+    const messages = [
+      row({ id: 'sys-1', channel_type: 'agent', platform_id: 'ag-x', thread_id: null }),
+      row({
+        id: 'm-channel-2',
+        platform_id: 'slack:C06HTHNR3DH',
+        channel_type: 'slack',
+        thread_id: null, // top-level channel mention
+      }),
+    ];
+    const r = extractRouting(messages);
+    expect(r.platformId).toBe('slack:C06HTHNR3DH');
+    expect(r.threadId).toBe(null);
+    expect(r.inReplyTo).toBe('m-channel-2');
+  });
+
+  it('falls back to messages[0] when no row carries platform_id (system-only batch)', () => {
+    const messages = [
+      row({ id: 'sys-only-1', channel_type: 'agent', platform_id: null, thread_id: null }),
+    ];
+    const r = extractRouting(messages);
+    expect(r.platformId).toBe(null);
+    expect(r.channelType).toBe('agent');
+    expect(r.inReplyTo).toBe('sys-only-1');
+  });
+
+  it('returns all-null routing for an empty batch', () => {
+    const r = extractRouting([]);
+    expect(r.platformId).toBe(null);
+    expect(r.channelType).toBe(null);
+    expect(r.threadId).toBe(null);
+    expect(r.inReplyTo).toBe(null);
+  });
+
+  it('prefers a thread-bearing chat row over an earlier platform-only row', () => {
+    const messages = [
+      row({
+        id: 'm-channel-1',
+        platform_id: 'slack:C06HTHNR3DH',
+        channel_type: 'slack',
+        thread_id: null,
+      }),
+      row({
+        id: 'm-thread-2',
+        platform_id: 'slack:C06HTHNR3DH',
+        channel_type: 'slack',
+        thread_id: 'slack:C06HTHNR3DH:1778199266.779799',
+      }),
+    ];
+    const r = extractRouting(messages);
+    expect(r.threadId).toBe('slack:C06HTHNR3DH:1778199266.779799');
+    expect(r.inReplyTo).toBe('m-thread-2');
   });
 });

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -90,10 +90,30 @@ export interface RoutingContext {
 
 /**
  * Extract routing context from a batch of messages.
- * Uses the first message's routing fields.
+ *
+ * Picks the first message that carries platform routing context, with a
+ * 3-tier fallback to avoid system actions ("agent" channel, no thread)
+ * at the head of a mixed batch from null-ing out the chat reply's
+ * thread context.
+ *
+ * Tiers:
+ *   1. message with both platform_id and thread_id (preserves thread)
+ *   2. message with platform_id only (channel-level reply)
+ *   3. messages[0] (legacy fallback for empty/system-only batches)
+ *
+ * Background — incident 2026-05-08, sess-1778201595257-akx9i0:
+ * after an install_packages approval the next batch had a
+ * channel_type='agent' approval-note row at messages[0] with
+ * thread_id=NULL. The legacy `messages[0]` pick propagated null into
+ * messages_out.thread_id for every subsequent chat reply (seq 15/17/19),
+ * so the chat-sdk-bridge dropped the Slack thread_ts and posted at
+ * channel root instead of in the thread.
  */
 export function extractRouting(messages: MessageInRow[]): RoutingContext {
-  const first = messages[0];
+  const first =
+    messages.find((m) => m.platform_id && m.thread_id) ??
+    messages.find((m) => m.platform_id) ??
+    messages[0];
   return {
     platformId: first?.platform_id ?? null,
     channelType: first?.channel_type ?? null,


### PR DESCRIPTION
## Summary

`extractRouting()` (`container/agent-runner/src/formatter.ts`) previously took `messages[0]`'s routing fields verbatim. When a batch begins with a non-chat system message — e.g. an `install_packages` approval-note row inserted with `channel_type='agent'`, `platform_id='ag-<group>'`, `thread_id=NULL` — it nulls out the routing context that the chat reply downstream inherits from `RoutingContext`, so `messages_out.thread_id` is written as `NULL`.

For the `chat-sdk-bridge` / `@chat-adapter/slack` stack this drops the Slack `thread_ts` on the outbound `chat.postMessage`, and the bot's reply posts at channel root instead of in the originating thread.

## Fix

Prefer the first row that actually carries platform routing, with a 3-tier fallback so legacy semantics survive when no routing-bearing row is present:

1. row with both `platform_id` and `thread_id` (preserves thread)
2. row with `platform_id` only (channel-level reply)
3. `messages[0]` (legacy fallback for empty / system-only batches)

```ts
const first =
  messages.find((m) => m.platform_id && m.thread_id) ??
  messages.find((m) => m.platform_id) ??
  messages[0];
```

## How it was found — production incident 2026-05-08

A Maskit Slack workspace running v2 (chat-sdk-bridge + `@chat-adapter/slack` v4.26.0) exhibited bot replies posting to channel root after a Slack thread reply triggered an `install_packages` approval. Direct DB inspection of `messages_out` (session `sess-1778201595257-akx9i0`):

| seq | kind   | thread_id |
|-----|--------|-----------|
| 13  | chat   | `slack:C06HTHNR3DH:1778201592.978489` ✅ |
| 11  | system | `NULL` (install_packages approval-note) |
| 15  | chat   | `NULL` ❌ regression starts |
| 17  | chat   | `NULL` ❌ |
| 19  | chat   | `NULL` ❌ |

A parallel session on the same channel (`sess-1778199269018`) that did not see a system action kept `thread_id` intact across the identical container rebuild, ruling out the rebuild itself as the cause.

## Verification

- **Unit**: 6 new cases under `extractRouting` covering each fallback tier + the empty batch + a regression test that reproduces the agent-channel-at-head shape from the incident.
- **Live**: patched container restarted via `clawstack restart tech` (host-mounted `/app/src`; no image rebuild needed). Subsequent thread replies landed back in the correct thread; DB query confirms `messages_out.thread_id` populated for sessions created after the restart (`sess-1778212541` / `sess-1778212430`), including multi-turn replies.

## Scope

`container/agent-runner/src/formatter.ts` only. No interface, type, or DB schema changes. Channel adapters (Slack chat-sdk-bridge included) already honour `thread_id` correctly when populated; the bug was upstream of them in routing extraction. Telegram / Discord paths that also feed through `extractRouting` benefit from the same fix.

## Relation to other open Slack-thread work

This is a different defect from the open PRs in #1745 (#522, #653, #682, #1589). Those address the `add-slack`/Bolt code path; this fixes routing extraction in the `chat-sdk-bridge` / `agent-runner` pipeline, which is where the upstream v2 codebase routes Slack messages today. The two areas are independent and the fixes are compatible.

Refs incident: Maskit production, `sess-1778201595257-akx9i0`, 2026-05-08T11:17:58 KST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)