### PR TITLE
setup: add files:read and files:write to Slack scope checklist

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -60,7 +60,7 @@ pnpm run build
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App** > **From scratch**
 2. Name it (e.g., "NanoClaw") and select your workspace
 3. Go to **OAuth & Permissions** and add Bot Token Scopes:
-   - `chat:write`, `im:write`, `channels:history`, `groups:history`, `im:history`, `channels:read`, `groups:read`, `users:read`, `reactions:write`
+   - `chat:write`, `im:write`, `channels:history`, `groups:history`, `im:history`, `channels:read`, `groups:read`, `users:read`, `reactions:write`, `files:read`, `files:write`
 4. Click **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-...`)
 5. Go to **Basic Information** and copy the **Signing Secret**
 

--- a/setup/channels/slack.ts
+++ b/setup/channels/slack.ts
@@ -146,6 +146,7 @@ async function walkThroughAppCreation(): Promise<'continue' | 'back'> {
       '     • chat:write',
       '     • users:read',
       '     • reactions:write',
+      '     • files:read, files:write',
       '  3. App Home → enable "Messages Tab" and "Allow users to send',
       '     slash commands and messages from the messages tab"',
       '  4. Basic Information → copy the "Signing Secret"',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Without `files:read`, `@chat-adapter/slack` cannot download attachments — Slack returns an HTML login page in place of file bytes and the adapter throws a `NetworkError`. Net result: the agent silently fails to read any file (PDF, image, etc.) sent in a DM. `files:write` is bundled in for symmetric outbound (`files.uploadV2`).

Two locations updated with the same two scopes:
- `setup/channels/slack.ts:149` — operator-facing scope checklist
- `.claude/skills/add-slack/SKILL.md:63` — same list, duplicated in the install skill

**Tested:** Reproduced the failure on a stock install, added the two scopes through the Slack OAuth & Permissions page, reinstalled the app, re-sent a PDF — agent ingested it cleanly. `permissions_updated: true` came back from `apps.manifest.update`, no `.env` change needed since `token_rotation_enabled` is false.

Closes #2457
