### PR TITLE
fix(webhook): make webhook server port configurable via WEBHOOK_PORT

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,14 @@ import { getContainerImageBase, getDefaultContainerImage, getInstallSlug } from 
 import { isValidTimezone } from './timezone.js';
 
 // Read config values from .env (falls back to process.env).
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER', 'ONECLI_URL', 'ONECLI_API_KEY', 'TZ']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'ONECLI_URL',
+  'ONECLI_API_KEY',
+  'TZ',
+  'WEBHOOK_PORT',
+]);
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
 export const ASSISTANT_HAS_OWN_NUMBER =
@@ -35,6 +42,7 @@ export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '1800
 export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+export const WEBHOOK_PORT = parseInt(process.env.WEBHOOK_PORT || envConfig.WEBHOOK_PORT || '3000', 10);
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(1, parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5);

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -11,9 +11,8 @@ import http from 'http';
 
 import type { Chat } from 'chat';
 
+import { WEBHOOK_PORT } from './config.js';
 import { log } from './log.js';
-
-const DEFAULT_PORT = 3000;
 
 interface WebhookEntry {
   chat: Chat;
@@ -79,8 +78,6 @@ export function registerWebhookAdapter(chat: Chat, adapterName: string): void {
 function ensureServer(): void {
   if (server) return;
 
-  const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
-
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';
 
@@ -118,8 +115,8 @@ function ensureServer(): void {
     }
   });
 
-  server.listen(port, '0.0.0.0', () => {
-    log.info('Webhook server started', { port, adapters: [...routes.keys()] });
+  server.listen(WEBHOOK_PORT, '0.0.0.0', () => {
+    log.info('Webhook server started', { port: WEBHOOK_PORT, adapters: [...routes.keys()] });
   });
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The webhook server was hardcoded to bind on port 3000 with no way to override it from `.env`. On installations where another service already uses port 3000, this caused a fatal `EADDRINUSE` crash on every startup, triggering the circuit breaker and leaving the `ncl` CLI socket stale (ECONNREFUSED).

**Changes:**
- `src/config.ts`: add `WEBHOOK_PORT` to the `readEnvFile` key list and export it as `WEBHOOK_PORT` constant (respects `process.env.WEBHOOK_PORT` → `.env` → default `3000`)
- `src/webhook-server.ts`: replace the inline `process.env.WEBHOOK_PORT` read and `DEFAULT_PORT` constant with the imported `WEBHOOK_PORT` from config

**Usage:** set `WEBHOOK_PORT=3001` (or any free port) in `.env` to move the webhook server off port 3000.