### PR TITLE
feat(self-mod): agent-initiated plugin install/uninstall + denial cache

### DIFF
--- a/.claude/skills/add-marketplace/SKILL.md
+++ b/.claude/skills/add-marketplace/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: add-marketplace
+description: Register a Claude Code plugin marketplace for a NanoClaw agent group. Operator-side; mirrors `claude plugin marketplace add` but writes to a per-group container.json. Triggers on "add marketplace", "register marketplace", "plugin marketplace".
+---
+
+# /add-marketplace
+
+Register a plugin marketplace in `groups/<folder>/container.json:plugins.marketplaces` so the agent's SDK loads plugins from it on next session start. Mirrors Claude Code's `claude plugin marketplace add` but scoped to one NanoClaw agent group.
+
+## Inputs
+
+Ask the operator (if not already provided):
+
+1. **Group folder** — the agent group to configure. List groups with `pnpm exec tsx scripts/q.ts data/v2.db "SELECT folder, name FROM agent_groups"` if the operator doesn't know.
+2. **Marketplace name** — a label for the marketplace within this group. Avoid spaces, slashes, dots-only.
+3. **Source** — one of the eight `extraKnownMarketplaces` source variants (see `src/container-config.ts:ExtraKnownMarketplaceSource`):
+   - `github` — `{ "source": "github", "repo": "owner/repo", "ref": "main" }`
+   - `git`    — `{ "source": "git",    "url": "https://...", "ref": "..." }`
+   - `url`    — `{ "source": "url",    "url": "https://example.com/marketplace.json", "headers": {...} }`
+   - `npm`    — `{ "source": "npm",    "package": "..." }`
+   - `file`   — `{ "source": "file",   "path": "/abs/path/marketplace.json" }`
+   - `directory` — `{ "source": "directory", "path": "/abs/path/" }`
+
+## Run
+
+```bash
+pnpm exec tsx scripts/add-marketplace.ts <group-folder> <name> '<source-json>'
+```
+
+The script validates the source schema, idempotently writes `container.json:plugins.marketplaces[<name>]`, and restarts the group's containers (so the next message picks up the new marketplace).
+
+## Private repos
+
+If the source points at a private github repo, run `/setup-private-plugins` once on this host first (registers the github PAT in OneCLI vault). Without it, the SDK's clone at session init will fail with a visible `plugin_install:failed` event but the session continues without the marketplace's plugins.
+
+## Verification
+
+After running:
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The new entry should be present. Send a message to the group; the agent's `init` event will list the loaded plugins (after the SDK clones the marketplace).

--- a/.claude/skills/install-plugin/SKILL.md
+++ b/.claude/skills/install-plugin/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: install-plugin
+description: Enable a Claude Code plugin in a NanoClaw agent group. Operator-side; mirrors `claude plugin install` but writes to a per-group container.json. Supports `--source` for one-shot register-and-install. Triggers on "install plugin", "enable plugin", "add plugin to group".
+---
+
+# /install-plugin
+
+Enable a plugin in `groups/<folder>/container.json:plugins.enabled`. The plugin's marketplace must already be registered (see `/add-marketplace`), or supply a `--source` to register it inline.
+
+## Inputs
+
+Ask the operator (if not already provided):
+
+1. **Group folder** — the agent group to configure.
+2. **Plugin spec** — `<plugin-name>@<marketplace-name>` (the format the SDK uses in `enabledPlugins`).
+3. **Optional `--source`** — JSON for `extraKnownMarketplaces` if the marketplace isn't yet registered. See `/add-marketplace` for the schema.
+
+## Run (marketplace already registered)
+
+```bash
+pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin>@<marketplace>
+```
+
+## Run (one-shot register + install)
+
+```bash
+pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin>@<marketplace> \
+  --source '{"source":"github","repo":"owner/repo","ref":"main"}'
+```
+
+The script writes both `marketplaces[<name>]` and `enabled[<spec>]=true` in a single locked update, then restarts the group. Single-restart semantics — no half-state window.
+
+## On disable / enable distinction
+
+Claude Code's CLI distinguishes "plugin installed but disabled" from "plugin uninstalled" because of its own cache management. **NanoClaw's SDK-driven model has no separate cache state per group** — there's just `plugins.enabled`. `/install-plugin` and `/uninstall-plugin` are the only switches. If documentation tells you to `claude plugin disable`, use `/uninstall-plugin` here.
+
+## Private repos
+
+If the source is a private github repo:
+
+1. Run `/setup-private-plugins` once on this host (registers a github PAT in OneCLI vault with `Authorization: Basic` injection for `github.com`).
+2. Then `/install-plugin` proceeds normally; the SDK clones via the OneCLI gateway with auth injected at the proxy layer.
+
+If the OneCLI entry isn't configured, this skill prints a warning and continues; the SDK clone will fail at session init with a visible `plugin_install:failed` event but the session continues without the plugin.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The new entry should be present. Send a message to the group; the agent's `init` event lists loaded plugins (after the SDK installs the marketplace+plugin).

--- a/.claude/skills/list-marketplaces/SKILL.md
+++ b/.claude/skills/list-marketplaces/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: list-marketplaces
+description: List the plugin marketplaces registered for a NanoClaw agent group. Operator-side; mirrors `claude plugin marketplace list` but scoped to one group's container.json. Triggers on "list marketplaces", "show marketplaces", "what marketplaces".
+---
+
+# /list-marketplaces
+
+Show the plugin marketplaces registered in `groups/<folder>/container.json:plugins.marketplaces`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The script prints JSON. Format it as a readable table for the operator: name, source type, key fields (repo/url/path).
+
+## Empty result
+
+If the JSON is `{}`, no marketplaces are registered for this group. Suggest `/add-marketplace` if the operator wanted plugins available.
+
+## See also
+
+- `/add-marketplace` — register a marketplace
+- `/list-plugins` — show enabled plugins (which require a registered marketplace)

--- a/.claude/skills/list-plugins/SKILL.md
+++ b/.claude/skills/list-plugins/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: list-plugins
+description: List the Claude Code plugins enabled for a NanoClaw agent group. Operator-side; mirrors `claude plugin list` but scoped to one group. Triggers on "list plugins", "show plugins", "what plugins".
+---
+
+# /list-plugins
+
+Show the plugins enabled in `groups/<folder>/container.json:plugins.enabled`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The script prints JSON. Format readably for the operator: each entry as `<plugin>@<marketplace>: <state>` (state = `true` for plain enable, version-array for version-pinned, or object for advanced enable).
+
+## See also
+
+- `/install-plugin` — enable a plugin
+- `/uninstall-plugin` — disable
+- `/list-marketplaces` — show registered marketplaces (which plugins reference by `@<name>`)

--- a/.claude/skills/remove-marketplace/SKILL.md
+++ b/.claude/skills/remove-marketplace/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: remove-marketplace
+description: Unregister a Claude Code plugin marketplace from a NanoClaw agent group. Refuses if any plugin from the marketplace is still enabled. Triggers on "remove marketplace", "unregister marketplace", "delete marketplace".
+---
+
+# /remove-marketplace
+
+Unregister a marketplace from `groups/<folder>/container.json:plugins.marketplaces`. Mirrors `claude plugin marketplace remove`.
+
+## Safety
+
+If any plugin in `plugins.enabled` references the marketplace (i.e., its key ends with `@<marketplace-name>`), the operation is refused. Run `/uninstall-plugin <plugin-spec>` for each referencing plugin first, then retry.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/remove-marketplace.ts <group-folder> <name>
+```
+
+The script validates references, removes the entry from `container.json`, and restarts the group's containers.
+
+## Note on SDK self-state
+
+The SDK keeps its own marketplace cache at `~/.claude/plugins/marketplaces/<name>/` (per session-shared dir), tracked in `known_marketplaces.json`. NanoClaw doesn't touch that — removing the `extraKnownMarketplaces` entry just stops the SDK from loading from there on next start. The cached clone is harmless and gets overwritten if the marketplace is re-registered.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+```
+
+The removed entry should be absent.

--- a/.claude/skills/setup-private-plugins/SKILL.md
+++ b/.claude/skills/setup-private-plugins/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: setup-private-plugins
+description: One-time-per-host setup that registers a GitHub PAT in the OneCLI vault so private github plugin clones work in NanoClaw containers. Triggers on "private plugins", "github auth for plugins", "setup private plugin auth".
+---
+
+# /setup-private-plugins
+
+Wires the OneCLI vault entry that lets the SDK clone private github plugins from inside a NanoClaw container, without ever putting the token on disk in the container or in `container.json`. Run once per host.
+
+## Background — why this is needed
+
+Github's git smart-HTTP only accepts HTTP Basic auth (NOT `Bearer`). The OneCLI gateway intercepts container HTTPS traffic and can inject auth headers — but the existing `GitHub` secret most operators have (with hostPattern `api.github.com` and `Bearer {value}`) covers the REST API only, not git clones from `github.com`.
+
+This skill installs a separate vault entry:
+
+| Field | Value |
+|---|---|
+| hostPattern | `github.com` |
+| headerName | `Authorization` |
+| valueFormat | `Basic {value}` |
+| value | base64-encoded `x-access-token:<your-PAT>` |
+
+After install, the OneCLI gateway injects `Authorization: Basic ...` into any container's HTTPS request to `github.com`, including the SDK's plugin clones. No token lands on disk in the container.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/setup-private-plugins.ts
+```
+
+The script:
+
+1. Checks for an existing `github.com` Basic-auth entry. If present, prompts to skip (or pass `--force` to overwrite).
+2. Reads your github PAT from `gh auth token` (the github CLI's stored credentials), OR pass `--token <pat>` explicitly.
+3. Encodes `base64("x-access-token:" + token)`.
+4. Calls `onecli secrets create` with the right shape.
+5. Reports success.
+
+## With explicit token
+
+```bash
+pnpm exec tsx scripts/setup-private-plugins.ts --token gho_yourPATHere
+```
+
+## Token requirements
+
+The PAT needs `repo` scope (read-only is enough for clones). Fine-grained PATs work; classic PATs work.
+
+## Verification
+
+```bash
+onecli secrets list | grep -A5 github.com
+```
+
+Should show your new entry with `hostPattern: "github.com"` and `valueFormat: "Basic {value}"`.
+
+End-to-end: register a private repo via `/install-plugin --source` (or `/add-marketplace`) and send a message to the group. The SDK's `plugin_install:installed` event should fire. If it fires `plugin_install:failed` with a 401-style error, the secret isn't being matched — verify the hostPattern and re-run with `--force`.
+
+## Restart not required
+
+OneCLI looks up secrets per request, so the new entry is live immediately. No NanoClaw restart needed.
+
+## Token rotation
+
+When you rotate the PAT, re-run with `--force` (or `--force --token <new-pat>`). The script updates the vault entry; the next container clone uses the new token.

--- a/.claude/skills/uninstall-plugin/SKILL.md
+++ b/.claude/skills/uninstall-plugin/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: uninstall-plugin
+description: Disable a Claude Code plugin in a NanoClaw agent group. Operator-side; mirrors `claude plugin uninstall`. The marketplace registration stays so other plugins from it remain installable. Triggers on "uninstall plugin", "disable plugin", "remove plugin from group".
+---
+
+# /uninstall-plugin
+
+Disable a plugin from `groups/<folder>/container.json:plugins.enabled`.
+
+## Run
+
+```bash
+pnpm exec tsx scripts/uninstall-plugin.ts <group-folder> <plugin>@<marketplace>
+```
+
+The script removes the entry, restarts the group's containers, and the SDK won't load that plugin on next start.
+
+## What stays
+
+The marketplace registration in `plugins.marketplaces` is untouched — other plugins from the same marketplace can still be enabled. To unregister the marketplace itself, use `/remove-marketplace` (which refuses if any plugin from it is still enabled).
+
+## NanoClaw doesn't distinguish "disabled" from "uninstalled"
+
+In Claude Code's CLI, `disable` keeps the plugin's cache files; `uninstall` removes them. NanoClaw's SDK-driven model has no separate per-group cache state — the only switch is `plugins.enabled`. So `/uninstall-plugin` is the universal "stop loading this plugin" verb.
+
+## Verification
+
+```bash
+pnpm exec tsx scripts/list-plugins.ts <group-folder>
+```
+
+The plugin should no longer be in the output. Send a message; the agent's `init` event should no longer list it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,18 @@ Each `/add-<name>` skill is idempotent: `git fetch origin <branch>` → copy mod
 
 ## Self-Modification
 
-One tier of agent self-modification today:
+One tier of agent self-modification today — four MCP tools the agent can fire from inside its container, each gated by admin approval:
 
-1. **`install_packages` / `add_mcp_server`** — changes to the per-agent-group container config only (apt/npm deps, wire an existing MCP server). Single admin approval per request; on approve, the handler in `src/modules/self-mod/apply.ts` rebuilds the image when needed (`install_packages` only) and restarts the container. `container/agent-runner/src/mcp-tools/self-mod.ts`.
+| Tool | Effect on approve | Image rebuild? | Notes |
+|---|---|---|---|
+| `install_packages` | Append apt/npm to `container.json:packages`; rebuild image; restart container | yes | apt + npm names sanitized at the tool boundary AND on the host |
+| `add_mcp_server` | Wire an existing MCP server into `container.json:mcpServers`; restart container | no — bun runs TS directly | Operator must already know the `command` + `args` |
+| `install_plugin` | Enable a Claude Code plugin in `container.json:plugins.enabled`; optional inline `source` registers the marketplace atomically; restart container | no | SDK clones + loads the plugin at next session start. Use this to add new skills/tools to a running agent. |
+| `uninstall_plugin` | Remove the entry from `container.json:plugins.enabled`; restart container | no | Marketplace registration stays so other plugins from it remain installable |
+
+All four go through `src/modules/self-mod/`: `request.ts` validates input + queues an approval; `apply.ts` runs on approve. MCP tool definitions: `container/agent-runner/src/mcp-tools/self-mod.ts`.
+
+**Denial-loop suppression.** All four register with `dedupeDenials: true`. On Reject, the response handler writes a row to `recent_denials` keyed on `(agent_group_id, sha256(action + canonical_payload))`. A subsequent identical request within 24h is suppressed at the request side — no new card reaches the admin; the agent gets a system note instead. Without this, an agent that drives its own retries (notably `install_plugin`) could wake the admin repeatedly with the same card. See [src/modules/approvals/recent-denials.ts](src/modules/approvals/recent-denials.ts) and migration `014-recent-denials`. Pruned at 7d by the host sweep.
 
 A second tier (direct source-level self-edits via a draft/activate flow) is planned but not yet implemented.
 

--- a/container/agent-runner/src/mcp-tools/self-mod.ts
+++ b/container/agent-runner/src/mcp-tools/self-mod.ts
@@ -117,4 +117,80 @@ export const addMcpServer: McpToolDefinition = {
   },
 };
 
-registerTools([installPackages, addMcpServer]);
+export const installPlugin: McpToolDefinition = {
+  tool: {
+    name: 'install_plugin',
+    description:
+      'Install a Claude Code plugin into your agent group. Plugins are loaded by the SDK at session init via container.json:plugins. Requires admin approval; fire-and-forget. On approval, the plugin is enabled in container.json, the container is restarted, and the SDK clones + installs the marketplace at next spawn. ' +
+      'plugin_spec is "name@marketplace" (the format the SDK uses). If the marketplace is not yet registered for this group, supply a `source` parameter — JSON matching extraKnownMarketplaces source schema (e.g. { "source": "github", "repo": "owner/repo", "ref": "main" }). For private github repos, the operator must have run /setup-private-plugins on the host first to wire the OneCLI vault entry.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        plugin_spec: { type: 'string', description: 'Plugin in "name@marketplace" format (e.g. "fmt@acme")' },
+        source: {
+          type: 'object',
+          description: 'Optional inline source for the marketplace if not yet registered. Must match SDK extraKnownMarketplaces schema. Skip if marketplace already registered for the group.',
+        },
+        reason: { type: 'string', description: 'Why this plugin is needed' },
+      },
+      required: ['plugin_spec'],
+    },
+  },
+  async handler(args) {
+    const pluginSpec = args.plugin_spec as string;
+    if (!pluginSpec || typeof pluginSpec !== 'string') return err('plugin_spec is required and must be a string');
+    if (!pluginSpec.includes('@')) return err('plugin_spec must be in "name@marketplace" format');
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'install_plugin',
+        plugin_spec: pluginSpec,
+        source: args.source ?? null,
+        reason: (args.reason as string) || '',
+      }),
+    });
+
+    log(`install_plugin: ${requestId} → "${pluginSpec}"${args.source ? ' (with inline source)' : ''}`);
+    return ok(`Plugin install request submitted. You will be notified when admin approves or rejects.`);
+  },
+};
+
+export const uninstallPlugin: McpToolDefinition = {
+  tool: {
+    name: 'uninstall_plugin',
+    description:
+      'Disable a previously-installed plugin from your agent group. Requires admin approval; fire-and-forget. The marketplace registration stays so other plugins from the same source remain installable. plugin_spec is "name@marketplace".',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        plugin_spec: { type: 'string', description: 'Plugin in "name@marketplace" format' },
+        reason: { type: 'string', description: 'Why this plugin should be removed' },
+      },
+      required: ['plugin_spec'],
+    },
+  },
+  async handler(args) {
+    const pluginSpec = args.plugin_spec as string;
+    if (!pluginSpec || typeof pluginSpec !== 'string') return err('plugin_spec is required and must be a string');
+    if (!pluginSpec.includes('@')) return err('plugin_spec must be in "name@marketplace" format');
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({
+        action: 'uninstall_plugin',
+        plugin_spec: pluginSpec,
+        reason: (args.reason as string) || '',
+      }),
+    });
+
+    log(`uninstall_plugin: ${requestId} → "${pluginSpec}"`);
+    return ok(`Plugin uninstall request submitted. You will be notified when admin approves or rejects.`);
+  },
+};
+
+registerTools([installPackages, addMcpServer, installPlugin, uninstallPlugin]);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -422,6 +422,13 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
     case 'compacted':
       log(`Compacted: ${event.text}`);
       break;
+    case 'plugin_install_failed':
+      // SDK failed to install a marketplace/plugin declared in
+      // settings.json:extraKnownMarketplaces. Log loudly so the operator
+      // notices when scanning agent logs; the agent's session continues
+      // without the failed plugin (SDK behavior, verified empirically).
+      log(`Plugin install failed: name=${event.name ?? '<unknown>'} error=${event.error.slice(0, 300)}`);
+      break;
   }
 }
 

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -333,6 +333,24 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
           const tn = message as { summary?: string };
           yield { type: 'progress', message: tn.summary || 'Task notification' };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'plugin_install') {
+          // SDK plugin install lifecycle (started/installed/failed/completed).
+          // Failures need explicit surfacing so the operator sees them; other
+          // statuses are activity-only signals — installs can take 30+ seconds
+          // for slow github clones, and the poll loop's idle timer would
+          // otherwise fire mid-clone and kill the session.
+          const m = message as { status?: string; name?: string; error?: string };
+          if (m.status === 'failed') {
+            log(`plugin_install failed: name=${m.name ?? '<unknown>'} error=${m.error?.slice(0, 200) ?? ''}`);
+            yield {
+              type: 'plugin_install_failed',
+              name: m.name ?? null,
+              error: m.error ?? 'unknown error',
+            };
+          } else if (m.status === 'installed') {
+            log(`plugin_install installed: ${m.name ?? '<unknown>'}`);
+          }
+          // started/completed: covered by the activity yield above.
         }
       }
       log(`Query completed after ${messageCount} SDK messages`);

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -87,4 +87,13 @@ export type ProviderEvent =
    * after compaction. Distinct from `result` so it doesn't mark the turn
    * completed or get dispatched as a chat message. See qwibitai/nanoclaw#2325.
    */
-  | { type: 'compacted'; text: string };
+  | { type: 'compacted'; text: string }
+  /**
+   * Plugin install failure event. Emitted by claude provider when the SDK
+   * fires a `plugin_install:failed` system message during marketplace clone
+   * or plugin install. Distinct from `error` because this isn't a poll-loop
+   * retry signal — the SDK continues the session without the failed
+   * plugin, and the host should log + surface the failure to the operator
+   * without aborting the turn.
+   */
+  | { type: 'plugin_install_failed'; name: string | null; error: string };

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -201,7 +201,7 @@ Access layer: `src/db/agent-destinations.ts`.
 
 Two workflows share this table:
 
-- **Session-bound MCP approvals** — `install_packages`, `add_mcp_server`. `session_id` is set.
+- **Session-bound MCP approvals** — `install_packages`, `add_mcp_server`, `install_plugin`, `uninstall_plugin`. `session_id` is set.
 - **OneCLI credential approvals** — `session_id` may be NULL; `agent_group_id` + `channel_type` + `platform_id` route the admin card.
 
 ```sql
@@ -227,6 +227,30 @@ CREATE INDEX idx_pending_approvals_action_status ON pending_approvals(action, st
 - `status`: `pending` | `approved` | `rejected` | `expired`.
 - `platform_message_id` lets the host edit the admin card in place after a decision.
 - Access layer: `src/db/sessions.ts`; sweep + delivery: `src/onecli-approvals.ts`.
+
+### 1.11a `recent_denials`
+
+Short-lived memory of admin-rejected approval requests, used to suppress denial loops on agent-initiated self-mods. Without this, an agent that drives its own retries (notably `install_plugin`) can wake the admin again on the next message after a single Reject because it has no built-in "denied recently" memory.
+
+```sql
+CREATE TABLE recent_denials (
+  agent_group_id TEXT NOT NULL,
+  action_hash    TEXT NOT NULL,
+  denied_at      INTEGER NOT NULL,
+  denied_by      TEXT NOT NULL,
+  PRIMARY KEY (agent_group_id, action_hash)
+);
+CREATE INDEX idx_recent_denials_denied_at ON recent_denials(denied_at);
+```
+
+- `action_hash`: `sha256(action + canonical(payload))`. Object keys are sorted before hashing so `{a, b}` and `{b, a}` collapse to the same row; arrays preserve order.
+- `denied_at`: unix epoch seconds.
+- TTL on the gate: 24h (`DENIAL_TTL_SECONDS`). Sweep deletes rows older than 7d (`DENIAL_MAX_AGE_SECONDS`).
+- Writer: `recordDenial()` in `src/modules/approvals/recent-denials.ts`, called from the approvals response handler when an action registered with `dedupeDenials: true` is rejected.
+- Reader: `findRecentDenial()`, called from `requestApproval()` when invoked with `dedupeDenials: true`. Hit → emit `notifyAgent()` and skip the admin card.
+- Cleanup: `cleanupOldDenials()` runs once per host sweep tick (`src/host-sweep.ts`).
+
+Currently opted-in: all four self-mod actions (`install_packages`, `add_mcp_server`, `install_plugin`, `uninstall_plugin`). Other approval flows (channel registration, sender registration, OneCLI credentials) are **not** dedupe-tracked because they're user-initiated and naturally bounded by chat cadence.
 
 ### 1.12 `unregistered_senders`
 

--- a/scripts/add-marketplace.ts
+++ b/scripts/add-marketplace.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { addMarketplace } from './lib/plugins-config.js';
 import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/add-marketplace.ts
+++ b/scripts/add-marketplace.ts
@@ -1,0 +1,86 @@
+/**
+ * scripts/add-marketplace.ts — register a plugin marketplace in a
+ * group's container.json. Mirrors `claude plugin marketplace add` but
+ * scoped to one NanoClaw agent group. After the mutation the group's
+ * containers are killed so the new marketplace takes effect on the
+ * next message (the SDK installs declared marketplaces at session
+ * init when CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1 is set).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/add-marketplace.ts <group-folder> <name> <source-json>
+ *
+ * <source-json> is a JSON string matching the SDK's
+ * `extraKnownMarketplaces` source schema. The eight variants are
+ * documented in src/container-config.ts:ExtraKnownMarketplaceSource.
+ *
+ * Examples:
+ *   tsx scripts/add-marketplace.ts mygroup acme \
+ *     '{"source":"github","repo":"acme/plugins","ref":"main"}'
+ *
+ *   tsx scripts/add-marketplace.ts mygroup local-test \
+ *     '{"source":"directory","path":"/Users/me/my-marketplace"}'
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { addMarketplace } from './lib/plugins-config.js';
+import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+
+async function main(): Promise<void> {
+  const [, , folder, name, sourceJson] = process.argv;
+  if (!folder || !name || !sourceJson) {
+    console.error('Usage: tsx scripts/add-marketplace.ts <group-folder> <name> <source-json>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(sourceJson);
+  } catch (err) {
+    console.error(`Invalid source JSON: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  let source;
+  try {
+    source = parseMarketplaceSource(parsedJson);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const result = await addMarketplace(folder, name, source);
+
+  if (result.added) {
+    console.log(`Registered marketplace "${name}" in group "${folder}".`);
+  } else if (result.replaced) {
+    console.log(`Updated marketplace "${name}" source in group "${folder}".`);
+  } else {
+    console.log(`Marketplace "${name}" already registered with the same source. No change.`);
+    return; // No restart needed.
+  }
+
+  // Restart the group so the new marketplace takes effect.
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/add-marketplace.ts
+++ b/scripts/add-marketplace.ts
@@ -25,8 +25,8 @@ import path from 'path';
 
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { addMarketplace } from './lib/plugins-config.js';
-import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+import { addMarketplace } from '../src/modules/plugins/config.js';
+import { parseMarketplaceSource } from '../src/modules/plugins/source-validator.js';
 
 async function main(): Promise<void> {
   const [, , folder, name, sourceJson] = process.argv;

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -25,8 +25,8 @@ import path from 'path';
 
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { installPlugin } from './lib/plugins-config.js';
-import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+import { installPlugin } from '../src/modules/plugins/config.js';
+import { parseMarketplaceSource } from '../src/modules/plugins/source-validator.js';
 import { findGithubGitSecret } from './lib/onecli-vault-helpers.js';
 
 async function main(): Promise<void> {

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -1,0 +1,117 @@
+/**
+ * scripts/install-plugin.ts — enable a plugin in a group's
+ * container.json. Optionally registers the marketplace inline via
+ * --source for the "register and install in one shot" workflow.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/install-plugin.ts <group-folder> <plugin-spec> [--source <json>]
+ *
+ * <plugin-spec> is `name@marketplace`. If <marketplace> isn't already
+ * registered for the group, --source is required.
+ *
+ * Examples:
+ *   tsx scripts/install-plugin.ts mygroup fmt@acme
+ *   tsx scripts/install-plugin.ts mygroup fmt@acme \
+ *     --source '{"source":"github","repo":"acme/plugins","ref":"main"}'
+ *
+ * Private-repo note: if the source is a private github/git URL, run
+ * `/setup-private-plugins` first to wire the OneCLI vault entry that
+ * lets the SDK clone privately. Without it the SDK clone fails at
+ * session init with a visible plugin_install:failed event but the
+ * session continues without that plugin.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { installPlugin } from './lib/plugins-config.js';
+import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
+import { findGithubGitSecret } from './lib/onecli-vault-helpers.js';
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      'Usage: tsx scripts/install-plugin.ts <group-folder> <plugin-spec> [--source <source-json>]',
+    );
+    process.exit(2);
+  }
+  const folder = args[0];
+  const pluginSpec = args[1];
+  let inlineSourceJson: string | undefined;
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--source' && i + 1 < args.length) {
+      inlineSourceJson = args[i + 1];
+      i++;
+    }
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let inlineSource;
+  if (inlineSourceJson) {
+    try {
+      inlineSource = parseMarketplaceSource(JSON.parse(inlineSourceJson));
+    } catch (err) {
+      console.error(`Invalid --source: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+
+    // Private-github pre-warning. If the source is a github/git URL and
+    // the OneCLI vault doesn't have a github.com entry with the right
+    // shape, the SDK clone will likely fail at session init. We DON'T
+    // block — operator may have other auth wired (SSH agent etc.).
+    const isGithubLike =
+      inlineSource.source === 'github' ||
+      (inlineSource.source === 'git' && /github\.com/i.test(inlineSource.url));
+    if (isGithubLike && !findGithubGitSecret()) {
+      console.error(
+        '(warning) Source points at github.com but no OneCLI vault entry was found ' +
+          'for github.com with `Authorization: Basic` injection. If this is a private ' +
+          'repository the SDK clone will fail at session init. Run /setup-private-plugins ' +
+          'to wire the github auth before continuing if needed. Proceeding with install...',
+      );
+    }
+  }
+
+  let result;
+  try {
+    result = await installPlugin(folder, pluginSpec, inlineSource);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (!result.wasEnabled && !result.marketplaceAdded) {
+    console.log(`Plugin "${pluginSpec}" already enabled. No change.`);
+    return;
+  }
+
+  if (result.marketplaceAdded && result.wasEnabled) {
+    console.log(`Registered marketplace and enabled plugin "${pluginSpec}" in group "${folder}".`);
+  } else if (result.marketplaceAdded) {
+    console.log(`Updated inline marketplace source for plugin "${pluginSpec}".`);
+  } else {
+    console.log(`Enabled plugin "${pluginSpec}" in group "${folder}".`);
+  }
+
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { installPlugin } from './lib/plugins-config.js';
 import { parseMarketplaceSource } from './lib/marketplace-source-validator.js';
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     }
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/lib/db-init.ts
+++ b/scripts/lib/db-init.ts
@@ -1,0 +1,16 @@
+/**
+ * scripts/lib/db-init.ts — shared DB-init boilerplate for operator
+ * scripts. Resolves the central DB path from DATA_DIR, initializes the
+ * connection, and runs migrations. Idempotent: safe to call once per
+ * script invocation.
+ */
+import path from 'path';
+
+import { DATA_DIR } from '../../src/config.js';
+import { initDb } from '../../src/db/connection.js';
+import { runMigrations } from '../../src/db/migrations/index.js';
+
+export function initOperatorDb(): void {
+  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  runMigrations(db);
+}

--- a/scripts/lib/marketplace-source-validator.test.ts
+++ b/scripts/lib/marketplace-source-validator.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateMarketplaceSource,
+  parseMarketplaceSource,
+} from './marketplace-source-validator.js';
+
+describe('validateMarketplaceSource — accepts every documented variant', () => {
+  it.each([
+    ['url with required fields', { source: 'url', url: 'https://x.com/m.json' }],
+    ['url with optional headers', {
+      source: 'url',
+      url: 'https://x.com/m.json',
+      headers: { Authorization: 'Bearer x' },
+    }],
+    ['github with repo only', { source: 'github', repo: 'owner/repo' }],
+    ['github with all fields', {
+      source: 'github',
+      repo: 'owner/repo',
+      ref: 'main',
+      path: 'sub/dir',
+      sparsePaths: ['plugins'],
+    }],
+    ['git with url only', { source: 'git', url: 'https://gitlab.com/x/y.git' }],
+    ['git with sparsePaths', {
+      source: 'git',
+      url: 'git@host:x/y.git',
+      sparsePaths: ['a', 'b'],
+    }],
+    ['npm', { source: 'npm', package: '@scope/pkg' }],
+    ['file', { source: 'file', path: '/abs/path/marketplace.json' }],
+    ['directory', { source: 'directory', path: '/abs/path/' }],
+    ['hostPattern', { source: 'hostPattern', hostPattern: '^github\\.com$' }],
+    ['pathPattern', { source: 'pathPattern', pathPattern: '.*' }],
+    ['settings', { source: 'settings', name: 'my-mp', plugins: [{ name: 'p' }] }],
+  ])('accepts %s', (_label, input) => {
+    const r = validateMarketplaceSource(input);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateMarketplaceSource — rejects bad inputs', () => {
+  it('rejects null', () => {
+    const r = validateMarketplaceSource(null);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects array (top-level non-object)', () => {
+    const r = validateMarketplaceSource([1, 2]);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown source type', () => {
+    const r = validateMarketplaceSource({ source: 'wat' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/unknown source type/);
+  });
+
+  it('rejects missing source field', () => {
+    const r = validateMarketplaceSource({ url: 'https://x' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects github with malformed repo', () => {
+    const r = validateMarketplaceSource({ source: 'github', repo: 'no-slash' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/owner\/repo/);
+  });
+
+  it('rejects github with empty repo', () => {
+    const r = validateMarketplaceSource({ source: 'github', repo: '' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects url with no url field', () => {
+    const r = validateMarketplaceSource({ source: 'url' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects url with non-string headers', () => {
+    const r = validateMarketplaceSource({
+      source: 'url',
+      url: 'https://x',
+      headers: { auth: 123 },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects npm with missing package', () => {
+    const r = validateMarketplaceSource({ source: 'npm' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects settings without plugins array', () => {
+    const r = validateMarketplaceSource({ source: 'settings', name: 'x' });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('parseMarketplaceSource throws on invalid', () => {
+  it('throws on bad source', () => {
+    expect(() => parseMarketplaceSource({ source: 'wat' })).toThrow(/Invalid marketplace source/);
+  });
+  it('returns typed source on valid', () => {
+    const s = parseMarketplaceSource({ source: 'github', repo: 'a/b', ref: 'main' });
+    expect(s.source).toBe('github');
+    if (s.source === 'github') {
+      expect(s.repo).toBe('a/b');
+      expect(s.ref).toBe('main');
+    }
+  });
+});

--- a/scripts/lib/marketplace-source-validator.ts
+++ b/scripts/lib/marketplace-source-validator.ts
@@ -1,0 +1,166 @@
+/**
+ * scripts/lib/marketplace-source-validator.ts — schema validation for
+ * `extraKnownMarketplaces` source variants.
+ *
+ * Mirrors the SDK's typed schema (eight variants). Used by
+ * /add-marketplace and /install-plugin --source to reject malformed
+ * source specs before they hit `container.json` (and from there, the
+ * SDK at next spawn — where the failure mode is harder to diagnose).
+ */
+import type { ExtraKnownMarketplaceSource } from '../../src/container-config.js';
+
+export type ValidationResult = { ok: true; source: ExtraKnownMarketplaceSource } | { ok: false; error: string };
+
+const KNOWN_SOURCE_TYPES = new Set([
+  'url',
+  'github',
+  'git',
+  'npm',
+  'file',
+  'directory',
+  'hostPattern',
+  'pathPattern',
+  'settings',
+]);
+
+/**
+ * Validate an arbitrary value as an `ExtraKnownMarketplaceSource`. Returns
+ * either a typed source or a human-readable error. Defensive against
+ * non-object inputs and unknown source types.
+ */
+export function validateMarketplaceSource(input: unknown): ValidationResult {
+  if (!isPlainObject(input)) {
+    return { ok: false, error: 'source must be an object' };
+  }
+  const sourceType = input.source;
+  if (typeof sourceType !== 'string') {
+    return { ok: false, error: 'source.source must be a string' };
+  }
+  if (!KNOWN_SOURCE_TYPES.has(sourceType)) {
+    return {
+      ok: false,
+      error: `unknown source type "${sourceType}"; expected one of: ${[...KNOWN_SOURCE_TYPES].join(', ')}`,
+    };
+  }
+
+  switch (sourceType) {
+    case 'url':
+      if (typeof input.url !== 'string' || !input.url) {
+        return { ok: false, error: 'url source: missing required `url` string' };
+      }
+      if (input.headers !== undefined && !isStringRecord(input.headers)) {
+        return { ok: false, error: 'url source: `headers` must be Record<string, string>' };
+      }
+      return {
+        ok: true,
+        source: { source: 'url', url: input.url, headers: input.headers as Record<string, string> | undefined },
+      };
+
+    case 'github':
+      if (typeof input.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(input.repo)) {
+        return { ok: false, error: 'github source: `repo` must be in `owner/repo` format' };
+      }
+      return {
+        ok: true,
+        source: {
+          source: 'github',
+          repo: input.repo,
+          ref: optionalString(input.ref),
+          path: optionalString(input.path),
+          sparsePaths: optionalStringArray(input.sparsePaths),
+        },
+      };
+
+    case 'git':
+      if (typeof input.url !== 'string' || !input.url) {
+        return { ok: false, error: 'git source: missing required `url` string' };
+      }
+      return {
+        ok: true,
+        source: {
+          source: 'git',
+          url: input.url,
+          ref: optionalString(input.ref),
+          path: optionalString(input.path),
+          sparsePaths: optionalStringArray(input.sparsePaths),
+        },
+      };
+
+    case 'npm':
+      if (typeof input.package !== 'string' || !input.package) {
+        return { ok: false, error: 'npm source: missing required `package` string' };
+      }
+      return { ok: true, source: { source: 'npm', package: input.package } };
+
+    case 'file':
+      if (typeof input.path !== 'string' || !input.path) {
+        return { ok: false, error: 'file source: missing required `path` string' };
+      }
+      return { ok: true, source: { source: 'file', path: input.path } };
+
+    case 'directory':
+      if (typeof input.path !== 'string' || !input.path) {
+        return { ok: false, error: 'directory source: missing required `path` string' };
+      }
+      return { ok: true, source: { source: 'directory', path: input.path } };
+
+    case 'hostPattern':
+      if (typeof input.hostPattern !== 'string' || !input.hostPattern) {
+        return { ok: false, error: 'hostPattern source: missing required `hostPattern` regex' };
+      }
+      return { ok: true, source: { source: 'hostPattern', hostPattern: input.hostPattern } };
+
+    case 'pathPattern':
+      if (typeof input.pathPattern !== 'string' || !input.pathPattern) {
+        return { ok: false, error: 'pathPattern source: missing required `pathPattern` regex' };
+      }
+      return { ok: true, source: { source: 'pathPattern', pathPattern: input.pathPattern } };
+
+    case 'settings':
+      if (typeof input.name !== 'string' || !input.name) {
+        return { ok: false, error: 'settings source: missing required `name` string' };
+      }
+      if (!Array.isArray(input.plugins)) {
+        return { ok: false, error: 'settings source: `plugins` must be an array' };
+      }
+      return { ok: true, source: { source: 'settings', name: input.name, plugins: input.plugins } };
+  }
+
+  return { ok: false, error: `unhandled source type "${sourceType}"` };
+}
+
+/**
+ * Convenience helper that throws on validation failure. Use in CLI
+ * orchestrator scripts where we want the error to bubble up as a
+ * non-zero exit with a clear message.
+ */
+export function parseMarketplaceSource(input: unknown): ExtraKnownMarketplaceSource {
+  const result = validateMarketplaceSource(input);
+  if (!result.ok) {
+    throw new Error(`Invalid marketplace source: ${result.error}`);
+  }
+  return result.source;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  if (!isPlainObject(v)) return false;
+  return Object.values(v).every((value) => typeof value === 'string');
+}
+
+function optionalString(v: unknown): string | undefined {
+  if (v === undefined) return undefined;
+  if (typeof v !== 'string') throw new Error('expected string or undefined');
+  return v;
+}
+
+function optionalStringArray(v: unknown): string[] | undefined {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v) || !v.every((s) => typeof s === 'string')) {
+    throw new Error('expected string[] or undefined');
+  }
+  return v as string[];
+}

--- a/scripts/lib/onecli-vault-helpers.test.ts
+++ b/scripts/lib/onecli-vault-helpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { findSecretForHost, findGithubGitSecret, type OneCliSecret } from './onecli-vault-helpers.js';
+
+const apiOnly: OneCliSecret = {
+  id: '1',
+  name: 'GitHub',
+  type: 'generic',
+  hostPattern: 'api.github.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'Authorization', valueFormat: 'Bearer {value}' },
+};
+
+const gitClone: OneCliSecret = {
+  id: '2',
+  name: 'GitHub Git Clone',
+  type: 'generic',
+  hostPattern: 'github.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'Authorization', valueFormat: 'Basic {value}' },
+};
+
+const otherHost: OneCliSecret = {
+  id: '3',
+  name: 'Anthropic',
+  type: 'generic',
+  hostPattern: 'api.anthropic.com',
+  pathPattern: null,
+  injectionConfig: { headerName: 'X-API-Key', valueFormat: '{value}' },
+};
+
+const noPattern: OneCliSecret = {
+  id: '4',
+  name: 'Misconfigured',
+  type: 'generic',
+  hostPattern: null,
+  pathPattern: null,
+};
+
+describe('findSecretForHost', () => {
+  it('returns null on empty list', () => {
+    expect(findSecretForHost('github.com', [])).toBeNull();
+  });
+
+  it('finds exact-match host', () => {
+    const r = findSecretForHost('github.com', [apiOnly, gitClone, otherHost]);
+    expect(r?.id).toBe('2');
+  });
+
+  it('does NOT match api.github.com against github.com (exact)', () => {
+    // Confirms the bug class: github.com pattern wouldn't fire on api.github.com.
+    const r = findSecretForHost('github.com', [apiOnly]);
+    expect(r).toBeNull();
+  });
+
+  it('matches regex patterns', () => {
+    const regex: OneCliSecret = {
+      ...gitClone,
+      hostPattern: '^github\\.com$',
+    };
+    expect(findSecretForHost('github.com', [regex])?.id).toBe('2');
+  });
+
+  it('skips entries with null hostPattern', () => {
+    expect(findSecretForHost('github.com', [noPattern])).toBeNull();
+  });
+
+  it('returns first match in list order', () => {
+    const r = findSecretForHost('github.com', [gitClone, { ...gitClone, id: 'second', name: 'Dup' }]);
+    expect(r?.id).toBe('2');
+  });
+});
+
+describe('findGithubGitSecret', () => {
+  it('returns null when only api.github.com Bearer entry present', () => {
+    expect(findGithubGitSecret([apiOnly])).toBeNull();
+  });
+
+  it('returns null when github.com entry exists but valueFormat is not Basic', () => {
+    const wrongFormat: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'Authorization', valueFormat: 'Bearer {value}' },
+    };
+    expect(findGithubGitSecret([wrongFormat])).toBeNull();
+  });
+
+  it('returns null when headerName is wrong', () => {
+    const wrongHeader: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'X-Custom', valueFormat: 'Basic {value}' },
+    };
+    expect(findGithubGitSecret([wrongHeader])).toBeNull();
+  });
+
+  it('finds the correctly-shaped github.com secret', () => {
+    const r = findGithubGitSecret([apiOnly, gitClone, otherHost]);
+    expect(r?.id).toBe('2');
+  });
+
+  it('case-insensitive on header name', () => {
+    const lower: OneCliSecret = {
+      ...gitClone,
+      injectionConfig: { headerName: 'authorization', valueFormat: 'Basic {value}' },
+    };
+    expect(findGithubGitSecret([lower])?.id).toBe('2');
+  });
+
+  it('returns null when no injectionConfig', () => {
+    const stripped: OneCliSecret = { ...gitClone, injectionConfig: undefined };
+    expect(findGithubGitSecret([stripped])).toBeNull();
+  });
+});

--- a/scripts/lib/onecli-vault-helpers.ts
+++ b/scripts/lib/onecli-vault-helpers.ts
@@ -1,0 +1,107 @@
+/**
+ * scripts/lib/onecli-vault-helpers.ts — minimal OneCLI vault
+ * introspection used by `/install-plugin --source` (private-repo
+ * pre-check) and `/setup-private-plugins` (idempotency).
+ *
+ * The vault never returns secret values to the host (by design; values
+ * only leave the gateway via header injection at request time). We
+ * only read METADATA: name, hostPattern, headerName, valueFormat.
+ */
+import { execFileSync } from 'child_process';
+
+export interface OneCliSecret {
+  id: string;
+  name: string;
+  type: string;
+  hostPattern: string | null;
+  pathPattern: string | null;
+  injectionConfig?: {
+    headerName?: string;
+    valueFormat?: string;
+    paramName?: string;
+    paramFormat?: string;
+  };
+}
+
+/**
+ * List all OneCLI vault secrets visible to the current OneCLI agent.
+ * Returns an empty array if onecli isn't installed or the gateway isn't
+ * reachable — callers should treat absence-of-secret as
+ * not-yet-configured, not as a hard error.
+ */
+export function listOneCliSecrets(): OneCliSecret[] {
+  let stdout: string;
+  try {
+    stdout = execFileSync('onecli', ['secrets', 'list'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stdout);
+    const data = parsed?.data;
+    if (!Array.isArray(data)) return [];
+    return data.filter((s) => s && typeof s === 'object') as OneCliSecret[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Return the first secret whose `hostPattern` matches the given host.
+ * Pattern is matched as a regex if it contains regex metacharacters,
+ * otherwise as an exact-equals check. (OneCLI itself accepts either
+ * form per gateway docs; we only care here about identifying when a
+ * secret is wired.)
+ *
+ * Returns `null` if no matching secret exists.
+ */
+export function findSecretForHost(host: string, secrets?: OneCliSecret[]): OneCliSecret | null {
+  const list = secrets ?? listOneCliSecrets();
+  for (const s of list) {
+    if (!s.hostPattern) continue;
+    if (matchesHost(s.hostPattern, host)) return s;
+  }
+  return null;
+}
+
+function matchesHost(pattern: string, host: string): boolean {
+  // Exact match first (most common case).
+  if (pattern === host) return true;
+  // Treat as regex if it has anchor or class metacharacters.
+  if (/[$^*+?()[\]{}|\\]/.test(pattern)) {
+    try {
+      return new RegExp(pattern).test(host);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a github.com secret is configured for git smart-HTTP auth
+ * (the format `/setup-private-plugins` writes). Used by
+ * `/install-plugin --source` to decide whether private-github clones
+ * will likely succeed before warning the operator.
+ *
+ * Returns the matching secret if present, else null.
+ */
+export function findGithubGitSecret(secrets?: OneCliSecret[]): OneCliSecret | null {
+  const list = secrets ?? listOneCliSecrets();
+  for (const s of list) {
+    if (!s.hostPattern) continue;
+    // We're looking for a github.com (NOT api.github.com) entry with
+    // Authorization: Basic format — that's what /setup-private-plugins
+    // installs, and what github's git smart-HTTP requires.
+    if (!matchesHost(s.hostPattern, 'github.com')) continue;
+    const cfg = s.injectionConfig;
+    if (cfg?.headerName?.toLowerCase() === 'authorization' && cfg.valueFormat?.startsWith('Basic ')) {
+      return s;
+    }
+  }
+  return null;
+}

--- a/scripts/lib/plugins-config.test.ts
+++ b/scripts/lib/plugins-config.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from '../../src/config.js';
+import {
+  addMarketplace,
+  removeMarketplace,
+  installPlugin,
+  uninstallPlugin,
+  listMarketplaces,
+  listEnabledPlugins,
+  parsePluginSpec,
+} from './plugins-config.js';
+import { writeContainerConfig } from '../../src/container-config.js';
+
+let testFolders: string[];
+
+beforeEach(() => {
+  testFolders = [];
+});
+
+afterEach(() => {
+  for (const folder of testFolders) {
+    fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+  }
+});
+
+function makeFolder(suffix: string): string {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  testFolders.push(folder);
+  fs.mkdirSync(path.join(GROUPS_DIR, folder), { recursive: true });
+  // Seed with empty container.json.
+  writeContainerConfig(folder, {
+    mcpServers: {},
+    packages: { apt: [], npm: [] },
+    additionalMounts: [],
+    skills: 'all',
+  });
+  return folder;
+}
+
+describe('parsePluginSpec', () => {
+  it('parses valid name@marketplace', () => {
+    expect(parsePluginSpec('foo@bar')).toEqual({ name: 'foo', marketplace: 'bar' });
+  });
+  it('rejects missing @', () => {
+    expect(() => parsePluginSpec('foo-bar')).toThrow(/name@marketplace/);
+  });
+  it('rejects empty name', () => {
+    expect(() => parsePluginSpec('@bar')).toThrow();
+  });
+  it('rejects empty marketplace', () => {
+    expect(() => parsePluginSpec('foo@')).toThrow();
+  });
+  it('rejects marketplace with whitespace', () => {
+    expect(() => parsePluginSpec('foo@bar baz')).toThrow();
+  });
+  it('rejects marketplace with slashes', () => {
+    expect(() => parsePluginSpec('foo@bar/baz')).toThrow();
+  });
+  it('handles @ inside plugin name (uses last @)', () => {
+    expect(parsePluginSpec('a@b@c')).toEqual({ name: 'a@b', marketplace: 'c' });
+  });
+});
+
+describe('addMarketplace / listMarketplaces', () => {
+  it('first add returns added=true', async () => {
+    const folder = makeFolder('add1');
+    const r = await addMarketplace(folder, 'mp1', {
+      source: 'github',
+      repo: 'a/b',
+    });
+    expect(r).toEqual({ added: true, replaced: false });
+    const list = listMarketplaces(folder);
+    expect(list.mp1?.source).toEqual({ source: 'github', repo: 'a/b' });
+  });
+
+  it('idempotent re-add returns added=false, replaced=false', async () => {
+    const folder = makeFolder('add-idem');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    expect(r).toEqual({ added: false, replaced: false });
+  });
+
+  it('different source replaces', async () => {
+    const folder = makeFolder('add-replace');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'old/repo' });
+    const r = await addMarketplace(folder, 'mp1', { source: 'github', repo: 'new/repo' });
+    expect(r).toEqual({ added: false, replaced: true });
+    const list = listMarketplaces(folder);
+    expect(list.mp1?.source).toMatchObject({ repo: 'new/repo' });
+  });
+
+  it('rejects invalid name', async () => {
+    const folder = makeFolder('add-bad');
+    await expect(
+      addMarketplace(folder, 'has space', { source: 'github', repo: 'a/b' }),
+    ).rejects.toThrow(/invalid characters/);
+  });
+});
+
+describe('removeMarketplace', () => {
+  it('removes when no plugins reference it', async () => {
+    const folder = makeFolder('rm1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r).toEqual({ removed: true, blockedBy: [] });
+    expect(listMarketplaces(folder).mp1).toBeUndefined();
+  });
+
+  it('returns removed=false for unknown name', async () => {
+    const folder = makeFolder('rm-unknown');
+    const r = await removeMarketplace(folder, 'never-added');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy).toEqual([]);
+  });
+
+  it('blocks when plugins reference it', async () => {
+    const folder = makeFolder('rm-blocked');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy).toEqual(['plug1@mp1']);
+    // Marketplace still there.
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+  });
+
+  it('blocks listing all referencing plugins', async () => {
+    const folder = makeFolder('rm-blocked-multi');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'a@mp1');
+    await installPlugin(folder, 'b@mp1');
+    await installPlugin(folder, 'c@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(false);
+    expect(r.blockedBy.sort()).toEqual(['a@mp1', 'b@mp1', 'c@mp1']);
+  });
+});
+
+describe('installPlugin', () => {
+  it('enables when marketplace already registered', async () => {
+    const folder = makeFolder('inst1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    const r = await installPlugin(folder, 'plug1@mp1');
+    expect(r).toEqual({ wasEnabled: true, marketplaceAdded: false });
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBe(true);
+  });
+
+  it('throws when marketplace not registered and no inline source', async () => {
+    const folder = makeFolder('inst-no-mp');
+    await expect(installPlugin(folder, 'plug1@mp1')).rejects.toThrow(/not registered/);
+  });
+
+  it('inline --source registers and enables in one shot', async () => {
+    const folder = makeFolder('inst-source');
+    const r = await installPlugin(folder, 'plug1@mp1', {
+      source: 'github',
+      repo: 'a/b',
+    });
+    expect(r).toEqual({ wasEnabled: true, marketplaceAdded: true });
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBe(true);
+  });
+
+  it('inline source updates existing marketplace if different', async () => {
+    const folder = makeFolder('inst-source-update');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'old/old' });
+    const r = await installPlugin(folder, 'plug1@mp1', {
+      source: 'github',
+      repo: 'new/new',
+    });
+    expect(r.marketplaceAdded).toBe(true);
+    expect(listMarketplaces(folder).mp1?.source).toMatchObject({ repo: 'new/new' });
+  });
+
+  it('idempotent re-enable returns wasEnabled=false', async () => {
+    const folder = makeFolder('inst-idem');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await installPlugin(folder, 'plug1@mp1');
+    expect(r).toEqual({ wasEnabled: false, marketplaceAdded: false });
+  });
+
+  it('rejects malformed plugin spec', async () => {
+    const folder = makeFolder('inst-bad-spec');
+    await expect(installPlugin(folder, 'no-at-sign')).rejects.toThrow(/name@marketplace/);
+  });
+});
+
+describe('uninstallPlugin', () => {
+  it('disables an enabled plugin', async () => {
+    const folder = makeFolder('uninst1');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    const r = await uninstallPlugin(folder, 'plug1@mp1');
+    expect(r.wasDisabled).toBe(true);
+    expect(listEnabledPlugins(folder)['plug1@mp1']).toBeUndefined();
+    // Marketplace stays.
+    expect(listMarketplaces(folder).mp1).toBeDefined();
+  });
+
+  it('returns wasDisabled=false if not enabled', async () => {
+    const folder = makeFolder('uninst-not-enabled');
+    const r = await uninstallPlugin(folder, 'plug1@mp1');
+    expect(r.wasDisabled).toBe(false);
+  });
+
+  it('after uninstall, removeMarketplace succeeds', async () => {
+    const folder = makeFolder('uninst-then-rm');
+    await addMarketplace(folder, 'mp1', { source: 'github', repo: 'a/b' });
+    await installPlugin(folder, 'plug1@mp1');
+    await uninstallPlugin(folder, 'plug1@mp1');
+    const r = await removeMarketplace(folder, 'mp1');
+    expect(r.removed).toBe(true);
+  });
+});

--- a/scripts/lib/plugins-config.ts
+++ b/scripts/lib/plugins-config.ts
@@ -1,0 +1,190 @@
+/**
+ * scripts/lib/plugins-config.ts — read/validate/write the
+ * `container.json:plugins` block, with safety checks for the operator
+ * skills (`/add-marketplace`, `/remove-marketplace`, `/install-plugin`,
+ * `/uninstall-plugin`).
+ *
+ * All mutations route through `updateContainerConfig()` so concurrent
+ * writers (multiple operator skills, self-mod approval handlers) are
+ * serialized via the file lock established in PR 1.
+ */
+import {
+  readContainerConfig,
+  updateContainerConfig,
+  type ExtraKnownMarketplaceSource,
+} from '../../src/container-config.js';
+import { parseMarketplaceSource } from './marketplace-source-validator.js';
+
+/**
+ * Add or update a marketplace entry in `container.json:plugins.marketplaces`.
+ * Idempotent — running with the same source is a no-op (returns
+ * `{ added: false, replaced: false }`). Updating with a different source
+ * replaces the entry (returns `{ added: false, replaced: true }`).
+ */
+export async function addMarketplace(
+  folder: string,
+  name: string,
+  source: ExtraKnownMarketplaceSource,
+): Promise<{ added: boolean; replaced: boolean }> {
+  validateMarketplaceName(name);
+  let added = false;
+  let replaced = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (!cfg.plugins) cfg.plugins = {};
+    if (!cfg.plugins.marketplaces) cfg.plugins.marketplaces = {};
+    const existing = cfg.plugins.marketplaces[name];
+    if (!existing) {
+      added = true;
+    } else if (JSON.stringify(existing.source) !== JSON.stringify(source)) {
+      replaced = true;
+    }
+    cfg.plugins.marketplaces[name] = { source };
+  });
+  return { added, replaced };
+}
+
+/**
+ * Remove a marketplace entry. Refuses if any plugin in
+ * `enabled` references this marketplace — operator must
+ * `/uninstall-plugin` those first.
+ *
+ * Returns `{ removed: false }` if the marketplace wasn't registered.
+ */
+export async function removeMarketplace(
+  folder: string,
+  name: string,
+): Promise<{ removed: boolean; blockedBy: string[] }> {
+  // Reference check first (read-only path).
+  const cfg = readContainerConfig(folder);
+  const enabled = cfg.plugins?.enabled ?? {};
+  const referencingKeys: string[] = [];
+  for (const key of Object.keys(enabled)) {
+    const at = key.lastIndexOf('@');
+    if (at > 0 && key.slice(at + 1) === name) {
+      referencingKeys.push(key);
+    }
+  }
+  if (referencingKeys.length > 0) {
+    return { removed: false, blockedBy: referencingKeys };
+  }
+
+  let removed = false;
+  await updateContainerConfig(folder, (c) => {
+    if (c.plugins?.marketplaces?.[name]) {
+      delete c.plugins.marketplaces[name];
+      removed = true;
+    }
+  });
+  return { removed, blockedBy: [] };
+}
+
+export function listMarketplaces(folder: string): Record<string, { source: ExtraKnownMarketplaceSource }> {
+  const cfg = readContainerConfig(folder);
+  return cfg.plugins?.marketplaces ?? {};
+}
+
+/**
+ * Enable a plugin. The plugin spec is `<plugin-name>@<marketplace-name>`.
+ * If `inlineSource` is provided, the marketplace is registered (or
+ * updated) atomically with the enable — convenience for the
+ * "register and install in one shot" flow.
+ *
+ * If the marketplace isn't registered and no `inlineSource` is provided,
+ * throws.
+ */
+export async function installPlugin(
+  folder: string,
+  pluginSpec: string,
+  inlineSource?: ExtraKnownMarketplaceSource,
+): Promise<{ wasEnabled: boolean; marketplaceAdded: boolean }> {
+  const { name, marketplace } = parsePluginSpec(pluginSpec);
+  let wasEnabled = false;
+  let marketplaceAdded = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (!cfg.plugins) cfg.plugins = {};
+    if (!cfg.plugins.marketplaces) cfg.plugins.marketplaces = {};
+    if (!cfg.plugins.enabled) cfg.plugins.enabled = {};
+
+    // Register marketplace if needed (and inline source provided).
+    if (!cfg.plugins.marketplaces[marketplace]) {
+      if (!inlineSource) {
+        throw new Error(
+          `Marketplace "${marketplace}" is not registered for this group. Run /add-marketplace first, or pass --source to register inline.`,
+        );
+      }
+      cfg.plugins.marketplaces[marketplace] = { source: inlineSource };
+      marketplaceAdded = true;
+    } else if (inlineSource) {
+      // Update if inline source provided and differs.
+      if (JSON.stringify(cfg.plugins.marketplaces[marketplace].source) !== JSON.stringify(inlineSource)) {
+        cfg.plugins.marketplaces[marketplace] = { source: inlineSource };
+        marketplaceAdded = true;
+      }
+    }
+
+    if (cfg.plugins.enabled[pluginSpec] !== true) {
+      cfg.plugins.enabled[pluginSpec] = true;
+      wasEnabled = true;
+    }
+
+    // Sanity unused — keeps pluginName reachable in TS without an unused-var warning.
+    void name;
+  });
+  return { wasEnabled, marketplaceAdded };
+}
+
+/**
+ * Disable a plugin. Removes the entry from `enabled`. The marketplace
+ * registration stays so other plugins from it can still be enabled.
+ */
+export async function uninstallPlugin(
+  folder: string,
+  pluginSpec: string,
+): Promise<{ wasDisabled: boolean }> {
+  // Validate format up front so a typo doesn't silently no-op.
+  parsePluginSpec(pluginSpec);
+  let wasDisabled = false;
+  await updateContainerConfig(folder, (cfg) => {
+    if (cfg.plugins?.enabled?.[pluginSpec] !== undefined) {
+      delete cfg.plugins.enabled[pluginSpec];
+      wasDisabled = true;
+    }
+  });
+  return { wasDisabled };
+}
+
+export function listEnabledPlugins(
+  folder: string,
+): Record<string, boolean | string[] | { [k: string]: unknown }> {
+  const cfg = readContainerConfig(folder);
+  return cfg.plugins?.enabled ?? {};
+}
+
+/**
+ * Parse `<plugin-name>@<marketplace-name>` into its components. Throws
+ * with a clear message on malformed input.
+ */
+export function parsePluginSpec(spec: string): { name: string; marketplace: string } {
+  const at = spec.lastIndexOf('@');
+  if (at <= 0 || at === spec.length - 1) {
+    throw new Error(`Plugin spec must be in "name@marketplace" format; got "${spec}"`);
+  }
+  const name = spec.slice(0, at);
+  const marketplace = spec.slice(at + 1);
+  validateMarketplaceName(marketplace);
+  if (!name) throw new Error(`Plugin name cannot be empty in spec "${spec}"`);
+  return { name, marketplace };
+}
+
+function validateMarketplaceName(name: string): void {
+  // Match the SDK's marketplace-name validation: non-empty, no spaces,
+  // no `/`, no `\`, no `..`. Some reserved names are also rejected
+  // upstream, but we leave that to the SDK.
+  if (!name) throw new Error('Marketplace name cannot be empty');
+  if (/[\s/\\]/.test(name)) {
+    throw new Error(`Marketplace name "${name}" contains invalid characters (no spaces, slashes, or backslashes)`);
+  }
+  if (name === '..' || name === '.') {
+    throw new Error(`Marketplace name "${name}" is reserved`);
+  }
+}

--- a/scripts/list-marketplaces.ts
+++ b/scripts/list-marketplaces.ts
@@ -9,7 +9,7 @@
  */
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { listMarketplaces } from './lib/plugins-config.js';
+import { listMarketplaces } from '../src/modules/plugins/config.js';
 
 const folder = process.argv[2];
 if (!folder) {

--- a/scripts/list-marketplaces.ts
+++ b/scripts/list-marketplaces.ts
@@ -1,0 +1,26 @@
+/**
+ * scripts/list-marketplaces.ts — print the registered marketplaces for
+ * a group.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/list-marketplaces.ts <group-folder>
+ *
+ * Outputs JSON to stdout (the SKILL.md prompts Claude to format it).
+ */
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { listMarketplaces } from './lib/plugins-config.js';
+
+const folder = process.argv[2];
+if (!folder) {
+  console.error('Usage: tsx scripts/list-marketplaces.ts <group-folder>');
+  process.exit(2);
+}
+
+initDb();
+if (!getAgentGroupByFolder(folder)) {
+  console.error(`No agent group with folder "${folder}"`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(listMarketplaces(folder), null, 2));

--- a/scripts/list-marketplaces.ts
+++ b/scripts/list-marketplaces.ts
@@ -7,7 +7,7 @@
  *
  * Outputs JSON to stdout (the SKILL.md prompts Claude to format it).
  */
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { listMarketplaces } from './lib/plugins-config.js';
 
@@ -17,7 +17,7 @@ if (!folder) {
   process.exit(2);
 }
 
-initDb();
+initOperatorDb();
 if (!getAgentGroupByFolder(folder)) {
   console.error(`No agent group with folder "${folder}"`);
   process.exit(1);

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -4,7 +4,7 @@
  * Usage:
  *   pnpm exec tsx scripts/list-plugins.ts <group-folder>
  */
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { listEnabledPlugins } from './lib/plugins-config.js';
 
@@ -14,7 +14,7 @@ if (!folder) {
   process.exit(2);
 }
 
-initDb();
+initOperatorDb();
 if (!getAgentGroupByFolder(folder)) {
   console.error(`No agent group with folder "${folder}"`);
   process.exit(1);

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -6,7 +6,7 @@
  */
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { listEnabledPlugins } from './lib/plugins-config.js';
+import { listEnabledPlugins } from '../src/modules/plugins/config.js';
 
 const folder = process.argv[2];
 if (!folder) {

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -1,0 +1,23 @@
+/**
+ * scripts/list-plugins.ts — print enabled plugins for a group.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/list-plugins.ts <group-folder>
+ */
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { listEnabledPlugins } from './lib/plugins-config.js';
+
+const folder = process.argv[2];
+if (!folder) {
+  console.error('Usage: tsx scripts/list-plugins.ts <group-folder>');
+  process.exit(2);
+}
+
+initDb();
+if (!getAgentGroupByFolder(folder)) {
+  console.error(`No agent group with folder "${folder}"`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(listEnabledPlugins(folder), null, 2));

--- a/scripts/remove-marketplace.ts
+++ b/scripts/remove-marketplace.ts
@@ -9,7 +9,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { removeMarketplace } from './lib/plugins-config.js';
 
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/remove-marketplace.ts
+++ b/scripts/remove-marketplace.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { removeMarketplace } from './lib/plugins-config.js';
+import { removeMarketplace } from '../src/modules/plugins/config.js';
 
 async function main(): Promise<void> {
   const [, , folder, name] = process.argv;

--- a/scripts/remove-marketplace.ts
+++ b/scripts/remove-marketplace.ts
@@ -1,0 +1,59 @@
+/**
+ * scripts/remove-marketplace.ts — unregister a plugin marketplace from
+ * a group's container.json. Refuses if any plugin from the marketplace
+ * is currently enabled (operator must `/uninstall-plugin` first).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/remove-marketplace.ts <group-folder> <name>
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { removeMarketplace } from './lib/plugins-config.js';
+
+async function main(): Promise<void> {
+  const [, , folder, name] = process.argv;
+  if (!folder || !name) {
+    console.error('Usage: tsx scripts/remove-marketplace.ts <group-folder> <name>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  const result = await removeMarketplace(folder, name);
+
+  if (result.blockedBy.length > 0) {
+    console.error(
+      `Cannot remove marketplace "${name}": it has enabled plugins. ` +
+        `Run /uninstall-plugin for each first:\n  ${result.blockedBy.join('\n  ')}`,
+    );
+    process.exit(1);
+  }
+
+  if (!result.removed) {
+    console.log(`Marketplace "${name}" was not registered. No change.`);
+    return;
+  }
+
+  console.log(`Removed marketplace "${name}" from group "${folder}".`);
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/restart-group.ts
+++ b/scripts/restart-group.ts
@@ -25,7 +25,7 @@ import { execFileSync } from 'child_process';
 
 import { CONTAINER_INSTALL_LABEL } from '../src/config.js';
 import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { getSessionsByAgentGroup } from '../src/db/sessions.js';
 
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
 
   const group = getAgentGroupByFolder(folder);
   if (!group) {

--- a/scripts/restart-group.ts
+++ b/scripts/restart-group.ts
@@ -1,0 +1,99 @@
+/**
+ * scripts/restart-group.ts — multi-session-aware container kill helper.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/restart-group.ts <agent-group-folder>
+ *
+ * Used by the operator skills (`/install-plugin`, `/add-marketplace`,
+ * etc.) after they mutate `container.json`. Lists all docker containers
+ * running with this install's label whose name matches the group's
+ * `nanoclaw-v2-<folder>-*` prefix, and stops each one. Idle sessions
+ * (no running container) are not touched — they'll respawn with the
+ * new config naturally on the next message.
+ *
+ * Race semantics: write `container.json` BEFORE invoking this script,
+ * with no awaits between the write and the kill. The host sweep runs
+ * every 60s and respawns sessions on due messages; if the sweep fires
+ * between our write and our kill, the new container picks up the new
+ * config and there's nothing for us to kill — that's fine.
+ *
+ * Exits non-zero only on docker/runtime errors. "Nothing was running"
+ * is a successful exit (operators should still see the new config on
+ * next message).
+ */
+import { execFileSync } from 'child_process';
+
+import { CONTAINER_INSTALL_LABEL } from '../src/config.js';
+import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { getSessionsByAgentGroup } from '../src/db/sessions.js';
+
+interface RestartResult {
+  killed: string[];
+  idleSessions: number;
+  totalSessions: number;
+}
+
+async function main(): Promise<void> {
+  const folder = process.argv[2];
+  if (!folder) {
+    console.error('Usage: tsx scripts/restart-group.ts <agent-group-folder>');
+    process.exit(2);
+  }
+
+  initDb();
+
+  const group = getAgentGroupByFolder(folder);
+  if (!group) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  const sessions = getSessionsByAgentGroup(group.id);
+  const result: RestartResult = { killed: [], idleSessions: 0, totalSessions: sessions.length };
+
+  // Inventory currently-running containers via docker label, filter by
+  // name prefix. Container names are nanoclaw-v2-<folder>-<timestamp>
+  // (see container-runner.ts buildContainerArgs).
+  const namePrefix = `nanoclaw-v2-${folder}-`;
+  let runningNames: string[] = [];
+  try {
+    const out = execFileSync(
+      CONTAINER_RUNTIME_BIN,
+      ['ps', '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    runningNames = out.trim().split('\n').filter((n) => n.startsWith(namePrefix));
+  } catch (err) {
+    console.error(`Failed to list running containers: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  // Kill each. Sequence matters: write-then-kill avoids the sweep-race
+  // where a tick between writes and kills could spawn the new container
+  // on stale config. The kill calls themselves are independent.
+  for (const name of runningNames) {
+    try {
+      execFileSync(CONTAINER_RUNTIME_BIN, ['stop', '--time', '5', name], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+      result.killed.push(name);
+    } catch (err) {
+      // Stop might race with natural exit; treat as best-effort.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`(warning) failed to stop ${name}: ${msg}`);
+    }
+  }
+
+  // Idle session count = sessions that exist but have no running container.
+  result.idleSessions = sessions.length - result.killed.length;
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/setup-private-plugins.ts
+++ b/scripts/setup-private-plugins.ts
@@ -1,0 +1,136 @@
+/**
+ * scripts/setup-private-plugins.ts — one-time-per-host: register a
+ * GitHub PAT in the OneCLI vault with the host pattern + auth format
+ * required for git smart-HTTP clones (NOT the same format as github
+ * REST API access — github's git protocol only accepts HTTP Basic).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/setup-private-plugins.ts [--token <pat>]
+ *
+ * Without --token, attempts to read the token from `gh auth token`
+ * (the user's existing github CLI auth, if installed).
+ *
+ * This adds an entry that:
+ *   - hostPattern: github.com  (separate from any existing api.github.com entry)
+ *   - headerName:  Authorization
+ *   - valueFormat: Basic {value}
+ *   - value:       base64("x-access-token:<PAT>")
+ *
+ * After this, agent containers running under OneCLI gateway can clone
+ * private github repos via the SDK's plugin install path. Verified
+ * empirically; see docs/internal/plugin-install-empirical-test.md (in
+ * fork-internal docs).
+ *
+ * Idempotent: if a github.com Authorization-Basic secret is already
+ * registered, prompts whether to overwrite (or skip when --force not
+ * passed).
+ */
+import { execFileSync, spawnSync } from 'child_process';
+
+import { findGithubGitSecret } from './lib/onecli-vault-helpers.js';
+
+interface Args {
+  token?: string;
+  force: boolean;
+  name: string;
+}
+
+function parseArgs(): Args {
+  const args: Args = { force: false, name: 'GitHub Git Clone' };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--token' && i + 1 < argv.length) {
+      args.token = argv[++i];
+    } else if (a === '--force') {
+      args.force = true;
+    } else if (a === '--name' && i + 1 < argv.length) {
+      args.name = argv[++i];
+    } else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: tsx scripts/setup-private-plugins.ts [--token <pat>] [--name <secret-name>] [--force]',
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function getGhToken(): string | null {
+  try {
+    const out = execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const t = out.trim();
+    return t.length > 0 ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const args = parseArgs();
+
+  // Check for existing github.com git secret. Idempotency.
+  const existing = findGithubGitSecret();
+  if (existing && !args.force) {
+    console.log(
+      `A OneCLI vault entry for github.com with Basic auth is already registered: ${existing.name} (${existing.id}).`,
+    );
+    console.log('Re-run with --force to overwrite.');
+    process.exit(0);
+  }
+
+  // Resolve token.
+  let token = args.token;
+  if (!token) {
+    token = getGhToken() ?? undefined;
+    if (!token) {
+      console.error(
+        'No --token provided and `gh auth token` did not return a token. ' +
+          'Either install/authenticate the github CLI (https://cli.github.com) ' +
+          'or pass --token <pat> explicitly. The PAT needs `repo` scope for private clones.',
+      );
+      process.exit(1);
+    }
+  }
+
+  // Encode as base64(x-access-token:<token>) per github's git
+  // smart-HTTP HTTP Basic format.
+  const encoded = Buffer.from(`x-access-token:${token}`).toString('base64');
+
+  // Hand off to onecli secrets create. Don't echo the token; pass via
+  // argv (still ends up in process listings briefly, but onecli's CLI
+  // doesn't expose a stdin path).
+  const oneCliArgs = [
+    'secrets',
+    'create',
+    '--name',
+    args.name,
+    '--type',
+    'generic',
+    '--value',
+    encoded,
+    '--host-pattern',
+    'github.com',
+    '--header-name',
+    'Authorization',
+    '--value-format',
+    'Basic {value}',
+  ];
+
+  const result = spawnSync('onecli', oneCliArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString('utf8') ?? '';
+    console.error('Failed to create OneCLI secret:');
+    console.error(stderr);
+    process.exit(1);
+  }
+
+  console.log(`Registered "${args.name}" in OneCLI vault for host github.com.`);
+  console.log('Private github plugin clones will work in any agent container running under OneCLI.');
+  console.log('No restart required — the gateway picks up new secrets at request time.');
+}
+
+main();

--- a/scripts/uninstall-plugin.ts
+++ b/scripts/uninstall-plugin.ts
@@ -9,7 +9,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { initDb } from '../src/db/connection.js';
+import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { uninstallPlugin } from './lib/plugins-config.js';
 
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  initDb();
+  initOperatorDb();
   if (!getAgentGroupByFolder(folder)) {
     console.error(`No agent group with folder "${folder}"`);
     process.exit(1);

--- a/scripts/uninstall-plugin.ts
+++ b/scripts/uninstall-plugin.ts
@@ -1,0 +1,57 @@
+/**
+ * scripts/uninstall-plugin.ts — disable a plugin in a group's
+ * container.json. The marketplace registration stays so other plugins
+ * from it remain installable.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/uninstall-plugin.ts <group-folder> <plugin-spec>
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { initDb } from '../src/db/connection.js';
+import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { uninstallPlugin } from './lib/plugins-config.js';
+
+async function main(): Promise<void> {
+  const [, , folder, pluginSpec] = process.argv;
+  if (!folder || !pluginSpec) {
+    console.error('Usage: tsx scripts/uninstall-plugin.ts <group-folder> <plugin-spec>');
+    process.exit(2);
+  }
+
+  initDb();
+  if (!getAgentGroupByFolder(folder)) {
+    console.error(`No agent group with folder "${folder}"`);
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = await uninstallPlugin(folder, pluginSpec);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (!result.wasDisabled) {
+    console.log(`Plugin "${pluginSpec}" was not enabled. No change.`);
+    return;
+  }
+
+  console.log(`Disabled plugin "${pluginSpec}" in group "${folder}".`);
+  restart(folder);
+}
+
+function restart(folder: string): void {
+  const scriptPath = path.join(import.meta.dirname || path.dirname(new URL(import.meta.url).pathname), 'restart-group.ts');
+  const result = spawnSync('pnpm', ['exec', 'tsx', scriptPath, folder], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error('Restart helper exited with non-zero status; the new config will apply on next idle respawn.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/uninstall-plugin.ts
+++ b/scripts/uninstall-plugin.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { initOperatorDb } from './lib/db-init.js';
 import { getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { uninstallPlugin } from './lib/plugins-config.js';
+import { uninstallPlugin } from '../src/modules/plugins/config.js';
 
 async function main(): Promise<void> {
   const [, , folder, pluginSpec] = process.argv;

--- a/src/container-config.test.ts
+++ b/src/container-config.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { GROUPS_DIR } from './config.js';
+
+let originalGroupsDir: string;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  // Mock GROUPS_DIR by using a temp dir as the root and making config.ts
+  // read from it. Since GROUPS_DIR is exported as a const we instead create
+  // a real folder under the existing GROUPS_DIR and clean it up.
+  originalGroupsDir = GROUPS_DIR;
+  tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'nanoclaw-cfg-test-'));
+});
+
+afterEach(async () => {
+  await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+});
+
+// We test by creating a real folder under GROUPS_DIR with a unique name
+// per test so we don't pollute or collide with other groups.
+function makeTestFolder(suffix: string): string {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  const full = path.join(GROUPS_DIR, folder);
+  fs.mkdirSync(full, { recursive: true });
+  return folder;
+}
+
+function cleanupFolder(folder: string): void {
+  fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+}
+
+describe('container-config: atomic write + advisory lock', () => {
+  it('writeContainerConfig is atomic (write-then-rename)', async () => {
+    const { writeContainerConfig, readContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('atomic');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+      const cfg = readContainerConfig(folder);
+      expect(cfg.skills).toBe('all');
+      // No .tmp.* leftover after rename.
+      const dir = path.join(GROUPS_DIR, folder);
+      const entries = fs.readdirSync(dir);
+      expect(entries.filter((e) => e.includes('.tmp.'))).toEqual([]);
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+
+  it('updateContainerConfig serializes concurrent writers', async () => {
+    const { updateContainerConfig, readContainerConfig, writeContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('concurrent');
+    try {
+      // Seed with a known starting state.
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+
+      // Fire 10 concurrent updates each adding a unique package. Without
+      // locking + atomic writes, lost updates would mean fewer than 10 in
+      // the final state.
+      const writers = Array.from({ length: 10 }, (_, i) =>
+        updateContainerConfig(folder, (cfg) => {
+          cfg.packages.apt.push(`pkg-${i}`);
+        }),
+      );
+      await Promise.all(writers);
+
+      const final = readContainerConfig(folder);
+      expect(final.packages.apt.sort()).toEqual(Array.from({ length: 10 }, (_, i) => `pkg-${i}`).sort());
+    } finally {
+      cleanupFolder(folder);
+    }
+  }, 15000);
+
+  it('updateContainerConfig releases lock on mutator throw', async () => {
+    const { updateContainerConfig, writeContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('throw');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+      });
+
+      await expect(
+        updateContainerConfig(folder, () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      // Lock should be released so a follow-up update doesn't hang.
+      await updateContainerConfig(folder, (cfg) => {
+        cfg.packages.apt.push('after-throw');
+      });
+      // No assertion needed — successful return means the lock was free.
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+
+  it('readContainerConfig handles missing file', async () => {
+    const { readContainerConfig } = await import('./container-config.js');
+    const cfg = readContainerConfig('__nonexistent-group-xyz123');
+    expect(cfg.skills).toBe('all');
+    expect(cfg.mcpServers).toEqual({});
+  });
+
+  it('plugins field round-trips through write+read', async () => {
+    const { writeContainerConfig, readContainerConfig } = await import('./container-config.js');
+    const folder = makeTestFolder('plugins');
+    try {
+      writeContainerConfig(folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: {
+            'my-mp': {
+              source: { source: 'github', repo: 'foo/bar', ref: 'main' },
+            },
+          },
+          enabled: { 'my-plugin@my-mp': true },
+        },
+      });
+      const cfg = readContainerConfig(folder);
+      expect(cfg.plugins?.marketplaces?.['my-mp']?.source).toEqual({
+        source: 'github',
+        repo: 'foo/bar',
+        ref: 'main',
+      });
+      expect(cfg.plugins?.enabled?.['my-plugin@my-mp']).toBe(true);
+    } finally {
+      cleanupFolder(folder);
+    }
+  });
+});

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -2,12 +2,17 @@
  * Per-group container config, stored as a plain JSON file at
  * `groups/<folder>/container.json`. Mounted read-only inside the container
  * at `/workspace/agent/container.json` — the runner reads it at startup but
- * cannot modify it. Config changes go through the self-mod approval flow.
+ * cannot modify it.
  *
- * All fields are optional — a missing file or a partial file both resolve
- * to sensible defaults. Writes are atomic-enough (write-then-rename is not
- * worth the ceremony here since there's only one writer in practice: the
- * host, from the delivery thread that processes approved system actions).
+ * Writers: multiple host-side surfaces (operator-driven `/install-plugin`
+ * skill, agent-driven self-mod approval handlers, container-runner's
+ * runtime-field sync at spawn). To avoid lost-update races between
+ * concurrent writers, all read-modify-write sequences must go through
+ * `updateContainerConfig()` which acquires an advisory lock and writes
+ * atomically (write-then-rename).
+ *
+ * Direct callers of `writeContainerConfig` should be limited to first-write
+ * paths where the file doesn't exist yet (e.g. `initContainerConfig`).
  */
 import fs from 'fs';
 import path from 'path';
@@ -30,6 +35,33 @@ export interface AdditionalMountConfig {
   readonly?: boolean;
 }
 
+/**
+ * Source variants for `extraKnownMarketplaces` entries. Mirrors the SDK's
+ * typed schema verbatim — see `extraKnownMarketplaces` in the SDK type
+ * definitions. Don't reshape; pass through to settings.json as-is.
+ */
+export type ExtraKnownMarketplaceSource =
+  | { source: 'url'; url: string; headers?: Record<string, string> }
+  | { source: 'github'; repo: string; ref?: string; path?: string; sparsePaths?: string[] }
+  | { source: 'git'; url: string; ref?: string; path?: string; sparsePaths?: string[] }
+  | { source: 'npm'; package: string }
+  | { source: 'file'; path: string }
+  | { source: 'directory'; path: string }
+  | { source: 'hostPattern'; hostPattern: string }
+  | { source: 'pathPattern'; pathPattern: string }
+  | { source: 'settings'; name: string; plugins: unknown[] };
+
+export interface PluginsConfig {
+  /** Marketplaces to register. Same shape as SDK's extraKnownMarketplaces. */
+  marketplaces?: Record<string, { source: ExtraKnownMarketplaceSource }>;
+  /**
+   * Plugin enablement keyed by "plugin-id@marketplace-id". Mirrors SDK's
+   * `enabledPlugins` value union — boolean flag, version-constraint array,
+   * or object form. Don't narrow to just boolean.
+   */
+  enabled?: Record<string, boolean | string[] | { [k: string]: unknown }>;
+}
+
 export interface ContainerConfig {
   mcpServers: Record<string, McpServerConfig>;
   packages: { apt: string[]; npm: string[] };
@@ -47,6 +79,13 @@ export interface ContainerConfig {
   agentGroupId?: string;
   /** Max messages per prompt. Falls back to code default if unset. */
   maxMessagesPerPrompt?: number;
+  /**
+   * Plugin marketplaces and enabled plugins. When set, the host writes these
+   * into per-group `settings.json` (`extraKnownMarketplaces` / `enabledPlugins`)
+   * and sets `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1` + `CLAUDE_CODE_REMOTE=1` in
+   * the container env so the SDK installs them at session init.
+   */
+  plugins?: PluginsConfig;
 }
 
 function emptyConfig(): ContainerConfig {
@@ -62,11 +101,19 @@ function configPath(folder: string): string {
   return path.join(GROUPS_DIR, folder, 'container.json');
 }
 
+function lockPath(folder: string): string {
+  return path.join(GROUPS_DIR, folder, 'container.json.lock');
+}
+
 /**
  * Read the container config for a group, returning sensible defaults for
  * any missing fields (or an entirely empty config if the file is absent).
  * Never throws for missing / malformed files — corruption logs a warning
  * via console.error and falls back to empty.
+ *
+ * Reads are unlocked: writes are atomic via write-then-rename, so a reader
+ * always observes either the previous complete file or the next complete
+ * file, never a half-written one.
  */
 export function readContainerConfig(folder: string): ContainerConfig {
   const p = configPath(folder);
@@ -87,6 +134,7 @@ export function readContainerConfig(folder: string): ContainerConfig {
       assistantName: raw.assistantName,
       agentGroupId: raw.agentGroupId,
       maxMessagesPerPrompt: raw.maxMessagesPerPrompt,
+      plugins: raw.plugins,
     };
   } catch (err) {
     console.error(`[container-config] failed to parse ${p}: ${String(err)}`);
@@ -95,32 +143,117 @@ export function readContainerConfig(folder: string): ContainerConfig {
 }
 
 /**
- * Write the container config for a group, creating the groups/<folder>/
- * directory if necessary. Pretty-printed JSON so diffs in the activation
- * flow are reviewable.
+ * Write the container config for a group atomically (write-then-rename),
+ * creating the groups/<folder>/ directory if necessary. Pretty-printed JSON
+ * so diffs in the activation flow are reviewable.
+ *
+ * **Concurrency:** this is the low-level writer. For read-modify-write
+ * sequences from concurrent writers (operator skills, agent self-mod,
+ * runtime-field sync), use `updateContainerConfig()` which acquires an
+ * advisory lock first.
  */
 export function writeContainerConfig(folder: string, config: ContainerConfig): void {
   const p = configPath(folder);
   const dir = path.dirname(p);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n');
+  const tmp = `${p}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+  fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n');
+  fs.renameSync(tmp, p);
+}
+
+const LOCK_STALE_MS = 60_000;
+const LOCK_TIMEOUT_MS = 30_000;
+const LOCK_POLL_MS = 50;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire an advisory lock at `<configPath>.lock`. The lockfile contains
+ * `<pid>` as a debugging aid. Stale locks (older than LOCK_STALE_MS) are
+ * cleared on next acquire to recover from crashed writers. Polls every
+ * LOCK_POLL_MS ms with jitter; throws after LOCK_TIMEOUT_MS.
+ */
+async function acquireLock(folder: string): Promise<() => void> {
+  const lp = lockPath(folder);
+  const dir = path.dirname(lp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const start = Date.now();
+  while (true) {
+    try {
+      const fd = fs.openSync(lp, 'wx');
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } finally {
+        fs.closeSync(fd);
+      }
+      // Got the lock; return a release function.
+      return () => {
+        try {
+          fs.unlinkSync(lp);
+        } catch {
+          /* lock already gone — release is best-effort */
+        }
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+      // Lock held by another process. Check for staleness.
+      try {
+        const stat = fs.statSync(lp);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          // Stale — try to clear it. Race-safe: if another process clears it
+          // between our stat and unlink, the next acquire attempt will retry.
+          try {
+            fs.unlinkSync(lp);
+          } catch {
+            /* race with another acquirer — fine */
+          }
+          continue;
+        }
+      } catch {
+        // Lock disappeared between EEXIST and stat — retry.
+        continue;
+      }
+      if (Date.now() - start > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timeout acquiring container.json lock for group "${folder}"`);
+      }
+      await sleep(LOCK_POLL_MS + Math.random() * LOCK_POLL_MS);
+    }
+  }
 }
 
 /**
  * Apply a mutator function to a group's container config and persist the
- * result. Convenient for append-style changes like `install_packages` and
- * `add_mcp_server` handlers.
+ * result, atomically and serialized against concurrent writers.
+ *
+ * The mutator may be sync or async. Returns the updated config.
+ *
+ * Use this for any read-modify-write sequence: appending to packages,
+ * adding/removing plugin marketplaces, syncing runtime identity fields,
+ * etc.
  */
-export function updateContainerConfig(folder: string, mutate: (config: ContainerConfig) => void): ContainerConfig {
-  const config = readContainerConfig(folder);
-  mutate(config);
-  writeContainerConfig(folder, config);
-  return config;
+export async function updateContainerConfig(
+  folder: string,
+  mutate: (config: ContainerConfig) => void | Promise<void>,
+): Promise<ContainerConfig> {
+  const release = await acquireLock(folder);
+  try {
+    const config = readContainerConfig(folder);
+    await mutate(config);
+    writeContainerConfig(folder, config);
+    return config;
+  } finally {
+    release();
+  }
 }
 
 /**
  * Initialize an empty container.json for a group if one doesn't already
- * exist. Idempotent — used from `group-init.ts`.
+ * exist. Idempotent — used from `group-init.ts`. No lock required because
+ * this is a first-write path: the file doesn't exist yet.
  */
 export function initContainerConfig(folder: string): boolean {
   const p = configPath(folder);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -19,7 +19,7 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
-import { readContainerConfig, writeContainerConfig } from './container-config.js';
+import { readContainerConfig, updateContainerConfig } from './container-config.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -125,7 +125,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   // Ensure container.json has the agent group identity fields the runner needs.
   // Written at spawn time so the runner can read them from the RO mount.
-  ensureRuntimeFields(containerConfig, agentGroup);
+  await ensureRuntimeFields(containerConfig, agentGroup);
 
   // Resolve the effective provider + any host-side contribution it declares
   // (extra mounts, env passthrough). Computed once and threaded through both
@@ -401,27 +401,30 @@ function syncSkillSymlinks(claudeDir: string, containerConfig: import('./contain
  * Written at spawn time so they're always current even if the DB values
  * change (e.g. group rename). Only writes if values differ to avoid
  * unnecessary file churn.
+ *
+ * Goes through `updateContainerConfig` so this read-modify-write is
+ * serialized against concurrent writers (operator skills editing
+ * container.json, self-mod approval handlers, etc.).
  */
-function ensureRuntimeFields(
+async function ensureRuntimeFields(
   containerConfig: import('./container-config.js').ContainerConfig,
   agentGroup: AgentGroup,
-): void {
-  let dirty = false;
-  if (containerConfig.agentGroupId !== agentGroup.id) {
-    containerConfig.agentGroupId = agentGroup.id;
-    dirty = true;
-  }
-  if (containerConfig.groupName !== agentGroup.name) {
-    containerConfig.groupName = agentGroup.name;
-    dirty = true;
-  }
-  if (containerConfig.assistantName !== agentGroup.name) {
-    containerConfig.assistantName = agentGroup.name;
-    dirty = true;
-  }
-  if (dirty) {
-    writeContainerConfig(agentGroup.folder, containerConfig);
-  }
+): Promise<void> {
+  const dirty =
+    containerConfig.agentGroupId !== agentGroup.id ||
+    containerConfig.groupName !== agentGroup.name ||
+    containerConfig.assistantName !== agentGroup.name;
+  if (!dirty) return;
+
+  const updated = await updateContainerConfig(agentGroup.folder, (cfg) => {
+    cfg.agentGroupId = agentGroup.id;
+    cfg.groupName = agentGroup.name;
+    cfg.assistantName = agentGroup.name;
+  });
+  // Sync the in-memory copy used downstream by the spawn flow.
+  containerConfig.agentGroupId = updated.agentGroupId;
+  containerConfig.groupName = updated.groupName;
+  containerConfig.assistantName = updated.assistantName;
 }
 
 async function buildContainerArgs(
@@ -438,6 +441,20 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Plugin install via SDK headless mode. Gated on `container.json:plugins`
+  // being non-empty so we don't pay the install path on every spawn for
+  // groups that don't use plugins. CLAUDE_CODE_REMOTE forces HTTPS over
+  // the SSH default — without it, github source URLs resolve as
+  // `git@github.com:` and bypass the OneCLI proxy entirely (see plan F7).
+  const hasPlugins =
+    !!containerConfig.plugins &&
+    (Object.keys(containerConfig.plugins.marketplaces ?? {}).length > 0 ||
+      Object.keys(containerConfig.plugins.enabled ?? {}).length > 0);
+  if (hasPlugins) {
+    args.push('-e', 'CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1');
+    args.push('-e', 'CLAUDE_CODE_REMOTE=1');
+  }
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {
@@ -536,9 +553,12 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
     fs.unlinkSync(tmpDockerfile);
   }
 
-  // Store the image tag in groups/<folder>/container.json
-  containerConfig.imageTag = imageTag;
-  writeContainerConfig(agentGroup.folder, containerConfig);
+  // Store the image tag in groups/<folder>/container.json. Goes through
+  // updateContainerConfig so concurrent edits (e.g. an operator running
+  // /install-plugin while a build is in progress) don't lose updates.
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
+    cfg.imageTag = imageTag;
+  });
 
   log.info('Per-agent-group image built', { agentGroupId, imageTag });
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -477,6 +477,19 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // OneCLI's applyContainerConfig sets NODE_EXTRA_CA_CERTS, SSL_CERT_FILE,
+  // DENO_CERT for various runtimes — but NOT GIT_SSL_CAINFO. Git's HTTPS
+  // verification therefore uses the system CA bundle and rejects the
+  // OneCLI MITM cert when traffic flows through HTTPS_PROXY. The SDK's
+  // marketplace/plugin clones happen via `git clone` and silently fail
+  // with "server certificate verification failed". Mirror the cert path
+  // OneCLI just injected into GIT_SSL_CAINFO so git trusts the gateway.
+  const nodeCaArg = args.find((a, i) => i > 0 && args[i - 1] === '-e' && a.startsWith('NODE_EXTRA_CA_CERTS='));
+  if (nodeCaArg) {
+    const caPath = nodeCaArg.slice('NODE_EXTRA_CA_CERTS='.length);
+    args.push('-e', `GIT_SSL_CAINFO=${caPath}`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 

--- a/src/db/migrations/014-recent-denials.ts
+++ b/src/db/migrations/014-recent-denials.ts
@@ -1,0 +1,32 @@
+/**
+ * `recent_denials` — short-lived memory of admin-rejected approval requests.
+ *
+ * Without this, an agent that drives its own approvals (today: install_plugin,
+ * tomorrow: any agent-initiated self-mod) can wake the admin repeatedly with
+ * the same card after a single Deny, because the agent's transcript still
+ * shows the install as its last attempt and it has no built-in "denied
+ * recently" memory.
+ *
+ * The approvals primitive consults this table on opt-in calls
+ * (`dedupeDenials: true`) and short-circuits with a `notifyAgent` instead of
+ * creating a fresh pending row.
+ */
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration014: Migration = {
+  version: 14,
+  name: 'recent-denials',
+  up(db: Database.Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS recent_denials (
+        agent_group_id TEXT NOT NULL,
+        action_hash    TEXT NOT NULL,
+        denied_at      INTEGER NOT NULL,
+        denied_by      TEXT NOT NULL,
+        PRIMARY KEY (agent_group_id, action_hash)
+      );
+      CREATE INDEX IF NOT EXISTS idx_recent_denials_denied_at ON recent_denials(denied_at);
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -10,6 +10,7 @@ import { migration010 } from './010-engage-modes.js';
 import { migration011 } from './011-pending-sender-approvals.js';
 import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
+import { migration014 } from './014-recent-denials.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -31,6 +32,7 @@ const migrations: Migration[] = [
   migration011,
   migration012,
   migration013,
+  migration014,
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/group-init.test.ts
+++ b/src/group-init.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR, DATA_DIR } from './config.js';
+import { initGroupFilesystem } from './group-init.js';
+import { writeContainerConfig } from './container-config.js';
+import type { AgentGroup } from './types.js';
+
+let testFolders: string[];
+
+beforeEach(() => {
+  testFolders = [];
+});
+
+afterEach(() => {
+  for (const folder of testFolders) {
+    fs.rmSync(path.join(GROUPS_DIR, folder), { recursive: true, force: true });
+  }
+});
+
+function makeGroup(suffix: string): AgentGroup {
+  const folder = `__test-${process.pid}-${Date.now()}-${suffix}`;
+  testFolders.push(folder);
+  fs.mkdirSync(path.join(GROUPS_DIR, folder), { recursive: true });
+  return {
+    id: `agent-${suffix}`,
+    name: `test-${suffix}`,
+    folder,
+    container_config: '{}',
+  } as unknown as AgentGroup;
+}
+
+function readSettings(group: AgentGroup): Record<string, unknown> {
+  const p = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared', 'settings.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function cleanupSession(group: AgentGroup): void {
+  fs.rmSync(path.join(DATA_DIR, 'v2-sessions', group.id), { recursive: true, force: true });
+}
+
+describe('group-init: ensurePluginsConfig', () => {
+  it('first-init with plugins declared in container.json populates settings.json', () => {
+    const group = makeGroup('first-init');
+    try {
+      // Pre-populate container.json BEFORE first init (operator-set scenario).
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: {
+            mp1: { source: { source: 'github', repo: 'foo/bar' } },
+          },
+          enabled: { 'plugin1@mp1': true },
+        },
+      });
+
+      initGroupFilesystem(group);
+
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toMatchObject({
+        mp1: { source: { source: 'github', repo: 'foo/bar' } },
+      });
+      expect(settings.enabledPlugins).toMatchObject({ 'plugin1@mp1': true });
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('idempotent — running twice in a row produces same result', () => {
+    const group = makeGroup('idempotent');
+    try {
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+      initGroupFilesystem(group);
+      const before = JSON.stringify(readSettings(group));
+      initGroupFilesystem(group);
+      const after = JSON.stringify(readSettings(group));
+      expect(after).toBe(before);
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('additive merge — preserves pre-existing extraKnownMarketplaces entries', () => {
+    const group = makeGroup('merge');
+    try {
+      // Pre-populate settings.json with an unrelated entry (simulates SDK
+      // self-write or operator hand-edit).
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      const settingsFile = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(
+        settingsFile,
+        JSON.stringify({
+          env: { FOO: 'bar' },
+          extraKnownMarketplaces: {
+            'pre-existing': { source: { source: 'github', repo: 'old/old' } },
+          },
+        }),
+      );
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { 'mp-new': { source: { source: 'github', repo: 'new/new' } } },
+        },
+      });
+
+      initGroupFilesystem(group);
+
+      const settings = readSettings(group);
+      const mps = settings.extraKnownMarketplaces as Record<string, unknown>;
+      // Both entries present.
+      expect(mps['pre-existing']).toBeDefined();
+      expect(mps['mp-new']).toBeDefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('handles malformed settings.json gracefully (rewrites)', () => {
+    const group = makeGroup('malformed');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{ this is: not valid JSON');
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+
+      // Must not throw.
+      expect(() => initGroupFilesystem(group)).not.toThrow();
+
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toMatchObject({
+        mp1: { source: { source: 'github', repo: 'foo/bar' } },
+      });
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('handles top-level non-object settings.json (rewrites)', () => {
+    const group = makeGroup('nonobject');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '[]');
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'foo/bar' } } },
+        },
+      });
+
+      expect(() => initGroupFilesystem(group)).not.toThrow();
+      const settings = readSettings(group);
+      expect(settings.extraKnownMarketplaces).toBeDefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('no plugins declared — no-op (does not touch settings.json marketplaces blocks)', () => {
+    const group = makeGroup('noplugins');
+    try {
+      // Just init — no plugins in container.json.
+      initGroupFilesystem(group);
+      const settings = readSettings(group);
+      // Default settings shouldn't grow extraKnownMarketplaces / enabledPlugins.
+      expect(settings.extraKnownMarketplaces).toBeUndefined();
+      expect(settings.enabledPlugins).toBeUndefined();
+    } finally {
+      cleanupSession(group);
+    }
+  });
+
+  it('container.json wins on key collision', () => {
+    const group = makeGroup('collision');
+    try {
+      const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeDir, 'settings.json'),
+        JSON.stringify({
+          extraKnownMarketplaces: {
+            mp1: { source: { source: 'github', repo: 'OLD/OLD' } },
+          },
+        }),
+      );
+
+      writeContainerConfig(group.folder, {
+        mcpServers: {},
+        packages: { apt: [], npm: [] },
+        additionalMounts: [],
+        skills: 'all',
+        plugins: {
+          marketplaces: { mp1: { source: { source: 'github', repo: 'NEW/NEW' } } },
+        },
+      });
+
+      initGroupFilesystem(group);
+      const settings = readSettings(group);
+      const entry = (settings.extraKnownMarketplaces as Record<string, { source: { repo: string } }>)?.mp1?.source
+        ?.repo;
+      expect(entry).toBe('NEW/NEW');
+    } finally {
+      cleanupSession(group);
+    }
+  });
+});

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR, GROUPS_DIR } from './config.js';
-import { initContainerConfig } from './container-config.js';
+import { initContainerConfig, readContainerConfig } from './container-config.js';
 import { log } from './log.js';
 import type { AgentGroup } from './types.js';
 
@@ -87,6 +87,13 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
     ensurePreCompactHook(settingsFile, initialized);
   }
 
+  // Plugin config is sourced from groups/<folder>/container.json:plugins
+  // and merged into settings.json on every spawn. Runs unconditionally
+  // (outside the existsSync branches above) so first-init-with-plugins
+  // works AND existing groups pick up container.json edits without manual
+  // settings.json touches.
+  ensurePluginsConfig(settingsFile, group, initialized);
+
   // Skills directory — created empty here; symlinks are synced at spawn
   // time by container-runner.ts based on container.json skills selection.
   const skillsDst = path.join(claudeDir, 'skills');
@@ -103,6 +110,98 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
       steps: initialized,
     });
   }
+}
+
+/**
+ * Mirror per-group `container.json:plugins` into `settings.json`'s
+ * `extraKnownMarketplaces` and `enabledPlugins` blocks so the SDK loads
+ * declared plugins on next spawn.
+ *
+ * Defensive against stale-format settings.json (missing blocks, malformed
+ * JSON, top-level non-object) — never crashes group init. On parse failure
+ * logs a warning and falls back to a fresh-write path.
+ *
+ * **Additive-only.** Pre-existing keys not declared in container.json are
+ * preserved (the SDK writes its own state to a separate registry at
+ * `~/.claude/plugins/known_marketplaces.json`, so additive-only is safe).
+ * A future `pruneUndeclared` mode is gated on empirical confirmation that
+ * the SDK doesn't write back to settings.json — see F1 in the plan.
+ *
+ * Idempotent: running twice in a row produces the same file.
+ */
+function ensurePluginsConfig(settingsFile: string, group: AgentGroup, initialized: string[]): void {
+  let plugins;
+  try {
+    plugins = readContainerConfig(group.folder).plugins;
+  } catch (err) {
+    log.warn('ensurePluginsConfig: failed to read container.json', {
+      group: group.folder,
+      err: String(err),
+    });
+    return;
+  }
+
+  const desiredMarketplaces = plugins?.marketplaces ?? {};
+  const desiredEnabled = plugins?.enabled ?? {};
+  const hasContent = Object.keys(desiredMarketplaces).length > 0 || Object.keys(desiredEnabled).length > 0;
+  if (!hasContent) return;
+
+  // Defensive parse of existing settings.json. Stale-format and malformed
+  // cases fall back to an empty object that we'll merge into.
+  let settings: Record<string, unknown>;
+  try {
+    const raw = fs.readFileSync(settingsFile, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      log.warn('ensurePluginsConfig: settings.json top-level is not an object; rewriting', {
+        group: group.folder,
+      });
+      settings = {};
+    } else {
+      settings = parsed as Record<string, unknown>;
+    }
+  } catch (err) {
+    log.warn('ensurePluginsConfig: settings.json malformed; rewriting', {
+      group: group.folder,
+      err: String(err),
+    });
+    settings = {};
+  }
+
+  // Merge marketplaces. Existing entries not declared in container.json
+  // are preserved (additive-only). Existing entries with the same key are
+  // overwritten by container.json's value (container.json wins).
+  const existingMarketplaces = isPlainObject(settings.extraKnownMarketplaces) ? settings.extraKnownMarketplaces : {};
+  const mergedMarketplaces: Record<string, unknown> = { ...existingMarketplaces };
+  let changed = false;
+  for (const [name, entry] of Object.entries(desiredMarketplaces)) {
+    if (JSON.stringify(mergedMarketplaces[name]) !== JSON.stringify(entry)) {
+      mergedMarketplaces[name] = entry;
+      changed = true;
+    }
+  }
+
+  // Same merge logic for enabledPlugins.
+  const existingEnabled = isPlainObject(settings.enabledPlugins) ? settings.enabledPlugins : {};
+  const mergedEnabled: Record<string, unknown> = { ...existingEnabled };
+  for (const [key, value] of Object.entries(desiredEnabled)) {
+    if (JSON.stringify(mergedEnabled[key]) !== JSON.stringify(value)) {
+      mergedEnabled[key] = value;
+      changed = true;
+    }
+  }
+
+  if (!changed) return;
+
+  settings.extraKnownMarketplaces = mergedMarketplaces;
+  settings.enabledPlugins = mergedEnabled;
+
+  fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n');
+  initialized.push('settings.json (plugins config)');
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
 const PRE_COMPACT_COMMAND = 'bun /app/src/compact-instructions.ts';

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -141,6 +141,19 @@ async function sweep(): Promise<void> {
     log.error('Host sweep error', { err });
   }
 
+  // MODULE-HOOK:approvals-recent-denials-cleanup:start
+  // Drop denial rows older than DENIAL_MAX_AGE_SECONDS (7d). Independent of
+  // session sweep — denials are central-DB rows, not per-session. Failures
+  // here must not stop the sweep loop.
+  try {
+    const { cleanupOldDenials } = await import('./modules/approvals/recent-denials.js');
+    const dropped = cleanupOldDenials();
+    if (dropped > 0) log.info('Pruned old denial rows', { count: dropped });
+  } catch (err) {
+    log.warn('Denial cleanup failed', { err });
+  }
+  // MODULE-HOOK:approvals-recent-denials-cleanup:end
+
   setTimeout(sweep, SWEEP_INTERVAL_MS);
 }
 

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -31,6 +31,7 @@ import { writeSessionMessage } from '../../session-manager.js';
 import type { MessagingGroup, Session } from '../../types.js';
 import { getAdminsOfAgentGroup, getGlobalAdmins, getOwners } from '../permissions/db/user-roles.js';
 import { ensureUserDm } from '../permissions/user-dm.js';
+import { findRecentDenial, hashAction } from './recent-denials.js';
 
 /** Two-button approval UI — the only options the primitive supports today. */
 const APPROVAL_OPTIONS: RawOption[] = [
@@ -54,17 +55,37 @@ export interface ApprovalHandlerContext {
 
 export type ApprovalHandler = (ctx: ApprovalHandlerContext) => Promise<void>;
 
-const approvalHandlers = new Map<string, ApprovalHandler>();
+export interface RegisterApprovalHandlerOptions {
+  /**
+   * When true, the response handler records a denial row on Reject so a
+   * subsequent identical request (same action + payload, same agent group)
+   * is suppressed for 24h. Pair with `requestApproval({ dedupeDenials: true })`
+   * on the request side. See recent-denials.ts.
+   */
+  dedupeDenials?: boolean;
+}
 
-export function registerApprovalHandler(action: string, handler: ApprovalHandler): void {
+const approvalHandlers = new Map<string, ApprovalHandler>();
+const dedupeTrackedActions = new Set<string>();
+
+export function registerApprovalHandler(
+  action: string,
+  handler: ApprovalHandler,
+  opts: RegisterApprovalHandlerOptions = {},
+): void {
   if (approvalHandlers.has(action)) {
     log.warn('Approval handler re-registered (overwriting)', { action });
   }
   approvalHandlers.set(action, handler);
+  if (opts.dedupeDenials) dedupeTrackedActions.add(action);
 }
 
 export function getApprovalHandler(action: string): ApprovalHandler | undefined {
   return approvalHandlers.get(action);
+}
+
+export function isDedupeTrackedAction(action: string): boolean {
+  return dedupeTrackedActions.has(action);
 }
 
 // ── Approver picking ──
@@ -153,6 +174,16 @@ export interface RequestApprovalOptions {
   title: string;
   /** Card body shown to the admin. */
   question: string;
+  /**
+   * Opt in to denial-loop suppression. When true:
+   *   - Before creating the pending row, check `recent_denials` for an
+   *     identical (action, payload) within the TTL. If hit, skip the
+   *     approval and emit a `notifyAgent` instead.
+   *   - On reject, the response handler records a denial row.
+   * Use for agent-initiated approvals (self-mod) where an agent might
+   * otherwise loop on the same request after a single Deny.
+   */
+  dedupeDenials?: boolean;
 }
 
 /**
@@ -162,7 +193,24 @@ export interface RequestApprovalOptions {
  * approval handler for this action via the response dispatcher.
  */
 export async function requestApproval(opts: RequestApprovalOptions): Promise<void> {
-  const { session, action, payload, title, question, agentName } = opts;
+  const { session, action, payload, title, question, agentName, dedupeDenials } = opts;
+
+  if (dedupeDenials) {
+    const recent = findRecentDenial(session.agent_group_id, hashAction(action, payload));
+    if (recent) {
+      const deniedAt = new Date(recent.denied_at * 1000).toISOString();
+      log.info('Approval suppressed by recent denial', {
+        action,
+        agentGroupId: session.agent_group_id,
+        deniedAt,
+      });
+      notifyAgent(
+        session,
+        `Your ${action} request matches one an admin denied at ${deniedAt}. Don't auto-retry the same request — surface it to the user with context if you believe it should be reconsidered.`,
+      );
+      return;
+    }
+  }
 
   const approvers = pickApprover(session.agent_group_id);
   if (approvers.length === 0) {

--- a/src/modules/approvals/recent-denials.test.ts
+++ b/src/modules/approvals/recent-denials.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import {
+  cleanupOldDenials,
+  DENIAL_MAX_AGE_SECONDS,
+  DENIAL_TTL_SECONDS,
+  findRecentDenial,
+  hashAction,
+  recordDenial,
+} from './recent-denials.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('hashAction', () => {
+  it('is deterministic for same action + payload', () => {
+    const a = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    const b = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    expect(a).toBe(b);
+  });
+
+  it('is independent of object key order', () => {
+    const a = hashAction('install_plugin', { plugin_spec: 'foo@bar', reason: 'why' });
+    const b = hashAction('install_plugin', { reason: 'why', plugin_spec: 'foo@bar' });
+    expect(a).toBe(b);
+  });
+
+  it('is independent of nested key order', () => {
+    const a = hashAction('install_plugin', { source: { source: 'github', repo: 'a/b', ref: 'main' } });
+    const b = hashAction('install_plugin', { source: { ref: 'main', repo: 'a/b', source: 'github' } });
+    expect(a).toBe(b);
+  });
+
+  it('differs when action differs', () => {
+    expect(hashAction('install_plugin', { x: 1 })).not.toBe(hashAction('uninstall_plugin', { x: 1 }));
+  });
+
+  it('differs when payload differs', () => {
+    expect(hashAction('install_plugin', { x: 1 })).not.toBe(hashAction('install_plugin', { x: 2 }));
+  });
+
+  it('preserves array order in hash (arrays are not sorted)', () => {
+    expect(hashAction('a', { items: [1, 2, 3] })).not.toBe(hashAction('a', { items: [3, 2, 1] }));
+  });
+});
+
+describe('recordDenial / findRecentDenial', () => {
+  it('returns null when no denial recorded', () => {
+    expect(findRecentDenial('group-a', hashAction('foo', {}))).toBeNull();
+  });
+
+  it('finds a fresh denial', () => {
+    const h = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    recordDenial('group-a', h, 'admin:1');
+    const found = findRecentDenial('group-a', h);
+    expect(found).not.toBeNull();
+    expect(found?.denied_by).toBe('admin:1');
+  });
+
+  it('does not return a denial older than TTL', () => {
+    const h = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    const tooOld = Math.floor(Date.now() / 1000) - DENIAL_TTL_SECONDS - 60;
+    recordDenial('group-a', h, 'admin:1', tooOld);
+    expect(findRecentDenial('group-a', h)).toBeNull();
+  });
+
+  it('returns a denial right at TTL edge (not yet expired)', () => {
+    const h = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    const now = Math.floor(Date.now() / 1000);
+    recordDenial('group-a', h, 'admin:1', now - DENIAL_TTL_SECONDS + 5);
+    expect(findRecentDenial('group-a', h, DENIAL_TTL_SECONDS, now)).not.toBeNull();
+  });
+
+  it('scopes denials by agent_group_id', () => {
+    const h = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    recordDenial('group-a', h, 'admin:1');
+    expect(findRecentDenial('group-b', h)).toBeNull();
+  });
+
+  it('upserts on duplicate (agent_group_id, action_hash)', () => {
+    const h = hashAction('install_plugin', { plugin_spec: 'foo@bar' });
+    const t1 = Math.floor(Date.now() / 1000) - 100;
+    const t2 = Math.floor(Date.now() / 1000);
+    recordDenial('group-a', h, 'admin:1', t1);
+    recordDenial('group-a', h, 'admin:2', t2);
+    const found = findRecentDenial('group-a', h);
+    expect(found?.denied_at).toBe(t2);
+    expect(found?.denied_by).toBe('admin:2');
+  });
+});
+
+describe('cleanupOldDenials', () => {
+  it('deletes rows older than max age, keeps newer ones', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const h1 = hashAction('a', { i: 1 });
+    const h2 = hashAction('a', { i: 2 });
+    recordDenial('g', h1, 'u', now - DENIAL_MAX_AGE_SECONDS - 1000);
+    recordDenial('g', h2, 'u', now - 60);
+    const deleted = cleanupOldDenials(DENIAL_MAX_AGE_SECONDS, now);
+    expect(deleted).toBe(1);
+    // h2 still findable (within TTL)
+    expect(findRecentDenial('g', h2, DENIAL_TTL_SECONDS, now)).not.toBeNull();
+    // h1 gone
+    expect(findRecentDenial('g', h1, DENIAL_MAX_AGE_SECONDS + 10000, now)).toBeNull();
+  });
+
+  it('returns 0 when no rows are stale', () => {
+    const h = hashAction('a', {});
+    recordDenial('g', h, 'u');
+    expect(cleanupOldDenials()).toBe(0);
+  });
+});

--- a/src/modules/approvals/recent-denials.ts
+++ b/src/modules/approvals/recent-denials.ts
@@ -1,0 +1,99 @@
+/**
+ * Denial-cache helpers for the approvals primitive.
+ *
+ * Agent-initiated approvals (`requestApproval({ dedupeDenials: true })`)
+ * record a denial row when the admin clicks Reject. A subsequent identical
+ * request within `DENIAL_TTL_SECONDS` short-circuits with a `notifyAgent`
+ * instead of waking the admin again.
+ *
+ * Hash inputs are canonicalized (sorted keys) so payload key order doesn't
+ * change the hash. Action + canonical(payload) is the cache key, scoped by
+ * agent_group_id so two groups asking for the same install don't share
+ * decisions.
+ */
+import crypto from 'crypto';
+
+import { getDb } from '../../db/index.js';
+
+/** TTL within which a fresh identical request is suppressed. 24h. */
+export const DENIAL_TTL_SECONDS = 24 * 60 * 60;
+
+/** Rows older than this are deleted by the periodic sweep. 7 days. */
+export const DENIAL_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+export interface RecentDenial {
+  agent_group_id: string;
+  action_hash: string;
+  denied_at: number;
+  denied_by: string;
+}
+
+/**
+ * Stable hash for `(action, payload)`. Canonicalizes the payload object so
+ * key insertion order doesn't change the hash. Non-objects are serialized
+ * directly.
+ */
+export function hashAction(action: string, payload: unknown): string {
+  const canonical = canonicalize(payload);
+  const h = crypto.createHash('sha256');
+  h.update(action);
+  h.update('\x00');
+  h.update(JSON.stringify(canonical));
+  return h.digest('hex');
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[k] = canonicalize((value as Record<string, unknown>)[k]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+export function recordDenial(agentGroupId: string, actionHash: string, deniedBy: string, nowSeconds?: number): void {
+  const ts = nowSeconds ?? Math.floor(Date.now() / 1000);
+  getDb()
+    .prepare(
+      `INSERT INTO recent_denials (agent_group_id, action_hash, denied_at, denied_by)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(agent_group_id, action_hash) DO UPDATE SET
+         denied_at = excluded.denied_at,
+         denied_by = excluded.denied_by`,
+    )
+    .run(agentGroupId, actionHash, ts, deniedBy);
+}
+
+/**
+ * Returns the most recent denial row for `(agentGroupId, actionHash)` if
+ * younger than `ttlSeconds`, else null.
+ */
+export function findRecentDenial(
+  agentGroupId: string,
+  actionHash: string,
+  ttlSeconds: number = DENIAL_TTL_SECONDS,
+  nowSeconds?: number,
+): RecentDenial | null {
+  const cutoff = (nowSeconds ?? Math.floor(Date.now() / 1000)) - ttlSeconds;
+  const row = getDb()
+    .prepare(
+      `SELECT agent_group_id, action_hash, denied_at, denied_by
+       FROM recent_denials
+       WHERE agent_group_id = ? AND action_hash = ? AND denied_at >= ?`,
+    )
+    .get(agentGroupId, actionHash, cutoff) as RecentDenial | undefined;
+  return row ?? null;
+}
+
+/** Delete rows older than `maxAgeSeconds`. Returns the number deleted. */
+export function cleanupOldDenials(
+  maxAgeSeconds: number = DENIAL_MAX_AGE_SECONDS,
+  nowSeconds?: number,
+): number {
+  const cutoff = (nowSeconds ?? Math.floor(Date.now() / 1000)) - maxAgeSeconds;
+  const r = getDb().prepare('DELETE FROM recent_denials WHERE denied_at < ?').run(cutoff);
+  return Number(r.changes);
+}

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -19,7 +19,8 @@ import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { PendingApproval } from '../../types.js';
 import { ONECLI_ACTION, resolveOneCLIApproval } from './onecli-approvals.js';
-import { getApprovalHandler } from './primitive.js';
+import { getApprovalHandler, isDedupeTrackedAction } from './primitive.js';
+import { hashAction, recordDenial } from './recent-denials.js';
 
 export async function handleApprovalsResponse(payload: ResponsePayload): Promise<boolean> {
   // OneCLI credential approvals — resolved via in-memory Promise first.
@@ -70,6 +71,18 @@ async function handleRegisteredApproval(
   };
 
   if (selectedOption !== 'approve') {
+    if (isDedupeTrackedAction(approval.action)) {
+      try {
+        const payload = JSON.parse(approval.payload);
+        recordDenial(session.agent_group_id, hashAction(approval.action, payload), userId);
+      } catch (err) {
+        log.warn('Failed to record denial — payload parse failed', {
+          approvalId: approval.approval_id,
+          action: approval.action,
+          err,
+        });
+      }
+    }
     notify(`Your ${approval.action} request was rejected by admin.`);
     log.info('Approval rejected', { approvalId: approval.approval_id, action: approval.action, userId });
     deletePendingApproval(approval.approval_id);

--- a/src/modules/plugins/config.test.ts
+++ b/src/modules/plugins/config.test.ts
@@ -94,9 +94,9 @@ describe('addMarketplace / listMarketplaces', () => {
 
   it('rejects invalid name', async () => {
     const folder = makeFolder('add-bad');
-    await expect(
-      addMarketplace(folder, 'has space', { source: 'github', repo: 'a/b' }),
-    ).rejects.toThrow(/invalid characters/);
+    await expect(addMarketplace(folder, 'has space', { source: 'github', repo: 'a/b' })).rejects.toThrow(
+      /invalid characters/,
+    );
   });
 });
 

--- a/src/modules/plugins/config.test.ts
+++ b/src/modules/plugins/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
-import { GROUPS_DIR } from '../../src/config.js';
+import { GROUPS_DIR } from '../../config.js';
 import {
   addMarketplace,
   removeMarketplace,
@@ -11,8 +11,8 @@ import {
   listMarketplaces,
   listEnabledPlugins,
   parsePluginSpec,
-} from './plugins-config.js';
-import { writeContainerConfig } from '../../src/container-config.js';
+} from './config.js';
+import { writeContainerConfig } from '../../container-config.js';
 
 let testFolders: string[];
 

--- a/src/modules/plugins/config.ts
+++ b/src/modules/plugins/config.ts
@@ -1,8 +1,9 @@
 /**
- * scripts/lib/plugins-config.ts — read/validate/write the
- * `container.json:plugins` block, with safety checks for the operator
- * skills (`/add-marketplace`, `/remove-marketplace`, `/install-plugin`,
- * `/uninstall-plugin`).
+ * Plugin/marketplace config helpers — read/validate/write the
+ * `container.json:plugins` block. Used by operator skills
+ * (`/add-marketplace`, `/remove-marketplace`, `/install-plugin`,
+ * `/uninstall-plugin`) and the self-mod install_plugin/uninstall_plugin
+ * approval handlers.
  *
  * All mutations route through `updateContainerConfig()` so concurrent
  * writers (multiple operator skills, self-mod approval handlers) are
@@ -12,8 +13,8 @@ import {
   readContainerConfig,
   updateContainerConfig,
   type ExtraKnownMarketplaceSource,
-} from '../../src/container-config.js';
-import { parseMarketplaceSource } from './marketplace-source-validator.js';
+} from '../../container-config.js';
+import { parseMarketplaceSource } from './source-validator.js';
 
 /**
  * Add or update a marketplace entry in `container.json:plugins.marketplaces`.

--- a/src/modules/plugins/config.ts
+++ b/src/modules/plugins/config.ts
@@ -138,10 +138,7 @@ export async function installPlugin(
  * Disable a plugin. Removes the entry from `enabled`. The marketplace
  * registration stays so other plugins from it can still be enabled.
  */
-export async function uninstallPlugin(
-  folder: string,
-  pluginSpec: string,
-): Promise<{ wasDisabled: boolean }> {
+export async function uninstallPlugin(folder: string, pluginSpec: string): Promise<{ wasDisabled: boolean }> {
   // Validate format up front so a typo doesn't silently no-op.
   parsePluginSpec(pluginSpec);
   let wasDisabled = false;
@@ -154,9 +151,7 @@ export async function uninstallPlugin(
   return { wasDisabled };
 }
 
-export function listEnabledPlugins(
-  folder: string,
-): Record<string, boolean | string[] | { [k: string]: unknown }> {
+export function listEnabledPlugins(folder: string): Record<string, boolean | string[] | { [k: string]: unknown }> {
   const cfg = readContainerConfig(folder);
   return cfg.plugins?.enabled ?? {};
 }

--- a/src/modules/plugins/source-validator.test.ts
+++ b/src/modules/plugins/source-validator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateMarketplaceSource,
   parseMarketplaceSource,
-} from './marketplace-source-validator.js';
+} from './source-validator.js';
 
 describe('validateMarketplaceSource — accepts every documented variant', () => {
   it.each([

--- a/src/modules/plugins/source-validator.test.ts
+++ b/src/modules/plugins/source-validator.test.ts
@@ -1,31 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import {
-  validateMarketplaceSource,
-  parseMarketplaceSource,
-} from './source-validator.js';
+import { validateMarketplaceSource, parseMarketplaceSource } from './source-validator.js';
 
 describe('validateMarketplaceSource — accepts every documented variant', () => {
   it.each([
     ['url with required fields', { source: 'url', url: 'https://x.com/m.json' }],
-    ['url with optional headers', {
-      source: 'url',
-      url: 'https://x.com/m.json',
-      headers: { Authorization: 'Bearer x' },
-    }],
+    [
+      'url with optional headers',
+      {
+        source: 'url',
+        url: 'https://x.com/m.json',
+        headers: { Authorization: 'Bearer x' },
+      },
+    ],
     ['github with repo only', { source: 'github', repo: 'owner/repo' }],
-    ['github with all fields', {
-      source: 'github',
-      repo: 'owner/repo',
-      ref: 'main',
-      path: 'sub/dir',
-      sparsePaths: ['plugins'],
-    }],
+    [
+      'github with all fields',
+      {
+        source: 'github',
+        repo: 'owner/repo',
+        ref: 'main',
+        path: 'sub/dir',
+        sparsePaths: ['plugins'],
+      },
+    ],
     ['git with url only', { source: 'git', url: 'https://gitlab.com/x/y.git' }],
-    ['git with sparsePaths', {
-      source: 'git',
-      url: 'git@host:x/y.git',
-      sparsePaths: ['a', 'b'],
-    }],
+    [
+      'git with sparsePaths',
+      {
+        source: 'git',
+        url: 'git@host:x/y.git',
+        sparsePaths: ['a', 'b'],
+      },
+    ],
     ['npm', { source: 'npm', package: '@scope/pkg' }],
     ['file', { source: 'file', path: '/abs/path/marketplace.json' }],
     ['directory', { source: 'directory', path: '/abs/path/' }],

--- a/src/modules/plugins/source-validator.ts
+++ b/src/modules/plugins/source-validator.ts
@@ -1,13 +1,12 @@
 /**
- * scripts/lib/marketplace-source-validator.ts — schema validation for
- * `extraKnownMarketplaces` source variants.
+ * Schema validation for `extraKnownMarketplaces` source variants.
  *
  * Mirrors the SDK's typed schema (eight variants). Used by
  * /add-marketplace and /install-plugin --source to reject malformed
  * source specs before they hit `container.json` (and from there, the
  * SDK at next spawn — where the failure mode is harder to diagnose).
  */
-import type { ExtraKnownMarketplaceSource } from '../../src/container-config.js';
+import type { ExtraKnownMarketplaceSource } from '../../container-config.js';
 
 export type ValidationResult = { ok: true; source: ExtraKnownMarketplaceSource } | { ok: false; error: string };
 

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -17,6 +17,7 @@ import { getAgentGroup } from '../../db/agent-groups.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { ApprovalHandler } from '../approvals/index.js';
+import { installPlugin, uninstallPlugin } from '../plugins/config.js';
 
 export const applyInstallPackages: ApprovalHandler = async ({ session, payload, userId, notify }) => {
   const agentGroup = getAgentGroup(session.agent_group_id);
@@ -63,6 +64,78 @@ export const applyInstallPackages: ApprovalHandler = async ({ session, payload, 
     );
     log.error('Bundled rebuild failed after install approval', { agentGroupId: session.agent_group_id, err: e });
   }
+};
+
+export const applyInstallPlugin: ApprovalHandler = async ({ session, payload, userId, notify }) => {
+  const agentGroup = getAgentGroup(session.agent_group_id);
+  if (!agentGroup) {
+    notify('install_plugin approved but agent group missing.');
+    return;
+  }
+
+  const pluginSpec = payload.plugin_spec as string;
+  const inlineSource = (payload.source as Parameters<typeof installPlugin>[2]) || undefined;
+
+  let result;
+  try {
+    result = await installPlugin(agentGroup.folder, pluginSpec, inlineSource);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    notify(`install_plugin failed: ${msg}`);
+    log.error('install_plugin apply error', { agentGroupId: session.agent_group_id, err });
+    return;
+  }
+
+  log.info('Plugin install approved', { agentGroupId: session.agent_group_id, userId, pluginSpec });
+  killContainer(session.id, 'install_plugin applied');
+  // Schedule a follow-up so the new container reports the install outcome
+  // back to chat. SDK plugin_install events fire at session init; we want
+  // the agent to verify and report success/failure to the user.
+  writeSessionMessage(session.agent_group_id, session.id, {
+    id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    kind: 'chat',
+    timestamp: new Date().toISOString(),
+    platformId: session.agent_group_id,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({
+      text: `Plugin "${pluginSpec}" install ${result.marketplaceAdded ? '+ marketplace registration ' : ''}applied. Container restarting. On next message, check whether the plugin's tools/skills appear in your context — if a plugin_install:failed log line was emitted, surface the error to the user.`,
+      sender: 'system',
+      senderId: 'system',
+    }),
+    processAfter: new Date(Date.now() + 5000)
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, ''),
+  });
+};
+
+export const applyUninstallPlugin: ApprovalHandler = async ({ session, payload, userId, notify }) => {
+  const agentGroup = getAgentGroup(session.agent_group_id);
+  if (!agentGroup) {
+    notify('uninstall_plugin approved but agent group missing.');
+    return;
+  }
+
+  const pluginSpec = payload.plugin_spec as string;
+  let result;
+  try {
+    result = await uninstallPlugin(agentGroup.folder, pluginSpec);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    notify(`uninstall_plugin failed: ${msg}`);
+    log.error('uninstall_plugin apply error', { agentGroupId: session.agent_group_id, err });
+    return;
+  }
+
+  if (!result.wasDisabled) {
+    notify(`Plugin "${pluginSpec}" was not enabled. No change.`);
+    return;
+  }
+
+  log.info('Plugin uninstall approved', { agentGroupId: session.agent_group_id, userId, pluginSpec });
+  killContainer(session.id, 'uninstall_plugin applied');
+  notify(`Plugin "${pluginSpec}" disabled. Your container will restart with the new config on the next message.`);
 };
 
 export const applyAddMcpServer: ApprovalHandler = async ({ session, payload, userId, notify }) => {

--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -24,7 +24,7 @@ export const applyInstallPackages: ApprovalHandler = async ({ session, payload, 
     notify('install_packages approved but agent group missing.');
     return;
   }
-  updateContainerConfig(agentGroup.folder, (cfg) => {
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
     if (payload.apt) cfg.packages.apt.push(...(payload.apt as string[]));
     if (payload.npm) cfg.packages.npm.push(...(payload.npm as string[]));
   });
@@ -71,7 +71,7 @@ export const applyAddMcpServer: ApprovalHandler = async ({ session, payload, use
     notify('add_mcp_server approved but agent group missing.');
     return;
   }
-  updateContainerConfig(agentGroup.folder, (cfg) => {
+  await updateContainerConfig(agentGroup.folder, (cfg) => {
     cfg.mcpServers[payload.name as string] = {
       command: payload.command as string,
       args: (payload.args as string[]) || [],

--- a/src/modules/self-mod/index.ts
+++ b/src/modules/self-mod/index.ts
@@ -28,7 +28,12 @@ registerDeliveryAction('add_mcp_server', handleAddMcpServer);
 registerDeliveryAction('install_plugin', handleInstallPlugin);
 registerDeliveryAction('uninstall_plugin', handleUninstallPlugin);
 
-registerApprovalHandler('install_packages', applyInstallPackages);
-registerApprovalHandler('add_mcp_server', applyAddMcpServer);
-registerApprovalHandler('install_plugin', applyInstallPlugin);
-registerApprovalHandler('uninstall_plugin', applyUninstallPlugin);
+// Dedupe denial loops on agent-initiated self-mods. Without this flag the
+// response handler never records a denial row on Reject, so the request-side
+// gate has nothing to find and the same approval card wakes the admin again
+// on the next agent retry. Pair with `dedupeDenials: true` in each
+// requestApproval call (src/modules/self-mod/request.ts).
+registerApprovalHandler('install_packages', applyInstallPackages, { dedupeDenials: true });
+registerApprovalHandler('add_mcp_server', applyAddMcpServer, { dedupeDenials: true });
+registerApprovalHandler('install_plugin', applyInstallPlugin, { dedupeDenials: true });
+registerApprovalHandler('uninstall_plugin', applyUninstallPlugin, { dedupeDenials: true });

--- a/src/modules/self-mod/index.ts
+++ b/src/modules/self-mod/index.ts
@@ -20,18 +20,8 @@
  */
 import { registerDeliveryAction } from '../../delivery.js';
 import { registerApprovalHandler } from '../approvals/index.js';
-import {
-  applyAddMcpServer,
-  applyInstallPackages,
-  applyInstallPlugin,
-  applyUninstallPlugin,
-} from './apply.js';
-import {
-  handleAddMcpServer,
-  handleInstallPackages,
-  handleInstallPlugin,
-  handleUninstallPlugin,
-} from './request.js';
+import { applyAddMcpServer, applyInstallPackages, applyInstallPlugin, applyUninstallPlugin } from './apply.js';
+import { handleAddMcpServer, handleInstallPackages, handleInstallPlugin, handleUninstallPlugin } from './request.js';
 
 registerDeliveryAction('install_packages', handleInstallPackages);
 registerDeliveryAction('add_mcp_server', handleAddMcpServer);

--- a/src/modules/self-mod/index.ts
+++ b/src/modules/self-mod/index.ts
@@ -20,11 +20,25 @@
  */
 import { registerDeliveryAction } from '../../delivery.js';
 import { registerApprovalHandler } from '../approvals/index.js';
-import { applyAddMcpServer, applyInstallPackages } from './apply.js';
-import { handleAddMcpServer, handleInstallPackages } from './request.js';
+import {
+  applyAddMcpServer,
+  applyInstallPackages,
+  applyInstallPlugin,
+  applyUninstallPlugin,
+} from './apply.js';
+import {
+  handleAddMcpServer,
+  handleInstallPackages,
+  handleInstallPlugin,
+  handleUninstallPlugin,
+} from './request.js';
 
 registerDeliveryAction('install_packages', handleInstallPackages);
 registerDeliveryAction('add_mcp_server', handleAddMcpServer);
+registerDeliveryAction('install_plugin', handleInstallPlugin);
+registerDeliveryAction('uninstall_plugin', handleUninstallPlugin);
 
 registerApprovalHandler('install_packages', applyInstallPackages);
 registerApprovalHandler('add_mcp_server', applyAddMcpServer);
+registerApprovalHandler('install_plugin', applyInstallPlugin);
+registerApprovalHandler('uninstall_plugin', applyUninstallPlugin);

--- a/src/modules/self-mod/request.ts
+++ b/src/modules/self-mod/request.ts
@@ -63,6 +63,72 @@ export async function handleInstallPackages(content: Record<string, unknown>, se
   });
 }
 
+export async function handleInstallPlugin(content: Record<string, unknown>, session: Session): Promise<void> {
+  const agentGroup = getAgentGroup(session.agent_group_id);
+  if (!agentGroup) {
+    notifyAgent(session, 'install_plugin failed: agent group not found.');
+    return;
+  }
+
+  const pluginSpec = content.plugin_spec as string;
+  if (!pluginSpec || !pluginSpec.includes('@')) {
+    notifyAgent(session, 'install_plugin failed: plugin_spec must be in "name@marketplace" format.');
+    return;
+  }
+  const [, marketplace] = pluginSpec.split('@');
+  if (!marketplace) {
+    notifyAgent(session, 'install_plugin failed: marketplace name missing after "@".');
+    return;
+  }
+
+  // Validate inline source if provided. Use the same validator the operator
+  // skills use, so the same schema rules apply for agent-initiated installs.
+  let validatedSource: unknown = null;
+  if (content.source) {
+    try {
+      const { parseMarketplaceSource } = await import('../plugins/source-validator.js');
+      validatedSource = parseMarketplaceSource(content.source);
+    } catch (err) {
+      notifyAgent(session, `install_plugin failed: ${err instanceof Error ? err.message : String(err)}`);
+      log.warn('install_plugin: invalid source rejected', { spec: pluginSpec, err });
+      return;
+    }
+  }
+
+  const reason = (content.reason as string) || '';
+  const sourceDesc = validatedSource ? ` (with inline source: ${JSON.stringify(validatedSource).slice(0, 100)})` : '';
+  await requestApproval({
+    session,
+    agentName: agentGroup.name,
+    action: 'install_plugin',
+    payload: { plugin_spec: pluginSpec, source: validatedSource, reason },
+    title: 'Install Plugin Request',
+    question: `Agent "${agentGroup.name}" wants to install plugin:\n${pluginSpec}${sourceDesc}${reason ? `\nReason: ${reason}` : ''}\n\nThe plugin will be cloned and loaded by the SDK at next session start. Container will restart on approval.`,
+  });
+}
+
+export async function handleUninstallPlugin(content: Record<string, unknown>, session: Session): Promise<void> {
+  const agentGroup = getAgentGroup(session.agent_group_id);
+  if (!agentGroup) {
+    notifyAgent(session, 'uninstall_plugin failed: agent group not found.');
+    return;
+  }
+  const pluginSpec = content.plugin_spec as string;
+  if (!pluginSpec || !pluginSpec.includes('@')) {
+    notifyAgent(session, 'uninstall_plugin failed: plugin_spec must be in "name@marketplace" format.');
+    return;
+  }
+  const reason = (content.reason as string) || '';
+  await requestApproval({
+    session,
+    agentName: agentGroup.name,
+    action: 'uninstall_plugin',
+    payload: { plugin_spec: pluginSpec, reason },
+    title: 'Uninstall Plugin Request',
+    question: `Agent "${agentGroup.name}" wants to disable plugin:\n${pluginSpec}${reason ? `\nReason: ${reason}` : ''}\n\nThe marketplace registration stays so other plugins from it remain installable. Container will restart on approval.`,
+  });
+}
+
 export async function handleAddMcpServer(content: Record<string, unknown>, session: Session): Promise<void> {
   const agentGroup = getAgentGroup(session.agent_group_id);
   if (!agentGroup) {

--- a/src/modules/self-mod/request.ts
+++ b/src/modules/self-mod/request.ts
@@ -60,6 +60,7 @@ export async function handleInstallPackages(content: Record<string, unknown>, se
     payload: { apt, npm, reason },
     title: 'Install Packages Request',
     question: `Agent "${agentGroup.name}" is attempting to install a package + rebuild container:\n${packageList}${reason ? `\nReason: ${reason}` : ''}`,
+    dedupeDenials: true,
   });
 }
 
@@ -104,6 +105,7 @@ export async function handleInstallPlugin(content: Record<string, unknown>, sess
     payload: { plugin_spec: pluginSpec, source: validatedSource, reason },
     title: 'Install Plugin Request',
     question: `Agent "${agentGroup.name}" wants to install plugin:\n${pluginSpec}${sourceDesc}${reason ? `\nReason: ${reason}` : ''}\n\nThe plugin will be cloned and loaded by the SDK at next session start. Container will restart on approval.`,
+    dedupeDenials: true,
   });
 }
 
@@ -126,6 +128,7 @@ export async function handleUninstallPlugin(content: Record<string, unknown>, se
     payload: { plugin_spec: pluginSpec, reason },
     title: 'Uninstall Plugin Request',
     question: `Agent "${agentGroup.name}" wants to disable plugin:\n${pluginSpec}${reason ? `\nReason: ${reason}` : ''}\n\nThe marketplace registration stays so other plugins from it remain installable. Container will restart on approval.`,
+    dedupeDenials: true,
   });
 }
 
@@ -153,5 +156,6 @@ export async function handleAddMcpServer(content: Record<string, unknown>, sessi
     },
     title: 'Add MCP Request',
     question: `Agent "${agentGroup.name}" is attempting to add a new MCP server:\n${serverName} (${command})`,
+    dedupeDenials: true,
   });
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,15 @@ export default defineConfig({
     // container/agent-runner tests run under Bun (they depend on bun:sqlite).
     // See container/agent-runner/package.json "test" script.
     include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'scripts/**/*.test.ts'],
+    // Vitest 4 auto-discovers package.json files as workspace projects, which
+    // would pick up container/agent-runner/ (whose tests use `bun:test` and
+    // can't run under vitest). Excluding the directory keeps host-only.
+    exclude: [
+      '**/node_modules/**',
+      '**/container/**',
+      '**/data/**',
+      '**/logs/**',
+      '**/.claude/**',
+    ],
   },
 });


### PR DESCRIPTION
## Summary
Adds two self-mod actions (`install_plugin`, `uninstall_plugin`) the container agent can fire, gated by admin approval, and a generic denial cache so a rejected approval can't wake the admin again with an identical payload.

- `install_plugin` — agent requests a plugin be enabled in `container.json:plugins.enabled`. Optional inline `source` arg lets the agent register a not-yet-known marketplace atomically in the same approval round-trip.
- `uninstall_plugin` — symmetric removal. Marketplace registration stays so other plugins from it remain installable.
- `recent_denials` table (24h TTL, 7d sweep) keyed on `(agent_group_id, sha256(action + canonical_payload))`. All four self-mod actions (`install_packages`, `add_mcp_server`, `install_plugin`, `uninstall_plugin`) opt in via `dedupeDenials: true`. Subsequent identical request within TTL is suppressed at the request side — agent gets a system note instead of a fresh approval card.
- Approve path: `container.json` updated atomically through the existing advisory-locked `updateContainerConfig`; container killed for respawn on the new config; SDK clones via OneCLI proxy at next session start.
- Co-locates the operator-skill plugin libs under `src/modules/plugins/` (renamed from `scripts/lib/`) so host code can import them. Operator scripts now route through the same shared modules.

## Stacked on
This PR is stacked on **#2365** (plugins config) and **#2367** (operator skills). Please review/merge those first — the diff here will shrink from ~3100 lines (44 files) to ~650 lines (23 files) once they land. The C7-only review surface is:

- `src/modules/self-mod/{request,apply,index}.ts` — new actions
- `src/modules/approvals/{primitive,response-handler,recent-denials*}.ts` — denial cache
- `src/db/migrations/014-recent-denials.ts` — schema
- `src/host-sweep.ts` — 7d cleanup
- `container/agent-runner/src/mcp-tools/self-mod.ts` — MCP tool defs
- `src/modules/plugins/*` — relocated from `scripts/lib/` for host import
- `CLAUDE.md`, `docs/db-central.md` — docs

## Why
With #2365, plugins are configured per-group in `container.json`. C7 closes the loop so the agent itself can request a plugin install through the standard admin-approval flow:

  agent → MCP tool → admin DM card → Approve → atomic container.json update → container restart → SDK clone

The denial cache exists because the agent drives its own retries (notably `install_plugin` after a transient marketplace failure). Without dedupe a rejected request could spam the admin with the same card.

## Test plan
- [x] Host vitest suite green (374 tests, including new `recent-denials` and renamed plugin-libs tests)
- [x] `pnpm run build` clean
- [ ] Approve path verified end-to-end against a private github marketplace (agent → MCP → DM card → Approve → atomic register + enable → container restart → SDK clone via OneCLI proxy)
- [ ] Reject path verified: `recent_denials` row written, identical retry within 24h suppressed without waking admin