### PR TITLE
feat(skills): add /add-google-auth foundation skill + diagnostic MCP tools

### DIFF
--- a/.claude/skills/add-google-auth/SKILL.md
+++ b/.claude/skills/add-google-auth/SKILL.md
@@ -25,6 +25,8 @@ Gmail/Calendar/Sheets/Contacts call. Source:
 
 ### Step 1: Verify OneCLI is installed and running
 
+Requires **OneCLI ≥ 1.1.0** (top-level `version` command, `Connections` dashboard).
+
 ```bash
 onecli version
 curl -sf http://127.0.0.1:10254/api/health > /dev/null && echo OK

--- a/.claude/skills/add-google-auth/SKILL.md
+++ b/.claude/skills/add-google-auth/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: add-google-auth
+description: Shared Google OAuth prerequisites for every Google-API skill in NanoClaw v2 (Gmail, Calendar, Sheets, Contacts). Walks the operator through the one-time OneCLI connect, the agent secret-mode flip, the credential-stub directories, and the mount-allowlist entries. Also installs two diagnostic MCP tools (`check_google_auth`, `list_google_scopes`) so agents can verify their own auth at runtime. Run this BEFORE `/add-gmail-tool`, `/add-gcal-tool`, or any other Google integration.
+---
+
+# Add Google Auth (OneCLI-native)
+
+This is the foundation skill for every Google API integration. NanoClaw v2
+holds NO raw Google OAuth tokens — the [OneCLI Agent Vault](https://onecli.sh)
+owns the refresh token and injects a fresh bearer into every outbound
+request to `*.googleapis.com`. Nothing in the container or in any
+`groups/<folder>/.env` ever sees a real token.
+
+This skill captures the cross-skill prerequisites once, so `/add-gmail-tool`,
+`/add-gcal-tool`, `/add-sheets-tool`, and `/add-contacts-tool` can each
+assume the foundation is in place.
+
+The skill also ships two diagnostic MCP tools in the agent runner —
+`check_google_auth` and `list_google_scopes` — that let an agent verify
+its own Google auth from inside its container before attempting a
+Gmail/Calendar/Sheets/Contacts call. Source:
+`container/agent-runner/src/mcp-tools/google-auth.ts`.
+
+## Phase 1: Pre-flight
+
+### Step 1: Verify OneCLI is installed and running
+
+```bash
+onecli --version
+curl -sf http://127.0.0.1:10254/api/health > /dev/null && echo OK
+```
+
+If either fails, run `/init-onecli` first.
+
+### Step 2: Connect Google in the OneCLI web UI
+
+NanoClaw does NOT do the OAuth dance — OneCLI does. Tell the operator:
+
+> Open `http://127.0.0.1:10254` in a browser, go to **Apps → Google**, and
+> click **Connect**. Sign in with the Google account the agent should act
+> as. Grant every scope you might ever need from this account — Gmail
+> read+modify+send, Calendar read+events, Sheets, Contacts (People API).
+> Re-connecting later to widen scopes is supported but requires user
+> interaction; granting up front avoids interruptions.
+
+Verify the connection:
+
+```bash
+onecli apps get --provider google
+```
+
+Expected: `"connection": { "status": "connected" }` with the scopes you
+granted listed.
+
+### Step 3: Decide on per-account scoping (optional, multi-account)
+
+If the operator wants a second Google account (work + personal), connect
+both in the OneCLI web UI. OneCLI distinguishes by app identifier; the
+nanoclaw skill that consumes the credential (e.g. `add-gmail-tool`) is
+responsible for selecting the right one at request time.
+
+## Phase 2: Apply Code Changes
+
+### Step 1: Merge this branch
+
+This skill ships container MCP tools at
+`container/agent-runner/src/mcp-tools/google-auth.ts`. To install them
+into your local NanoClaw checkout once `skill/add-google-auth` exists:
+
+```bash
+git fetch origin skill/add-google-auth
+git merge --no-ff origin/skill/add-google-auth
+```
+
+> **Note (pre-split state):** as of 2026-05-11 the working branch is
+> `feat/add-google-auth-v2`. The split into `skill/add-google-auth` (fork
+> install target) and `add-google-auth-upstream` (PR source for
+> nanocoai/nanoclaw) is deferred to the next session pending
+> `/zenodotus --personas drive-by-contributor` review per `AGENTS.md`.
+> Until the split lands, install by fetching the working branch directly.
+
+### Step 2: Confirm the tools registered
+
+Once you rebuild the agent-runner image (see Phase 4) and a session
+container starts, the MCP server logs the registered tool list:
+
+```bash
+docker logs $(docker ps -q --filter 'name=nanoclaw-v2-' | head -1) 2>&1 \
+  | grep 'MCP server started' | tail -1
+```
+
+`check_google_auth` and `list_google_scopes` should appear in the list.
+
+## Phase 3: Wire Per-Agent-Group
+
+### Step 1: Flip the agent's OneCLI secret mode to `all`
+
+This is the most common source of "401 from a Google API after everything
+looks wired" — auto-created agents start in `selective` secret mode and
+no Google secret is attached even though the vault has one.
+
+For each agent group that should have Google access:
+
+```bash
+# Find the OneCLI agent id (the identifier is the agent group id).
+onecli agents list
+
+# Flip to `all` so any vault secret with a matching host pattern injects.
+onecli agents set-secret-mode --id <agent-id> --mode all
+
+# Verify
+onecli agents secrets --id <agent-id>
+```
+
+If your security posture requires `selective`:
+
+```bash
+GOOGLE_IDS=$(onecli secrets list \
+  | jq -r '[.data[] | select(.name | test("(?i)google|gmail|calendar")) | .id] | join(",")')
+CURRENT=$(onecli agents secrets --id <agent-id> | jq -r '[.data[]] | join(",")')
+MERGED=$(printf '%s' "$CURRENT,$GOOGLE_IDS" | tr ',' '\n' | sort -u | paste -sd ',' -)
+onecli agents set-secrets --id <agent-id> --secret-ids "$MERGED"
+```
+
+No container restart is needed — the OneCLI gateway resolves secrets per
+request, so the next outbound call picks up the new assignment.
+
+### Step 2: Pre-create the shared stub directories
+
+Most Google MCP servers (`@gongrzhe/server-gmail-autoauth-mcp`,
+`@cocal/google-calendar-mcp`, etc.) refuse to start without local
+credential files on disk. The pattern for every Google integration is the
+same: a directory under `$HOME` holding two stub files with the literal
+value `onecli-managed`, which the OneCLI gateway rewrites in flight.
+
+This skill does NOT pre-create the per-API stubs — each downstream
+`/add-<tool>` skill writes the stubs in its own conventional location
+(`~/.gmail-mcp/`, `~/.calendar-mcp/`, etc.) so that uninstalling one
+integration cleans up its own stubs. Just make sure the directories live
+somewhere covered by the mount allowlist:
+
+### Step 3: Verify the mount allowlist
+
+```bash
+cat ~/.config/nanoclaw/mount-allowlist.json
+```
+
+A parent of every `~/.<google-thing>-mcp/` directory (typically just
+`/home/<user>` or `$HOME`) must appear under `allowedRoots`. If not, run
+`/manage-mounts` and add it once.
+
+## Phase 4: Build and Restart
+
+```bash
+pnpm run build
+./container/build.sh
+systemctl --user restart nanoclaw   # Linux
+# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+```
+
+Kill any existing agent containers so they respawn with the new MCP tool
+registry:
+
+```bash
+docker ps -q --filter 'name=nanoclaw-v2-' | xargs -r docker kill
+```
+
+## Phase 5: Verify
+
+### Step 1: From a wired agent, run the diagnostic
+
+> Tell the agent: **"Use `check_google_auth` to verify your Google
+> auth."**
+
+Expected: `Google auth OK — connected as <email>.` If the agent reports
+a 401, return to Phase 3 Step 1 and verify secret mode. If it reports a
+network error, the OneCLI proxy is not wired into the container — check
+`HTTPS_PROXY` in `groups/<folder>/container.json`.
+
+### Step 2: Inspect granted scopes
+
+> Tell the agent: **"Run `list_google_scopes`."**
+
+Expected: a list like
+
+```
+Granted scopes (access token expires in 3599s):
+  - https://www.googleapis.com/auth/gmail.readonly
+  - https://www.googleapis.com/auth/gmail.modify
+  - https://www.googleapis.com/auth/calendar.events
+  ...
+```
+
+If a scope you need is missing, return to Phase 1 Step 2 and re-connect
+Google in the OneCLI web UI with the expanded scope set.
+
+## Removal
+
+This skill is shared infrastructure — removing it likely breaks every
+`/add-<google>-tool` skill currently installed. Before removing:
+
+```bash
+grep -l 'mcp__google_auth\|check_google_auth\|list_google_scopes' \
+  groups/*/container.json .claude/skills/*/SKILL.md 2>/dev/null
+```
+
+If anything references the diagnostic tools, leave the skill in place.
+
+To remove:
+
+1. Delete the line `import './google-auth.js';` from
+   `container/agent-runner/src/mcp-tools/index.ts`.
+2. Delete `container/agent-runner/src/mcp-tools/google-auth.ts` and
+   `google-auth.test.ts`.
+3. `pnpm run build && ./container/build.sh && systemctl --user restart nanoclaw`.
+4. (Optional) Disconnect Google in the OneCLI web UI.
+
+## Notes
+
+- **No host wrapper, no Python, no `.env` keys.** v1 shipped a
+  `scripts/google_reauth.py` and a `~/.config/nanoclaw/secrets/google-gmail.json`
+  refresh-token file. v2 deletes both — OneCLI owns the OAuth flow end to
+  end. If you find yourself reaching for an env var or a host-side
+  refresh script, stop and re-read the [OneCLI section in
+  CLAUDE.md](../../CLAUDE.md).
+- **Scopes are decided at OneCLI connect time.** The diagnostic
+  `list_google_scopes` reads what was granted; it cannot widen the grant.
+  Widening requires the operator to re-connect Google in the OneCLI web
+  UI.
+- **The diagnostic tools never see a real token.** They issue HTTPS GETs
+  with no Authorization header (or with the literal `onecli-managed`
+  placeholder for `tokeninfo`); OneCLI injects the bearer at the proxy
+  boundary. This is by design — the agent process must remain
+  credential-free.
+
+## Credits & references
+
+- **OneCLI Agent Vault:** `https://onecli.sh` — the canonical credential
+  store and proxy. The full pattern is documented in [skill patterns for
+  NanoClaw v2 — API skills](../../docs/skill-patterns-v2.md) (available on
+  the `feat/skill-patterns-v2-doc` branch as of 2026-05-11).
+- **Container MCP tool layout:** modeled on `self-mod.ts` per the v2
+  skill-patterns doc; barrel-imported in
+  `container/agent-runner/src/mcp-tools/index.ts`.
+- **Downstream consumers:** `/add-gmail-tool`, `/add-gcal-tool`,
+  `/add-sheets-tool` (planned, #53), `/add-contacts-tool` (planned, #52),
+  `/add-calendar-mgmt` (planned, #55).
+- **Issue tracker:** `nanocoai/nanoclaw#50`.

--- a/.claude/skills/add-google-auth/SKILL.md
+++ b/.claude/skills/add-google-auth/SKILL.md
@@ -61,23 +61,14 @@ responsible for selecting the right one at request time.
 
 ## Phase 2: Apply Code Changes
 
-### Step 1: Merge this branch
+### Step 1: Install the container MCP tools
 
-This skill ships container MCP tools at
-`container/agent-runner/src/mcp-tools/google-auth.ts`. To install them
-into your local NanoClaw checkout once `skill/add-google-auth` exists:
-
-```bash
-git fetch origin skill/add-google-auth
-git merge --no-ff origin/skill/add-google-auth
-```
-
-> **Note (pre-split state):** as of 2026-05-11 the working branch is
-> `feat/add-google-auth-v2`. The split into `skill/add-google-auth` (fork
-> install target) and `add-google-auth-upstream` (PR source for
-> nanocoai/nanoclaw) is deferred to the next session pending
-> `/zenodotus --personas drive-by-contributor` review per `AGENTS.md`.
-> Until the split lands, install by fetching the working branch directly.
+This skill ships two container MCP tools at
+`container/agent-runner/src/mcp-tools/google-auth.ts` and a test file
+alongside it. On a fresh NanoClaw checkout the files arrive with the
+clone — no branch merge needed. On an existing checkout that predates
+this skill, `git pull` on `main` picks them up; proceed to Phase 4 to
+rebuild and reload.
 
 ### Step 2: Confirm the tools registered
 
@@ -236,13 +227,10 @@ To remove:
 ## Credits & references
 
 - **OneCLI Agent Vault:** `https://onecli.sh` — the canonical credential
-  store and proxy. The full pattern is documented in [skill patterns for
-  NanoClaw v2 — API skills](../../docs/skill-patterns-v2.md) (available on
-  the `feat/skill-patterns-v2-doc` branch as of 2026-05-11).
-- **Container MCP tool layout:** modeled on `self-mod.ts` per the v2
-  skill-patterns doc; barrel-imported in
+  store and proxy.
+- **Container MCP tool layout:** modeled on the existing `self-mod.ts`
+  MCP-tool module; barrel-imported in
   `container/agent-runner/src/mcp-tools/index.ts`.
-- **Downstream consumers:** `/add-gmail-tool`, `/add-gcal-tool`,
-  `/add-sheets-tool` (planned, #53), `/add-contacts-tool` (planned, #52),
-  `/add-calendar-mgmt` (planned, #55).
-- **Issue tracker:** `nanocoai/nanoclaw#50`.
+- **Downstream consumers:** future per-API skills (Gmail, Calendar,
+  Sheets, Contacts) depend on this foundation skill and are out of scope
+  for this PR.

--- a/.claude/skills/add-google-auth/SKILL.md
+++ b/.claude/skills/add-google-auth/SKILL.md
@@ -26,7 +26,7 @@ Gmail/Calendar/Sheets/Contacts call. Source:
 ### Step 1: Verify OneCLI is installed and running
 
 ```bash
-onecli --version
+onecli version
 curl -sf http://127.0.0.1:10254/api/health > /dev/null && echo OK
 ```
 
@@ -36,21 +36,32 @@ If either fails, run `/init-onecli` first.
 
 NanoClaw does NOT do the OAuth dance — OneCLI does. Tell the operator:
 
-> Open `http://127.0.0.1:10254` in a browser, go to **Apps → Google**, and
-> click **Connect**. Sign in with the Google account the agent should act
-> as. Grant every scope you might ever need from this account — Gmail
-> read+modify+send, Calendar read+events, Sheets, Contacts (People API).
-> Re-connecting later to widen scopes is supported but requires user
-> interaction; granting up front avoids interruptions.
+> Open `http://127.0.0.1:10254` in a browser, go to **Connections**, and
+> click **Connect** on each Google service the agent needs — typically
+> **Google Calendar**, **Gmail**, **Google Drive**, **Google Sheets**,
+> **Google Contacts**. Sign in with the Google account the agent should
+> act as. Grant every scope you might ever need from this account; widen
+> later by reconnecting, but each reconnect requires user interaction so
+> granting up front avoids interruptions.
+
+OneCLI's dashboard groups OAuth by Google service (one Connect button per
+API), not by Google account. To connect a second account (work +
+personal), click **Connect** again on the same service tile and sign in
+with the other account — OneCLI distinguishes per-app connections by
+identifier; the downstream skill (e.g. `add-gmail-tool`) selects the
+right one at request time.
 
 Verify the connection:
 
 ```bash
-onecli apps get --provider google
+curl -s http://127.0.0.1:10254/api/connections \
+  | jq '[.[] | select(.provider | test("(?i)google"))] | map({provider, status, scopes})'
 ```
 
-Expected: `"connection": { "status": "connected" }` with the scopes you
-granted listed.
+Expected: a non-empty array with `"status": "connected"` for each Google
+service you connected, and a `scopes` field listing what was granted.
+An empty array (`[]`) means the OAuth dance has not completed — re-open
+the dashboard and finish the Connect flow.
 
 ### Step 3: Decide on per-account scoping (optional, multi-account)
 

--- a/container/agent-runner/src/mcp-tools/google-auth.test.ts
+++ b/container/agent-runner/src/mcp-tools/google-auth.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for google-auth MCP tools. The tools issue HTTPS GETs to
+ * googleapis.com endpoints with no Authorization header, relying on the
+ * OneCLI proxy to inject credentials. The test mocks the fetch seam.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+
+import { __setFetchForTesting, checkGoogleAuth, listGoogleScopes, TOKENINFO_URL, USERINFO_URL } from './google-auth.js';
+
+interface MockResponse {
+  ok: boolean;
+  status: number;
+  bodyText: string;
+}
+
+function jsonResponse(status: number, body: unknown): MockResponse {
+  return { ok: status >= 200 && status < 300, status, bodyText: JSON.stringify(body) };
+}
+
+function mockFetch(routes: Record<string, MockResponse | (() => MockResponse)>) {
+  return async (input: string): Promise<Response> => {
+    // Match by URL prefix so query strings on the tokeninfo URL don't matter.
+    const route = Object.keys(routes).find((k) => input.startsWith(k));
+    if (!route) throw new Error(`Unexpected fetch URL: ${input}`);
+    const entry = routes[route];
+    const r = typeof entry === 'function' ? entry() : entry;
+    return {
+      ok: r.ok,
+      status: r.status,
+      text: async () => r.bodyText,
+      json: async () => JSON.parse(r.bodyText),
+    } as unknown as Response;
+  };
+}
+
+afterEach(() => {
+  __setFetchForTesting(null);
+});
+
+describe('check_google_auth', () => {
+  it('returns OK with the connected account email on 200', async () => {
+    __setFetchForTesting(
+      mockFetch({
+        [USERINFO_URL]: jsonResponse(200, { email: 'agent@example.com', sub: '12345' }),
+      }),
+    );
+
+    const result = await checkGoogleAuth.handler({});
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('Google auth OK');
+    expect(text).toContain('agent@example.com');
+  });
+
+  it('returns an error with status + connect hint when OneCLI is not injecting a credential (401)', async () => {
+    __setFetchForTesting(
+      mockFetch({
+        [USERINFO_URL]: { ok: false, status: 401, bodyText: '{"error":"unauthorized"}' },
+      }),
+    );
+
+    const result = await checkGoogleAuth.handler({});
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('401');
+    expect(text).toContain('OneCLI gateway has no Google credential');
+    expect(text).toContain('127.0.0.1:10254');
+  });
+
+  it('surfaces fetch exceptions as errors', async () => {
+    __setFetchForTesting(async () => {
+      throw new Error('proxy unreachable');
+    });
+
+    const result = await checkGoogleAuth.handler({});
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('proxy unreachable');
+  });
+});
+
+describe('list_google_scopes', () => {
+  it('returns the granted scopes on a 200 tokeninfo response', async () => {
+    __setFetchForTesting(
+      mockFetch({
+        [TOKENINFO_URL]: jsonResponse(200, {
+          scope: 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/calendar.events',
+          expires_in: 3599,
+        }),
+      }),
+    );
+
+    const result = await listGoogleScopes.handler({});
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('gmail.readonly');
+    expect(text).toContain('calendar.events');
+    expect(text).toContain('3599s');
+  });
+
+  it('reports a clear error when the OneCLI gateway does not rewrite the placeholder token (400)', async () => {
+    __setFetchForTesting(
+      mockFetch({
+        [TOKENINFO_URL]: { ok: false, status: 400, bodyText: '{"error":"invalid_token"}' },
+      }),
+    );
+
+    const result = await listGoogleScopes.handler({});
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('400');
+    expect(text).toContain('not rewriting the access_token');
+  });
+});

--- a/container/agent-runner/src/mcp-tools/google-auth.ts
+++ b/container/agent-runner/src/mcp-tools/google-auth.ts
@@ -1,0 +1,149 @@
+/**
+ * Google auth diagnostic MCP tools.
+ *
+ * NanoClaw v2 does NOT hold raw Google OAuth tokens. The OneCLI gateway
+ * (HTTPS_PROXY) intercepts outbound requests to *.googleapis.com and
+ * injects `Authorization: Bearer <real-token>` from the OneCLI vault.
+ * Agents never see the token value.
+ *
+ * These tools exist purely to let an agent confirm — at runtime, from
+ * inside its container — that the OneCLI proxy is wired and that the
+ * operator has connected a Google account with the expected scopes.
+ * They are a foundation for downstream Google-API skills (Gmail,
+ * Calendar, Sheets, Contacts) so each skill does not re-implement the
+ * same connectivity probe.
+ *
+ * No credential is read here. No env var is read here. No vault API is
+ * called. The probe is just an HTTPS GET — if OneCLI is wired and the
+ * agent's secret-mode is `all` (or has the relevant secret assigned),
+ * the call succeeds; otherwise the gateway returns an error response
+ * with a `connect_url` per the onecli-gateway container skill.
+ */
+import { registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+// Exported for tests; production callers go through the MCP handlers.
+export const TOKENINFO_URL = 'https://www.googleapis.com/oauth2/v3/tokeninfo';
+export const USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
+
+interface FetchLike {
+  (input: string, init?: RequestInit): Promise<Response>;
+}
+
+// Internal seam so tests can inject a mock without monkey-patching globalThis.fetch.
+let _fetch: FetchLike = (input, init) => fetch(input, init);
+
+export function __setFetchForTesting(f: FetchLike | null): void {
+  _fetch = f ?? ((input, init) => fetch(input, init));
+}
+
+async function probeUserinfo(): Promise<
+  { ok: true; email?: string; subject?: string } | { ok: false; status: number; body: string }
+> {
+  // OneCLI proxy injects the bearer header for requests matching its
+  // Google host-pattern. We deliberately send NO Authorization header
+  // ourselves — the agent must not handle credentials.
+  const res = await _fetch(USERINFO_URL, { method: 'GET' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    return { ok: false, status: res.status, body: body.slice(0, 500) };
+  }
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  return {
+    ok: true,
+    email: typeof data.email === 'string' ? data.email : undefined,
+    subject: typeof data.sub === 'string' ? data.sub : undefined,
+  };
+}
+
+async function probeTokeninfo(): Promise<
+  { ok: true; scopes: string[]; expiresIn?: number } | { ok: false; status: number; body: string }
+> {
+  // tokeninfo wants the access_token as a query param OR header. With
+  // OneCLI in front, we pass a placeholder query value; the gateway
+  // rewrites it. If the gateway is not wired, Google rejects the
+  // placeholder with 400, which is the signal the operator needs to
+  // run `/add-google-auth` (or whatever the install skill is named).
+  const url = `${TOKENINFO_URL}?access_token=onecli-managed`;
+  const res = await _fetch(url, { method: 'GET' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    return { ok: false, status: res.status, body: body.slice(0, 500) };
+  }
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  const scopeStr = typeof data.scope === 'string' ? data.scope : '';
+  const scopes = scopeStr.split(/\s+/).filter(Boolean);
+  const expiresIn =
+    typeof data.expires_in === 'string'
+      ? Number(data.expires_in)
+      : typeof data.expires_in === 'number'
+        ? data.expires_in
+        : undefined;
+  return { ok: true, scopes, expiresIn };
+}
+
+export const checkGoogleAuth: McpToolDefinition = {
+  tool: {
+    name: 'check_google_auth',
+    description:
+      'Verify the agent has working Google OAuth via the OneCLI proxy. Calls googleapis.com/oauth2/v3/userinfo with no Authorization header — the OneCLI gateway injects the bearer. Returns the connected account email on success, or the upstream error (with status) on failure so the agent can surface the OneCLI connect URL to the operator.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+  },
+  async handler() {
+    try {
+      const r = await probeUserinfo();
+      if (r.ok) {
+        const who = r.email ?? r.subject ?? '(unknown)';
+        return ok(`Google auth OK — connected as ${who}.`);
+      }
+      return err(
+        `Google userinfo returned ${r.status}. ${r.body || '(empty body)'} ` +
+          `— if this is 401/403, the OneCLI gateway has no Google credential for this agent. ` +
+          `Run '/add-google-auth' or open http://127.0.0.1:10254 → Apps → Google to connect.`,
+      );
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  },
+};
+
+export const listGoogleScopes: McpToolDefinition = {
+  tool: {
+    name: 'list_google_scopes',
+    description:
+      'List the OAuth scopes currently granted on the OneCLI-managed Google token for this agent. Useful for checking before attempting a Gmail/Calendar/Sheets/Contacts call that needs a specific scope.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+  },
+  async handler() {
+    try {
+      const r = await probeTokeninfo();
+      if (r.ok) {
+        if (r.scopes.length === 0) return ok('No scopes reported by tokeninfo.');
+        const expiry = r.expiresIn !== undefined ? ` (access token expires in ${r.expiresIn}s)` : '';
+        return ok(`Granted scopes${expiry}:\n${r.scopes.map((s) => `  - ${s}`).join('\n')}`);
+      }
+      return err(
+        `Google tokeninfo returned ${r.status}. ${r.body || '(empty body)'} ` +
+          `— if 400 with 'invalid_token', the OneCLI gateway is not rewriting the access_token param for this agent.`,
+      );
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  },
+};
+
+registerTools([checkGoogleAuth, listGoogleScopes]);

--- a/container/agent-runner/src/mcp-tools/google-auth.ts
+++ b/container/agent-runner/src/mcp-tools/google-auth.ts
@@ -64,14 +64,25 @@ async function probeUserinfo(): Promise<
   };
 }
 
+/**
+ * Probe Google's `tokeninfo` endpoint to surface granted scopes + expiry.
+ *
+ * OneCLI contract: the literal `access_token=onecli-managed` is the
+ * placeholder the OneCLI gateway recognizes and rewrites in flight,
+ * substituting the real bearer it holds for this agent. Nothing in this
+ * container ever sees a real token — the placeholder is intentional and
+ * load-bearing. If the gateway is not wired (or this container's traffic
+ * is not flowing through the OneCLI proxy), Google rejects the
+ * placeholder with HTTP 400, which is the diagnostic signal the operator
+ * needs to re-run `/add-google-auth`.
+ *
+ * Same literal appears in every downstream Google MCP credential stub
+ * (e.g. `~/.gmail-mcp/credentials.json`); see `add-google-auth` SKILL.md
+ * Phase 3 Step 2.
+ */
 async function probeTokeninfo(): Promise<
   { ok: true; scopes: string[]; expiresIn?: number } | { ok: false; status: number; body: string }
 > {
-  // tokeninfo wants the access_token as a query param OR header. With
-  // OneCLI in front, we pass a placeholder query value; the gateway
-  // rewrites it. If the gateway is not wired, Google rejects the
-  // placeholder with 400, which is the signal the operator needs to
-  // run `/add-google-auth` (or whatever the install skill is named).
   const url = `${TOKENINFO_URL}?access_token=onecli-managed`;
   const res = await _fetch(url, { method: 'GET' });
   if (!res.ok) {

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -10,6 +10,7 @@ import './scheduling.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+import './google-auth.js';
 import { startMcpServer } from './server.js';
 
 function log(msg: string): void {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

This skill is a foundation-tier integration: it ships shared OneCLI Google-OAuth prerequisites plus two diagnostic MCP tools (`check_google_auth`, `list_google_scopes`) that downstream Google-API skills (Gmail, Calendar, Sheets, Contacts) all build on. Closest fit in the six-option taxonomy is **Feature skill** (source changes + SKILL.md); flagging here in case maintainers prefer to recategorize.

## Description

Adds `/add-google-auth` — a foundation skill for every NanoClaw v2 Google-API integration. NanoClaw v2 holds no raw Google OAuth tokens: the [OneCLI Agent Vault](https://onecli.sh) owns the refresh token and injects a fresh bearer into every outbound request to `*.googleapis.com`. This skill captures the cross-skill prerequisites (one-time OneCLI connect, agent secret-mode flip, credential-stub directories, mount-allowlist) so that downstream `/add-gmail-tool`, `/add-gcal-tool`, `/add-sheets-tool`, `/add-contacts-tool` skills can each assume the foundation is in place.

Two diagnostic MCP tools ship in the same change:

- **`check_google_auth`** — agent calls Google `userinfo` (no Authorization header; OneCLI injects), reports `connected as <email>` or surfaces the specific error class.
- **`list_google_scopes`** — agent calls Google `tokeninfo` (literal `access_token=onecli-managed` placeholder the OneCLI gateway rewrites), reports granted scopes + expiry.

Both tools are credential-free by design — the agent process never sees a real bearer; the OneCLI proxy at `127.0.0.1:10254` substitutes it at request time. Source: `container/agent-runner/src/mcp-tools/google-auth.ts` (149 LOC) + tests (114 LOC).

### Diff scope

```
.claude/skills/add-google-auth/SKILL.md                         | 261 +++++++++++++
container/agent-runner/src/mcp-tools/google-auth.ts             | 149 ++++++++
container/agent-runner/src/mcp-tools/google-auth.test.ts        | 114 ++++++
container/agent-runner/src/mcp-tools/index.ts                   |   1 +
```

Cumulative: 4 files, +524/-0 net.

### Independent review (Zenodotus drive-by-contributor panel)

Three rounds of cold-reader review against this branch:

| Round | SHA | Verdict | TTFS | Blockers | New / changed since prior |
|---|---|---|---|---|---|
| r1 | `0fc8e13` | conditional | 18m | 1 (Versioning 🔴) — Phase 2 Step 1 referenced a non-existent branch | initial review |
| r2 | `5a80b8f` | conditional | 6m | 0 — r1 blocker fixed | dropped pre-split note + forward refs |
| **r3** | **`c5a0ff9`** (HEAD) | **conditional** | **8m** | **0** | docs-drift fixes against live OneCLI 1.1.0 + JSDoc + min-version note |

r3 verdict is the softest of the three — every remaining finding is a one-line follow-up or a trunk-policy carry-forward documented below. Reviewer's gut-feel verbatim: *"Honestly? Yeah, I'd open a PR here. … Ship with the one-line version note."* (The one-line version note has been added — commit `c5a0ff9` documents OneCLI ≥ 1.1.0 in SKILL.md Phase 1 Step 1.)

### Known follow-ups (r3 minors, deferred from this PR)

| Where | What | Why deferred |
|---|---|---|
| `.claude/skills/add-google-auth/SKILL.md` Phase 4 | Verification step (sentinel string / image timestamp) confirming the rebuild picked up the new MCP tools, beyond `docker logs` | Polish — happy with addressing in a follow-up PR if maintainers prefer. |
| `container/agent-runner/src/mcp-tools/google-auth.test.ts` | Test for the userinfo "200 but no email field" → `subject`-only fallback branch (`google-auth.ts` L60-64) | Polish — uncovered branch is a graceful fallback that returns a sensible string; behavior is correct, test is missing. |

### Carried-forward observations (out of scope for this PR)

Surfaced across r1–r3 but declared not adjudicable from the contribution side:

1. **CHANGELOG drift** — `CHANGELOG.md` stops at 2.0.54, `package.json` is 2.0.56, and no entry exists for this PR. Understanding from `CONTRIBUTING.md` is that the `bump-version` workflow owns the changelog; happy to add an entry if maintainers prefer a different process for contributor PRs.
2. **MCP tools vs CONTRIBUTING "trunk = bug/security/simplification only"** — this PR adds new MCP tools (the diagnostics), which CONTRIBUTING.md L… frames as trunk-by-exception. The intent here is foundation-tier infra for the Google skill family, not a feature add per se; happy to re-categorize or split.
3. **Missing `.github/ISSUE_TEMPLATE/`** — surfaced by drive-by-contributor lens; out of scope for a feature PR.

If any of these should be addressed in this PR rather than separately, point me at the right shape.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files: `google-auth.ts`, `google-auth.test.ts`)
- [x] SKILL.md is under 500 lines (261 lines)
- [x] I tested this skill on a fresh clone

### Test results

- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` — clean
- `cd container/agent-runner && bun test src/mcp-tools/google-auth.test.ts` — 5 pass / 0 fail / 16 expect() calls
- Live OneCLI 1.1.0 probe of the documented CLI verbs and `/api/connections` endpoint — three docs-drift fixes landed in `192c45e` and are reflected in r3.

### Branch source

This PR is opened from `Kromatic-Innovation/nanoclaw:add-google-auth-upstream` (the fork's upstream-PR-candidate branch). Same skill lives on the fork as `skill/add-google-auth` for downstream install testing; the two are kept in sync via cherry-pick.
