### PR TITLE
fix(core-instructions): require message wrapping for single-destination agents

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -1,6 +1,6 @@
 ## Sending messages
 
-Your final response is delivered via the `## Sending messages` rules in your runtime system prompt (single-destination: just write; multi-destination: use `<message to="name">...</message>` blocks). See that section for the current destination list.
+**Every response** must be wrapped in `<message to="name">...</message>` blocks — even if you only have one destination. Bare text outside of `<message>` blocks is scratchpad (logged but never sent). See the `## Sending messages` section in your runtime system prompt for the current destination list and names.
 
 ### Mid-turn updates (`send_message`)
 


### PR DESCRIPTION
## Summary

- The parenthetical "(single-destination: just write)" in `core.instructions.md` was stale after 9db39b2 removed the bare-text routing fallback
- Agents following this hint had their responses silently dropped to scratchpad instead of being delivered
- Now requires `<message to="name">...</message>` wrapping for all responses, regardless of destination count

## Test plan

- [ ] Verify single-destination agent responses are delivered (not dropped to scratchpad)
- [ ] Verify multi-destination agents continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)