### PR TITLE
feat(skills): /add-hindsight — bring-your-own Hindsight MCP for per-group long-term memory

### DIFF
--- a/.claude/skills/add-hindsight/SKILL.md
+++ b/.claude/skills/add-hindsight/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: add-hindsight
+description: Wire NanoClaw v2 agents to a separately-running Hindsight MCP instance. Per-group long-term memory bank with semantic recall, retain, and reflect tools. Bring-your-own Hindsight stack — this skill only wires NanoClaw to it.
+---
+
+# Add Hindsight Memory
+
+Connects NanoClaw v2 agent groups to a **separately-deployed** `hindsight-mcp`
+stdio server (which itself proxies to a [Vectorize.io Hindsight](https://github.com/vectorize-io/hindsight)
+engine). Adds three MCP tools to wired groups:
+
+- `mcp__hindsight__memory_recall` — semantic search across past memories
+- `mcp__hindsight__memory_retain` — persist a durable fact
+- `mcp__hindsight__memory_reflect` — synthesise an answer from memories with evidence
+
+Each group gets its own bank, addressed by `group=<group-folder>` under a
+configurable bank prefix (default `nanoclaw`).
+
+## Prerequisites — out of scope for this skill
+
+This skill **does not deploy Hindsight**. It assumes you already have:
+
+1. A running **Hindsight engine** (the Vectorize.io HTTP service) reachable
+   from the NanoClaw host. Hindsight's own docs cover deployment.
+2. A built **`hindsight-mcp` stdio binary** at some host path, e.g.
+   `/home/hindsight-mcp/app/dist/server-stdio.js`. The binary is a small
+   stdio MCP wrapper that translates between the MCP protocol and
+   Hindsight's HTTP API. (Upstream source: `vectorize-io/hindsight-mcp`
+   or similar; ask your operator.)
+3. ACLs that let NanoClaw's container uid (1001 = `node`) **read** the
+   binary path (typically `setfacl -R -m u:1001:rX <path>`).
+
+If any of those are missing, set them up first — they're independent of
+NanoClaw.
+
+## Phase 1: Pre-flight
+
+Define your environment variables (substitute your actual values):
+
+```bash
+# Path on the host where the hindsight-mcp stdio binary lives:
+HINDSIGHT_BIN_PATH=/path/to/hindsight-mcp/app
+
+# Hindsight engine HTTP endpoint (reachable from the NanoClaw host):
+HINDSIGHT_ENGINE_URL=http://hindsight.example.local:3850
+
+# Bank prefix — banks will be named "<prefix>:<group-folder>". Pick once,
+# don't change later or you'll lose existing memories.
+HINDSIGHT_BANK_PREFIX=nanoclaw
+```
+
+Verify reachability + permissions:
+
+```bash
+# Engine reachable?
+curl -fsS "$HINDSIGHT_ENGINE_URL/health"
+# Expected: {"status":"ok",...}
+
+# Binary readable by container uid?
+ls -la "$HINDSIGHT_BIN_PATH/dist/server-stdio.js"
+
+# Binary speaks MCP correctly? (initialize + tools/list smoke test)
+HINDSIGHT_URL="$HINDSIGHT_ENGINE_URL" HINDSIGHT_BANK_PREFIX="$HINDSIGHT_BANK_PREFIX" \
+  bash -c '(printf "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"s\",\"version\":\"0.1\"}}}\n{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n"; sleep 3) | timeout 5 node '"$HINDSIGHT_BIN_PATH"'/dist/server-stdio.js 2>&1 | head -5'
+# Should print three JSON-RPC responses including a `tools/list` with
+# memory_recall, memory_retain, memory_reflect.
+```
+
+If any check fails, fix it before continuing — the agent will get
+`ENOENT` or `connection refused` otherwise.
+
+## Phase 2: Mount-allowlist
+
+Add `$HINDSIGHT_BIN_PATH` to NanoClaw's mount allowlist
+(`~/.config/nanoclaw/mount-allowlist.json`). Run `/manage-mounts` and
+add an entry like:
+
+```json
+{
+  "path": "/path/to/hindsight-mcp/app",
+  "allowReadWrite": false,
+  "description": "Hindsight MCP stdio binary + node_modules (read-only)"
+}
+```
+
+Restart the NanoClaw service so the allowlist reloads
+(`systemctl --user restart nanoclaw-v2-<id>.service`).
+
+## Phase 3: Wire each group that should have memory
+
+For each agent group, run the `ncl` commands below. Substitute
+`<group-id>` from `ncl groups list`.
+
+```bash
+GID=<group-id>
+
+# Add the hindsight MCP server. The instructions string tells the agent
+# which group to use for its bank and pins the discipline-skill hint.
+ncl groups config add-mcp-server \
+  --id "$GID" \
+  --name hindsight \
+  --command node \
+  --args '["/workspace/extra/hindsight-mcp/dist/server-stdio.js"]' \
+  --env "$(jq -nc --arg url "$HINDSIGHT_ENGINE_URL" --arg pfx "$HINDSIGHT_BANK_PREFIX" \
+    '{HINDSIGHT_URL: $url, HINDSIGHT_BANK_PREFIX: $pfx}')"
+```
+
+The mount itself (`additional_mounts`) is not yet exposed via `ncl groups
+config` as of NanoClaw v2.0.56 — until that lands, add it via direct DB
+update:
+
+```bash
+sqlite3 data/v2.db <<SQL
+UPDATE container_configs
+SET additional_mounts = json_insert(
+  COALESCE(additional_mounts, '[]'),
+  '\$[#]',
+  json_object(
+    'hostPath', '$HINDSIGHT_BIN_PATH',
+    'containerPath', 'hindsight-mcp',
+    'readonly', json('true')
+  )
+)
+WHERE agent_group_id = '$GID';
+SQL
+```
+
+Then restart the group's containers so the new config takes effect:
+
+```bash
+ncl groups restart --id "$GID"
+```
+
+## Phase 4: Verify
+
+Send the group's agent a message that should trigger recall, e.g. ask
+about something you discussed in a prior turn. The agent should call
+`mcp__hindsight__memory_recall` before answering. Check logs:
+
+```bash
+tail -100 logs/nanoclaw.log | grep -iE 'hindsight|mcp'
+```
+
+The first call may take 1-2s while the stdio MCP server starts.
+
+## Phase 5: Discipline
+
+The wired agent automatically loads `container/skills/hindsight/SKILL.md`
+on first turn — that file contains the *discipline* (when to recall,
+when to retain, what NOT to retain, common anti-patterns). Without it,
+agents tend to over-retain or never retain. **Don't skip it** — see
+`container/skills/hindsight/SKILL.md` for the why.
+
+## Removal
+
+```bash
+GID=<group-id>
+ncl groups config remove-mcp-server --id "$GID" --name hindsight
+sqlite3 data/v2.db "UPDATE container_configs SET additional_mounts = (
+  SELECT json_group_array(value) FROM json_each(additional_mounts)
+  WHERE json_extract(value, '$.containerPath') != 'hindsight-mcp'
+) WHERE agent_group_id = '$GID';"
+ncl groups restart --id "$GID"
+```
+
+(Optional) Remove the mount-allowlist entry via `/manage-mounts` if no
+other tooling needs it.
+
+## Credits & references
+
+- **Hindsight engine**: [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight)
+  (Apache 2.0). Graph-extracting memory with semantic search.
+- **hindsight-mcp stdio binary**: ships independently; this skill is
+  protocol-only — it doesn't care which implementation as long as it
+  exposes `memory_recall` / `memory_retain` / `memory_reflect` via MCP.
+- **Related skills**: `/add-mnemon` (graph-based memory, different
+  backend) is a sibling memory option. Pick one — running both is
+  redundant.

--- a/container/skills/hindsight/SKILL.md
+++ b/container/skills/hindsight/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: hindsight
+description: Long-term memory discipline for agents wired to the hindsight MCP server. You MUST consult this skill at the start of every substantive turn to decide whether to recall and what (if anything) to retain afterwards. Available only when `mcp__hindsight__*` tools are present.
+---
+
+# Hindsight Memory Discipline
+
+You have a per-group long-term memory bank addressed by `group=<this group's folder>`. The MCP server exposes three tools:
+
+- `mcp__hindsight__memory_recall(group, query, budget)` — semantic search across past memories. Returns ranked observations + extracted entities. Read-only; cheap.
+- `mcp__hindsight__memory_retain(group, content, context?)` — persist a one- or two-sentence durable fact. The bank LLM extracts entities and links to the knowledge graph. Costs tokens server-side; pollution is permanent.
+- `mcp__hindsight__memory_reflect(group, query, budget)` — synthesise an answer from memories with evidence. Heavier than recall.
+
+**`group`** is always your agent group's folder name. Don't switch groups; you can only read your own bank. The server-side bank prefix is configured by the operator (default `nanoclaw:`) so the full bank id is `<prefix>:<folder>`.
+
+## When to recall
+
+At the start of any turn that *might* benefit from prior context:
+
+- The user references a person, project, decision, or topic by name → recall on the named entity.
+- The user asks "do you remember…", "what did we talk about…", "is X still…" → recall on the topic.
+- The user shares a new fact that overlaps with old territory ("I switched the deploy target") → recall on the territory before answering.
+
+You may *skip* recall for:
+- Pure pleasantries ("hi", "thanks", "ok").
+- Self-contained tool tasks where past context cannot help ("schedule X", "what's 2+5", "open URL Y").
+- Commands you fully understand from the current message alone.
+
+When in doubt, recall — it's read-only and cheap. Use `budget: "low"` by default, `"mid"` for ambiguous queries, `"high"` only for genuinely open-ended reflection (and prefer `memory_reflect` for that).
+
+## When to retain
+
+Selectively, after a turn produces something durable. Save:
+
+- **Facts about the user** — name, location, role, relationships, preferences they state.
+- **Facts about projects** — repos they own, stacks they use, deployment targets, ports, conventions.
+- **Decisions** — both what and why ("we picked Postgres over MySQL because of jsonb").
+- **Lessons / pitfalls** — recurring failure modes, "this dependency breaks if you bump past X".
+- **Pointers** — paths, URLs, channel ids, where things live ("staging API gateway lives at `api.staging.example.com`").
+
+Do NOT save:
+
+- Pleasantries, ack messages, transient state.
+- Verbatim user messages — the bank is not a chat log.
+- Secrets, tokens, API keys, OAuth credentials, passwords. Even if the user pastes one, do not retain it.
+- Anything already obvious from the current codebase, README, or globally-loaded files.
+- Speculation, future plans not yet confirmed, draft ideas.
+
+**If unsure, don't retain.** The bank is searched on every future turn — pollution is more expensive than missing one fact.
+
+## How to retain well
+
+A retained memory should be:
+
+- **One or two sentences max.** Long blobs hurt search relevance.
+- **Self-contained.** A future turn must understand it without reading the surrounding conversation. Bad: "He said yes." Good: "Operator approved the database cutover on 2026-03-14."
+- **Specific.** Include names, dates, numbers, paths. Avoid pronouns and vague time references ("recently" → use a date).
+- **Factual, not interpretive.** "User prefers terse replies" beats "User seems to prefer terse replies".
+
+The optional `context` argument is a short hint (e.g. `"infra-cutover"`, `"deploy-config"`) — useful for grouping in the bank, not user-facing.
+
+## Anti-patterns
+
+- **Phantom retain.** Saying "Got it, saved." without actually calling `memory_retain`. If you didn't call the tool, the memory does not exist. Never claim retention you didn't execute.
+- **Retain-everything.** Calling retain on every turn or on the entire user message. Pollutes the bank, degrades future recall.
+- **Recall-without-acting.** Calling recall and then ignoring the result in your answer. Either use what came back or don't recall.
+- **Cross-group leakage.** Calling recall/retain with a `group` other than your own folder. You can't read other groups' banks anyway, but writing under a wrong group fragments memory.
+- **Replaying the recall block verbatim.** Don't paste recall results back to the user. Synthesise them into your answer.
+
+## Smoke check (when in doubt)
+
+If a turn just produced a clear durable fact, ask yourself: "Would a future me, with no chat history, want this?" If yes, retain. If you're hedging — don't.


### PR DESCRIPTION
## Summary

Adds an opt-in `/add-hindsight` skill that wires NanoClaw v2 agent groups to a separately-deployed [Hindsight](https://github.com/vectorize-io/hindsight) memory engine (via a stdio MCP wrapper). Each wired group gets a per-group long-term memory bank with three tools:

- `mcp__hindsight__memory_recall` — semantic search across past memories
- `mcp__hindsight__memory_retain` — persist a durable fact
- `mcp__hindsight__memory_reflect` — synthesise an answer with evidence

## Why

`/add-mnemon` already exists for graph-based memory. Hindsight is a sibling option backed by Vectorize.io's Hindsight engine — different backend, different tradeoffs (Hindsight extracts entities + links into a knowledge graph server-side, queryable with budgets). Operators with a Vectorize stack on-hand can plug it in via this skill.

Pick one or the other — running both is redundant. The skill mentions this in its Credits section.

## Scope (deliberately minimal)

**Two files. Zero source code changes.**

- `.claude/skills/add-hindsight/SKILL.md` — operator setup walkthrough
- `container/skills/hindsight/SKILL.md` — in-container memory discipline (when to recall, when to retain, anti-patterns)

The setup uses existing `ncl groups config add-mcp-server` for the MCP server entry. The `additional_mounts` step is documented as a direct sqlite UPDATE — happy to drop that line if/when `ncl groups config add-mount` lands upstream as a separate PR.

## Prereqs (out of scope for this skill)

The skill is "bring-your-own Hindsight" — it does not deploy the engine. Operator must already have:

1. A running Hindsight HTTP engine reachable from the NanoClaw host
2. A built `hindsight-mcp` stdio binary at a host path
3. ACLs that let NanoClaw's container uid read the binary

The SKILL.md spells these out + provides a smoke-test command that exercises the binary end-to-end before any agent wiring happens, so failed installs fail loudly during setup, not at agent invocation time.

## Why opt-in (no auto-wire)

Per CONTRIBUTING.md: "Source code changes should only be things 90%+ of users need." Most users won't have a Hindsight stack lying around, so auto-wiring at group-init isn't the right shape. The skill is a one-time per-group action, documented end-to-end.

## Testing

Verified on a NanoClaw v2.0.56 install with an existing Hindsight stack reachable over a private network:

- Group wired with `ncl groups config add-mcp-server hindsight ...` + `additional_mounts` sqlite UPDATE
- Container respawn picks up the new MCP server (visible in agent logs: `Additional MCP server: hindsight (node)`)
- Agent successfully calls `mcp__hindsight__memory_recall` / `memory_retain` / `memory_reflect` against the engine
- Disabling the wiring (`config remove-mcp-server hindsight`) and respawning the container removes the tools cleanly

The discipline skill (`container/skills/hindsight/SKILL.md`) is loaded automatically by the agent on first turn — it's a standard container skill, no special wiring required.

## Test plan for reviewers

- [ ] `cat .claude/skills/add-hindsight/SKILL.md` — confirm setup is operator-runnable end-to-end without prior knowledge
- [ ] `cat container/skills/hindsight/SKILL.md` — confirm discipline is generic (no install-specific examples)
- [ ] Optional: dry-run the setup against a local Hindsight stack if you have one

🤖 Generated with [Claude Code](https://claude.com/claude-code)