### PR TITLE
feat(skills): add SKILL_DATA_DIR per-group persistent state mount

### DIFF
--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -15,6 +15,23 @@ cat ~/.config/nanoclaw/mount-allowlist.json 2>/dev/null || echo "No mount allowl
 
 Show the current config to the user in a readable format: which directories are allowed, whether non-main agents are read-only.
 
+## Built-in Host-Managed Mounts (Informational)
+
+Every agent container also gets these host-managed mounts wired by NanoClaw itself. They are NOT in the allowlist file and cannot be removed via this skill — they're part of the runtime contract:
+
+| Container path | Source | Mode | Purpose |
+|---|---|---|---|
+| `/workspace` | `data/v2-sessions/<session-id>/` | RW | Session DBs (`inbound.db`, `outbound.db`), heartbeat, working files |
+| `/workspace/agent` | `groups/<folder>/` | RW | Per-group memory (`CLAUDE.local.md`), agent's working dir |
+| `/workspace/agent/container.json` | `groups/<folder>/container.json` | RO | Per-group config the runner reads at startup |
+| `/workspace/skill-data` | `data/v2-sessions/<group-id>/skill-data/` | RW | Per-group persistent skill state, survives restarts |
+| `/home/node/.claude` | `data/v2-sessions/<group-id>/.claude-shared/` | RW | Claude Code state (settings.json, plugins/, skill symlinks) |
+| `/workspace/global` | `groups/global/` | RO | Cross-group shared memory (if present) |
+| `/app/skills` | `container/skills/` | RO | Shared skill source — symlinks in `~/.claude/skills/` point here |
+| `/app/src` | `container/agent-runner/src/` | RO | Agent-runner source code |
+
+When auditing the per-group write surface, list these alongside the operator-allowlist mounts. Anything writable inside a container is one of: a per-session/per-group host-managed dir (above), or an entry from `~/.config/nanoclaw/mount-allowlist.json`.
+
 ## Add Directories
 
 Ask which directories the user wants agents to access. For each path:

--- a/docs/agent-runner-details.md
+++ b/docs/agent-runner-details.md
@@ -712,11 +712,17 @@ These are ephemeral to the container's lifetime. When the container is killed an
 
 The agent-runner receives configuration via:
 
-- **Environment variables:** `AGENT_PROVIDER` (claude/codex/opencode), `NANOCLAW_ADMIN_USER_ID`, provider-specific vars (API keys, model overrides), `TZ`
+- **Environment variables:** `AGENT_PROVIDER` (claude/codex/opencode), `NANOCLAW_ADMIN_USER_ID`, provider-specific vars (API keys, model overrides), `TZ`, `SKILL_DATA_DIR` (per-group persistent skill state path; see below)
 - **Fixed mount paths:** Session DB at `/workspace/session.db`. Agent group folder at `/workspace/agent/`. System prompt from `/workspace/agent/CLAUDE.md` and `/workspace/global/CLAUDE.md`.
 - **Optional startup config:** Some config may be passed as a JSON file at a fixed path (e.g., `/workspace/config.json`) for things like the session ID to resume, assistant name, and admin user ID. This avoids overloading environment variables.
 
 The agent-runner reads config, creates the provider, and enters the poll loop. No stdin, no initial prompt — messages are already in the session DB.
+
+### Persistent Skill Data (`SKILL_DATA_DIR`)
+
+Every agent container has `SKILL_DATA_DIR=/workspace/skill-data` set, mounted from `data/v2-sessions/<group-id>/skill-data/` (RW, per-group). Skills that need to persist state across container restarts — caches, OAuth tokens, small databases, scratch artifacts — write here. Distinct from `/workspace/agent` (the agent's working dir for user-facing files) and `/workspace` (session DBs + heartbeat). Each agent group has its own dir; sessions within a group share it.
+
+Created by `group-init.ts` at first spawn; mounted by `container-runner.ts`'s `buildMounts`. Bypasses the operator-side mount allowlist (`validateAdditionalMounts`) because it's host-managed, not operator-declared. The `/manage-mounts` skill enumerates it as an informational "host-managed" row so operators auditing the per-group write surface see the complete picture.
 
 ### Provider Factory
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -310,6 +310,18 @@ function buildMounts(
   // skill symlinks)
   mounts.push({ hostPath: claudeDir, containerPath: '/home/node/.claude', readonly: false });
 
+  // Per-group persistent skill data at /workspace/skill-data. Skills
+  // (e.g. ones that cache API responses, store OAuth state, or maintain
+  // small databases) write here and reads survive across container
+  // restarts. Distinct from /workspace/agent which is the agent's working
+  // dir for user-facing files; skill-data is for skill-internal state.
+  // Host-managed (not operator-declared); intentionally bypasses
+  // validateAdditionalMounts. The /manage-mounts skill enumerates this as
+  // an informational "host-managed" row so operators can audit the full
+  // per-group write surface.
+  const skillDataDir = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, 'skill-data');
+  mounts.push({ hostPath: skillDataDir, containerPath: '/workspace/skill-data', readonly: false });
+
   // Shared agent-runner source — read-only, same code for all groups.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
   mounts.push({ hostPath: agentRunnerSrc, containerPath: '/app/src', readonly: true });
@@ -438,6 +450,11 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Per-group persistent state dir for skill-internal use. The mount is
+  // wired in buildMounts; the env var tells skills (and any tooling that
+  // wants to persist data across container restarts) where to land.
+  args.push('-e', 'SKILL_DATA_DIR=/workspace/skill-data');
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -95,6 +95,15 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
     initialized.push('skills/');
   }
 
+  // Per-group persistent skill data directory. Mounted at
+  // /workspace/skill-data inside the container; set as SKILL_DATA_DIR env.
+  // Survives container restarts; isolated per agent group.
+  const skillDataDir = path.join(DATA_DIR, 'v2-sessions', group.id, 'skill-data');
+  if (!fs.existsSync(skillDataDir)) {
+    fs.mkdirSync(skillDataDir, { recursive: true });
+    initialized.push('skill-data/');
+  }
+
   if (initialized.length > 0) {
     log.info('Initialized group filesystem', {
       group: group.name,


### PR DESCRIPTION
## Summary

Add a per-group persistent skill data directory at `/workspace/skill-data`, set as `SKILL_DATA_DIR` env. Skills that need state across container restarts (caches, OAuth tokens, small databases, etc.) now have a dedicated home distinct from `/workspace/agent` (the agent's user-facing working dir) and `/workspace` (session DBs + heartbeat).

Mounted from `data/v2-sessions/<group-id>/skill-data/` (RW, per-group). Created in group-init at first spawn; mount wired in `container-runner.ts:buildMounts`. Bypasses the operator-side mount allowlist (`validateAdditionalMounts`) because this is host-managed, not operator-declared.

## Documentation

- New "Persistent Skill Data" subsection in `docs/agent-runner-details.md`.
- `manage-mounts` skill enumerates all built-in host-managed mounts (`workspace`, `agent`, `container.json`, `skill-data`, `.claude`, `global`, `/app/skills`, `/app/src`) so an operator auditing per-group write surface sees the complete picture, not just the operator-allowlist entries.

## Test plan

- [x] Container builds and spawns
- [x] `SKILL_DATA_DIR` env var present in container
- [x] `data/v2-sessions/<group-id>/skill-data/` created on first init
- [x] Survives container restart (file written before restart still readable after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
