### PR TITLE
fix(destinations): remove misleading scratchpad clause from internal-tag description

### DIFF
--- a/container/agent-runner/src/destinations.ts
+++ b/container/agent-runner/src/destinations.ts
@@ -116,7 +116,7 @@ function buildDestinationsSection(): string {
   }
   lines.push('');
   lines.push(
-    'Wrap each delivered message in a `<message to="name">…</message>` block; include several blocks in one response to address several destinations. `<internal>…</internal>` marks thinking you don\'t want sent — anything outside these tags is also treated as scratchpad.',
+    'Wrap each delivered message in a `<message to="name">…</message>` block; include several blocks in one response to address several destinations. `<internal>…</internal>` marks thinking you don\'t want sent.',
   );
   lines.push('');
   lines.push(


### PR DESCRIPTION
## Summary
- Follow-up to #2467. Removes the trailing "anything outside these tags is also treated as scratchpad" clause from the `<internal>` tag description in `destinations.ts`.
- The clause contradicted the rest of the system prompt, which requires every delivered message to be wrapped in `<message>` blocks. Saying bare text is "also treated as scratchpad" implied it's a valid alternative, which it isn't.

## Test plan
- [ ] Verify single-destination prompt still renders cleanly
- [ ] Verify multi-destination prompt still renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)