### PR TITLE
docs: update CONTRIBUTING.md repo references after nanocoai migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 1. **Check for existing work.** Search open PRs and issues before starting:
    ```bash
-   gh pr list --repo qwibitai/nanoclaw --search "<your feature>"
-   gh issue list --repo qwibitai/nanoclaw --search "<your feature>"
+   gh pr list --repo nanocoai/nanoclaw --search "<your feature>"
+   gh issue list --repo nanocoai/nanoclaw --search "<your feature>"
    ```
    If a related PR or issue exists, build on it rather than duplicating effort.
 
@@ -43,7 +43,7 @@ Add capabilities to NanoClaw by merging a git branch. The SKILL.md contains setu
 3. Claude walks through interactive setup (env vars, bot creation, etc.)
 
 **Contributing a feature skill:**
-1. Fork `qwibitai/nanoclaw` and branch from `main`
+1. Fork `nanocoai/nanoclaw` and branch from `main`
 2. Make the code changes (new files, modified source, updated `package.json`, etc.)
 3. Add a SKILL.md in `.claude/skills/<name>/` with setup instructions — step 1 should be merging the branch
 4. Open a PR. We'll create the `skill/<name>` branch from your work


### PR DESCRIPTION
The CONTRIBUTING.md "Before You Start" example commands and the feature-skill fork instructions still point to the pre-migration `qwibitai/nanoclaw` URL. Updating three references to `nanocoai/nanoclaw` so new contributors copy-pasting the example `gh` commands hit the live repo directly instead of relying on GitHub's redirect.

## Changes

Three string replacements in `CONTRIBUTING.md`:
- L7: `gh pr list --repo qwibitai/nanoclaw ...` → `nanocoai/nanoclaw`
- L8: `gh issue list --repo qwibitai/nanoclaw ...` → `nanocoai/nanoclaw`
- L46: `Fork \`qwibitai/nanoclaw\` and branch from \`main\`` → `nanocoai/nanoclaw`

## Scope note

A repo-wide code search finds ~25 files with `qwibitai/nanoclaw` references (README, CHANGELOG, docs, container/agent-runner code, several skill SKILL.md files). Per the "one thing per PR" rule in CONTRIBUTING.md itself, this PR is intentionally limited to the contributing guide — the place where a stale URL most directly impacts new contributors. Happy to follow up with separate focused PRs (or a single coordinated sweep) for the rest if maintainers prefer.