### PR TITLE
feat/add watchdog

### DIFF
--- a/.claude/skills/add-watchdog/SKILL.md
+++ b/.claude/skills/add-watchdog/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: add-watchdog
+description: Install the NanoClaw watchdog — a systemd timer that runs every 15 minutes to detect failed/stuck digest sessions and invokes Claude Code to auto-remediate before the user notices digests stopped. Detects three failure modes: dead recurring series (status=failed AND recurrence IS NOT NULL), stuck processing (status=processing >45 min with stale heartbeat), and service down. Use when the user wants proactive digest failure detection and auto-recovery.
+---
+
+# add-watchdog
+
+Installs `scripts/watchdog.ts` and a systemd timer that runs it every 15 minutes.
+On detecting an issue, the watchdog invokes `claude --dangerously-skip-permissions -p "..."` to fix it and inject a WhatsApp notification task.
+
+## Prerequisites
+
+- NanoClaw is already set up and running (`systemctl --user status nanoclaw-v2-*.service` returns active)
+- `claude` CLI is authenticated (`claude whoami` works without interactive prompt)
+- Running from the NanoClaw repo root
+
+## Install
+
+### 1. Detect the NanoClaw service name and repo path
+
+```bash
+systemctl --user list-units 'nanoclaw-v2-*.service' --no-legend | awk '{print $1}'
+pwd
+```
+
+Record both values — needed to configure the watchdog.
+
+### 2. Copy scripts
+
+```bash
+cp "${CLAUDE_SKILL_DIR}/scripts/watchdog.ts"        scripts/watchdog.ts
+cp "${CLAUDE_SKILL_DIR}/scripts/watchdog-prompt.ts" scripts/watchdog-prompt.ts
+```
+
+### 3. Patch service name and repo path
+
+Replace the placeholders in the copied scripts:
+
+```bash
+REPO="$(pwd)"
+SERVICE="<service name from step 1>"
+
+sed -i "s|__NANOCLAW_SERVICE_NAME__|${SERVICE}|g" scripts/watchdog.ts
+sed -i "s|__NANOCLAW_SERVICE_NAME__|${SERVICE}|g" scripts/watchdog-prompt.ts
+sed -i "s|__NANOCLAW_REPO__|${REPO}|g"            scripts/watchdog-prompt.ts
+```
+
+### 4. Generate setup files
+
+```bash
+cp "${CLAUDE_SKILL_DIR}/setup/watchdog.timer"              setup/watchdog.timer
+cp "${CLAUDE_SKILL_DIR}/setup/install-watchdog-timer.sh"   setup/install-watchdog-timer.sh
+chmod +x setup/install-watchdog-timer.sh
+
+# Generate watchdog.service with correct paths
+REPO="$(pwd)"
+sed "s|__NANOCLAW_REPO__|${REPO}|g" "${CLAUDE_SKILL_DIR}/setup/watchdog.service" > setup/watchdog.service
+```
+
+### 5. Install the systemd timer
+
+```bash
+bash setup/install-watchdog-timer.sh
+```
+
+### 6. Verify installation
+
+```bash
+# Dry-run — should print "no issues detected" (or list real issues if any)
+pnpm exec tsx scripts/watchdog.ts --dry-run
+
+# Confirm timer is scheduled
+systemctl --user list-timers | grep watchdog
+```
+
+## Usage
+
+The watchdog runs automatically every 15 minutes via systemd.
+
+Manual invocation:
+
+```bash
+# Dry run — detect only, no claude invocation
+pnpm exec tsx scripts/watchdog.ts --dry-run
+
+# Normal run — detect and auto-remediate
+pnpm exec tsx scripts/watchdog.ts
+
+# Override paths
+pnpm exec tsx scripts/watchdog.ts --dry-run --sessions-dir /path/to/data/v2-sessions --repo /path/to/nanoclaw
+```
+
+Logs at `logs/watchdog.log` — each run appends timestamped entries; claude invocations include full output.
+
+## What it detects
+
+| Check | Condition | Fix |
+|-------|-----------|-----|
+| Dead recurring | `status='failed' AND recurrence IS NOT NULL` | Reset `tries=0`, `status='pending'` |
+| Stuck processing | `status='processing'` >45 min + stale heartbeat | Reset row, stop stuck container |
+| Service down | `systemctl --user is-active` non-zero | `systemctl --user restart` |
+
+After each fix, the watchdog instructs Claude to inject a `kind='task'` row into `inbound.db` so the agent notifies the user via their channel.
+
+## Troubleshooting
+
+### `claude` not found by systemd
+
+Systemd services may have a restricted PATH. Find the full path and hard-code it in the service file:
+
+```bash
+which claude
+# Then edit setup/watchdog.service — replace 'pnpm exec tsx scripts/watchdog.ts'
+# with the full command, e.g. using the full claude path
+```
+
+Reinstall after editing: `bash setup/install-watchdog-timer.sh`
+
+### Watchdog finds no sessions
+
+Check that `data/v2-sessions/` exists and contains `<agent_group_id>/<session_id>/inbound.db`. Run `pnpm exec tsx scripts/watchdog.ts --dry-run` from the repo root.
+
+### Timer not firing
+
+```bash
+systemctl --user status nanoclaw-watchdog.timer
+systemctl --user status nanoclaw-watchdog.service
+journalctl --user -u nanoclaw-watchdog.service --since "1 hour ago"
+```
+
+### `--dangerously-skip-permissions` requires interactive auth
+
+Run `claude whoami` to verify auth works non-interactively. If it prompts, complete auth first then re-run the watchdog.

--- a/.claude/skills/add-watchdog/scripts/watchdog-prompt.ts
+++ b/.claude/skills/add-watchdog/scripts/watchdog-prompt.ts
@@ -1,0 +1,125 @@
+import type { WatchdogIssue } from './watchdog.js';
+
+const SERVICE_NAME = '__NANOCLAW_SERVICE_NAME__';
+
+export function buildPrompt(issue: WatchdogIssue, agentGroupName: string, repo: string): string {
+  const sessionBlock = issue.sessionId
+    ? `Session info:
+  agentGroupId : ${issue.agentGroupId}
+  agentGroupName: ${agentGroupName}
+  sessionId    : ${issue.sessionId}
+  dbPath       : ${issue.dbPath}`.trim()
+    : `agentGroupName: ${agentGroupName} (global issue — no specific session)`;
+
+  return `
+You are remediating a NanoClaw watchdog alert. Work from the repo at: ${repo}
+
+${sessionBlock}
+
+Issue type  : ${issue.type}
+Issue detail: ${issue.detail}
+
+---
+REMEDIATION STEPS
+---
+
+${buildFixInstructions(issue, agentGroupName, repo)}
+
+${buildNotifyInstructions(issue, agentGroupName, repo)}
+
+Log what you did at each step to stdout.
+`.trim();
+}
+
+function buildFixInstructions(issue: WatchdogIssue, agentGroupName: string, repo: string): string {
+  switch (issue.type) {
+    case 'dead-recurring':   return buildDeadRecurringFix(issue, repo);
+    case 'stuck-processing': return buildStuckProcessingFix(issue, repo);
+    case 'service-down':     return buildServiceDownFix(agentGroupName, repo);
+    default: {
+      const _exhaustive: never = issue.type;
+      return `Unknown issue type: ${_exhaustive}`;
+    }
+  }
+}
+
+function buildDeadRecurringFix(issue: WatchdogIssue, repo: string): string {
+  return `
+STEP 1 — Find the failed recurring row:
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "SELECT id, recurrence, tries, platform_id, channel_type, thread_id FROM messages_in WHERE status='failed' AND recurrence IS NOT NULL"
+
+STEP 2 — Reset it to pending so NanoClaw will pick it up again:
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "UPDATE messages_in SET status='pending', tries=0 WHERE status='failed' AND recurrence IS NOT NULL"
+
+STEP 3 — Confirm the reset (should show status=pending, tries=0):
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "SELECT id, status, tries, recurrence FROM messages_in WHERE recurrence IS NOT NULL ORDER BY timestamp DESC LIMIT 5"
+`.trim();
+}
+
+function buildStuckProcessingFix(issue: WatchdogIssue, repo: string): string {
+  return `
+STEP 1 — Find the stuck processing row:
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "SELECT id, timestamp FROM messages_in WHERE status='processing' AND datetime(timestamp) < datetime('now','-45 minutes')"
+
+STEP 2 — Reset it to pending:
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "UPDATE messages_in SET status='pending', tries=0 WHERE status='processing' AND datetime(timestamp) < datetime('now','-45 minutes')"
+
+STEP 3 — Find and stop the stuck container (NanoClaw will respawn automatically):
+  docker ps --filter label=nanoclaw.session=${issue.sessionId}
+  (If listed, stop it: docker stop <container_id>)
+
+STEP 4 — Confirm no more stuck rows:
+  pnpm exec tsx scripts/q.ts "${issue.dbPath}" "SELECT id, status, tries FROM messages_in WHERE status='processing'"
+`.trim();
+}
+
+function buildServiceDownFix(agentGroupName: string, repo: string): string {
+  return `
+STEP 1 — Restart the NanoClaw service:
+  systemctl --user restart ${SERVICE_NAME}
+
+STEP 2 — Confirm it came back up:
+  sleep 5 && systemctl --user is-active ${SERVICE_NAME}
+
+STEP 3 — Find most recently active session for agent group "${agentGroupName}":
+  find ${repo}/data/v2-sessions -name '.heartbeat' -printf '%T@ %p\\n' | sort -n | tail -5
+  Use that session's inbound.db for the notification inject below.
+`.trim();
+}
+
+function buildNotifyInstructions(issue: WatchdogIssue, agentGroupName: string, repo: string): string {
+  const dbPathRef = issue.type === 'service-down'
+    ? '<inbound.db path found in STEP 3 above>'
+    : issue.dbPath;
+
+  const issueSummary = describeIssue(issue, agentGroupName);
+
+  return `
+NOTIFICATION INJECT — after fix steps, insert a pending task so the agent notifies the user:
+
+  A) Find routing coordinates:
+     pnpm exec tsx scripts/q.ts "${dbPathRef}" "SELECT platform_id, channel_type, thread_id FROM messages_in WHERE status IN ('completed','pending') AND platform_id IS NOT NULL ORDER BY timestamp DESC LIMIT 1"
+
+  B) Compute next even seq:
+     pnpm exec tsx scripts/q.ts "${dbPathRef}" "SELECT COALESCE(MAX(seq),0) FROM messages_in"
+     Add 2 if even, or round up to next even number.
+
+  C) Insert notification task (substitute real values):
+     pnpm exec tsx scripts/q.ts "${dbPathRef}" "INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger) VALUES ('watchdog-notify-$(date +%s%3N)', <next_even_seq>, 'task', datetime('now'), 'pending', '<platform_id>', '<channel_type>', '<thread_id>', '{\"text\":\"Watchdog detected and fixed an issue: ${issueSummary}. Please notify the user with a brief summary.\"}', NULL, NULL, 'watchdog-notify-$(date +%s%3N)', 1)"
+
+  D) Log what was done.
+`.trim();
+}
+
+function describeIssue(issue: WatchdogIssue, agentGroupName: string): string {
+  switch (issue.type) {
+    case 'dead-recurring':
+      return `dead-recurring in agent ${agentGroupName} (${issue.detail})`;
+    case 'stuck-processing':
+      return `stuck-processing in agent ${agentGroupName} session ${issue.sessionId} (${issue.detail})`;
+    case 'service-down':
+      return `service-down — ${SERVICE_NAME} was not active`;
+    default:
+      return `${issue.type} — ${issue.detail}`;
+  }
+}

--- a/.claude/skills/add-watchdog/scripts/watchdog.ts
+++ b/.claude/skills/add-watchdog/scripts/watchdog.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env tsx
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import { execSync, spawnSync } from 'child_process';
+import { buildPrompt } from './watchdog-prompt.js';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+
+function getArg(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx !== -1 && args[idx + 1]) return args[idx + 1];
+  return undefined;
+}
+
+const repo = getArg('--repo') ?? process.cwd();
+const sessionsDir = getArg('--sessions-dir') ?? path.join(repo, 'data', 'v2-sessions');
+
+const SERVICE_NAME = '__NANOCLAW_SERVICE_NAME__';
+const STUCK_THRESHOLD_MIN = 45;
+const STUCK_THRESHOLD_MS = STUCK_THRESHOLD_MIN * 60 * 1000;
+
+const logsDir = path.join(repo, 'logs');
+const logFile = path.join(logsDir, 'watchdog.log');
+let logDirEnsured = false;
+
+function ensureLogDir(): void {
+  if (!logDirEnsured) {
+    if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+    logDirEnsured = true;
+  }
+}
+
+function log(level: 'INFO' | 'WARN' | 'ERROR', message: string): void {
+  const line = `[${new Date().toISOString()}] [${level}] ${message}`;
+  console.log(line);
+  try {
+    ensureLogDir();
+    fs.appendFileSync(logFile, line + '\n');
+  } catch (e) {
+    console.error(`[watchdog] Failed to write to log file: ${e}`);
+  }
+}
+
+export interface WatchdogIssue {
+  agentGroupId: string;
+  sessionId: string;
+  dbPath: string;
+  type: 'dead-recurring' | 'stuck-processing' | 'service-down';
+  detail: string;
+}
+
+function discoverSessions(): Array<{ agentGroupId: string; sessionId: string; dbPath: string }> {
+  const results: Array<{ agentGroupId: string; sessionId: string; dbPath: string }> = [];
+
+  if (!fs.existsSync(sessionsDir)) {
+    log('WARN', `Sessions directory does not exist: ${sessionsDir}`);
+    return results;
+  }
+
+  let agentGroupDirs: string[];
+  try {
+    agentGroupDirs = fs.readdirSync(sessionsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+  } catch (e) {
+    log('ERROR', `Failed to read sessions directory: ${e}`);
+    return results;
+  }
+
+  for (const agentGroupId of agentGroupDirs) {
+    const agGroupPath = path.join(sessionsDir, agentGroupId);
+    let sessionDirs: string[];
+    try {
+      sessionDirs = fs.readdirSync(agGroupPath, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch (e) {
+      log('WARN', `Failed to read agent group dir ${agGroupPath}: ${e}`);
+      continue;
+    }
+
+    for (const sessionId of sessionDirs) {
+      const dbPath = path.join(agGroupPath, sessionId, 'inbound.db');
+      if (fs.existsSync(dbPath)) {
+        results.push({ agentGroupId, sessionId, dbPath });
+      }
+    }
+  }
+
+  return results;
+}
+
+interface FailedRecurringRow { id: string; recurrence: string; tries: number; }
+
+function checkDeadRecurring(agentGroupId: string, sessionId: string, dbPath: string): WatchdogIssue[] {
+  let db: Database.Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    db.pragma('busy_timeout = 3000');
+    const rows = db.prepare(
+      `SELECT id, recurrence, tries FROM messages_in WHERE status='failed' AND recurrence IS NOT NULL`,
+    ).all() as FailedRecurringRow[];
+    return rows.map(row => ({
+      agentGroupId, sessionId, dbPath,
+      type: 'dead-recurring' as const,
+      detail: `message id=${row.id} tries=${row.tries} recurrence=${row.recurrence}`,
+    }));
+  } catch (e) {
+    log('WARN', `check-dead-recurring: failed to query ${dbPath}: ${e}`);
+    return [];
+  } finally {
+    db?.close();
+  }
+}
+
+interface ProcessingRow { id: string; timestamp: string; }
+
+function isHeartbeatStale(heartbeatPath: string): boolean {
+  try {
+    const stat = fs.statSync(heartbeatPath);
+    return Date.now() - stat.mtimeMs > STUCK_THRESHOLD_MS;
+  } catch {
+    return true;
+  }
+}
+
+function checkStuckProcessing(agentGroupId: string, sessionId: string, dbPath: string): WatchdogIssue[] {
+  let db: Database.Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    db.pragma('busy_timeout = 3000');
+    const rows = db.prepare(
+      `SELECT id, timestamp FROM messages_in
+       WHERE status='processing'
+         AND datetime(timestamp) < datetime('now', '-${STUCK_THRESHOLD_MIN} minutes')`,
+    ).all() as ProcessingRow[];
+
+    if (rows.length === 0) return [];
+
+    const heartbeatPath = path.join(path.dirname(dbPath), '.heartbeat');
+    if (!isHeartbeatStale(heartbeatPath)) return [];
+
+    return rows.map(row => ({
+      agentGroupId, sessionId, dbPath,
+      type: 'stuck-processing' as const,
+      detail: `message id=${row.id} timestamp=${row.timestamp} heartbeat=absent-or-stale`,
+    }));
+  } catch (e) {
+    log('WARN', `check-stuck-processing: failed to query ${dbPath}: ${e}`);
+    return [];
+  } finally {
+    db?.close();
+  }
+}
+
+function checkServiceDown(): WatchdogIssue | null {
+  try {
+    execSync(`systemctl --user is-active ${SERVICE_NAME}`, { stdio: 'pipe' });
+    return null;
+  } catch {
+    return {
+      agentGroupId: '', sessionId: '', dbPath: '',
+      type: 'service-down',
+      detail: `${SERVICE_NAME} is not active`,
+    };
+  }
+}
+
+const centralDb = path.join(repo, 'data', 'v2.db');
+
+function lookupAgentGroupName(agentGroupId: string): string {
+  if (!agentGroupId) return 'unknown';
+  let db: Database.Database | null = null;
+  try {
+    db = new Database(centralDb, { readonly: true });
+    db.pragma('busy_timeout = 3000');
+    const row = db.prepare('SELECT name FROM agent_groups WHERE id = ?').get(agentGroupId) as
+      | { name: string } | undefined;
+    return row?.name ?? agentGroupId;
+  } catch (e) {
+    log('WARN', `lookupAgentGroupName: could not query central DB: ${e}`);
+    return agentGroupId;
+  } finally {
+    db?.close();
+  }
+}
+
+function handleIssue(issue: WatchdogIssue): void {
+  const agentGroupName = lookupAgentGroupName(issue.agentGroupId);
+  const prompt = buildPrompt(issue, agentGroupName, repo);
+
+  const header =
+    `\n${'='.repeat(72)}\n` +
+    `[${new Date().toISOString()}] WATCHDOG REMEDIATION: ${issue.type}\n` +
+    `  agentGroupId=${issue.agentGroupId} sessionId=${issue.sessionId}\n` +
+    `  detail=${issue.detail}\n` +
+    `${'='.repeat(72)}\n`;
+
+  log('INFO', `invoking claude for issue: ${issue.type} (agent=${agentGroupName})`);
+
+  const result = spawnSync('claude', ['--dangerously-skip-permissions', '-p', prompt], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+
+  const stderrBlock = result.stderr?.trim() ? `--- stderr ---\n${result.stderr}` : '';
+  const output = [header, result.stdout ?? '', stderrBlock, `--- exit code: ${result.status ?? 'null'} ---\n`]
+    .filter(Boolean).join('\n');
+
+  try {
+    ensureLogDir();
+    fs.appendFileSync(logFile, output);
+  } catch (e) {
+    console.error(`[watchdog] Failed to append claude output to log: ${e}`);
+  }
+
+  if (result.status !== 0) {
+    log('WARN', `claude exited with code ${result.status} for issue ${issue.type}`);
+  } else {
+    log('INFO', `claude remediation complete for issue: ${issue.type}`);
+  }
+}
+
+async function main(): Promise<void> {
+  ensureLogDir();
+  log('INFO', `watchdog starting (dry-run=${dryRun}, sessions-dir=${sessionsDir})`);
+
+  const issues: WatchdogIssue[] = [];
+
+  const sessions = discoverSessions();
+  log('INFO', `discovered ${sessions.length} session(s)`);
+
+  for (const { agentGroupId, sessionId, dbPath } of sessions) {
+    issues.push(
+      ...checkDeadRecurring(agentGroupId, sessionId, dbPath),
+      ...checkStuckProcessing(agentGroupId, sessionId, dbPath),
+    );
+  }
+
+  const serviceIssue = checkServiceDown();
+  if (serviceIssue) issues.push(serviceIssue);
+
+  if (issues.length === 0) {
+    log('INFO', 'no issues detected');
+  } else {
+    log('WARN', `detected ${issues.length} issue(s):`);
+    for (const issue of issues) {
+      const loc = issue.sessionId
+        ? `ag=${issue.agentGroupId} sess=${issue.sessionId}`
+        : 'global';
+      log('WARN', `  [${issue.type}] ${loc} — ${issue.detail}`);
+    }
+  }
+
+  if (dryRun) {
+    log('INFO', 'dry-run mode — exiting without remediation');
+    process.exit(0);
+  }
+
+  for (const issue of issues) {
+    handleIssue(issue);
+  }
+
+  log('INFO', 'watchdog done');
+}
+
+main().catch(e => {
+  log('ERROR', `watchdog crashed: ${e}`);
+  process.exit(1);
+});

--- a/.claude/skills/add-watchdog/setup/install-watchdog-timer.sh
+++ b/.claude/skills/add-watchdog/setup/install-watchdog-timer.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+mkdir -p "$SYSTEMD_USER_DIR"
+
+cp "$SCRIPT_DIR/watchdog.service" "$SYSTEMD_USER_DIR/nanoclaw-watchdog.service"
+cp "$SCRIPT_DIR/watchdog.timer"   "$SYSTEMD_USER_DIR/nanoclaw-watchdog.timer"
+
+systemctl --user daemon-reload
+systemctl --user enable --now nanoclaw-watchdog.timer
+
+echo "NanoClaw watchdog timer installed and started."
+systemctl --user status nanoclaw-watchdog.timer --no-pager

--- a/.claude/skills/add-watchdog/setup/watchdog.service
+++ b/.claude/skills/add-watchdog/setup/watchdog.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=NanoClaw watchdog — detect and fix stuck digest sessions
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=__NANOCLAW_REPO__
+ExecStart=/bin/bash -c 'cd __NANOCLAW_REPO__ && pnpm exec tsx scripts/watchdog.ts'
+StandardOutput=append:__NANOCLAW_REPO__/logs/watchdog.log
+StandardError=append:__NANOCLAW_REPO__/logs/watchdog.log

--- a/.claude/skills/add-watchdog/setup/watchdog.timer
+++ b/.claude/skills/add-watchdog/setup/watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run NanoClaw watchdog every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Unit=nanoclaw-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ Check these first when something goes wrong:
 | Host logs | `logs/nanoclaw.error.log` first (delivery failures, crash-loop backoff, warnings), then `logs/nanoclaw.log` for the full routing chain |
 | Setup logs | `logs/setup.log` (overall), `logs/setup-steps/*.log` (per-step: bootstrap, environment, container, onecli, mounts, service, etc.) |
 | Session DBs | `data/v2-sessions/<agent-group>/<session>/` — `inbound.db` (`messages_in`: did the message reach the container?), `outbound.db` (`messages_out`: did the agent produce a response?) |
+| Watchdog log | `logs/watchdog.log` — auto-remediation runs, issues detected, claude output |
 
 Note: container logs are lost after the container exits (`--rm` flag). If the agent silently failed inside the container, there's no persistent log to inspect.
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [x] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Install the NanoClaw watchdog — a systemd timer that runs every 15 minutes to detect failed/stuck digest sessions and invokes Claude Code to auto-remediate before the user notices messages stopped. Detects three failure modes: dead recurring series (status=failed AND recurrence IS NOT NULL), stuck processing (status=processing >45 min with stale heartbeat), and service down. Use when the user wants proactive  failure detection and auto-recovery.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
