### PR TITLE
skill(x-integration): port to v2 + open to Linux + full feature parity (25 tools)

### DIFF
--- a/.claude/skills/x-integration/SKILL.md
+++ b/.claude/skills/x-integration/SKILL.md
@@ -1,417 +1,289 @@
 ---
 name: x-integration
-description: X (Twitter) integration for NanoClaw. Post tweets, like, reply, retweet, and quote. Use for setup, testing, or troubleshooting X functionality. Triggers on "setup x", "x integration", "twitter", "post tweet", "tweet".
+description: Read, post, and engage with X (Twitter) via your real Chromium-based browser. Triggers on "setup x", "x integration", "twitter", "post tweet", "tweet", "dm", "export bookmarks".
 ---
 
 # X (Twitter) Integration
 
-Browser automation for X interactions via WhatsApp.
+MCP tools that automate every common X action through *your real browser* (Chrome, Brave, or Chromium — whichever you have installed). Drives the user's logged-in profile so X's bot detection sees a normal session. Channel-agnostic: works with whatever channel adapter you have wired (Signal, Discord, Slack, etc.).
 
-> **Compatibility:** NanoClaw v1.0.0. Directory structure may change in future versions.
+> **Compatibility:** NanoClaw v2. Cross-platform: macOS and Linux.
+>
+> **Delete safety:** `x_delete_tweet` requires the caller to pass a substring of the tweet body as `text_must_match`. The host script reads the live tweet first and refuses to delete unless the substring is present — guards against URL hallucinations and copy-paste mistakes without adding an approval gate.
 
-## Features
+## Tool catalog
 
-| Action | Tool | Description |
-|--------|------|-------------|
-| Post | `x_post` | Publish new tweets |
-| Like | `x_like` | Like any tweet |
-| Reply | `x_reply` | Reply to tweets |
-| Retweet | `x_retweet` | Retweet without comment |
-| Quote | `x_quote` | Quote tweet with comment |
+### Read (8)
+| Tool | Args | What it does |
+|------|------|--------------|
+| `x_read_tweet` | `tweet_url` | Fetch a single tweet (text, author, timestamp, image alt-text, engagement counts). The "what do you think of this link" workflow. |
+| `x_read_thread` | `tweet_url`, `limit?` | Tweet plus its replies. For summarizing discussions. |
+| `x_read_user` | `handle`, `limit?` | A user's recent tweets. "What's @foo been saying lately." |
+| `x_read_bookmarks` | `limit?` (≤100), `cursor?` | Your bookmarked tweets, newest first. To walk full history, chain calls: pass back the `NEXT_CURSOR` value emitted in each response as `cursor` until no more cursor returned. Higher cap than other read tools (100 vs 50) because each paginated call re-scrolls past prior items. |
+| `x_read_list` | `list_url`, `limit?` | Tweets in any X list. "What's on Robert Scoble's AI list." |
+| `x_read_timeline` | `limit?` | Your home timeline (For You / Following). |
+| `x_read_notifications` | `limit?` | Your mentions/replies feed. |
+| `x_search` | `query`, `latest?`, `limit?` | Search X for tweets. |
+
+### Compose (3) — with optional media + native scheduling
+| Tool | Args | What it does |
+|------|------|--------------|
+| `x_post` | `content`, `media?[]`, `schedule_at?` | Post a tweet. Optionally attach up to 4 images. Optionally `schedule_at` (ISO 8601 with timezone) — uses X's native scheduler so the tweet sits in X's queue regardless of NanoClaw uptime. |
+| `x_reply` | `tweet_url`, `content`, `media?[]`, `schedule_at?` | Reply to a tweet. Same media + schedule support. |
+| `x_quote` | `tweet_url`, `comment`, `media?[]`, `schedule_at?` | Quote-tweet with a comment. Same media + schedule support. |
+
+### Engagement (9) — toggles + delete
+| Tool | Args |
+|------|------|
+| `x_like` / `x_unlike` | `tweet_url` |
+| `x_retweet` / `x_unretweet` | `tweet_url` |
+| `x_bookmark` / `x_unbookmark` | `tweet_url` |
+| `x_follow` / `x_unfollow` | `handle` |
+| `x_delete_tweet` | `tweet_url`, `text_must_match` (≥5-char substring of tweet body — safety guard) |
+
+### Scheduling queue (2)
+| Tool | Args | What it does |
+|------|------|--------------|
+| `x_list_scheduled` | — | List your pending scheduled tweets in X's queue. |
+| `x_cancel_scheduled` | `index?` or `text_match?` | Cancel a scheduled tweet. Pass the 1-based index from `x_list_scheduled` or a substring of the body. |
+
+### DMs (3)
+| Tool | Args | What it does |
+|------|------|--------------|
+| `x_read_dm_inbox` | `limit?` | List of DM conversations (handles, unread state, last-message preview). Does **not** mark anything read. |
+| `x_read_dm_thread` | `handle`, `limit?` | Messages in one DM conversation. **CAVEAT:** opens the thread, which marks unread messages as read on X. Unavoidable. Don't call casually on threads with unread context the user wants to see fresh. |
+| `x_send_dm` | `handle`, `content` | Send a DM to a single user. |
+
+### Bulk export (1)
+| Tool | Args | What it does |
+|------|------|--------------|
+| `x_export_bookmarks` | `reset?` | Resumable bulk-dump of all bookmarks to CSV at `/workspace/group/captures/bookmarks.csv`. Each call scrolls for ~75 seconds (well under the 120s host script timeout) and appends new rows; a sidecar `.progress.json` file records the last exported tweet ID. For users with thousands of bookmarks, the agent calls this in a loop until the response says "End of bookmarks reached." Pass `reset=true` to truncate the CSV and start fresh. CSV columns: `id, url, author_handle, author_name, timestamp, text, image_alt_texts, likes, retweets, replies, is_reply, is_retweet`. RFC 4180 quoting. |
+
+## How it works
+
+| Layer | Where | What |
+|-------|-------|------|
+| Container MCP tool | `container/agent-runner/src/mcp-tools/x-integration.ts` | Each tool writes a `kind:'system'` row to `messages_out` with `{ action, requestId, ...args }` and returns immediately ("submitted; result will arrive shortly"). |
+| Host delivery action | `src/modules/x-integration/index.ts` | `registerDeliveryAction('x_*', …)` for 24 actions. Each handler routes through `pacedRun()` (a single host-process Promise chain that enforces a **10-second floor between any two X actions** — protects the account from anti-spam tripping). Then spawns the matching `scripts/<name>.ts` via `tsx`, awaits exit, calls `notifyAgent(session, result)` to write the outcome back into `inbound.db` (which also wakes the container). |
+| Browser scripts | `.claude/skills/x-integration/scripts/<name>.ts` | Playwright + your persistent browser profile at `data/x-browser-profile/`. Reads JSON from stdin, writes a `ScriptResult` JSON line to stdout. |
+| DOM glue | `lib/locators.ts`, `lib/extract.ts` | Every CSS / data-testid selector AND every tweet/profile/DM parser is centralized. When X breaks something, *that's* the only place to update. |
+
+The agent UX is async: one "submitted" reply, then a follow-up message ~10–60s later with the result. This is the v2 idiom (no sync request-response on system actions).
 
 ## Prerequisites
 
-Before using this skill, ensure:
+1. **A Chromium-based browser** on the host. Bundled Chromium does **not** work — X bot-detection blocks it.
+   - **Linux:** `command -v google-chrome-stable google-chrome chromium-browser chromium brave-browser` should return a path. If not:
+     - Chrome: `sudo apt install google-chrome-stable`
+     - Brave: add the Brave repo, then `sudo apt install brave-browser`
+     - Chromium: `sudo apt install chromium-browser`
+   - **macOS:** `mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'" | head -1` (or `com.brave.Browser` for Brave). If not, install from <https://www.google.com/chrome/> or <https://brave.com/download/>.
+   - **Pin a specific browser:** `CHROME_PATH=/usr/bin/brave-browser` in `.env` overrides auto-detection.
+2. **Desktop session** for the one-time interactive login (`DISPLAY=:1` or similar). Truly headless servers: run setup on a workstation and rsync `data/x-browser-profile/` to the server.
+3. **NanoClaw v2** with the host running and channel adapter wired.
 
-1. **NanoClaw is installed and running** - WhatsApp connected, service active
-2. **Dependencies installed**:
-   ```bash
-   pnpm ls playwright dotenv-cli || pnpm install playwright dotenv-cli
-   ```
-3. **CHROME_PATH configured** in `.env` (if Chrome is not at default location):
-   ```bash
-   # Find your Chrome path
-   mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'" 2>/dev/null | head -1
-   # Add to .env
-   CHROME_PATH=/path/to/Google Chrome.app/Contents/MacOS/Google Chrome
-   ```
+## Install
 
-## Quick Start
+All paths relative to NanoClaw repo root.
 
-```bash
-# 1. Setup authentication (interactive)
-pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
-# Verify: data/x-auth.json should exist after successful login
-
-# 2. Rebuild container to include skill
-./container/build.sh
-# Verify: Output shows "COPY .claude/skills/x-integration/agent.ts"
-
-# 3. Rebuild host and restart service
-pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
-# Verify: launchctl list | grep nanoclaw (macOS) or systemctl --user status nanoclaw (Linux)
-```
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CHROME_PATH` | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | Chrome executable path |
-| `NANOCLAW_ROOT` | `process.cwd()` | Project root directory |
-| `LOG_LEVEL` | `info` | Logging level (debug, info, warn, error) |
-
-Set in `.env` file (loaded via `dotenv-cli` at runtime):
+### 1. Verify a browser
 
 ```bash
-# .env
-CHROME_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+# Linux
+command -v google-chrome-stable google-chrome chromium-browser chromium brave-browser
+
+# macOS
+mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'" | head -1
+mdfind "kMDItemCFBundleIdentifier == 'com.brave.Browser'" | head -1
 ```
 
-### Configuration File
+### 2. Install host dep
 
-Edit `lib/config.ts` to modify defaults:
+The skill uses `playwright-core` (not `playwright`) — we point `executablePath` at your real browser, so the bundled-browser auto-download is wasted bandwidth.
 
-```typescript
-export const config = {
-    // Browser viewport
-    viewport: { width: 1280, height: 800 },
-
-    // Timeouts (milliseconds)
-    timeouts: {
-        navigation: 30000,    // Page navigation
-        elementWait: 5000,    // Wait for element
-        afterClick: 1000,     // Delay after click
-        afterFill: 1000,      // Delay after form fill
-        afterSubmit: 3000,    // Delay after submit
-        pageLoad: 3000,       // Initial page load
-    },
-
-    // Tweet limits
-    limits: {
-        tweetMaxLength: 280,
-    },
-};
-```
-
-### Data Directories
-
-Paths relative to project root:
-
-| Path | Purpose | Git |
-|------|---------|-----|
-| `data/x-browser-profile/` | Chrome profile with X session | Ignored |
-| `data/x-auth.json` | Auth state marker | Ignored |
-| `logs/nanoclaw.log` | Service logs (contains X operation logs) | Ignored |
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Container (Linux VM)                                       │
-│  └── agent.ts → MCP tool definitions (x_post, etc.)    │
-│      └── Writes IPC request to /workspace/ipc/tasks/       │
-└──────────────────────┬──────────────────────────────────────┘
-                       │ IPC (file system)
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  Host (macOS)                                               │
-│  └── src/ipc.ts → processTaskIpc()                         │
-│      └── host.ts → handleXIpc()                         │
-│          └── spawn subprocess → scripts/*.ts               │
-│              └── Playwright → Chrome → X Website           │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Why This Design?
-
-- **API is expensive** - X official API requires paid subscription ($100+/month) for posting
-- **Bot browsers get blocked** - X detects and bans headless browsers and common automation fingerprints
-- **Must use user's real browser** - Reuses the user's actual Chrome on Host with real browser fingerprint to avoid detection
-- **One-time authorization** - User logs in manually once, session persists in Chrome profile for future use
-
-### File Structure
-
-```
-.claude/skills/x-integration/
-├── SKILL.md          # This documentation
-├── host.ts           # Host-side IPC handler
-├── agent.ts          # Container-side MCP tool definitions
-├── lib/
-│   ├── config.ts     # Centralized configuration
-│   └── browser.ts    # Playwright utilities
-└── scripts/
-    ├── setup.ts      # Interactive login
-    ├── post.ts       # Post tweet
-    ├── like.ts       # Like tweet
-    ├── reply.ts      # Reply to tweet
-    ├── retweet.ts    # Retweet
-    └── quote.ts      # Quote tweet
-```
-
-### Integration Points
-
-To integrate this skill into NanoClaw, make the following modifications:
-
----
-
-**1. Host side: `src/ipc.ts`**
-
-Add import after other local imports:
-```typescript
-import { handleXIpc } from '../.claude/skills/x-integration/host.js';
-```
-
-Modify `processTaskIpc` function's switch statement default case:
-```typescript
-// Find:
-default:
-logger.warn({ type: data.type }, 'Unknown IPC task type');
-
-// Replace with:
-default:
-const handled = await handleXIpc(data, sourceGroup, isMain, DATA_DIR);
-if (!handled) {
-    logger.warn({ type: data.type }, 'Unknown IPC task type');
-}
-```
-
----
-
-**2. Container side: `container/agent-runner/src/ipc-mcp.ts`**
-
-Add import after `cron-parser` import:
-```typescript
-// @ts-ignore - Copied during Docker build from .claude/skills/x-integration/
-import { createXTools } from './skills/x-integration/agent.js';
-```
-
-Add to the end of tools array (before the closing `]`):
-```typescript
-    ...createXTools({ groupFolder, isMain })
-```
-
----
-
-**3. Build script: `container/build.sh`**
-
-Change build context from `container/` to project root (required to access `.claude/skills/`):
-```bash
-# Find:
-docker build -t "${IMAGE_NAME}:${TAG}" .
-
-# Replace with:
-cd "$SCRIPT_DIR/.."
-docker build -t "${IMAGE_NAME}:${TAG}" -f container/Dockerfile .
-```
-
----
-
-**4. Dockerfile: `container/Dockerfile`**
-
-First, update the build context paths (required to access `.claude/skills/` from project root):
-```dockerfile
-# Find:
-COPY agent-runner/package*.json ./
-...
-COPY agent-runner/ ./
-
-# Replace with:
-COPY container/agent-runner/package*.json ./
-...
-COPY container/agent-runner/ ./
-```
-
-Then add COPY line after `COPY container/agent-runner/ ./` and before `RUN pnpm run build`:
-```dockerfile
-# Copy skill MCP tools
-COPY .claude/skills/x-integration/agent.ts ./src/skills/x-integration/
-```
-
-## Setup
-
-All paths below are relative to project root (`NANOCLAW_ROOT`).
-
-### 1. Check Chrome Path
+Pin a version that's at least 3 days old (NanoClaw's pnpm policy: `minimumReleaseAge: 4320`):
 
 ```bash
-# Check if Chrome exists at configured path
-cat .env | grep CHROME_PATH
-ls -la "$(grep CHROME_PATH .env | cut -d= -f2)" 2>/dev/null || \
-echo "Chrome not found - update CHROME_PATH in .env"
+pnpm view playwright-core time | tail -10
+# Pick a version stamped ≥3 days ago, then:
+pnpm add playwright-core@<that-version>
 ```
 
-### 2. Run Authentication
+### 3. Install the container MCP tool
 
 ```bash
-pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
+cp .claude/skills/x-integration/agent.ts \
+   container/agent-runner/src/mcp-tools/x-integration.ts
+
+grep -q "x-integration" container/agent-runner/src/mcp-tools/index.ts \
+  || sed -i.bak "/^import { startMcpServer }/i\\
+import './x-integration.js';" container/agent-runner/src/mcp-tools/index.ts \
+  && rm -f container/agent-runner/src/mcp-tools/index.ts.bak
 ```
 
-This opens Chrome for manual X login. Session saved to `data/x-browser-profile/`.
+`/app/src` is bind-mounted RO from `container/agent-runner/src/`, so this file goes live on the next session spawn — no Docker rebuild.
 
-**Verify success:**
+### 4. Install the host module
+
 ```bash
-cat data/x-auth.json  # Should show {"authenticated": true, ...}
+mkdir -p src/modules/x-integration
+cp .claude/skills/x-integration/host.ts src/modules/x-integration/index.ts
+
+grep -q "x-integration" src/modules/index.ts \
+  || echo "import './x-integration/index.js';" >> src/modules/index.ts
 ```
 
-### 3. Rebuild Container
+### 5. Run interactive login (one-time)
+
+Opens your browser on the desktop. Log in to X. Return to terminal, press Enter. Session saves to `data/x-browser-profile/`.
 
 ```bash
-./container/build.sh
+pnpm exec tsx --env-file=.env .claude/skills/x-integration/scripts/setup.ts
 ```
 
-**Verify success:**
+Verify:
+
 ```bash
-./container/build.sh 2>&1 | grep -i "agent.ts"  # Should show COPY line
+test -f data/x-auth.json && echo "logged in" || echo "run setup again"
 ```
 
-### 4. Restart Service
+### 6. Build the host
 
 ```bash
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
 ```
 
-**Verify success:**
-```bash
-launchctl list | grep nanoclaw  # macOS — should show PID and exit code 0 or -
-# Linux: systemctl --user status nanoclaw
-```
-
-## Usage via WhatsApp
-
-Replace `@Assistant` with your configured trigger name (`ASSISTANT_NAME` in `.env`):
-
-```
-@Assistant post a tweet: Hello world!
-
-@Assistant like this tweet https://x.com/user/status/123
-
-@Assistant reply to https://x.com/user/status/123 with: Great post!
-
-@Assistant retweet https://x.com/user/status/123
-
-@Assistant quote https://x.com/user/status/123 with comment: Interesting
-```
-
-**Note:** Only the main group can use X tools. Other groups will receive an error.
-
-## Testing
-
-Scripts require environment variables from `.env`. Use `dotenv-cli` to load them:
-
-### Check Authentication Status
+### 7. Restart the service
 
 ```bash
-# Check if auth file exists and is valid
-cat data/x-auth.json 2>/dev/null && echo "Auth configured" || echo "Auth not configured"
+# Linux
+systemctl --user restart nanoclaw
 
-# Check if browser profile exists
-ls -la data/x-browser-profile/ 2>/dev/null | head -5
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
 ```
 
-### Re-authenticate (if expired)
+## Usage examples
 
-```bash
-pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
+Address your assistant by name (`ASSISTANT_NAME` in `.env`):
+
+```
+What's in my bookmarks lately?
+What do you think of https://x.com/karpathy/status/<id>?
+Summarize this thread: https://x.com/<user>/status/<id>
+What's @scoble been posting on AI?
+Search X for "noumenon" — top 10.
+
+Post a tweet: gm. Sovereignty is a daily practice.
+Reply to https://x.com/<id> with: this matches my experience.
+Like https://x.com/<id>
+Bookmark https://x.com/<id>
+Follow @karpathy
+
+Schedule this for tomorrow 9am PT: <text>
+What scheduled tweets do I have?
+Cancel scheduled tweet #2.
+
+What DMs are in my inbox?
+Read my DM thread with @<friend>.
+DM @<friend>: thanks for the link earlier.
 ```
 
-### Test Post (will actually post)
+Each command produces (a) one acknowledgment from the agent, (b) a follow-up with the result ~10–60s later.
 
-```bash
-echo '{"content":"Test tweet - please ignore"}' | pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/post.ts
-```
+## Pacing
 
-### Test Like
-
-```bash
-echo '{"tweetUrl":"https://x.com/user/status/123"}' | pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/like.ts
-```
-
-Or export `CHROME_PATH` manually before running:
-
-```bash
-export CHROME_PATH="/path/to/chrome"
-echo '{"content":"Test"}' | pnpm exec tsx .claude/skills/x-integration/scripts/post.ts
-```
+The host serializes all X actions through a 10-second-minimum mutex. If the agent fires "like 5 tweets in a row," they'll execute sequentially with at least 10s between each — which keeps your account well below X's anti-spam thresholds. Knob lives at `lib/config.ts`'s `pacing.actionDelayMs`; raise it if you ever start seeing X warnings.
 
 ## Troubleshooting
 
-### Authentication Expired
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| "No Chromium-family browser found" | None installed | Install Chrome / Brave / Chromium (see Prerequisites). |
+| "X login expired" in result | Session aged out / X forced re-auth | Re-run setup; no service restart needed. |
+| Tool returns "submitted" but no follow-up | Host delivery action not registered | Check `src/modules/index.ts` has `import './x-integration/index.js';`, ran `pnpm run build`, restarted. |
+| MCP tool not visible to agent | Container barrel not updated | Check `container/agent-runner/src/mcp-tools/index.ts` has the import; kill the agent's container — next user message respawns on new source. |
+| `SingletonLock` errors | Stale browser-profile lock | Auto-cleaned next run; if persistent: `rm data/x-browser-profile/Singleton*` |
+| Setup hangs at "Press Enter when logged in" | `DISPLAY` unset / no GUI | Run setup on a workstation, rsync `data/x-browser-profile/` to server. |
+| One specific tool returns "Could not find X" | X UI changed and that selector broke | Check `logs/x-failures/` for screenshot + DOM snapshot; update the relevant entry in `lib/locators.ts`. The selectors most likely to break first: scheduling, DM compose, scheduled-tweets queue. |
+| Bot-detection warnings on the account | Pacing too tight (shouldn't happen at 10s) | Raise `pacing.actionDelayMs` in `lib/config.ts` to 20000 or 30000; rebuild + restart. |
+
+Logs:
 
 ```bash
-pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+grep -i "x-integration\|x_post\|x_like\|x_read\|x_send_dm" logs/nanoclaw.log | tail -30
+ls -la logs/x-failures/   # screenshots + DOM dumps from script failures
 ```
 
-### Browser Lock Files
+## Privacy
 
-If Chrome fails to launch:
+DMs are sensitive. Three protections shipped:
 
-```bash
-rm -f data/x-browser-profile/SingletonLock
-rm -f data/x-browser-profile/SingletonSocket
-rm -f data/x-browser-profile/SingletonCookie
+- `x_send_dm` / `x_read_dm_inbox` / `x_read_dm_thread` log only the action + requestId, **not** message bodies, into `nanoclaw.log`.
+- `x_read_dm_inbox` does not open individual threads — read receipts only fire on `x_read_dm_thread`.
+- `x_read_dm_thread`'s tool description tells the agent that opening a thread marks unread messages as read; the agent should not call it casually.
+
+## Configuration
+
+| Knob | Where | Default |
+|------|-------|---------|
+| `CHROME_PATH` | `.env` | Auto-detected (CHROME_PATH override > Chrome > Brave > Chromium). Pin to force a specific browser. |
+| Browser profile dir | `lib/config.ts` `browserDataDir` | `data/x-browser-profile/` |
+| Auth marker file | `lib/config.ts` `authPath` | `data/x-auth.json` |
+| Tweet char limit | `lib/config.ts` `limits.tweetMaxLength` | 280 |
+| DM char limit | `lib/config.ts` `limits.dmMaxLength` | 10000 |
+| Read result cap | `lib/config.ts` `limits.readMax` | 50 |
+| Media per tweet | `lib/config.ts` `limits.mediaMaxPerTweet` | 4 |
+| **Action pacing** | `lib/config.ts` `pacing.actionDelayMs` | **10000 (10s)** |
+| Per-action timeout | `host.ts` `SCRIPT_TIMEOUT_MS` | 120s |
+| Failure dump dir | `lib/config.ts` `failureDumpDir` | `logs/x-failures/` |
+
+## File map
+
 ```
-
-### Check Logs
-
-```bash
-# Host logs (relative to project root)
-grep -i "x_post\|x_like\|x_reply\|handleXIpc" logs/nanoclaw.log | tail -20
-
-# Script errors
-grep -i "error\|failed" logs/nanoclaw.log | tail -20
-```
-
-### Script Timeout
-
-Default timeout is 2 minutes (120s). Increase in `host.ts`:
-
-```typescript
-const timer = setTimeout(() => {
-  proc.kill('SIGTERM');
-  resolve({ success: false, message: 'Script timed out (120s)' });
-}, 120000);  // ← Increase this value
-```
-
-### X UI Selector Changes
-
-If X updates their UI, selectors in scripts may break. Current selectors:
-
-| Element | Selector |
-|---------|----------|
-| Tweet input | `[data-testid="tweetTextarea_0"]` |
-| Post button | `[data-testid="tweetButtonInline"]` |
-| Reply button | `[data-testid="reply"]` |
-| Like | `[data-testid="like"]` |
-| Unlike | `[data-testid="unlike"]` |
-| Retweet | `[data-testid="retweet"]` |
-| Unretweet | `[data-testid="unretweet"]` |
-| Confirm retweet | `[data-testid="retweetConfirm"]` |
-| Modal dialog | `[role="dialog"][aria-modal="true"]` |
-| Modal submit | `[data-testid="tweetButton"]` |
-
-### Container Build Issues
-
-If MCP tools not found in container:
-
-```bash
-# Verify build copies skill
-./container/build.sh 2>&1 | grep -i skill
-
-# Check container has the file
-docker run nanoclaw-agent ls -la /app/src/skills/
+.claude/skills/x-integration/
+├── SKILL.md                  # this file
+├── agent.ts                  # template → container/agent-runner/src/mcp-tools/x-integration.ts
+├── host.ts                   # template → src/modules/x-integration/index.ts
+├── lib/
+│   ├── chrome-detect.ts      # CHROME_PATH > Chrome > Brave > Chromium > throw
+│   ├── config.ts             # config object (limits, pacing, paths)
+│   ├── browser.ts            # Playwright wrappers, ensureLoggedIn, captureFailure, runScript harness
+│   ├── locators.ts           # ALL CSS / data-testid selectors (single source of truth)
+│   └── extract.ts            # parseTweetCard, collectTweets, DM parsers, renderers
+└── scripts/
+    ├── setup.ts              # one-time interactive login
+    ├── read-tweet.ts         # x_read_tweet
+    ├── read-thread.ts        # x_read_thread
+    ├── read-user.ts          # x_read_user
+    ├── read-bookmarks.ts     # x_read_bookmarks
+    ├── read-list.ts          # x_read_list
+    ├── read-timeline.ts      # x_read_timeline
+    ├── read-notifications.ts # x_read_notifications
+    ├── search.ts             # x_search
+    ├── post.ts               # x_post (media + schedule)
+    ├── reply.ts              # x_reply (media + schedule)
+    ├── quote.ts              # x_quote (media + schedule)
+    ├── like.ts               # x_like
+    ├── unlike.ts             # x_unlike
+    ├── retweet.ts            # x_retweet
+    ├── unretweet.ts          # x_unretweet
+    ├── bookmark.ts           # x_bookmark
+    ├── unbookmark.ts         # x_unbookmark
+    ├── follow.ts             # x_follow
+    ├── unfollow.ts           # x_unfollow
+    ├── delete-tweet.ts       # x_delete_tweet (text-echo safety guard)
+    ├── list-scheduled.ts     # x_list_scheduled
+    ├── cancel-scheduled.ts   # x_cancel_scheduled
+    ├── read-dm-inbox.ts      # x_read_dm_inbox
+    ├── read-dm-thread.ts     # x_read_dm_thread
+    └── send-dm.ts            # x_send_dm
 ```
 
 ## Security
 
-- `data/x-browser-profile/` - Contains X session cookies (in `.gitignore`)
-- `data/x-auth.json` - Auth state marker (in `.gitignore`)
-- Only main group can use X tools (enforced in `agent.ts` and `host.ts`)
-- Scripts run as subprocesses with limited environment
+- `data/x-browser-profile/` and `data/x-auth.json` are gitignored — session cookies never enter version control.
+- `x_delete_tweet` is the only irreversible action with a built-in safety guard: the caller must pass a substring of the tweet body as `text_must_match`, and the host script reads the live tweet to verify the substring is present before clicking delete. This catches URL hallucinations and copy-paste mistakes without adding an approval round-trip.
+- DM bodies are redacted from `nanoclaw.log`.
+- Posting / liking / following / deleting are not approval-gated. If you want admin approval gating per action, model it as a separate skill that wraps these tools — don't add an approval flag here.
+- The MCP tools ship via the runner once installed, so all agent groups see them. Finer-grained per-group gating is a future addition.

--- a/.claude/skills/x-integration/agent.ts
+++ b/.claude/skills/x-integration/agent.ts
@@ -1,243 +1,608 @@
 /**
- * X Integration - MCP Tool Definitions (Agent/Container Side)
+ * X-integration MCP tools (container side, NanoClaw v2).
  *
- * These tools run inside the container and communicate with the host via IPC.
- * The host-side implementation is in host.ts.
+ * 25 tools total, in six families:
+ *   - Read (8):    x_read_tweet, x_read_thread, x_read_user,
+ *                  x_read_bookmarks, x_read_list, x_read_timeline,
+ *                  x_read_notifications, x_search
+ *   - Compose (3): x_post, x_reply, x_quote (with media + schedule_at)
+ *   - Engage (9): x_like / x_unlike, x_retweet / x_unretweet,
+ *                  x_bookmark / x_unbookmark, x_follow / x_unfollow,
+ *                  x_delete_tweet (text-echo guard, see below)
+ *   - Schedule (2): x_list_scheduled, x_cancel_scheduled
+ *   - DM (3):     x_read_dm_inbox, x_read_dm_thread, x_send_dm
+ *   - Bulk (1):   x_export_bookmarks (resumable CSV dump)
  *
- * Note: This file is compiled in the container, not on the host.
- * The @ts-ignore is needed because the SDK is only available in the container.
+ * Safety on x_delete_tweet: tool requires a `text_must_match` substring of
+ * the tweet body. The host script reads the live tweet and refuses to
+ * delete unless the substring is present. Guards against URL hallucinations
+ * and copy-paste errors. No approval gate — consistent with the skill's
+ * stance ("don't gate per action; wrap if you want approvals").
+ *
+ * Mechanism (mirrors mcp-tools/self-mod.ts): every tool writes a
+ * kind:'system' row with content = JSON.stringify({action, requestId,
+ * ...args}) and returns immediately. The host runs the action
+ * asynchronously and notifies the agent with the result via
+ * notifyAgent() → kind:'chat' row in inbound.db (which also wakes the
+ * container, so the result lands on the next turn).
+ *
+ * Imports below are written for the install destination
+ * container/agent-runner/src/mcp-tools/x-integration.ts.
  */
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { writeMessageOut } from '../db/messages-out.js';
+import { registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
 
-// @ts-ignore - SDK available in container environment only
-import { tool } from '@anthropic-ai/claude-agent-sdk';
-import { z } from 'zod';
-import fs from 'fs';
-import path from 'path';
+const TWEET_MAX = 280;
+const DM_MAX = 10000;
+const READ_MAX = 50;
+/** Higher cap for x_read_bookmarks: paginated walks pay a fixed
+ *  re-scroll cost per call, so larger batches amortize better. */
+const BOOKMARKS_READ_MAX = 100;
+const MEDIA_MAX = 4;
 
-// IPC directories (inside container)
-const IPC_DIR = '/workspace/ipc';
-const TASKS_DIR = path.join(IPC_DIR, 'tasks');
-const RESULTS_DIR = path.join(IPC_DIR, 'x_results');
-
-function writeIpcFile(dir: string, data: object): string {
-  fs.mkdirSync(dir, { recursive: true });
-  const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`;
-  const filepath = path.join(dir, filename);
-  const tempPath = `${filepath}.tmp`;
-  fs.writeFileSync(tempPath, JSON.stringify(data, null, 2));
-  fs.renameSync(tempPath, filepath);
-  return filename;
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-async function waitForResult(requestId: string, maxWait = 60000): Promise<{ success: boolean; message: string }> {
-  const resultFile = path.join(RESULTS_DIR, `${requestId}.json`);
-  const pollInterval = 1000;
-  let elapsed = 0;
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
 
-  while (elapsed < maxWait) {
-    if (fs.existsSync(resultFile)) {
-      try {
-        const result = JSON.parse(fs.readFileSync(resultFile, 'utf-8'));
-        fs.unlinkSync(resultFile);
-        return result;
-      } catch (err) {
-        return { success: false, message: `Failed to read result: ${err}` };
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+// ── Factory ──────────────────────────────────────────────────
+
+interface XToolSpec {
+  /** Tool name as the agent sees it. */
+  name: string;
+  /** Tool description for the agent. */
+  description: string;
+  /** Raw JSON-Schema (matches mcp-tools/self-mod.ts shape — no zod). */
+  inputSchema: Tool['inputSchema'];
+  /** Action key — must match a registerDeliveryAction() in host.ts. */
+  action: string;
+  /** Pre-flight validation. Return error message string OR null if ok. */
+  validate?: (args: Record<string, unknown>) => string | null;
+  /** Map raw args → outbound-message payload. Defaults to identity. */
+  buildPayload?: (args: Record<string, unknown>) => Record<string, unknown>;
+  /** Override the "submitted" reply text. */
+  submittedMessage?: string;
+}
+
+function makeXTool(spec: XToolSpec): McpToolDefinition {
+  return {
+    tool: {
+      name: spec.name,
+      description: spec.description,
+      inputSchema: spec.inputSchema,
+    },
+    async handler(args) {
+      if (spec.validate) {
+        const validationError = spec.validate(args);
+        if (validationError) return err(validationError);
+      }
+      const requestId = generateId(spec.name);
+      const payload = spec.buildPayload ? spec.buildPayload(args) : args;
+      writeMessageOut({
+        id: requestId,
+        kind: 'system',
+        content: JSON.stringify({ action: spec.action, requestId, ...payload }),
+      });
+      log(`${spec.name}: ${requestId}`);
+      return ok(spec.submittedMessage ?? `${spec.name} submitted; result will arrive in a follow-up message.`);
+    },
+  };
+}
+
+// ── Common validators ───────────────────────────────────────
+
+function requireTweetUrl(args: Record<string, unknown>): string | null {
+  if (!args.tweet_url) return 'tweet_url is required.';
+  return null;
+}
+
+function requireHandle(args: Record<string, unknown>): string | null {
+  if (!args.handle) return 'handle is required.';
+  return null;
+}
+
+function validateLimit(args: Record<string, unknown>): string | null {
+  if (args.limit !== undefined) {
+    const n = args.limit as number;
+    if (!Number.isInteger(n) || n < 1 || n > READ_MAX) {
+      return `limit must be an integer between 1 and ${READ_MAX}.`;
+    }
+  }
+  return null;
+}
+
+function validateTweetText(args: Record<string, unknown>, field: string, label: string): string | null {
+  const text = args[field] as string | undefined;
+  if (!text || text.length === 0) return `${label} cannot be empty.`;
+  if (text.length > TWEET_MAX) return `${label} exceeds ${TWEET_MAX} characters (current: ${text.length}).`;
+  return null;
+}
+
+function validateMedia(args: Record<string, unknown>): string | null {
+  const media = args.media as string[] | undefined;
+  if (!media) return null;
+  if (!Array.isArray(media)) return 'media must be an array of file paths.';
+  if (media.length > MEDIA_MAX) return `media: maximum ${MEDIA_MAX} images per tweet.`;
+  for (const p of media) {
+    if (typeof p !== 'string' || p.length === 0) return 'media entries must be non-empty file paths.';
+  }
+  return null;
+}
+
+function validateScheduleAt(args: Record<string, unknown>): string | null {
+  const raw = args.schedule_at as string | undefined;
+  if (!raw) return null;
+  // Must be ISO 8601 with explicit Z or offset (no naive timestamps).
+  if (!/[zZ]$|[+\-]\d{2}:?\d{2}$/.test(raw)) {
+    return 'schedule_at must be ISO 8601 with explicit timezone (e.g., 2026-05-07T09:00:00-07:00 or 2026-05-07T16:00:00Z).';
+  }
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return `schedule_at: not a valid ISO 8601 timestamp ("${raw}").`;
+  if (d.getTime() < Date.now()) return 'schedule_at must be in the future.';
+  return null;
+}
+
+// ── Schema fragments (re-used) ──────────────────────────────
+
+const tweetUrlSchema = {
+  type: 'string',
+  description: 'Tweet URL (e.g. https://x.com/user/status/123) or raw tweet ID.',
+};
+
+const handleSchema = {
+  type: 'string',
+  description: 'X handle (with or without leading @).',
+};
+
+const limitSchema = {
+  type: 'number',
+  description: `How many items to fetch (1–${READ_MAX}, default 20).`,
+  default: 20,
+};
+
+const mediaSchema = {
+  type: 'array',
+  items: { type: 'string' },
+  description: `Optional. Up to ${MEDIA_MAX} absolute paths to image files inside the container (e.g. /workspace/agent/captures/foo.png) to attach.`,
+};
+
+const scheduleAtSchema = {
+  type: 'string',
+  description: 'Optional. ISO 8601 timestamp with explicit timezone (e.g. 2026-05-07T09:00:00-07:00). When present, the post is queued in X\'s native schedule rather than published immediately.',
+};
+
+// ── Read tools ──────────────────────────────────────────────
+
+export const xReadTweet = makeXTool({
+  name: 'x_read_tweet',
+  description: 'Fetch a single tweet (text, author, timestamp, image alt-text, engagement counts) by URL or ID. Use this for "what do you think of this link" workflows.',
+  action: 'x_read_tweet',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xReadThread = makeXTool({
+  name: 'x_read_thread',
+  description: 'Fetch a tweet plus its parent chain and top replies. Use this when summarizing a discussion.',
+  action: 'x_read_thread',
+  inputSchema: {
+    type: 'object' as const,
+    properties: { tweet_url: tweetUrlSchema, limit: limitSchema },
+    required: ['tweet_url'],
+  },
+  validate: (a) => requireTweetUrl(a) ?? validateLimit(a),
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url, limit: args.limit ?? 20 }),
+});
+
+export const xReadUser = makeXTool({
+  name: 'x_read_user',
+  description: 'Fetch a user\'s recent tweets. Use this for "what has @foo been saying lately".',
+  action: 'x_read_user',
+  inputSchema: {
+    type: 'object' as const,
+    properties: { handle: handleSchema, limit: limitSchema },
+    required: ['handle'],
+  },
+  validate: (a) => requireHandle(a) ?? validateLimit(a),
+  buildPayload: (args) => ({ handle: args.handle, limit: args.limit ?? 20 }),
+});
+
+export const xReadBookmarks = makeXTool({
+  name: 'x_read_bookmarks',
+  description: `Read the user's bookmarked tweets, newest first. Returns up to ${BOOKMARKS_READ_MAX} per call. To walk full bookmark history, call once without cursor, then repeatedly pass the NEXT_CURSOR value from each response back as the \`cursor\` argument until the response no longer contains a NEXT_CURSOR line.`,
+  action: 'x_read_bookmarks',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      limit: {
+        type: 'number',
+        description: `How many items to fetch (1–${BOOKMARKS_READ_MAX}, default 20). Larger batches amortize the per-call re-scroll cost when paginating.`,
+        default: 20,
+      },
+      cursor: {
+        type: 'string',
+        description: 'Optional. Pagination cursor (a tweet ID) returned as NEXT_CURSOR in a previous x_read_bookmarks response. The next batch picks up immediately after this tweet.',
+      },
+    },
+  },
+  validate: (a) => {
+    if (a.limit !== undefined) {
+      const n = a.limit as number;
+      if (!Number.isInteger(n) || n < 1 || n > BOOKMARKS_READ_MAX) {
+        return `limit must be an integer between 1 and ${BOOKMARKS_READ_MAX}.`;
       }
     }
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
-    elapsed += pollInterval;
-  }
+    if (a.cursor !== undefined && (typeof a.cursor !== 'string' || a.cursor.length === 0)) {
+      return 'cursor must be a non-empty string (a tweet ID from a previous NEXT_CURSOR).';
+    }
+    return null;
+  },
+  buildPayload: (args) => ({
+    limit: args.limit ?? 20,
+    cursor: typeof args.cursor === 'string' && args.cursor.length > 0 ? args.cursor : null,
+  }),
+});
 
-  return { success: false, message: 'Request timed out' };
-}
+export const xReadList = makeXTool({
+  name: 'x_read_list',
+  description: 'Read tweets in an X list (yours or anyone\'s — pass the list URL).',
+  action: 'x_read_list',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      list_url: { type: 'string', description: 'X list URL, e.g. https://x.com/i/lists/123456789.' },
+      limit: limitSchema,
+    },
+    required: ['list_url'],
+  },
+  validate: (a) => (a.list_url ? validateLimit(a) : 'list_url is required.'),
+  buildPayload: (args) => ({ listUrl: args.list_url, limit: args.limit ?? 20 }),
+});
 
-export interface SkillToolsContext {
-  groupFolder: string;
-  isMain: boolean;
-}
+export const xReadTimeline = makeXTool({
+  name: 'x_read_timeline',
+  description: 'Read the user\'s home timeline (the For You / Following feed).',
+  action: 'x_read_timeline',
+  inputSchema: { type: 'object' as const, properties: { limit: limitSchema } },
+  validate: validateLimit,
+  buildPayload: (args) => ({ limit: args.limit ?? 20 }),
+});
 
-/**
- * Create X integration MCP tools
- */
-export function createXTools(ctx: SkillToolsContext) {
-  const { groupFolder, isMain } = ctx;
+export const xReadNotifications = makeXTool({
+  name: 'x_read_notifications',
+  description: 'Read the user\'s mentions / interactions feed on X.',
+  action: 'x_read_notifications',
+  inputSchema: { type: 'object' as const, properties: { limit: limitSchema } },
+  validate: validateLimit,
+  buildPayload: (args) => ({ limit: args.limit ?? 20 }),
+});
 
-  return [
-    tool(
-      'x_post',
-      `Post a tweet to X (Twitter). Main group only.
+export const xSearch = makeXTool({
+  name: 'x_search',
+  description: 'Search X for tweets matching a query.',
+  action: 'x_search',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      query: { type: 'string', description: 'Search query.' },
+      latest: { type: 'boolean', description: 'If true, sort by Latest instead of Top. Default false.' },
+      limit: limitSchema,
+    },
+    required: ['query'],
+  },
+  validate: (a) => (a.query ? validateLimit(a) : 'query is required.'),
+  buildPayload: (args) => ({ query: args.query, latest: args.latest ?? false, limit: args.limit ?? 20 }),
+});
 
-The host machine will execute the browser automation to post the tweet.
-Make sure the content is appropriate and within X's character limit (280 chars for text).`,
-      {
-        content: z.string().max(280).describe('The tweet content to post (max 280 characters)')
+// ── Compose tools (with media + schedule) ───────────────────
+
+export const xPost = makeXTool({
+  name: 'x_post',
+  description: 'Post a tweet on X. Optional: attach images, schedule for later (X-native scheduling — survives even if NanoClaw is offline). Fire-and-forget; result arrives in a follow-up message.',
+  action: 'x_post',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      content: { type: 'string', description: `Tweet text (max ${TWEET_MAX} chars).` },
+      media: mediaSchema,
+      schedule_at: scheduleAtSchema,
+    },
+    required: ['content'],
+  },
+  validate: (a) =>
+    validateTweetText(a, 'content', 'Tweet') ?? validateMedia(a) ?? validateScheduleAt(a),
+  buildPayload: (args) => ({
+    content: args.content,
+    media: args.media ?? [],
+    scheduleAt: args.schedule_at ?? null,
+  }),
+});
+
+export const xReply = makeXTool({
+  name: 'x_reply',
+  description: 'Reply to a tweet on X. Optional media + scheduling.',
+  action: 'x_reply',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      tweet_url: tweetUrlSchema,
+      content: { type: 'string', description: `Reply text (max ${TWEET_MAX} chars).` },
+      media: mediaSchema,
+      schedule_at: scheduleAtSchema,
+    },
+    required: ['tweet_url', 'content'],
+  },
+  validate: (a) =>
+    requireTweetUrl(a) ??
+    validateTweetText(a, 'content', 'Reply') ??
+    validateMedia(a) ??
+    validateScheduleAt(a),
+  buildPayload: (args) => ({
+    tweetUrl: args.tweet_url,
+    content: args.content,
+    media: args.media ?? [],
+    scheduleAt: args.schedule_at ?? null,
+  }),
+});
+
+export const xQuote = makeXTool({
+  name: 'x_quote',
+  description: 'Quote-tweet on X with your own comment. Optional media + scheduling.',
+  action: 'x_quote',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      tweet_url: tweetUrlSchema,
+      comment: { type: 'string', description: `Quote comment (max ${TWEET_MAX} chars).` },
+      media: mediaSchema,
+      schedule_at: scheduleAtSchema,
+    },
+    required: ['tweet_url', 'comment'],
+  },
+  validate: (a) =>
+    requireTweetUrl(a) ??
+    validateTweetText(a, 'comment', 'Quote comment') ??
+    validateMedia(a) ??
+    validateScheduleAt(a),
+  buildPayload: (args) => ({
+    tweetUrl: args.tweet_url,
+    comment: args.comment,
+    media: args.media ?? [],
+    scheduleAt: args.schedule_at ?? null,
+  }),
+});
+
+// ── Engagement toggles ──────────────────────────────────────
+
+export const xLike = makeXTool({
+  name: 'x_like',
+  description: 'Like a tweet on X.',
+  action: 'x_like',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xUnlike = makeXTool({
+  name: 'x_unlike',
+  description: 'Remove your like from a tweet on X.',
+  action: 'x_unlike',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xRetweet = makeXTool({
+  name: 'x_retweet',
+  description: 'Retweet a tweet on X (no comment).',
+  action: 'x_retweet',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xUnretweet = makeXTool({
+  name: 'x_unretweet',
+  description: 'Undo your retweet of a tweet on X.',
+  action: 'x_unretweet',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xBookmark = makeXTool({
+  name: 'x_bookmark',
+  description: 'Bookmark a tweet on X.',
+  action: 'x_bookmark',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xUnbookmark = makeXTool({
+  name: 'x_unbookmark',
+  description: 'Remove a bookmark on X.',
+  action: 'x_unbookmark',
+  inputSchema: { type: 'object' as const, properties: { tweet_url: tweetUrlSchema }, required: ['tweet_url'] },
+  validate: requireTweetUrl,
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url }),
+});
+
+export const xFollow = makeXTool({
+  name: 'x_follow',
+  description: 'Follow a user on X.',
+  action: 'x_follow',
+  inputSchema: { type: 'object' as const, properties: { handle: handleSchema }, required: ['handle'] },
+  validate: requireHandle,
+  buildPayload: (args) => ({ handle: args.handle }),
+});
+
+export const xUnfollow = makeXTool({
+  name: 'x_unfollow',
+  description: 'Unfollow a user on X.',
+  action: 'x_unfollow',
+  inputSchema: { type: 'object' as const, properties: { handle: handleSchema }, required: ['handle'] },
+  validate: requireHandle,
+  buildPayload: (args) => ({ handle: args.handle }),
+});
+
+export const xDeleteTweet = makeXTool({
+  name: 'x_delete_tweet',
+  description:
+    'Irreversibly delete one of your own tweets on X. ' +
+    'REQUIRES text_must_match — a distinctive substring (≥5 chars) of the tweet body. ' +
+    'The host script reads the live tweet first and refuses to delete unless the substring is present. ' +
+    'This guards against URL hallucinations and copy-paste errors. ' +
+    'Always read the tweet (x_read_tweet) before calling delete, and pass back a phrase from it as text_must_match.',
+  action: 'x_delete_tweet',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      tweet_url: tweetUrlSchema,
+      text_must_match: {
+        type: 'string',
+        description:
+          'A distinctive substring (≥5 chars) of the tweet body. Safety guard — script will refuse to delete if not present.',
+        minLength: 5,
       },
-      async (args: { content: string }) => {
-        if (!isMain) {
-          return {
-            content: [{ type: 'text', text: 'Only the main group can post tweets.' }],
-            isError: true
-          };
-        }
+    },
+    required: ['tweet_url', 'text_must_match'],
+  },
+  validate: (args) => {
+    const url = requireTweetUrl(args);
+    if (url) return url;
+    const m = args.text_must_match;
+    if (typeof m !== 'string' || m.trim().length < 5) {
+      return 'text_must_match must be a string of at least 5 non-whitespace characters from the tweet body.';
+    }
+    return null;
+  },
+  buildPayload: (args) => ({ tweetUrl: args.tweet_url, textMustMatch: args.text_must_match }),
+});
 
-        if (args.content.length > 280) {
-          return {
-            content: [{ type: 'text', text: `Tweet exceeds 280 character limit (current: ${args.content.length})` }],
-            isError: true
-          };
-        }
+// ── Scheduling ──────────────────────────────────────────────
 
-        const requestId = `xpost-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        writeIpcFile(TASKS_DIR, {
-          type: 'x_post',
-          requestId,
-          content: args.content,
-          groupFolder,
-          timestamp: new Date().toISOString()
-        });
+export const xListScheduled = makeXTool({
+  name: 'x_list_scheduled',
+  description: 'List your pending scheduled tweets on X.',
+  action: 'x_list_scheduled',
+  inputSchema: { type: 'object' as const, properties: {} },
+});
 
-        const result = await waitForResult(requestId);
-        return {
-          content: [{ type: 'text', text: result.message }],
-          isError: !result.success
-        };
-      }
-    ),
+export const xCancelScheduled = makeXTool({
+  name: 'x_cancel_scheduled',
+  description: 'Cancel a scheduled tweet from X\'s queue. Pass the index from x_list_scheduled (1-based) or a substring of the tweet text.',
+  action: 'x_cancel_scheduled',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      index: { type: 'number', description: '1-based index from x_list_scheduled output.' },
+      text_match: { type: 'string', description: 'Substring of the scheduled tweet text. Use if you don\'t have the index.' },
+    },
+  },
+  validate: (a) => {
+    if (a.index === undefined && !a.text_match) {
+      return 'Pass either index (from x_list_scheduled) or text_match.';
+    }
+    return null;
+  },
+  buildPayload: (args) => ({ index: args.index ?? null, textMatch: args.text_match ?? null }),
+});
 
-    tool(
-      'x_like',
-      `Like a tweet on X (Twitter). Main group only.
+// ── DMs ─────────────────────────────────────────────────────
 
-Provide the tweet URL or tweet ID to like.`,
-      {
-        tweet_url: z.string().describe('The tweet URL (e.g., https://x.com/user/status/123) or tweet ID')
+export const xReadDmInbox = makeXTool({
+  name: 'x_read_dm_inbox',
+  description: 'Read the user\'s DM inbox — list of conversations with unread state and last-message preview. Does not mark anything read.',
+  action: 'x_read_dm_inbox',
+  inputSchema: { type: 'object' as const, properties: { limit: limitSchema } },
+  validate: validateLimit,
+  buildPayload: (args) => ({ limit: args.limit ?? 20 }),
+});
+
+export const xReadDmThread = makeXTool({
+  name: 'x_read_dm_thread',
+  description: 'Read messages in a single DM conversation by recipient handle. CAVEAT: opening the thread marks unread messages as read on X — this is unavoidable. Don\'t call this casually on threads with unread context the user wants to see fresh.',
+  action: 'x_read_dm_thread',
+  inputSchema: {
+    type: 'object' as const,
+    properties: { handle: handleSchema, limit: limitSchema },
+    required: ['handle'],
+  },
+  validate: (a) => requireHandle(a) ?? validateLimit(a),
+  buildPayload: (args) => ({ handle: args.handle, limit: args.limit ?? 30 }),
+});
+
+export const xSendDm = makeXTool({
+  name: 'x_send_dm',
+  description: 'Send a direct message to a single user on X by handle.',
+  action: 'x_send_dm',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      handle: handleSchema,
+      content: { type: 'string', description: `Message body (max ${DM_MAX} chars).` },
+    },
+    required: ['handle', 'content'],
+  },
+  validate: (a) => {
+    if (!a.handle) return 'handle is required.';
+    const text = a.content as string | undefined;
+    if (!text || text.length === 0) return 'content cannot be empty.';
+    if (text.length > DM_MAX) return `content exceeds ${DM_MAX} characters (current: ${text.length}).`;
+    return null;
+  },
+  buildPayload: (args) => ({ handle: args.handle, content: args.content }),
+});
+
+// ── Bulk export ─────────────────────────────────────────────
+
+export const xExportBookmarks = makeXTool({
+  name: 'x_export_bookmarks',
+  description: `Export all of the user's bookmarks to a CSV file at /workspace/group/captures/bookmarks.csv. Resumable: each call scrolls for ~75 seconds, appends new rows, and saves a progress sidecar. For users with thousands of bookmarks, call repeatedly until the response says "End of bookmarks reached." Pass reset=true to start over (truncates the CSV). After export completes, read or analyze the CSV with normal file tools.`,
+  action: 'x_export_bookmarks',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      reset: {
+        type: 'boolean',
+        description: 'If true, delete the existing CSV + progress sidecar and start fresh. Default false (resume from where the last call stopped).',
+        default: false,
       },
-      async (args: { tweet_url: string }) => {
-        if (!isMain) {
-          return {
-            content: [{ type: 'text', text: 'Only the main group can interact with X.' }],
-            isError: true
-          };
-        }
+    },
+  },
+  validate: (a) => {
+    if (a.reset !== undefined && typeof a.reset !== 'boolean') {
+      return 'reset must be a boolean.';
+    }
+    return null;
+  },
+  buildPayload: (args) => ({ reset: args.reset === true }),
+});
 
-        const requestId = `xlike-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        writeIpcFile(TASKS_DIR, {
-          type: 'x_like',
-          requestId,
-          tweetUrl: args.tweet_url,
-          groupFolder,
-          timestamp: new Date().toISOString()
-        });
+// ── Register all tools ──────────────────────────────────────
 
-        const result = await waitForResult(requestId);
-        return {
-          content: [{ type: 'text', text: result.message }],
-          isError: !result.success
-        };
-      }
-    ),
-
-    tool(
-      'x_reply',
-      `Reply to a tweet on X (Twitter). Main group only.
-
-Provide the tweet URL and your reply content.`,
-      {
-        tweet_url: z.string().describe('The tweet URL (e.g., https://x.com/user/status/123) or tweet ID'),
-        content: z.string().max(280).describe('The reply content (max 280 characters)')
-      },
-      async (args: { tweet_url: string; content: string }) => {
-        if (!isMain) {
-          return {
-            content: [{ type: 'text', text: 'Only the main group can interact with X.' }],
-            isError: true
-          };
-        }
-
-        const requestId = `xreply-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        writeIpcFile(TASKS_DIR, {
-          type: 'x_reply',
-          requestId,
-          tweetUrl: args.tweet_url,
-          content: args.content,
-          groupFolder,
-          timestamp: new Date().toISOString()
-        });
-
-        const result = await waitForResult(requestId);
-        return {
-          content: [{ type: 'text', text: result.message }],
-          isError: !result.success
-        };
-      }
-    ),
-
-    tool(
-      'x_retweet',
-      `Retweet a tweet on X (Twitter). Main group only.
-
-Provide the tweet URL to retweet.`,
-      {
-        tweet_url: z.string().describe('The tweet URL (e.g., https://x.com/user/status/123) or tweet ID')
-      },
-      async (args: { tweet_url: string }) => {
-        if (!isMain) {
-          return {
-            content: [{ type: 'text', text: 'Only the main group can interact with X.' }],
-            isError: true
-          };
-        }
-
-        const requestId = `xretweet-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        writeIpcFile(TASKS_DIR, {
-          type: 'x_retweet',
-          requestId,
-          tweetUrl: args.tweet_url,
-          groupFolder,
-          timestamp: new Date().toISOString()
-        });
-
-        const result = await waitForResult(requestId);
-        return {
-          content: [{ type: 'text', text: result.message }],
-          isError: !result.success
-        };
-      }
-    ),
-
-    tool(
-      'x_quote',
-      `Quote tweet on X (Twitter). Main group only.
-
-Retweet with your own comment added.`,
-      {
-        tweet_url: z.string().describe('The tweet URL (e.g., https://x.com/user/status/123) or tweet ID'),
-        comment: z.string().max(280).describe('Your comment for the quote tweet (max 280 characters)')
-      },
-      async (args: { tweet_url: string; comment: string }) => {
-        if (!isMain) {
-          return {
-            content: [{ type: 'text', text: 'Only the main group can interact with X.' }],
-            isError: true
-          };
-        }
-
-        const requestId = `xquote-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        writeIpcFile(TASKS_DIR, {
-          type: 'x_quote',
-          requestId,
-          tweetUrl: args.tweet_url,
-          comment: args.comment,
-          groupFolder,
-          timestamp: new Date().toISOString()
-        });
-
-        const result = await waitForResult(requestId);
-        return {
-          content: [{ type: 'text', text: result.message }],
-          isError: !result.success
-        };
-      }
-    )
-  ];
-}
+registerTools([
+  xReadTweet, xReadThread, xReadUser, xReadBookmarks, xReadList,
+  xReadTimeline, xReadNotifications, xSearch,
+  xPost, xReply, xQuote,
+  xLike, xUnlike, xRetweet, xUnretweet, xBookmark, xUnbookmark, xFollow, xUnfollow,
+  xDeleteTweet,
+  xListScheduled, xCancelScheduled,
+  xReadDmInbox, xReadDmThread, xSendDm,
+  xExportBookmarks,
+]);

--- a/.claude/skills/x-integration/host.ts
+++ b/.claude/skills/x-integration/host.ts
@@ -1,155 +1,332 @@
 /**
- * X Integration IPC Handler
+ * X-integration host module (NanoClaw v2).
  *
- * Handles all x_* IPC messages from container agents.
- * This is the entry point for X integration in the host process.
+ * Registers 24 delivery-action handlers (see agent.ts for the full
+ * tool list — read, compose, engage, schedule, DM). Each handler:
+ *   1. Validates the inbound system payload.
+ *   2. Goes through pacedRun() — a single host-process Promise chain
+ *      that enforces a 10-second floor between sequential X actions.
+ *      This is what protects the account from anti-spam tripping when
+ *      the agent fires several actions in quick succession.
+ *   3. Spawns the matching scripts/<name>.ts via tsx.
+ *   4. Calls notifyAgent(session, result) — writes the outcome back as
+ *      a kind:'chat' row in inbound.db AND wakes the container so the
+ *      result lands on the next agent turn.
+ *
+ * Defense in depth: there is intentionally NO handler for
+ * 'x_delete_tweet'. The MCP tool isn't defined, no script exists, and
+ * delivery.ts will log "Unknown system action" and drop a forged row.
+ *
+ * Imports below are written for the install destination
+ * src/modules/x-integration/index.ts.
  */
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
 
-import { spawn } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import { PROJECT_ROOT } from '../../config.js';
+import type { DeliveryActionHandler } from '../../delivery.js';
+import { registerDeliveryAction } from '../../delivery.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { notifyAgent } from '../approvals/index.js';
 
-import { logger } from '../../../src/logger.js';
+const SCRIPTS_DIR = path.join(PROJECT_ROOT, '.claude', 'skills', 'x-integration', 'scripts');
+/**
+ * Invoke tsx via its node_modules .bin shim. Avoids depending on pnpm
+ * being on PATH — important under systemd, where the unit env doesn't
+ * inherit nvm/pnpm-cli paths from the user's interactive shell.
+ */
+const TSX_BIN = path.join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const SCRIPT_TIMEOUT_MS = 120_000;
+const ACTION_DELAY_MS = 10_000;
 
-interface SkillResult {
+interface ScriptResult {
   success: boolean;
   message: string;
   data?: unknown;
 }
 
-// Run a skill script as subprocess
-async function runScript(script: string, args: object): Promise<SkillResult> {
-  const scriptPath = path.join(process.cwd(), '.claude', 'skills', 'x-integration', 'scripts', `${script}.ts`);
+// ── Pacing ──────────────────────────────────────────────────
+// Single Promise chain serializes ALL X actions across this host
+// process. Each action runs after the previous one finishes, with at
+// least ACTION_DELAY_MS between releases. Two simultaneous calls from
+// different agent turns will queue automatically. This is structurally
+// stronger than per-script sleep — sleep can't enforce delay between
+// separate subprocess invocations.
+let actionChain: Promise<void> = Promise.resolve();
 
+function pacedRun<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = actionChain;
+  let release!: () => void;
+  actionChain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return prev
+    .catch(() => {})
+    .then(() => fn())
+    .finally(() => {
+      setTimeout(release, ACTION_DELAY_MS);
+    });
+}
+
+// ── Subprocess runner ───────────────────────────────────────
+
+function runScript(scriptName: string, args: Record<string, unknown>): Promise<ScriptResult> {
+  const scriptPath = path.join(SCRIPTS_DIR, `${scriptName}.ts`);
+
+  // Prepend the running node binary's directory to PATH so tsx's shim
+  // can find `node` even when launched under systemd (which doesn't
+  // inherit nvm/pnpm/etc paths from the user's interactive shell).
+  const nodeDir = path.dirname(process.execPath);
   return new Promise((resolve) => {
-    const proc = spawn('pnpm', ['exec', 'tsx', scriptPath], {
-      cwd: process.cwd(),
-      env: { ...process.env, NANOCLAW_ROOT: process.cwd() },
-      stdio: ['pipe', 'pipe', 'pipe']
+    const proc = spawn(TSX_BIN, [scriptPath], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        NANOCLAW_ROOT: PROJECT_ROOT,
+        PATH: `${nodeDir}:${process.env.PATH || ''}`,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
 
     let stdout = '';
-    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    let stderr = '';
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
     proc.stdin.write(JSON.stringify(args));
     proc.stdin.end();
 
     const timer = setTimeout(() => {
       proc.kill('SIGTERM');
-      resolve({ success: false, message: 'Script timed out (120s)' });
-    }, 120000);
+      resolve({ success: false, message: `${scriptName}.ts timed out after ${SCRIPT_TIMEOUT_MS / 1000}s.` });
+    }, SCRIPT_TIMEOUT_MS);
 
     proc.on('close', (code) => {
       clearTimeout(timer);
       if (code !== 0) {
-        resolve({ success: false, message: `Script exited with code: ${code}` });
+        const tail = stderr.trim().split('\n').slice(-3).join(' | ').slice(0, 400);
+        resolve({
+          success: false,
+          message: `${scriptName}.ts exited with code ${code}${tail ? ` — ${tail}` : ''}.`,
+        });
         return;
       }
       try {
-        const lines = stdout.trim().split('\n');
-        resolve(JSON.parse(lines[lines.length - 1]));
-      } catch {
-        resolve({ success: false, message: `Failed to parse output: ${stdout.slice(0, 200)}` });
+        const lines = stdout.trim().split('\n').filter((l) => l.length > 0);
+        const last = lines[lines.length - 1] || '{}';
+        resolve(JSON.parse(last) as ScriptResult);
+      } catch (parseErr) {
+        resolve({
+          success: false,
+          message: `${scriptName}.ts: failed to parse output (${parseErr instanceof Error ? parseErr.message : String(parseErr)}). Tail: ${stdout.slice(-200)}`,
+        });
       }
     });
 
-    proc.on('error', (err) => {
+    proc.on('error', (spawnErr) => {
       clearTimeout(timer);
-      resolve({ success: false, message: `Failed to spawn: ${err.message}` });
+      resolve({ success: false, message: `${scriptName}.ts: failed to spawn (${spawnErr.message}).` });
     });
   });
 }
 
-// Write result to IPC results directory
-function writeResult(dataDir: string, sourceGroup: string, requestId: string, result: SkillResult): void {
-  const resultsDir = path.join(dataDir, 'ipc', sourceGroup, 'x_results');
-  fs.mkdirSync(resultsDir, { recursive: true });
-  fs.writeFileSync(path.join(resultsDir, `${requestId}.json`), JSON.stringify(result));
-}
-
-/**
- * Handle X integration IPC messages
- *
- * @returns true if message was handled, false if not an X message
- */
-export async function handleXIpc(
-  data: Record<string, unknown>,
-  sourceGroup: string,
-  isMain: boolean,
-  dataDir: string
-): Promise<boolean> {
-  const type = data.type as string;
-
-  // Only handle x_* types
-  if (!type?.startsWith('x_')) {
-    return false;
-  }
-
-  // Only main group can use X integration
-  if (!isMain) {
-    logger.warn({ sourceGroup, type }, 'X integration blocked: not main group');
-    return true;
-  }
-
-  const requestId = data.requestId as string;
-  if (!requestId) {
-    logger.warn({ type }, 'X integration blocked: missing requestId');
-    return true;
-  }
-
-  logger.info({ type, requestId }, 'Processing X request');
-
-  let result: SkillResult;
-
-  switch (type) {
-    case 'x_post':
-      if (!data.content) {
-        result = { success: false, message: 'Missing content' };
-        break;
-      }
-      result = await runScript('post', { content: data.content });
-      break;
-
-    case 'x_like':
-      if (!data.tweetUrl) {
-        result = { success: false, message: 'Missing tweetUrl' };
-        break;
-      }
-      result = await runScript('like', { tweetUrl: data.tweetUrl });
-      break;
-
-    case 'x_reply':
-      if (!data.tweetUrl || !data.content) {
-        result = { success: false, message: 'Missing tweetUrl or content' };
-        break;
-      }
-      result = await runScript('reply', { tweetUrl: data.tweetUrl, content: data.content });
-      break;
-
-    case 'x_retweet':
-      if (!data.tweetUrl) {
-        result = { success: false, message: 'Missing tweetUrl' };
-        break;
-      }
-      result = await runScript('retweet', { tweetUrl: data.tweetUrl });
-      break;
-
-    case 'x_quote':
-      if (!data.tweetUrl || !data.comment) {
-        result = { success: false, message: 'Missing tweetUrl or comment' };
-        break;
-      }
-      result = await runScript('quote', { tweetUrl: data.tweetUrl, comment: data.comment });
-      break;
-
-    default:
-      return false;
-  }
-
-  writeResult(dataDir, sourceGroup, requestId, result);
+function notify(session: Session, action: string, requestId: string, result: ScriptResult): void {
+  const prefix = result.success ? action : `${action} failed`;
+  notifyAgent(session, `${prefix}: ${result.message}`);
   if (result.success) {
-    logger.info({ type, requestId }, 'X request completed');
+    log.info('x-integration action complete', { action, requestId });
   } else {
-    logger.error({ type, requestId, message: result.message }, 'X request failed');
+    log.warn('x-integration action failed', { action, requestId });
   }
-  return true;
 }
+
+// ── Handler factory ─────────────────────────────────────────
+
+interface XHandlerSpec {
+  /** Action key — must match the MCP tool's action in agent.ts. */
+  action: string;
+  /** Script filename (without .ts). */
+  scriptName: string;
+  /** Required content keys; missing → fast-fail with notifyAgent. */
+  required?: string[];
+  /** Map system content → script stdin. Default: identity (no transform). */
+  buildArgs?: (content: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * If true, log line redacts content lengths instead of body. Used for
+   * DM tools so message text doesn't end up in nanoclaw.log.
+   */
+  redactLogs?: boolean;
+}
+
+function makeXHandler(spec: XHandlerSpec): DeliveryActionHandler {
+  return async (content, session) => {
+    const requestId = (content.requestId as string) || 'unknown';
+    if (spec.required) {
+      for (const key of spec.required) {
+        if (content[key] === undefined || content[key] === null || content[key] === '') {
+          notifyAgent(session, `${spec.action} failed: missing ${key}.`);
+          return;
+        }
+      }
+    }
+    if (spec.redactLogs) {
+      log.info('x-integration: starting (redacted)', { action: spec.action, requestId });
+    } else {
+      log.info('x-integration: starting', { action: spec.action, requestId });
+    }
+    const args = spec.buildArgs ? spec.buildArgs(content) : content;
+    const result = await pacedRun(() => runScript(spec.scriptName, args));
+    notify(session, spec.action, requestId, result);
+  };
+}
+
+// ── Registrations (no x_delete_tweet — defense in depth) ────
+
+// Read
+registerDeliveryAction('x_read_tweet', makeXHandler({
+  action: 'x_read_tweet', scriptName: 'read-tweet',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_read_thread', makeXHandler({
+  action: 'x_read_thread', scriptName: 'read-thread',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl, limit: c.limit ?? 20 }),
+}));
+registerDeliveryAction('x_read_user', makeXHandler({
+  action: 'x_read_user', scriptName: 'read-user',
+  required: ['handle'],
+  buildArgs: (c) => ({ handle: c.handle, limit: c.limit ?? 20 }),
+}));
+registerDeliveryAction('x_read_bookmarks', makeXHandler({
+  action: 'x_read_bookmarks', scriptName: 'read-bookmarks',
+  buildArgs: (c) => ({ limit: c.limit ?? 20, cursor: c.cursor ?? null }),
+}));
+registerDeliveryAction('x_read_list', makeXHandler({
+  action: 'x_read_list', scriptName: 'read-list',
+  required: ['listUrl'],
+  buildArgs: (c) => ({ listUrl: c.listUrl, limit: c.limit ?? 20 }),
+}));
+registerDeliveryAction('x_read_timeline', makeXHandler({
+  action: 'x_read_timeline', scriptName: 'read-timeline',
+  buildArgs: (c) => ({ limit: c.limit ?? 20 }),
+}));
+registerDeliveryAction('x_read_notifications', makeXHandler({
+  action: 'x_read_notifications', scriptName: 'read-notifications',
+  buildArgs: (c) => ({ limit: c.limit ?? 20 }),
+}));
+registerDeliveryAction('x_search', makeXHandler({
+  action: 'x_search', scriptName: 'search',
+  required: ['query'],
+  buildArgs: (c) => ({ query: c.query, latest: c.latest ?? false, limit: c.limit ?? 20 }),
+}));
+
+// Compose
+registerDeliveryAction('x_post', makeXHandler({
+  action: 'x_post', scriptName: 'post',
+  required: ['content'],
+  buildArgs: (c) => ({ content: c.content, media: c.media ?? [], scheduleAt: c.scheduleAt ?? null }),
+}));
+registerDeliveryAction('x_reply', makeXHandler({
+  action: 'x_reply', scriptName: 'reply',
+  required: ['tweetUrl', 'content'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl, content: c.content, media: c.media ?? [], scheduleAt: c.scheduleAt ?? null }),
+}));
+registerDeliveryAction('x_quote', makeXHandler({
+  action: 'x_quote', scriptName: 'quote',
+  required: ['tweetUrl', 'comment'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl, comment: c.comment, media: c.media ?? [], scheduleAt: c.scheduleAt ?? null }),
+}));
+
+// Engagement toggles
+registerDeliveryAction('x_like', makeXHandler({
+  action: 'x_like', scriptName: 'like',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_unlike', makeXHandler({
+  action: 'x_unlike', scriptName: 'unlike',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_retweet', makeXHandler({
+  action: 'x_retweet', scriptName: 'retweet',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_unretweet', makeXHandler({
+  action: 'x_unretweet', scriptName: 'unretweet',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_bookmark', makeXHandler({
+  action: 'x_bookmark', scriptName: 'bookmark',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_unbookmark', makeXHandler({
+  action: 'x_unbookmark', scriptName: 'unbookmark',
+  required: ['tweetUrl'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl }),
+}));
+registerDeliveryAction('x_follow', makeXHandler({
+  action: 'x_follow', scriptName: 'follow',
+  required: ['handle'],
+  buildArgs: (c) => ({ handle: c.handle }),
+}));
+registerDeliveryAction('x_unfollow', makeXHandler({
+  action: 'x_unfollow', scriptName: 'unfollow',
+  required: ['handle'],
+  buildArgs: (c) => ({ handle: c.handle }),
+}));
+
+// Delete tweet — irreversibly removes one of the user's own tweets.
+// The script enforces a text-echo safety guard (tweetUrl + textMustMatch);
+// host handler just passes both fields through. No approval gate — consistent
+// with the skill's per-action trust model. See scripts/delete-tweet.ts for
+// the safety logic.
+registerDeliveryAction('x_delete_tweet', makeXHandler({
+  action: 'x_delete_tweet', scriptName: 'delete-tweet',
+  required: ['tweetUrl', 'textMustMatch'],
+  buildArgs: (c) => ({ tweetUrl: c.tweetUrl, textMustMatch: c.textMustMatch }),
+}));
+
+// Scheduling
+registerDeliveryAction('x_list_scheduled', makeXHandler({
+  action: 'x_list_scheduled', scriptName: 'list-scheduled',
+  buildArgs: () => ({}),
+}));
+registerDeliveryAction('x_cancel_scheduled', makeXHandler({
+  action: 'x_cancel_scheduled', scriptName: 'cancel-scheduled',
+  buildArgs: (c) => ({ index: c.index ?? null, textMatch: c.textMatch ?? null }),
+}));
+
+// Bulk export (separate handler so we can document the long-running nature)
+registerDeliveryAction('x_export_bookmarks', makeXHandler({
+  action: 'x_export_bookmarks', scriptName: 'export-bookmarks',
+  buildArgs: (c) => ({ reset: c.reset === true }),
+}));
+
+// DMs (redacted logging — bodies stay out of nanoclaw.log)
+registerDeliveryAction('x_read_dm_inbox', makeXHandler({
+  action: 'x_read_dm_inbox', scriptName: 'read-dm-inbox',
+  buildArgs: (c) => ({ limit: c.limit ?? 20 }),
+  redactLogs: true,
+}));
+registerDeliveryAction('x_read_dm_thread', makeXHandler({
+  action: 'x_read_dm_thread', scriptName: 'read-dm-thread',
+  required: ['handle'],
+  buildArgs: (c) => ({ handle: c.handle, limit: c.limit ?? 30 }),
+  redactLogs: true,
+}));
+registerDeliveryAction('x_send_dm', makeXHandler({
+  action: 'x_send_dm', scriptName: 'send-dm',
+  required: ['handle', 'content'],
+  buildArgs: (c) => ({ handle: c.handle, content: c.content }),
+  redactLogs: true,
+}));

--- a/.claude/skills/x-integration/lib/browser.ts
+++ b/.claude/skills/x-integration/lib/browser.ts
@@ -3,10 +3,11 @@
  * Used by all X scripts
  */
 
-import { chromium, BrowserContext, Page } from 'playwright';
+import { chromium, BrowserContext, Page } from 'playwright-core';
 import fs from 'fs';
 import path from 'path';
 import { config } from './config.js';
+import { X_SELECTORS } from './locators.js';
 
 export { config };
 
@@ -65,6 +66,58 @@ export function validateContent(content: string | undefined, type = 'Tweet'): Sc
     return { success: false, message: `${type} exceeds ${config.limits.tweetMaxLength} character limit (current: ${content.length})` };
   }
   return null; // Valid
+}
+
+/**
+ * Validate DM content (10k char cap, much higher than tweet).
+ */
+export function validateDmContent(content: string | undefined): ScriptResult | null {
+  if (!content || content.length === 0) {
+    return { success: false, message: 'DM content cannot be empty' };
+  }
+  if (content.length > config.limits.dmMaxLength) {
+    return { success: false, message: `DM exceeds ${config.limits.dmMaxLength} character limit (current: ${content.length})` };
+  }
+  return null;
+}
+
+/**
+ * Verify the page is in a logged-in state. Side-nav account switcher is
+ * the canonical "you are logged in" element on every X page after the
+ * initial load. If it's missing AND the login form is present, the
+ * session has aged out and the user must re-run setup.
+ */
+export async function ensureLoggedIn(page: Page): Promise<ScriptResult | null> {
+  const switcher = await page.locator(X_SELECTORS.accountSwitcher).first().isVisible().catch(() => false);
+  if (switcher) return null;
+  const loginForm = await page.locator(X_SELECTORS.loginUsernameInput).first().isVisible().catch(() => false);
+  if (loginForm) {
+    return { success: false, message: 'X login expired. Re-run interactive setup: pnpm exec tsx --env-file=.env .claude/skills/x-integration/scripts/setup.ts' };
+  }
+  // Neither marker visible — could be a transient load issue. Wait a beat and retry once.
+  await page.waitForTimeout(2000);
+  const switcherRetry = await page.locator(X_SELECTORS.accountSwitcher).first().isVisible().catch(() => false);
+  if (switcherRetry) return null;
+  return { success: false, message: 'X login state could not be verified (account-switcher missing). Page may have failed to load — retry, or re-run setup.' };
+}
+
+/**
+ * On error, dump a screenshot + DOM snapshot to logs/x-failures/ for
+ * post-mortem. The agent never sees this — it's host-side debug aid for
+ * Scott when a selector breaks.
+ */
+export async function captureFailure(page: Page, label: string): Promise<string> {
+  try {
+    fs.mkdirSync(config.failureDumpDir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const base = path.join(config.failureDumpDir, `${stamp}-${label}`);
+    await page.screenshot({ path: `${base}.png`, fullPage: true }).catch(() => {});
+    const html = await page.content().catch(() => '');
+    if (html) fs.writeFileSync(`${base}.html`, html);
+    return base;
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/.claude/skills/x-integration/lib/chrome-detect.ts
+++ b/.claude/skills/x-integration/lib/chrome-detect.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-platform Chromium-family browser detection for the X-integration skill.
+ *
+ * Resolves the user's *real* browser so X's bot detection sees a normal
+ * logged-in session. Supports Chrome, Chromium, and Brave (all Chromium-
+ * based — Playwright's `chromium` driver works with any of them via
+ * `executablePath`).
+ *
+ * Resolution order:
+ *   1. CHROME_PATH env var — explicit override, wins over auto-detection.
+ *      Pin Brave with `CHROME_PATH=/usr/bin/brave-browser` (or the macOS
+ *      bundle path) to force Brave even if Chrome is also installed.
+ *   2. Platform-specific probe — Chrome variants first (most common),
+ *      then Brave, then Chromium.
+ *   3. Throw with an actionable install hint.
+ *
+ * Why no fallback to Playwright's bundled Chromium: the entire point of the
+ * skill is to drive the user's *real* browser. Bundled Chromium fails X's
+ * bot-detection check.
+ */
+
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+export function detectChromePath(): string {
+  const override = process.env.CHROME_PATH;
+  if (override && fs.existsSync(override)) {
+    return override;
+  }
+
+  const platform = os.platform();
+
+  if (platform === 'darwin') {
+    const macAppDirs: Array<{ app: string; exe: string; bundleId: string }> = [
+      {
+        app: '/Applications/Google Chrome.app',
+        exe: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        bundleId: 'com.google.Chrome',
+      },
+      {
+        app: '/Applications/Brave Browser.app',
+        exe: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+        bundleId: 'com.brave.Browser',
+      },
+      {
+        app: '/Applications/Chromium.app',
+        exe: '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        bundleId: 'org.chromium.Chromium',
+      },
+    ];
+    for (const { exe } of macAppDirs) {
+      if (fs.existsSync(exe)) return exe;
+    }
+    for (const { bundleId } of macAppDirs) {
+      try {
+        const bundle = execSync(
+          `mdfind "kMDItemCFBundleIdentifier == '${bundleId}'" 2>/dev/null | head -1`,
+          { encoding: 'utf8' },
+        ).trim();
+        if (bundle) {
+          const match = macAppDirs.find((d) => d.bundleId === bundleId);
+          if (match) {
+            const exe = bundle + match.exe.slice(match.app.length);
+            if (fs.existsSync(exe)) return exe;
+          }
+        }
+      } catch {}
+    }
+  } else if (platform === 'linux') {
+    const candidates = [
+      'google-chrome-stable',
+      'google-chrome',
+      'brave-browser',
+      'brave',
+      'chromium-browser',
+      'chromium',
+    ];
+    for (const cmd of candidates) {
+      try {
+        const found = execSync(`which ${cmd} 2>/dev/null`, { encoding: 'utf8' }).trim();
+        if (found && fs.existsSync(found)) return found;
+      } catch {}
+    }
+    for (const path of ['/snap/bin/chromium', '/snap/bin/brave', '/opt/brave.com/brave/brave']) {
+      if (fs.existsSync(path)) return path;
+    }
+
+    // Detect Flatpak installs and emit a specific error — Playwright cannot
+    // launch a sandboxed Flatpak browser via executablePath. Users have to
+    // install the native package alongside.
+    try {
+      const flatpakList = execSync('flatpak list --app 2>/dev/null', { encoding: 'utf8' });
+      const hasBrave = /com\.brave\.Browser/i.test(flatpakList);
+      const hasChrome = /com\.google\.Chrome/i.test(flatpakList);
+      const hasChromium = /org\.chromium\.Chromium/i.test(flatpakList);
+      if (hasBrave || hasChrome || hasChromium) {
+        const which = hasBrave ? 'Brave' : hasChrome ? 'Chrome' : 'Chromium';
+        const installCmd = hasBrave
+          ? 'install brave-browser as a .deb (curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list && sudo apt update && sudo apt install brave-browser)'
+          : hasChrome
+            ? 'install google-chrome-stable as a .deb (sudo apt install google-chrome-stable)'
+            : 'install chromium-browser as a .deb (sudo apt install chromium-browser)';
+        throw new Error(
+          `${which} detected as Flatpak (sandboxed) — Playwright cannot drive sandboxed Flatpak browsers. Please ${installCmd}. Both installs can coexist.`,
+        );
+      }
+    } catch (e) {
+      // Re-throw the explicit Flatpak error; swallow `flatpak` not-found
+      if (e instanceof Error && e.message.includes('Flatpak')) throw e;
+    }
+  }
+
+  const installHint =
+    platform === 'linux'
+      ? 'Install one of: `sudo apt install google-chrome-stable` | `sudo apt install brave-browser` (after adding the Brave repo) | `sudo apt install chromium-browser`. Or set CHROME_PATH in .env to an explicit binary.'
+      : platform === 'darwin'
+        ? 'Install Chrome (https://www.google.com/chrome/), Brave (https://brave.com/download/), or Chromium. Or set CHROME_PATH in .env.'
+        : 'Install a Chromium-based browser and set CHROME_PATH in .env.';
+  throw new Error(`No Chromium-family browser found on ${platform}. ${installHint}`);
+}

--- a/.claude/skills/x-integration/lib/config.ts
+++ b/.claude/skills/x-integration/lib/config.ts
@@ -6,6 +6,7 @@
  */
 
 import path from 'path';
+import { detectChromePath } from './chrome-detect.js';
 
 // Project root - can be overridden for different deployments
 const PROJECT_ROOT = process.env.NANOCLAW_ROOT || process.cwd();
@@ -14,10 +15,10 @@ const PROJECT_ROOT = process.env.NANOCLAW_ROOT || process.cwd();
  * Configuration object with all settings
  */
 export const config = {
-  // Chrome executable path
-  // Default: standard macOS Chrome location
-  // Override: CHROME_PATH environment variable
-  chromePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  // Chrome executable path. Resolution: CHROME_PATH env > platform probe.
+  // Throws at first access if no Chrome is installed — fail loud so the
+  // user sees an install hint instead of a silent Playwright launch error.
+  chromePath: detectChromePath(),
 
   // Browser profile directory for persistent login sessions
   browserDataDir: path.join(PROJECT_ROOT, 'data', 'x-browser-profile'),
@@ -41,10 +42,27 @@ export const config = {
     pageLoad: 3000,
   },
 
-  // X character limits
+  // X character limits + per-tool result caps
   limits: {
     tweetMaxLength: 280,
+    /** Direct-message body cap (X allows up to 10,000 chars in DMs). */
+    dmMaxLength: 10000,
+    /** Cap on items returned by each read tool — protects against
+     * runaway scrolls and stays comfortably under the 120s timeout. */
+    readMax: 50,
+    /** Cap on attached images per tweet (X UI allows 4). */
+    mediaMaxPerTweet: 4,
   },
+
+  // Pacing — minimum wall-clock spacing between sequential X actions.
+  // Enforced by host.ts's pacedRun() mutex, NOT by per-script sleep
+  // (sleep can't enforce delay across separate subprocess invocations).
+  pacing: {
+    actionDelayMs: 10000,
+  },
+
+  // Where script failures dump screenshots + DOM snapshots for debugging.
+  failureDumpDir: path.join(PROJECT_ROOT, 'logs', 'x-failures'),
 
   // Chrome launch arguments
   chromeArgs: [

--- a/.claude/skills/x-integration/lib/extract.ts
+++ b/.claude/skills/x-integration/lib/extract.ts
@@ -1,0 +1,292 @@
+/**
+ * DOM-extraction primitives for X read scripts.
+ *
+ * Every read tool that returns tweet/user/DM data routes through here.
+ * When X changes a DOM structure, fix it once and all 8 read tools pick
+ * up the change.
+ *
+ * Selectors live in lib/locators.ts. This file holds the *parsing* logic
+ * — converting Playwright Locators into typed JS objects. Two layers
+ * makes it cheap to swap a selector without re-deriving extraction.
+ */
+
+import type { Locator, Page } from 'playwright-core';
+import { X_SELECTORS } from './locators.js';
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface ParsedTweet {
+  id: string;
+  url: string;
+  authorHandle: string;
+  authorName: string;
+  text: string;
+  timestamp: string;
+  imageAltTexts: string[];
+  metrics: { likes: number; retweets: number; replies: number; bookmarks?: number };
+  isReply: boolean;
+  isRetweet: boolean;
+}
+
+export interface ParsedDmMessage {
+  text: string;
+  /** ISO timestamp if extractable, else null. */
+  timestamp: string | null;
+  /** "you" if sent by the logged-in user, else "them". */
+  direction: 'you' | 'them';
+}
+
+export interface ParsedDmConversation {
+  /** Conversation handle (the other party's @handle, no leading @). */
+  handle: string;
+  displayName: string;
+  /** Last message preview text. */
+  preview: string;
+  unread: boolean;
+  /** Timestamp string as rendered (X uses relative — "2h", "Apr 3" — leave as-is). */
+  timeLabel: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Parse "1.2K" / "5,432" / "12" into a number. */
+function parseMetric(raw: string | null | undefined): number {
+  if (!raw) return 0;
+  const cleaned = raw.replace(/,/g, '').trim();
+  if (/^\d+$/.test(cleaned)) return parseInt(cleaned, 10);
+  const match = cleaned.match(/^(\d+(?:\.\d+)?)([KMB])$/i);
+  if (match) {
+    const n = parseFloat(match[1]);
+    const mult = match[2].toUpperCase() === 'K' ? 1e3 : match[2].toUpperCase() === 'M' ? 1e6 : 1e9;
+    return Math.round(n * mult);
+  }
+  return 0;
+}
+
+/** Extract tweet ID + author handle from a status URL. */
+function parseStatusUrl(url: string): { handle: string; tweetId: string } | null {
+  const m = url.match(/(?:x\.com|twitter\.com)\/(\w+)\/status\/(\d+)/);
+  if (!m) return null;
+  return { handle: m[1], tweetId: m[2] };
+}
+
+// ── Tweet card parsing ───────────────────────────────────────
+
+/**
+ * Parse a single tweet article. Tolerant — missing pieces become empty
+ * strings or zero rather than throwing, so a partially-rendered card
+ * still yields a usable record.
+ */
+export async function parseTweetCard(article: Locator): Promise<ParsedTweet> {
+  // Permalink + ID via the timestamp anchor
+  let url = '';
+  let id = '';
+  let handle = '';
+  let timestamp = '';
+  try {
+    const timeEl = article.locator(X_SELECTORS.tweetTime).first();
+    if (await timeEl.count()) {
+      timestamp = (await timeEl.getAttribute('datetime')) || '';
+      const anchor = timeEl.locator('xpath=ancestor::a').first();
+      if (await anchor.count()) {
+        const href = (await anchor.getAttribute('href')) || '';
+        url = href.startsWith('http') ? href : `https://x.com${href}`;
+        const parsed = parseStatusUrl(url);
+        if (parsed) {
+          id = parsed.tweetId;
+          handle = parsed.handle;
+        }
+      }
+    }
+  } catch {}
+
+  // Author display name
+  let authorName = '';
+  try {
+    const nameEl = article.locator(X_SELECTORS.tweetUserName).first();
+    if (await nameEl.count()) {
+      authorName = ((await nameEl.innerText()) || '').split('\n')[0].trim();
+    }
+  } catch {}
+  if (!handle) {
+    // Fallback: pluck handle from the User-Name block
+    try {
+      const nameEl = article.locator(X_SELECTORS.tweetUserName).first();
+      const txt = (await nameEl.innerText()) || '';
+      const m = txt.match(/@([\w]+)/);
+      if (m) handle = m[1];
+    } catch {}
+  }
+
+  // Tweet text (may be empty for media-only posts)
+  let text = '';
+  try {
+    const textEl = article.locator(X_SELECTORS.tweetText).first();
+    if (await textEl.count()) {
+      text = ((await textEl.innerText()) || '').trim();
+    }
+  } catch {}
+
+  // Image alt-text (the agent uses these for vision-without-vision)
+  const imageAltTexts: string[] = [];
+  try {
+    const imgs = article.locator(X_SELECTORS.tweetImage);
+    const count = await imgs.count();
+    for (let i = 0; i < count; i++) {
+      const alt = await imgs.nth(i).getAttribute('alt');
+      if (alt && alt !== 'Image') imageAltTexts.push(alt);
+    }
+  } catch {}
+
+  // Engagement metrics — read aria-labels off the action buttons
+  const metrics = { likes: 0, retweets: 0, replies: 0, bookmarks: undefined as number | undefined };
+  for (const [key, sel] of [
+    ['likes', X_SELECTORS.like],
+    ['likes', X_SELECTORS.unlike],
+    ['retweets', X_SELECTORS.retweet],
+    ['retweets', X_SELECTORS.unretweet],
+    ['replies', X_SELECTORS.reply],
+  ] as const) {
+    try {
+      const btn = article.locator(sel).first();
+      if (!(await btn.count())) continue;
+      const label = (await btn.getAttribute('aria-label')) || '';
+      const match = label.match(/([\d,.]+\s*[KMB]?)/);
+      if (match) {
+        const n = parseMetric(match[1]);
+        if (n > 0) metrics[key] = n;
+      }
+    } catch {}
+  }
+
+  // Heuristic flags
+  const lowerHtml = (await article.innerHTML().catch(() => '')).toLowerCase();
+  const isReply = lowerHtml.includes('replying to');
+  const isRetweet = lowerHtml.includes('reposted');
+
+  return {
+    id,
+    url,
+    authorHandle: handle,
+    authorName,
+    text,
+    timestamp,
+    imageAltTexts,
+    metrics,
+    isReply,
+    isRetweet,
+  };
+}
+
+/**
+ * Scroll-and-collect: scrape up to `limit` tweets from a feed. Each scroll
+ * waits for new articles to attach before parsing. De-dupes by tweet ID.
+ *
+ * `skipUntilId` enables pseudo-cursor pagination on infinite-scroll feeds
+ * (X's bookmarks / search / timeline have no native cursor in the DOM).
+ * When set, the scroll-and-parse loop runs in a "fast-forward" phase that
+ * marks tweets as seen without adding them to the result; collection
+ * begins on the round AFTER the marker tweet appears in the DOM. This
+ * lets the caller walk an infinite feed in batches by passing back the
+ * last tweet ID from the previous batch. Cost: each paginated call
+ * re-scrolls everything up to the marker before collecting fresh items,
+ * so deeper walks are progressively slower.
+ */
+export async function collectTweets(
+  page: Page,
+  limit: number,
+  options: { scrollMaxRounds?: number; scrollPauseMs?: number; skipUntilId?: string } = {},
+): Promise<ParsedTweet[]> {
+  const maxRounds = options.scrollMaxRounds ?? 30;
+  const pauseMs = options.scrollPauseMs ?? 800;
+  const skipUntilId = options.skipUntilId;
+  const seen = new Set<string>();
+  const tweets: ParsedTweet[] = [];
+  let pastMarker = !skipUntilId;
+
+  for (let round = 0; round < maxRounds && tweets.length < limit; round++) {
+    const articles = page.locator(X_SELECTORS.tweet);
+    const count = await articles.count();
+    for (let i = 0; i < count && tweets.length < limit; i++) {
+      const parsed = await parseTweetCard(articles.nth(i));
+      if (!parsed.id || seen.has(parsed.id)) continue;
+      seen.add(parsed.id);
+      if (!pastMarker) {
+        if (parsed.id === skipUntilId) pastMarker = true;
+        continue;
+      }
+      tweets.push(parsed);
+    }
+    if (tweets.length >= limit) break;
+    await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+    await page.waitForTimeout(pauseMs);
+  }
+
+  return tweets;
+}
+
+// ── Pretty-print for notifyAgent ─────────────────────────────
+
+export function renderTweet(t: ParsedTweet): string {
+  const head = `${t.authorName || '?'} (@${t.authorHandle || '?'})${t.timestamp ? ` · ${t.timestamp}` : ''}`;
+  const body = t.text || '(no text — media or quote-only)';
+  const meta = `❤ ${t.metrics.likes}  🔁 ${t.metrics.retweets}  💬 ${t.metrics.replies}`;
+  const alt = t.imageAltTexts.length ? `\nImages: ${t.imageAltTexts.map((a) => `"${a}"`).join(', ')}` : '';
+  const link = t.url ? `\n${t.url}` : '';
+  return `${head}\n${body}\n${meta}${alt}${link}`;
+}
+
+export function renderTweetList(tweets: ParsedTweet[], header?: string): string {
+  if (tweets.length === 0) return `${header ?? 'No tweets found.'}\n(0 results)`;
+  const blocks = tweets.map((t, i) => `[${i + 1}] ${renderTweet(t)}`);
+  return `${header ?? `${tweets.length} tweet${tweets.length === 1 ? '' : 's'}:`}\n\n${blocks.join('\n\n---\n\n')}`;
+}
+
+// ── DM parsing ───────────────────────────────────────────────
+
+export async function parseDmConversation(row: Locator): Promise<ParsedDmConversation> {
+  let handle = '';
+  let displayName = '';
+  let preview = '';
+  let unread = false;
+  let timeLabel = '';
+
+  try {
+    const txt = ((await row.innerText()) || '').trim();
+    // Inbox row format (typical): "Display Name\n@handle · 2h\nPreview text..."
+    const lines = txt.split('\n').map((l) => l.trim()).filter(Boolean);
+    if (lines[0]) displayName = lines[0];
+    if (lines[1]) {
+      const m = lines[1].match(/@([\w]+)(?:\s*·\s*(.+))?/);
+      if (m) {
+        handle = m[1];
+        timeLabel = m[2] || '';
+      }
+    }
+    if (lines[2]) preview = lines[2];
+    // Heuristic: unread rows have an unread indicator dot — try multiple paths
+    const dot = await row.locator('[aria-label*="unread" i], [data-testid="unreadDot"]').count().catch(() => 0);
+    unread = dot > 0;
+  } catch {}
+
+  return { handle, displayName, preview, unread, timeLabel };
+}
+
+export function renderDmInbox(conversations: ParsedDmConversation[]): string {
+  if (conversations.length === 0) return 'DM inbox is empty.';
+  const blocks = conversations.map((c, i) => {
+    const head = `[${i + 1}] ${c.displayName} (@${c.handle})${c.unread ? ' · UNREAD' : ''}${c.timeLabel ? ` · ${c.timeLabel}` : ''}`;
+    return `${head}\n${c.preview}`;
+  });
+  return `${conversations.length} conversation${conversations.length === 1 ? '' : 's'}:\n\n${blocks.join('\n\n---\n\n')}`;
+}
+
+export function renderDmThread(messages: ParsedDmMessage[], handle: string): string {
+  if (messages.length === 0) return `No messages found in DM thread with @${handle}.`;
+  const blocks = messages.map((m) => {
+    const who = m.direction === 'you' ? 'YOU' : `@${handle}`;
+    const time = m.timestamp ? ` (${m.timestamp})` : '';
+    return `${who}${time}: ${m.text}`;
+  });
+  return `DM thread with @${handle} (${messages.length} message${messages.length === 1 ? '' : 's'}):\n\n${blocks.join('\n')}`;
+}

--- a/.claude/skills/x-integration/lib/locators.ts
+++ b/.claude/skills/x-integration/lib/locators.ts
@@ -1,0 +1,152 @@
+/**
+ * X (Twitter) DOM selectors — single source of truth.
+ *
+ * Every CSS / data-testid selector used by any script in this skill lives
+ * here. When X redeploys and a selector breaks, this is the one place to
+ * update — the change propagates to all 25 tools.
+ *
+ * Selector confidence:
+ *   - HIGH: composer textarea, tweet card, like/retweet/bookmark/reply
+ *     buttons, account switcher, login username — these are stable and
+ *     have v1-skill provenance plus public X-tooling community usage.
+ *   - MEDIUM: profile follow/unfollow, retweet confirm sheet — pattern is
+ *     stable but X has reshuffled these in the past.
+ *   - LOW (verify on first failure): scheduling UI, DM composer/inbox,
+ *     scheduled-tweets queue — these are inferred from observed DOM
+ *     patterns and may need adjustment after first user-test.
+ */
+
+export const X_SELECTORS = {
+  // ─── Composer ─────────────────────────────────────────────
+  /** Main tweet textarea on home/compose. */
+  tweetTextarea: '[data-testid="tweetTextarea_0"]',
+  /** "Post" button in inline composer (home page). */
+  tweetButtonInline: '[data-testid="tweetButtonInline"]',
+  /** "Post" / "Reply" / "Schedule" button in modal composer. */
+  tweetButtonModal: '[data-testid="tweetButton"]',
+  /** File input for image attachments inside composer. */
+  fileInput: 'input[data-testid="fileInput"], input[type="file"][accept*="image"]',
+  /** Schedule (clock) icon in composer toolbar. */
+  scheduleIconButton: '[data-testid="scheduleOption"]',
+  /** "Confirm" button in scheduling modal. */
+  scheduleConfirmButton: '[data-testid="scheduledConfirmationPrimaryAction"]',
+  /** Date input in scheduling modal. */
+  scheduleDateInput: 'input[type="date"], [data-testid="Date_picker_calendar_button"]',
+  /** Time input in scheduling modal. */
+  scheduleTimeInput: 'input[type="time"]',
+
+  // ─── Tweet card (any list/timeline) ───────────────────────
+  /** Article wrapping a single tweet. */
+  tweet: 'article[data-testid="tweet"]',
+  /** Tweet text content. */
+  tweetText: '[data-testid="tweetText"]',
+  /** Tweet author name+handle block. */
+  tweetUserName: '[data-testid="User-Name"]',
+  /** Tweet timestamp (anchor with the status URL + datetime). */
+  tweetTime: 'time',
+  /** Like button (when not yet liked). */
+  like: '[data-testid="like"]',
+  /** Unlike button (when already liked — same node, different testid post-state). */
+  unlike: '[data-testid="unlike"]',
+  /** Retweet entry button. */
+  retweet: '[data-testid="retweet"]',
+  /** Unretweet entry button. */
+  unretweet: '[data-testid="unretweet"]',
+  /** Confirm-retweet button in popup menu. */
+  retweetConfirm: '[data-testid="retweetConfirm"]',
+  /** Confirm-unretweet button. */
+  unretweetConfirm: '[data-testid="unretweetConfirm"]',
+  /** Bookmark button (not yet bookmarked). */
+  bookmark: '[data-testid="bookmark"]',
+  /** Remove-bookmark button (already bookmarked). */
+  removeBookmark: '[data-testid="removeBookmark"]',
+  /** Reply button on a tweet card. */
+  reply: '[data-testid="reply"]',
+  /** Generic confirmation modal "Confirm" button. */
+  confirmationSheetConfirm: '[data-testid="confirmationSheetConfirm"]',
+  /** Modal dialog wrapper. */
+  modalDialog: '[role="dialog"][aria-modal="true"]',
+
+  // ─── Profile ─────────────────────────────────────────────
+  /** Follow button on a profile page. data-testid ends with "-follow". */
+  followButton: '[data-testid$="-follow"]',
+  /** Unfollow button on a profile page. data-testid ends with "-unfollow". */
+  unfollowButton: '[data-testid$="-unfollow"]',
+  /** Profile name / handle area. */
+  userName: '[data-testid="UserName"]',
+
+  // ─── Search ───────────────────────────────────────────────
+  /** Search input on /explore. */
+  searchInput: '[data-testid="SearchBox_Search_Input"]',
+  /** Search results filter — "Latest" tab. */
+  searchLatestTab: 'a[role="tab"][href*="f=live"]',
+
+  // ─── Login state ──────────────────────────────────────────
+  /** Side-nav account switcher button — present iff logged in. */
+  accountSwitcher: '[data-testid="SideNav_AccountSwitcher_Button"]',
+  /** Login form username input — present iff logged out. */
+  loginUsernameInput: 'input[autocomplete="username"]',
+
+  // ─── DMs ──────────────────────────────────────────────────
+  /** Conversation row in inbox (clickable to open thread). */
+  dmConversation: '[data-testid="conversation"]',
+  /** "New message" button in inbox. */
+  dmNewMessageButton: '[data-testid="NewDM_Button"]',
+  /** Recipient input in compose-DM dialog. */
+  dmComposeSearchInput: '[data-testid="searchPeople"], input[name="searchQuery"]',
+  /** First search result row in compose-DM. */
+  dmSearchResultUser: '[data-testid="TypeaheadUser"]',
+  /** "Next" button after picking recipient(s). */
+  dmComposeNextButton: '[data-testid="nextButton"]',
+  /** DM message text input. */
+  dmComposerTextInput: '[data-testid="dmComposerTextInput"]',
+  /** Send button in DM thread. */
+  dmComposerSendButton: '[data-testid="dmComposerSendButton"]',
+  /** Individual message bubble in a thread. */
+  dmMessageEntry: '[data-testid="messageEntry"]',
+
+  // ─── Image alt-text on tweet media ────────────────────────
+  /** Image inside tweet card. alt attribute carries alt-text or "Image". */
+  tweetImage: 'img[draggable="true"][alt]',
+
+  // ─── Tweet caret menu (used by delete-tweet) ──────────────
+  /** Three-dot caret button on a tweet card that opens the action menu. */
+  caret: '[data-testid="caret"]',
+  /** Dropdown menu items in the caret-opened action menu. Filter by inner text in the script. */
+  dropdownMenuItem: '[data-testid="Dropdown"] [role="menuitem"]',
+};
+
+/**
+ * URL helpers — also single-sourced so behavior changes (e.g., x.com →
+ * twitter.com fallback) only need one edit.
+ */
+export const X_URLS = {
+  base: 'https://x.com',
+  home: 'https://x.com/home',
+  login: 'https://x.com/login',
+  explore: 'https://x.com/explore',
+  bookmarks: 'https://x.com/i/bookmarks',
+  notifications: 'https://x.com/notifications',
+  scheduledTweets: 'https://x.com/compose/post/unsent/scheduled',
+  dmInbox: 'https://x.com/messages',
+  dmCompose: 'https://x.com/messages/compose',
+
+  /** Profile page for a handle (no leading @). */
+  profile: (handle: string) => `https://x.com/${handle.replace(/^@/, '')}`,
+
+  /** Tweet permalink. */
+  tweet: (handle: string, tweetId: string) =>
+    `https://x.com/${handle.replace(/^@/, '')}/status/${tweetId}`,
+
+  /** Universal tweet permalink (handle-agnostic — X redirects). */
+  tweetById: (tweetId: string) => `https://x.com/i/status/${tweetId}`,
+
+  /** Search query URL. */
+  search: (query: string, latest = false) => {
+    const u = new URL('https://x.com/search');
+    u.searchParams.set('q', query);
+    u.searchParams.set('src', 'typed_query');
+    if (latest) u.searchParams.set('f', 'live');
+    return u.toString();
+  },
+};

--- a/.claude/skills/x-integration/scripts/bookmark.ts
+++ b/.claude/skills/x-integration/scripts/bookmark.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X like — like a tweet.
+ * X bookmark — bookmark a tweet.
  */
 
 import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
@@ -8,7 +8,7 @@ import { X_SELECTORS } from '../lib/locators.js';
 
 interface Input { tweetUrl: string }
 
-async function likeTweet(input: Input): Promise<ScriptResult> {
+async function bookmark(input: Input): Promise<ScriptResult> {
   if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
 
   const context = await getBrowserContext();
@@ -19,23 +19,23 @@ async function likeTweet(input: Input): Promise<ScriptResult> {
     if (auth) return auth;
 
     const article = nav.page.locator(X_SELECTORS.tweet).first();
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Already liked (no-op).' };
+    if (await article.locator(X_SELECTORS.removeBookmark).isVisible().catch(() => false)) {
+      return { success: true, message: 'Already bookmarked (no-op).' };
     }
-    const btn = article.locator(X_SELECTORS.like);
+    const btn = article.locator(X_SELECTORS.bookmark);
     await btn.waitFor({ timeout: config.timeouts.elementWait });
     await btn.click();
     await nav.page.waitForTimeout(config.timeouts.afterClick);
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Liked.' };
+    if (await article.locator(X_SELECTORS.removeBookmark).isVisible().catch(() => false)) {
+      return { success: true, message: 'Bookmarked.' };
     }
-    await captureFailure(nav.page, 'like-no-verify');
-    return { success: false, message: 'Click registered but unlike-state not visible — verify manually.' };
+    await captureFailure(nav.page, 'bookmark-no-verify');
+    return { success: false, message: 'Click registered but remove-bookmark state not visible — verify manually.' };
   } catch (err) {
-    return { success: false, message: `like error: ${err instanceof Error ? err.message : String(err)}` };
+    return { success: false, message: `bookmark error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
     await context.close();
   }
 }
 
-runScript<Input>(likeTweet);
+runScript<Input>(bookmark);

--- a/.claude/skills/x-integration/scripts/cancel-scheduled.ts
+++ b/.claude/skills/x-integration/scripts/cancel-scheduled.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X cancel-scheduled — remove a scheduled tweet from X's queue.
+ *
+ * Selection: pass `index` (1-based, from list-scheduled) OR `textMatch`
+ * (substring of the tweet text). The script clicks into the card, opens
+ * the overflow menu, hits "Delete" / "Discard", and confirms.
+ *
+ * Selectors are LOW confidence — X reshuffles this UI periodically.
+ * Verify on user-test, update lib/locators.ts if needed.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { index?: number | null; textMatch?: string | null }
+
+async function cancelScheduled(input: Input): Promise<ScriptResult> {
+  if ((input.index === undefined || input.index === null) && !input.textMatch) {
+    return { success: false, message: 'Pass either index (1-based) or textMatch (substring of tweet body).' };
+  }
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.scheduledTweets, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const cards = page.locator('[role="button"]').filter({ hasText: /Will send on|Scheduled for/ });
+    const count = await cards.count();
+    if (count === 0) return { success: false, message: 'No scheduled tweets to cancel.' };
+
+    let target = -1;
+    if (input.index !== undefined && input.index !== null) {
+      const idx = input.index as number;
+      if (idx < 1 || idx > count) {
+        return { success: false, message: `index out of range: have ${count} scheduled tweet(s), got ${idx}.` };
+      }
+      target = idx - 1;
+    } else if (input.textMatch) {
+      const match = input.textMatch.toLowerCase();
+      for (let i = 0; i < count; i++) {
+        const text = ((await cards.nth(i).innerText()) || '').toLowerCase();
+        if (text.includes(match)) {
+          target = i;
+          break;
+        }
+      }
+      if (target < 0) {
+        return { success: false, message: `No scheduled tweet matched "${input.textMatch}".` };
+      }
+    }
+
+    // Open the card via "Edit", then in the resulting compose UI hit
+    // "Delete" / overflow → discard → confirm.
+    await cards.nth(target).click();
+    await page.waitForTimeout(config.timeouts.afterClick);
+
+    // Look for an explicit "Delete" / "Discard" button. Multiple X
+    // releases have different testids — try each.
+    const deleteSelectors = [
+      '[data-testid="confirmationSheetCancel"]',
+      'button:has-text("Delete")',
+      'button:has-text("Discard")',
+      '[data-testid="unsentTweetsList-DiscardButton"]',
+    ];
+    let clicked = false;
+    for (const sel of deleteSelectors) {
+      const el = page.locator(sel).first();
+      if (await el.isVisible().catch(() => false)) {
+        await el.click();
+        clicked = true;
+        break;
+      }
+    }
+    if (!clicked) {
+      await captureFailure(page, 'cancel-scheduled-no-delete-btn');
+      return { success: false, message: 'Could not find a Delete/Discard button — X UI may have changed. Check logs/x-failures/.' };
+    }
+    await page.waitForTimeout(config.timeouts.afterClick);
+
+    // Some flows have a confirmation sheet
+    const confirm = page.locator(X_SELECTORS.confirmationSheetConfirm).first();
+    if (await confirm.isVisible().catch(() => false)) {
+      await confirm.click();
+      await page.waitForTimeout(config.timeouts.afterSubmit);
+    }
+
+    return { success: true, message: `Canceled scheduled tweet #${target + 1}.` };
+  } catch (err) {
+    await captureFailure(page, 'cancel-scheduled-error');
+    return { success: false, message: `cancel-scheduled error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(cancelScheduled);

--- a/.claude/skills/x-integration/scripts/delete-tweet.ts
+++ b/.claude/skills/x-integration/scripts/delete-tweet.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X delete-tweet — irreversibly remove a tweet from your account.
+ *
+ * Safety: requires `textMustMatch` (a substring of the actual tweet body).
+ * The script reads the live tweet first; if the expected substring isn't
+ * present, it refuses to delete. This forces the agent to have actually
+ * read the tweet before invoking, and guards against URL hallucinations
+ * (wrong tweet id, copy-paste error, agent confusion about which tweet).
+ *
+ * No approval gate — consistent with the skill's stance ("don't gate per
+ * action; wrap if you want approvals"). The text-echo guard is the local
+ * safety mechanism that fits the existing trust model for engagement
+ * actions like x_post and x_unfollow.
+ */
+import {
+  getBrowserContext,
+  navigateToTweet,
+  runScript,
+  config,
+  ScriptResult,
+  ensureLoggedIn,
+  captureFailure,
+} from '../lib/browser.js';
+import { X_SELECTORS } from '../lib/locators.js';
+
+interface Input {
+  tweetUrl: string;
+  textMustMatch: string;
+}
+
+const MIN_MATCH_LEN = 5;
+
+async function deleteTweet(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+  if (!input.textMustMatch || input.textMustMatch.trim().length < MIN_MATCH_LEN) {
+    return {
+      success: false,
+      message: `textMustMatch required (min ${MIN_MATCH_LEN} chars). Pass a distinctive substring of the tweet body to confirm you read it first.`,
+    };
+  }
+  const expected = input.textMustMatch.trim().toLowerCase();
+
+  const context = await getBrowserContext();
+  try {
+    const nav = await navigateToTweet(context, input.tweetUrl);
+    if (!nav.success) return { success: false, message: nav.error || 'Navigation failed.' };
+    const auth = await ensureLoggedIn(nav.page);
+    if (auth) return auth;
+
+    const article = nav.page.locator(X_SELECTORS.tweet).first();
+    await article.waitFor({ timeout: config.timeouts.elementWait });
+
+    // Safety guard: actually read the tweet and verify it matches the caller's expectation.
+    const actualText = (await article.locator(X_SELECTORS.tweetText).first().innerText().catch(() => '')).trim();
+    if (!actualText) {
+      await captureFailure(nav.page, 'delete-tweet-no-body');
+      return {
+        success: false,
+        message: 'Could not read tweet body to verify; refusing to delete without confirmation.',
+      };
+    }
+    if (!actualText.toLowerCase().includes(expected)) {
+      return {
+        success: false,
+        message:
+          `Safety guard: actual tweet body does not contain expected substring. ` +
+          `Expected: "${input.textMustMatch}". ` +
+          `Actual (first 200 chars): "${actualText.slice(0, 200)}${actualText.length > 200 ? '…' : ''}". ` +
+          `Refusing to delete. Re-read the tweet to confirm you have the right URL.`,
+      };
+    }
+
+    // Open the caret menu on this tweet
+    const caret = article.locator(X_SELECTORS.caret).first();
+    await caret.waitFor({ timeout: config.timeouts.elementWait });
+    await caret.click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
+
+    // Find and click the "Delete" menu item
+    const menuItems = nav.page.locator(X_SELECTORS.dropdownMenuItem);
+    const deleteItem = menuItems.filter({ hasText: /^Delete$/i }).first();
+    if (!(await deleteItem.isVisible().catch(() => false))) {
+      await captureFailure(nav.page, 'delete-tweet-no-menu-item');
+      return {
+        success: false,
+        message: 'Delete menu item not visible in caret dropdown — either not your tweet, or X UI changed.',
+      };
+    }
+    await deleteItem.click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
+
+    // Confirm in the modal
+    const confirm = nav.page.locator(X_SELECTORS.confirmationSheetConfirm).first();
+    await confirm.waitFor({ timeout: config.timeouts.elementWait });
+    await confirm.click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
+
+    // Verify: the article element should no longer be visible (tweet removed from page).
+    if (await article.isVisible().catch(() => false)) {
+      await captureFailure(nav.page, 'delete-tweet-still-visible');
+      return {
+        success: false,
+        message: 'Click registered but tweet still visible after confirmation — delete may not have taken effect.',
+      };
+    }
+
+    const preview = actualText.slice(0, 100) + (actualText.length > 100 ? '…' : '');
+    return { success: true, message: `Deleted tweet: "${preview}"` };
+  } catch (err) {
+    return { success: false, message: `delete-tweet error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(deleteTweet);

--- a/.claude/skills/x-integration/scripts/export-bookmarks.ts
+++ b/.claude/skills/x-integration/scripts/export-bookmarks.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X export-bookmarks — bulk-dump all bookmarks to CSV.
+ *
+ * Why a separate tool from read-bookmarks:
+ *   - Read returns rows in the chat reply, capped at 100/call. For users
+ *     with thousands of bookmarks, the cursor-in-chat pattern multiplies
+ *     round-trips and burns context.
+ *   - Export writes a CSV file directly; the agent gets only a summary.
+ *
+ * Why resumable instead of one giant call:
+ *   - The host's per-script timeout is 120s. Single-call full export
+ *     would time out on any non-trivial history.
+ *   - State sidecar `<csv>.progress.json` records `{lastId, totalRows}`
+ *     so each invocation skips past prior rows and appends fresh ones.
+ *   - Each call has a soft time budget (~75s) so it finishes before the
+ *     host's hard timeout, leaving headroom for parse + I/O.
+ *
+ * Output location:
+ *   groups/main/captures/bookmarks.csv  (host path)
+ *   /workspace/group/captures/bookmarks.csv  (agent's view via container mount)
+ *
+ * For now, group=main is hardcoded — only the main group uses X
+ * integration in this install. If/when other groups want their own
+ * export, thread the agent group folder in via host buildArgs.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { parseTweetCard, type ParsedTweet } from '../lib/extract.js';
+import { X_URLS, X_SELECTORS } from '../lib/locators.js';
+
+interface Input { reset?: boolean }
+
+interface Progress {
+  /** Tweet ID of the most recently exported bookmark (the one the next
+   *  call should fast-forward past). */
+  lastId: string | null;
+  /** Total rows in the CSV (excluding header). */
+  totalRows: number;
+  /** ISO timestamp of last successful flush. */
+  lastUpdated: string;
+}
+
+const PROJECT_ROOT = process.env.NANOCLAW_ROOT || process.cwd();
+const CSV_PATH = path.join(PROJECT_ROOT, 'groups', 'main', 'captures', 'bookmarks.csv');
+const PROGRESS_PATH = `${CSV_PATH}.progress.json`;
+const CSV_HEADER = 'id,url,author_handle,author_name,timestamp,text,image_alt_texts,likes,retweets,replies,is_reply,is_retweet';
+
+/** Soft time budget per invocation. The host kills the script at 120s
+ *  hard timeout; we exit voluntarily at 75s with everything flushed. */
+const TIME_BUDGET_MS = 75_000;
+
+/** Pause between scroll-trigger and re-parse. Same as collectTweets. */
+const SCROLL_PAUSE_MS = 800;
+
+// ── CSV serialization (RFC 4180) ─────────────────────────────
+
+function csvEscape(field: string): string {
+  if (/[",\n\r]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+function tweetToCsvRow(t: ParsedTweet): string {
+  const cells = [
+    t.id,
+    t.url,
+    t.authorHandle,
+    t.authorName,
+    t.timestamp,
+    t.text,
+    t.imageAltTexts.join(' | '),
+    String(t.metrics.likes),
+    String(t.metrics.retweets),
+    String(t.metrics.replies),
+    t.isReply ? '1' : '0',
+    t.isRetweet ? '1' : '0',
+  ];
+  return cells.map((c) => csvEscape(c ?? '')).join(',');
+}
+
+// ── Progress sidecar ─────────────────────────────────────────
+
+function readProgress(): Progress {
+  try {
+    const raw = fs.readFileSync(PROGRESS_PATH, 'utf8');
+    const p = JSON.parse(raw);
+    return {
+      lastId: typeof p.lastId === 'string' ? p.lastId : null,
+      totalRows: Number.isInteger(p.totalRows) ? p.totalRows : 0,
+      lastUpdated: typeof p.lastUpdated === 'string' ? p.lastUpdated : new Date().toISOString(),
+    };
+  } catch {
+    return { lastId: null, totalRows: 0, lastUpdated: new Date().toISOString() };
+  }
+}
+
+function writeProgress(p: Progress): void {
+  fs.writeFileSync(PROGRESS_PATH, JSON.stringify(p, null, 2));
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+async function exportBookmarks(input: Input): Promise<ScriptResult> {
+  const reset = input.reset === true;
+
+  // Ensure target directory exists
+  fs.mkdirSync(path.dirname(CSV_PATH), { recursive: true });
+
+  // Reset clears CSV + sidecar; otherwise resume from progress.json
+  if (reset) {
+    if (fs.existsSync(CSV_PATH)) fs.unlinkSync(CSV_PATH);
+    if (fs.existsSync(PROGRESS_PATH)) fs.unlinkSync(PROGRESS_PATH);
+  }
+
+  const isFreshFile = !fs.existsSync(CSV_PATH);
+  if (isFreshFile) {
+    fs.writeFileSync(CSV_PATH, CSV_HEADER + '\n');
+  }
+
+  const progress = readProgress();
+  const skipUntilId = progress.lastId ?? undefined;
+
+  const startedAt = Date.now();
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  let pageError: string | null = null;
+  let newRows = 0;
+  let lastNewId: string | null = progress.lastId;
+  let oldestNewTimestamp: string | null = null;
+
+  try {
+    await page.goto(X_URLS.bookmarks, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) {
+      await context.close();
+      return auth;
+    }
+
+    // Custom scroll-and-collect loop (NOT collectTweets) so we can:
+    //   - Track elapsed time precisely against TIME_BUDGET_MS
+    //   - Flush rows to disk incrementally so a mid-run crash still
+    //     preserves what we already collected
+    //   - Detect "scroll stalled" (height not increasing → end of feed)
+    const seen = new Set<string>();
+    let pastMarker = !skipUntilId;
+    let prevScrollHeight = 0;
+    let stalledRounds = 0;
+
+    // Open CSV in append mode for this session
+    const csvFd = fs.openSync(CSV_PATH, 'a');
+
+    try {
+      while (Date.now() - startedAt < TIME_BUDGET_MS) {
+        const articles = page.locator(X_SELECTORS.tweet);
+        const count = await articles.count();
+        let collectedThisRound = 0;
+
+        for (let i = 0; i < count; i++) {
+          if (Date.now() - startedAt >= TIME_BUDGET_MS) break;
+          const parsed = await parseTweetCard(articles.nth(i));
+          if (!parsed.id || seen.has(parsed.id)) continue;
+          seen.add(parsed.id);
+          if (!pastMarker) {
+            if (parsed.id === skipUntilId) pastMarker = true;
+            continue;
+          }
+          // New tweet — flush a CSV row and bump counters
+          fs.writeSync(csvFd, tweetToCsvRow(parsed) + '\n');
+          newRows += 1;
+          collectedThisRound += 1;
+          lastNewId = parsed.id;
+          if (parsed.timestamp) oldestNewTimestamp = parsed.timestamp;
+        }
+
+        // End-of-feed detection: scroll height didn't grow for several
+        // consecutive rounds AND no new tweets parsed → we're done.
+        const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+        if (scrollHeight === prevScrollHeight && collectedThisRound === 0) {
+          stalledRounds += 1;
+          if (stalledRounds >= 3) break;
+        } else {
+          stalledRounds = 0;
+          prevScrollHeight = scrollHeight;
+        }
+
+        if (Date.now() - startedAt >= TIME_BUDGET_MS) break;
+        await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+        await page.waitForTimeout(SCROLL_PAUSE_MS);
+      }
+    } finally {
+      fs.closeSync(csvFd);
+    }
+
+    // Update progress sidecar regardless of how the loop exited (timed
+    // out vs feed-end vs error). Lets the next call resume cleanly.
+    if (newRows > 0 && lastNewId) {
+      writeProgress({
+        lastId: lastNewId,
+        totalRows: progress.totalRows + newRows,
+        lastUpdated: new Date().toISOString(),
+      });
+    } else if (isFreshFile || reset) {
+      // First call with no rows — still write a sidecar so subsequent
+      // calls don't think it's a fresh start.
+      writeProgress({
+        lastId: progress.lastId,
+        totalRows: progress.totalRows,
+        lastUpdated: new Date().toISOString(),
+      });
+    }
+
+    const totalRows = progress.totalRows + newRows;
+    const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+    // Decide whether more work is likely available.
+    // Heuristic: if we collected >0 rows in this call, there's probably
+    // more (we cut off at the time budget). If we collected 0 AND the
+    // marker was found (or was already null on a fresh export), the
+    // feed is exhausted.
+    const moreAvailable = newRows > 0;
+
+    const summary = [
+      `Bookmark export — appended ${newRows} row${newRows === 1 ? '' : 's'} in ${elapsedSec}s.`,
+      `CSV: ${CSV_PATH}`,
+      `(Agent path: /workspace/group/captures/bookmarks.csv)`,
+      `Total rows: ${totalRows}.`,
+      oldestNewTimestamp ? `Oldest new bookmark: ${oldestNewTimestamp}.` : null,
+      moreAvailable
+        ? `More likely available — call x_export_bookmarks again to continue.`
+        : `End of bookmarks reached.`,
+    ].filter(Boolean).join(' ');
+
+    return {
+      success: true,
+      message: summary,
+      data: {
+        csvPath: CSV_PATH,
+        agentPath: '/workspace/group/captures/bookmarks.csv',
+        appendedRows: newRows,
+        totalRows,
+        moreAvailable,
+        oldestNewTimestamp,
+      },
+    };
+  } catch (err) {
+    pageError = err instanceof Error ? err.message : String(err);
+    await captureFailure(page, 'export-bookmarks-error');
+    // Still update progress so partial exports are resumable
+    if (newRows > 0 && lastNewId) {
+      writeProgress({
+        lastId: lastNewId,
+        totalRows: progress.totalRows + newRows,
+        lastUpdated: new Date().toISOString(),
+      });
+    }
+    return {
+      success: false,
+      message: `export-bookmarks error after ${newRows} row(s): ${pageError}. Progress saved — re-run x_export_bookmarks to resume.`,
+    };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(exportBookmarks);

--- a/.claude/skills/x-integration/scripts/follow.ts
+++ b/.claude/skills/x-integration/scripts/follow.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X follow — follow a user. Navigates to their profile, clicks Follow.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { handle: string }
+
+async function follow(input: Input): Promise<ScriptResult> {
+  if (!input.handle) return { success: false, message: 'handle required.' };
+  const handle = input.handle.replace(/^@/, '');
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.profile(handle), { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    if (await page.locator(X_SELECTORS.unfollowButton).isVisible().catch(() => false)) {
+      return { success: true, message: `Already following @${handle} (no-op).` };
+    }
+    const btn = page.locator(X_SELECTORS.followButton);
+    await btn.waitFor({ timeout: config.timeouts.elementWait });
+    await btn.click();
+    await page.waitForTimeout(config.timeouts.afterClick);
+    if (await page.locator(X_SELECTORS.unfollowButton).isVisible().catch(() => false)) {
+      return { success: true, message: `Followed @${handle}.` };
+    }
+    await captureFailure(page, 'follow-no-verify');
+    return { success: false, message: `Click registered but unfollow-state not visible — @${handle} may have follow-restrictions on. Verify manually.` };
+  } catch (err) {
+    return { success: false, message: `follow error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(follow);

--- a/.claude/skills/x-integration/scripts/list-scheduled.ts
+++ b/.claude/skills/x-integration/scripts/list-scheduled.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X list-scheduled — list pending scheduled tweets in X's queue.
+ *
+ * URL: /compose/post/unsent/scheduled. Each scheduled item renders as
+ * a card with the body text and a scheduled-for timestamp. Selectors
+ * here are LOW confidence (X may rename the wrapper) — verify on first
+ * user-test failure and update lib/locators.ts if needed.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input {}
+
+interface ScheduledItem {
+  index: number;
+  text: string;
+  scheduledFor: string;
+}
+
+async function listScheduled(_input: Input): Promise<ScriptResult> {
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.scheduledTweets, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    // Each scheduled card: a clickable row with the tweet text + a "Will
+    // send on …" line. We scrape the visible cards, parse text + time.
+    const cards = page.locator('[role="button"]').filter({ hasText: /Will send on|Scheduled for/ });
+    const count = await cards.count();
+    const items: ScheduledItem[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = ((await cards.nth(i).innerText()) || '').trim();
+      if (!text) continue;
+      // Heuristic split: last line is usually the schedule meta.
+      const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+      const metaIdx = lines.findIndex((l) => /Will send on|Scheduled for/i.test(l));
+      const tweetText = lines.slice(0, metaIdx === -1 ? lines.length : metaIdx).join(' ');
+      const scheduledFor = metaIdx === -1 ? '' : lines.slice(metaIdx).join(' ');
+      items.push({ index: i + 1, text: tweetText, scheduledFor });
+    }
+
+    if (items.length === 0) {
+      return { success: true, message: 'No scheduled tweets in queue.', data: [] };
+    }
+    const blocks = items.map((it) => `[${it.index}] ${it.scheduledFor}\n  ${it.text.slice(0, 200)}${it.text.length > 200 ? '…' : ''}`);
+    return {
+      success: true,
+      message: `Scheduled tweets (${items.length}):\n\n${blocks.join('\n\n')}`,
+      data: items,
+    };
+  } catch (err) {
+    await captureFailure(page, 'list-scheduled-error');
+    return { success: false, message: `list-scheduled error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(listScheduled);

--- a/.claude/skills/x-integration/scripts/post.ts
+++ b/.claude/skills/x-integration/scripts/post.ts
@@ -1,66 +1,111 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X Integration - Post Tweet
- * Usage: echo '{"content":"Hello world"}' | pnpm exec tsx post.ts
+ * X post — publish a tweet, optionally with media + native scheduling.
+ *
+ * Flow:
+ *   1. Navigate to /home (use the inline composer).
+ *   2. Click into the tweet textarea, fill content.
+ *   3. (Optional) Set <input type="file"> with media paths.
+ *   4. (Optional) Click the schedule icon, set date/time, confirm.
+ *   5. Click the inline post button (label changes to "Schedule" when
+ *      a scheduled time is set).
  */
 
-import { getBrowserContext, runScript, validateContent, config, ScriptResult } from '../lib/browser.js';
+import fs from 'fs';
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure, validateContent } from '../lib/browser.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
 
-interface PostInput {
-  content: string;
-}
+interface Input { content: string; media?: string[]; scheduleAt?: string | null }
 
-async function postTweet(input: PostInput): Promise<ScriptResult> {
-  const { content } = input;
+async function postTweet(input: Input): Promise<ScriptResult> {
+  const validation = validateContent(input.content, 'Tweet');
+  if (validation) return validation;
 
-  const validationError = validateContent(content, 'Tweet');
-  if (validationError) return validationError;
+  const media = input.media ?? [];
+  if (media.length > config.limits.mediaMaxPerTweet) {
+    return { success: false, message: `media: maximum ${config.limits.mediaMaxPerTweet} images per tweet.` };
+  }
+  for (const p of media) {
+    if (!fs.existsSync(p)) return { success: false, message: `media file not found: ${p}` };
+  }
 
-  let context = null;
+  const scheduleAt = input.scheduleAt ? new Date(input.scheduleAt) : null;
+  if (scheduleAt && (isNaN(scheduleAt.getTime()) || scheduleAt.getTime() < Date.now())) {
+    return { success: false, message: `scheduleAt must be a future ISO timestamp (got "${input.scheduleAt}").` };
+  }
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
   try {
-    context = await getBrowserContext();
-    const page = context.pages()[0] || await context.newPage();
-
-    await page.goto('https://x.com/home', { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.goto(X_URLS.home, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(config.timeouts.pageLoad);
 
-    // Check if logged in
-    const isLoggedIn = await page.locator('[data-testid="SideNav_AccountSwitcher_Button"]').isVisible().catch(() => false);
-    if (!isLoggedIn) {
-      const onLoginPage = await page.locator('input[autocomplete="username"]').isVisible().catch(() => false);
-      if (onLoginPage) {
-        return { success: false, message: 'X login expired. Run /x-integration to re-authenticate.' };
-      }
-    }
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
 
-    // Find and fill tweet input
-    const tweetInput = page.locator('[data-testid="tweetTextarea_0"]');
-    await tweetInput.waitFor({ timeout: config.timeouts.elementWait * 2 });
-    await tweetInput.click();
-    await page.waitForTimeout(config.timeouts.afterClick / 2);
-    await tweetInput.fill(content);
+    const textarea = page.locator(X_SELECTORS.tweetTextarea);
+    await textarea.waitFor({ timeout: config.timeouts.elementWait * 2 });
+    await textarea.click();
+    await textarea.fill(input.content);
     await page.waitForTimeout(config.timeouts.afterFill);
 
-    // Click post button
-    const postButton = page.locator('[data-testid="tweetButtonInline"]');
-    await postButton.waitFor({ timeout: config.timeouts.elementWait });
-
-    const isDisabled = await postButton.getAttribute('aria-disabled');
-    if (isDisabled === 'true') {
-      return { success: false, message: 'Post button disabled. Content may be empty or exceed character limit.' };
+    // Media: locate the first file input under the composer ancestor.
+    if (media.length > 0) {
+      const fileInput = page.locator(X_SELECTORS.fileInput).first();
+      await fileInput.waitFor({ state: 'attached', timeout: config.timeouts.elementWait });
+      await fileInput.setInputFiles(media);
+      // X processes media asynchronously — wait for thumbnails to appear.
+      await page.waitForTimeout(3000 + media.length * 1000);
     }
 
-    await postButton.click();
+    // Schedule (X-native)
+    if (scheduleAt) {
+      const scheduleBtn = page.locator(X_SELECTORS.scheduleIconButton);
+      await scheduleBtn.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleBtn.click();
+      await page.waitForTimeout(config.timeouts.afterClick);
+
+      // Use the explicit date/time inputs in the modal. Format: yyyy-mm-dd / HH:MM (24h).
+      const yyyy = scheduleAt.getFullYear();
+      const mm = String(scheduleAt.getMonth() + 1).padStart(2, '0');
+      const dd = String(scheduleAt.getDate()).padStart(2, '0');
+      const HH = String(scheduleAt.getHours()).padStart(2, '0');
+      const MM = String(scheduleAt.getMinutes()).padStart(2, '0');
+
+      const dateInput = page.locator('input[type="date"]').first();
+      const timeInput = page.locator('input[type="time"]').first();
+      if (await dateInput.count()) {
+        await dateInput.fill(`${yyyy}-${mm}-${dd}`);
+      }
+      if (await timeInput.count()) {
+        await timeInput.fill(`${HH}:${MM}`);
+      }
+      await page.waitForTimeout(config.timeouts.afterFill);
+
+      const scheduleConfirm = page.locator(X_SELECTORS.scheduleConfirmButton);
+      await scheduleConfirm.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleConfirm.click();
+      await page.waitForTimeout(config.timeouts.afterSubmit);
+    }
+
+    const postBtn = page.locator(X_SELECTORS.tweetButtonInline);
+    await postBtn.waitFor({ timeout: config.timeouts.elementWait });
+    if ((await postBtn.getAttribute('aria-disabled')) === 'true') {
+      return { success: false, message: 'Post button disabled — content may be empty or invalid.' };
+    }
+    await postBtn.click();
     await page.waitForTimeout(config.timeouts.afterSubmit);
 
-    return {
-      success: true,
-      message: `Tweet posted: ${content.slice(0, 50)}${content.length > 50 ? '...' : ''}`
-    };
-
+    const headline = scheduleAt
+      ? `Tweet scheduled for ${scheduleAt.toISOString()}`
+      : `Tweet posted: ${input.content.slice(0, 80)}${input.content.length > 80 ? '…' : ''}`;
+    return { success: true, message: headline };
+  } catch (err) {
+    await captureFailure(page, 'post-error');
+    return { success: false, message: `post error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
-    if (context) await context.close();
+    await context.close();
   }
 }
 
-runScript<PostInput>(postTweet);
+runScript<Input>(postTweet);

--- a/.claude/skills/x-integration/scripts/quote.ts
+++ b/.claude/skills/x-integration/scripts/quote.ts
@@ -1,80 +1,107 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X Integration - Quote Tweet
- * Usage: echo '{"tweetUrl":"https://x.com/user/status/123","comment":"My thoughts"}' | pnpm exec tsx quote.ts
+ * X quote — quote-tweet with comment, optional media + schedule.
+ *
+ * Flow: navigate to tweet → click retweet icon → click "Quote" in
+ * popup → modal opens with the source tweet attached → fill comment →
+ * optional media → optional schedule → click modal "Post" button.
  */
 
-import { getBrowserContext, navigateToTweet, runScript, validateContent, config, ScriptResult } from '../lib/browser.js';
+import fs from 'fs';
+import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure, validateContent } from '../lib/browser.js';
+import { X_SELECTORS } from '../lib/locators.js';
 
-interface QuoteInput {
-  tweetUrl: string;
-  comment: string;
-}
+interface Input { tweetUrl: string; comment: string; media?: string[]; scheduleAt?: string | null }
 
-async function quoteTweet(input: QuoteInput): Promise<ScriptResult> {
-  const { tweetUrl, comment } = input;
+async function quote(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+  const validation = validateContent(input.comment, 'Quote comment');
+  if (validation) return validation;
 
-  if (!tweetUrl) {
-    return { success: false, message: 'Please provide a tweet URL' };
+  const media = input.media ?? [];
+  if (media.length > config.limits.mediaMaxPerTweet) {
+    return { success: false, message: `media: maximum ${config.limits.mediaMaxPerTweet} images per quote tweet.` };
+  }
+  for (const p of media) {
+    if (!fs.existsSync(p)) return { success: false, message: `media file not found: ${p}` };
   }
 
-  const validationError = validateContent(comment, 'Comment');
-  if (validationError) return validationError;
+  const scheduleAt = input.scheduleAt ? new Date(input.scheduleAt) : null;
+  if (scheduleAt && (isNaN(scheduleAt.getTime()) || scheduleAt.getTime() < Date.now())) {
+    return { success: false, message: `scheduleAt must be a future ISO timestamp (got "${input.scheduleAt}").` };
+  }
 
-  let context = null;
+  const context = await getBrowserContext();
   try {
-    context = await getBrowserContext();
-    const { page, success, error } = await navigateToTweet(context, tweetUrl);
+    const nav = await navigateToTweet(context, input.tweetUrl);
+    if (!nav.success) return { success: false, message: nav.error || 'Navigation failed.' };
+    const auth = await ensureLoggedIn(nav.page);
+    if (auth) return auth;
 
-    if (!success) {
-      return { success: false, message: error || 'Navigation failed' };
-    }
+    const article = nav.page.locator(X_SELECTORS.tweet).first();
+    // Open the retweet popup, then choose "Quote" rather than retweetConfirm.
+    await article.locator(X_SELECTORS.retweet).first().click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
 
-    // Click retweet button to open menu
-    const tweet = page.locator('article[data-testid="tweet"]').first();
-    const retweetButton = tweet.locator('[data-testid="retweet"]');
-    await retweetButton.waitFor({ timeout: config.timeouts.elementWait });
-    await retweetButton.click();
-    await page.waitForTimeout(config.timeouts.afterClick);
-
-    // Click quote option
-    const quoteOption = page.getByRole('menuitem').filter({ hasText: /Quote/i });
+    // The "Quote" entry has its own data-testid in modern X: "quoteOption".
+    // Fall back to text-match if the testid changes.
+    const quoteOption = nav.page.locator('[data-testid="quoteOption"], div[role="menuitem"]:has-text("Quote")').first();
     await quoteOption.waitFor({ timeout: config.timeouts.elementWait });
     await quoteOption.click();
-    await page.waitForTimeout(config.timeouts.afterClick * 1.5);
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
 
-    // Find dialog with aria-modal="true"
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
-    await dialog.waitFor({ timeout: config.timeouts.elementWait });
+    const textarea = nav.page.locator(X_SELECTORS.tweetTextarea);
+    await textarea.waitFor({ timeout: config.timeouts.elementWait * 2 });
+    await textarea.fill(input.comment);
+    await nav.page.waitForTimeout(config.timeouts.afterFill);
 
-    // Fill comment
-    const quoteInput = dialog.locator('[data-testid="tweetTextarea_0"]');
-    await quoteInput.waitFor({ timeout: config.timeouts.elementWait });
-    await quoteInput.click();
-    await page.waitForTimeout(config.timeouts.afterClick / 2);
-    await quoteInput.fill(comment);
-    await page.waitForTimeout(config.timeouts.afterFill);
-
-    // Click submit button
-    const submitButton = dialog.locator('[data-testid="tweetButton"]');
-    await submitButton.waitFor({ timeout: config.timeouts.elementWait });
-
-    const isDisabled = await submitButton.getAttribute('aria-disabled');
-    if (isDisabled === 'true') {
-      return { success: false, message: 'Submit button disabled. Content may be empty or exceed character limit.' };
+    if (media.length > 0) {
+      const fileInput = nav.page.locator(X_SELECTORS.fileInput).first();
+      await fileInput.waitFor({ state: 'attached', timeout: config.timeouts.elementWait });
+      await fileInput.setInputFiles(media);
+      await nav.page.waitForTimeout(3000 + media.length * 1000);
     }
 
-    await submitButton.click();
-    await page.waitForTimeout(config.timeouts.afterSubmit);
+    if (scheduleAt) {
+      const scheduleBtn = nav.page.locator(X_SELECTORS.scheduleIconButton);
+      await scheduleBtn.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleBtn.click();
+      await nav.page.waitForTimeout(config.timeouts.afterClick);
 
-    return {
-      success: true,
-      message: `Quote tweet posted: ${comment.slice(0, 50)}${comment.length > 50 ? '...' : ''}`
-    };
+      const yyyy = scheduleAt.getFullYear();
+      const mm = String(scheduleAt.getMonth() + 1).padStart(2, '0');
+      const dd = String(scheduleAt.getDate()).padStart(2, '0');
+      const HH = String(scheduleAt.getHours()).padStart(2, '0');
+      const MM = String(scheduleAt.getMinutes()).padStart(2, '0');
+      const dateInput = nav.page.locator('input[type="date"]').first();
+      const timeInput = nav.page.locator('input[type="time"]').first();
+      if (await dateInput.count()) await dateInput.fill(`${yyyy}-${mm}-${dd}`);
+      if (await timeInput.count()) await timeInput.fill(`${HH}:${MM}`);
+      await nav.page.waitForTimeout(config.timeouts.afterFill);
 
+      const scheduleConfirm = nav.page.locator(X_SELECTORS.scheduleConfirmButton);
+      await scheduleConfirm.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleConfirm.click();
+      await nav.page.waitForTimeout(config.timeouts.afterSubmit);
+    }
+
+    const submit = nav.page.locator(X_SELECTORS.tweetButtonModal);
+    await submit.waitFor({ timeout: config.timeouts.elementWait });
+    if ((await submit.getAttribute('aria-disabled')) === 'true') {
+      return { success: false, message: 'Post button disabled — comment may be invalid.' };
+    }
+    await submit.click();
+    await nav.page.waitForTimeout(config.timeouts.afterSubmit);
+
+    const headline = scheduleAt
+      ? `Quote tweet scheduled for ${scheduleAt.toISOString()}`
+      : `Quote tweet posted: ${input.comment.slice(0, 80)}${input.comment.length > 80 ? '…' : ''}`;
+    return { success: true, message: headline };
+  } catch (err) {
+    return { success: false, message: `quote error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
-    if (context) await context.close();
+    await context.close();
   }
 }
 
-runScript<QuoteInput>(quoteTweet);
+runScript<Input>(quote);

--- a/.claude/skills/x-integration/scripts/read-bookmarks.ts
+++ b/.claude/skills/x-integration/scripts/read-bookmarks.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-bookmarks — fetch the user's bookmarked tweets, newest first.
+ *
+ * Pagination: X's bookmarks page is an infinite-scroll list with no
+ * native cursor. We fake one by treating the oldest tweet ID from the
+ * previous batch as a marker — the next call scrolls past everything
+ * up to and including that ID before it starts collecting again.
+ * Caller walks full history by chaining: first call without `cursor`,
+ * subsequent calls pass `nextCursor` from the prior result until no
+ * `nextCursor` is returned.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { limit?: number; cursor?: string | null }
+
+/** Hard ceiling for `limit` on this tool. Higher than the global READ_MAX
+ *  because bookmark walks benefit from larger batches (each paginated
+ *  call has to re-scroll past the cursor anyway). */
+const BOOKMARKS_LIMIT_MAX = 100;
+
+/** Scroll budget — enough for a paginated walk that has to skip past
+ *  hundreds of already-seen items before collecting fresh ones. Bounded
+ *  by the host's 120s script timeout; ~100 rounds × 800ms ≈ 80s of
+ *  scrolling, leaving room for parse time. */
+const SCROLL_MAX_ROUNDS = 100;
+
+async function readBookmarks(input: Input): Promise<ScriptResult> {
+  const limit = Math.min(input.limit ?? 20, BOOKMARKS_LIMIT_MAX);
+  const cursor = input.cursor && input.cursor.length > 0 ? input.cursor : undefined;
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.bookmarks, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit, {
+      scrollMaxRounds: SCROLL_MAX_ROUNDS,
+      skipUntilId: cursor,
+    });
+
+    // Heuristic: if we filled the limit, assume more are available and
+    // emit a cursor. If we returned fewer than asked, the feed is likely
+    // exhausted — drop the cursor so the agent stops.
+    const nextCursor = tweets.length === limit && tweets[tweets.length - 1]?.id
+      ? tweets[tweets.length - 1].id
+      : undefined;
+
+    const header = `Bookmarks${cursor ? ' (continued)' : ''} — ${tweets.length} tweet${tweets.length === 1 ? '' : 's'}:`;
+    const cursorLine = nextCursor
+      ? `\n\nNEXT_CURSOR: ${nextCursor}\n(More bookmarks available. Call x_read_bookmarks again with cursor=${nextCursor} to fetch the next batch.)`
+      : '\n\n(End of bookmarks reached, or all bookmarks since cursor returned.)';
+
+    return {
+      success: true,
+      message: renderTweetList(tweets, header) + cursorLine,
+      data: { tweets, nextCursor: nextCursor ?? null },
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-bookmarks-error');
+    return { success: false, message: `read-bookmarks error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readBookmarks);

--- a/.claude/skills/x-integration/scripts/read-dm-inbox.ts
+++ b/.claude/skills/x-integration/scripts/read-dm-inbox.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-dm-inbox — list DM conversations with unread + last-message preview.
+ *
+ * Does NOT mark anything as read (stays on the inbox page; doesn't
+ * open individual threads). Each row is a [data-testid="conversation"]
+ * which we parse via lib/extract.parseDmConversation.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { parseDmConversation, renderDmInbox, ParsedDmConversation } from '../lib/extract.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { limit?: number }
+
+async function readDmInbox(input: Input): Promise<ScriptResult> {
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.dmInbox, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const rows = page.locator(X_SELECTORS.dmConversation);
+    const count = Math.min(await rows.count(), limit);
+    const conversations: ParsedDmConversation[] = [];
+    for (let i = 0; i < count; i++) {
+      conversations.push(await parseDmConversation(rows.nth(i)));
+    }
+
+    return {
+      success: true,
+      message: renderDmInbox(conversations),
+      data: conversations,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-dm-inbox-error');
+    return { success: false, message: `read-dm-inbox error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readDmInbox);

--- a/.claude/skills/x-integration/scripts/read-dm-thread.ts
+++ b/.claude/skills/x-integration/scripts/read-dm-thread.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-dm-thread — read messages in a DM thread by recipient handle.
+ *
+ * CAVEAT: opening the thread marks unread messages as read on X. This
+ * is unavoidable — X's web UI dispatches a read receipt as soon as the
+ * thread renders. SKILL.md surfaces this caveat to users.
+ *
+ * Strategy: open inbox, click the conversation whose row contains
+ * "@<handle>", then scrape [data-testid="messageEntry"] elements.
+ * Direction (you / them) is inferred from CSS positioning (right-side
+ * bubbles are "you").
+ */
+
+import type { Locator } from 'playwright-core';
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { renderDmThread, ParsedDmMessage } from '../lib/extract.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { handle: string; limit?: number }
+
+async function parseMessage(entry: Locator): Promise<ParsedDmMessage> {
+  let text = '';
+  let timestamp: string | null = null;
+  let direction: 'you' | 'them' = 'them';
+
+  try {
+    text = ((await entry.innerText()) || '').trim();
+  } catch {}
+  try {
+    const timeEl = entry.locator('time').first();
+    if (await timeEl.count()) timestamp = (await timeEl.getAttribute('datetime')) || null;
+  } catch {}
+  // Direction heuristic: X aligns own messages to the right (margin-left auto).
+  // Try to infer from a parent's text-align / justify-content.
+  try {
+    const align = await entry.evaluate((el) => {
+      let cur = el as HTMLElement | null;
+      for (let i = 0; i < 6 && cur; i++) {
+        const cs = window.getComputedStyle(cur);
+        if (cs.justifyContent === 'flex-end' || cs.alignItems === 'flex-end') return 'you';
+        if (cs.justifyContent === 'flex-start' || cs.alignItems === 'flex-start') return 'them';
+        cur = cur.parentElement;
+      }
+      return 'them';
+    });
+    direction = align as 'you' | 'them';
+  } catch {}
+
+  return { text, timestamp, direction };
+}
+
+async function readDmThread(input: Input): Promise<ScriptResult> {
+  if (!input.handle) return { success: false, message: 'handle required.' };
+  const handle = input.handle.replace(/^@/, '');
+  const limit = Math.min(input.limit ?? 30, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.dmInbox, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    // Find the row whose visible text contains "@<handle>" (case-insensitive)
+    const rows = page.locator(X_SELECTORS.dmConversation);
+    const count = await rows.count();
+    let target = -1;
+    const needle = `@${handle}`.toLowerCase();
+    for (let i = 0; i < count; i++) {
+      const txt = ((await rows.nth(i).innerText()) || '').toLowerCase();
+      if (txt.includes(needle)) {
+        target = i;
+        break;
+      }
+    }
+    if (target < 0) {
+      return { success: false, message: `No DM conversation found with @${handle} in the inbox. They may not have messaged you, or may not be in your inbox cache.` };
+    }
+    await rows.nth(target).click();
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const messageEntries = page.locator(X_SELECTORS.dmMessageEntry);
+    const msgCount = Math.min(await messageEntries.count(), limit);
+    const messages: ParsedDmMessage[] = [];
+    for (let i = 0; i < msgCount; i++) {
+      messages.push(await parseMessage(messageEntries.nth(i)));
+    }
+
+    return {
+      success: true,
+      message: renderDmThread(messages, handle),
+      data: messages,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-dm-thread-error');
+    return { success: false, message: `read-dm-thread error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readDmThread);

--- a/.claude/skills/x-integration/scripts/read-list.ts
+++ b/.claude/skills/x-integration/scripts/read-list.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-list — fetch tweets in any X list (yours or someone else's).
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+
+interface Input { listUrl: string; limit?: number }
+
+async function readList(input: Input): Promise<ScriptResult> {
+  if (!input.listUrl) return { success: false, message: 'listUrl required.' };
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(input.listUrl, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit);
+    if (tweets.length === 0) {
+      await captureFailure(page, 'read-list-empty');
+      return { success: false, message: `No tweets on list ${input.listUrl} — list may be empty, private, or URL invalid.` };
+    }
+    return {
+      success: true,
+      message: renderTweetList(tweets, `List (${input.listUrl}) — ${tweets.length} tweet${tweets.length === 1 ? '' : 's'}:`),
+      data: tweets,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-list-error');
+    return { success: false, message: `read-list error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readList);

--- a/.claude/skills/x-integration/scripts/read-notifications.ts
+++ b/.claude/skills/x-integration/scripts/read-notifications.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-notifications — fetch the mentions/interactions feed.
+ *
+ * The notifications page contains a mix of cards: tweets that mention
+ * you (which parseTweetCard handles), follow notifications, and
+ * like/retweet aggregates (which don't render as <article
+ * data-testid="tweet">). We collect tweets via collectTweets and
+ * surface them; non-tweet notifications are skipped silently.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { limit?: number }
+
+async function readNotifications(input: Input): Promise<ScriptResult> {
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.notifications, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit);
+    return {
+      success: true,
+      message: renderTweetList(tweets, `Notifications — ${tweets.length} mention/reply${tweets.length === 1 ? '' : 's'} (non-tweet notifications like follows/likes are not shown):`),
+      data: tweets,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-notifications-error');
+    return { success: false, message: `read-notifications error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readNotifications);

--- a/.claude/skills/x-integration/scripts/read-thread.ts
+++ b/.claude/skills/x-integration/scripts/read-thread.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-thread — fetch a tweet plus its top replies.
+ *
+ * X's thread UI: opening a tweet's permalink shows the parent tweet
+ * (first article on page) followed by its replies in subsequent
+ * articles. We collect all visible articles up to `limit`, mark the
+ * first one as the root, the rest as replies.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure, extractTweetId } from '../lib/browser.js';
+import { collectTweets, renderTweet, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { tweetUrl: string; limit?: number }
+
+async function readThread(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    const id = extractTweetId(input.tweetUrl);
+    const url = id ? X_URLS.tweetById(id) : input.tweetUrl;
+    await page.goto(url, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit);
+    if (tweets.length === 0) {
+      await captureFailure(page, 'read-thread-empty');
+      return { success: false, message: 'Thread page produced no tweets — may have failed to load.' };
+    }
+
+    const root = tweets[0];
+    const replies = tweets.slice(1);
+    const header = `Thread root:\n\n${renderTweet(root)}\n\n=== ${replies.length} repl${replies.length === 1 ? 'y' : 'ies'} ===`;
+    return {
+      success: true,
+      message: replies.length > 0 ? `${header}\n\n${renderTweetList(replies, '').trim()}` : header,
+      data: { root, replies },
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-thread-error');
+    return { success: false, message: `read-thread error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readThread);

--- a/.claude/skills/x-integration/scripts/read-timeline.ts
+++ b/.claude/skills/x-integration/scripts/read-timeline.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-timeline — fetch the user's home timeline (For You / Following).
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { limit?: number }
+
+async function readTimeline(input: Input): Promise<ScriptResult> {
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.home, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit);
+    return {
+      success: true,
+      message: renderTweetList(tweets, `Home timeline — ${tweets.length} tweet${tweets.length === 1 ? '' : 's'}:`),
+      data: tweets,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-timeline-error');
+    return { success: false, message: `read-timeline error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readTimeline);

--- a/.claude/skills/x-integration/scripts/read-tweet.ts
+++ b/.claude/skills/x-integration/scripts/read-tweet.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-tweet — fetch a single tweet by URL or ID.
+ *
+ * Reads JSON from stdin: { tweetUrl: string }.
+ * Returns ScriptResult with renderTweet(t) in `message` and the parsed
+ * tweet object in `data` for any downstream tool that wants structured.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { extractTweetId } from '../lib/browser.js';
+import { parseTweetCard, renderTweet } from '../lib/extract.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { tweetUrl: string }
+
+async function readTweet(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    const id = extractTweetId(input.tweetUrl);
+    const url = id ? X_URLS.tweetById(id) : input.tweetUrl;
+    await page.goto(url, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const article = page.locator(X_SELECTORS.tweet).first();
+    const exists = await article.isVisible().catch(() => false);
+    if (!exists) {
+      await captureFailure(page, 'read-tweet-not-found');
+      return { success: false, message: 'Tweet not found (deleted, private, or URL invalid).' };
+    }
+
+    const tweet = await parseTweetCard(article);
+    return { success: true, message: renderTweet(tweet), data: tweet };
+  } catch (err) {
+    await captureFailure(page, 'read-tweet-error');
+    return { success: false, message: `read-tweet error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readTweet);

--- a/.claude/skills/x-integration/scripts/read-user.ts
+++ b/.claude/skills/x-integration/scripts/read-user.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X read-user — fetch a user's recent tweets from their profile.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { handle: string; limit?: number }
+
+async function readUser(input: Input): Promise<ScriptResult> {
+  if (!input.handle) return { success: false, message: 'handle required.' };
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+  const handle = input.handle.replace(/^@/, '');
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.profile(handle), { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    // Profile-not-found pages render with no tweet articles.
+    const tweets = await collectTweets(page, limit);
+    if (tweets.length === 0) {
+      await captureFailure(page, 'read-user-empty');
+      return {
+        success: false,
+        message: `No tweets visible on @${handle}'s profile — account may not exist, be private, or the page failed to load.`,
+      };
+    }
+
+    return {
+      success: true,
+      message: renderTweetList(tweets, `@${handle} — ${tweets.length} recent tweet${tweets.length === 1 ? '' : 's'}:`),
+      data: tweets,
+    };
+  } catch (err) {
+    await captureFailure(page, 'read-user-error');
+    return { success: false, message: `read-user error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(readUser);

--- a/.claude/skills/x-integration/scripts/reply.ts
+++ b/.claude/skills/x-integration/scripts/reply.ts
@@ -1,74 +1,100 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X Integration - Reply to Tweet
- * Usage: echo '{"tweetUrl":"https://x.com/user/status/123","content":"Great post!"}' | pnpm exec tsx reply.ts
+ * X reply — reply to a tweet, optionally with media + native scheduling.
+ *
+ * Flow: navigate to tweet → click reply icon → modal opens → fill text
+ * → optional media → optional schedule → click modal "Reply" button.
  */
 
-import { getBrowserContext, navigateToTweet, runScript, validateContent, config, ScriptResult } from '../lib/browser.js';
+import fs from 'fs';
+import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure, validateContent } from '../lib/browser.js';
+import { X_SELECTORS } from '../lib/locators.js';
 
-interface ReplyInput {
-  tweetUrl: string;
-  content: string;
-}
+interface Input { tweetUrl: string; content: string; media?: string[]; scheduleAt?: string | null }
 
-async function replyToTweet(input: ReplyInput): Promise<ScriptResult> {
-  const { tweetUrl, content } = input;
+async function reply(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+  const validation = validateContent(input.content, 'Reply');
+  if (validation) return validation;
 
-  if (!tweetUrl) {
-    return { success: false, message: 'Please provide a tweet URL' };
+  const media = input.media ?? [];
+  if (media.length > config.limits.mediaMaxPerTweet) {
+    return { success: false, message: `media: maximum ${config.limits.mediaMaxPerTweet} images per reply.` };
+  }
+  for (const p of media) {
+    if (!fs.existsSync(p)) return { success: false, message: `media file not found: ${p}` };
   }
 
-  const validationError = validateContent(content, 'Reply');
-  if (validationError) return validationError;
+  const scheduleAt = input.scheduleAt ? new Date(input.scheduleAt) : null;
+  if (scheduleAt && (isNaN(scheduleAt.getTime()) || scheduleAt.getTime() < Date.now())) {
+    return { success: false, message: `scheduleAt must be a future ISO timestamp (got "${input.scheduleAt}").` };
+  }
 
-  let context = null;
+  const context = await getBrowserContext();
   try {
-    context = await getBrowserContext();
-    const { page, success, error } = await navigateToTweet(context, tweetUrl);
+    const nav = await navigateToTweet(context, input.tweetUrl);
+    if (!nav.success) return { success: false, message: nav.error || 'Navigation failed.' };
+    const auth = await ensureLoggedIn(nav.page);
+    if (auth) return auth;
 
-    if (!success) {
-      return { success: false, message: error || 'Navigation failed' };
+    const article = nav.page.locator(X_SELECTORS.tweet).first();
+    await article.locator(X_SELECTORS.reply).first().click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
+
+    // Modal textarea (same testid as inline composer in modal scope)
+    const textarea = nav.page.locator(X_SELECTORS.tweetTextarea);
+    await textarea.waitFor({ timeout: config.timeouts.elementWait * 2 });
+    await textarea.fill(input.content);
+    await nav.page.waitForTimeout(config.timeouts.afterFill);
+
+    if (media.length > 0) {
+      const fileInput = nav.page.locator(X_SELECTORS.fileInput).first();
+      await fileInput.waitFor({ state: 'attached', timeout: config.timeouts.elementWait });
+      await fileInput.setInputFiles(media);
+      await nav.page.waitForTimeout(3000 + media.length * 1000);
     }
 
-    // Click reply button
-    const tweet = page.locator('article[data-testid="tweet"]').first();
-    const replyButton = tweet.locator('[data-testid="reply"]');
-    await replyButton.waitFor({ timeout: config.timeouts.elementWait });
-    await replyButton.click();
-    await page.waitForTimeout(config.timeouts.afterClick * 1.5);
+    if (scheduleAt) {
+      const scheduleBtn = nav.page.locator(X_SELECTORS.scheduleIconButton);
+      await scheduleBtn.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleBtn.click();
+      await nav.page.waitForTimeout(config.timeouts.afterClick);
 
-    // Find dialog with aria-modal="true" to avoid matching other dialogs
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
-    await dialog.waitFor({ timeout: config.timeouts.elementWait });
+      const yyyy = scheduleAt.getFullYear();
+      const mm = String(scheduleAt.getMonth() + 1).padStart(2, '0');
+      const dd = String(scheduleAt.getDate()).padStart(2, '0');
+      const HH = String(scheduleAt.getHours()).padStart(2, '0');
+      const MM = String(scheduleAt.getMinutes()).padStart(2, '0');
 
-    // Fill reply content
-    const replyInput = dialog.locator('[data-testid="tweetTextarea_0"]');
-    await replyInput.waitFor({ timeout: config.timeouts.elementWait });
-    await replyInput.click();
-    await page.waitForTimeout(config.timeouts.afterClick / 2);
-    await replyInput.fill(content);
-    await page.waitForTimeout(config.timeouts.afterFill);
+      const dateInput = nav.page.locator('input[type="date"]').first();
+      const timeInput = nav.page.locator('input[type="time"]').first();
+      if (await dateInput.count()) await dateInput.fill(`${yyyy}-${mm}-${dd}`);
+      if (await timeInput.count()) await timeInput.fill(`${HH}:${MM}`);
+      await nav.page.waitForTimeout(config.timeouts.afterFill);
 
-    // Click submit button
-    const submitButton = dialog.locator('[data-testid="tweetButton"]');
-    await submitButton.waitFor({ timeout: config.timeouts.elementWait });
-
-    const isDisabled = await submitButton.getAttribute('aria-disabled');
-    if (isDisabled === 'true') {
-      return { success: false, message: 'Submit button disabled. Content may be empty or exceed character limit.' };
+      const scheduleConfirm = nav.page.locator(X_SELECTORS.scheduleConfirmButton);
+      await scheduleConfirm.waitFor({ timeout: config.timeouts.elementWait });
+      await scheduleConfirm.click();
+      await nav.page.waitForTimeout(config.timeouts.afterSubmit);
     }
 
-    await submitButton.click();
-    await page.waitForTimeout(config.timeouts.afterSubmit);
+    const submit = nav.page.locator(X_SELECTORS.tweetButtonModal);
+    await submit.waitFor({ timeout: config.timeouts.elementWait });
+    if ((await submit.getAttribute('aria-disabled')) === 'true') {
+      return { success: false, message: 'Reply button disabled — content may be invalid.' };
+    }
+    await submit.click();
+    await nav.page.waitForTimeout(config.timeouts.afterSubmit);
 
-    return {
-      success: true,
-      message: `Reply posted: ${content.slice(0, 50)}${content.length > 50 ? '...' : ''}`
-    };
-
+    const headline = scheduleAt
+      ? `Reply scheduled for ${scheduleAt.toISOString()}`
+      : `Reply posted to ${input.tweetUrl}`;
+    return { success: true, message: headline };
+  } catch (err) {
+    return { success: false, message: `reply error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
-    if (context) await context.close();
+    await context.close();
   }
 }
 
-runScript<ReplyInput>(replyToTweet);
+runScript<Input>(reply);

--- a/.claude/skills/x-integration/scripts/retweet.ts
+++ b/.claude/skills/x-integration/scripts/retweet.ts
@@ -1,62 +1,50 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X Integration - Retweet
- * Usage: echo '{"tweetUrl":"https://x.com/user/status/123"}' | pnpm exec tsx retweet.ts
+ * X retweet — retweet a tweet (no comment).
+ *
+ * Flow: click retweet button → menu opens → click "Repost" / confirm.
  */
 
-import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult } from '../lib/browser.js';
+import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_SELECTORS } from '../lib/locators.js';
 
-interface RetweetInput {
-  tweetUrl: string;
-}
+interface Input { tweetUrl: string }
 
-async function retweet(input: RetweetInput): Promise<ScriptResult> {
-  const { tweetUrl } = input;
+async function retweet(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
 
-  if (!tweetUrl) {
-    return { success: false, message: 'Please provide a tweet URL' };
-  }
-
-  let context = null;
+  const context = await getBrowserContext();
   try {
-    context = await getBrowserContext();
-    const { page, success, error } = await navigateToTweet(context, tweetUrl);
+    const nav = await navigateToTweet(context, input.tweetUrl);
+    if (!nav.success) return { success: false, message: nav.error || 'Navigation failed.' };
+    const auth = await ensureLoggedIn(nav.page);
+    if (auth) return auth;
 
-    if (!success) {
-      return { success: false, message: error || 'Navigation failed' };
+    const article = nav.page.locator(X_SELECTORS.tweet).first();
+    if (await article.locator(X_SELECTORS.unretweet).isVisible().catch(() => false)) {
+      return { success: true, message: 'Already retweeted (no-op).' };
     }
+    const rtBtn = article.locator(X_SELECTORS.retweet);
+    await rtBtn.waitFor({ timeout: config.timeouts.elementWait });
+    await rtBtn.click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
 
-    const tweet = page.locator('article[data-testid="tweet"]').first();
-    const unretweetButton = tweet.locator('[data-testid="unretweet"]');
-    const retweetButton = tweet.locator('[data-testid="retweet"]');
+    // Confirm in popup
+    const confirm = nav.page.locator(X_SELECTORS.retweetConfirm);
+    await confirm.waitFor({ timeout: config.timeouts.elementWait });
+    await confirm.click();
+    await nav.page.waitForTimeout(config.timeouts.afterSubmit);
 
-    // Check if already retweeted
-    const alreadyRetweeted = await unretweetButton.isVisible().catch(() => false);
-    if (alreadyRetweeted) {
-      return { success: true, message: 'Tweet already retweeted' };
+    if (await article.locator(X_SELECTORS.unretweet).isVisible().catch(() => false)) {
+      return { success: true, message: 'Retweeted.' };
     }
-
-    await retweetButton.waitFor({ timeout: config.timeouts.elementWait });
-    await retweetButton.click();
-    await page.waitForTimeout(config.timeouts.afterClick);
-
-    // Click retweet confirm option
-    const retweetConfirm = page.locator('[data-testid="retweetConfirm"]');
-    await retweetConfirm.waitFor({ timeout: config.timeouts.elementWait });
-    await retweetConfirm.click();
-    await page.waitForTimeout(config.timeouts.afterClick * 2);
-
-    // Verify
-    const nowRetweeted = await unretweetButton.isVisible().catch(() => false);
-    if (nowRetweeted) {
-      return { success: true, message: 'Retweet successful' };
-    }
-
-    return { success: false, message: 'Retweet action completed but could not verify success' };
-
+    await captureFailure(nav.page, 'retweet-no-verify');
+    return { success: false, message: 'Click sequence completed but unretweet-state not visible — verify manually.' };
+  } catch (err) {
+    return { success: false, message: `retweet error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
-    if (context) await context.close();
+    await context.close();
   }
 }
 
-runScript<RetweetInput>(retweet);
+runScript<Input>(retweet);

--- a/.claude/skills/x-integration/scripts/search.ts
+++ b/.claude/skills/x-integration/scripts/search.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X search — fetch tweets matching a query.
+ */
+
+import { getBrowserContext, runScript, ScriptResult, config, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { collectTweets, renderTweetList } from '../lib/extract.js';
+import { X_URLS } from '../lib/locators.js';
+
+interface Input { query: string; latest?: boolean; limit?: number }
+
+async function search(input: Input): Promise<ScriptResult> {
+  if (!input.query) return { success: false, message: 'query required.' };
+  const limit = Math.min(input.limit ?? 20, config.limits.readMax);
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.search(input.query, !!input.latest), { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const tweets = await collectTweets(page, limit);
+    const sortLabel = input.latest ? 'Latest' : 'Top';
+    return {
+      success: true,
+      message: renderTweetList(tweets, `Search "${input.query}" (${sortLabel}) — ${tweets.length} tweet${tweets.length === 1 ? '' : 's'}:`),
+      data: tweets,
+    };
+  } catch (err) {
+    await captureFailure(page, 'search-error');
+    return { success: false, message: `search error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(search);

--- a/.claude/skills/x-integration/scripts/send-dm.ts
+++ b/.claude/skills/x-integration/scripts/send-dm.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X send-dm — send a single DM to a user by handle.
+ *
+ * Strategy: navigate to /messages/compose, type the recipient's handle
+ * in the search field, click the first matching user result, click
+ * Next, type the message in the DM textarea, click Send.
+ *
+ * Selectors are LOW confidence (X reshuffles the DM compose modal
+ * occasionally) — verify on first user-test failure.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure, validateDmContent } from '../lib/browser.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { handle: string; content: string }
+
+async function sendDm(input: Input): Promise<ScriptResult> {
+  if (!input.handle) return { success: false, message: 'handle required.' };
+  const handle = input.handle.replace(/^@/, '');
+  const validation = validateDmContent(input.content);
+  if (validation) return validation;
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.dmCompose, { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    const search = page.locator(X_SELECTORS.dmComposeSearchInput).first();
+    await search.waitFor({ timeout: config.timeouts.elementWait });
+    await search.fill(handle);
+    await page.waitForTimeout(config.timeouts.afterFill);
+
+    // First search result. X may render multiple — match the one whose
+    // visible text contains the exact handle.
+    const result = page.locator(X_SELECTORS.dmSearchResultUser).filter({ hasText: new RegExp(`@${handle}\\b`, 'i') }).first();
+    if (!(await result.isVisible().catch(() => false))) {
+      // Fallback: just take the first result
+      const firstResult = page.locator(X_SELECTORS.dmSearchResultUser).first();
+      if (!(await firstResult.isVisible().catch(() => false))) {
+        await captureFailure(page, 'send-dm-no-results');
+        return { success: false, message: `No search results for @${handle}. They may not exist, or may have DMs disabled from non-followers.` };
+      }
+      await firstResult.click();
+    } else {
+      await result.click();
+    }
+    await page.waitForTimeout(config.timeouts.afterClick);
+
+    const next = page.locator(X_SELECTORS.dmComposeNextButton);
+    if (await next.isVisible().catch(() => false)) {
+      await next.click();
+      await page.waitForTimeout(config.timeouts.afterClick);
+    }
+
+    const textInput = page.locator(X_SELECTORS.dmComposerTextInput);
+    await textInput.waitFor({ timeout: config.timeouts.elementWait });
+    await textInput.fill(input.content);
+    await page.waitForTimeout(config.timeouts.afterFill);
+
+    const sendBtn = page.locator(X_SELECTORS.dmComposerSendButton);
+    await sendBtn.waitFor({ timeout: config.timeouts.elementWait });
+    if ((await sendBtn.getAttribute('aria-disabled')) === 'true') {
+      return { success: false, message: 'Send button disabled — message may be invalid or recipient blocked DMs.' };
+    }
+    await sendBtn.click();
+    await page.waitForTimeout(config.timeouts.afterSubmit);
+
+    return { success: true, message: `DM sent to @${handle}.` };
+  } catch (err) {
+    await captureFailure(page, 'send-dm-error');
+    return { success: false, message: `send-dm error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(sendDm);

--- a/.claude/skills/x-integration/scripts/setup.ts
+++ b/.claude/skills/x-integration/scripts/setup.ts
@@ -6,7 +6,7 @@
  * Interactive script - opens browser for manual login
  */
 
-import { chromium } from 'playwright';
+import { chromium } from 'playwright-core';
 import * as readline from 'readline';
 import fs from 'fs';
 import path from 'path';

--- a/.claude/skills/x-integration/scripts/unbookmark.ts
+++ b/.claude/skills/x-integration/scripts/unbookmark.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X like — like a tweet.
+ * X unbookmark — remove a bookmark.
  */
 
 import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
@@ -8,7 +8,7 @@ import { X_SELECTORS } from '../lib/locators.js';
 
 interface Input { tweetUrl: string }
 
-async function likeTweet(input: Input): Promise<ScriptResult> {
+async function unbookmark(input: Input): Promise<ScriptResult> {
   if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
 
   const context = await getBrowserContext();
@@ -19,23 +19,23 @@ async function likeTweet(input: Input): Promise<ScriptResult> {
     if (auth) return auth;
 
     const article = nav.page.locator(X_SELECTORS.tweet).first();
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Already liked (no-op).' };
+    if (await article.locator(X_SELECTORS.bookmark).isVisible().catch(() => false)) {
+      return { success: true, message: 'Not bookmarked (no-op).' };
     }
-    const btn = article.locator(X_SELECTORS.like);
+    const btn = article.locator(X_SELECTORS.removeBookmark);
     await btn.waitFor({ timeout: config.timeouts.elementWait });
     await btn.click();
     await nav.page.waitForTimeout(config.timeouts.afterClick);
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Liked.' };
+    if (await article.locator(X_SELECTORS.bookmark).isVisible().catch(() => false)) {
+      return { success: true, message: 'Unbookmarked.' };
     }
-    await captureFailure(nav.page, 'like-no-verify');
-    return { success: false, message: 'Click registered but unlike-state not visible — verify manually.' };
+    await captureFailure(nav.page, 'unbookmark-no-verify');
+    return { success: false, message: 'Click registered but bookmark state not visible — verify manually.' };
   } catch (err) {
-    return { success: false, message: `like error: ${err instanceof Error ? err.message : String(err)}` };
+    return { success: false, message: `unbookmark error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
     await context.close();
   }
 }
 
-runScript<Input>(likeTweet);
+runScript<Input>(unbookmark);

--- a/.claude/skills/x-integration/scripts/unfollow.ts
+++ b/.claude/skills/x-integration/scripts/unfollow.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X unfollow — unfollow a user. Click unfollow → confirmation sheet
+ * → Confirm.
+ */
+
+import { getBrowserContext, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_SELECTORS, X_URLS } from '../lib/locators.js';
+
+interface Input { handle: string }
+
+async function unfollow(input: Input): Promise<ScriptResult> {
+  if (!input.handle) return { success: false, message: 'handle required.' };
+  const handle = input.handle.replace(/^@/, '');
+
+  const context = await getBrowserContext();
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    await page.goto(X_URLS.profile(handle), { timeout: config.timeouts.navigation, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(config.timeouts.pageLoad);
+
+    const auth = await ensureLoggedIn(page);
+    if (auth) return auth;
+
+    if (await page.locator(X_SELECTORS.followButton).isVisible().catch(() => false)) {
+      return { success: true, message: `Not following @${handle} (no-op).` };
+    }
+    const btn = page.locator(X_SELECTORS.unfollowButton);
+    await btn.waitFor({ timeout: config.timeouts.elementWait });
+    await btn.click();
+    await page.waitForTimeout(config.timeouts.afterClick);
+
+    // Confirmation sheet
+    const confirm = page.locator(X_SELECTORS.confirmationSheetConfirm);
+    await confirm.waitFor({ timeout: config.timeouts.elementWait });
+    await confirm.click();
+    await page.waitForTimeout(config.timeouts.afterSubmit);
+
+    if (await page.locator(X_SELECTORS.followButton).isVisible().catch(() => false)) {
+      return { success: true, message: `Unfollowed @${handle}.` };
+    }
+    await captureFailure(page, 'unfollow-no-verify');
+    return { success: false, message: `Click sequence completed but follow-state not visible — verify manually.` };
+  } catch (err) {
+    return { success: false, message: `unfollow error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(unfollow);

--- a/.claude/skills/x-integration/scripts/unlike.ts
+++ b/.claude/skills/x-integration/scripts/unlike.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env pnpm exec tsx
 /**
- * X like — like a tweet.
+ * X unlike — remove your like from a tweet.
  */
 
 import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
@@ -8,7 +8,7 @@ import { X_SELECTORS } from '../lib/locators.js';
 
 interface Input { tweetUrl: string }
 
-async function likeTweet(input: Input): Promise<ScriptResult> {
+async function unlikeTweet(input: Input): Promise<ScriptResult> {
   if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
 
   const context = await getBrowserContext();
@@ -19,23 +19,23 @@ async function likeTweet(input: Input): Promise<ScriptResult> {
     if (auth) return auth;
 
     const article = nav.page.locator(X_SELECTORS.tweet).first();
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Already liked (no-op).' };
+    if (await article.locator(X_SELECTORS.like).isVisible().catch(() => false)) {
+      return { success: true, message: 'Not liked (no-op).' };
     }
-    const btn = article.locator(X_SELECTORS.like);
+    const btn = article.locator(X_SELECTORS.unlike);
     await btn.waitFor({ timeout: config.timeouts.elementWait });
     await btn.click();
     await nav.page.waitForTimeout(config.timeouts.afterClick);
-    if (await article.locator(X_SELECTORS.unlike).isVisible().catch(() => false)) {
-      return { success: true, message: 'Liked.' };
+    if (await article.locator(X_SELECTORS.like).isVisible().catch(() => false)) {
+      return { success: true, message: 'Unliked.' };
     }
-    await captureFailure(nav.page, 'like-no-verify');
-    return { success: false, message: 'Click registered but unlike-state not visible — verify manually.' };
+    await captureFailure(nav.page, 'unlike-no-verify');
+    return { success: false, message: 'Click registered but like-state not visible — verify manually.' };
   } catch (err) {
-    return { success: false, message: `like error: ${err instanceof Error ? err.message : String(err)}` };
+    return { success: false, message: `unlike error: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
     await context.close();
   }
 }
 
-runScript<Input>(likeTweet);
+runScript<Input>(unlikeTweet);

--- a/.claude/skills/x-integration/scripts/unretweet.ts
+++ b/.claude/skills/x-integration/scripts/unretweet.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env pnpm exec tsx
+/**
+ * X unretweet — undo your retweet.
+ *
+ * Flow: click unretweet button → menu opens → click "Undo repost".
+ */
+
+import { getBrowserContext, navigateToTweet, runScript, config, ScriptResult, ensureLoggedIn, captureFailure } from '../lib/browser.js';
+import { X_SELECTORS } from '../lib/locators.js';
+
+interface Input { tweetUrl: string }
+
+async function unretweet(input: Input): Promise<ScriptResult> {
+  if (!input.tweetUrl) return { success: false, message: 'tweetUrl required.' };
+
+  const context = await getBrowserContext();
+  try {
+    const nav = await navigateToTweet(context, input.tweetUrl);
+    if (!nav.success) return { success: false, message: nav.error || 'Navigation failed.' };
+    const auth = await ensureLoggedIn(nav.page);
+    if (auth) return auth;
+
+    const article = nav.page.locator(X_SELECTORS.tweet).first();
+    if (await article.locator(X_SELECTORS.retweet).isVisible().catch(() => false)) {
+      return { success: true, message: 'Not retweeted (no-op).' };
+    }
+    const urtBtn = article.locator(X_SELECTORS.unretweet);
+    await urtBtn.waitFor({ timeout: config.timeouts.elementWait });
+    await urtBtn.click();
+    await nav.page.waitForTimeout(config.timeouts.afterClick);
+
+    const confirm = nav.page.locator(X_SELECTORS.unretweetConfirm);
+    await confirm.waitFor({ timeout: config.timeouts.elementWait });
+    await confirm.click();
+    await nav.page.waitForTimeout(config.timeouts.afterSubmit);
+
+    if (await article.locator(X_SELECTORS.retweet).isVisible().catch(() => false)) {
+      return { success: true, message: 'Unretweeted.' };
+    }
+    await captureFailure(nav.page, 'unretweet-no-verify');
+    return { success: false, message: 'Click sequence completed but retweet-state not visible — verify manually.' };
+  } catch (err) {
+    return { success: false, message: `unretweet error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    await context.close();
+  }
+}
+
+runScript<Input>(unretweet);


### PR DESCRIPTION
## Summary

Rewrites `/x-integration` for NanoClaw v2, ports it to Linux, and expands the surface from 5 v1 tools (post/like/reply/retweet/quote) to **25 tools** covering every common X (Twitter) action a human can do via the web UI — read, compose with media + native scheduling, full engagement-toggle pairs, delete (with text-echo safety guard), scheduled-tweet management, DMs, and bulk bookmark export.

The v1 skill was macOS-only and targeted v2-removed integration points. This PR adopts the v2 idiom: `kind:'system'` outbound rows dispatched via `registerDeliveryAction()` and result delivery via `notifyAgent()` from `src/modules/approvals/primitive.ts`.

## What's new vs v1

- **v2 mechanism.** Tools write `kind:'system'` rows; host dispatches by action key through `pacedRun()` (10s mutex), spawns the matching `scripts/<name>.ts` via tsx, and calls `notifyAgent()` so the result wakes the container.
- **Cross-platform browser detection** (`lib/chrome-detect.ts`): `CHROME_PATH` env → Chrome → Brave → Chromium on macOS (`mdfind`) and Linux (`which`). Flatpak browsers detected and rejected with a `.deb`-install hint. No fallback to Playwright's bundled Chromium — that's what defeats X's bot detection in the first place.
- **20 new tools.** Read (8), Compose (3 with `media[]` + native `schedule_at`), Engagement (9 including `x_delete_tweet`), Schedule queue (2), DMs (3), Bulk bookmark export (1).
- **`x_delete_tweet` with text-echo safety guard.** Delete is the only irreversible action without built-in undo. The tool requires `text_must_match` (≥5-char substring of the tweet body). The host script reads the live tweet first and refuses to delete unless the substring is present — guards against URL hallucinations and copy-paste mistakes without adding an approval round-trip.
- **Concentrated DOM volatility.** `lib/locators.ts` (all CSS/data-testid selectors) and `lib/extract.ts` (all parsers). When X redeploys, those are the only files to update.
- **Privacy + safety**: DM bodies redacted from `nanoclaw.log`; per-action 120s timeout + screenshot+DOM-dump capture on failure (`logs/x-failures/`); 10s mutex pacing.

## How it works

```
Container (Bun)                 Host (Node)
mcp-tools/x-integration.ts  →   src/modules/x-integration/index.ts
  25 tools, makeXTool()          25 registerDeliveryAction() handlers
  writeMessageOut(system)        pacedRun ⟶ spawn tsx script ⟶ notifyAgent
        ↓                                    ↑
   outbound.db  ─────────────────────────  inbound.db + wake
```

## How it was tested

End-to-end on Linux (Pop!_OS) over several weeks: every read flow, every compose flow with media + native scheduling, all engagement toggle pairs, schedule queue list/cancel-by-index/cancel-by-text-match, full DM round-trip, bulk bookmark export across paginated calls. Delete tested in two modes — valid `text_must_match` (success) and deliberately-wrong `text_must_match` (refused with clear error). macOS compatibility preserved from prior v1 skill.

## Usage

```
What's in my bookmarks lately?
Summarize this thread: https://x.com/<user>/status/<id>
Post a tweet: gm. Sovereignty is a daily practice.
Reply to https://x.com/<id> with: this matches my experience.
Schedule this for tomorrow 9am PT: <text>
What DMs are in my inbox?
DM @<friend>: thanks for the link earlier.
Delete my tweet https://x.com/<id> — it contains "deprecated"
```

Each command produces one acknowledgment, then a follow-up with the result ~10–60s later.

## Test plan

- [x] Linux (Pop!_OS) end-to-end on all 25 tools
- [x] Browser detection: Chrome, Brave, Chromium auto-detected; Flatpak rejected
- [x] DM body redaction verified in nanoclaw.log
- [x] Delete tested with both valid and deliberately-wrong text_must_match
- [ ] macOS smoke test (preserved from v1; reviewer-side verification welcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)