### PR TITLE
fix: teach agent to use OneCLI gateway credentials after MCP server install

### DIFF
--- a/container/agent-runner/src/mcp-tools/self-mod.instructions.md
+++ b/container/agent-runner/src/mcp-tools/self-mod.instructions.md
@@ -22,4 +22,4 @@ Use **`add_mcp_server`** to add an MCP server to your configuration. Browse avai
 add_mcp_server({ name: "memory", command: "pnpm", args: ["dlx", "@modelcontextprotocol/server-memory"] })
 ```
 
-Do not ask the user to give you credentials. Credentials are managed by the user in the OneCLI agent vault. Add a "placeholder" string instead of the credential, and ask the user to add the credential to the vault. You can make a test request before the secret is added and the vault proxy will respond with the local url of the vault dashboard on the user's machine and a link to a form for adding that specific credential.
+Do not ask the user to give you credentials or tell them how to create credentials (OAuth, API keys, etc.) — NEVER fabricate credential setup instructions. Credentials are handled by the OneCLI gateway. Use `"onecli-managed"` as the placeholder value for any credential env vars or config fields. After the MCP server is installed and the container restarts, load `/onecli-gateway` for the full credential-handling flow (connect URLs, stubs, error recovery).

--- a/container/skills/onecli-gateway/instructions.md
+++ b/container/skills/onecli-gateway/instructions.md
@@ -4,4 +4,4 @@ Your HTTP requests go through the OneCLI proxy, which injects real credentials a
 
 Use any method: curl, Python, a CLI tool, whatever fits. If a tool checks for credentials locally, pass any placeholder value — the proxy replaces it with real credentials at request time.
 
-If you get a `401`/`403`/`app_not_connected`, run `/onecli-gateway` for the full error-handling flow. Never ask the user for API keys or tokens — if credentials are missing, the fix is connecting the service in OneCLI.
+If you get a `401`/`403`/`app_not_connected`, the error response contains a `connect_url` — you MUST show it to the user as a bare URL on its own line (no angle brackets, no markdown link syntax) so they can click to connect. Run `/onecli-gateway` for the full error-handling flow. Never ask the user for API keys or tokens.


### PR DESCRIPTION
  ## Summary

  - Agent was fabricating manual OAuth setup instructions after installing MCP servers (e.g. telling users to go to Google Cloud Console and create credentials)
  - Self-mod instructions now forbid fabricating credential flows and direct the agent to use `"onecli-managed"` placeholders + load `/onecli-gateway` skill post-install
  - Gateway fragment now requires showing the `connect_url` from error responses instead of vaguely saying "connect in OneCLI"

  ## Test plan

  - [x] Ask agent to install an MCP server that needs credentials (e.g. Google Workspace)
  - [x] After install + restart, verify agent does NOT fabricate OAuth setup instructions
  - [x] Trigger an `app_not_connected` error and verify agent shows the `connect_url`
  - [x] Verify agent loads `/onecli-gateway` skill for credential error handling