### PR TITLE
fix(telegram): prevent legacy Markdown parse errors from URLs and stray backticks

### DIFF
--- a/src/channels/telegram-markdown-sanitize.test.ts
+++ b/src/channels/telegram-markdown-sanitize.test.ts
@@ -58,6 +58,30 @@ describe('sanitizeTelegramLegacyMarkdown', () => {
     expect(sanitizeTelegramLegacyMarkdown('')).toBe('');
   });
 
+  it('percent-encodes underscores inside bare URLs so chat-adapter autolinks do not break', () => {
+    const input = 'see https://github.com/regent-vcs/re_gent for the code';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).toBe('see https://github.com/regent-vcs/re%5Fgent for the code');
+  });
+
+  it('keeps a paired in-text _italic_ even when a URL underscore is encoded', () => {
+    const input = '_label_ with link https://github.com/regent-vcs/re_gent';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).toBe('_label_ with link https://github.com/regent-vcs/re%5Fgent');
+  });
+
+  it('strips stray backtick that would open an unclosed Telegram code entity', () => {
+    const input = 'run the `db:migrate command';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).not.toContain('`');
+  });
+
+  it('strips stray backticks from unclosed fenced code blocks', () => {
+    const input = 'see below:\n```\nsome code without closing fence';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).not.toContain('`');
+  });
+
   it('replaces dash list bullets with • so the adapter does not re-emit `*` markers', () => {
     expect(sanitizeTelegramLegacyMarkdown('- one\n- two')).toBe('• one\n• two');
   });

--- a/src/channels/telegram-markdown-sanitize.ts
+++ b/src/channels/telegram-markdown-sanitize.ts
@@ -8,15 +8,25 @@
  * (vercel/chat PR #367 adds the knob; a follow-up is needed for the converter).
  */
 
-const CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
+const CODE_PATTERN = /```[\s\S]*?```|`[^`\n]+`/g;
 const PLACEHOLDER_PREFIX = '\x00CODE';
 const PLACEHOLDER_SUFFIX = '\x00';
+
+// Bare URLs that the chat-adapter would otherwise CommonMark-autolink into
+// `[url](url)` form. Underscores inside the resulting label become unbalanced
+// italic delimiters that Telegram's legacy Markdown parser rejects with
+// "can't parse entities: Can't find end of the entity starting at byte offset N".
+// Percent-encoding `_` to `%5F` keeps the URL clickable (clients decode it)
+// while removing the parser-confusing character.
+const URL_PATTERN = /https?:\/\/\S+/g;
 
 export function sanitizeTelegramLegacyMarkdown(input: string): string {
   if (!input) return input;
 
+  let text = input.replace(URL_PATTERN, (url) => url.replace(/_/g, '%5F'));
+
   const codeSegments: string[] = [];
-  let text = input.replace(CODE_PATTERN, (m) => {
+  text = text.replace(CODE_PATTERN, (m) => {
     codeSegments.push(m);
     return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
   });
@@ -36,10 +46,13 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
   text = text.replace(/\*\*([^*\n]+?)\*\*/g, '*$1*');
   text = text.replace(/__([^_\n]+?)__/g, '_$1_');
 
-  const starCount = (text.match(/\*/g) ?? []).length;
-  const underCount = (text.match(/_/g) ?? []).length;
-  if (starCount % 2 !== 0 || underCount % 2 !== 0) {
-    text = text.replace(/[*_]/g, '');
+  // Strip independently so an unbalanced count of one delimiter doesn't also
+  // wipe out the (balanced) formatting of the other.
+  if ((text.match(/\*/g) ?? []).length % 2 !== 0) {
+    text = text.replace(/\*/g, '');
+  }
+  if ((text.match(/_/g) ?? []).length % 2 !== 0) {
+    text = text.replace(/_/g, '');
   }
 
   const openBrackets = (text.match(/\[/g) ?? []).length;
@@ -47,6 +60,11 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
   if (openBrackets !== closeBrackets) {
     text = text.replace(/[[\]]/g, '');
   }
+
+  // Any backtick remaining after code extraction is stray — it was never part of
+  // a valid code span. Telegram's legacy Markdown parser would open a code entity
+  // at that position and never find the closing backtick, causing a parse error.
+  text = text.replace(/`/g, '');
 
   return text.replace(
     new RegExp(`${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, 'g'),


### PR DESCRIPTION
## Summary

Three related fixes to `sanitizeTelegramLegacyMarkdown` so common message patterns no longer trigger `Bad Request: can't parse entities` from Telegram's legacy Markdown parser:

- **Percent-encode `_` in bare URLs** to `%5F` before any other processing. The chat-adapter autolinks bare URLs into CommonMark `[url](url)` form; underscores in the resulting label are read as italic delimiters and trip an unbalanced-entity error. Clients still render the link correctly because they decode `%5F`.
- **Strip any backtick that survives code-span extraction.** The previous regex `` `[^`\n]*` `` matched empty `` `` `` pairs but left truly stray single backticks (e.g. `` `db:migrate ``) and unclosed fenced blocks intact, causing Telegram to open a code entity it never closed. Tightened the pattern to require ≥1 char between backticks, then stripped any leftover backtick.
- **Strip `*` and `_` independently** when one is unbalanced. Previously, an odd count of either delimiter wiped both, destroying the (balanced) formatting of the other.

## Test plan

- [x] `pnpm exec vitest run src/channels/telegram-markdown-sanitize.test.ts` — 19 passed
- [ ] Send a Telegram message containing a URL with underscores (e.g. `https://github.com/regent-vcs/re_gent`) — should deliver without 400
- [ ] Send a Telegram message with a stray/unclosed backtick (e.g. `` run the `db:migrate command ``) — should deliver without 400
- [ ] Send a message mixing a paired `_italic_` and a URL with underscores — italic should render, URL should remain clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)