### PR TITLE
fix(container): make claude binary resolvable from agent-runner

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -90,7 +90,7 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 #     binary (linux-arm64 variant on our image). Without the allowlist
 #     the SDK fails at spawn time with "native binary not found".
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -275,7 +275,7 @@ export class ClaudeProvider implements AgentProvider {
         cwd: input.cwd,
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,
-        pathToClaudeCodeExecutable: '/pnpm/claude',
+        pathToClaudeCodeExecutable: '/pnpm/bin/claude',
         systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
         allowedTools: TOOL_ALLOWLIST,
         disallowedTools: SDK_DISALLOWED_TOOLS,


### PR DESCRIPTION
## Summary

Setup with the default Claude provider currently fails on the first message with:

```
Error: Claude Code native binary not found at /pnpm/claude.
Please ensure Claude Code is installed via native installer or
specify a valid path with options.pathToClaudeCodeExecutable.
```

Two changes together fix it:

1. **`container/Dockerfile`** — `PATH="$PNPM_HOME:$PATH"` pointed at `/pnpm`, but pnpm-global installs binaries to `$PNPM_HOME/bin`. Now `PATH="$PNPM_HOME/bin:$PATH"`.
2. **`container/agent-runner/src/providers/claude.ts`** — `pathToClaudeCodeExecutable` was hardcoded to `/pnpm/claude`, which bypasses PATH entirely. Now `/pnpm/bin/claude`, the actual location pnpm installs to.

Either change alone is insufficient: the agent-runner's hardcoded path wins over PATH, and the Dockerfile-only fix would still leave the SDK pointed at a non-existent file. Both are required.

## Test plan
- [ ] `./container/build.sh` succeeds.
- [ ] `docker run --rm --entrypoint /bin/sh nanoclaw-agent-v2-<slug>:latest -c 'which claude'` returns `/pnpm/bin/claude`.
- [ ] Sending a message in a wired channel produces an agent reply with no `native binary not found` entry in `logs/nanoclaw.error.log`.