### PR TITLE
fix(container): gracefully handle missing on_wake column

### DIFF
--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -10,6 +10,19 @@
 import { getConfig } from '../config.js';
 import { openInboundDb, getOutboundDb } from './connection.js';
 
+// Cache whether inbound.db has the on_wake column (added in v2.0.48).
+// The container opens inbound.db read-only, so it can't ALTER —
+// gracefully degrade when running against an older session DB.
+let _hasOnWake: boolean | null = null;
+function hasOnWakeColumn(db: ReturnType<typeof openInboundDb>): boolean {
+  if (_hasOnWake !== null) return _hasOnWake;
+  const cols = new Set(
+    (db.prepare("PRAGMA table_info('messages_in')").all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  _hasOnWake = cols.has('on_wake');
+  return _hasOnWake;
+}
+
 export interface MessageInRow {
   id: string;
   seq: number | null;
@@ -54,12 +67,13 @@ export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   const outbound = getOutboundDb();
 
   try {
+    const onWakeFilter = hasOnWakeColumn(inbound) ? 'AND (on_wake = 0 OR ?1 = 1)' : '';
     const pending = inbound
       .prepare(
         `SELECT * FROM messages_in
          WHERE status = 'pending'
            AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
-           AND (on_wake = 0 OR ?1 = 1)
+           ${onWakeFilter}
          ORDER BY seq DESC
          LIMIT ?2`,
       )


### PR DESCRIPTION
## Summary
- Container opens `inbound.db` read-only — it can't `ALTER TABLE` to add the `on_wake` column
- If the host hasn't restarted (and run `migrateMessagesInTable`) after pulling the on-wake PR, the container query crashes on the missing column, causing a restart loop
- Detects the column via `PRAGMA table_info` (cached) and conditionally includes the filter clause

## Test plan
- [x] Existing `on_wake filtering` tests pass (28 tests)
- [ ] Verify container starts cleanly against a pre-migration session DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)