### PR TITLE
feat(container): add lighthouse CLI for site audits

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -22,6 +22,7 @@ ARG INSTALL_CJK_FONTS=false
 ARG CLAUDE_CODE_VERSION=2.1.116
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=latest
+ARG LIGHTHOUSE_VERSION=13.3.0
 ARG BUN_VERSION=1.3.12
 
 # ---- System dependencies -----------------------------------------------------
@@ -100,6 +101,9 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "agent-browser@${AGENT_BROWSER_VERSION}"
+
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "lighthouse@${LIGHTHOUSE_VERSION}"
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"


### PR DESCRIPTION
## Summary
- Pins Lighthouse 13.3.0 in `container/Dockerfile` via `pnpm install -g lighthouse@${LIGHTHOUSE_VERSION}`.
- Reuses the existing Chromium installed for agent-browser — no new apt packages.

## Build smoke tests
- `./container/build.sh` succeeds in ~47s.
- `docker run --rm --entrypoint lighthouse nanoclaw-agent:latest --version` → `13.3.0`.
- `docker run --rm --entrypoint lighthouse nanoclaw-agent:latest https://example.com --output=json --quiet --chrome-flags="--headless --no-sandbox"` produces complete JSON audit.

## Why
Local perf / SEO / a11y / best-practices audits with no external API cost. Underpins the upcoming audit-website composite-stack rewrite (replacing squirrel).
