### PR TITLE
fix(session-manager): chown new session dirs when host runs as root

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -10,6 +10,7 @@
  *   3. One writer per file — DELETE-mode journal-unlink isn't atomic across
  *      the mount; concurrent writers corrupt the DB.
  */
+import { execFileSync } from 'child_process';
 import type Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
@@ -140,6 +141,25 @@ export function initSessionFolder(agentGroupId: string, sessionId: string): void
 
   ensureSchema(inboundDbPath(agentGroupId, sessionId), 'inbound');
   ensureSchema(outboundDbPath(agentGroupId, sessionId), 'outbound');
+
+  // When the host runs as root, files are written with uid=0. The agent image
+  // ships with `USER node` (uid 1000) and Claude Code refuses to run as root
+  // (`--dangerously-skip-permissions cannot be used with root/sudo privileges`),
+  // so we cannot work around the ownership mismatch by passing `--user 0:0`.
+  // Chown the session tree to 1000:1000 so the container's `node` user can
+  // write outbound.db and touch the heartbeat file. No-op when the host
+  // already runs as the container UID (1000) or any non-root UID — those
+  // paths fall through to the existing `--user $hostUid:$hostGid` mapping
+  // in container-runner.ts.
+  if (process.getuid?.() === 0) {
+    try {
+      execFileSync('chown', ['-R', '1000:1000', dir], { stdio: 'ignore' });
+    } catch {
+      // best-effort; if chown fails the agent will fail later with a clearer
+      // SQLite "attempt to write a readonly database" error and the host
+      // sweep retries the message until the operator notices.
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Linux installs that run NanoClaw as root with the data directory on a network filesystem hit an unrecoverable container spawn loop. Two constraints collide:

1. The agent image ships with `USER node` (uid 1000) and Claude Code refuses to run as root:

   ```
   --dangerously-skip-permissions cannot be used with root/sudo privileges
   ```

   So `--user 0:0` on `docker run` is not a workaround.

2. The host process writes `inbound.db` and the session-folder scaffolding as uid 0. On a network filesystem (NFS in my case) the container's uid 1000 cannot write `outbound.db` or `touch` the heartbeat file. `bun:sqlite` surfaces this as:

   ```
   Fatal error: attempt to write a readonly database
   ```

The container exits code=1 microseconds after `agent-runner` startup, the host sweep retries a few times, then marks the inbound message completed without ever sending a response.

## What this changes

`initSessionFolder` chowns each freshly-created session directory to `1000:1000` when `process.getuid() === 0`. No-op for any non-root host UID — those paths fall through to the existing `--user $hostUid:$hostGid` mapping in `container-runner.ts`. `execFileSync('chown', ...)` is best-effort: if it fails, the agent fails later with the clearer SQLite error and the sweep retries until the operator notices.

## Test plan

- [x] `pnpm run build` passes (no new deps, no type changes).
- [x] On the affected host (root + NFS-backed `/pods`), reproduced the spawn loop on `main`. With this patch applied, `chown -R 1000:1000 <session-dir>` runs at session create, the container's `node` user can write `outbound.db`, and Telegram round-trip completes (verified end-to-end).
- [ ] Doesn't run when host UID != 0, so no behavior change for the normal Mac/Linux-as-non-root install.

## Reproducer

```bash
# On a host running as root, with /pods on NFS:
sudo -i
cd /pods/nanoclaw-v2
systemctl start nanoclaw-v2-<slug>
# Send any inbound to the bot. Container exits ~370ms after spawn.
journalctl -u nanoclaw-v2-<slug> | grep "readonly database"
```

## Notes / things to discuss

- The hard-coded `1000:1000` matches the image's `USER node` directive but isn't future-proof if the image ever changes UID. If you'd prefer, this could be made configurable via env var (e.g. `NANOCLAW_CONTAINER_UID:GID`) or read from the image at startup. Happy to fold in either approach.
- Existing session dirs created before the patch is applied won't be chowned automatically — operators on affected setups will need a one-time `chown -R 1000:1000 data/v2-sessions/`.
- This was discovered finishing a v1→v2 migration; full incident notes in the migration record (separate from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)