### PR TITLE
fix(container-runner): raise install_packages build timeout to 15min

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -530,7 +530,7 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
     execSync(`${CONTAINER_RUNTIME_BIN} build -t ${imageTag} -f ${tmpDockerfile} .`, {
       cwd: DATA_DIR,
       stdio: 'pipe',
-      timeout: 300_000,
+      timeout: 900_000,
     });
   } finally {
     fs.unlinkSync(tmpDockerfile);


### PR DESCRIPTION
## Summary

- Raises the `execSync` timeout in `buildAgentGroupImage()` from 5 minutes (`300_000` ms) to 15 minutes (`900_000` ms).
- Surfaced via the `install_packages` self-mod flow: a real install with apt + npm packages on a slow network hit `spawnSync /bin/sh ETIMEDOUT` mid-build, leaving the agent group's container image not rebuilt and the pending install silently abandoned.
- The previous timeout was tight specifically for first-time package installs — that's the only path that exercises this code, so the worst-case is also the common case here.

## Test plan

- [ ] Trigger an `install_packages` approval that adds at least one apt package (e.g. `ffmpeg`) on a fresh image, verify build completes without ETIMEDOUT.
- [ ] Verify the original guard still fires for a genuinely hung build (kill `dockerd` mid-build → expect timeout after 15 min, not silent hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)