### PR TITLE
fix(ci): workflows no-op after repo rename — update repository guards

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-version:
-    if: github.repository == 'qwibitai/nanoclaw'
+    if: github.repository == 'nanocoai/nanoclaw'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-tokens:
-    if: github.repository == 'qwibitai/nanoclaw'
+    if: github.repository == 'nanocoai/nanoclaw'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

After the `qwibitai/nanoclaw` → `nanocoai/nanoclaw` rename, both workflows still have:

```yaml
if: github.repository == 'qwibitai/nanoclaw'
```

`github.repository` evaluates to `nanocoai/nanoclaw` on the live repo, so the guard is **false** and both jobs silently no-op on every push and dispatch. The workflows still appear in the Actions tab and show "Success" because the job is *skipped entirely* — there's no visible failure to alert anyone.

This PR replaces the literal in both guards with `nanocoai/nanoclaw`.

### Files

- **EDIT** `.github/workflows/bump-version.yml` — guard literal updated (one-line change)
- **EDIT** `.github/workflows/update-tokens.yml` — same one-line change

### Why a guard at all?

The guard prevents these workflows from running on forks — which would fail on missing secrets (`APP_ID`, `APP_PRIVATE_KEY`) or, worse, attempt to push back to a maintainer's fork. Now that the canonical repo has moved, the guard needs to track it.

## Testing

- [ ] Merge, then push a no-op commit (or dispatch `update-tokens` via the Actions tab) and confirm the job runs to completion instead of being skipped.
- [ ] Confirm forks still see the job skipped (no accidental runs on contributor forks).
