### PR TITLE
feat(slack): per-message thread for top-level posts in per-thread sessions

### DIFF
--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -25,6 +25,19 @@ registerChannelAdapter('slack', {
         return null;
       }
     };
+    // Slack encodes top-level posts with an empty thread_ts (see
+    // ChannelAdapter.rewriteThreadIdForSession for why this matters). Mint
+    // a per-message id by re-encoding with the message ts as thread_ts;
+    // in-thread events already carry a real thread_ts so we no-op.
+    bridge.rewriteThreadIdForSession = (threadId: string, messageId: string): string => {
+      try {
+        const decoded = slackAdapter.decodeThreadId(threadId);
+        if (decoded.threadTs) return threadId;
+        return slackAdapter.encodeThreadId({ channel: decoded.channel, threadTs: messageId });
+      } catch {
+        return threadId;
+      }
+    };
     return bridge;
   },
 });


### PR DESCRIPTION
## TL;DR

Before: a wiring with `session_mode=per-thread` on a Slack DM collapses every top-level DM into one ever-growing session, and the bot's replies post as flat top-level messages.
After: each top-level DM becomes its own session and the bot's reply posts in-thread.

(No change in `session_mode=shared`. Depends on #2471.)

## Summary

Implements `ChannelAdapter.rewriteThreadIdForSession` on the Slack adapter. When a wiring is in `session_mode=per-thread`, top-level Slack posts (DMs and channel posts without a parent thread) each get their own thread/session instead of all collapsing under the same threadId. The reply posts in-thread.

## Why

Slack's `@chat-adapter/slack` encodes top-level (un-threaded) messages with `thread_ts=""`. For DMs that means every unsolicited message arrives with the same threadId — so a wiring with `session_mode=per-thread` on a DM degenerates to a single ever-growing session, and outbound replies post as flat channel messages (because `postMessage` reads `thread_ts` from the threadId and empty means "post at top level").

The rewriter re-encodes the threadId with the message's own `ts` as `thread_ts`. Each top-level post becomes its own thread/session AND Slack auto-creates the thread on first reply. In-thread events already carry a real `thread_ts`, so `decoded.threadTs` is non-empty and the rewrite no-ops.

## Why no toggle

The router only consults this hook when the wiring's effective `session_mode` is `per-thread` (see #2471 against `main`). `shared` / `agent-shared` users see no change. Operators who explicitly opt into per-thread DMs get the correct behavior without any new config flag.

## Depends on

- nanocoai/nanoclaw#2471 (host-side hook on `main`).
- Once that lands and `channels` next merges `main`, this PR rebases trivially. Verified locally by combining both patches: build + channel tests green.

## Files

- `src/channels/slack.ts` — attaches `bridge.rewriteThreadIdForSession`.

## Test plan

- [ ] Verify with `session_mode=per-thread` DM wiring: top-level DM sends create distinct sessions; bot replies post in-thread.
- [ ] Verify with `session_mode=shared` DM wiring: no change from today's behavior (hook not consulted).
- [ ] Verify in-thread DM events still resolve to the same thread (decoded.threadTs non-empty → no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)