### PR TITLE
docs(manage-channels): warn against agent-shared with per-thread channels

### DIFF
--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -43,8 +43,8 @@ For each unwired channel:
 
 Present a multiple-choice with a contextual recommendation. The three options:
 
-- **Same conversation** (`--session-mode "agent-shared"` + existing folder) — all messages land in one session. Recommend for webhook + chat combos (GitHub + Slack).
-- **Same agent, separate conversations** (`--session-mode "shared"` + existing folder) — shared workspace/memory, independent threads. Recommend for same user across platforms.
+- **Same conversation** (`--session-mode "agent-shared"` + existing folder) — all messages land in one session. Recommend for webhook + chat combos (GitHub + Slack). **Do not use** if the agent group also has `per-thread` channels (e.g. GitHub): an active PR session will absorb incoming DMs and reply on the wrong channel.
+- **Same agent, separate conversations** (`--session-mode "shared"` + existing folder) — shared workspace/memory, independent threads. Recommend for same user across platforms (Signal DM, Telegram, etc.).
 - **Separate agent** (new `--folder`) — full isolation. Recommend when different people are involved.
 
 Use the channel's `typical-use` and `default-isolation` fields to pick the recommendation. Offer to explain more if the user is unsure — reference `docs/isolation-model.md` for the detailed explanation.


### PR DESCRIPTION
## Summary

- Adds a one-line warning to the `agent-shared` option in the isolation question: don't use it when the same agent group also has `per-thread` channels (e.g. GitHub), as an active PR session will absorb DMs and reply on the wrong channel.
- Updates the `shared` description to call out Signal DM / Telegram as the right fit.

## Test plan

- [ ] Read through and verify the guidance is accurate and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)