### PR TITLE
fix(mount-security): tolerate allowlist entries missing path field

### DIFF
--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -220,6 +220,14 @@ function matchesBlockedPattern(realPath: string, blockedPatterns: string[]): str
  */
 function findAllowedRoot(realPath: string, allowedRoots: AllowedRoot[]): AllowedRoot | null {
   for (const root of allowedRoots) {
+    if (!root.path) {
+      // Defensive: a malformed allowlist entry without a `path` field would
+      // otherwise crash expandPath() with TypeError, taking down the whole
+      // mount-validation path and any container spawn that depends on it.
+      // Log + skip so a single bad entry can't deny service.
+      log.warn('Allowlist entry missing path field — skipping', { root });
+      continue;
+    }
     const expandedRoot = expandPath(root.path);
     const realRoot = getRealPath(expandedRoot);
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

If an entry in the mount allowlist has no `path` field, `expandPath(root.path)` inside `findAllowedRoot` throws `TypeError: Cannot read properties of undefined (reading 'startsWith')`. The error propagates out of `validateAdditionalMounts` and out of `buildMounts`, crashing every container spawn that runs through this validator.

Symptom path observed in production: container spawn fails silently in `buildMounts`, the inbound message stays pending, host-sweep retries on its next tick, hits the same crash, eventually decides the container "isn't running" and runs orphan-claim cleanup. From the user's perspective: messages just stop being answered. From the logs: a single `TypeError` with no other context.

## Where the malformed entry comes from

The current writer (`setup/mounts.ts`) only produces well-formed entries, so in normal operation this code path never fires. The defensive guard exists for cases where an entry can still be malformed:

- Hand-edits to the allowlist file
- In-place migrations that don't catch all schema changes
- Future code paths that synthesize entries

In any of those cases, a single bad entry shouldn't take down all container spawns.

## Fix

```ts
function findAllowedRoot(realPath: string, allowedRoots: AllowedRoot[]): AllowedRoot | null {
  for (const root of allowedRoots) {
    if (!root.path) {
      log.warn('Allowlist entry missing path field — skipping', { root });
      continue;
    }
    const expandedRoot = expandPath(root.path);
    // ...
  }
}
```

The warning logs the offending entry so its source can be diagnosed (the entry's shape often reveals which writer produced it). Subsequent valid entries are still evaluated normally.

## Files

- `src/modules/mount-security/index.ts` — 4-line additive guard.

## Test plan

- Unaffected by existing tests; behavior change is "throws on malformed entry" → "warns + skips on malformed entry" which can't be triggered by the well-formed entries the rest of the codebase produces.