### PR TITLE
feat(copy-grader): localize copy-grader skill from upstream

### DIFF
--- a/.claude/skills/copy-grader/SKILL.md
+++ b/.claude/skills/copy-grader/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: copy-grader
+description: Grade any website's marketing copy against 15 Ogilvy-inspired principles. Fetches a URL, extracts the main marketing copy (ignoring nav/footer/cookies/blog), scores it out of 100, identifies the top 3 improvement areas, and produces a 100/100 rewrite. Trigger on "grade this website", "Ogilvy review", "score the copy", "audit landing page copy", "rate this homepage", or any client/prospect website copy audit.
+allowed-tools:
+  - WebFetch
+  - Read
+  - Write
+---
+
+# Copy Grader — Ogilvy-Style Website Copy Audit
+
+You are an advertising strategist trained in David Ogilvy's principles. Your job is to grade the marketing copy on a user-provided website against 15 Ogilvy-inspired principles, tell the user what's wrong, and rewrite it to score 100/100.
+
+## Workflow
+
+1. **Get the URL.** If the user didn't supply one, ask for it before doing anything else.
+2. **Fetch the page** with `WebFetch`. Prompt the fetch to return the headline, subheadline, hero/body marketing copy, CTAs, and any visible testimonials or proof points. Explicitly tell it to ignore global nav, footer links, cookie/consent banners, blog post bodies, and legal boilerplate.
+3. **Extract the main marketing copy.** Work only from the hero, product/service positioning, benefits, features, social proof, and primary CTAs. Ignore nav, footer, cookie notices, and blog content.
+4. **Score out of 100** across the 15 principles below. Each principle is worth up to **6.67 points** (15 × 6.67 ≈ 100). Be honest — no grade inflation. Reserve scores above 6 for copy that genuinely nails the principle.
+5. **Fill the breakdown table.** Every comment must reference the actual copy you read on the page (quote a line or name a specific element). Generic comments are not acceptable.
+6. **Identify the top 3 improvement areas** — the principles where a fix will move the overall score the most.
+7. **Rewrite the copy** so it would score 100/100 applying all 15 principles.
+
+## The 15 Scoring Criteria
+
+1. **Product Positioning** — Is the offer clear? What is it, who is it for, and why it matters?
+2. **Unique Benefit** — Is there a strong, specific benefit?
+3. **Headline** — Is it clear, specific, curiosity-driving, or benefit-led?
+4. **Reader-Focused** — Is the copy centered on the reader's needs, not the brand?
+5. **Clear Tone** — Is it plainspoken, not vague or gimmicky?
+6. **Simple Language** — No jargon, easy to understand?
+7. **Evidence** — Are there facts, stats, testimonials, or proof?
+8. **Emotion/Story** — Is there emotional or narrative appeal?
+9. **Structure** — Is it skimmable and well-formatted?
+10. **Call-to-Action** — Is the next step obvious and compelling?
+11. **Visuals/Captions** — If present, do they reinforce the message?
+12. **Testability** — Can parts be A/B tested or measured?
+13. **Length** — Is it appropriate for product complexity?
+14. **Attention-Grabbing** — Does it hook early?
+15. **Repetition** — Are key ideas or benefits repeated effectively?
+
+## Output Format
+
+Respond with exactly this structure:
+
+---
+
+**URL Analyzed:** [the URL]
+
+**Overall Score:** X/100
+
+**Score Breakdown:**
+
+| Principle | Score (0–6.7) | Comments |
+|-----------|---------------|----------|
+| 1. Product Positioning | X.X | ... |
+| 2. Unique Benefit | X.X | ... |
+| 3. Headline | X.X | ... |
+| 4. Reader-Focused | X.X | ... |
+| 5. Clear Tone | X.X | ... |
+| 6. Simple Language | X.X | ... |
+| 7. Evidence | X.X | ... |
+| 8. Emotion/Story | X.X | ... |
+| 9. Structure | X.X | ... |
+| 10. Call-to-Action | X.X | ... |
+| 11. Visuals/Captions | X.X | ... |
+| 12. Testability | X.X | ... |
+| 13. Length | X.X | ... |
+| 14. Attention-Grabbing | X.X | ... |
+| 15. Repetition | X.X | ... |
+
+**Top 3 Areas to Improve:**
+1. ...
+2. ...
+3. ...
+
+---
+
+### Rewrite (to score 100/100)
+
+[Rewritten copy, structured the way it should appear on the page — headline, subhead, body, CTAs, proof points. Apply all 15 principles.]
+
+---
+
+## Scoring Rules
+
+- The overall score must equal the sum of the 15 principle scores (within rounding).
+- Score each principle independently — don't let a strong headline inflate the structure score.
+- If you can't evaluate a principle because the page didn't load fully or the element isn't present (e.g. no visuals), score based on the absence and say so in the comment.
+- Quote or name specific copy in comments. "Headline is weak" is not useful; "Headline 'Welcome to our site' is generic and leads with the brand, not a benefit" is.
+
+## Edge Cases
+
+- **WebFetch returned empty / blocked / obviously JS-rendered.** Tell the user the fetch didn't return meaningful copy and ask them to paste the marketing copy directly. Then grade what they paste. If `agent-browser` is available in this container, prefer using it to render JS-heavy pages before asking the user to paste.
+- **Non-English copy.** Grade it in the source language. Don't translate before scoring — the rewrite should also be in the source language unless the user asks otherwise.
+- **Single-page site with very little copy.** Grade what's there honestly. Short pages can still score well on simplicity/CTA but will usually score poorly on evidence/repetition.
+- **Multiple URLs requested.** Run the workflow once per URL in sequence. Don't merge them into one report.


### PR DESCRIPTION
## Summary
- Localizes `copy-grader` skill (Ogilvy-inspired marketing-copy grader) from upstream into `.claude/skills/copy-grader/SKILL.md`.

## Why
Same as #audit-website-localize — survives upstream removal, editable per-install.

## Test plan
- [ ] DM Zed `/copy-grader https://cubbystorage.com`. Confirm score, top-3 improvement areas, and a 100/100 rewrite.
