### PR TITLE
fix(cli): routed-with-reply-to-cli claims chat slot

### DIFF
--- a/src/channels/cli.test.ts
+++ b/src/channels/cli.test.ts
@@ -1,0 +1,145 @@
+/**
+ * CLI channel — routed-with-reply-to-cli behavior.
+ *
+ * A routed message (has `to` field) with `reply_to` pointing back to
+ * cli/local should claim the chat slot so that deliver() can reach the
+ * originating connection. Currently the routed path skips claimChatSlot(),
+ * so deliver() finds client===null and returns undefined — the reply is
+ * dropped. Task 2 fixes this; this test pins the desired behavior first.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import net from 'net';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// vi.mock must be hoisted before any regular imports that transitively load
+// the module being mocked.  DATA_DIR is resolved eagerly in config.ts so we
+// replace it here with a per-test temp dir that gets swapped in beforeEach.
+let tmpDir = '';
+
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../config.js')>('../config.js');
+  return {
+    ...actual,
+    get DATA_DIR() {
+      return tmpDir;
+    },
+  };
+});
+
+import type { InboundEvent, OutboundMessage } from './adapter.js';
+import { teardownChannelAdapters } from './channel-registry.js';
+
+describe('cli channel — routed with reply_to=cli claims chat slot', () => {
+  let captured: InboundEvent[] = [];
+  let resolveInbound: () => void = () => {};
+  let inboundCaptured: Promise<void>;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-test-'));
+    captured = [];
+    inboundCaptured = new Promise<void>((r) => {
+      resolveInbound = r;
+    });
+
+    // Import fresh cli adapter and init it.  The adapter self-registers on
+    // import so we can't re-register, but teardownChannelAdapters() in
+    // afterEach clears activeAdapters, and initChannelAdapters() re-runs
+    // setup() on every registered factory.
+    const { initChannelAdapters } = await import('./channel-registry.js');
+    // Side-effect import to ensure cli registers itself (idempotent).
+    await import('./cli.js');
+
+    await initChannelAdapters((_adapter) => ({
+      onInbound: async () => {},
+      onInboundEvent: async (event) => {
+        captured.push(event);
+        resolveInbound();
+      },
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+  });
+
+  afterEach(async () => {
+    await teardownChannelAdapters();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('delivers reply to the routed-with-reply-to-cli connection', async () => {
+    const sockPath = path.join(tmpDir, 'cli.sock');
+
+    const client = net.connect(sockPath);
+    await new Promise<void>((r, rej) => {
+      client.once('connect', () => r());
+      client.once('error', rej);
+    });
+
+    // Always close the client at the end so teardownChannelAdapters() doesn't
+    // hang waiting for the server to drain open connections.
+    try {
+      const lines: string[] = [];
+      client.on('data', (chunk) => {
+        for (const line of chunk.toString('utf8').split('\n')) {
+          if (line.trim()) lines.push(line);
+        }
+      });
+
+      // Send routed message with reply_to pointing back to cli/local.
+      client.write(
+        JSON.stringify({
+          text: 'hello',
+          to: { channelType: 'telegram', platformId: 'tg:123', threadId: null },
+          reply_to: { channelType: 'cli', platformId: 'local', threadId: null },
+        }) + '\n',
+      );
+
+      // Wait deterministically for the inbound event to reach the stub.
+      await Promise.race([
+        inboundCaptured,
+        new Promise<void>((_, rej) => setTimeout(() => rej(new Error('inbound event never captured')), 1000)),
+      ]);
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]!.replyTo).toEqual({
+        channelType: 'cli',
+        platformId: 'local',
+        threadId: null,
+      });
+
+      // Set up a deterministic promise that resolves when the reply line arrives.
+      let resolveDelivered: () => void = () => {};
+      const deliveredPromise = new Promise<void>((r) => {
+        resolveDelivered = r;
+      });
+      client.on('data', (chunk) => {
+        for (const line of chunk.toString('utf8').split('\n')) {
+          if (line.includes('"world"')) resolveDelivered();
+        }
+      });
+
+      // Now have the cli adapter deliver a response back to 'local'.
+      // With the current (broken) behaviour the chat slot was not claimed, so
+      // deliver() finds client===null and the line never arrives.
+      const { getChannelAdapter } = await import('./channel-registry.js');
+      const adapter = getChannelAdapter('cli')!;
+      await adapter.deliver('local', null, {
+        kind: 'chat',
+        content: { text: 'world' },
+      } as OutboundMessage);
+
+      // This assertion is what FAILS before Task 2's fix:
+      // the reply is silently dropped because the chat slot was never claimed.
+      await Promise.race([
+        deliveredPromise,
+        new Promise<void>((_, rej) => setTimeout(() => rej(new Error('reply never received')), 1000)),
+      ]);
+      expect(lines.some((l) => l.includes('"world"'))).toBe(true);
+    } finally {
+      client.destroy();
+      // Give the server a moment to notice the connection closed.
+      await new Promise<void>((r) => setTimeout(r, 20));
+    }
+  });
+});

--- a/src/channels/cli.ts
+++ b/src/channels/cli.ts
@@ -200,7 +200,19 @@ function createAdapter(): ChannelAdapter {
     if (to) {
       // Routed message — admin transport. Build a full InboundEvent targeting
       // `to`'s channel/platform, and let `reply_to` (if any) redirect replies.
-      // Does NOT claim the chat slot, so an active terminal chat isn't evicted.
+      // Does NOT claim the chat slot by default, so an active terminal chat
+      // isn't evicted (the reply_to=cli/local exception below is the only
+      // case where this branch claims).
+
+      // If the routed sender wants the response back on this same connection
+      // (reply_to points at cli/local), claim the chat slot so deliver() can
+      // reach this socket. Multiple concurrent claws (including any active
+      // interactive chat user) will supersede each other; single-client
+      // semantics, by design.
+      if (replyTo && replyTo.channelType === 'cli' && replyTo.platformId === PLATFORM_ID) {
+        claimChatSlot();
+      }
+
       const event: InboundEvent = {
         channelType: to.channelType,
         platformId: to.platformId,


### PR DESCRIPTION
## Summary

The CLI channel adapter (`src/channels/cli.ts`) currently has a small hole that prevents one-shot CLI tools from receiving the agent's reply on the same connection.

When a client sends a routed message with `reply_to` pointing back at `cli/local` (`{text, to: <some-channel-mg>, reply_to: {channelType:"cli", platformId:"local", threadId:null}}`), the router correctly stamps the inbound row's delivery address with `reply_to`, and the agent's reply is dispatched to the `cli` adapter's `deliver()`. But `deliver()` writes to the single `client` slot, and routed (`to`-bearing) connections currently never claim that slot. The reply hits `if (!client) return;` and is silently dropped.

The plain-chat path is unchanged. Routed-without-reply-to and routed-with-reply-to-elsewhere (e.g. admin transports pushing to Telegram, where the reply is supposed to go to the Telegram chat, not the operator's terminal) also stay unchanged. The new behavior only fires when the routed sender explicitly asks for the response back on `cli/local`.

This unlocks one-shot CLI clients that send a routed message and read the reply on the same connection (for example, a future TUI that opens a connection per send). Multiple concurrent claimants supersede each other (single-client semantics, by design, matches the existing chat-slot model).

## Changes

- `src/channels/cli.ts`: in the `if (to)` branch of `handleLine`, claim the chat slot when `replyTo.channelType === 'cli'` and `replyTo.platformId === PLATFORM_ID`. Existing comment block updated to acknowledge the exception.
- `src/channels/cli.test.ts` (new): one vitest test that pins the contract. Sets up the cli adapter with a stubbed `onInboundEvent`, opens a Unix-socket client, sends a routed-with-reply-to-cli frame, verifies the inbound event carries the right `replyTo`, then calls `adapter.deliver('local', null, ...)` and asserts the response reaches the client. Uses deterministic Promise-based waits with 1s timeout guards.

## Test plan

- [x] vitest run src/channels/cli.test.ts (1 test passes)
- [x] full pnpm test suite green (41 files / 427 tests, no regressions)
- [x] verified manually that plain chat.ts interactive sessions still work
- [x] verified manually that routed-without-reply-to (e.g. admin transport pushing to a Telegram chat) does not claim the slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)