### PR TITLE
[security] fix(agent-to-agent): authorize create_agent actions

### DIFF
--- a/src/modules/agent-to-agent/create-agent.test.ts
+++ b/src/modules/agent-to-agent/create-agent.test.ts
@@ -1,0 +1,140 @@
+import fs from 'fs';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../config.js')>('../../config.js');
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-create-agent/data',
+    GROUPS_DIR: '/tmp/nanoclaw-test-create-agent/groups',
+  };
+});
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+import { handleCreateAgent } from './create-agent.js';
+import { getDestinationByName } from './db/agent-destinations.js';
+import {
+  closeDb,
+  createAgentGroup,
+  createSession,
+  getAgentGroupByFolder,
+  getDb,
+  initTestDb,
+  runMigrations,
+} from '../../db/index.js';
+import { addMember } from '../permissions/db/agent-group-members.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { createUser } from '../permissions/db/users.js';
+import { initSessionFolder } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-create-agent';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedSource(agentGroupId: string): Session {
+  createAgentGroup({
+    id: agentGroupId,
+    name: agentGroupId,
+    folder: agentGroupId,
+    agent_provider: null,
+    created_at: now(),
+  });
+  const session: Session = {
+    id: `sess-${agentGroupId}`,
+    agent_group_id: agentGroupId,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: now(),
+  };
+  createSession(session);
+  initSessionFolder(agentGroupId, session.id);
+  return session;
+}
+
+function agentGroupCount(): number {
+  return (getDb().prepare('SELECT COUNT(*) AS count FROM agent_groups').get() as { count: number }).count;
+}
+
+describe('handleCreateAgent authorization', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const db = initTestDb();
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('denies create_agent from a member-only source agent without mutating groups or destinations', async () => {
+    const session = seedSource('ag-untrusted');
+    createUser({ id: 'telegram:member', kind: 'telegram', display_name: 'Member', created_at: now() });
+    addMember({ user_id: 'telegram:member', agent_group_id: 'ag-untrusted', added_by: null, added_at: now() });
+
+    await handleCreateAgent({ action: 'create_agent', requestId: 'poc', name: 'Evil Child' }, session);
+
+    expect(agentGroupCount()).toBe(1);
+    expect(getAgentGroupByFolder('evil-child')).toBeUndefined();
+    expect(getDestinationByName('ag-untrusted', 'evil-child')).toBeUndefined();
+  });
+
+  it('denies create_agent from a child group even when a global owner exists elsewhere', async () => {
+    const session = seedSource('ag-child');
+    createUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+    grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+
+    await handleCreateAgent({ action: 'create_agent', requestId: 'poc', name: 'Grandchild' }, session);
+
+    expect(agentGroupCount()).toBe(1);
+    expect(getAgentGroupByFolder('grandchild')).toBeUndefined();
+    expect(getDestinationByName('ag-child', 'grandchild')).toBeUndefined();
+  });
+
+  it('allows create_agent from a source group explicitly tied to a global owner', async () => {
+    const session = seedSource('ag-owner');
+    createUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+    grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    addMember({ user_id: 'telegram:owner', agent_group_id: 'ag-owner', added_by: null, added_at: now() });
+
+    await handleCreateAgent({ action: 'create_agent', requestId: 'ok', name: 'Trusted Child' }, session);
+
+    const child = getAgentGroupByFolder('trusted-child');
+    expect(child).toBeDefined();
+    expect(getDestinationByName('ag-owner', 'trusted-child')?.target_id).toBe(child!.id);
+    expect(getDestinationByName(child!.id, 'parent')?.target_id).toBe('ag-owner');
+  });
+
+  it('allows create_agent from a source group with a scoped admin', async () => {
+    const session = seedSource('ag-admin');
+    createUser({ id: 'telegram:admin', kind: 'telegram', display_name: 'Admin', created_at: now() });
+    grantRole({
+      user_id: 'telegram:admin',
+      role: 'admin',
+      agent_group_id: 'ag-admin',
+      granted_by: null,
+      granted_at: now(),
+    });
+
+    await handleCreateAgent({ action: 'create_agent', requestId: 'ok', name: 'Scoped Admin Child' }, session);
+
+    const child = getAgentGroupByFolder('scoped-admin-child');
+    expect(child).toBeDefined();
+    expect(getDestinationByName('ag-admin', 'scoped-admin-child')?.target_id).toBe(child!.id);
+  });
+});

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -9,6 +9,7 @@ import path from 'path';
 
 import { GROUPS_DIR } from '../../config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
 import { getSession } from '../../db/sessions.js';
 import { wakeContainer } from '../../container-runner.js';
 import { initGroupFilesystem } from '../../group-init.js';
@@ -34,6 +35,42 @@ function notifyAgent(session: Session, text: string): void {
   }
 }
 
+/**
+ * Host-side authorization for the admin-only create_agent action.
+ *
+ * The container controls outbound system messages, so hiding the MCP tool is
+ * not a security boundary. Only sessions belonging to an agent group that is
+ * currently tied to a privileged operator may create new persistent agent
+ * groups and destination ACL rows:
+ *
+ * - a scoped admin for the same agent group; or
+ * - a global owner/admin who also has an explicit membership row for this
+ *   agent group.
+ *
+ * The explicit-membership requirement prevents a compromised untrusted child
+ * from inheriting ambient global owner/admin power just because such a user
+ * exists somewhere else in the deployment.
+ */
+function canSourceCreateAgent(agentGroupId: string): boolean {
+  const row = getDb()
+    .prepare(
+      `SELECT 1
+         FROM user_roles ur
+        WHERE (ur.role = 'admin' AND ur.agent_group_id = ?)
+           OR (ur.role IN ('owner', 'admin')
+               AND ur.agent_group_id IS NULL
+               AND EXISTS (
+                 SELECT 1
+                   FROM agent_group_members m
+                  WHERE m.agent_group_id = ?
+                    AND m.user_id = ur.user_id
+               ))
+        LIMIT 1`,
+    )
+    .get(agentGroupId, agentGroupId);
+  return !!row;
+}
+
 export async function handleCreateAgent(content: Record<string, unknown>, session: Session): Promise<void> {
   const requestId = content.requestId as string;
   const name = content.name as string;
@@ -47,6 +84,16 @@ export async function handleCreateAgent(content: Record<string, unknown>, sessio
   }
 
   const localName = normalizeName(name);
+
+  if (!canSourceCreateAgent(sourceGroup.id)) {
+    notifyAgent(session, `Cannot create agent "${name}": this source agent is not authorized to create agents.`);
+    log.warn('create_agent denied: source agent group lacks admin authorization', {
+      sessionId: session.id,
+      sourceAgentGroup: sourceGroup.id,
+      name,
+    });
+    return;
+  }
 
   // Collision in the creator's destination namespace
   if (getDestinationByName(sourceGroup.id, localName)) {


### PR DESCRIPTION
## Summary

This PR hardens the host-side agent-to-agent management boundary for `create_agent` system actions.

It adds an authorization check before the host creates persistent agent groups or writes bidirectional `agent_destinations` ACL rows, and covers both denied and allowed paths with focused regression tests.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Untrusted agent session can emit a forged `create_agent` system action | Persistent agent group creation plus bidirectional agent-destination ACL mutation without an admin-owned source context | High |

## Before this PR

- The container-controlled `messages_out` database could contain `kind: "system"` messages with `action: "create_agent"`.
- `handleCreateAgent()` trusted that action and immediately created a new `agent_groups` row, initialized group filesystem state, and inserted bidirectional `agent_destinations` rows.
- The comment in the container MCP tool said the host re-checks permission, but the host-side handler did not actually enforce an admin/main/trusted source check.
- There was no regression coverage proving that member-only or child/untrusted source groups are denied.

## After this PR

- `handleCreateAgent()` now checks the source agent group before mutating host state.
- A source group may create agents only when it is tied to a privileged operator context:
  - a scoped admin for that same agent group, or
  - a global owner/admin who also has an explicit membership row for that source group.
- The explicit membership requirement prevents a compromised child/untrusted group from inheriting ambient global owner/admin authority just because such a user exists elsewhere in the deployment.
- Regression tests now lock in:
  - member-only source groups are denied;
  - child groups are denied even when a global owner exists elsewhere;
  - owner-tied source groups still work;
  - scoped-admin source groups still work.

## Why this matters

Agent containers control their outbound session database, so the presence or absence of an MCP tool in the container is not a sufficient security boundary. The trusted host must treat every outbound system action as potentially forged and re-check authorization at the point where central DB and host filesystem state are mutated.

Without this check, a less-trusted or compromised agent can create long-lived agent identities and routing ACLs, changing the topology of the deployment without an owner/admin decision.

## Attack flow

```text
Untrusted/compromised agent container
    -> writes { kind: "system", action: "create_agent" } to messages_out
        -> host delivery dispatches handleCreateAgent()
            -> host creates a persistent agent group and bidirectional ACL rows
```

## Affected code

| Issue | Files |
|-------|-------|
| Missing host-side authorization for `create_agent` | `src/modules/agent-to-agent/create-agent.ts`, `src/modules/agent-to-agent/create-agent.test.ts` |

## Root cause

Issue: untrusted agent session can create/manage new agent groups through `create_agent`

- Direct cause: `handleCreateAgent()` created agent groups and destination rows without checking whether the source session's agent group was admin/owner-tied.
- Boundary failure: the host relied on container/tool visibility comments even though the container-controlled outbound DB can forge system actions directly.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Untrusted `create_agent` system action mutates agent topology/ACLs | 8.5 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:L` |

Rationale:

- The attacker needs an existing untrusted/less-privileged agent execution context, so privileges are Low rather than None.
- The resulting impact crosses from that agent context into trusted host-managed central DB state, group filesystem initialization, and cross-agent routing ACLs.
- The proof does not claim direct host command execution or secret disclosure, so the assessment stays at High rather than Critical.

## Safe reproduction steps

1. Create a non-admin/member-only source agent group and active session in a local test database.
2. Call the real `handleCreateAgent()` with a forged system-action payload:

   ```json
   {
     "action": "create_agent",
     "requestId": "poc",
     "name": "Evil Child"
   }
   ```

3. On vulnerable code, observe that a new child `agent_groups` row is created and bidirectional `agent_destinations` rows are inserted.
4. With this PR, the same source is denied before group creation, filesystem initialization, or destination ACL mutation.

The new regression test `denies create_agent from a member-only source agent without mutating groups or destinations` covers this behavior directly.

## Expected vulnerable behavior

On vulnerable code, a non-main/untrusted source agent can create a persistent child agent and receive a new destination name for it. The child also receives a `parent` destination back to the source group, creating bidirectional agent-to-agent routing without an owner/admin authorization point.

## Changes in this PR

- Adds a host-side `canSourceCreateAgent()` guard in `handleCreateAgent()`.
- Denies unauthorized source groups before collision checks, folder creation, DB inserts, filesystem initialization, or destination projection.
- Allows the intended trusted paths for:
  - source groups explicitly tied to a global owner/admin through membership; and
  - source groups with a scoped admin role.
- Adds focused Vitest coverage for denied and allowed paths.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Authorization | `src/modules/agent-to-agent/create-agent.ts` | Adds host-side authorization before `create_agent` can mutate agent groups or destinations. |
| Tests | `src/modules/agent-to-agent/create-agent.test.ts` | Adds regression coverage for untrusted/member-only denial, child-group denial, owner-tied allow, and scoped-admin allow. |

## Maintainer impact

- The patch is intentionally narrow and only changes the `create_agent` delivery-action path.
- Existing owner/admin-managed source groups can still create companion agents.
- Member-only and child/untrusted groups now fail closed with a notification instead of mutating persistent topology.
- No channel adapter, provider, scheduling, or generic delivery behavior is changed.

## Fix rationale

The durable boundary is the host-side mutation point, not the container-side tool registry. A compromised container can write outbound system messages directly, so the handler that creates `agent_groups` and `agent_destinations` must enforce the authorization decision immediately before those writes.

Requiring explicit membership for global owner/admin authority keeps normal first-agent/owner workflows working while avoiding ambient privilege inheritance for unrelated child groups.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused create-agent authorization regression tests.
- [x] Adjacent agent-to-agent routing tests.
- [x] TypeScript typecheck.
- [x] Full Vitest suite.
- [x] ESLint on touched files.
- [x] Whitespace diff check.
- [x] Local test-artifact cleanup check for NanoClaw temp/config paths.

Executed with:

```bash
corepack pnpm exec vitest run src/modules/agent-to-agent/create-agent.test.ts --reporter=verbose
corepack pnpm exec prettier --write src/modules/agent-to-agent/create-agent.ts src/modules/agent-to-agent/create-agent.test.ts
corepack pnpm exec vitest run src/modules/agent-to-agent/create-agent.test.ts src/modules/agent-to-agent/agent-route.test.ts --reporter=verbose
corepack pnpm run typecheck
git diff --check
corepack pnpm test -- --run
corepack pnpm exec eslint src/modules/agent-to-agent/create-agent.ts src/modules/agent-to-agent/create-agent.test.ts
```


## Disclosure notes

- This PR is bounded to the `create_agent` host-side authorization gap.
- It does not claim direct host command execution, credential disclosure, or a container escape.
- The fix assumes outbound system actions are container-controlled and therefore must be authorized by the host before central DB or filesystem mutation.
- No unrelated files were changed.
