### PR TITLE
fix(add-vercel): correct OneCLI jq paths and skip 'all'-mode agents

### DIFF
--- a/.claude/skills/add-vercel/SKILL.md
+++ b/.claude/skills/add-vercel/SKILL.md
@@ -85,19 +85,23 @@ Verify:
 onecli secrets list | grep -i vercel
 ```
 
-### Assign the secret to all agents
+### Assign the secret to selective-mode agents
 
-OneCLI uses selective secret mode — secrets must be explicitly assigned to each agent. Get the Vercel secret ID from the output above, then assign it to every agent:
+Agents in `secretMode: "all"` already auto-receive every secret whose host pattern matches — no assignment needed (and calling `set-secrets` on them would flip them to `selective` and strip that auto-access). Only `selective`-mode agents need explicit assignment. `set-secrets` REPLACES the entire list, so read-then-merge per agent:
 
 ```bash
-# set-secrets replaces the entire list — read and merge for each agent.
-VERCEL_SECRET_ID=$(onecli secrets list | jq -r '.data[] | select(.name | test("(?i)vercel")) | .id' | head -1)
-for agent in $(onecli agents list | jq -r '.data[].id'); do
-  CURRENT=$(onecli agents secrets --id "$agent" | jq -r '[.data[]] | join(",")')
-  MERGED=$(printf '%s' "$CURRENT,$VERCEL_SECRET_ID" | tr ',' '\n' | sort -u | paste -sd ',' -)
-  onecli agents set-secrets --id "$agent" --secret-ids "$MERGED"
+VERCEL_SECRET_ID=$(onecli secrets list | jq -r '.[] | select(.name | test("(?i)vercel")) | .id' | head -1)
+
+onecli agents list | jq -r '.[] | select(.secretMode=="selective") | "\(.id)\t\(.name)"' | \
+while IFS=$'\t' read -r agent name; do
+  CURRENT=$(onecli agents secrets --id "$agent" | jq -r '.[]')
+  MERGED=$(printf '%s\n%s\n' "$CURRENT" "$VERCEL_SECRET_ID" | grep -v '^$' | sort -u | paste -sd ',' -)
+  STATUS=$(onecli agents set-secrets --id "$agent" --secret-ids "$MERGED" | jq -r '.status')
+  echo "$name ($agent): $STATUS"
 done
 ```
+
+If only specific teams should have Vercel, narrow the jq filter — e.g., `select(.secretMode=="selective" and (.identifier // "" | test("mediamate|launchmate")))` matches by NanoClaw agent_group folder slug.
 
 ## Phase 4: Ensure Vercel CLI in Container Image
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)

## Description

The `Phase 3 — Assign the secret to all agents` block in `add-vercel/SKILL.md` has two bugs that silently misbehave on real installs.

**Bug 1 — wrong jq paths.** OneCLI's `/api/agents` and `/api/secrets` endpoints return bare arrays, not `{data: [...]}` envelopes. The skill uses `.data[]` and `[.data[]] | join(",")`, both of which evaluate to empty against the real response. The "merge" then collapses to just the new Vercel id and `set-secrets` effectively *replaces* every agent's secret list with one entry — silently dropping their other credentials (Anthropic, OpenAI, GitHub, etc.). The verify step in the skill only greps for `vercel`, so this isn't caught.

**Bug 2 — touches `all`-mode agents.** Agents in `secretMode: "all"` automatically receive every secret whose host pattern matches and need no explicit assignment. Calling `set-secrets` on an `all`-mode agent flips it to `selective` and strips that auto-access for every other secret. The default agent created by `/init-first-agent` is in `mode: all`, so the skill as-shipped breaks the primary owner DM agent on every fresh install.

## Fix

- Replace `.data[]` with `.[]` in both jq queries.
- Filter the agent loop to `select(.secretMode=="selective")` so `all`-mode agents are left alone.
- Echo the per-agent `status` from each `set-secrets` response so failures aren't silent.
- Add one trailing line showing operators how to narrow the loop to specific teams via the agent's `identifier` field (NanoClaw `agent_group_id`), since multi-team installs often want Vercel scoped to a subset.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

Tested against an install with 19 selective-mode agents + 1 default `all`-mode owner agent (OneCLI v1.1.0).