### PR TITLE
fix(compact): place destination reminder at end of compaction summary

### DIFF
--- a/container/agent-runner/src/compact-instructions.ts
+++ b/container/agent-runner/src/compact-instructions.ts
@@ -26,9 +26,9 @@ const instructions = [
   '2. Preserve the chronological message/reply sequence of recent exchanges.',
   '   The agent needs to see: who said what, in what order, and from which destination.',
   '',
-  '3. The `from` attribute identifies which destination sent the message.',
-  '   The agent MUST wrap all responses in <message to="name">...</message> blocks.',
-  `   Available destinations: ${names.length > 0 ? names.map((n) => `\`${n}\``).join(', ') : '(none)'}`,
+  '3. At the END of the compaction summary, include this verbatim reminder:',
+  '   "You MUST wrap all responses in <message to="name">...</message> blocks.',
+  `   Available destinations: ${names.length > 0 ? names.map((n) => `\`${n}\``).join(', ') : '(none)'}."`,
 ];
 
 console.log(instructions.join('\n'));


### PR DESCRIPTION
## Summary

- Updates the PreCompact hook instructions to tell the compactor to place the `<message to="name">` wrapping reminder **verbatim at the END** of the compaction summary
- Previously the instruction just asked to "preserve" routing info, which the compactor could place anywhere or summarize away — positioning it at the end ensures it's the last thing the agent sees after compaction

## Test plan

- [x] Verified the output of `compact-instructions.ts` includes the updated wording
- [ ] Monitor multi-destination agents after compaction to confirm wrapping behavior is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)