### PR TITLE
feat(serper): add Serper MCP env passthrough and /serper-search skill

### DIFF
--- a/.claude/skills/serper-search/SKILL.md
+++ b/.claude/skills/serper-search/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: serper-search
+description: Use the Serper MCP for raw Google SERP queries — organic results, "people also ask", related searches, knowledge graph, SERP-feature checks, competitor positioning, keyword discovery. Tools live behind `mcp__serper__*` (`google_search`, `scrape`). Triggers on "serper", "google serp", "people also ask", "related searches", "serp features", "keyword research", "what does google show for", "competitor positioning", "scrape this url".
+---
+
+# Serper Search
+
+The `serper` MCP exposes two Google-backed tools via Serper.dev:
+
+- `mcp__serper__google_search` — fetch the raw Google SERP for a query. Returns organic results, ads, "people also ask", related searches, and the knowledge graph when present. Use when the *shape* of the SERP matters, not just a factual answer.
+- `mcp__serper__scrape` — fetch a URL and return its content as markdown. Comparable to `WebFetch` but driven by Serper's scraper.
+
+## When to pick Serper vs the other tools
+
+| Question | Tool |
+|---|---|
+| "Who is X?" / "What is Y?" / single-fact lookup | `mcp__parallel-search__*` |
+| "Research X in depth — give me a citation-backed report" | `mcp__parallel-task__*` (always ask first, use scheduler pattern) |
+| "What does Google rank for `<keyword>`?" / "Show me the SERP" | `mcp__serper__google_search` |
+| "What are the related searches / PAA questions for `<topic>`?" | `mcp__serper__google_search` |
+| "Is competitor X ranking for keyword Y? Top 10 list?" | `mcp__serper__google_search` |
+| "Pull the markdown of this article" | `mcp__serper__scrape` (or `WebFetch` for simpler pages) |
+| Privacy-leaning ad-hoc general web search | Brave Search (`api.search.brave.com` via OneCLI) |
+| Need to interact with a page (click, login, JS render) | `agent-browser` |
+
+The mental model:
+
+- **Parallel** is for *answers*. It synthesizes across sources and hands back a written response.
+- **Serper** is for the *Google page itself*. The output is structured SERP data — same as opening google.com would give you.
+- **Brave** is a privacy-friendly general web search alternative — useful for cross-checking Google or when Google is geo-skewed for the question.
+
+If you're writing copy, picking keywords, or auditing how a brand appears to a searcher, you want Serper. If you want to know an answer, you want Parallel.
+
+## Example invocations
+
+1. **SEO research — what ranks today?**
+   > "Use Serper to search for `self storage software` and list the top 10 organic results plus the related searches."
+
+2. **PAA mining for content briefs.**
+   > "Pull the `people also ask` and related searches for `revops consultant` via Serper — I'm planning a landing page and want the question framing customers actually use."
+
+3. **Competitor positioning.**
+   > "Serper: search `meadowfi vs competitors` and `meadow finance review`. Tell me which competitors show up in the SERP and snippets."
+
+4. **Knowledge-graph check.**
+   > "Use Serper to search for `Cubby Storage`. Does Google have a knowledge graph entry yet? What does it pull in?"
+
+5. **Quick page scrape.**
+   > "Scrape https://www.firstcubby.com/about with Serper and summarize their positioning in 3 bullets."
+
+## Implementation notes
+
+- Auth path: stdio MCP via `serper-search-scrape-mcp-server` (npm, marcopesani's TypeScript implementation). Reads `SERPER_API_KEY` from container env. The host forwards the value from `.env` (host-side passthrough — see `collectMcpEnvPassthrough` in `src/container-runner.ts`) and the agent-runner expands the `${SERPER_API_KEY}` placeholder before spawning the MCP child (`expandMcpEnv` in `container/agent-runner/src/index.ts`).
+- Why stdio: Serper does not host an MCP-protocol endpoint, so the OneCLI proxy injection path (used for Parallel) is not available. The vault `SERPER` secret is configured for the canonical `X-API-KEY` header (no Bearer prefix) so it stays correct if/when an HTTP MCP becomes available.
+
+### Wiring it into a group
+
+Set `SERPER_API_KEY=...` in your host `.env`, then add the MCP to the agent group's container config:
+
+```bash
+ncl groups config add-mcp-server --id <agent-group-id> \
+  --name serper \
+  --command npx \
+  --args '["-y","serper-search-scrape-mcp-server@0.1.2"]' \
+  --env '{"SERPER_API_KEY":"${SERPER_API_KEY}"}'
+```
+
+Then restart the agent group: `ncl groups restart --id <agent-group-id>`.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -39,6 +39,21 @@ function log(msg: string): void {
 
 const CWD = '/workspace/agent';
 
+/**
+ * Expand `${VAR}` / `$VAR` placeholders in a stdio MCP's `env` block against
+ * the container's `process.env`. Used for stdio MCPs that read their API key
+ * directly (e.g. SERPER_API_KEY) — the host forwards the value via `-e` and
+ * we wire it into the SDK-spawned MCP child here.
+ */
+function expandMcpEnv(env: Record<string, string>): Record<string, string> {
+  const placeholderRe = /\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/g;
+  const expanded: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(env)) {
+    expanded[key] = raw.replace(placeholderRe, (_, braced, bare) => process.env[braced || bare] ?? '');
+  }
+  return expanded;
+}
+
 async function main(): Promise<void> {
   const config = loadConfig();
   const providerName = config.provider.toLowerCase() as ProviderName;
@@ -82,7 +97,7 @@ async function main(): Promise<void> {
   };
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
-    mcpServers[name] = serverConfig;
+    mcpServers[name] = { ...serverConfig, env: expandMcpEnv(serverConfig.env ?? {}) };
     log(`Additional MCP server: ${name} (${serverConfig.command})`);
   }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -11,6 +11,7 @@ import { OneCLI } from '@onecli-sh/sdk';
 
 import { CONTAINER_IMAGE, DATA_DIR, GROUPS_DIR, ONECLI_API_KEY, ONECLI_URL, TIMEZONE } from './config.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
+import { readEnvFile } from './env.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -372,6 +373,36 @@ function ensureRuntimeFields(
   }
 }
 
+/**
+ * Scan a container.json for `${VAR}` / `$VAR` placeholders inside stdio MCP
+ * `env` blocks, then read those variables from the host `.env` and return
+ * the values to forward to the container. The agent-runner inside the
+ * container substitutes the placeholders before spawning the MCP process.
+ *
+ * Escape hatch for stdio MCPs that read their API key directly (e.g.
+ * `SERPER_API_KEY` for the Serper MCP). HTTP MCPs should rely on the
+ * OneCLI proxy injection path instead.
+ */
+function collectMcpEnvPassthrough(
+  containerConfig: import('./container-config.js').ContainerConfig,
+): Record<string, string> {
+  const placeholderRe = /\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/g;
+  const wanted = new Set<string>();
+  for (const server of Object.values(containerConfig.mcpServers ?? {})) {
+    if (!server.env) continue;
+    for (const value of Object.values(server.env)) {
+      for (const m of value.matchAll(placeholderRe)) wanted.add(m[1] || m[2]);
+    }
+  }
+  if (wanted.size === 0) return {};
+  const values = readEnvFile([...wanted]);
+  const missing = [...wanted].filter((k) => !values[k]);
+  if (missing.length > 0) {
+    log.warn('MCP env passthrough: missing keys in .env', { missing, groupName: containerConfig.groupName });
+  }
+  return values;
+}
+
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
@@ -392,6 +423,16 @@ async function buildContainerArgs(
     for (const [key, value] of Object.entries(providerContribution.env)) {
       args.push('-e', `${key}=${value}`);
     }
+  }
+
+  // MCP env passthrough: stdio MCPs that bake their API key into outgoing
+  // requests can't use the OneCLI proxy injection path — they read a key
+  // from process.env at startup. Scan container.json mcpServers for any
+  // `${VAR}` placeholders, read those vars from .env, and forward them.
+  // The agent-runner inside the container does the actual substitution
+  // before spawning the MCP child — see container/agent-runner/src/index.ts.
+  for (const [key, value] of Object.entries(collectMcpEnvPassthrough(containerConfig))) {
+    args.push('-e', `${key}=${value}`);
   }
 
   // OneCLI gateway — injects HTTPS_PROXY + certs so container API calls


### PR DESCRIPTION
## Summary
- Adds Serper.dev integration via the community stdio MCP `serper-search-scrape-mcp-server`.
- New `/serper-search` skill (`.claude/skills/serper-search/SKILL.md`) with picking guidance vs. Parallel / Brave and example invocations.
- Adds `collectMcpEnvPassthrough` to `src/container-runner.ts` + `expandMcpEnv` to `container/agent-runner/src/index.ts` — generic infrastructure for stdio MCPs that read their API key from `process.env` (HTTP MCPs continue to use the OneCLI proxy injection path).

## Why
Serper does not host an MCP-protocol endpoint, so the only practical wiring is the community stdio server, which reads `SERPER_API_KEY` directly. The env-passthrough infra is generalized so future stdio MCPs (Firecrawl, etc.) can reuse it.

## Test plan
- [ ] Add `SERPER_API_KEY` to `.env`.
- [ ] Wire the MCP into the relevant group(s) — DB-backed via `ncl groups config add-mcp-server --name serper --command npx --args '["-y","serper-search-scrape-mcp-server@0.1.2"]' --env '{"SERPER_API_KEY":"${SERPER_API_KEY}"}'`.
- [ ] Restart NanoClaw, DM Zed: "Use Serper to search for 'claude code mcp serper' and list the top 3 results." Confirm `mcp__serper__*` tool calls.
