### PR TITLE
fix(whatsapp): route inbound media through shared session inbox

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -345,30 +345,37 @@ registerChannelAdapter('whatsapp', {
     ): Promise<
       Array<{
         type: string;
-        name: string | undefined;
+        name: string;
         mimeType: string | undefined;
         size: number;
         data: string;
       }>
     > {
-      const mediaTypes: Array<{ key: string; type: string }> = [
-        { key: 'imageMessage', type: 'image' },
-        { key: 'videoMessage', type: 'video' },
-        { key: 'audioMessage', type: 'audio' },
-        { key: 'documentMessage', type: 'document' },
+      // Non-document WhatsApp media (image/video/audio) usually has no
+      // fileName, so we must supply a typed extension. Without it, the
+      // shared extractor falls back to a generic extensionless
+      // `attachment-<ts>`, and when the agent forwards the saved file via
+      // `send_file`, `buildMediaMessage` keys on the extension to pick
+      // image/video/audio vs. document — extensionless ⇒ wrong as document.
+      const mediaTypes: Array<{ key: string; type: string; ext: string }> = [
+        { key: 'imageMessage', type: 'image', ext: '.jpg' },
+        { key: 'videoMessage', type: 'video', ext: '.mp4' },
+        { key: 'audioMessage', type: 'audio', ext: '.ogg' },
+        { key: 'documentMessage', type: 'document', ext: '' },
       ];
       const results: Array<{
         type: string;
-        name: string | undefined;
+        name: string;
         mimeType: string | undefined;
         size: number;
         data: string;
       }> = [];
-      for (const { key, type } of mediaTypes) {
+      for (const { key, type, ext } of mediaTypes) {
         if (!normalized[key]) continue;
         try {
           const buffer = await downloadMediaMessage(msg, 'buffer', {});
-          const name = normalized[key].fileName as string | undefined;
+          const rawName = normalized[key].fileName as string | undefined;
+          const name = rawName && rawName.length > 0 ? rawName : `${type}-${Date.now()}${ext}`;
           const mimeType = normalized[key].mimetype as string | undefined;
           results.push({
             type,

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -38,8 +38,7 @@ import {
 } from '@whiskeysockets/baileys';
 import type { GroupMetadata, WAMessageKey, WAMessage, WASocket } from '@whiskeysockets/baileys';
 
-import { isSafeAttachmentName } from '../attachment-safety.js';
-import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME, DATA_DIR } from '../config.js';
+import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 import { registerChannelAdapter } from './channel-registry.js';
@@ -331,41 +330,54 @@ registerChannelAdapter('whatsapp', {
       }
     }
 
-    /** Download media from an inbound message, save to /workspace/attachments/. */
+    /**
+     * Download inbound media as base64 `data` on each attachment object. The
+     * host's session-manager.extractAttachmentFiles stages every entry into
+     * <sessionDir>/inbox/<msgId>/<filename>, reachable in the container at
+     * /workspace/inbox/<msgId>/<filename>. Routing the bytes through the
+     * shared extractor keeps WhatsApp on the same code path as chat-sdk
+     * channels and inherits its path-traversal hardening for filenames.
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async function downloadInboundMedia(
       msg: WAMessage,
       normalized: any,
-    ): Promise<Array<{ type: string; name: string; localPath: string }>> {
-      const mediaTypes: Array<{ key: string; type: string; ext: string }> = [
-        { key: 'imageMessage', type: 'image', ext: '.jpg' },
-        { key: 'videoMessage', type: 'video', ext: '.mp4' },
-        { key: 'audioMessage', type: 'audio', ext: '.ogg' },
-        { key: 'documentMessage', type: 'document', ext: '' },
+    ): Promise<
+      Array<{
+        type: string;
+        name: string | undefined;
+        mimeType: string | undefined;
+        size: number;
+        data: string;
+      }>
+    > {
+      const mediaTypes: Array<{ key: string; type: string }> = [
+        { key: 'imageMessage', type: 'image' },
+        { key: 'videoMessage', type: 'video' },
+        { key: 'audioMessage', type: 'audio' },
+        { key: 'documentMessage', type: 'document' },
       ];
-      const results: Array<{ type: string; name: string; localPath: string }> = [];
-      for (const { key, type, ext } of mediaTypes) {
+      const results: Array<{
+        type: string;
+        name: string | undefined;
+        mimeType: string | undefined;
+        size: number;
+        data: string;
+      }> = [];
+      for (const { key, type } of mediaTypes) {
         if (!normalized[key]) continue;
         try {
           const buffer = await downloadMediaMessage(msg, 'buffer', {});
-          // documentMessage.fileName is attacker-controlled and rides through
-          // WhatsApp's E2E channel — Meta can't sanitize it server-side. Without
-          // this guard, a `..`-laden fileName escapes attachDir on path.join.
-          const rawFilename = normalized[key].fileName;
-          const fallback = `${type}-${Date.now()}${ext}`;
-          const filename = isSafeAttachmentName(rawFilename) ? rawFilename : fallback;
-          if (rawFilename && filename !== rawFilename) {
-            log.warn('Refused unsafe attachment filename — would escape attachments dir', {
-              rawFilename,
-              replacement: filename,
-            });
-          }
-          const attachDir = path.join(DATA_DIR, 'attachments');
-          fs.mkdirSync(attachDir, { recursive: true });
-          const filePath = path.join(attachDir, filename);
-          fs.writeFileSync(filePath, buffer);
-          results.push({ type, name: filename, localPath: `attachments/${filename}` });
-          log.info('Media downloaded', { type, filename });
+          const name = normalized[key].fileName as string | undefined;
+          const mimeType = normalized[key].mimetype as string | undefined;
+          results.push({
+            type,
+            name,
+            mimeType,
+            size: buffer.byteLength,
+            data: buffer.toString('base64'),
+          });
+          log.info('Media downloaded', { type, name, size: buffer.byteLength });
         } catch (err) {
           log.warn('Failed to download media', { type, err });
         }


### PR DESCRIPTION
## Summary

WhatsApp inbound media (images, video, audio, documents) was being staged to `<repo>/data/attachments/<filename>` on the host and tagged with `localPath: attachments/<filename>` (`src/channels/whatsapp.ts` `downloadInboundMedia`). Containers only mount the per-session directory at `/workspace` (`src/container-runner.ts`), so `data/attachments/` is unreachable from inside any agent. Agents saw the formatter line "saved to `/workspace/attachments/<file>`" but the path didn't exist.

This fix routes WhatsApp media through the same path chat-sdk channels already use: hand the buffer to `session-manager.extractAttachmentFiles` via a base64 `data` field on the attachment object. The extractor writes files to `<sessionDir>/inbox/<msgId>/<filename>` (reachable at `/workspace/inbox/<msgId>/<filename>`) and applies the existing path-traversal hardening — `lstat`/`realpath` containment, `wx` flag, basename guard on message id and filename.

Net effect: WhatsApp document delivery actually works, and every channel now stages inbound attachments through one code path.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm test` — 423/423 pass (existing inbound-attachment safety tests at `src/host-core.test.ts:168-255` exercise the shared extractor path that WhatsApp now uses)
- [x] `pnpm run lint` — no new warnings in `src/channels/whatsapp.ts` (17 → 17 identical warnings, line numbers shifted only)
- [x] `pnpm run build` clean
- [ ] Manual: send a document via WhatsApp DM/group, confirm container sees the file at `/workspace/inbox/<msgId>/<filename>`

## Notes

- Removes now-unused imports: `isSafeAttachmentName` (sanitization happens in the shared extractor) and `DATA_DIR` (no more host-side staging).
- Base64 inflation through `inbound.db` is the same trade chat-sdk channels already pay; the row is short-lived (extractor writes to disk and rewrites the JSON before the container reads it).
- File naming behavior matches chat-sdk channels: `att.name` (from `documentMessage.fileName`) when present, else `deriveAttachmentName` synthesizes `attachment-<ts>.<ext>` from `att.mimeType` / `att.type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)