### PR TITLE
fix(chat-sdk-bridge): fetch attachment URL when adapter lacks fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -155,6 +155,23 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           } catch (err) {
             log.warn('Failed to download attachment', { type: att.type, err });
           }
+        } else if (att.url) {
+          // Some adapters expose only `url`, no fetchData. redirect:'error'
+          // is required — host can reach localhost services like OneCLI :10254.
+          const MAX_BYTES = 50 * 1024 * 1024;
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), 30_000);
+          try {
+            const response = await fetch(att.url, { redirect: 'error', signal: controller.signal });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const declared = Number(response.headers.get('content-length') ?? '0');
+            if (declared > MAX_BYTES) throw new Error(`attachment too large: ${declared} bytes`);
+            entry.data = Buffer.from(await response.arrayBuffer()).toString('base64');
+          } catch (err) {
+            log.warn('Failed to download attachment from URL', { type: att.type, url: att.url, err });
+          } finally {
+            clearTimeout(timer);
+          }
         }
         enriched.push(entry);
       }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** Discord attachments are dropped silently — add a URL-fetch fallback when the chat-sdk adapter doesn't expose `fetchData`.

**Why.** The bridge gates attachment download on `att.fetchData` (`chat-sdk-bridge.ts:151`). `@chat-adapter/discord` sets only `url` on every published version 4.3.0–4.28.1. Result: no base64 `data`, `extractAttachmentFiles` skips the row, no inbox folder, the agent sees `[file: name.ext]` with no path. Slack/Telegram/Teams/gchat/Webex all set `fetchData`, so this is Discord-only. It's the gap behind deleting `add-image-vision` in `53c11a2`.

**How.** Fall back to `fetch(att.url)` with `redirect: 'error'` (SSRF guard — host runs OneCLI vault on `:10254`), a 30s `AbortController` timeout (Node `fetch` has none by default), and a 50 MB `content-length` cap. Discord CDN URLs are signed and expire ~24h after issue, so fetch-on-receive is correct by design — bytes are persisted before the URL goes stale.

**Tested.** Build clean, 323/323 tests, verified end-to-end on Discord (file DM → inbox path written → agent reads it). Slack/etc. unaffected — new code is `else if`, only fires when `fetchData` is absent.