### PR TITLE
fix(setup/onecli): restrict admin API and postgres to loopback after OneCLI install

### DIFF
--- a/setup/onecli.test.ts
+++ b/setup/onecli.test.ts
@@ -6,10 +6,12 @@ import path from 'path';
 /**
  * Tests for the OneCLI compose hardening step. Verifies that the rewrite
  * pins the admin API (:10254) and Postgres (:5432) to 127.0.0.1, leaves the
- * gateway (:10255) alone, and is idempotent / fails safe on unknown layouts.
+ * gateway (:10255) alone, fixes up the installer's config.json and .env
+ * admin URLs, and is idempotent / fails safe on unknown layouts.
  *
- * Tests operate on a tempdir copy of the upstream compose shape — no docker
- * calls, no real OneCLI install.
+ * Tests operate on a tempdir copy of the upstream compose shape, with an
+ * injected docker-inspect stub for the detection helper — no real docker,
+ * no real OneCLI install.
  */
 
 const UPSTREAM_COMPOSE = `services:
@@ -27,10 +29,14 @@ const UPSTREAM_COMPOSE = `services:
 describe('hardenOneCliBinds', () => {
   let tempDir: string;
   let composePath: string;
+  let envPath: string;
+  let configPath: string;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'onecli-harden-test-'));
     composePath = path.join(tempDir, 'docker-compose.yml');
+    envPath = path.join(tempDir, '.env');
+    configPath = path.join(tempDir, 'config.json');
   });
 
   afterEach(() => {
@@ -41,7 +47,7 @@ describe('hardenOneCliBinds', () => {
     const { hardenOneCliBinds } = await import('./onecli.js');
     fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
 
-    const result = hardenOneCliBinds(composePath);
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
     expect(result.changed).toBe(true);
 
     const patched = fs.readFileSync(composePath, 'utf-8');
@@ -55,10 +61,10 @@ describe('hardenOneCliBinds', () => {
   it('is a no-op when the marker is already present', async () => {
     const { hardenOneCliBinds } = await import('./onecli.js');
     fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
-    hardenOneCliBinds(composePath);
+    hardenOneCliBinds({ composePath, envPath, configPath });
     const firstPass = fs.readFileSync(composePath, 'utf-8');
 
-    const result = hardenOneCliBinds(composePath);
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
     expect(result.changed).toBe(false);
     expect(result.reason).toBe('already_patched');
     expect(fs.readFileSync(composePath, 'utf-8')).toBe(firstPass);
@@ -69,7 +75,7 @@ describe('hardenOneCliBinds', () => {
     const mystery = `services:\n  onecli:\n    image: something-else\n    ports:\n      - "10254:10254"\n`;
     fs.writeFileSync(composePath, mystery);
 
-    const result = hardenOneCliBinds(composePath);
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
     expect(result.changed).toBe(false);
     expect(result.reason).toBe('layout_unrecognized');
     expect(fs.readFileSync(composePath, 'utf-8')).toBe(mystery);
@@ -79,9 +85,167 @@ describe('hardenOneCliBinds', () => {
     const { hardenOneCliBinds } = await import('./onecli.js');
     const missing = path.join(tempDir, 'nope.yml');
 
-    const result = hardenOneCliBinds(missing);
+    const result = hardenOneCliBinds({ composePath: missing, envPath, configPath });
     expect(result.changed).toBe(false);
     expect(result.reason).toBe('compose_missing');
     expect(fs.existsSync(missing)).toBe(false);
+  });
+
+  it('rewrites config.json api-host from bridge IP to 127.0.0.1', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    fs.writeFileSync(configPath, JSON.stringify({ 'api-host': 'http://172.17.0.1:10254' }, null, 2));
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    expect(result.adminUrlRewritten).toBe(true);
+
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(cfg['api-host']).toBe('http://127.0.0.1:10254');
+  });
+
+  it('preserves a gateway-port URL in config.json (only :10254 gets swapped)', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    fs.writeFileSync(configPath, JSON.stringify({ 'api-host': 'http://172.17.0.1:10255' }, null, 2));
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    // No admin URL to rewrite (this api-host is the gateway port).
+    expect(result.adminUrlRewritten).toBe(false);
+
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(cfg['api-host']).toBe('http://172.17.0.1:10255');
+  });
+
+  it('leaves config.json alone if api-host already points to loopback', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    const original = JSON.stringify({ 'api-host': 'http://127.0.0.1:10254', other: 'kept' }, null, 2);
+    fs.writeFileSync(configPath, original);
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    expect(result.adminUrlRewritten).toBe(false);
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(original);
+  });
+
+  it('rewrites ~/.onecli/.env ONECLI_URL when it has a bridge-IP admin URL', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    fs.writeFileSync(
+      envPath,
+      'ONECLI_BIND_HOST=172.17.0.1\nONECLI_URL=http://172.17.0.1:10254\nOTHER=keep\n',
+    );
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    expect(result.adminUrlRewritten).toBe(true);
+
+    const env = fs.readFileSync(envPath, 'utf-8');
+    expect(env).toContain('ONECLI_URL=http://127.0.0.1:10254');
+    expect(env).toContain('ONECLI_BIND_HOST=172.17.0.1');
+    expect(env).toContain('OTHER=keep');
+  });
+
+  it('leaves ~/.onecli/.env alone when ONECLI_URL is the gateway port (:10255)', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    const original = 'ONECLI_URL=http://172.17.0.1:10255\n';
+    fs.writeFileSync(envPath, original);
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    expect(result.adminUrlRewritten).toBe(false);
+    expect(fs.readFileSync(envPath, 'utf-8')).toBe(original);
+  });
+
+  it('treats missing config.json and .env as no-ops (security fix still lands)', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    // No config.json, no .env (matches the affected-box layout).
+
+    const result = hardenOneCliBinds({ composePath, envPath, configPath });
+    expect(result.changed).toBe(true);
+    expect(result.adminUrlRewritten).toBe(false);
+    expect(fs.existsSync(configPath)).toBe(false);
+    expect(fs.existsSync(envPath)).toBe(false);
+  });
+});
+
+describe('swapHostInAdminUrl', () => {
+  it('swaps a non-loopback host on the admin port to 127.0.0.1', async () => {
+    const { swapHostInAdminUrl } = await import('./onecli.js');
+    expect(swapHostInAdminUrl('http://172.17.0.1:10254')).toBe('http://127.0.0.1:10254');
+    expect(swapHostInAdminUrl('http://172.17.0.1:10254/api/health')).toBe('http://127.0.0.1:10254/api/health');
+    expect(swapHostInAdminUrl('https://10.0.0.5:10254')).toBe('https://127.0.0.1:10254');
+  });
+
+  it('leaves already-loopback admin URLs unchanged', async () => {
+    const { swapHostInAdminUrl } = await import('./onecli.js');
+    expect(swapHostInAdminUrl('http://127.0.0.1:10254')).toBe('http://127.0.0.1:10254');
+    expect(swapHostInAdminUrl('http://localhost:10254')).toBe('http://localhost:10254');
+  });
+
+  it('leaves gateway-port URLs unchanged', async () => {
+    const { swapHostInAdminUrl } = await import('./onecli.js');
+    expect(swapHostInAdminUrl('http://172.17.0.1:10255')).toBe('http://172.17.0.1:10255');
+  });
+
+  it('leaves non-matching URLs unchanged', async () => {
+    const { swapHostInAdminUrl } = await import('./onecli.js');
+    expect(swapHostInAdminUrl('not-a-url')).toBe('not-a-url');
+    expect(swapHostInAdminUrl('')).toBe('');
+  });
+});
+
+describe('detectUnsafeOneCliBinds', () => {
+  let tempDir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'onecli-detect-test-'));
+    envPath = path.join(tempDir, '.env');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('flags a non-loopback :10254 bind reported by docker inspect', async () => {
+    const { detectUnsafeOneCliBinds } = await import('./onecli.js');
+    const inspectFn = (_c: string, port: string) => (port === '10254/tcp' ? '172.17.0.1' : null);
+
+    expect(detectUnsafeOneCliBinds({ inspectFn, envPath })).toBe('172.17.0.1');
+  });
+
+  it('returns null when docker inspect reports loopback', async () => {
+    const { detectUnsafeOneCliBinds } = await import('./onecli.js');
+    const inspectFn = (_c: string, port: string) => (port === '10254/tcp' ? '127.0.0.1' : null);
+
+    expect(detectUnsafeOneCliBinds({ inspectFn, envPath })).toBeNull();
+  });
+
+  it('falls back to ~/.onecli/.env when docker inspect fails', async () => {
+    const { detectUnsafeOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(envPath, 'ONECLI_BIND_HOST=172.17.0.1\n');
+    const inspectFn = () => null;
+
+    expect(detectUnsafeOneCliBinds({ inspectFn, envPath })).toBe('172.17.0.1');
+  });
+
+  it('returns null when inspect fails and .env shows loopback', async () => {
+    const { detectUnsafeOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(envPath, 'ONECLI_BIND_HOST=127.0.0.1\n');
+    const inspectFn = () => null;
+
+    expect(detectUnsafeOneCliBinds({ inspectFn, envPath })).toBeNull();
+  });
+
+  it('returns null when inspect fails and .env is missing', async () => {
+    const { detectUnsafeOneCliBinds } = await import('./onecli.js');
+    const inspectFn = () => null;
+
+    expect(detectUnsafeOneCliBinds({ inspectFn, envPath })).toBeNull();
   });
 });

--- a/setup/onecli.test.ts
+++ b/setup/onecli.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Tests for the OneCLI compose hardening step. Verifies that the rewrite
+ * pins the admin API (:10254) and Postgres (:5432) to 127.0.0.1, leaves the
+ * gateway (:10255) alone, and is idempotent / fails safe on unknown layouts.
+ *
+ * Tests operate on a tempdir copy of the upstream compose shape — no docker
+ * calls, no real OneCLI install.
+ */
+
+const UPSTREAM_COMPOSE = `services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "\${ONECLI_BIND_HOST:-127.0.0.1}:\${POSTGRES_PORT:-5432}:5432"
+  onecli:
+    image: onecli/onecli:latest
+    ports:
+      - "\${ONECLI_BIND_HOST:-127.0.0.1}:\${ONECLI_APP_PORT:-10254}:10254"
+      - "\${ONECLI_BIND_HOST:-127.0.0.1}:\${ONECLI_GATEWAY_PORT:-10255}:10255"
+`;
+
+describe('hardenOneCliBinds', () => {
+  let tempDir: string;
+  let composePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'onecli-harden-test-'));
+    composePath = path.join(tempDir, 'docker-compose.yml');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('pins admin API and Postgres to 127.0.0.1 and leaves the gateway alone', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+
+    const result = hardenOneCliBinds(composePath);
+    expect(result.changed).toBe(true);
+
+    const patched = fs.readFileSync(composePath, 'utf-8');
+    expect(patched).toContain('"127.0.0.1:${POSTGRES_PORT:-5432}:5432"');
+    expect(patched).toContain('"127.0.0.1:${ONECLI_APP_PORT:-10254}:10254"');
+    // Gateway must keep the env-driven bind so containers can still reach it.
+    expect(patched).toContain('"${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}:10255"');
+    expect(patched).toMatch(/^# nanoclaw: admin\+postgres pinned to loopback/);
+  });
+
+  it('is a no-op when the marker is already present', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    fs.writeFileSync(composePath, UPSTREAM_COMPOSE);
+    hardenOneCliBinds(composePath);
+    const firstPass = fs.readFileSync(composePath, 'utf-8');
+
+    const result = hardenOneCliBinds(composePath);
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe('already_patched');
+    expect(fs.readFileSync(composePath, 'utf-8')).toBe(firstPass);
+  });
+
+  it('no-ops and warns when the compose layout is unrecognized', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    const mystery = `services:\n  onecli:\n    image: something-else\n    ports:\n      - "10254:10254"\n`;
+    fs.writeFileSync(composePath, mystery);
+
+    const result = hardenOneCliBinds(composePath);
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe('layout_unrecognized');
+    expect(fs.readFileSync(composePath, 'utf-8')).toBe(mystery);
+  });
+
+  it('no-ops when the compose file does not exist', async () => {
+    const { hardenOneCliBinds } = await import('./onecli.js');
+    const missing = path.join(tempDir, 'nope.yml');
+
+    const result = hardenOneCliBinds(missing);
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe('compose_missing');
+    expect(fs.existsSync(missing)).toBe(false);
+  });
+});

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -21,9 +21,18 @@ import { emitStatus } from './status.js';
 
 const LOCAL_BIN = path.join(os.homedir(), '.local', 'bin');
 
-// Path where the upstream OneCLI installer writes the generated compose file.
-// Both the installer and `docker compose` commands operate on this path.
-const ONECLI_COMPOSE_PATH = path.join(os.homedir(), '.onecli', 'docker-compose.yml');
+// The OneCLI installer writes everything under ~/.onecli/. We touch three
+// files: the compose file (rewrite ports), config.json (admin URL the CLI
+// uses), and optionally .env (admin URL the runtime SDK reads — may not
+// exist on every install shape, so all writes to it are best-effort).
+const ONECLI_DIR = path.join(os.homedir(), '.onecli');
+const ONECLI_COMPOSE_PATH = path.join(ONECLI_DIR, 'docker-compose.yml');
+const ONECLI_ENV_PATH = path.join(ONECLI_DIR, '.env');
+const ONECLI_CONFIG_PATH = path.join(ONECLI_DIR, 'config.json');
+
+// The compose file sets `container_name: onecli` on the gateway service,
+// so this name is stable across compose recreations and version bumps.
+const ONECLI_CONTAINER = 'onecli';
 
 // Marker comment we write into the compose file so re-running setup detects
 // our prior rewrite and no-ops instead of re-patching (or worse, double-patching).
@@ -155,6 +164,21 @@ function removeLegacyOnecliContainers(): string {
   return out.join('\n');
 }
 
+type HardenPaths = {
+  composePath?: string;
+  envPath?: string;
+  configPath?: string;
+};
+
+type HardenResult = {
+  changed: boolean;
+  reason?: string;
+  // When hardening succeeds we may have rewritten the admin URL in the
+  // installer's config.json. Callers use this to keep NanoClaw's own ONECLI_URL
+  // in sync (the URL extracted from install stdout still has the old bind).
+  adminUrlRewritten?: boolean;
+};
+
 /**
  * Rewrite the OneCLI-generated docker-compose so the admin API (:10254) and
  * Postgres (:5432) bind to 127.0.0.1, while the proxy gateway (:10255) keeps
@@ -162,16 +186,25 @@ function removeLegacyOnecliContainers(): string {
  * the docker0 bridge IP, which makes the admin API and Postgres reachable
  * from every container on the host's default bridge — see onecli/onecli#268.
  *
+ * After the compose rewrite, also fix up:
+ *   - ~/.onecli/config.json:  api-host (the CLI's pointer to the admin API)
+ *   - ~/.onecli/.env:         ONECLI_URL (read by the runtime SDK)
+ * so the host can still reach the admin API at its new loopback bind. Both
+ * are best-effort — the security fix is the compose rewrite. `.env` may not
+ * exist depending on installer version, and that's fine.
+ *
  * The rewrite is a targeted regex on lines we recognize, with a marker comment
  * for idempotency. If the upstream compose shape changes in a way we don't
  * recognize, we warn and no-op rather than corrupt the file.
  *
- * `composePath` is an optional override for tests; production code uses the
- * module-level ONECLI_COMPOSE_PATH constant.
+ * `paths` is an optional override for tests; production code uses the
+ * module-level constants.
  */
-export function hardenOneCliBinds(
-  composePath: string = ONECLI_COMPOSE_PATH,
-): { changed: boolean; reason?: string } {
+export function hardenOneCliBinds(paths: HardenPaths = {}): HardenResult {
+  const composePath = paths.composePath ?? ONECLI_COMPOSE_PATH;
+  const envPath = paths.envPath ?? ONECLI_ENV_PATH;
+  const configPath = paths.configPath ?? ONECLI_CONFIG_PATH;
+
   if (!fs.existsSync(composePath)) {
     log.warn('OneCLI compose file not found — skipping bind hardening', { composePath });
     return { changed: false, reason: 'compose_missing' };
@@ -206,10 +239,120 @@ export function hardenOneCliBinds(
   // Prepend the marker so a re-run is a no-op. Keep it as the very first line
   // so `head -1` / quick visual inspection finds it.
   patched = `${NANOCLAW_HARDEN_MARKER}\n${patched}`;
-
   fs.writeFileSync(composePath, patched);
   log.info('Pinned OneCLI admin API and Postgres to 127.0.0.1', { composePath });
-  return { changed: true };
+
+  const configChanged = patchOnecliConfigJson(configPath);
+  const envChanged = patchOnecliEnvAdminUrl(envPath);
+
+  return { changed: true, adminUrlRewritten: configChanged || envChanged };
+}
+
+/**
+ * Swap the host portion of a URL with `127.0.0.1` *only* when the URL is the
+ * admin port (:10254) and the host isn't already loopback. Returns the URL
+ * unchanged otherwise — gateway URLs (:10255) must stay on the bridge IP so
+ * agent containers can keep reaching the proxy.
+ */
+export function swapHostInAdminUrl(url: string): string {
+  const m = url.match(/^(https?:\/\/)([^:/]+)(:10254\b.*)$/);
+  if (!m) return url;
+  if (m[2] === '127.0.0.1' || m[2] === 'localhost') return url;
+  return `${m[1]}127.0.0.1${m[3]}`;
+}
+
+function patchOnecliConfigJson(configPath: string): boolean {
+  if (!fs.existsSync(configPath)) return false;
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    const apiHost = obj['api-host'];
+    if (typeof apiHost !== 'string') return false;
+    const swapped = swapHostInAdminUrl(apiHost);
+    if (swapped === apiHost) return false;
+    obj['api-host'] = swapped;
+    fs.writeFileSync(configPath, JSON.stringify(obj, null, 2) + '\n');
+    log.info('Updated OneCLI config.json api-host to 127.0.0.1', { configPath });
+    return true;
+  } catch (err) {
+    log.warn('Could not update OneCLI config.json — leave it for manual fix', { configPath, err });
+    return false;
+  }
+}
+
+function patchOnecliEnvAdminUrl(envPath: string): boolean {
+  if (!fs.existsSync(envPath)) return false;
+  try {
+    const original = fs.readFileSync(envPath, 'utf-8');
+    // Only rewrite admin URL lines (port 10254). Leave gateway URLs (10255) alone.
+    const re = /^(\s*ONECLI_URL\s*=\s*)("?)(https?:\/\/)([^:/"]+)(:10254\b[^"\n]*)("?)\s*$/m;
+    const m = original.match(re);
+    if (!m) return false;
+    const host = m[4];
+    if (host === '127.0.0.1' || host === 'localhost') return false;
+    const patched = original.replace(re, '$1$2$3127.0.0.1$5$6');
+    if (patched === original) return false;
+    fs.writeFileSync(envPath, patched);
+    log.info('Updated ~/.onecli/.env ONECLI_URL to 127.0.0.1', { envPath });
+    return true;
+  } catch (err) {
+    log.warn('Could not update ~/.onecli/.env', { envPath, err });
+    return false;
+  }
+}
+
+type PortInspector = (container: string, port: string) => string | null;
+
+/**
+ * Read the actual host-side bind for a given container:port from
+ * `docker inspect`. Returns null if docker isn't reachable, the container
+ * isn't running, or that port isn't bound. This is the source of truth —
+ * .env and compose `${...}` defaults can disagree with reality.
+ */
+function inspectPortBind(container: string, port: string): string | null {
+  try {
+    const out = execSync(
+      `docker inspect ${JSON.stringify(container)} --format '{{json .NetworkSettings.Ports}}'`,
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+    ).trim();
+    const ports = JSON.parse(out) as Record<string, Array<{ HostIp?: string }> | null>;
+    const binding = ports[port]?.[0];
+    if (binding?.HostIp) return binding.HostIp;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function readEnvBindHost(envPath: string): string | null {
+  if (!fs.existsSync(envPath)) return null;
+  try {
+    const content = fs.readFileSync(envPath, 'utf-8');
+    const m = content.match(/^\s*ONECLI_BIND_HOST\s*=\s*(.+?)\s*$/m);
+    if (!m) return null;
+    const bind = m[1].replace(/^["']|["']$/g, '');
+    return bind || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Where should the gateway (:10255) bind to after we recreate the containers?
+ * Whatever the currently-running gateway is bound to. Fall back to the
+ * installer's .env, then to loopback. We need this because the compose file's
+ * `:10255` line is `${ONECLI_BIND_HOST:-127.0.0.1}` — if our subprocess env
+ * doesn't have ONECLI_BIND_HOST set, the default loopback wins and every
+ * agent container loses the proxy on next reconcile.
+ */
+function detectGatewayBindHost(opts: { envPath?: string; inspectFn?: PortInspector } = {}): string {
+  const inspect = opts.inspectFn ?? inspectPortBind;
+  const envPath = opts.envPath ?? ONECLI_ENV_PATH;
+  const fromInspect = inspect(ONECLI_CONTAINER, '10255/tcp');
+  if (fromInspect) return fromInspect;
+  const fromEnv = readEnvBindHost(envPath);
+  if (fromEnv) return fromEnv;
+  return '127.0.0.1';
 }
 
 /**
@@ -219,37 +362,47 @@ export function hardenOneCliBinds(
  * and leaves the rest alone. We don't fail the install if this errors —
  * the rewrite already landed and a `docker compose up -d` on next boot will
  * pick it up.
+ *
+ * We must pass `ONECLI_BIND_HOST` explicitly because the installer set it
+ * only in its own shell, and the compose file's `:10255` line falls back to
+ * `127.0.0.1` if it's not in the environment.
  */
 function applyHardenedCompose(composePath: string = ONECLI_COMPOSE_PATH): void {
+  const bindHost = detectGatewayBindHost();
   try {
     execSync(`docker compose -f ${JSON.stringify(composePath)} up -d`, {
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ONECLI_BIND_HOST: bindHost },
     });
   } catch (err) {
     log.warn('docker compose up -d after bind hardening failed (will apply on next boot)', { err });
   }
 }
 
+type DetectOptions = {
+  envPath?: string;
+  inspectFn?: PortInspector;
+};
+
 /**
  * --reuse mode helper: detect whether an existing OneCLI install has the
  * admin port bound to anything other than loopback, so we can warn without
- * rewriting someone else's file. We check the compose marker first (our own
- * patch), then the installer's .env for ONECLI_BIND_HOST. Returns the unsafe
- * bind value if detected, otherwise null.
+ * rewriting someone else's file. `docker inspect` is the source of truth;
+ * fall back to the installer's .env only if inspect fails (container not
+ * running, docker not on PATH, etc.). Returns the unsafe bind value if
+ * detected, otherwise null.
  */
-function detectUnsafeOneCliBinds(composePath: string = ONECLI_COMPOSE_PATH): string | null {
-  if (!fs.existsSync(composePath)) return null;
-  const composeContent = fs.readFileSync(composePath, 'utf-8');
-  if (composeContent.includes(NANOCLAW_HARDEN_MARKER)) return null;
-
-  const envPath = path.join(path.dirname(composePath), '.env');
-  if (!fs.existsSync(envPath)) return null;
-  const envContent = fs.readFileSync(envPath, 'utf-8');
-  const m = envContent.match(/^\s*ONECLI_BIND_HOST\s*=\s*(.+?)\s*$/m);
-  if (!m) return null;
-  const bind = m[1].replace(/^["']|["']$/g, '');
-  if (!bind || bind === '127.0.0.1' || bind === 'localhost') return null;
-  return bind;
+export function detectUnsafeOneCliBinds(opts: DetectOptions = {}): string | null {
+  const inspect = opts.inspectFn ?? inspectPortBind;
+  const envPath = opts.envPath ?? ONECLI_ENV_PATH;
+  const adminBind = inspect(ONECLI_CONTAINER, '10254/tcp');
+  if (adminBind) {
+    if (adminBind === '127.0.0.1' || adminBind === 'localhost') return null;
+    return adminBind;
+  }
+  const envBind = readEnvBindHost(envPath);
+  if (envBind && envBind !== '127.0.0.1' && envBind !== 'localhost') return envBind;
+  return null;
 }
 
 function installOnecli(): { stdout: string; ok: boolean } {
@@ -488,7 +641,8 @@ export async function run(args: string[]): Promise<void> {
         'Existing OneCLI binds admin API and Postgres on a non-loopback address. ' +
           'Containers on that network can reach the admin API and Postgres directly. ' +
           'See onecli/onecli#268. To remediate: stop the gateway, re-run setup without --reuse, ' +
-          'or manually pin :10254 and :5432 to 127.0.0.1 in ~/.onecli/docker-compose.yml.',
+          'or manually pin :10254 and :5432 to 127.0.0.1 in ~/.onecli/docker-compose.yml, ' +
+          'and update the admin URL in ~/.onecli/config.json (and ~/.onecli/.env if present).',
         { bind: unsafeBind },
       );
     }
@@ -535,7 +689,12 @@ export async function run(args: string[]): Promise<void> {
   const harden = hardenOneCliBinds();
   if (harden.changed) applyHardenedCompose();
 
-  const url = extractUrlFromOutput(res.stdout);
+  // The URL the installer printed still has the bridge IP. If we just hardened
+  // the admin port to loopback, that URL is now dead from the host's POV —
+  // swap the host portion to 127.0.0.1 so `api-host` and NanoClaw's own
+  // ONECLI_URL match the new bind. Gateway URLs (:10255) are left alone.
+  const extracted = extractUrlFromOutput(res.stdout);
+  const url = harden.changed && extracted ? swapHostInAdminUrl(extracted) : extracted;
   if (!url) {
     emitStatus('ONECLI', {
       INSTALLED: true,
@@ -567,7 +726,9 @@ export async function run(args: string[]): Promise<void> {
     HEALTHY: healthy,
     HARDENED: harden.changed,
     HARDEN_NOTE: harden.changed
-      ? 'admin_api_and_postgres_pinned_to_loopback'
+      ? harden.adminUrlRewritten
+        ? 'admin_api_and_postgres_pinned_to_loopback_and_admin_url_rewritten'
+        : 'admin_api_and_postgres_pinned_to_loopback'
       : harden.reason ?? 'no_change',
     // Install succeeded regardless — a failed health poll often just means
     // the endpoint is auth-gated or the gateway hasn't finished warming up.

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -21,6 +21,15 @@ import { emitStatus } from './status.js';
 
 const LOCAL_BIN = path.join(os.homedir(), '.local', 'bin');
 
+// Path where the upstream OneCLI installer writes the generated compose file.
+// Both the installer and `docker compose` commands operate on this path.
+const ONECLI_COMPOSE_PATH = path.join(os.homedir(), '.onecli', 'docker-compose.yml');
+
+// Marker comment we write into the compose file so re-running setup detects
+// our prior rewrite and no-ops instead of re-patching (or worse, double-patching).
+// References the upstream issue so anyone reading the file can find context.
+const NANOCLAW_HARDEN_MARKER = '# nanoclaw: admin+postgres pinned to loopback (onecli/onecli#268)';
+
 function childEnv(): NodeJS.ProcessEnv {
   const parts = [LOCAL_BIN];
   if (process.env.PATH) parts.push(process.env.PATH);
@@ -144,6 +153,103 @@ function removeLegacyOnecliContainers(): string {
     }
   }
   return out.join('\n');
+}
+
+/**
+ * Rewrite the OneCLI-generated docker-compose so the admin API (:10254) and
+ * Postgres (:5432) bind to 127.0.0.1, while the proxy gateway (:10255) keeps
+ * whatever the installer chose. On bare-metal Linux the installer auto-picks
+ * the docker0 bridge IP, which makes the admin API and Postgres reachable
+ * from every container on the host's default bridge — see onecli/onecli#268.
+ *
+ * The rewrite is a targeted regex on lines we recognize, with a marker comment
+ * for idempotency. If the upstream compose shape changes in a way we don't
+ * recognize, we warn and no-op rather than corrupt the file.
+ *
+ * `composePath` is an optional override for tests; production code uses the
+ * module-level ONECLI_COMPOSE_PATH constant.
+ */
+export function hardenOneCliBinds(
+  composePath: string = ONECLI_COMPOSE_PATH,
+): { changed: boolean; reason?: string } {
+  if (!fs.existsSync(composePath)) {
+    log.warn('OneCLI compose file not found — skipping bind hardening', { composePath });
+    return { changed: false, reason: 'compose_missing' };
+  }
+
+  const original = fs.readFileSync(composePath, 'utf-8');
+  if (original.includes(NANOCLAW_HARDEN_MARKER)) {
+    return { changed: false, reason: 'already_patched' };
+  }
+
+  // Match the three port lines we expect from upstream's compose. The bind
+  // host is captured in group 1 so we can decide what to swap. We only rewrite
+  // admin (:10254) and postgres (:5432); the gateway (:10255) is left alone
+  // because the bridge IP is the *correct* bind there.
+  const adminRe = /^(\s*-\s*)"\$\{ONECLI_BIND_HOST:-127\.0\.0\.1\}:\$\{ONECLI_APP_PORT:-10254\}:10254"\s*$/m;
+  const pgRe = /^(\s*-\s*)"\$\{ONECLI_BIND_HOST:-127\.0\.0\.1\}:\$\{POSTGRES_PORT:-5432\}:5432"\s*$/m;
+
+  if (!adminRe.test(original) || !pgRe.test(original)) {
+    log.warn('OneCLI compose layout not recognized — leaving file untouched', { composePath });
+    return { changed: false, reason: 'layout_unrecognized' };
+  }
+
+  let patched = original.replace(
+    adminRe,
+    `$1"127.0.0.1:\${ONECLI_APP_PORT:-10254}:10254"`,
+  );
+  patched = patched.replace(
+    pgRe,
+    `$1"127.0.0.1:\${POSTGRES_PORT:-5432}:5432"`,
+  );
+
+  // Prepend the marker so a re-run is a no-op. Keep it as the very first line
+  // so `head -1` / quick visual inspection finds it.
+  patched = `${NANOCLAW_HARDEN_MARKER}\n${patched}`;
+
+  fs.writeFileSync(composePath, patched);
+  log.info('Pinned OneCLI admin API and Postgres to 127.0.0.1', { composePath });
+  return { changed: true };
+}
+
+/**
+ * After rewriting the compose file, ask docker to reconcile the running
+ * containers with the new port mappings. `up -d` is the right verb here:
+ * it stops and recreates only the services whose effective config changed,
+ * and leaves the rest alone. We don't fail the install if this errors —
+ * the rewrite already landed and a `docker compose up -d` on next boot will
+ * pick it up.
+ */
+function applyHardenedCompose(composePath: string = ONECLI_COMPOSE_PATH): void {
+  try {
+    execSync(`docker compose -f ${JSON.stringify(composePath)} up -d`, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    log.warn('docker compose up -d after bind hardening failed (will apply on next boot)', { err });
+  }
+}
+
+/**
+ * --reuse mode helper: detect whether an existing OneCLI install has the
+ * admin port bound to anything other than loopback, so we can warn without
+ * rewriting someone else's file. We check the compose marker first (our own
+ * patch), then the installer's .env for ONECLI_BIND_HOST. Returns the unsafe
+ * bind value if detected, otherwise null.
+ */
+function detectUnsafeOneCliBinds(composePath: string = ONECLI_COMPOSE_PATH): string | null {
+  if (!fs.existsSync(composePath)) return null;
+  const composeContent = fs.readFileSync(composePath, 'utf-8');
+  if (composeContent.includes(NANOCLAW_HARDEN_MARKER)) return null;
+
+  const envPath = path.join(path.dirname(composePath), '.env');
+  if (!fs.existsSync(envPath)) return null;
+  const envContent = fs.readFileSync(envPath, 'utf-8');
+  const m = envContent.match(/^\s*ONECLI_BIND_HOST\s*=\s*(.+?)\s*$/m);
+  if (!m) return null;
+  const bind = m[1].replace(/^["']|["']$/g, '');
+  if (!bind || bind === '127.0.0.1' || bind === 'localhost') return null;
+  return bind;
 }
 
 function installOnecli(): { stdout: string; ok: boolean } {
@@ -376,12 +482,23 @@ export async function run(args: string[]): Promise<void> {
     }
     writeEnvOnecliUrl(url);
     log.info('Reusing existing OneCLI', { url });
+    const unsafeBind = detectUnsafeOneCliBinds();
+    if (unsafeBind) {
+      log.warn(
+        'Existing OneCLI binds admin API and Postgres on a non-loopback address. ' +
+          'Containers on that network can reach the admin API and Postgres directly. ' +
+          'See onecli/onecli#268. To remediate: stop the gateway, re-run setup without --reuse, ' +
+          'or manually pin :10254 and :5432 to 127.0.0.1 in ~/.onecli/docker-compose.yml.',
+        { bind: unsafeBind },
+      );
+    }
     const healthy = await pollHealth(url, 5000);
     emitStatus('ONECLI', {
       INSTALLED: true,
       REUSED: true,
       ONECLI_URL: url,
       HEALTHY: healthy,
+      ...(unsafeBind ? { UNSAFE_BIND: unsafeBind, HARDEN_NOTE: 'admin_api_and_postgres_exposed_on_bridge' } : {}),
       STATUS: 'success',
       LOG: 'logs/setup.log',
     });
@@ -409,6 +526,14 @@ export async function run(args: string[]): Promise<void> {
     });
     process.exit(1);
   }
+
+  // Pin admin API (:10254) and Postgres (:5432) to 127.0.0.1 before we hand
+  // back to the rest of setup. The upstream installer picks the docker0
+  // bridge IP as ONECLI_BIND_HOST on bare-metal Linux, which makes both
+  // services reachable from any container on the host's default bridge.
+  // See onecli/onecli#268.
+  const harden = hardenOneCliBinds();
+  if (harden.changed) applyHardenedCompose();
 
   const url = extractUrlFromOutput(res.stdout);
   if (!url) {
@@ -440,6 +565,10 @@ export async function run(args: string[]): Promise<void> {
     INSTALLED: true,
     ONECLI_URL: url,
     HEALTHY: healthy,
+    HARDENED: harden.changed,
+    HARDEN_NOTE: harden.changed
+      ? 'admin_api_and_postgres_pinned_to_loopback'
+      : harden.reason ?? 'no_change',
     // Install succeeded regardless — a failed health poll often just means
     // the endpoint is auth-gated or the gateway hasn't finished warming up.
     // The next step (auth) will surface a genuinely broken gateway via


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2433. References [onecli/onecli#268](https://github.com/onecli/onecli/issues/268) and [onecli/onecli#263](https://github.com/onecli/onecli/issues/263).

OneCLI's installer auto-picks the `docker0` bridge IP as `ONECLI_BIND_HOST` on bare-metal Linux, and its `docker-compose.yml` uses that single variable for all three published ports — the proxy gateway (`:10255`), the admin API (`:10254`), and Postgres (`:5432`). The proxy needs to be on the bridge so agent containers can reach it; the admin API and Postgres do not. The net effect is that on a default NanoClaw install on a Linux host, every agent container can read every agent access token via unauthenticated HTTP at `http://<bridge-ip>:10254/api/agents`, and can also connect to Postgres directly with the documented default credentials.

This PR adds a small post-install step in `setup/onecli.ts` that rewrites the generated compose file to pin `:10254` and `:5432` to `127.0.0.1`, leaving `:10255` on whatever bind the installer chose. The proxy stays reachable from agent containers; the admin API and Postgres become loopback-only.

Filed upstream as [onecli/onecli#268](https://github.com/onecli/onecli/issues/268) with proposed fixes for the installer + compose template. This downstream patch protects NanoClaw users in the meantime, and remains a useful defense-in-depth step even after upstream lands their fix.

### What the patch does

- New `hardenOneCliBinds()` does a targeted regex rewrite of the upstream compose, replacing the `${ONECLI_BIND_HOST:-127.0.0.1}` prefix with a literal `127.0.0.1` on just the admin and Postgres port lines.
- Writes a marker comment (`# nanoclaw: admin+postgres pinned to loopback (onecli/onecli#268)`) at the top of the file so a re-run is a no-op and the source of the change is discoverable.
- If the upstream compose layout changes in a way we don't recognize, the function warns and leaves the file untouched — fail-loud-but-safe rather than corrupt the file.
- Calls `docker compose up -d` to reconcile running containers. Failure here is non-fatal; the rewrite has already landed and a subsequent compose-up will pick it up.
- `--reuse` mode does not rewrite (other apps may depend on the existing bind), but it does read `~/.onecli/.env`, detect a non-loopback `ONECLI_BIND_HOST`, and emit a warning + `UNSAFE_BIND` in the status block so operators see the exposure.
- `emitStatus('ONECLI', ...)` gains `HARDENED` + `HARDEN_NOTE` keys for observability.

### Tests

`setup/onecli.test.ts` adds four unit tests that operate on a tempdir copy of the upstream compose shape — no docker calls, no real OneCLI install:

- vanilla upstream compose → admin + postgres rewritten to `127.0.0.1`, gateway left untouched, marker prepended
- already-patched compose → no-op (`reason: already_patched`)
- unrecognized layout → no-op + warn (`reason: layout_unrecognized`), file untouched
- missing file → no-op + warn (`reason: compose_missing`)

All 327 tests pass locally; typecheck clean.

### Why a regex instead of a YAML parser

The upstream compose is small, hand-written, and the lines we care about are exact-match strings. A regex against those exact strings catches drift loudly (we warn and no-op), where a YAML parser would happily round-trip a renamed key and silently do nothing. The marker comment is the durable signal anyone reading the file can find.

### Scope

This patch is intentionally narrow. It does not change the OneCLI auth surface (that's upstream #263), and it does not touch the `--remote-url` path (those installs don't run a local gateway).

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
