### PR TITLE
feat(plugins): wire extraKnownMarketplaces + enabledPlugins via container.json

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -422,6 +422,13 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
     case 'compacted':
       log(`Compacted: ${event.text}`);
       break;
+    case 'plugin_install_failed':
+      // SDK failed to install a marketplace/plugin declared in
+      // settings.json:extraKnownMarketplaces. Log loudly so the operator
+      // notices when scanning agent logs; the agent's session continues
+      // without the failed plugin (SDK behavior, verified empirically).
+      log(`Plugin install failed: name=${event.name ?? '<unknown>'} error=${event.error.slice(0, 300)}`);
+      break;
   }
 }
 

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -333,6 +333,24 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
           const tn = message as { summary?: string };
           yield { type: 'progress', message: tn.summary || 'Task notification' };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'plugin_install') {
+          // SDK plugin install lifecycle (started/installed/failed/completed).
+          // Failures need explicit surfacing so the operator sees them; other
+          // statuses are activity-only signals — installs can take 30+ seconds
+          // for slow github clones, and the poll loop's idle timer would
+          // otherwise fire mid-clone and kill the session.
+          const m = message as { status?: string; name?: string; error?: string };
+          if (m.status === 'failed') {
+            log(`plugin_install failed: name=${m.name ?? '<unknown>'} error=${m.error?.slice(0, 200) ?? ''}`);
+            yield {
+              type: 'plugin_install_failed',
+              name: m.name ?? null,
+              error: m.error ?? 'unknown error',
+            };
+          } else if (m.status === 'installed') {
+            log(`plugin_install installed: ${m.name ?? '<unknown>'}`);
+          }
+          // started/completed: covered by the activity yield above.
         }
       }
       log(`Query completed after ${messageCount} SDK messages`);

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -87,4 +87,13 @@ export type ProviderEvent =
    * after compaction. Distinct from `result` so it doesn't mark the turn
    * completed or get dispatched as a chat message. See qwibitai/nanoclaw#2325.
    */
-  | { type: 'compacted'; text: string };
+  | { type: 'compacted'; text: string }
+  /**
+   * Plugin install failure event. Emitted by claude provider when the SDK
+   * fires a `plugin_install:failed` system message during marketplace clone
+   * or plugin install. Distinct from `error` because this isn't a poll-loop
+   * retry signal — the SDK continues the session without the failed
+   * plugin, and the host should log + surface the failure to the operator
+   * without aborting the turn.
+   */
+  | { type: 'plugin_install_failed'; name: string | null; error: string };

--- a/src/container-config.test.ts
+++ b/src/container-config.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { GROUPS_DIR } from './config.js';
+
+let originalGroupsDir: string;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  // Mock GROUPS_DIR by using a temp dir as the root and making config.ts
+  // read from it. Since GROUPS_DIR is exported as a const we instead create
+  // a real folder under the existing GROUPS_DIR and clean it up.
+  originalGroupsDir = GROUPS_DIR;
+  tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nanoclaw-cfg-test-'));
+});
+
+afterEach(async () => {
+  await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+});
+
+// We test by creating a real folder under GROUPS_DIR with a unique name
+// per test so we don't pollute or collide with other groups.
+function makeTestFolder(suffix: string): string {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  const full = path.join(GROUPS_DIR, folder);
+  fs.mkdirSync(full, { recursive: true });
+  return folder;
+}
+
+function cleanupFolder(folder: string): void {
+  fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+}
+
+describe('container-config: atomic write + advisory lock', () => {
+  it('writeContainerConfig is atomic (write-then-rename)', async () => {
+    const { writeContainerConfig, readContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('atomic');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+      const cfg = readContainerConfig(folder);
+      expect(cfg.skills).toBe('all');
+      // No .tmp.* leftover after rename.
+      const dir = path.join(GROUPS_DIR, folder);
+      const entries = fs.readdirSync(dir);
+      expect(entries.filter((e) => e.includes('.tmp.'))).toEqual([]);
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+
+  it('updateContainerConfig serializes concurrent writers', async () => {
+    const { updateContainerConfig, readContainerConfig, writeContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('concurrent');
+    try {
+      // Seed with a known starting state.
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+
+      // Fire 10 concurrent updates each adding a unique package. Without
+      // locking + atomic writes, lost updates would mean fewer than 10 in
+      // the final state.
+      const writers = Array.from({ length: 10 }, (_, i) =>
+        updateContainerConfig(folder, (cfg) => {
+          cfg.packages.apt.push(`pkg-${i}`);
+        }),
+      );
+      await Promise.all(writers);
+
+      const final = readContainerConfig(folder);
+      expect(final.packages.apt.sort()).toEqual(Array.from({ length: 10 }, (_, i) => `pkg-${i}`).sort());
+    } finally {
+      cleanupFolder(folder);
+    }
+  }, 15000);
+
+  it('updateContainerConfig releases lock on mutator throw', async () => {
+    const { updateContainerConfig, writeContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('throw');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+
+      await expect(
+        updateContainerConfig(folder, () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      // Lock should be released so a follow-up update doesn't hang.
+      await updateContainerConfig(folder, (cfg) => {
+        cfg.packages.apt.push('after-throw');
+      });
+      // No assertion needed — successful return means the lock was free.
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+
+  it('readContainerConfig handles missing file', async () => {
+    const { readContainerConfig } = await import('./container-config.js');
+    const cfg = readContainerConfig('__nonexistent-group-xyz123');
+    expect(cfg.skills).toBe('all');
+    expect(cfg.mcpServers).toEqual({});
+  });
+
+  it('plugins field round-trips through write+read', async () => {
+    const { writeContainerConfig, readContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('plugins');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: {
+            'my-mp': {
+              source: { source: 'github', repo: 'foo/bar', ref: 'main' },
+            },
+          },
+          enabled: { 'my-plugin@my-mp': true },
+        },
+      });
+      const cfg = readContainerConfig(folder);
+      expect(cfg.plugins?.marketplaces?.['my-mp']?.source).toEqual({
+        source: 'github',
+        repo: 'foo/bar',
+        ref: 'main',
+      });
+      expect(cfg.plugins?.enabled?.['my-plugin@my-mp']).toBe(true);
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+});

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -2,12 +2,17 @@
  * Per-group container config, stored as a plain JSON file at
  * `groups/<folder>/container.json`. Mounted read-only inside the container
  * at `/workspace/agent/container.json` — the runner reads it at startup but
- * cannot modify it. Config changes go through the self-mod approval flow.
+ * cannot modify it.
  *
- * All fields are optional — a missing file or a partial file both resolve
- * to sensible defaults. Writes are atomic-enough (write-then-rename is not
- * worth the ceremony here since there's only one writer in practice: the
- * host, from the delivery thread that processes approved system actions).
+ * Writers: multiple host-side surfaces (operator-driven `/install-plugin`
+ * skill, agent-driven self-mod approval handlers, container-runner's
+ * runtime-field sync at spawn). To avoid lost-update races between
+ * concurrent writers, all read-modify-write sequences must go through
+ * `updateContainerConfig()` which acquires an advisory lock and writes
+ * atomically (write-then-rename).
+ *
+ * Direct callers of `writeContainerConfig` should be limited to first-write
+ * paths where the file doesn't exist yet (e.g. `initContainerConfig`).
  */
 import fs from 'fs';
 import path from 'path';
@@ -30,6 +35,33 @@ export interface AdditionalMountConfig {
   readonly?: boolean;
 }
 
+/**
+ * Source variants for `extraKnownMarketplaces` entries. Mirrors the SDK's
+ * typed schema verbatim — see `extraKnownMarketplaces` in the SDK type
+ * definitions. Don't reshape; pass through to settings.json as-is.
+ */
+export type ExtraKnownMarketplaceSource =
+  | { source: 'url'; url: string; headers?: Record<string, string> }
+  | { source: 'github'; repo: string; ref?: string; path?: string; sparsePaths?: string[] }
+  | { source: 'git'; url: string; ref?: string; path?: string; sparsePaths?: string[] }
+  | { source: 'npm'; package: string }
+  | { source: 'file'; path: string }
+  | { source: 'directory'; path: string }
+  | { source: 'hostPattern'; hostPattern: string }
+  | { source: 'pathPattern'; pathPattern: string }
+  | { source: 'settings'; name: string; plugins: unknown[] };
+
+export interface PluginsConfig {
+  /** Marketplaces to register. Same shape as SDK's extraKnownMarketplaces. */
+  marketplaces?: Record<string, { source: ExtraKnownMarketplaceSource }>;
+  /**
+   * Plugin enablement keyed by "plugin-id@marketplace-id". Mirrors SDK's
+   * `enabledPlugins` value union — boolean flag, version-constraint array,
+   * or object form. Don't narrow to just boolean.
+   */
+  enabled?: Record<string, boolean | string[] | { [k: string]: unknown }>;
+}
+
 export interface ContainerConfig {
   mcpServers: Record<string, McpServerConfig>;
   packages: { apt: string[]; npm: string[] };
@@ -47,6 +79,13 @@ export interface ContainerConfig {
   agentGroupId?: string;
   /** Max messages per prompt. Falls back to code default if unset. */
   maxMessagesPerPrompt?: number;
+  /**
+   * Plugin marketplaces and enabled plugins. When set, the host writes these
+   * into per-group `settings.json` (`extraKnownMarketplaces` / `enabledPlugins`)
+   * and sets `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1` + `CLAUDE_CODE_REMOTE=1` in
+   * the container env so the SDK installs them at session init.
+   */
+  plugins?: PluginsConfig;
 }
 
 function emptyConfig(): ContainerConfig {
@@ -62,11 +101,19 @@ function configPath(folder: string): string {
   return path.join(GROUPS_DIR, folder, 'container.json');
 }
 
+function lockPath(folder: string): string {
+  return path.join(GROUPS_DIR, folder, 'container.json.lock');
+}
+
 /**
  * Read the container config for a group, returning sensible defaults for
  * any missing fields (or an entirely empty config if the file is absent).
  * Never throws for missing / malformed files — corruption logs a warning
  * via console.error and falls back to empty.
+ *
+ * Reads are unlocked: writes are atomic via write-then-rename, so a reader
+ * always observes either the previous complete file or the next complete
+ * file, never a half-written one.
  */
 export function readContainerConfig(folder: string): ContainerConfig {
   const p = configPath(folder);
@@ -87,6 +134,7 @@ export function readContainerConfig(folder: string): ContainerConfig {
       assistantName: raw.assistantName,
       agentGroupId: raw.agentGroupId,
       maxMessagesPerPrompt: raw.maxMessagesPerPrompt,
+      plugins: raw.plugins,
     };
   } catch (err) {
     console.error(`[container-config] failed to parse ${p}: ${String(err)}`);
@@ -95,32 +143,117 @@ export function readContainerConfig(folder: string): ContainerConfig {
 }
 
 /**
- * Write the container config for a group, creating the groups/<folder>/
- * directory if necessary. Pretty-printed JSON so diffs in the activation
- * flow are reviewable.
+ * Write the container config for a group atomically (write-then-rename),
+ * creating the groups/<folder>/ directory if necessary. Pretty-printed JSON
+ * so diffs in the activation flow are reviewable.
+ *
+ * **Concurrency:** this is the low-level writer. For read-modify-write
+ * sequences from concurrent writers (operator skills, agent self-mod,
+ * runtime-field sync), use `updateContainerConfig()` which acquires an
+ * advisory lock first.
  */
 export function writeContainerConfig(folder: string, config: ContainerConfig): void {
   const p = configPath(folder);
   const dir = path.dirname(p);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n');
+  const tmp = `${p}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+  fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n');
+  fs.renameSync(tmp, p);
+}
+
+const LOCK_STALE_MS = 60_000;
+const LOCK_TIMEOUT_MS = 30_000;
+const LOCK_POLL_MS = 50;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire an advisory lock at `<configPath>.lock`. The lockfile contains
+ * `<pid>` as a debugging aid. Stale locks (older than LOCK_STALE_MS) are
+ * cleared on next acquire to recover from crashed writers. Polls every
+ * LOCK_POLL_MS ms with jitter; throws after LOCK_TIMEOUT_MS.
+ */
+async function acquireLock(folder: string): Promise<() => void> {
+  const lp = lockPath(folder);
+  const dir = path.dirname(lp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const start = Date.now();
+  while (true) {
+    try {
+      const fd = fs.openSync(lp, 'wx');
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } finally {
+        fs.closeSync(fd);
+      }
+      // Got the lock; return a release function.
+      return () => {
+        try {
+          fs.unlinkSync(lp);
+        } catch {
+          /* lock already gone — release is best-effort */
+        }
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+      // Lock held by another process. Check for staleness.
+      try {
+        const stat = fs.statSync(lp);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          // Stale — try to clear it. Race-safe: if another process clears it
+          // between our stat and unlink, the next acquire attempt will retry.
+          try {
+            fs.unlinkSync(lp);
+          } catch {
+            /* race with another acquirer — fine */
+          }
+          continue;
+        }
+      } catch {
+        // Lock disappeared between EEXIST and stat — retry.
+        continue;
+      }
+      if (Date.now() - start > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timeout acquiring container.json lock for group "${folder}"`);
+      }
+      await sleep(LOCK_POLL_MS + Math.random() * LOCK_POLL_MS);
+    }
+  }
 }
 
 /**
  * Apply a mutator function to a group's container config and persist the
- * result. Convenient for append-style changes like `install_packages` and
- * `add_mcp_server` handlers.
+ * result, atomically and serialized against concurrent writers.
+ *
+ * The mutator may be sync or async. Returns the updated config.
+ *
+ * Use this for any read-modify-write sequence: appending to packages,
+ * adding/removing plugin marketplaces, syncing runtime identity fields,
+ * etc.
  */
-export function updateContainerConfig(folder: string, mutate: (config: ContainerConfig) => void): ContainerConfig {
-  const config = readContainerConfig(folder);
-  mutate(config);
-  writeContainerConfig(folder, config);
-  return config;
+export async function updateContainerConfig(
+  folder: string,
+  mutate: (config: ContainerConfig) => void | Promise<void>,
+): Promise<ContainerConfig> {
+  const release = await acquireLock(folder);
+  try {
+    const config = readContainerConfig(folder);
+    await mutate(config);
+    writeContainerConfig(folder, config);
+    return config;
+  } finally {
+    release();
+  }
 }
 
 /**
  * Initialize an empty container.json for a group if one doesn't already
- * exist. Idempotent — used from `group-init.ts`.
+ * exist. Idempotent — used from `group-init.ts`. No lock required because
+ * this is a first-write path: the file doesn't exist yet.
  */
 export function initContainerConfig(folder: string): boolean {
   const p = configPath(folder);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -19,7 +19,7 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
-import { readContainerConfig, writeContainerConfig } from './container-config.js';
+import { readContainerConfig, updateContainerConfig } from './container-config.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -125,7 +125,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   // Ensure container.json has the agent group identity fields the runner needs.
   // Written at spawn time so the runner can read them from the RO mount.
-  ensureRuntimeFields(containerConfig, agentGroup);
+  await ensureRuntimeFields(containerConfig, agentGroup);
 
   // Resolve the effective provider + any host-side contribution it declares
   // (extra mounts, env passthrough). Computed once and threaded through both
@@ -401,27 +401,30 @@ function syncSkillSymlinks(claudeDir: string, containerConfig: import('./contain
  * Written at spawn time so they're always current even if the DB values
  * change (e.g. group rename). Only writes if values differ to avoid
  * unnecessary file churn.
+ *
+ * Goes through `updateContainerConfig` so this read-modify-write is
+ * serialized against concurrent writers (operator skills editing
+ * container.json, self-mod approval handlers, etc.).
  */
-function ensureRuntimeFields(
+async function ensureRuntimeFields(
   containerConfig: import('./container-config.js').ContainerConfig,
   agentGroup: AgentGroup,
-): void {
-  let dirty = false;
-  if (containerConfig.agentGroupId !== agentGroup.id) {
-    containerConfig.agentGroupId = agentGroup.id;
-    dirty = true;
-  }
-  if (containerConfig.groupName !== agentGroup.name) {
-    containerConfig.groupName = agentGroup.name;
-    dirty = true;
-  }
-  if (containerConfig.assistantName !== agentGroup.name) {
-    containerConfig.assistantName = agentGroup.name;
-    dirty = true;
-  }
-  if (dirty) {
-    writeContainerConfig(agentGroup.folder, containerConfig);
-  }
+): Promise<void> {
+  const dirty =
+    containerConfig.agentGroupId !== agentGroup.id ||
+    containerConfig.groupName !== agentGroup.name ||
+    containerConfig.assistantName !== agentGroup.name;
+  if (!dirty) return;
+
+  const updated = await updateContainerConfig(agentGroup.folder, (cfg) => {
+    cfg.agentGroupId = agentGroup.id;
+    cfg.groupName = agentGroup.name;
+    cfg.assistantName = agentGroup.name;
+  });
+  // Sync the in-memory copy used downstream by the spawn flow.
+  containerConfig.agentGroupId = updated.agentGroupId;
+  containerConfig.groupName = updated.groupName;
+  containerConfig.assistantName = updated.assistantName;
 }
 
 async function buildContainerArgs(
@@ -438,6 +441,20 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Plugin install via SDK headless mode. Gated on `container.json:plugins`
+  // being non-empty so we don't pay the install path on every spawn for
+  // groups that don't use plugins. CLAUDE_CODE_REMOTE forces HTTPS over
+  // the SSH default — without it, github source URLs resolve as
+  // `git@github.com:` and bypass the OneCLI proxy entirely (see plan F7).
+  const hasPlugins =
+    !!containerConfig.plugins &&
+    (Object.keys(containerConfig.plugins.marketplaces ?? {}).length > 0 ||
+      Object.keys(containerConfig.plugins.enabled ?? {}).length > 0);
+  if (hasPlugins) {
+    args.push('-e', 'CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1');
+    args.push('-e', 'CLAUDE_CODE_REMOTE=1');
+  }
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {
@@ -536,9 +553,12 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
     fs.unlinkSync(tmpDockerfile);
   }
 
-  // Store the image tag in groups/<folder>/container.json
-  containerConfig.imageTag = imageTag;
-  writeContainerConfig(agentGroup.folder, containerConfig);
+  // Store the image tag in groups/<folder>/container.json. Goes through
+  // updateContainerConfig so concurrent edits (e.g. an operator running
+  // /install-plugin while a build is in progress) don't lose updates.
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
+    cfg.imageTag = imageTag;
+  });
 
   log.info('Per-agent-group image built', { agentGroupId, imageTag });
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -477,6 +477,19 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // OneCLI's applyContainerConfig sets NODE_EXTRA_CA_CERTS, SSL_CERT_FILE,
+  // DENO_CERT for various runtimes — but NOT GIT_SSL_CAINFO. Git's HTTPS
+  // verification therefore uses the system CA bundle and rejects the
+  // OneCLI MITM cert when traffic flows through HTTPS_PROXY. The SDK's
+  // marketplace/plugin clones happen via `git clone` and silently fail
+  // with "server certificate verification failed". Mirror the cert path
+  // OneCLI just injected into GIT_SSL_CAINFO so git trusts the gateway.
+  const nodeCaArg = args.find((a, i) => i > 0 && args[i - 1] === '-e' && a.startsWith('NODE_EXTRA_CA_CERTS='));
+  if (nodeCaArg) {
+    const caPath = nodeCaArg.slice('NODE_EXTRA_CA_CERTS='.length);
+    args.push('-e', `GIT_SSL_CAINFO=${caPath}`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 

--- a/src/group-init.test.ts
+++ b/src/group-init.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR, DATA_DIR } from './config.js';
+import { initGroupFilesystem } from './group-init.js';
+import { writeContainerConfig } from './container-config.js';
+import type { AgentGroup } from './types.js';
+
+let testFolders: string[];
+
+beforeEach(() => {
+  testFolders = [];
+});
+
+afterEach(() => {
+  for (const folder of testFolders) {
+    fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+  }
+});
+
+function makeGroup(suffix: string): AgentGroup {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  testFolders.push(folder);
+  fs.mkdirSync(path.join(GROUPS_DIR, folder), { recursive: true });
+  return {
+    id: `agent-${suffix}`,
+    name: `test-${suffix}`,
+    folder,
+    container_config: '{}',
+  } as unknown as AgentGroup;
+}
+
+function readSettings(group: AgentGroup): Record<string, unknown> {
+  const p = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared', 'settings.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function cleanupSession(group: AgentGroup): void {
+  fs.rmSync(path.join(DATA_DIR, 'v2-sessions', group.id), { recursive: true, force: true });
+}
+
+describe('group-init: ensurePluginsConfig', () => {
+  it('first-init with plugins declared in container.json populates settings.json', () => {
+    const group = makeGroup('first-init');
+    try {
+      // Pre-populate container.json BEFORE first init (operator-set scenario).
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: {
+            mp1: { source: { source: 'github', repo: 'foo/bar' } },
+          },
+          enabled: { 'plugin1@mp1': true },
+        },
+      });
+
+      initGroupFilesystem(group);
+
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toMatchObject({
+        mp1: { source: { source: 'github', repo: 'foo/bar' } },
+      });
+      expect(settings.enabledPlugins).toMatchObject({ 'plugin1@mp1': true });
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('idempotent — running twice in a row produces same result', () => {
+    const group = makeGroup('idempotent');
+    try {
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+      initGroupFilesystem(group);
+      const before = JSON.stringify(readSettings(group));
+      initGroupFilesystem(group);
+      const after = JSON.stringify(readSettings(group));
+      expect(after).toBe(before);
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('additive merge — preserves pre-existing extraKnownMarketplaces entries', () => {
+    const group = makeGroup('merge');
+    try {
+      // Pre-populate settings.json with an unrelated entry (simulates SDK
+      // self-write or operator hand-edit).
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      const settingsFile = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(
+        settingsFile,
+        JSON.stringify({
+          env: { FOO: 'bar' },
+          extraKnownMarketplaces: {
+            'pre-existing': { source: { source: 'github', repo: 'old/old' } },
+          },
+        }),
+      );
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { 'mp-new': { source: { source: 'github', repo: 'new/new' } } },
+        },
+      });
+
+      initGroupFilesystem(group);
+
+      const settings = readSettings(group);
+      const mps = settings.extraKnownMarketplaces as Record<string, unknown>;
+      // Both entries present.
+      expect(mps['pre-existing']).toBeDefined();
+      expect(mps['mp-new']).toBeDefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('handles malformed settings.json gracefully (rewrites)', () => {
+    const group = makeGroup('malformed');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{ this is: not valid JSON');
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+
+      // Must not throw.
+      expect(() => initGroupFilesystem(group)).not.toThrow();
+
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toMatchObject({
+        mp1: { source: { source: 'github', repo: 'foo/bar' } },
+      });
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('handles top-level non-object settings.json (rewrites)', () => {
+    const group = makeGroup('nonobject');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '[]');
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+
+      expect(() => initGroupFilesystem(group)).not.toThrow();
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toBeDefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('no plugins declared — no-op (does not touch settings.json marketplaces blocks)', () => {
+    const group = makeGroup('noplugins');
+    try {
+      // Just init — no plugins in container.json.
+      initGroupFilesystem(group);
+      const settings = readSettings(group);
+      // Default settings shouldn't grow extraKnownMarketplaces / enabledPlugins.
+      expect(settings.extraKnownMarketplaces).toBeUndefined();
+      expect(settings.enabledPlugins).toBeUndefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('container.json wins on key collision', () => {
+    const group = makeGroup('collision');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeDir, 'settings.json'),
+        JSON.stringify({
+          extraKnownMarketplaces: {
+            mp1: { source: { source: 'github', repo: 'OLD/OLD' } },
+          },
+        }),
+      );
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'NEW/NEW' } } },
+        },
+      });
+
+      initGroupFilesystem(group);
+      const settings = readSettings(group);
+      const entry = (settings.extraKnownMarketplaces as Record<string, { source: { repo: string } }>)?.mp1?.source
+        ?.repo;
+      expect(entry).toBe('NEW/NEW');
+    } finally {
+      cleanupSession(group);
+    }
+  });
+});

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR, GROUPS_DIR } from './config.js';
-import { initContainerConfig } from './container-config.js';
+import { initContainerConfig, readContainerConfig } from './container-config.js';
 import { log } from './log.js';
 import type { AgentGroup } from './types.js';
 
@@ -87,6 +87,13 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
     ensurePreCompactHook(settingsFile, initialized);
   }
 
+  // Plugin config is sourced from groups/<folder>/container.json:plugins
+  // and merged into settings.json on every spawn. Runs unconditionally
+  // (outside the existsSync branches above) so first-init-with-plugins
+  // works AND existing groups pick up container.json edits without manual
+  // settings.json touches.
+  ensurePluginsConfig(settingsFile, group, initialized);
+
   // Skills directory — created empty here; symlinks are synced at spawn
   // time by container-runner.ts based on container.json skills selection.
   const skillsDst = path.join(claudeDir, 'skills');
@@ -103,6 +110,98 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
       steps: initialized,
     });
   }
+}
+
+/**
+ * Mirror per-group `container.json:plugins` into `settings.json`'s
+ * `extraKnownMarketplaces` and `enabledPlugins` blocks so the SDK loads
+ * declared plugins on next spawn.
+ *
+ * Defensive against stale-format settings.json (missing blocks, malformed
+ * JSON, top-level non-object) — never crashes group init. On parse failure
+ * logs a warning and falls back to a fresh-write path.
+ *
+ * **Additive-only.** Pre-existing keys not declared in container.json are
+ * preserved (the SDK writes its own state to a separate registry at
+ * `~/.claude/plugins/known_marketplaces.json`, so additive-only is safe).
+ * A future `pruneUndeclared` mode is gated on empirical confirmation that
+ * the SDK doesn't write back to settings.json — see F1 in the plan.
+ *
+ * Idempotent: running twice in a row produces the same file.
+ */
+function ensurePluginsConfig(settingsFile: string, group: AgentGroup, initialized: string[]): void {
+  let plugins;
+  try {
+    plugins = readContainerConfig(group.folder).plugins;
+  } catch (err) {
+    log.warn('ensurePluginsConfig: failed to read container.json', {
+      group: group.folder,
+      err: String(err),
+    });
+    return;
+  }
+
+  const desiredMarketplaces = plugins?.marketplaces ?? {};
+  const desiredEnabled = plugins?.enabled ?? {};
+  const hasContent = Object.keys(desiredMarketplaces).length > 0 || Object.keys(desiredEnabled).length > 0;
+  if (!hasContent) return;
+
+  // Defensive parse of existing settings.json. Stale-format and malformed
+  // cases fall back to an empty object that we'll merge into.
+  let settings: Record<string, unknown>;
+  try {
+    const raw = fs.readFileSync(settingsFile, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      log.warn('ensurePluginsConfig: settings.json top-level is not an object; rewriting', {
+        group: group.folder,
+      });
+      settings = {};
+    } else {
+      settings = parsed as Record<string, unknown>;
+    }
+  } catch (err) {
+    log.warn('ensurePluginsConfig: settings.json malformed; rewriting', {
+      group: group.folder,
+      err: String(err),
+    });
+    settings = {};
+  }
+
+  // Merge marketplaces. Existing entries not declared in container.json
+  // are preserved (additive-only). Existing entries with the same key are
+  // overwritten by container.json's value (container.json wins).
+  const existingMarketplaces = isPlainObject(settings.extraKnownMarketplaces) ? settings.extraKnownMarketplaces : {};
+  const mergedMarketplaces: Record<string, unknown> = { ...existingMarketplaces };
+  let changed = false;
+  for (const [name, entry] of Object.entries(desiredMarketplaces)) {
+    if (JSON.stringify(mergedMarketplaces[name]) !== JSON.stringify(entry)) {
+      mergedMarketplaces[name] = entry;
+      changed = true;
+    }
+  }
+
+  // Same merge logic for enabledPlugins.
+  const existingEnabled = isPlainObject(settings.enabledPlugins) ? settings.enabledPlugins : {};
+  const mergedEnabled: Record<string, unknown> = { ...existingEnabled };
+  for (const [key, value] of Object.entries(desiredEnabled)) {
+    if (JSON.stringify(mergedEnabled[key]) !== JSON.stringify(value)) {
+      mergedEnabled[key] = value;
+      changed = true;
+    }
+  }
+
+  if (!changed) return;
+
+  settings.extraKnownMarketplaces = mergedMarketplaces;
+  settings.enabledPlugins = mergedEnabled;
+
+  fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n');
+  initialized.push('settings.json (plugins config)');
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
 const PRE_COMPACT_COMMAND = 'bun /app/src/compact-instructions.ts';

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -24,7 +24,7 @@ export const applyInstallPackages: ApprovalHandler = async ({ session, payload, 
     notify('install_packages approved but agent group missing.');
     return;
   }
-  updateContainerConfig(agentGroup.folder, (cfg) => {
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
     if (payload.apt) cfg.packages.apt.push(...(payload.apt as string[]));
     if (payload.npm) cfg.packages.npm.push(...(payload.npm as string[]));
   });
@@ -71,7 +71,7 @@ export const applyAddMcpServer: ApprovalHandler = async ({ session, payload, use
     notify('add_mcp_server approved but agent group missing.');
     return;
   }
-  updateContainerConfig(agentGroup.folder, (cfg) => {
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
     cfg.mcpServers[payload.name as string] = {
       command: payload.command as string,
       args: (payload.args as string[]) || [],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,15 @@ export default defineConfig({
     // container/agent-runner tests run under Bun (they depend on bun:sqlite).
     // See container/agent-runner/package.json "test" script.
     include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'scripts/**/*.test.ts'],
+    // Vitest 4 auto-discovers package.json files as workspace projects, which
+    // would pick up container/agent-runner/ (whose tests use `bun:test` and
+    // can't run under vitest). Excluding the directory keeps host-only.
+    exclude: [
+      '**/node_modules/**',
+      '**/container/**',
+      '**/data/**',
+      '**/logs/**',
+      '**/.claude/**',
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Add per-group plugin support via the SDK's settings-driven install path. Operators declare marketplaces + enabled plugins in `groups/<folder>/container.json:plugins`; the host mirrors them into per-group `settings.json` (`extraKnownMarketplaces` / `enabledPlugins`) on every spawn, and the container env gets `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1` + `CLAUDE_CODE_REMOTE=1` (gated on plugins being non-empty).

Also lays the foundation for safe concurrent writes to `container.json` (needed by the per-group operator skills in a follow-up PR).

## What's new

**Host:**
- `ContainerConfig.plugins` field with the SDK's typed `extraKnownMarketplaces` source schema (8 variants) and `enabledPlugins` value union (boolean | string[] | object).
- New `updateContainerConfig(folder, mutate)` async helper. Atomic write-then-rename in `writeContainerConfig`. Advisory file lock (60s stale TTL, jittered polling). Existing `applyInstallPackages` / `applyAddMcpServer` callers routed through the locked path; `ensureRuntimeFields` and per-group imageTag write also locked.
- `ensurePluginsConfig()` in group-init mirrors `container.json:plugins` into `settings.json` on every spawn. Defensive against malformed/non-object/stale-format settings.json. Additive merge (entries already present in settings.json that aren't in container.json are preserved).
- container-runner sets `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1` + `CLAUDE_CODE_REMOTE=1` when plugins block is non-empty. `CLAUDE_CODE_REMOTE` is mandatory — without it, github source URLs default to SSH and bypass the OneCLI gateway entirely.
- Drive-by fix bundled: `GIT_SSL_CAINFO` is now set to mirror `NODE_EXTRA_CA_CERTS`. OneCLI's `applyContainerConfig()` injects the latter for various language runtimes but not for git, so the SDK's marketplace clones (which shell out to `git clone`) failed with "server certificate verification failed" through the gateway. With the new env, git trusts the OneCLI MITM cert and clones complete normally.

**Container:**
- Provider event types: new `plugin_install_failed` variant on `ProviderEvent`.
- `claude.ts:translateEvents()` handles SDK `plugin_install` system messages — `failed` status emits the new event, others are activity-only.
- `poll-loop.ts:handleEvent` logs `plugin_install_failed` events for operator visibility.

## Tests

- 12 new vitest cases in `src/container-config.test.ts` and `src/group-init.test.ts`:
  - Atomic write (no `.tmp.*` leftovers after rename)
  - 10 concurrent writers serialized via the lock (vitest spawns in parallel)
  - Lock release on mutator throw (no deadlock)
  - Defensive parsing: malformed JSON, non-object top level, missing blocks
  - First-init with plugins pre-declared in container.json
  - Idempotent re-merge
  - Additive merge preserves pre-existing settings.json entries
  - container.json wins on key collision
  - Plugins-config round-trip through write+read
- Vitest config exclude pattern added so `**/container/**` (which uses `bun:test`) doesn't get picked up by host vitest under v4's auto-workspace discovery.

## How operators use it

Without follow-up operator skills, an operator can already use this PR by hand-editing `groups/<folder>/container.json`:

```json
{
  "plugins": {
    "marketplaces": {
      "anthropic": {
        "source": { "source": "github", "repo": "anthropics/skills", "ref": "main" }
      }
    },
    "enabled": { "doc-coauthoring@anthropic": true }
  }
}
```

Restart the group; the SDK installs the marketplace + plugins at next session init.

## Empirical verification

End-to-end: container respawned after declaring `xiaolai-marketplace` in `container.json:plugins`. `plugin_install:installed` fires inside the container; SDK clones marketplace into `~/.claude/plugins/marketplaces/xiaolai/`; `installed_plugins.json` and `known_marketplaces.json` both written by SDK as expected; agent's `init` event lists the new `codex-toolkit` plugin.

For the failure path: declaring a private repo without the corresponding OneCLI vault github auth produces a `plugin_install:failed` event with a clear "marketplace.json not found" or "authentication failed" message — surfaced via the new `plugin_install_failed` provider event.

## Test plan

- [x] `pnpm test` (host) passes — 435 tests, including 12 new ones for this change
- [x] `bun run typecheck` (container) clean
- [x] End-to-end: container spawns with new env, SDK installs marketplace, plugin loads in agent's init event
- [x] Failure mode: clone fails → `plugin_install_failed` event → operator sees error in host log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
