### PR TITLE
feat(skills): seven operator skills for plugin/marketplace management

### DIFF
--- a/.claude/skills/add-marketplace/SKILL.md
+++ b/.claude/skills/add-marketplace/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: add-marketplace
+description: Register a Claude Code plugin marketplace for a NanoClaw agent group. Operator-side; mirrors `claude plugin marketplace add` but writes to a per-group container.json. Triggers on "add marketplace", "register marketplace", "plugin marketplace".
+---
+
+# /add-marketplace
+
+Register a plugin marketplace in `groups/<folder>/container.json:plugins.marketplaces` so the agent's SDK loads plugins from it on next session start. Mirrors Claude Code's `claude plugin marketplace add` but scoped to one NanoClaw agent group.
+
+## Inputs
+
+Ask the operator (if not already provided):
+
+1. **Group folder** — the agent group to configure. List groups with `pnpm exec tsx scripts/q.ts data/v2.db "SELECT folder, name FROM agent_groups"` if the operator doesn't know.
+2. **Marketplace name** — a label for the marketplace within this group. Avoid spaces, slashes, dots-only.
+3. **Source** — one of the eight `extraKnownMarketplaces` source variants (see `src/container-config.ts:ExtraKnownMarketplaceSource`):
+   - `github` — `{ "source": "github", "repo": "owner/repo", "ref": "main" }`
+   - `git`    — `{ "source": "git",    "url": "https://...", "ref": "..." }`
+   - `url`    — `{ "source": "url",    "url": "https://example.com/marketplace.json", "headers": {...} }`
+   - `npm`    — `{ "source": "npm",    "package": "..." }`
+   - `file`   — `{ "source": "file",   "path": "/abs/path/marketplace.json" }`
+   - `directory` — `{ "source": "directory", "path": "/abs/path/" }`
+
+## Run
+
+```bash
+pnpm exec tsx scripts/add-marketplace.ts <group-folder> <name> '<source-json>'
+```
+
+The script validates the source schema, idempotently writes `container.json:plugins.marketplaces[<name>]`, and restarts the group's containers (so the next message picks up the new marketplace).
+
+## Private repos
+
+If the source points at a private github repo, run `/setup-private-plugins` once on this host first (registers the github PAT in OneCLI vault). Without it, the SDK's clone at session init will fail with a visible `plugin_install:failed` event but the session continues without the marketplace's plugins.
+
+## Verification
+
+After running:
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The new entry should be present. Send a message to the group; the agent's `init` event will list the loaded plugins (after the SDK clones the marketplace).

--- a/.claude/skills/install-plugin/SKILL.md
+++ b/.claude/skills/install-plugin/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: install-plugin
+description: Enable a Claude Code plugin in a NanoClaw agent group. Operator-side; mirrors `claude plugin install` but writes to a per-group container.json. Supports `--source` for one-shot register-and-install. Triggers on "install plugin", "enable plugin", "add plugin to group".
+---
+
+# /install-plugin
+
+Enable a plugin in `groups/<folder>/container.json:plugins.enabled`. The plugin's marketplace must already be registered (see `/add-marketplace`), or supply a `--source` to register it inline.
+
+## Inputs
+
+Ask the operator (if not already provided):
+
+1. **Group folder** — the agent group to configure.
+2. **Plugin spec** — `<plugin-name>@<marketplace-name>` (the format the SDK uses in `enabledPlugins`).
+3. **Optional `--source`** — JSON for `extraKnownMarketplaces` if the marketplace isn't yet registered. See `/add-marketplace` for the schema.
+
+## Run (marketplace already registered)
+
+```bash
+pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin>@<marketplace>
+```
+
+## Run (one-shot register + install)
+
+```bash
+pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin>@<marketplace> \
+  --source '{"source":"github","repo":"owner/repo","ref":"main"}'
+```
+
+The script writes both `marketplaces[<name>]` and `enabled[<spec>]=true` in a single locked update, then restarts the group. Single-restart semantics — no half-state window.
+
+## On disable / enable distinction
+
+Claude Code's CLI distinguishes "plugin installed but disabled" from "plugin uninstalled" because of its own cache management. **NanoClaw's SDK-driven model has no separate cache state per group** — there's just `plugins.enabled`. `/install-plugin` and `/uninstall-plugin` are the only switches. If documentation tells you to `claude plugin disable`, use `/uninstall-plugin` here.
+
+## Private repos
+
+If the source is a private github repo:
+
+1. Run `/setup-private-plugins` once on this host (registers a github PAT in OneCLI vault with `Authorization: Basic` injection for `github.com`).
+2. Then `/install-plugin` proceeds normally; the SDK clones via the OneCLI gateway with auth injected at the proxy layer.
+
+If the OneCLI entry isn't configured, this skill prints a warning and continues; the SDK clone will fail at session init with a visible `plugin_install:failed` event but the session continues without the plugin.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The new entry should be present. Send a message to the group; the agent's `init` event lists loaded plugins (after the SDK installs the marketplace+plugin).

--- a/.claude/skills/list-marketplaces/SKILL.md
+++ b/.claude/skills/list-marketplaces/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: list-marketplaces
+description: List the plugin marketplaces registered for a NanoClaw agent group. Operator-side; mirrors `claude plugin marketplace list` but scoped to one group's container.json. Triggers on "list marketplaces", "show marketplaces", "what marketplaces".
+---
+
+# /list-marketplaces
+
+Show the plugin marketplaces registered in `groups/<folder>/container.json:plugins.marketplaces`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The script prints JSON. Format it as a readable table for the operator: name, source type, key fields (repo/url/path).
+
+## Empty result
+
+If the JSON is `{}`, no marketplaces are registered for this group. Suggest `/add-marketplace` if the operator wanted plugins available.
+
+## See also
+
+- `/add-marketplace` — register a marketplace
+- `/list-plugins` — show enabled plugins (which require a registered marketplace)

--- a/.claude/skills/list-plugins/SKILL.md
+++ b/.claude/skills/list-plugins/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: list-plugins
+description: List the Claude Code plugins enabled for a NanoClaw agent group. Operator-side; mirrors `claude plugin list` but scoped to one group. Triggers on "list plugins", "show plugins", "what plugins".
+---
+
+# /list-plugins
+
+Show the plugins enabled in `groups/<folder>/container.json:plugins.enabled`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The script prints JSON. Format readably for the operator: each entry as `<plugin>@<marketplace>: <state>` (state = `true` for plain enable, version-array for version-pinned, or object for advanced enable).
+
+## See also
+
+- `/install-plugin` — enable a plugin
+- `/uninstall-plugin` — disable
+- `/list-marketplaces` — show registered marketplaces (which plugins reference by `@<name>`)

--- a/.claude/skills/remove-marketplace/SKILL.md
+++ b/.claude/skills/remove-marketplace/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: remove-marketplace
+description: Unregister a Claude Code plugin marketplace from a NanoClaw agent group. Refuses if any plugin from the marketplace is still enabled. Triggers on "remove marketplace", "unregister marketplace", "delete marketplace".
+---
+
+# /remove-marketplace
+
+Unregister a marketplace from `groups/<folder>/container.json:plugins.marketplaces`. Mirrors `claude plugin marketplace remove`.
+
+## Safety
+
+If any plugin in `plugins.enabled` references the marketplace (i.e., its key ends with `@<marketplace-name>`), the operation is refused. Run `/uninstall-plugin <plugin-spec>` for each referencing plugin first, then retry.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/remove-marketplace.ts <group-folder> <name>
+```
+
+The script validates references, removes the entry from `container.json`, and restarts the group's containers.
+
+## Note on SDK self-state
+
+The SDK keeps its own marketplace cache at `~/.claude/plugins/marketplaces/<name>/` (per session-shared dir), tracked in `known_marketplaces.json`. NanoClaw doesn't touch that — removing the `extraKnownMarketplaces` entry just stops the SDK from loading from there on next start. The cached clone is harmless and gets overwritten if the marketplace is re-registered.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The removed entry should be absent.

--- a/.claude/skills/setup-private-plugins/SKILL.md
+++ b/.claude/skills/setup-private-plugins/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: setup-private-plugins
+description: One-time-per-host setup that registers a GitHub PAT in the OneCLI vault so private github plugin clones work in NanoClaw containers. Triggers on "private plugins", "github auth for plugins", "setup private plugin auth".
+---
+
+# /setup-private-plugins
+
+Wires the OneCLI vault entry that lets the SDK clone private github plugins from inside a NanoClaw container, without ever putting the token on disk in the container or in `container.json`. Run once per host.
+
+## Background — why this is needed
+
+Github's git smart-HTTP only accepts HTTP Basic auth (NOT `Bearer`). The OneCLI gateway intercepts container HTTPS traffic and can inject auth headers — but the existing `GitHub` secret most operators have (with hostPattern `api.github.com` and `Bearer {value}`) covers the REST API only, not git clones from `github.com`.
+
+This skill installs a separate vault entry:
+
+| Field | Value |
+|---|---|
+| hostPattern | `github.com` |
+| headerName | `Authorization` |
+| valueFormat | `Basic {value}` |
+| value | base64-encoded `x-access-token:<your-PAT>` |
+
+After install, the OneCLI gateway injects `Authorization: Basic ...` into any container's HTTPS request to `github.com`, including the SDK's plugin clones. No token lands on disk in the container.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/setup-private-plugins.ts
+```
+
+The script:
+
+1. Checks for an existing `github.com` Basic-auth entry. If present, prompts to skip (or pass `--force` to overwrite).
+2. Reads your github PAT from `gh auth token` (the github CLI's stored credentials), OR pass `--token <pat>` explicitly.
+3. Encodes `base64("x-access-token:" + token)`.
+4. Calls `onecli secrets create` with the right shape.
+5. Reports success.
+
+## With explicit token
+
+```bash
+pnpm exec tsx scripts/setup-private-plugins.ts --token gho_yourPATHere
+```
+
+## Token requirements
+
+The PAT needs `repo` scope (read-only is enough for clones). Fine-grained PATs work; classic PATs work.
+
+## Verification
+
+```bash
+onecli secrets list | grep -A5 github.com
+```
+
+Should show your new entry with `hostPattern: "github.com"` and `valueFormat: "Basic {value}"`.
+
+End-to-end: register a private repo via `/install-plugin --source` (or `/add-marketplace`) and send a message to the group. The SDK's `plugin_install:installed` event should fire. If it fires `plugin_install:failed` with a 401-style error, the secret isn't being matched — verify the hostPattern and re-run with `--force`.
+
+## Restart not required
+
+OneCLI looks up secrets per request, so the new entry is live immediately. No NanoClaw restart needed.
+
+## Token rotation
+
+When you rotate the PAT, re-run with `--force` (or `--force --token <new-pat>`). The script updates the vault entry; the next container clone uses the new token.

--- a/.claude/skills/uninstall-plugin/SKILL.md
+++ b/.claude/skills/uninstall-plugin/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: uninstall-plugin
+description: Disable a Claude Code plugin in a NanoClaw agent group. Operator-side; mirrors `claude plugin uninstall`. The marketplace registration stays so other plugins from it remain installable. Triggers on "uninstall plugin", "disable plugin", "remove plugin from group".
+---
+
+# /uninstall-plugin
+
+Disable a plugin from `groups/<folder>/container.json:plugins.enabled`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/uninstall-plugin.ts <group-folder> <plugin>@<marketplace>
+```
+
+The script removes the entry, restarts the group's containers, and the SDK won't load that plugin on next start.
+
+## What stays
+
+The marketplace registration in `plugins.marketplaces` is untouched — other plugins from the same marketplace can still be enabled. To unregister the marketplace itself, use `/remove-marketplace` (which refuses if any plugin from it is still enabled).
+
+## NanoClaw doesn't distinguish "disabled" from "uninstalled"
+
+In Claude Code's CLI, `disable` keeps the plugin's cache files; `uninstall` removes them. NanoClaw's SDK-driven model has no separate per-group cache state — the only switch is `plugins.enabled`. So `/uninstall-plugin` is the universal "stop loading this plugin" verb.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The plugin should no longer be in the output. Send a message; the agent's `init` event should no longer list it.

--- a/scripts/add-marketplace.ts
+++ b/scripts/add-marketplace.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { addMarketplace } from './lib/plugins-config.js';
 import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/add-marketplace.ts
+++ b/scripts/add-marketplace.ts
@@ -1,0 +1,86 @@
+/**
+ * scripts/add-marketplace.ts — register a plugin marketplace in a
+ * group's container.json. Mirrors `claude plugin marketplace add` but
+ * scoped to one NanoClaw agent group. After the mutation the group's
+ * containers are killed so the new marketplace takes effect on the
+ * next message (the SDK installs declared marketplaces at session
+ * init when CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1 is set).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/add-marketplace.ts <group-folder> <name> <source-json>
+ *
+ * <source-json> is a JSON string matching the SDK's
+ * `extraKnownMarketplaces` source schema. The eight variants are
+ * documented in src/container-config.ts:ExtraKnownMarketplaceSource.
+ *
+ * Examples:
+ *   tsx scripts/add-marketplace.ts mygroup acme \
+ *     '{"source":"github","repo":"acme/plugins","ref":"main"}'
+ *
+ *   tsx scripts/add-marketplace.ts mygroup local-test \
+ *     '{"source":"directory","path":"/Users/me/my-marketplace"}'
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { addMarketplace } from './lib/plugins-config.js';
+import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+
+async function main(): Promise<void> {
+  const [, , folder, name, sourceJson] = process.argv;
+  if (!folder || !name || !sourceJson) {
+    console.error('Usage: tsx scripts/add-marketplace.ts <group-folder> <name> <source-json>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(sourceJson);
+  } catch (err) {
+    console.error(`Invalid source JSON: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  let source;
+  try {
+    source = parseMarketplaceSource(parsedJson);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const result = await addMarketplace(folder, name, source);
+
+  if (result.added) {
+    console.log(`Registered marketplace "${name}" in group "${folder}".`);
+  } else if (result.replaced) {
+    console.log(`Updated marketplace "${name}" source in group "${folder}".`);
+  } else {
+    console.log(`Marketplace "${name}" already registered with the same source. No change.`);
+    return; // No restart needed.
+  }
+
+  // Restart the group so the new marketplace takes effect.
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -1,0 +1,117 @@
+/**
+ * scripts/install-plugin.ts — enable a plugin in a group's
+ * container.json. Optionally registers the marketplace inline via
+ * --source for the "register and install in one shot" workflow.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin-spec> [--source <json>]
+ *
+ * <plugin-spec> is `name@marketplace`. If <marketplace> isn't already
+ * registered for the group, --source is required.
+ *
+ * Examples:
+ *   tsx scripts/install-plugin.ts mygroup fmt@acme
+ *   tsx scripts/install-plugin.ts mygroup fmt@acme \
+ *     --source '{"source":"github","repo":"acme/plugins","ref":"main"}'
+ *
+ * Private-repo note: if the source is a private github/git URL, run
+ * `/setup-private-plugins` first to wire the OneCLI vault entry that
+ * lets the SDK clone privately. Without it the SDK clone fails at
+ * session init with a visible plugin_install:failed event but the
+ * session continues without that plugin.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { installPlugin } from './lib/plugins-config.js';
+import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+import { findGithubGitSecret } from './lib/onecli-vault-helpers.js';
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      'Usage: tsx scripts/install-plugin.ts <group-folder> <plugin-spec> [--source <source-json>]',
+    );
+    process.exit(2);
+  }
+  const folder = args[0];
+  const pluginSpec = args[1];
+  let inlineSourceJson: string | undefined;
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--source' && i + 1 < args.length) {
+      inlineSourceJson = args[i + 1];
+      i++;
+    }
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let inlineSource;
+  if (inlineSourceJson) {
+    try {
+      inlineSource = parseMarketplaceSource(JSON.parse(inlineSourceJson));
+    } catch (err) {
+      console.error(`Invalid --source: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+
+    // Private-github pre-warning. If the source is a github/git URL and
+    // the OneCLI vault doesn't have a github.com entry with the right
+    // shape, the SDK clone will likely fail at session init. We DON'T
+    // block — operator may have other auth wired (SSH agent etc.).
+    const isGithubLike =
+      inlineSource.source === 'github' ||
+      (inlineSource.source === 'git' && /github\.com/i.test(inlineSource.url));
+    if (isGithubLike && !findGithubGitSecret()) {
+      console.error(
+        '(warning) Source points at github.com but no OneCLI vault entry was found ' +
+          'for github.com with `Authorization: Basic` injection. If this is a private ' +
+          'repository the SDK clone will fail at session init. Run /setup-private-plugins ' +
+          'to wire the github auth before continuing if needed. Proceeding with install...',
+      );
+    }
+  }
+
+  let result;
+  try {
+    result = await installPlugin(folder, pluginSpec, inlineSource);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (!result.wasEnabled && !result.marketplaceAdded) {
+    console.log(`Plugin "${pluginSpec}" already enabled. No change.`);
+    return;
+  }
+
+  if (result.marketplaceAdded && result.wasEnabled) {
+    console.log(`Registered marketplace and enabled plugin "${pluginSpec}" in group "${folder}".`);
+  } else if (result.marketplaceAdded) {
+    console.log(`Updated inline marketplace source for plugin "${pluginSpec}".`);
+  } else {
+    console.log(`Enabled plugin "${pluginSpec}" in group "${folder}".`);
+  }
+
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { installPlugin } from './lib/plugins-config.js';
 import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     }
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/lib/db-init.ts
+++ b/scripts/lib/db-init.ts
@@ -1,0 +1,16 @@
+/**
+ * scripts/lib/db-init.ts — shared DB-init boilerplate for operator
+ * scripts. Resolves the central DB path from DATA_DIR, initializes the
+ * connection, and runs migrations. Idempotent: safe to call once per
+ * script invocation.
+ */
+import path from 'path';
+
+import { DATA_DIR } from '../../src/config.js';
+import { initDb } from '../../src/db/connection.js';
+import { runMigrations } from '../../src/db/migrations/index.js';
+
+export function initOperatorDb(): void {
+  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  runMigrations(db);
+}

--- a/scripts/lib/marketplace-source-validator.test.ts
+++ b/scripts/lib/marketplace-source-validator.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateMarketplaceSource,
+  parseMarketplaceSource,
+} from './marketplace-source-validator.js';
+
+describe('validateMarketplaceSource — accepts every documented variant', () => {
+  it.each([
+    ['url with required fields', { source: 'url', url: 'https://x.com/m.json' }],
+    ['url with optional headers', {
+      source: 'url',
+      url: 'https://x.com/m.json',
+      headers: { Authorization: 'Bearer x' },
+    }],
+    ['github with repo only', { source: 'github', repo: 'owner/repo' }],
+    ['github with all fields', {
+      source: 'github',
+      repo: 'owner/repo',
+      ref: 'main',
+      path: 'sub/dir',
+      sparsePaths: ['plugins'],
+    }],
+    ['git with url only', { source: 'git', url: 'https://gitlab.com/x/y.git' }],
+    ['git with sparsePaths', {
+      source: 'git',
+      url: 'git@host:x/y.git',
+      sparsePaths: ['a', 'b'],
+    }],
+    ['npm', { source: 'npm', package: '@scope/pkg' }],
+    ['file', { source: 'file', path: '/abs/path/marketplace.json' }],
+    ['directory', { source: 'directory', path: '/abs/path/' }],
+    ['hostPattern', { source: 'hostPattern', hostPattern: '^github\\.com$' }],
+    ['pathPattern', { source: 'pathPattern', pathPattern: '.*' }],
+    ['settings', { source: 'settings', name: 'my-mp', plugins: [{ name: 'p' }] }],
+  ])('accepts %s', (_label, input) => {
+    const r = validateMarketplaceSource(input);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateMarketplaceSource — rejects bad inputs', () => {
+  it('rejects null', () => {
+    const r = validateMarketplaceSource(null);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects array (top-level non-object)', () => {
+    const r = validateMarketplaceSource([1, 2]);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown source type', () => {
+    const r = validateMarketplaceSource({ source: 'wat' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/unknown source type/);
+  });
+
+  it('rejects missing source field', () => {
+    const r = validateMarketplaceSource({ url: 'https://x' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects github with malformed repo', () => {
+    const r = validateMarketplaceSource({ source: 'github', repo: 'no-slash' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/owner\/repo/);
+  });
+
+  it('rejects github with empty repo', () => {
+    const r = validateMarketplaceSource({ source: 'github', repo: '' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects url with no url field', () => {
+    const r = validateMarketplaceSource({ source: 'url' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects url with non-string headers', () => {
+    const r = validateMarketplaceSource({
+      source: 'url',
+      url: 'https://x',
+      headers: { auth: 123 },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects npm with missing package', () => {
+    const r = validateMarketplaceSource({ source: 'npm' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects settings without plugins array', () => {
+    const r = validateMarketplaceSource({ source: 'settings', name: 'x' });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('parseMarketplaceSource throws on invalid', () => {
+  it('throws on bad source', () => {
+    expect(() => parseMarketplaceSource({ source: 'wat' })).toThrow(/Invalid marketplace source/);
+  });
+  it('returns typed source on valid', () => {
+    const s = parseMarketplaceSource({ source: 'github', repo: 'a/b', ref: 'main' });
+    expect(s.source).toBe('github');
+    if (s.source === 'github') {
+      expect(s.repo).toBe('a/b');
+      expect(s.ref).toBe('main');
+    }
+  });
+});

--- a/scripts/lib/marketplace-source-validator.ts
+++ b/scripts/lib/marketplace-source-validator.ts
@@ -1,0 +1,166 @@
+/**
+ * scripts/lib/marketplace-source-validator.ts — schema validation for
+ * `extraKnownMarketplaces` source variants.
+ *
+ * Mirrors the SDK's typed schema (eight variants). Used by
+ * /add-marketplace and /install-plugin --source to reject malformed
+ * source specs before they hit `container.json` (and from there, the
+ * SDK at next spawn — where the failure mode is harder to diagnose).
+ */
+import type { ExtraKnownMarketplaceSource } from '../../src/container-config.js';
+
+export type ValidationResult = { ok: true; source: ExtraKnownMarketplaceSource } | { ok: false; error: string };
+
+const KNOWN_SOURCE_TYPES = new Set([
+  'url',
+  'github',
+  'git',
+  'npm',
+  'file',
+  'directory',
+  'hostPattern',
+  'pathPattern',
+  'settings',
+]);
+
+/**
+ * Validate an arbitrary value as an `ExtraKnownMarketplaceSource`. Returns
+ * either a typed source or a human-readable error. Defensive against
+ * non-object inputs and unknown source types.
+ */
+export function validateMarketplaceSource(input: unknown): ValidationResult {
+  if (!isPlainObject(input)) {
+    return { ok: false, error: 'source must be an object' };
+  }
+  const sourceType = input.source;
+  if (typeof sourceType !== 'string') {
+    return { ok: false, error: 'source.source must be a string' };
+  }
+  if (!KNOWN_SOURCE_TYPES.has(sourceType)) {
+    return {
+      ok: false,
+      error: `unknown source type "${sourceType}"; expected one of: ${[...KNOWN_SOURCE_TYPES].join(', ')}`,
+    };
+  }
+
+  switch (sourceType) {
+    case 'url':
+      if (typeof input.url !== 'string' || !input.url) {
+        return { ok: false, error: 'url source: missing required `url` string' };
+      }
+      if (input.headers !== undefined && !isStringRecord(input.headers)) {
+        return { ok: false, error: 'url source: `headers` must be Record<string, string>' };
+      }
+      return {
+        ok: true,
+        source: { source: 'url', url: input.url, headers: input.headers as Record<string, string> | undefined },
+      };
+
+    case 'github':
+      if (typeof input.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(input.repo)) {
+        return { ok: false, error: 'github source: `repo` must be in `owner/repo` format' };
+      }
+      return {
+        ok: true,
+        source: {
+          source: 'github',
+          repo: input.repo,
+          ref: optionalString(input.ref),
+          path: optionalString(input.path),
+          sparsePaths: optionalStringArray(input.sparsePaths),
+        },
+      };
+
+    case 'git':
+      if (typeof input.url !== 'string' || !input.url) {
+        return { ok: false, error: 'git source: missing required `url` string' };
+      }
+      return {
+        ok: true,
+        source: {
+          source: 'git',
+          url: input.url,
+          ref: optionalString(input.ref),
+          path: optionalString(input.path),
+          sparsePaths: optionalStringArray(input.sparsePaths),
+        },
+      };
+
+    case 'npm':
+      if (typeof input.package !== 'string' || !input.package) {
+        return { ok: false, error: 'npm source: missing required `package` string' };
+      }
+      return { ok: true, source: { source: 'npm', package: input.package } };
+
+    case 'file':
+      if (typeof input.path !== 'string' || !input.path) {
+        return { ok: false, error: 'file source: missing required `path` string' };
+      }
+      return { ok: true, source: { source: 'file', path: input.path } };
+
+    case 'directory':
+      if (typeof input.path !== 'string' || !input.path) {
+        return { ok: false, error: 'directory source: missing required `path` string' };
+      }
+      return { ok: true, source: { source: 'directory', path: input.path } };
+
+    case 'hostPattern':
+      if (typeof input.hostPattern !== 'string' || !input.hostPattern) {
+        return { ok: false, error: 'hostPattern source: missing required `hostPattern` regex' };
+      }
+      return { ok: true, source: { source: 'hostPattern', hostPattern: input.hostPattern } };
+
+    case 'pathPattern':
+      if (typeof input.pathPattern !== 'string' || !input.pathPattern) {
+        return { ok: false, error: 'pathPattern source: missing required `pathPattern` regex' };
+      }
+      return { ok: true, source: { source: 'pathPattern', pathPattern: input.pathPattern } };
+
+    case 'settings':
+      if (typeof input.name !== 'string' || !input.name) {
+        return { ok: false, error: 'settings source: missing required `name` string' };
+      }
+      if (!Array.isArray(input.plugins)) {
+        return { ok: false, error: 'settings source: `plugins` must be an array' };
+      }
+      return { ok: true, source: { source: 'settings', name: input.name, plugins: input.plugins } };
+  }
+
+  return { ok: false, error: `unhandled source type "${sourceType}"` };
+}
+
+/**
+ * Convenience helper that throws on validation failure. Use in CLI
+ * orchestrator scripts where we want the error to bubble up as a
+ * non-zero exit with a clear message.
+ */
+export function parseMarketplaceSource(input: unknown): ExtraKnownMarketplaceSource {
+  const result = validateMarketplaceSource(input);
+  if (!result.ok) {
+    throw new Error(`Invalid marketplace source: ${result.error}`);
+  }
+  return result.source;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  if (!isPlainObject(v)) return false;
+  return Object.values(v).every((value) => typeof value === 'string');
+}
+
+function optionalString(v: unknown): string | undefined {
+  if (v === undefined) return undefined;
+  if (typeof v !== 'string') throw new Error('expected string or undefined');
+  return v;
+}
+
+function optionalStringArray(v: unknown): string[] | undefined {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v) || !v.every((s) => typeof s === 'string')) {
+    throw new Error('expected string[] or undefined');
+  }
+  return v as string[];
+}

--- a/scripts/lib/onecli-vault-helpers.test.ts
+++ b/scripts/lib/onecli-vault-helpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { findSecretForHost, findGithubGitSecret, type OneCliSecret } from './onecli-vault-helpers.js';
+
+const apiOnly: OneCliSecret = {
+  id: '1',
+  name: 'GitHub',
+  type: 'generic',
+  hostPattern: 'api.github.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'Authorization', valueFormat: 'Bearer {value}' },
+};
+
+const gitClone: OneCliSecret = {
+  id: '2',
+  name: 'GitHub Git Clone',
+  type: 'generic',
+  hostPattern: 'github.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'Authorization', valueFormat: 'Basic {value}' },
+};
+
+const otherHost: OneCliSecret = {
+  id: '3',
+  name: 'Anthropic',
+  type: 'generic',
+  hostPattern: 'api.anthropic.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'X-API-Key', valueFormat: '{value}' },
+};
+
+const noPattern: OneCliSecret = {
+  id: '4',
+  name: 'Misconfigured',
+  type: 'generic',
+  hostPattern: null,
+  pathPattern: null,
+};
+
+describe('findSecretForHost', () => {
+  it('returns null on empty list', () => {
+    expect(findSecretForHost('github.com', [])).toBeNull();
+  });
+
+  it('finds exact-match host', () => {
+    const r = findSecretForHost('github.com', [apiOnly, gitClone, otherHost]);
+    expect(r?.id).toBe('2');
+  });
+
+  it('does NOT match api.github.com against github.com (exact)', () => {
+    // Confirms the bug class: github.com pattern wouldn't fire on api.github.com.
+    const r = findSecretForHost('github.com', [apiOnly]);
+    expect(r).toBeNull();
+  });
+
+  it('matches regex patterns', () => {
+    const regex: OneCliSecret = {
+      ...gitClone,
+      hostPattern: '^github\\.com$',
+    };
+    expect(findSecretForHost('github.com', [regex])?.id).toBe('2');
+  });
+
+  it('skips entries with null hostPattern', () => {
+    expect(findSecretForHost('github.com', [noPattern])).toBeNull();
+  });
+
+  it('returns first match in list order', () => {
+    const r = findSecretForHost('github.com', [gitClone, { ...gitClone, id: 'second', name: 'Dup' }]);
+    expect(r?.id).toBe('2');
+  });
+});
+
+describe('findGithubGitSecret', () => {
+  it('returns null when only api.github.com Bearer entry present', () => {
+    expect(findGithubGitSecret([apiOnly])).toBeNull();
+  });
+
+  it('returns null when github.com entry exists but valueFormat is not Basic', () => {
+    const wrongFormat: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'Authorization', valueFormat: 'Bearer {value}' },
+    };
+    expect(findGithubGitSecret([wrongFormat])).toBeNull();
+  });
+
+  it('returns null when headerName is wrong', () => {
+    const wrongHeader: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'X-Custom', valueFormat: 'Basic {value}' },
+    };
+    expect(findGithubGitSecret([wrongHeader])).toBeNull();
+  });
+
+  it('finds the correctly-shaped github.com secret', () => {
+    const r = findGithubGitSecret([apiOnly, gitClone, otherHost]);
+    expect(r?.id).toBe('2');
+  });
+
+  it('case-insensitive on header name', () => {
+    const lower: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'authorization', valueFormat: 'Basic {value}' },
+    };
+    expect(findGithubGitSecret([lower])?.id).toBe('2');
+  });
+
+  it('returns null when no injectionConfig', () => {
+    const stripped: OneCliSecret = { ...gitClone, injectionConfig: undefined };
+    expect(findGithubGitSecret([stripped])).toBeNull();
+  });
+});

--- a/scripts/lib/onecli-vault-helpers.ts
+++ b/scripts/lib/onecli-vault-helpers.ts
@@ -1,0 +1,107 @@
+/**
+ * scripts/lib/onecli-vault-helpers.ts — minimal OneCLI vault
+ * introspection used by `/install-plugin --source` (private-repo
+ * pre-check) and `/setup-private-plugins` (idempotency).
+ *
+ * The vault never returns secret values to the host (by design; values
+ * only leave the gateway via header injection at request time). We
+ * only read METADATA: name, hostPattern, headerName, valueFormat.
+ */
+import { execFileSync } from 'child_process';
+
+export interface OneCliSecret {
+  id: string;
+  name: string;
+  type: string;
+  hostPattern: string | null;
+  pathPattern: string | null;
+  injectionConfig?: {
+    headerName?: string;
+    valueFormat?: string;
+    paramName?: string;
+    paramFormat?: string;
+  };
+}
+
+/**
+ * List all OneCLI vault secrets visible to the current OneCLI agent.
+ * Returns an empty array if onecli isn't installed or the gateway isn't
+ * reachable — callers should treat absence-of-secret as
+ * not-yet-configured, not as a hard error.
+ */
+export function listOneCliSecrets(): OneCliSecret[] {
+  let stdout: string;
+  try {
+    stdout = execFileSync('onecli', ['secrets', 'list'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stdout);
+    const data = parsed?.data;
+    if (!Array.isArray(data)) return [];
+    return data.filter((s) => s && typeof s === 'object') as OneCliSecret[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Return the first secret whose `hostPattern` matches the given host.
+ * Pattern is matched as a regex if it contains regex metacharacters,
+ * otherwise as an exact-equals check. (OneCLI itself accepts either
+ * form per gateway docs; we only care here about identifying when a
+ * secret is wired.)
+ *
+ * Returns `null` if no matching secret exists.
+ */
+export function findSecretForHost(host: string, secrets?: OneCliSecret[]): OneCliSecret | null {
+  const list = secrets ?? listOneCliSecrets();
+  for (const s of list) {
+    if (!s.hostPattern) continue;
+    if (matchesHost(s.hostPattern, host)) return s;
+  }
+  return null;
+}
+
+function matchesHost(pattern: string, host: string): boolean {
+  // Exact match first (most common case).
+  if (pattern === host) return true;
+  // Treat as regex if it has anchor or class metacharacters.
+  if (/[$^*+?()[\]{}|\\]/.test(pattern)) {
+    try {
+      return new RegExp(pattern).test(host);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a github.com secret is configured for git smart-HTTP auth
+ * (the format `/setup-private-plugins` writes). Used by
+ * `/install-plugin --source` to decide whether private-github clones
+ * will likely succeed before warning the operator.
+ *
+ * Returns the matching secret if present, else null.
+ */
+export function findGithubGitSecret(secrets?: OneCliSecret[]): OneCliSecret | null {
+  const list = secrets ?? listOneCliSecrets();
+  for (const s of list) {
+    if (!s.hostPattern) continue;
+    // We're looking for a github.com (NOT api.github.com) entry with
+    // Authorization: Basic format — that's what /setup-private-plugins
+    // installs, and what github's git smart-HTTP requires.
+    if (!matchesHost(s.hostPattern, 'github.com')) continue;
+    const cfg = s.injectionConfig;
+    if (cfg?.headerName?.toLowerCase() === 'authorization' && cfg.valueFormat?.startsWith('Basic ')) {
+      return s;
+    }
+  }
+  return null;
+}

--- a/scripts/lib/plugins-config.test.ts
+++ b/scripts/lib/plugins-config.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from '../../src/config.js';
+import {
+  addMarketplace,
+  removeMarketplace,
+  installPlugin,
+  uninstallPlugin,
+  listMarketplaces,
+  listEnabledPlugins,
+  parsePluginSpec,
+} from './plugins-config.js';
+import { writeContainerConfig } from '../../src/container-config.js';
+
+let testFolders: string[];
+
+beforeEach(() => {
+  testFolders = [];
+});
+
+afterEach(() => {
+  for (const folder of testFolders) {
+    fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+  }
+});
+
+function makeFolder(suffix: string): string {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  testFolders.push(folder);
+  fs.mkdirSync(path.join(GROUPS_DIR, folder), { recursive: true });
+  // Seed with empty container.json.
+  writeContainerConfig(folder, {
+    mcpServers: {},
+    packages: { apt: [], npm: [] },
+    additionalMounts: [],
+    skills: 'all',
+  });
+  return folder;
+}
+
+describe('parsePluginSpec', () => {
+  it('parses valid name@marketplace', () => {
+    expect(parsePluginSpec('foo@bar')).toEqual({ name: 'foo', marketplace: 'bar' });
+  });
+  it('rejects missing @', () => {
+    expect(() => parsePluginSpec('foo-bar')).toThrow(/name@marketplace/);
+  });
+  it('rejects empty name', () => {
+    expect(() => parsePluginSpec('@bar')).toThrow();
+  });
+  it('rejects empty marketplace', () => {
+    expect(() => parsePluginSpec('foo@')).toThrow();
+  });
+  it('rejects marketplace with whitespace', () => {
+    expect(() => parsePluginSpec('foo@bar baz')).toThrow();
+  });
+  it('rejects marketplace with slashes', () => {
+    expect(() => parsePluginSpec('foo@bar/baz')).toThrow();
+  });
+  it('handles @ inside plugin name (uses last @)', () => {
+    expect(parsePluginSpec('a@b@c')).toEqual({ name: 'a@b', marketplace: 'c' });
+  });
+});
+
+describe('addMarketplace / listMarketplaces', () => {
+  it('first add returns added=true', async () => {
+    const folder = makeFolder('add1');
+    const r = await addMarketplace(folder, 'mp1', {
+      source: 'github',
+      repo: 'a/b',
+    });
+    expect(r).toEqual({ added: true, replaced: false });
+    const list = listMarketplaces(folder);
+    expect(list.mp1?.source).toEqual({ source: 'github', repo: 'a/b' });
+  });
+
+  it('idempotent re-add returns added=false, replaced=false', async () => {
+    const folder = makeFolder('add-idem');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    expect(r).toEqual({ added: false, replaced: false });
+  });
+
+  it('different source replaces', async () => {
+    const folder = makeFolder('add-replace');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'old/repo' });
+    const r = await addMarketplace(folder, 'mp1', { source: 'github', repo: 'new/repo' });
+    expect(r).toEqual({ added: false, replaced: true });
+    const list = listMarketplaces(folder);
+    expect(list.mp1?.source).toMatchObject({ repo: 'new/repo' });
+  });
+
+  it('rejects invalid name', async () => {
+    const folder = makeFolder('add-bad');
+    await expect(
+      addMarketplace(folder, 'has space', { source: 'github', repo: 'a/b' }),
+    ).rejects.toThrow(/invalid characters/);
+  });
+});
+
+describe('removeMarketplace', () => {
+  it('removes when no plugins reference it', async () => {
+    const folder = makeFolder('rm1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r).toEqual({ removed: true, blockedBy: [] });
+    expect(listMarketplaces(folder).mp1).toBeUndefined();
+  });
+
+  it('returns removed=false for unknown name', async () => {
+    const folder = makeFolder('rm-unknown');
+    const r = await removeMarketplace(folder, 'never-added');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy).toEqual([]);
+  });
+
+  it('blocks when plugins reference it', async () => {
+    const folder = makeFolder('rm-blocked');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy).toEqual(['plug1@mp1']);
+    // Marketplace still there.
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+  });
+
+  it('blocks listing all referencing plugins', async () => {
+    const folder = makeFolder('rm-blocked-multi');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'a@mp1');
+    await installPlugin(folder, 'b@mp1');
+    await installPlugin(folder, 'c@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy.sort()).toEqual(['a@mp1', 'b@mp1', 'c@mp1']);
+  });
+});
+
+describe('installPlugin', () => {
+  it('enables when marketplace already registered', async () => {
+    const folder = makeFolder('inst1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await installPlugin(folder, 'plug1@mp1');
+    expect(r).toEqual({ wasEnabled: true, marketplaceAdded: false });
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBe(true);
+  });
+
+  it('throws when marketplace not registered and no inline source', async () => {
+    const folder = makeFolder('inst-no-mp');
+    await expect(installPlugin(folder, 'plug1@mp1')).rejects.toThrow(/not registered/);
+  });
+
+  it('inline --source registers and enables in one shot', async () => {
+    const folder = makeFolder('inst-source');
+    const r = await installPlugin(folder, 'plug1@mp1', {
+      source: 'github',
+      repo: 'a/b',
+    });
+    expect(r).toEqual({ wasEnabled: true, marketplaceAdded: true });
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBe(true);
+  });
+
+  it('inline source updates existing marketplace if different', async () => {
+    const folder = makeFolder('inst-source-update');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'old/old' });
+    const r = await installPlugin(folder, 'plug1@mp1', {
+      source: 'github',
+      repo: 'new/new',
+    });
+    expect(r.marketplaceAdded).toBe(true);
+    expect(listMarketplaces(folder).mp1?.source).toMatchObject({ repo: 'new/new' });
+  });
+
+  it('idempotent re-enable returns wasEnabled=false', async () => {
+    const folder = makeFolder('inst-idem');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await installPlugin(folder, 'plug1@mp1');
+    expect(r).toEqual({ wasEnabled: false, marketplaceAdded: false });
+  });
+
+  it('rejects malformed plugin spec', async () => {
+    const folder = makeFolder('inst-bad-spec');
+    await expect(installPlugin(folder, 'no-at-sign')).rejects.toThrow(/name@marketplace/);
+  });
+});
+
+describe('uninstallPlugin', () => {
+  it('disables an enabled plugin', async () => {
+    const folder = makeFolder('uninst1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await uninstallPlugin(folder, 'plug1@mp1');
+    expect(r.wasDisabled).toBe(true);
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBeUndefined();
+    // Marketplace stays.
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+  });
+
+  it('returns wasDisabled=false if not enabled', async () => {
+    const folder = makeFolder('uninst-not-enabled');
+    const r = await uninstallPlugin(folder, 'plug1@mp1');
+    expect(r.wasDisabled).toBe(false);
+  });
+
+  it('after uninstall, removeMarketplace succeeds', async () => {
+    const folder = makeFolder('uninst-then-rm');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    await uninstallPlugin(folder, 'plug1@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(true);
+  });
+});

--- a/scripts/lib/plugins-config.ts
+++ b/scripts/lib/plugins-config.ts
@@ -1,0 +1,190 @@
+/**
+ * scripts/lib/plugins-config.ts — read/validate/write the
+ * `container.json:plugins` block, with safety checks for the operator
+ * skills (`/add-marketplace`, `/remove-marketplace`, `/install-plugin`,
+ * `/uninstall-plugin`).
+ *
+ * All mutations route through `updateContainerConfig()` so concurrent
+ * writers (multiple operator skills, self-mod approval handlers) are
+ * serialized via the file lock established in PR 1.
+ */
+import {
+  readContainerConfig,
+  updateContainerConfig,
+  type ExtraKnownMarketplaceSource,
+} from '../../src/container-config.js';
+import { parseMarketplaceSource } from './marketplace-source-validator.js';
+
+/**
+ * Add or update a marketplace entry in `container.json:plugins.marketplaces`.
+ * Idempotent — running with the same source is a no-op (returns
+ * `{ added: false, replaced: false }`). Updating with a different source
+ * replaces the entry (returns `{ added: false, replaced: true }`).
+ */
+export async function addMarketplace(
+  folder: string,
+  name: string,
+  source: ExtraKnownMarketplaceSource,
+): Promise<{ added: boolean; replaced: boolean }> {
+  validateMarketplaceName(name);
+  let added = false;
+  let replaced = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (!cfg.plugins) cfg.plugins = {};
+    if (!cfg.plugins.marketplaces) cfg.plugins.marketplaces = {};
+    const existing = cfg.plugins.marketplaces[name];
+    if (!existing) {
+      added = true;
+    } else if (JSON.stringify(existing.source) !== JSON.stringify(source)) {
+      replaced = true;
+    }
+    cfg.plugins.marketplaces[name] = { source };
+  });
+  return { added, replaced };
+}
+
+/**
+ * Remove a marketplace entry. Refuses if any plugin in
+ * `enabled` references this marketplace — operator must
+ * `/uninstall-plugin` those first.
+ *
+ * Returns `{ removed: false }` if the marketplace wasn't registered.
+ */
+export async function removeMarketplace(
+  folder: string,
+  name: string,
+): Promise<{ removed: boolean; blockedBy: string[] }> {
+  // Reference check first (read-only path).
+  const cfg = readContainerConfig(folder);
+  const enabled = cfg.plugins?.enabled ?? {};
+  const referencingKeys: string[] = [];
+  for (const key of Object.keys(enabled)) {
+    const at = key.lastIndexOf('@');
+    if (at > 0 && key.slice(at + 1) === name) {
+      referencingKeys.push(key);
+    }
+  }
+  if (referencingKeys.length > 0) {
+    return { removed: false, blockedBy: referencingKeys };
+  }
+
+  let removed = false;
+  await updateContainerConfig(folder, (c) => {
+    if (c.plugins?.marketplaces?.[name]) {
+      delete c.plugins.marketplaces[name];
+      removed = true;
+    }
+  });
+  return { removed, blockedBy: [] };
+}
+
+export function listMarketplaces(folder: string): Record<string, { source: ExtraKnownMarketplaceSource }> {
+  const cfg = readContainerConfig(folder);
+  return cfg.plugins?.marketplaces ?? {};
+}
+
+/**
+ * Enable a plugin. The plugin spec is `<plugin-name>@<marketplace-name>`.
+ * If `inlineSource` is provided, the marketplace is registered (or
+ * updated) atomically with the enable — convenience for the
+ * "register and install in one shot" flow.
+ *
+ * If the marketplace isn't registered and no `inlineSource` is provided,
+ * throws.
+ */
+export async function installPlugin(
+  folder: string,
+  pluginSpec: string,
+  inlineSource?: ExtraKnownMarketplaceSource,
+): Promise<{ wasEnabled: boolean; marketplaceAdded: boolean }> {
+  const { name, marketplace } = parsePluginSpec(pluginSpec);
+  let wasEnabled = false;
+  let marketplaceAdded = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (!cfg.plugins) cfg.plugins = {};
+    if (!cfg.plugins.marketplaces) cfg.plugins.marketplaces = {};
+    if (!cfg.plugins.enabled) cfg.plugins.enabled = {};
+
+    // Register marketplace if needed (and inline source provided).
+    if (!cfg.plugins.marketplaces[marketplace]) {
+      if (!inlineSource) {
+        throw new Error(
+          `Marketplace "${marketplace}" is not registered for this group. Run /add-marketplace first, or pass --source to register inline.`,
+        );
+      }
+      cfg.plugins.marketplaces[marketplace] = { source: inlineSource };
+      marketplaceAdded = true;
+    } else if (inlineSource) {
+      // Update if inline source provided and differs.
+      if (JSON.stringify(cfg.plugins.marketplaces[marketplace].source) !== JSON.stringify(inlineSource)) {
+        cfg.plugins.marketplaces[marketplace] = { source: inlineSource };
+        marketplaceAdded = true;
+      }
+    }
+
+    if (cfg.plugins.enabled[pluginSpec] !== true) {
+      cfg.plugins.enabled[pluginSpec] = true;
+      wasEnabled = true;
+    }
+
+    // Sanity unused — keeps pluginName reachable in TS without an unused-var warning.
+    void name;
+  });
+  return { wasEnabled, marketplaceAdded };
+}
+
+/**
+ * Disable a plugin. Removes the entry from `enabled`. The marketplace
+ * registration stays so other plugins from it can still be enabled.
+ */
+export async function uninstallPlugin(
+  folder: string,
+  pluginSpec: string,
+): Promise<{ wasDisabled: boolean }> {
+  // Validate format up front so a typo doesn't silently no-op.
+  parsePluginSpec(pluginSpec);
+  let wasDisabled = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (cfg.plugins?.enabled?.[pluginSpec] !== undefined) {
+      delete cfg.plugins.enabled[pluginSpec];
+      wasDisabled = true;
+    }
+  });
+  return { wasDisabled };
+}
+
+export function listEnabledPlugins(
+  folder: string,
+): Record<string, boolean | string[] | { [k: string]: unknown }> {
+  const cfg = readContainerConfig(folder);
+  return cfg.plugins?.enabled ?? {};
+}
+
+/**
+ * Parse `<plugin-name>@<marketplace-name>` into its components. Throws
+ * with a clear message on malformed input.
+ */
+export function parsePluginSpec(spec: string): { name: string; marketplace: string } {
+  const at = spec.lastIndexOf('@');
+  if (at <= 0 || at === spec.length - 1) {
+    throw new Error(`Plugin spec must be in "name@marketplace" format; got "${spec}"`);
+  }
+  const name = spec.slice(0, at);
+  const marketplace = spec.slice(at + 1);
+  validateMarketplaceName(marketplace);
+  if (!name) throw new Error(`Plugin name cannot be empty in spec "${spec}"`);
+  return { name, marketplace };
+}
+
+function validateMarketplaceName(name: string): void {
+  // Match the SDK's marketplace-name validation: non-empty, no spaces,
+  // no `/`, no `\`, no `..`. Some reserved names are also rejected
+  // upstream, but we leave that to the SDK.
+  if (!name) throw new Error('Marketplace name cannot be empty');
+  if (/[\s/\\]/.test(name)) {
+    throw new Error(`Marketplace name "${name}" contains invalid characters (no spaces, slashes, or backslashes)`);
+  }
+  if (name === '..' || name === '.') {
+    throw new Error(`Marketplace name "${name}" is reserved`);
+  }
+}

--- a/scripts/list-marketplaces.ts
+++ b/scripts/list-marketplaces.ts
@@ -1,0 +1,26 @@
+/**
+ * scripts/list-marketplaces.ts — print the registered marketplaces for
+ * a group.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+ *
+ * Outputs JSON to stdout (the SKILL.md prompts Claude to format it).
+ */
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { listMarketplaces } from './lib/plugins-config.js';
+
+const folder = process.argv[2];
+if (!folder) {
+  console.error('Usage: tsx scripts/list-marketplaces.ts <group-folder>');
+  process.exit(2);
+}
+
+initDb();
+if (!getAgentGroupByFolder(folder)) {
+  console.error(`No agent group with folder "${folder}"`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(listMarketplaces(folder), null, 2));

--- a/scripts/list-marketplaces.ts
+++ b/scripts/list-marketplaces.ts
@@ -7,7 +7,7 @@
  *
  * Outputs JSON to stdout (the SKILL.md prompts Claude to format it).
  */
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { listMarketplaces } from './lib/plugins-config.js';
 
@@ -17,7 +17,7 @@ if (!folder) {
   process.exit(2);
 }
 
-initDb();
+initOperatorDb();
 if (!getAgentGroupByFolder(folder)) {
   console.error(`No agent group with folder "${folder}"`);
   process.exit(1);

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -4,7 +4,7 @@
  * Usage:
  *   pnpm exec tsx scripts/list-plugins.ts <group-folder>
  */
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { listEnabledPlugins } from './lib/plugins-config.js';
 
@@ -14,7 +14,7 @@ if (!folder) {
   process.exit(2);
 }
 
-initDb();
+initOperatorDb();
 if (!getAgentGroupByFolder(folder)) {
   console.error(`No agent group with folder "${folder}"`);
   process.exit(1);

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -1,0 +1,23 @@
+/**
+ * scripts/list-plugins.ts — print enabled plugins for a group.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/list-plugins.ts <group-folder>
+ */
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { listEnabledPlugins } from './lib/plugins-config.js';
+
+const folder = process.argv[2];
+if (!folder) {
+  console.error('Usage: tsx scripts/list-plugins.ts <group-folder>');
+  process.exit(2);
+}
+
+initDb();
+if (!getAgentGroupByFolder(folder)) {
+  console.error(`No agent group with folder "${folder}"`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(listEnabledPlugins(folder), null, 2));

--- a/scripts/remove-marketplace.ts
+++ b/scripts/remove-marketplace.ts
@@ -9,7 +9,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { removeMarketplace } from './lib/plugins-config.js';
 
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/remove-marketplace.ts
+++ b/scripts/remove-marketplace.ts
@@ -1,0 +1,59 @@
+/**
+ * scripts/remove-marketplace.ts — unregister a plugin marketplace from
+ * a group's container.json. Refuses if any plugin from the marketplace
+ * is currently enabled (operator must `/uninstall-plugin` first).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/remove-marketplace.ts <group-folder> <name>
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { removeMarketplace } from './lib/plugins-config.js';
+
+async function main(): Promise<void> {
+  const [, , folder, name] = process.argv;
+  if (!folder || !name) {
+    console.error('Usage: tsx scripts/remove-marketplace.ts <group-folder> <name>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  const result = await removeMarketplace(folder, name);
+
+  if (result.blockedBy.length > 0) {
+    console.error(
+      `Cannot remove marketplace "${name}": it has enabled plugins. ` +
+        `Run /uninstall-plugin for each first:\n  ${result.blockedBy.join('\n  ')}`,
+    );
+    process.exit(1);
+  }
+
+  if (!result.removed) {
+    console.log(`Marketplace "${name}" was not registered. No change.`);
+    return;
+  }
+
+  console.log(`Removed marketplace "${name}" from group "${folder}".`);
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/restart-group.ts
+++ b/scripts/restart-group.ts
@@ -25,7 +25,7 @@ import { execFileSync } from 'child_process';
 
 import { CONTAINER_INSTALL_LABEL } from '../src/config.js';
 import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { getSessionsByAgentGroup } from '../src/db/sessions.js';
 
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
 
   const group = getAgentGroupByFolder(folder);
   if (!group) {

--- a/scripts/restart-group.ts
+++ b/scripts/restart-group.ts
@@ -1,0 +1,99 @@
+/**
+ * scripts/restart-group.ts — multi-session-aware container kill helper.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/restart-group.ts <agent-group-folder>
+ *
+ * Used by the operator skills (`/install-plugin`, `/add-marketplace`,
+ * etc.) after they mutate `container.json`. Lists all docker containers
+ * running with this install's label whose name matches the group's
+ * `nanoclaw-v2-<folder>-*` prefix, and stops each one. Idle sessions
+ * (no running container) are not touched — they'll respawn with the
+ * new config naturally on the next message.
+ *
+ * Race semantics: write `container.json` BEFORE invoking this script,
+ * with no awaits between the write and the kill. The host sweep runs
+ * every 60s and respawns sessions on due messages; if the sweep fires
+ * between our write and our kill, the new container picks up the new
+ * config and there's nothing for us to kill — that's fine.
+ *
+ * Exits non-zero only on docker/runtime errors. "Nothing was running"
+ * is a successful exit (operators should still see the new config on
+ * next message).
+ */
+import { execFileSync } from 'child_process';
+
+import { CONTAINER_INSTALL_LABEL } from '../src/config.js';
+import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { getSessionsByAgentGroup } from '../src/db/sessions.js';
+
+interface RestartResult {
+  killed: string[];
+  idleSessions: number;
+  totalSessions: number;
+}
+
+async function main(): Promise<void> {
+  const folder = process.argv[2];
+  if (!folder) {
+    console.error('Usage: tsx scripts/restart-group.ts <agent-group-folder>');
+    process.exit(2);
+  }
+
+  initDb();
+
+  const group = getAgentGroupByFolder(folder);
+  if (!group) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  const sessions = getSessionsByAgentGroup(group.id);
+  const result: RestartResult = { killed: [], idleSessions: 0, totalSessions: sessions.length };
+
+  // Inventory currently-running containers via docker label, filter by
+  // name prefix. Container names are nanoclaw-v2-<folder>-<timestamp>
+  // (see container-runner.ts buildContainerArgs).
+  const namePrefix = `nanoclaw-v2-${folder}-`;
+  let runningNames: string[] = [];
+  try {
+    const out = execFileSync(
+      CONTAINER_RUNTIME_BIN,
+      ['ps', '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    runningNames = out.trim().split('\n').filter((n) => n.startsWith(namePrefix));
+  } catch (err) {
+    console.error(`Failed to list running containers: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  // Kill each. Sequence matters: write-then-kill avoids the sweep-race
+  // where a tick between writes and kills could spawn the new container
+  // on stale config. The kill calls themselves are independent.
+  for (const name of runningNames) {
+    try {
+      execFileSync(CONTAINER_RUNTIME_BIN, ['stop', '--time', '5', name], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+      result.killed.push(name);
+    } catch (err) {
+      // Stop might race with natural exit; treat as best-effort.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`(warning) failed to stop ${name}: ${msg}`);
+    }
+  }
+
+  // Idle session count = sessions that exist but have no running container.
+  result.idleSessions = sessions.length - result.killed.length;
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/setup-private-plugins.ts
+++ b/scripts/setup-private-plugins.ts
@@ -1,0 +1,136 @@
+/**
+ * scripts/setup-private-plugins.ts — one-time-per-host: register a
+ * GitHub PAT in the OneCLI vault with the host pattern + auth format
+ * required for git smart-HTTP clones (NOT the same format as github
+ * REST API access — github's git protocol only accepts HTTP Basic).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/setup-private-plugins.ts [--token <pat>]
+ *
+ * Without --token, attempts to read the token from `gh auth token`
+ * (the user's existing github CLI auth, if installed).
+ *
+ * This adds an entry that:
+ *   - hostPattern: github.com  (separate from any existing api.github.com entry)
+ *   - headerName:  Authorization
+ *   - valueFormat: Basic {value}
+ *   - value:       base64("x-access-token:<PAT>")
+ *
+ * After this, agent containers running under OneCLI gateway can clone
+ * private github repos via the SDK's plugin install path. Verified
+ * empirically; see docs/internal/plugin-install-empirical-test.md (in
+ * fork-internal docs).
+ *
+ * Idempotent: if a github.com Authorization-Basic secret is already
+ * registered, prompts whether to overwrite (or skip when --force not
+ * passed).
+ */
+import { execFileSync, spawnSync } from 'child_process';
+
+import { findGithubGitSecret } from './lib/onecli-vault-helpers.js';
+
+interface Args {
+  token?: string;
+  force: boolean;
+  name: string;
+}
+
+function parseArgs(): Args {
+  const args: Args = { force: false, name: 'GitHub Git Clone' };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--token' && i + 1 < argv.length) {
+      args.token = argv[++i];
+    } else if (a === '--force') {
+      args.force = true;
+    } else if (a === '--name' && i + 1 < argv.length) {
+      args.name = argv[++i];
+    } else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: tsx scripts/setup-private-plugins.ts [--token <pat>] [--name <secret-name>] [--force]',
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function getGhToken(): string | null {
+  try {
+    const out = execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const t = out.trim();
+    return t.length > 0 ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const args = parseArgs();
+
+  // Check for existing github.com git secret. Idempotency.
+  const existing = findGithubGitSecret();
+  if (existing && !args.force) {
+    console.log(
+      `A OneCLI vault entry for github.com with Basic auth is already registered: ${existing.name} (${existing.id}).`,
+    );
+    console.log('Re-run with --force to overwrite.');
+    process.exit(0);
+  }
+
+  // Resolve token.
+  let token = args.token;
+  if (!token) {
+    token = getGhToken() ?? undefined;
+    if (!token) {
+      console.error(
+        'No --token provided and `gh auth token` did not return a token. ' +
+          'Either install/authenticate the github CLI (https://cli.github.com) ' +
+          'or pass --token <pat> explicitly. The PAT needs `repo` scope for private clones.',
+      );
+      process.exit(1);
+    }
+  }
+
+  // Encode as base64(x-access-token:<token>) per github's git
+  // smart-HTTP HTTP Basic format.
+  const encoded = Buffer.from(`x-access-token:${token}`).toString('base64');
+
+  // Hand off to onecli secrets create. Don't echo the token; pass via
+  // argv (still ends up in process listings briefly, but onecli's CLI
+  // doesn't expose a stdin path).
+  const oneCliArgs = [
+    'secrets',
+    'create',
+    '--name',
+    args.name,
+    '--type',
+    'generic',
+    '--value',
+    encoded,
+    '--host-pattern',
+    'github.com',
+    '--header-name',
+    'Authorization',
+    '--value-format',
+    'Basic {value}',
+  ];
+
+  const result = spawnSync('onecli', oneCliArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString('utf8') ?? '';
+    console.error('Failed to create OneCLI secret:');
+    console.error(stderr);
+    process.exit(1);
+  }
+
+  console.log(`Registered "${args.name}" in OneCLI vault for host github.com.`);
+  console.log('Private github plugin clones will work in any agent container running under OneCLI.');
+  console.log('No restart required — the gateway picks up new secrets at request time.');
+}
+
+main();

--- a/scripts/uninstall-plugin.ts
+++ b/scripts/uninstall-plugin.ts
@@ -9,7 +9,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { uninstallPlugin } from './lib/plugins-config.js';
 
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/uninstall-plugin.ts
+++ b/scripts/uninstall-plugin.ts
@@ -1,0 +1,57 @@
+/**
+ * scripts/uninstall-plugin.ts — disable a plugin in a group's
+ * container.json. The marketplace registration stays so other plugins
+ * from it remain installable.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/uninstall-plugin.ts <group-folder> <plugin-spec>
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { uninstallPlugin } from './lib/plugins-config.js';
+
+async function main(): Promise<void> {
+  const [, , folder, pluginSpec] = process.argv;
+  if (!folder || !pluginSpec) {
+    console.error('Usage: tsx scripts/uninstall-plugin.ts <group-folder> <plugin-spec>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = await uninstallPlugin(folder, pluginSpec);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (!result.wasDisabled) {
+    console.log(`Plugin "${pluginSpec}" was not enabled. No change.`);
+    return;
+  }
+
+  console.log(`Disabled plugin "${pluginSpec}" in group "${folder}".`);
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds operator-side skills aligned with Claude Code's plugin/marketplace verb taxonomy, scoped to one NanoClaw agent group's `container.json`. Each skill is a thin SKILL.md wrapper around a `tsx` orchestrator script that mutates `container.json` and invokes a shared restart helper.

## Depends on #2365

This PR depends on #2365 (`feat(plugins): wire extraKnownMarketplaces + enabledPlugins via container.json`). Specifically: `scripts/lib/plugins-config.ts` imports `ExtraKnownMarketplaceSource`, `updateContainerConfig`, and types from `src/container-config.ts` that #2365 introduces. **Merge #2365 first; this PR is non-functional without it.**

## Skills (with the underlying claude CLI verb each mirrors)

| Skill | Maps to |
|---|---|
| `/add-marketplace` | `claude plugin marketplace add` |
| `/remove-marketplace` | `claude plugin marketplace remove` (with safety: refuses if any plugin from the marketplace is enabled) |
| `/list-marketplaces` | `claude plugin marketplace list` |
| `/install-plugin` | `claude plugin install` (with optional `--source` for one-shot register+install) |
| `/uninstall-plugin` | `claude plugin uninstall` |
| `/list-plugins` | `claude plugin list` |
| `/setup-private-plugins` | NanoClaw-specific; one-time-per-host github PAT → OneCLI vault entry for private clones |

## Deliberate departures from claude CLI

- **No `/enable-plugin` / `/disable-plugin`.** NanoClaw's SDK-driven model has no per-group cache state distinct from the enabled set; install/uninstall are the only switches. Documented in `install-plugin/SKILL.md` so operators reading Claude Code docs aren't confused.
- **No `/update-marketplace`.** SDK handles refresh autonomously per request (per the v2.1.120 30s cool-down).

## Shared infrastructure in scripts/lib/

- `db-init.ts` — operator-script DB init boilerplate (mirrors how `init-cli-agent.ts` does it). Without this, every script crashes before touching the DB.
- `marketplace-source-validator.ts` — validates the eight typed `extraKnownMarketplaces` source variants up-front.
- `plugins-config.ts` — `addMarketplace` / `removeMarketplace` (with enabled-plugin reference safety) / `installPlugin` / `uninstallPlugin` / `listMarketplaces` / `listEnabledPlugins`. All mutators route through #2365's locked `updateContainerConfig` primitive.
- `onecli-vault-helpers.ts` — read-only `onecli secrets list` introspection. Used by `/install-plugin --source` for private-repo pre-warning and `/setup-private-plugins` for idempotency.

`scripts/restart-group.ts` — docker-label-based multi-session-aware container kill helper. Lists nanoclaw containers matching the group's name prefix, stops each. Idle sessions left to respawn naturally.

## Tests

60 unit tests across the three plugin lib modules:

- `marketplace-source-validator.test.ts` — every typed source variant accepted (12 cases), every invalid input rejected (10 cases), `parseMarketplaceSource` throws-on-invalid contract.
- `plugins-config.test.ts` — `parsePluginSpec` edge cases, addMarketplace idempotency + replace, removeMarketplace blocking when plugins reference, installPlugin with/without inline source, idempotency, uninstallPlugin + post-uninstall remove flow. Mutators exercised through the locked `updateContainerConfig` path.
- `onecli-vault-helpers.test.ts` — hostPattern matching (exact + regex), the `api.github.com` vs `github.com` distinction, `findGithubGitSecret` rejecting wrong header / wrong format / missing config / Bearer-instead-of-Basic.

## End-to-end verification

Tested 24 scenarios against a live agent group: add → list → idempotent re-add → install → list → idempotent → remove blocked while plugin enabled → uninstall → remove unblocked → final state empty. The `--source` one-shot register+install path exercised separately. Pre-warning fires correctly when source points at github.com but no Basic-auth OneCLI vault entry exists.

## Test plan

- [x] All 7 skills register (visible in slash menu)
- [x] All 7 orchestrator scripts run without crashing
- [x] 60 lib unit tests pass
- [ ] Reviewer needs #2365 merged first (or merged together) — without it, `scripts/lib/plugins-config.ts` fails at import time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
