### PR TITLE
fix(channels/whatsapp): single-timer reconnect + clean teardown

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -381,6 +381,40 @@ registerChannelAdapter('whatsapp', {
     // Outgoing queue for messages sent while disconnected
     const outgoingQueue: Array<{ jid: string; text: string; mentions?: string[] }> = [];
     let flushing = false;
+    // Reconnection state. `reconnectTimer` is the single pending timer —
+    // tracked so we never schedule a duplicate (multiple disconnect events
+    // during a 440 storm would otherwise stack timers and fight each other)
+    // and so teardown() can cancel a pending attempt that would keep the
+    // event loop alive past process.exit(). `consecutiveFailures` drives
+    // exponential backoff: each failed attempt doubles the next delay,
+    // resetting on success.
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let consecutiveFailures = 0;
+
+    function scheduleReconnect(): void {
+      if (reconnectTimer !== null) {
+        log.debug('Reconnect already scheduled, skipping duplicate');
+        return;
+      }
+      // First attempt: immediate. Subsequent: 5s, 10s, 20s, 40s, capped at 60s.
+      const delayMs =
+        consecutiveFailures === 0
+          ? 0
+          : Math.min(RECONNECT_DELAY_MS * 2 ** (consecutiveFailures - 1), 60_000);
+      log.info('Reconnecting...', { delayMs, consecutiveFailures });
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connectSocket()
+          .then(() => {
+            consecutiveFailures = 0;
+          })
+          .catch((err) => {
+            consecutiveFailures++;
+            log.error('Reconnect failed', { err, consecutiveFailures });
+            scheduleReconnect();
+          });
+      }, delayMs);
+    }
 
     // Sent message cache for retry/re-encrypt requests
     const sentMessageCache = new Map<string, any>();
@@ -674,15 +708,7 @@ registerChannelAdapter('whatsapp', {
           log.info('WhatsApp connection closed', { reason, shouldReconnect, shuttingDown });
 
           if (shouldReconnect) {
-            log.info('Reconnecting...');
-            connectSocket().catch((err) => {
-              log.error('Failed to reconnect, retrying in 5s', { err });
-              setTimeout(() => {
-                connectSocket().catch((err2) => {
-                  log.error('Reconnection retry failed', { err: err2 });
-                });
-              }, RECONNECT_DELAY_MS);
-            });
+            scheduleReconnect();
           } else if (reason === DisconnectReason.loggedOut) {
             // Server-side logout (account unlinked, 401, etc.). Clear auth so
             // the next start prompts for a fresh pair — stale creds would
@@ -1025,7 +1051,26 @@ registerChannelAdapter('whatsapp', {
       async teardown() {
         shuttingDown = true;
         connected = false;
-        sock?.end(undefined);
+        // Cancel any pending reconnect timer. Without this, a timer scheduled
+        // just before teardown will fire after we've torn down — calling
+        // connectSocket() during shutdown, keeping the event loop alive past
+        // process.exit() being called, and ultimately stalling the host's
+        // graceful shutdown until systemd escalates to SIGKILL.
+        if (reconnectTimer !== null) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+        // sock.end() / sock.ws.close() send a close-frame and await the
+        // server's ack. During a 440 storm the server doesn't ack, so the
+        // close hangs indefinitely. terminate() drops the underlying TCP
+        // connection without negotiation — which is what we want during
+        // teardown: stop talking, exit promptly.
+        const ws = (sock as unknown as { ws?: { terminate?: () => void } } | undefined)?.ws;
+        if (ws?.terminate) {
+          ws.terminate();
+        } else {
+          sock?.end(undefined);
+        }
         log.info('WhatsApp adapter shut down');
       },
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Two related bugs in `src/channels/whatsapp.ts` that combine to produce a self-sustaining 440 storm and a hung graceful shutdown.

### Bug 1: reconnect timer stacking

The reconnect path called `connectSocket()` synchronously on every `connection.update` close event, with a nested `setTimeout` for a single hardcoded retry. When WhatsApp returned status 440 ("Conflict — another client connected") in rapid succession (e.g., during a session conflict, network blip, or two NanoClaw processes briefly racing for the same session), close events stacked timers and fired N parallel `connectSocket()` calls. Each new attempt produced another 440 (the server saw multiple clients), making the storm self-sustaining. After the two hardcoded attempts the adapter also gave up entirely — so transient outages required manual intervention to recover.

### Bug 2: teardown hangs forever during 440 storms

`teardown()` called `sock.end(undefined)`, which sends a WebSocket close-frame and awaits the server's ack. During a 440 storm the server doesn't ack — the close hangs indefinitely, holding the event loop open past `process.exit()` and stalling graceful shutdown. systemd has to escalate to `SIGKILL` after `TimeoutStopSec` to actually terminate the process.

## Fix

**Single `reconnectTimer` + `scheduleReconnect()` helper.** No-ops if a timer is already pending — this is the dedup that prevents storm stacking. Subsequent disconnect events while a reconnect is queued get silently coalesced.

**Exponential backoff** via a `consecutiveFailures` counter: 0, 5s, 10s, 20s, 40s, capped at 60s. Resets on a successful `connectSocket()`. On failure the helper recurses with the next-larger delay rather than giving up after a fixed retry count, so transient outages eventually recover without manual intervention.

**Teardown** clears the pending reconnect timer (so it can't fire after teardown and reopen the socket), and prefers `ws.terminate()` over `sock.end()` to drop the underlying TCP connection without waiting for the never-coming close-frame ack. Falls back to `sock.end(undefined)` if the underlying ws shim doesn't expose `terminate`.

## Behavioral change vs current

- Previously: two failed reconnect attempts → adapter silently gives up forever.
- Now: retries indefinitely with exponential backoff capped at 60s.

This is the right shape for a long-running personal-assistant process — transient outages (network blips, server-side hiccups, momentary 440s) should self-heal without operator intervention. Combined with the dedup, the retry loop is bounded in resource use no matter how often disconnect events fire.

## Files

- `src/channels/whatsapp.ts` — single file changed; +55/-10 lines.

## Notes

- The `ws.terminate()` cast goes through `unknown` because Baileys' `WASocket` type doesn't expose the underlying ws shim publicly. The runtime API is stable in `ws@8.x` (Baileys' transitive dep). Falls back gracefully if `terminate` isn't present.
- This adapter lives on the `channels` branch (per nanoclaw's skill-installed-channels architecture), so this PR targets `channels`, not `main`.