### PR TITLE
feat(network): hooks to allow skills to regulate agents' internet access

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -38,6 +38,7 @@ import {
   type ProviderContainerContribution,
   type VolumeMount,
 } from './providers/provider-container-registry.js';
+import { getNetworkPolicyProvider } from './modules/network/index.js';
 import {
   heartbeatPath,
   markContainerRunning,
@@ -431,6 +432,10 @@ async function buildContainerArgs(
     throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
   }
   log.info('OneCLI gateway applied', { containerName });
+
+  // Network policy hook — here the provider can add flags like `--network`, etc.
+  // No-op is default (if no provider is registered).
+  await getNetworkPolicyProvider()?.applyContainerArgs?.(args, { agentGroup });
 
   // Host gateway
   args.push(...hostGatewayArgs());

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-container-configs.js';
 import { migration015 } from './015-cli-scope.js';
+import { migrationInternetAccessPolicy } from './internet-access-policy-field.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -35,6 +36,7 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migrationInternetAccessPolicy,
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/db/migrations/internet-access-policy-field.ts
+++ b/src/db/migrations/internet-access-policy-field.ts
@@ -1,0 +1,34 @@
+/**
+ * Internet-access policy field.
+ *
+ * Adds an opaque column that core writes nothing to and reads nothing
+ * from — it exists so a registered `NetworkPolicyProvider` (skill) has
+ * a place to persist per-agent outbound-internet policy without adding
+ * its own table.
+ *
+ *   - `agent_groups.internet_access_policy` (TEXT, nullable) — JSON blob;
+ *     the provider's per-agent policy descriptor (e.g. WAN bucket, ACL
+ *     list).
+ *
+ * Inter-agent directionality is intentionally not modeled here:
+ * `agent_destinations` rows are already one-way grants (one row per
+ * direction), so absence of the inverse row encodes "the target cannot
+ * reply via this mechanism." Any stateful semantics a future provider
+ * might want (e.g. time-windowed reply grants) belong in a provider-
+ * owned table, not on the destination row.
+ *
+ * Backward-compat: existing `agent_groups` rows get `NULL` (no policy
+ * configured). With no provider registered, the column influences no
+ * code path.
+ */
+import type Database from 'better-sqlite3';
+
+import type { Migration } from './index.js';
+
+export const migrationInternetAccessPolicy: Migration = {
+  version: 14,
+  name: 'internet-access-policy-field',
+  up(db: Database.Database) {
+    db.exec(`ALTER TABLE agent_groups ADD COLUMN internet_access_policy TEXT`);
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import { startCliServer, stopCliServer } from './cli/socket-server.js';
 
 import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
 import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from './channels/channel-registry.js';
+import { getNetworkPolicyProvider } from './modules/network/index.js';
 
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
@@ -81,6 +82,9 @@ async function main(): Promise<void> {
 
   // 1c. One-time filesystem cutover — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
+
+  // 1c. Set up network policy if provider is registered; no-op is default.
+  await getNetworkPolicyProvider()?.ensure?.();
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -22,3 +22,4 @@ import './scheduling/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './network/index.js';

--- a/src/modules/network/index.ts
+++ b/src/modules/network/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Network policy provider barrel.
+ *
+ * Core ships with no provider registered.
+ * Skills implementing `NetworkPolicyProvider` append self-registration here.
+ * Example: Squid backend of `/agent-network`
+ */
+
+export type { ContainerArgsContext, NetworkPolicyProvider } from './types.js';
+export {
+  getNetworkPolicyProvider,
+  registerNetworkPolicyProvider,
+  resetNetworkPolicyProviderForTests,
+} from './registry.js';

--- a/src/modules/network/registry.test.ts
+++ b/src/modules/network/registry.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getNetworkPolicyProvider,
+  registerNetworkPolicyProvider,
+  resetNetworkPolicyProviderForTests,
+} from './index.js';
+
+afterEach(() => {
+  resetNetworkPolicyProviderForTests();
+});
+
+describe('network policy registry', () => {
+  it('returns undefined when no provider is registered', () => {
+    expect(getNetworkPolicyProvider()).toBeUndefined();
+  });
+
+  it('returns the registered provider', () => {
+    const provider = { ensure: async () => {} };
+    registerNetworkPolicyProvider(provider);
+    expect(getNetworkPolicyProvider()).toBe(provider);
+  });
+
+  it('throws on double-registration', () => {
+    registerNetworkPolicyProvider({});
+    expect(() => registerNetworkPolicyProvider({})).toThrow(/already registered/);
+  });
+
+  it('exposes optional hooks unchanged', async () => {
+    let ensureCalls = 0;
+    let applyCalls = 0;
+    registerNetworkPolicyProvider({
+      ensure: async () => {
+        ensureCalls += 1;
+      },
+      applyContainerArgs: async () => {
+        applyCalls += 1;
+      },
+    });
+    const p = getNetworkPolicyProvider()!;
+    await p.ensure?.();
+    await p.applyContainerArgs?.([], {
+      agentGroup: { id: 'g', name: 'g', folder: 'g', agent_provider: null, created_at: 'now' },
+    });
+    expect(ensureCalls).toBe(1);
+    expect(applyCalls).toBe(1);
+  });
+});

--- a/src/modules/network/registry.ts
+++ b/src/modules/network/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * Network policy provider registry.
+ *
+ * Singleton: at most one provider may be registered. Skills register on
+ * import (top-level call) via `src/modules/network/index.ts`. Core call
+ * sites use `getNetworkPolicyProvider()?.<hook>?.(…)` so an unregistered
+ * registry is a true no-op.
+ */
+import type { NetworkPolicyProvider } from './types.js';
+
+let provider: NetworkPolicyProvider | undefined;
+
+export function registerNetworkPolicyProvider(p: NetworkPolicyProvider): void {
+  if (provider) {
+    throw new Error('A NetworkPolicyProvider is already registered');
+  }
+  provider = p;
+}
+
+export function getNetworkPolicyProvider(): NetworkPolicyProvider | undefined {
+  return provider;
+}
+
+/** Test-only: drop the registered provider. Not for production code paths. */
+export function resetNetworkPolicyProviderForTests(): void {
+  provider = undefined;
+}

--- a/src/modules/network/types.ts
+++ b/src/modules/network/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Network policy provider — extension point for per-agent egress policy.
+ *
+ * Core ships with no provider registered; behavior is unchanged from before
+ * this hook existed. A skill (e.g. `/agent-network`) registers an
+ * implementation that decides container outbound posture (Docker network,
+ * proxy env, ACLs).
+ *
+ * Inter-agent messaging is NOT regulated here — that's already handled by
+ * row presence in `agent_destinations` (no row → no communication, enforced
+ * inside `routeAgentMessage`). The skill's LAN-side configuration consists
+ * of inserting and deleting those rows, not running through this hook.
+ *
+ * Two optional hooks, each invoked at a different point in the host:
+ *
+ *   - `ensure`             — once at host startup, after migrations.
+ *   - `applyContainerArgs` — every container spawn, just after OneCLI
+ *                            credentials are wired and before mounts/image.
+ *                            The provider mutates `args` in place to add
+ *                            `--network`, env vars, etc.
+ */
+import type { AgentGroup } from '../../types.js';
+
+export interface ContainerArgsContext {
+  agentGroup: AgentGroup;
+}
+
+export interface NetworkPolicyProvider {
+  /** One-time setup at host startup (e.g. ensure Docker network + proxy container). */
+  ensure?(): Promise<void>;
+
+  /** Per-spawn hook: mutate Docker args based on the agent's network policy. */
+  applyContainerArgs?(args: string[], ctx: ContainerArgsContext): Promise<void>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface AgentGroup {
   folder: string;
   /** @deprecated Use container_configs.provider instead. */
   agent_provider: string | null;
+  internet_access_policy?: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Type of Change

- [X] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
Manage agent containers' outbound networks via skills. Trunk behavior is unchanged — no network provider is registered by default, and every hook defaults to no-op.

This is the **hooks-only** half of a two-PR split. The next PR will provide the first implementation of a network provider (a Squid-based implementation) plus the `/agent-network` skill that drives it. Splitting lets the extension concept be reviewed solo—without the weight of a concrete implementation.

### Added

- **`NetworkPolicyProvider` interface** (`src/modules/network/types.ts`) — two optional hooks:
  - `ensure()` — called once on host startup, after migrations. Intended for one-time infra setup (build images, create networks, start containers).
  - `applyContainerArgs(args, ctx)` — called per session spawn, **after** OneCLI's `applyContainerConfig`, so a provider can append `--network` / `-e HTTPS_PROXY=…` etc.
- **Single-slot registry** (`src/modules/network/registry.ts`) — one provider at a time. `registerNetworkPolicyProvider` / `getNetworkPolicyProvider`.
- **Hook call-sites:**
  - `src/index.ts` step 1c: `await getNetworkPolicyProvider()?.ensure?.()`.
  - `src/container-runner.ts` `buildContainerArgs`: invokes `applyContainerArgs` after the OneCLI gateway is wired.
- **`agent_groups.internet_access_policy`** — TEXT column added via a new migration (`internet-access-policy-field`). The core does not parse it; providers own the schema for the JSON inside.
- **Type declaration** — `internet_access_policy?: string` on `AgentGroup` so TS callers can read it without any-casts (separate commit so the data surface is reviewable on its own).

## Does NOT add
- No provider. `getNetworkPolicyProvider()` returns `undefined` on trunk.
- No new dependencies.
- No reads or writes of `internet_access_policy` outside the migration.
- No CLI or skill files.

## Why split it
1. Easy to review the concept and hooks in this PR; it's minimal and has no effect absent an actual implementation. Meanwhile the actual implementation PR will be ~2.5k LOC and pulls in a Squid container image, a programmatic CLI, and a skill.
2. Hooks likely to be reused by other network strategies (e.g., a future no-egress provider for offline agents, or a different proxy backend).  

## Verification
- `pnpm run build` ✓
- `pnpm test` ✓ — all existing tests pass; new unit tests for the registry cover register/get/replace behavior.
- Live: host bounces cleanly, agent containers spawn identically (no hook fires because no provider is registered).

## Follow-up
Another PR (`pr/squid-policy-provider`) adds the first concrete `NetworkPolicyProvider` and the `/agent-network` skill on top of this.