### PR TITLE
feat(channels): voice transcription hook in Chat SDK bridge

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -17,6 +17,7 @@ import {
   type Message as ChatMessage,
 } from 'chat';
 import { log } from '../log.js';
+import { isAudioAttachment, transcribeAudioBuffer } from '../transcription.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
 import { getAskQuestionRender } from '../db/sessions.js';
@@ -150,6 +151,20 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           try {
             const buffer = await att.fetchData();
             entry.data = buffer.toString('base64');
+
+            // Opt-in voice transcription: when WHISPER_BIN is set and the
+            // attachment is audio, transcribe the buffer via whisper.cpp and
+            // surface the transcript both on the attachment entry (for any
+            // downstream consumer) and inline in the message content (so the
+            // agent sees it as plain text alongside the audio file placeholder).
+            if (process.env.WHISPER_BIN && isAudioAttachment(entry)) {
+              const transcript = await transcribeAudioBuffer(buffer);
+              if (transcript) {
+                entry.transcript = transcript;
+                const existing = typeof serialized.content === 'string' ? serialized.content : '';
+                serialized.content = existing ? `${existing}\n[Voice: ${transcript}]` : `[Voice: ${transcript}]`;
+              }
+            }
           } catch (err) {
             log.warn('Failed to download attachment', { type: att.type, err });
           }

--- a/src/transcription.test.ts
+++ b/src/transcription.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('./log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// child_process.execFile is wrapped via util.promisify. Mock the callback-style
+// function so the promisified version resolves with whatever we queue.
+const execFileMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _bin: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: '', stderr: '' });
+    },
+  ),
+);
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  },
+}));
+
+import { isAudioAttachment, transcribeAudioBuffer } from './transcription.js';
+
+describe('isAudioAttachment', () => {
+  it('returns true for audio/* mimeTypes', () => {
+    expect(isAudioAttachment({ mimeType: 'audio/ogg' })).toBe(true);
+    expect(isAudioAttachment({ mimeType: 'audio/mpeg' })).toBe(true);
+    expect(isAudioAttachment({ mimeType: 'audio/mp4' })).toBe(true);
+  });
+
+  it('returns true for type "audio" or "voice" when mimeType is missing', () => {
+    expect(isAudioAttachment({ type: 'audio' })).toBe(true);
+    expect(isAudioAttachment({ type: 'voice' })).toBe(true);
+  });
+
+  it('returns false for non-audio attachments', () => {
+    expect(isAudioAttachment({ mimeType: 'image/jpeg' })).toBe(false);
+    expect(isAudioAttachment({ mimeType: 'application/pdf' })).toBe(false);
+    expect(isAudioAttachment({ type: 'document' })).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isAudioAttachment(null)).toBe(false);
+    expect(isAudioAttachment(undefined)).toBe(false);
+    expect(isAudioAttachment({})).toBe(false);
+  });
+});
+
+describe('transcribeAudioBuffer', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when WHISPER_BIN is unset', async () => {
+    delete process.env.WHISPER_BIN;
+    const result = await transcribeAudioBuffer(Buffer.from('fake audio'));
+    expect(result).toBeNull();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('returns trimmed transcript on success', async () => {
+    process.env.WHISPER_BIN = 'whisper-cli';
+    execFileMock
+      .mockImplementationOnce((_bin, _args, _opts, cb) => {
+        // ffmpeg call — stdout empty is fine
+        cb(null, { stdout: '', stderr: '' });
+      })
+      .mockImplementationOnce((_bin, _args, _opts, cb) => {
+        // whisper-cli call — transcript with trailing whitespace
+        cb(null, { stdout: '  hello there  \n', stderr: '' });
+      });
+
+    const result = await transcribeAudioBuffer(Buffer.from('fake audio'));
+    expect(result).toBe('hello there');
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when whisper produces empty output', async () => {
+    process.env.WHISPER_BIN = 'whisper-cli';
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, { stdout: '   \n', stderr: '' });
+    });
+
+    const result = await transcribeAudioBuffer(Buffer.from('fake audio'));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when ffmpeg or whisper throws', async () => {
+    process.env.WHISPER_BIN = 'whisper-cli';
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(new Error('command failed'), { stdout: '', stderr: 'boom' });
+    });
+
+    const result = await transcribeAudioBuffer(Buffer.from('fake audio'));
+    expect(result).toBeNull();
+  });
+});

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -60,17 +60,13 @@ export async function transcribeAudioBuffer(audioBuffer: Buffer): Promise<string
 
     // whisper.cpp expects 16 kHz mono WAV. Run ffmpeg to normalize regardless
     // of the input container so we don't have to special-case ogg/mp3/m4a/etc.
-    await execFileAsync(
-      'ffmpeg',
-      ['-i', tmpIn, '-ar', '16000', '-ac', '1', '-f', 'wav', '-y', tmpWav],
-      { timeout: FFMPEG_TIMEOUT_MS },
-    );
+    await execFileAsync('ffmpeg', ['-i', tmpIn, '-ar', '16000', '-ac', '1', '-f', 'wav', '-y', tmpWav], {
+      timeout: FFMPEG_TIMEOUT_MS,
+    });
 
-    const { stdout } = await execFileAsync(
-      bin,
-      ['-m', whisperModel(), '-f', tmpWav, '--no-timestamps', '-nt'],
-      { timeout: WHISPER_TIMEOUT_MS },
-    );
+    const { stdout } = await execFileAsync(bin, ['-m', whisperModel(), '-f', tmpWav, '--no-timestamps', '-nt'], {
+      timeout: WHISPER_TIMEOUT_MS,
+    });
 
     const transcript = stdout.trim();
     return transcript || null;

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -1,0 +1,102 @@
+/**
+ * Channel-agnostic voice transcription via whisper.cpp.
+ *
+ * Accepts a raw audio buffer (any format ffmpeg can read) and returns the
+ * transcribed text, or null if transcription fails or yields empty output.
+ *
+ * Opt-in via `WHISPER_BIN`. When unset, callers must skip — this module never
+ * runs whisper unprompted, because the binary may not be installed.
+ *
+ * Requirements:
+ *   - `ffmpeg` on PATH (for the input → 16 kHz mono WAV conversion that
+ *     whisper.cpp expects)
+ *   - `whisper-cli` (or any whisper.cpp-compatible binary) at `WHISPER_BIN`
+ *   - A whisper model file at `WHISPER_MODEL`
+ *     (default: `data/models/ggml-base.bin` relative to cwd)
+ */
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+import { log } from './log.js';
+
+const execFileAsync = promisify(execFile);
+
+const FFMPEG_TIMEOUT_MS = 30_000;
+const WHISPER_TIMEOUT_MS = 60_000;
+
+function whisperBin(): string | null {
+  return process.env.WHISPER_BIN || null;
+}
+
+function whisperModel(): string {
+  return process.env.WHISPER_MODEL || path.join(process.cwd(), 'data', 'models', 'ggml-base.bin');
+}
+
+/**
+ * Transcribe a buffer of audio bytes. Returns null on any failure or if the
+ * transcript is empty; callers should treat null as "no transcript available"
+ * and not as an error to propagate.
+ *
+ * Writes the input to two temp files (the original bytes and a normalized
+ * 16 kHz mono WAV) and cleans both up regardless of outcome.
+ */
+export async function transcribeAudioBuffer(audioBuffer: Buffer): Promise<string | null> {
+  const bin = whisperBin();
+  if (!bin) {
+    log.debug('transcribeAudioBuffer skipped — WHISPER_BIN not set');
+    return null;
+  }
+
+  const tmpDir = os.tmpdir();
+  const id = `nanoclaw-voice-${Date.now()}-${process.pid}`;
+  const tmpIn = path.join(tmpDir, `${id}.in`);
+  const tmpWav = path.join(tmpDir, `${id}.wav`);
+
+  try {
+    fs.writeFileSync(tmpIn, audioBuffer);
+
+    // whisper.cpp expects 16 kHz mono WAV. Run ffmpeg to normalize regardless
+    // of the input container so we don't have to special-case ogg/mp3/m4a/etc.
+    await execFileAsync(
+      'ffmpeg',
+      ['-i', tmpIn, '-ar', '16000', '-ac', '1', '-f', 'wav', '-y', tmpWav],
+      { timeout: FFMPEG_TIMEOUT_MS },
+    );
+
+    const { stdout } = await execFileAsync(
+      bin,
+      ['-m', whisperModel(), '-f', tmpWav, '--no-timestamps', '-nt'],
+      { timeout: WHISPER_TIMEOUT_MS },
+    );
+
+    const transcript = stdout.trim();
+    return transcript || null;
+  } catch (err) {
+    log.warn('Voice transcription failed', { err: err instanceof Error ? err.message : String(err) });
+    return null;
+  } finally {
+    for (const f of [tmpIn, tmpWav]) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+/**
+ * Heuristic: does this attachment look like audio worth transcribing?
+ *
+ * Checks `mimeType` first (set by most adapters), falls back to coarse
+ * `type` (set by Telegram for stickers/voice/etc. where no MIME is supplied).
+ */
+export function isAudioAttachment(att: { mimeType?: string | null; type?: string | null } | undefined | null): boolean {
+  if (!att) return false;
+  if (att.mimeType && att.mimeType.startsWith('audio/')) return true;
+  if (att.type === 'audio' || att.type === 'voice') return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in voice transcription pass** to the shared Chat SDK bridge. When `WHISPER_BIN` is set and an inbound attachment looks like audio, the bridge runs whisper.cpp on the buffer after `fetchData()` and appends the transcript to the message content as `[Voice: <transcript>]`.

When `WHISPER_BIN` is unset (the default), the new code path is a no-op — zero behavior change for existing installs.

## Why one bridge hook instead of per-adapter

The Chat SDK bridge is shared by Discord, Slack, Teams, Webex, Google Chat, and every future Chat SDK-supported platform. Hooking transcription here means all bridge-based channels gain voice support from a single integration point. The bridge already handles attachment download centrally (`messageToInbound` → `att.fetchData()`), so the transcription pass slots in naturally right after the buffer is in hand.

Sibling effort: @ira-at-work's #2317 (`/add-voice-transcription-free-whisper`) patches Signal/Telegram/WhatsApp adapters directly (they don't go through the Chat SDK bridge). That PR + this one would together cover every channel.

Demand signal: #2426 (just opened by @b1ek) — "LLM cant see the image in discord" — voice transcription is the same kind of gap.

## Files

- **`src/transcription.ts`** (new, ~95 lines): `transcribeAudioBuffer(Buffer): Promise<string | null>` plus `isAudioAttachment(att)` helper. Channel-agnostic. Shells out to `ffmpeg` for input normalization (any container → 16 kHz mono WAV) and `whisper-cli` for the transcript. Returns null on any failure or empty output; the bridge only injects `[Voice: ...]` when the transcript is non-empty.
- **`src/channels/chat-sdk-bridge.ts`** (+15 lines): gated transcription pass inside `messageToInbound()`. Runs only when `process.env.WHISPER_BIN` is set **and** the attachment passes `isAudioAttachment` (`mimeType: audio/*` or coarse `type: 'audio'`/`'voice'`).
- **`src/transcription.test.ts`** (new, 8 tests): `isAudioAttachment` truth table; `transcribeAudioBuffer` env-gate, trim, empty-output, and execFile-failure paths.

Total: 3 files, +236 lines.

## Pairs with

A sibling PR against `main` adds the user-facing skill metadata: `.claude/skills/add-discord-voice-transcription/{SKILL.md, REMOVE.md, VERIFY.md}` following the @ddaniels Signal template (#1953). It instructs users to fetch the modified `chat-sdk-bridge.ts` and the new `transcription.ts` from `origin/channels` after this PR lands.

## Test plan

- [x] `pnpm run build` — clean (3 pre-existing errors in deltachat/slack/telegram unrelated to this change)
- [x] `npx vitest run src/transcription.test.ts` — 8/8 passing
- [x] `npx vitest run src/channels/chat-sdk-bridge.test.ts` — 7/7 passing (unchanged)
- [ ] Live test: send a Discord voice memo with `WHISPER_BIN=whisper-cli` set, confirm the agent receives `[Voice: <transcript>]` inline. Will run this once the channels-branch checkout is up.
- [ ] Live test: same with `WHISPER_BIN` unset, confirm voice attachments arrive as plain audio placeholders (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)