### PR TITLE
fix(welcome): stop emitting the greeting twice

### DIFF
--- a/container/agent-runner/src/destinations.test.ts
+++ b/container/agent-runner/src/destinations.test.ts
@@ -27,18 +27,18 @@ describe('buildSystemPromptAddendum — multi-destination routing guidance', () 
 
     const prompt = buildSystemPromptAddendum('Casa');
 
-    expect(prompt).toContain('Default routing');
+    expect(prompt).toContain('default to addressing the destination it came `from`');
     expect(prompt).toContain('from="name"');
     expect(prompt).toContain('`casa`');
     expect(prompt).toContain('`whatsapp-mg-17780`');
   });
 
-  it('requires explicit wrapping even for a single destination', () => {
+  it('describes message wrapping for a single destination', () => {
     seedDestination('casa', 'Casa', 'whatsapp', 'group-1@g.us');
 
     const prompt = buildSystemPromptAddendum('Casa');
 
-    expect(prompt).toContain('All output must be wrapped');
+    expect(prompt).toContain('Wrap each delivered message');
     expect(prompt).toContain('<message to="name">');
     expect(prompt).toContain('`casa`');
   });
@@ -47,7 +47,7 @@ describe('buildSystemPromptAddendum — multi-destination routing guidance', () 
     const prompt = buildSystemPromptAddendum('Casa');
 
     expect(prompt).toContain('no configured destinations');
-    expect(prompt).not.toContain('Default routing');
+    expect(prompt).not.toContain('default to addressing');
   });
 
   it('includes default-routing and wrapping instructions for single destination', () => {
@@ -55,9 +55,9 @@ describe('buildSystemPromptAddendum — multi-destination routing guidance', () 
 
     const prompt = buildSystemPromptAddendum('Casa');
 
-    expect(prompt).toContain('All output must be wrapped');
+    expect(prompt).toContain('Wrap each delivered message');
     expect(prompt).toContain('<message to="name">');
-    expect(prompt).toContain('Default routing');
+    expect(prompt).toContain('default to addressing the destination it came `from`');
     expect(prompt).toContain('`casa`');
   });
 });

--- a/container/agent-runner/src/destinations.ts
+++ b/container/agent-runner/src/destinations.ts
@@ -115,16 +115,16 @@ function buildDestinationsSection(): string {
     }
   }
   lines.push('');
-  lines.push('**All output must be wrapped.** Use `<message to="name">...</message>` for content to send, or `<internal>...</internal>` for scratchpad.');
-  lines.push('You can include multiple `<message>` blocks in one response to send to multiple destinations.');
-  lines.push('Bare text (outside of `<message>` or `<internal>` blocks) is not allowed and will not be delivered.');
-  lines.push('');
   lines.push(
-    '**Default routing**: when replying to an incoming message, address the same destination the message came `from` — every inbound `<message>` tag carries a `from="name"` attribute that names the origin destination. Only address a different destination when the request itself asks you to (e.g., "tell Laura that…").',
+    'Wrap each delivered message in a `<message to="name">…</message>` block; include several blocks in one response to address several destinations. `<internal>…</internal>` marks thinking you don\'t want sent — anything outside these tags is also treated as scratchpad.',
   );
   lines.push('');
   lines.push(
-    'To send a message mid-response (e.g., an acknowledgment before a long task), call the `send_message` MCP tool with the `to` parameter set to a destination name.',
+    'When replying to an incoming message, default to addressing the destination it came `from` (every inbound `<message>` tag carries a `from="name"` attribute). Pick a different destination when the request asks for it (e.g., "tell Laura that…").',
+  );
+  lines.push('');
+  lines.push(
+    'The `send_message` MCP tool is the same delivery, available mid-turn — handy for a quick acknowledgment ("on it") before a slow tool call. Each `send_message` call and each final-response `<message>` block lands as its own message in the conversation, so they read as a sequence rather than as one combined reply.',
   );
   return lines.join('\n');
 }

--- a/container/skills/welcome/SKILL.md
+++ b/container/skills/welcome/SKILL.md
@@ -9,7 +9,7 @@ You've just been connected to a new user. This your time to shine and make a str
 
 ## What to do
 
-1. Send a short, warm greeting using `send_message`
+1. Send a short, warm greeting
 2. State your name (from your system prompt / CLAUDE.md)
 3. Signal that you're capable of a lot — but don't list everything upfront. Be intriguing, not encyclopedic
 4. Ask: would they like to explore what you can do, or jump straight into something?


### PR DESCRIPTION
## Summary

On a fresh install, the first welcome DM from a new agent was being delivered twice. Root cause was a conflict between the welcome skill and the sending-rules section of the runtime system prompt:

- `container/skills/welcome/SKILL.md` told the agent to send the greeting via `send_message`.
- The destinations addendum (since `1d4d920`) requires the final response to be wrapped in `<message to="…">` blocks — bare text is dropped to scratchpad.

So the agent obediently did both: one greeting via the MCP tool, one via the final wrapped output. Two near-identical messages, ~2 seconds apart.

## Changes

- **`container/skills/welcome/SKILL.md`** — drops the mechanism from step 1 ("Send a short, warm greeting") so the system prompt steers how it's delivered. Skills shouldn't hardcode the delivery surface.
- **`container/agent-runner/src/destinations.ts`** — rewords the runtime "## Sending messages" section to frame `<message>` blocks and `send_message` as the same delivery, with each call/block landing as its own message in the conversation — so they read as a sequence rather than as additive duplicates. Less "must"/"not allowed" framing, equally applicable to the welcome flow, mid-turn-ack flow, and regular reply flow.
- **`container/agent-runner/src/destinations.test.ts`** — assertions updated to match the new wording (still verifies wrapping guidance + default-routing nudge are present).

## Test plan

- [ ] Fresh install + first agent (`/init-first-agent`) on a DM channel — confirm exactly one welcome message is delivered.
- [ ] Existing install — send a regular message, confirm the agent's reply still lands wrapped in a `<message>` block.
- [ ] Trigger a longer turn (something with a slow tool call) — confirm `send_message` mid-turn ack + final `<message>` reply both land as separate messages, no duplication.
- [ ] `bun test container/agent-runner/src/destinations.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)