### PR TITLE
feat(skill): add /add-voice-transcription-chat-sdk

### DIFF
--- a/.claude/skills/add-voice-transcription-chat-sdk/REMOVE.md
+++ b/.claude/skills/add-voice-transcription-chat-sdk/REMOVE.md
@@ -1,0 +1,26 @@
+# Remove Voice Transcription (Chat SDK channels)
+
+The transcription hook is a no-op when `WHISPER_BIN` is unset, so the lightest
+"removal" is to just unset the env var:
+
+1. Remove `WHISPER_BIN` (and `WHISPER_MODEL` if set) from `.env`
+2. Sync env into the container: `cp .env data/env/env`
+3. Restart the service
+
+Voice attachments will then flow through as before — plain audio placeholders,
+no transcription.
+
+## Full removal (also deletes the code)
+
+If you want to remove the code as well:
+
+1. Delete `src/transcription.ts` and `src/transcription.test.ts`
+2. Revert `src/channels/chat-sdk-bridge.ts` to its pre-skill version:
+   ```bash
+   git fetch upstream main
+   git checkout upstream/main -- src/channels/chat-sdk-bridge.ts
+   ```
+3. Rebuild: `pnpm run build`
+
+This leaves your model files in `data/models/` untouched — delete them
+manually if you want the disk space back (`rm -rf data/models/ggml-*.bin`).

--- a/.claude/skills/add-voice-transcription-chat-sdk/SKILL.md
+++ b/.claude/skills/add-voice-transcription-chat-sdk/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: add-voice-transcription-chat-sdk
+description: Add local whisper.cpp voice transcription to any of NanoClaw's Chat SDK-bridged channels (Discord, Slack, Teams, Webex, Google Chat, …) via one shared hook. When a user sends a voice memo or audio file, it is transcribed offline and delivered to the agent inline as `[Voice: <transcript>]`.
+---
+
+# Add Voice Transcription (Chat SDK channels)
+
+Adds automatic voice message transcription to every channel that goes through NanoClaw's shared Chat SDK bridge — Discord, Slack, Teams, Webex, Google Chat, etc. — in a single hook. Audio attachments are transcribed with [whisper.cpp](https://github.com/ggerganov/whisper.cpp) on the host, and the transcript is appended to the inbound message content as `[Voice: <transcript>]` so the agent sees it as plain text alongside the audio file placeholder.
+
+No cloud API, no `OPENAI_API_KEY` — transcription is fully on-device.
+
+Sibling skill: `/add-voice-transcription-free-whisper` (PR #2317) covers Signal/Telegram/WhatsApp via per-adapter patches. This skill complements it by covering Chat SDK-bridged channels in one shared hook.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `src/transcription.ts` exists and `src/channels/chat-sdk-bridge.ts` imports `transcribeAudioBuffer`. If both are true, skip to Phase 3 (Configure).
+
+### Ask the user
+
+Use `AskUserQuestion`:
+
+> Do you want to install whisper.cpp and ffmpeg now, or have you already done that?
+
+If they need help, walk them through the install in Phase 2 step 1.
+
+## Phase 2: Apply Code Changes
+
+**Prerequisite:** At least one Chat SDK-bridged channel must be installed first (e.g. `skill/discord`, `skill/slack`). This skill hooks into the shared Chat SDK bridge those channels use.
+
+### 1. Install host dependencies
+
+`whisper-cli` (from whisper.cpp) and `ffmpeg`:
+
+**macOS:**
+
+```bash
+brew install whisper-cpp ffmpeg
+```
+
+**Debian / Ubuntu:**
+
+```bash
+sudo apt-get install -y ffmpeg
+# whisper.cpp: build from https://github.com/ggerganov/whisper.cpp
+```
+
+### 2. Download a model
+
+```bash
+mkdir -p data/models
+curl -L -o data/models/ggml-base.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
+```
+
+Other sizes: `ggml-tiny.bin` (~75 MB, faster, lower quality), `ggml-small.bin` (~466 MB), `ggml-medium.bin` (~1.5 GB), `ggml-large-v3.bin` (~3 GB).
+
+### 3. Ensure the skill-code remote
+
+The code is delivered as a small branch on a fork. Add the remote if it's missing:
+
+```bash
+git remote -v
+git remote add discord https://github.com/mtichikawa/nanoclaw-discord.git
+```
+
+### 4. Merge the skill branch
+
+```bash
+git fetch discord skill/voice-transcription-chat-sdk
+git merge discord/skill/voice-transcription-chat-sdk
+```
+
+The branch adds three files and touches nothing else, so the merge is conflict-free on a current `main`.
+
+This merges in:
+
+- `src/transcription.ts` — `transcribeAudioBuffer(Buffer)` + `isAudioAttachment(att)` helpers (channel-agnostic, shells out to ffmpeg + whisper-cli)
+- `src/transcription.test.ts` — 8 unit tests covering env-gate, trim, empty-output, and failure paths
+- Voice transcription hook in `src/channels/chat-sdk-bridge.ts` (15 lines, gated on `WHISPER_BIN`)
+
+If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides.
+
+### 5. Validate
+
+```bash
+pnpm install
+pnpm run build
+npx vitest run src/transcription.test.ts
+```
+
+All tests must pass and build must be clean before proceeding.
+
+## Phase 3: Configure
+
+Add to `.env`:
+
+```bash
+# Required: path to (or name of) the whisper.cpp binary on PATH
+WHISPER_BIN=whisper-cli
+
+# Optional: model file. Defaults to data/models/ggml-base.bin relative to cwd.
+# WHISPER_MODEL=/absolute/path/to/ggml-base.bin
+```
+
+Sync to container env:
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+```
+
+The transcription itself runs on the host — no whisper binary is needed inside the agent container.
+
+### Restart
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux
+systemctl --user restart nanoclaw
+```
+
+## Phase 4: Verify
+
+See [VERIFY.md](VERIFY.md). Send a voice memo to Discord; the agent should receive `[Voice: <transcript>]` inline alongside the audio file placeholder.
+
+## How it works
+
+1. Discord (or any Chat SDK-bridged channel) delivers a message with an audio attachment.
+2. `chat-sdk-bridge.ts` downloads the attachment via the adapter's `fetchData()`.
+3. If `WHISPER_BIN` is set **and** the attachment looks like audio (`mimeType: 'audio/*'` or coarse `type: 'audio'`/`'voice'`), the bridge calls `transcribeAudioBuffer(buffer)`:
+   - Writes the buffer to a temp file
+   - Runs `ffmpeg` to convert to 16 kHz mono WAV
+   - Runs `whisper-cli` with the configured model
+   - Returns the trimmed transcript (or `null` on failure)
+4. The transcript is appended to the inbound message content as `[Voice: <transcript>]`. The agent sees this inline alongside the existing `[audio: voice.ogg — saved to /workspace/inbox/...]` attachment placeholder, so Claude has both the transcript text **and** the original audio file available.
+
+When `WHISPER_BIN` is unset, the hook is a no-op — fully opt-in, zero overhead.
+
+## Troubleshooting
+
+### Voice messages still arrive as plain audio placeholders, no transcript
+
+1. Confirm `WHISPER_BIN` is set in `.env` **and** synced to `data/env/env`:
+   ```bash
+   grep WHISPER data/env/env
+   ```
+2. Confirm the binary exists on PATH (or at the configured absolute path):
+   ```bash
+   "$WHISPER_BIN" --help 2>&1 | head -5
+   ```
+3. Confirm the model file exists:
+   ```bash
+   ls -lh "${WHISPER_MODEL:-data/models/ggml-base.bin}"
+   ```
+4. Tail logs for the failure path:
+   ```bash
+   tail logs/nanoclaw.log | grep -i "Voice transcription"
+   ```
+
+### Transcription is slow
+
+Whisper model size dominates latency. On Apple Silicon, `whisper.cpp` builds with Metal acceleration enabled by default and is roughly real-time on `base`. On x86_64 CPU-only, expect ~5–15 s per minute of audio with `base`. Drop to `tiny` for snappier (and lower-quality) results, or step up to `small`/`medium` for better quality.
+
+### whisper-cli not found
+
+Install it (`brew install whisper-cpp` on macOS) or set `WHISPER_BIN` to an absolute path:
+
+```bash
+WHISPER_BIN=/Users/you/whisper.cpp/build/bin/whisper-cli
+```

--- a/.claude/skills/add-voice-transcription-chat-sdk/VERIFY.md
+++ b/.claude/skills/add-voice-transcription-chat-sdk/VERIFY.md
@@ -1,0 +1,19 @@
+# Verify Voice Transcription (Chat SDK channels)
+
+Send a voice memo (or any audio attachment) from a Chat SDK-bridged channel
+(Discord, Slack, …) to a channel where your NanoClaw bot has access. The agent should receive the audio file
+alongside an inline `[Voice: <transcript>]` block and respond to the
+transcribed content.
+
+If nothing transcribes:
+
+```bash
+tail logs/nanoclaw.log | grep -i "Voice transcription\|whisper"
+```
+
+`Voice transcription failed` indicates ffmpeg or whisper-cli returned an
+error — check both are installed and the model file path is correct. See
+SKILL.md "Troubleshooting" for the full checklist.
+
+A successful transcription leaves no specific log line by design; the
+transcript flows through with the rest of the inbound-message processing.


### PR DESCRIPTION
Opt-in voice transcription for Discord and every other Chat SDK-bridged channel (Slack, Teams, Webex, Google Chat, etc.) via local whisper.cpp on the host. No cloud API, no `OPENAI_API_KEY` — fully on-device.

Pairs with @ira-at-work's #2317 (`add-voice-transcription-free-whisper`) which patches Signal/Telegram/WhatsApp adapters directly. This skill is the bridge-side complement — one shared hook in `chat-sdk-bridge.ts` covers every Chat SDK-bridged channel. Together the two skills close the voice gap on every channel NanoClaw supports.

Addresses the Discord side of @b1ek's #2426 (LLM cant see the image in discord — same shape applies to voice today).

> **Updated per review (@ira-at-work):**
> - Removed the `src/*.ts` files — the PR is now skill-markdown only. The code installs by merging a small fork branch, the same pattern `add-voice-transcription` uses with `nanoclaw-whatsapp`.
> - Renamed `add-discord-voice-transcription` → `add-voice-transcription-chat-sdk`, since the hook lives in the shared Chat SDK bridge and covers every bridged channel, not just Discord.

## Type of Change

- [X] **Feature skill** - adds a channel or integration (code delivered via merge branch + SKILL.md)

## Description

The Chat SDK bridge is shared by every chat-sdk channel (Discord, Slack, Teams, Webex, Google Chat). Hooking transcription here means all bridge-based channels gain voice support from a single integration point, gated on `process.env.WHISPER_BIN` so it's a no-op for installs that don't opt in.

The PR itself is markdown only. The code (3 files) is delivered by merging a small branch from the fork — exactly like `add-voice-transcription` merges from `nanoclaw-whatsapp`:

```
git remote add discord https://github.com/mtichikawa/nanoclaw-discord.git
git fetch discord skill/voice-transcription-chat-sdk
git merge discord/skill/voice-transcription-chat-sdk
```

The branch adds three files and touches nothing else, so the merge is conflict-free on a current `main`.

**Skill files (this PR):**

- `.claude/skills/add-voice-transcription-chat-sdk/SKILL.md` — install instructions: pre-flight, prerequisites, merge the code branch, env vars, restart, troubleshooting.
- `.claude/skills/add-voice-transcription-chat-sdk/REMOVE.md` — lightweight unset-env path + full code revert.
- `.claude/skills/add-voice-transcription-chat-sdk/VERIFY.md` — send a voice memo, check inline transcript.

**Code delivered by the merge branch:**

- `src/transcription.ts` — `transcribeAudioBuffer(Buffer): Promise<string | null>` + `isAudioAttachment(att)` helper. Channel-agnostic. Shells out to `ffmpeg` (any container → 16 kHz mono WAV) and `whisper-cli`. Returns null on any failure or empty output; the bridge only injects `[Voice: …]` when the transcript is non-empty.
- `src/channels/chat-sdk-bridge.ts` — +15 lines inside `messageToInbound()`. The transcript is appended to `serialized.content` so the agent sees it inline alongside the audio file placeholder.
- `src/transcription.test.ts` — unit tests covering `isAudioAttachment`, env-gate, transcript trim, empty-output handling, and execFile-failure paths.

## For Skills

- [X] SKILL.md contains instructions, not inline code (code goes in separate files)
- [X] SKILL.md is under 500 lines (~170 lines)
- [ ] I tested this skill on a fresh clone — pending live end-to-end test; build + unit tests green (see test plan)

## Test plan

- [x] `pnpm run build` clean on main
- [x] `npx vitest run src/transcription.test.ts` — 8/8 passing
- [x] `npx vitest run src/channels/chat-sdk-bridge.test.ts` — 12/12 passing (no regression)
- [ ] Live: send a voice memo with `WHISPER_BIN=whisper-cli` set, confirm `[Voice: <transcript>]` reaches the agent
- [ ] Live: same with `WHISPER_BIN` unset, confirm no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
