### PR TITLE
fix(poll-loop) + feat(agent): session routing fix and pre-compaction notification

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -4,6 +4,7 @@ import { writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { clearContinuation, migrateLegacyContinuation, setContinuation } from './db/session-state.js';
 import { clearCurrentInReplyTo, setCurrentInReplyTo } from './current-batch.js';
+import { getSessionRouting } from './db/session-routing.js';
 import {
   formatMessages,
   extractRouting,
@@ -101,6 +102,17 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     markProcessing(ids);
 
     const routing = extractRouting(messages);
+    // session_routing is the authoritative reply channel set by the host on
+    // every container wake. Override the channel from extractRouting (which
+    // reads messages[0]) because agent-type inbound messages — e.g. approval
+    // notifications — can appear first in the batch and would otherwise
+    // misdirect plain-text replies to the agent channel instead of the user.
+    const sessionRouting = getSessionRouting();
+    if (sessionRouting.channel_type && sessionRouting.platform_id) {
+      routing.channelType = sessionRouting.channel_type;
+      routing.platformId = sessionRouting.platform_id;
+      routing.threadId = sessionRouting.thread_id;
+    }
 
     // Command handling: the host router gates filtered and unauthorized
     // admin commands before they reach the container. The only command

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { writeMessageOut } from '../db/messages-out.js';
+import { getSessionRouting } from '../db/session-routing.js';
 import { registerProvider } from './provider-registry.js';
 import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
@@ -192,6 +194,23 @@ function createPreCompactHook(assistantName?: string): HookCallback {
   return async (input) => {
     const preCompact = input as PreCompactHookInput;
     const { transcript_path: transcriptPath, session_id: sessionId } = preCompact;
+
+    // Notify the active channel before compaction so users know a delay is coming.
+    try {
+      const routing = getSessionRouting();
+      if (routing.channel_type && routing.platform_id) {
+        writeMessageOut({
+          id: `compact-notify-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+          kind: 'chat',
+          platform_id: routing.platform_id,
+          channel_type: routing.channel_type,
+          thread_id: routing.thread_id,
+          content: JSON.stringify({ text: 'Compacting context — brief processing delay expected.' }),
+        });
+      }
+    } catch (err) {
+      log(`PreCompact: failed to send notification: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
     if (!transcriptPath || !fs.existsSync(transcriptPath)) {
       log('No transcript found for archiving');


### PR DESCRIPTION
## Changes

### fix(poll-loop): use session_routing as authoritative reply channel (55ef489)

When the container restarts with pending inbound messages, the first message in the batch may be an agent-type approval notification rather than a user message. Previously, poll-loop.ts used this first message to determine the reply channel — causing all subsequent responses to be routed back to the agent channel instead of the user's Telegram.

This fix reads `session_routing` from the inbound DB and uses it as the authoritative reply channel, overriding any routing inferred from the first inbound message. Agent-type notifications can no longer poison routing.

**Practical impact:** Fixes a bug where MCP installations (which trigger a container restart) would cause the agent to stop responding to the user until the next session.

### feat(agent): pre-compaction notification to active channel (4ca4b01)

Context compaction produces a multi-second processing gap with no user-facing indication. This adds a pre-compaction hook in `container/agent-runner/src/providers/claude.ts` that:

1. Reads `session_routing` to identify the active channel (depends on the routing fix above)
2. Writes an outbound message before compaction begins: *"Compacting context — brief processing delay expected."*
3. After compaction, the existing compact_boundary event delivers: *"Context compacted (N tokens compacted)."*

Users are no longer left wondering why the agent has gone silent mid-session.

## Testing

Both fixes have been running in production on a live NanoClaw installation since 11 May 2026 without issues.

## Notes

- The second commit depends on the first. Both must be included together.
- These are the only two commits in this PR. Other local modifications are specific to this installation and are not included.