### PR TITLE
Conditional thread policy for Slack adapter (DM=top-level, channels=threaded)

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -124,6 +124,14 @@ export interface ChannelAdapter {
    */
   supportsThreads: boolean;
 
+  /**
+   * Per-destination thread policy override. When defined, the router consults
+   * this instead of `supportsThreads` to decide whether to collapse the inbound
+   * threadId. Useful for platforms like Slack where threads make sense in
+   * channels (C/G-prefixed IDs) but not in DMs (D-prefixed IDs).
+   */
+  shouldUseThreadsFor?(platformId: string): boolean;
+
   // Lifecycle
   setup(config: ChannelSetup): Promise<void>;
   teardown(): Promise<void>;

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -17,6 +17,7 @@ registerChannelAdapter('slack', {
       signingSecret: env.SLACK_SIGNING_SECRET,
     });
     const bridge = createChatSdkBridge({ adapter: slackAdapter, concurrency: 'concurrent', supportsThreads: true });
+    bridge.shouldUseThreadsFor = (platformId: string) => !platformId.startsWith('D');
     bridge.resolveChannelName = async (platformId: string) => {
       try {
         const info = await slackAdapter.fetchThread(platformId);

--- a/src/router.ts
+++ b/src/router.ts
@@ -145,8 +145,13 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   // 0. Apply the adapter's thread policy. Non-threaded adapters (Telegram,
   //    WhatsApp, iMessage, email) collapse threads to the channel.
   const adapter = getChannelAdapter(event.channelType);
-  if (adapter && !adapter.supportsThreads) {
-    event = { ...event, threadId: null };
+  if (adapter) {
+    const useThreads = adapter.shouldUseThreadsFor
+      ? adapter.shouldUseThreadsFor(event.platformId)
+      : adapter.supportsThreads;
+    if (!useThreads) {
+      event = { ...event, threadId: null };
+    }
   }
 
   const isMention = event.message.isMention === true;


### PR DESCRIPTION
## Summary

Adds optional `shouldUseThreadsFor(platformId)` on the `ChannelAdapter` interface. When defined, the router consults this instead of `supportsThreads` to decide whether to collapse the inbound `threadId`.

Slack adapter uses it to disable threading only for DM channels (D-prefix), preserving threaded behavior for public/private channels (C/G-prefix). This fixes an inconsistent file-send-vs-text-reply UX in Slack DMs by routing both through the same fallback-to-channel-id `tid`, so they post at the top level together.

Backward compatible — the field is optional; adapters that don't define it keep the existing `supportsThreads` boolean behavior.

## Files

- `src/channels/adapter.ts` — new optional `shouldUseThreadsFor` on `ChannelAdapter`.
- `src/router.ts` — gate uses the override when present, otherwise falls back to `supportsThreads`.
- `src/channels/slack.ts` — sets `shouldUseThreadsFor` to return `false` for D-prefixed (DM) platform IDs.

## Test plan

- [ ] Slack DM: inbound text + file reply both land at top level (no thread).
- [ ] Slack public/private channel @mention: replies still threaded into the originating thread.
- [ ] Other adapters (Telegram, WhatsApp, Discord) unaffected — no override, same `supportsThreads` behavior.