### PR TITLE
fix(cli,skills): use per-install slug for service names

### DIFF
--- a/.claude/skills/add-atomic-chat-tool/SKILL.md
+++ b/.claude/skills/add-atomic-chat-tool/SKILL.md
@@ -183,7 +183,7 @@ ATOMIC_CHAT_API_KEY=sk-...
 ### Restart the service
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```

--- a/.claude/skills/add-atomic-chat-tool/SKILL.md
+++ b/.claude/skills/add-atomic-chat-tool/SKILL.md
@@ -182,8 +182,10 @@ ATOMIC_CHAT_API_KEY=sk-...
 
 ### Restart the service
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```

--- a/.claude/skills/add-atomic-chat-tool/SKILL.md
+++ b/.claude/skills/add-atomic-chat-tool/SKILL.md
@@ -183,8 +183,9 @@ ATOMIC_CHAT_API_KEY=sk-...
 ### Restart the service
 
 ```bash
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
 ```
 
 ## Phase 4: Verify

--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -95,7 +95,7 @@ Generate the secret: `node -e "console.log('nc-' + require('crypto').randomBytes
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 systemctl --user restart $(systemd_unit)              # Linux
 # or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```

--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -93,9 +93,11 @@ Generate the secret: `node -e "console.log('nc-' + require('crypto').randomBytes
 
 ### 6. Build and restart
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```

--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -95,8 +95,9 @@ Generate the secret: `node -e "console.log('nc-' + require('crypto').randomBytes
 
 ```bash
 pnpm run build
-systemctl --user restart nanoclaw   # Linux
-# or: launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
+# or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```
 
 ### 7. Verify

--- a/.claude/skills/add-deltachat/REMOVE.md
+++ b/.claude/skills/add-deltachat/REMOVE.md
@@ -25,7 +25,7 @@ DC_SMTP_PORT
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 
 # Linux
 systemctl --user restart $(systemd_unit)

--- a/.claude/skills/add-deltachat/REMOVE.md
+++ b/.claude/skills/add-deltachat/REMOVE.md
@@ -23,9 +23,11 @@ DC_SMTP_PORT
 
 ## 3. Rebuild and restart
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 
 # Linux
 systemctl --user restart $(systemd_unit)

--- a/.claude/skills/add-deltachat/REMOVE.md
+++ b/.claude/skills/add-deltachat/REMOVE.md
@@ -25,12 +25,13 @@ DC_SMTP_PORT
 
 ```bash
 pnpm run build
+source setup/lib/install-slug.sh
 
 # Linux
-systemctl --user restart nanoclaw
+systemctl --user restart $(systemd_unit)
 
 # macOS
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 ```
 
 ## 4. Remove account data (optional)

--- a/.claude/skills/add-deltachat/SKILL.md
+++ b/.claude/skills/add-deltachat/SKILL.md
@@ -99,7 +99,7 @@ The `/set-avatar` command (send an image with that caption) is the easiest way t
 ### Restart
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 
 # Linux
 systemctl --user restart $(systemd_unit)
@@ -234,7 +234,7 @@ Set `DC_SMTP_SECURITY=1` and `DC_SMTP_PORT=465` in `.env`, then restart.
 
 ```bash
 rm -f dc-account/accounts.lock
-systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"
+systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"
 ```
 
 ### Bot not responding after restart

--- a/.claude/skills/add-deltachat/SKILL.md
+++ b/.claude/skills/add-deltachat/SKILL.md
@@ -98,8 +98,10 @@ The `/set-avatar` command (send an image with that caption) is the easiest way t
 
 ### Restart
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 
 # Linux
 systemctl --user restart $(systemd_unit)

--- a/.claude/skills/add-deltachat/SKILL.md
+++ b/.claude/skills/add-deltachat/SKILL.md
@@ -99,11 +99,13 @@ The `/set-avatar` command (send an image with that caption) is the easiest way t
 ### Restart
 
 ```bash
+source setup/lib/install-slug.sh
+
 # Linux
-systemctl --user restart nanoclaw
+systemctl --user restart $(systemd_unit)
 
 # macOS
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 ```
 
 On first start the adapter configures the email account (IMAP/SMTP credentials, calls `configure()`). Subsequent starts skip straight to `startIo()`. Account data is stored in `dc-account/` in the project root (or your `DC_ACCOUNT_DIR`).
@@ -232,7 +234,7 @@ Set `DC_SMTP_SECURITY=1` and `DC_SMTP_PORT=465` in `.env`, then restart.
 
 ```bash
 rm -f dc-account/accounts.lock
-systemctl --user restart nanoclaw
+systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"
 ```
 
 ### Bot not responding after restart

--- a/.claude/skills/add-emacs/SKILL.md
+++ b/.claude/skills/add-emacs/SKILL.md
@@ -164,7 +164,7 @@ If you changed `EMACS_CHANNEL_PORT` from the default:
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 # systemctl --user restart $(systemd_unit)             # Linux
 ```
@@ -241,7 +241,7 @@ grep -q "import './emacs.js'" src/channels/index.ts && echo "imported" || echo "
 
 ### No response from agent
 
-1. NanoClaw running: `launchctl list | grep nanoclaw` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux)
+1. NanoClaw running: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux) — run from the project root so the slug helper resolves
 2. Messaging group wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, ag.folder FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id JOIN agent_groups ag ON ag.id = mga.agent_group_id WHERE mg.channel_type = 'emacs'"`
 3. Logs show inbound: `grep 'channel_type=emacs\|Emacs' logs/nanoclaw.log | tail -20`
 
@@ -288,7 +288,7 @@ rm src/channels/emacs.ts src/channels/emacs.test.ts emacs/nanoclaw.el
 # Remove the `import './emacs.js';` line from src/channels/index.ts
 # Remove EMACS_* lines from .env
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 # systemctl --user restart $(systemd_unit)             # Linux
 

--- a/.claude/skills/add-emacs/SKILL.md
+++ b/.claude/skills/add-emacs/SKILL.md
@@ -162,9 +162,11 @@ If you changed `EMACS_CHANNEL_PORT` from the default:
 
 ## Restart NanoClaw
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 # systemctl --user restart $(systemd_unit)             # Linux
 ```
@@ -241,7 +243,7 @@ grep -q "import './emacs.js'" src/channels/index.ts && echo "imported" || echo "
 
 ### No response from agent
 
-1. NanoClaw running: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux) — run from the project root so the slug helper resolves
+1. NanoClaw running: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux)
 2. Messaging group wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, ag.folder FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id JOIN agent_groups ag ON ag.id = mga.agent_group_id WHERE mg.channel_type = 'emacs'"`
 3. Logs show inbound: `grep 'channel_type=emacs\|Emacs' logs/nanoclaw.log | tail -20`
 
@@ -283,12 +285,14 @@ If an agent outputs org-mode directly, markers get double-converted and render i
 
 ## Removal
 
+Run from your NanoClaw project root:
+
 ```bash
 rm src/channels/emacs.ts src/channels/emacs.test.ts emacs/nanoclaw.el
 # Remove the `import './emacs.js';` line from src/channels/index.ts
 # Remove EMACS_* lines from .env
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 # systemctl --user restart $(systemd_unit)             # Linux
 

--- a/.claude/skills/add-emacs/SKILL.md
+++ b/.claude/skills/add-emacs/SKILL.md
@@ -164,8 +164,9 @@ If you changed `EMACS_CHANNEL_PORT` from the default:
 
 ```bash
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
-# systemctl --user restart nanoclaw                # Linux
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
+# systemctl --user restart $(systemd_unit)             # Linux
 ```
 
 ## Verify
@@ -240,7 +241,7 @@ grep -q "import './emacs.js'" src/channels/index.ts && echo "imported" || echo "
 
 ### No response from agent
 
-1. NanoClaw running: `launchctl list | grep nanoclaw` (macOS) / `systemctl --user status nanoclaw` (Linux)
+1. NanoClaw running: `launchctl list | grep nanoclaw` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux)
 2. Messaging group wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, ag.folder FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id JOIN agent_groups ag ON ag.id = mga.agent_group_id WHERE mg.channel_type = 'emacs'"`
 3. Logs show inbound: `grep 'channel_type=emacs\|Emacs' logs/nanoclaw.log | tail -20`
 
@@ -287,8 +288,9 @@ rm src/channels/emacs.ts src/channels/emacs.test.ts emacs/nanoclaw.el
 # Remove the `import './emacs.js';` line from src/channels/index.ts
 # Remove EMACS_* lines from .env
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
-# systemctl --user restart nanoclaw                # Linux
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
+# systemctl --user restart $(systemd_unit)             # Linux
 
 # Remove the NanoClaw block from your Emacs config
 # Optionally clean up the messaging group:

--- a/.claude/skills/add-gcal-tool/SKILL.md
+++ b/.claude/skills/add-gcal-tool/SKILL.md
@@ -175,8 +175,14 @@ Run from your NanoClaw project root (where `data/v2.db` lives). The `$[#]` place
 
 ```bash
 pnpm run build
-systemctl --user restart nanoclaw   # Linux
-# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+```
+
+Run from your NanoClaw project root:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
 ```
 
 Kill any existing agent containers so they respawn with the new mcpServers config:
@@ -220,7 +226,7 @@ Common signals:
      WHERE agent_group_id = '<group-id>';"
    ```
 3. Remove `CALENDAR_MCP_VERSION` ARG and the calendar package from the Dockerfile install block.
-4. `pnpm run build && ./container/build.sh && systemctl --user restart nanoclaw`.
+4. `pnpm run build && ./container/build.sh && systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`.
 5. Optional: `rm -rf ~/.calendar-mcp/` and `onecli apps disconnect --provider google-calendar`.
 
 No `TOOL_ALLOWLIST` removal step — Phase 2 no longer edits it.

--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -139,7 +139,7 @@ If you're in the middle of `/setup`, return to the setup flow now.
 Otherwise, restart the service to pick up the new channel:
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -136,7 +136,9 @@ Use `per-thread` session mode so each PR/issue gets its own agent session.
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service to pick up the new channel — run from your NanoClaw project root:
+Otherwise, restart the service to pick up the new channel.
+
+Run from your NanoClaw project root:
 
 ```bash
 source setup/lib/install-slug.sh

--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -136,10 +136,10 @@ Use `per-thread` session mode so each PR/issue gets its own agent session.
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service to pick up the new channel:
+Otherwise, restart the service to pick up the new channel — run from your NanoClaw project root:
 
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -136,7 +136,13 @@ Use `per-thread` session mode so each PR/issue gets its own agent session.
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service (`systemctl --user restart nanoclaw` or `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`) to pick up the new channel.
+Otherwise, restart the service to pick up the new channel:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
+```
 
 ## Channel Info
 

--- a/.claude/skills/add-gmail-tool/SKILL.md
+++ b/.claude/skills/add-gmail-tool/SKILL.md
@@ -192,8 +192,14 @@ Run from your NanoClaw project root (where `data/v2.db` lives). The `$[#]` place
 
 ```bash
 pnpm run build
-systemctl --user restart nanoclaw  # Linux
-# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+```
+
+Run from your NanoClaw project root:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
 ```
 
 ## Phase 5: Verify
@@ -235,7 +241,7 @@ Common signals:
      WHERE agent_group_id = '<group-id>';"
    ```
 3. Remove the `GMAIL_MCP_VERSION` ARG and the `pnpm install -g @gongrzhe/server-gmail-autoauth-mcp` block from `container/Dockerfile`.
-4. `pnpm run build && ./container/build.sh && systemctl --user restart nanoclaw`.
+4. `pnpm run build && ./container/build.sh && systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`.
 5. (Optional) `rm -rf ~/.gmail-mcp/` if no other host-side tool needs the stubs.
 6. (Optional) Disconnect Gmail in OneCLI: `onecli apps disconnect --provider gmail`.
 

--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -76,7 +76,7 @@ If yes, ask the agent to schedule the lint task using the `schedule_task` MCP to
 ## Step 6: Restart
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -75,8 +75,10 @@ If yes, ask the agent to schedule the lint task using the `schedule_task` MCP to
 
 ## Step 6: Restart
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-karpathy-llm-wiki/SKILL.md
+++ b/.claude/skills/add-karpathy-llm-wiki/SKILL.md
@@ -76,8 +76,9 @@ If yes, ask the agent to schedule the lint task using the `schedule_task` MCP to
 ## Step 6: Restart
 
 ```bash
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
 ```
 
 Tell the user to test by sending a source to the wiki group.

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -159,7 +159,7 @@ If you're in the middle of `/setup`, return to the setup flow now.
 Otherwise, restart the service to pick up the new channel:
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -156,7 +156,9 @@ The `platform_id` must be `linear:<TEAM_KEY>` matching the `LINEAR_TEAM_KEY` env
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service to pick up the new channel — run from your NanoClaw project root:
+Otherwise, restart the service to pick up the new channel.
+
+Run from your NanoClaw project root:
 
 ```bash
 source setup/lib/install-slug.sh

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -156,10 +156,10 @@ The `platform_id` must be `linear:<TEAM_KEY>` matching the `LINEAR_TEAM_KEY` env
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service to pick up the new channel:
+Otherwise, restart the service to pick up the new channel — run from your NanoClaw project root:
 
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -156,7 +156,13 @@ The `platform_id` must be `linear:<TEAM_KEY>` matching the `LINEAR_TEAM_KEY` env
 
 If you're in the middle of `/setup`, return to the setup flow now.
 
-Otherwise, restart the service (`systemctl --user restart nanoclaw` or `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`) to pick up the new channel.
+Otherwise, restart the service to pick up the new channel:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
+```
 
 ## Channel Info
 

--- a/.claude/skills/add-mnemon/SKILL.md
+++ b/.claude/skills/add-mnemon/SKILL.md
@@ -90,7 +90,7 @@ docker run --rm --entrypoint mnemon nanoclaw-agent:latest --version
 ### Restart the service
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 systemctl --user restart $(systemd_unit)              # Linux
 # launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 ```

--- a/.claude/skills/add-mnemon/SKILL.md
+++ b/.claude/skills/add-mnemon/SKILL.md
@@ -89,8 +89,10 @@ docker run --rm --entrypoint mnemon nanoclaw-agent:latest --version
 
 ### Restart the service
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 ```

--- a/.claude/skills/add-mnemon/SKILL.md
+++ b/.claude/skills/add-mnemon/SKILL.md
@@ -90,8 +90,9 @@ docker run --rm --entrypoint mnemon nanoclaw-agent:latest --version
 ### Restart the service
 
 ```bash
-systemctl --user restart nanoclaw          # Linux
-# launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
+# launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
 ```
 
 ### Confirm mnemon hooks are registered

--- a/.claude/skills/add-ollama-provider/SKILL.md
+++ b/.claude/skills/add-ollama-provider/SKILL.md
@@ -133,7 +133,7 @@ file, not from env vars. This file is bind-mounted into the container as `~/.cla
 ```bash
 export PATH="/opt/homebrew/bin:$PATH"
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
 launchctl load   ~/Library/LaunchAgents/$(launchd_label).plist
 # Linux: systemctl --user restart $(systemd_unit)

--- a/.claude/skills/add-ollama-provider/SKILL.md
+++ b/.claude/skills/add-ollama-provider/SKILL.md
@@ -130,10 +130,12 @@ file, not from env vars. This file is bind-mounted into the container as `~/.cla
 
 ## 5. Build and restart
 
+Run from your NanoClaw project root:
+
 ```bash
 export PATH="/opt/homebrew/bin:$PATH"
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
 launchctl load   ~/Library/LaunchAgents/$(launchd_label).plist
 # Linux: systemctl --user restart $(systemd_unit)

--- a/.claude/skills/add-ollama-provider/SKILL.md
+++ b/.claude/skills/add-ollama-provider/SKILL.md
@@ -133,9 +133,10 @@ file, not from env vars. This file is bind-mounted into the container as `~/.cla
 ```bash
 export PATH="/opt/homebrew/bin:$PATH"
 pnpm run build
-launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
-launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
+launchctl load   ~/Library/LaunchAgents/$(launchd_label).plist
+# Linux: systemctl --user restart $(systemd_unit)
 ```
 
 ## 6. Verify

--- a/.claude/skills/add-ollama-tool/SKILL.md
+++ b/.claude/skills/add-ollama-tool/SKILL.md
@@ -123,7 +123,7 @@ OLLAMA_HOST=http://your-ollama-host:11434
 ### Restart the service
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-ollama-tool/SKILL.md
+++ b/.claude/skills/add-ollama-tool/SKILL.md
@@ -122,8 +122,10 @@ OLLAMA_HOST=http://your-ollama-host:11434
 
 ### Restart the service
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/add-ollama-tool/SKILL.md
+++ b/.claude/skills/add-ollama-tool/SKILL.md
@@ -123,8 +123,9 @@ OLLAMA_HOST=http://your-ollama-host:11434
 ### Restart the service
 
 ```bash
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
 ```
 
 ## Phase 4: Verify

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -233,17 +233,16 @@ Rebuild the main app and restart:
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```
 
-Wait 3 seconds for service to start, then verify:
+Wait 3 seconds for service to start, then verify (run from the project root so the slug helper resolves):
 ```bash
 sleep 3
-source setup/lib/install-slug.sh
-launchctl list | grep "$(launchd_label)"  # macOS
-# Linux: systemctl --user status $(systemd_unit)
+launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"  # macOS
+# Linux: systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"
 ```
 
 ### 8. Test Integration

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -229,16 +229,16 @@ echo '{}' | docker run -i --entrypoint /bin/echo nanoclaw-agent:latest "Containe
 
 ### 7. Restart Service
 
-Rebuild the main app and restart:
+Rebuild the main app and restart, from your NanoClaw project root:
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```
 
-Wait 3 seconds for service to start, then verify (run from the project root so the slug helper resolves):
+Wait 3 seconds for service to start, then verify:
 ```bash
 sleep 3
 launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"  # macOS

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -229,7 +229,9 @@ echo '{}' | docker run -i --entrypoint /bin/echo nanoclaw-agent:latest "Containe
 
 ### 7. Restart Service
 
-Rebuild the main app and restart, from your NanoClaw project root:
+Rebuild the main app and restart.
+
+Run from your NanoClaw project root:
 
 ```bash
 pnpm run build

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -233,15 +233,17 @@ Rebuild the main app and restart:
 
 ```bash
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
 ```
 
 Wait 3 seconds for service to start, then verify:
 ```bash
 sleep 3
-launchctl list | grep nanoclaw  # macOS
-# Linux: systemctl --user status nanoclaw
+source setup/lib/install-slug.sh
+launchctl list | grep "$(launchd_label)"  # macOS
+# Linux: systemctl --user status $(systemd_unit)
 ```
 
 ### 8. Test Integration
@@ -287,4 +289,4 @@ To remove Parallel AI integration:
 2. Revert changes to container-runner.ts and agent-runner/src/index.ts
 3. Remove Web Research Tools section from groups/main/CLAUDE.md
 4. Rebuild: `./container/build.sh && pnpm run build`
-5. Restart: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `systemctl --user restart nanoclaw` (Linux)
+5. Restart: `source setup/lib/install-slug.sh && launchctl kickstart -k gui/$(id -u)/$(launchd_label)` (macOS) or `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (Linux)

--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -91,7 +91,7 @@ No output = success.
 > ⚠ Stop NanoClaw before running signal-cli commands — the daemon holds an exclusive lock on its data directory while running.
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 
 # macOS
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
@@ -188,7 +188,7 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 ### Restart
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 
 # macOS
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)
@@ -287,7 +287,7 @@ If you see `Signal daemon not reachable at 127.0.0.1:7583` and `SIGNAL_MANAGE_DA
 
 1. Channel initialized: `grep "Signal channel connected" logs/nanoclaw.log | tail -1`
 2. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id WHERE mg.channel_type='signal'"`
-3. Service running: `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux)
+3. Service running: `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux) — run from the project root so the slug helper resolves
 4. **Check for duplicate service instances** — if `logs/nanoclaw.error.log` shows `No adapter for channel type channelType="signal"` despite the adapter starting, two NanoClaw processes are racing. See the `/debug` skill section "No adapter for channel type / Messages silently lost" for the full fix.
 
 ### Messages delivered but never arrive (null platformMsgId)

--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -90,8 +90,10 @@ No output = success.
 
 > ⚠ Stop NanoClaw before running signal-cli commands — the daemon holds an exclusive lock on its data directory while running.
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 
 # macOS
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
@@ -187,8 +189,10 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 
 ### Restart
 
+Run from your NanoClaw project root:
+
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 
 # macOS
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)
@@ -287,7 +291,7 @@ If you see `Signal daemon not reachable at 127.0.0.1:7583` and `SIGNAL_MANAGE_DA
 
 1. Channel initialized: `grep "Signal channel connected" logs/nanoclaw.log | tail -1`
 2. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id WHERE mg.channel_type='signal'"`
-3. Service running: `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux) — run from the project root so the slug helper resolves
+3. Service running: `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux)
 4. **Check for duplicate service instances** — if `logs/nanoclaw.error.log` shows `No adapter for channel type channelType="signal"` despite the adapter starting, two NanoClaw processes are racing. See the `/debug` skill section "No adapter for channel type / Messages silently lost" for the full fix.
 
 ### Messages delivered but never arrive (null platformMsgId)

--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -91,16 +91,18 @@ No output = success.
 > ⚠ Stop NanoClaw before running signal-cli commands — the daemon holds an exclusive lock on its data directory while running.
 
 ```bash
+source setup/lib/install-slug.sh
+
 # macOS
-launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
 signal-cli -a +1YOURNUMBER updateProfile --name "YourBotName"
 # optionally: --avatar /path/to/avatar.jpg
-launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl load ~/Library/LaunchAgents/$(launchd_label).plist
 
 # Linux
-systemctl --user stop nanoclaw
+systemctl --user stop $(systemd_unit)
 signal-cli -a +1YOURNUMBER updateProfile --name "YourBotName"
-systemctl --user start nanoclaw
+systemctl --user start $(systemd_unit)
 ```
 
 ### Path B: Link as secondary device
@@ -186,11 +188,13 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 ### Restart
 
 ```bash
+source setup/lib/install-slug.sh
+
 # macOS
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 
 # Linux
-systemctl --user restart nanoclaw
+systemctl --user restart $(systemd_unit)
 ```
 
 ## Wiring
@@ -283,7 +287,7 @@ If you see `Signal daemon not reachable at 127.0.0.1:7583` and `SIGNAL_MANAGE_DA
 
 1. Channel initialized: `grep "Signal channel connected" logs/nanoclaw.log | tail -1`
 2. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id = mga.messaging_group_id WHERE mg.channel_type='signal'"`
-3. Service running: `launchctl print gui/$(id -u)/com.nanoclaw` (macOS) / `systemctl --user status nanoclaw` (Linux)
+3. Service running: `launchctl print gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"` (macOS) / `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux)
 4. **Check for duplicate service instances** — if `logs/nanoclaw.error.log` shows `No adapter for channel type channelType="signal"` despite the adapter starting, two NanoClaw processes are racing. See the `/debug` skill section "No adapter for channel type / Messages silently lost" for the full fix.
 
 ### Messages delivered but never arrive (null platformMsgId)

--- a/.claude/skills/add-wechat/REMOVE.md
+++ b/.claude/skills/add-wechat/REMOVE.md
@@ -43,7 +43,7 @@ DELETE FROM messaging_groups WHERE channel_type = 'wechat';
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 systemctl --user restart $(systemd_unit)              # Linux
 # or
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS

--- a/.claude/skills/add-wechat/REMOVE.md
+++ b/.claude/skills/add-wechat/REMOVE.md
@@ -41,9 +41,11 @@ DELETE FROM messaging_groups WHERE channel_type = 'wechat';
 
 ### 6. Rebuild and restart
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # or
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS

--- a/.claude/skills/add-wechat/REMOVE.md
+++ b/.claude/skills/add-wechat/REMOVE.md
@@ -43,7 +43,8 @@ DELETE FROM messaging_groups WHERE channel_type = 'wechat';
 
 ```bash
 pnpm run build
-systemctl --user restart nanoclaw   # Linux
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
 # or
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```

--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -85,7 +85,7 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 Restart NanoClaw:
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 systemctl --user restart $(systemd_unit)              # Linux
 # or
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS

--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -82,10 +82,10 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 
 ### 2. Start the service and scan the QR
 
-Restart NanoClaw:
+Restart NanoClaw — run from your NanoClaw project root:
 
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # or
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS

--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -82,7 +82,9 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 
 ### 2. Start the service and scan the QR
 
-Restart NanoClaw — run from your NanoClaw project root:
+Restart NanoClaw.
+
+Run from your NanoClaw project root:
 
 ```bash
 source setup/lib/install-slug.sh

--- a/.claude/skills/add-wechat/SKILL.md
+++ b/.claude/skills/add-wechat/SKILL.md
@@ -85,9 +85,10 @@ Sync to container: `mkdir -p data/env && cp .env data/env/env`
 Restart NanoClaw:
 
 ```bash
-systemctl --user restart nanoclaw   # Linux
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
 # or
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```
 
 The adapter will print a **QR URL** to the logs and save it to `data/wechat/qr.txt`:

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -247,7 +247,7 @@ rm -rf store/auth/ && pnpm exec tsx setup/index.ts --step whatsapp-auth -- --met
 Signal sessions corrupted from rapid restarts. Clear sessions:
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 systemctl --user stop $(systemd_unit)
 rm store/auth/session-*.json
 systemctl --user start $(systemd_unit)
@@ -258,7 +258,7 @@ systemctl --user start $(systemd_unit)
 1. Auth exists: `test -f store/auth/creds.json`
 2. Connected: `grep "Connected to WhatsApp" logs/nanoclaw.log | tail -1`
 3. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id=mga.messaging_group_id WHERE mg.channel_type='whatsapp'"`
-4. Service running: `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"`
+4. Service running: `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (run from the project root so the slug helper resolves)
 
 ### "conflict" disconnection
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -244,7 +244,9 @@ rm -rf store/auth/ && pnpm exec tsx setup/index.ts --step whatsapp-auth -- --met
 
 ### "waiting for this message" on reactions
 
-Signal sessions corrupted from rapid restarts. Clear sessions — run from your NanoClaw project root:
+Signal sessions corrupted from rapid restarts. Clear sessions.
+
+Run from your NanoClaw project root:
 
 ```bash
 source setup/lib/install-slug.sh

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -244,10 +244,10 @@ rm -rf store/auth/ && pnpm exec tsx setup/index.ts --step whatsapp-auth -- --met
 
 ### "waiting for this message" on reactions
 
-Signal sessions corrupted from rapid restarts. Clear sessions:
+Signal sessions corrupted from rapid restarts. Clear sessions — run from your NanoClaw project root:
 
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 systemctl --user stop $(systemd_unit)
 rm store/auth/session-*.json
 systemctl --user start $(systemd_unit)
@@ -258,7 +258,7 @@ systemctl --user start $(systemd_unit)
 1. Auth exists: `test -f store/auth/creds.json`
 2. Connected: `grep "Connected to WhatsApp" logs/nanoclaw.log | tail -1`
 3. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id=mga.messaging_group_id WHERE mg.channel_type='whatsapp'"`
-4. Service running: `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (run from the project root so the slug helper resolves)
+4. Service running: `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"`
 
 ### "conflict" disconnection
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -247,9 +247,10 @@ rm -rf store/auth/ && pnpm exec tsx setup/index.ts --step whatsapp-auth -- --met
 Signal sessions corrupted from rapid restarts. Clear sessions:
 
 ```bash
-systemctl --user stop nanoclaw
+source setup/lib/install-slug.sh
+systemctl --user stop $(systemd_unit)
 rm store/auth/session-*.json
-systemctl --user start nanoclaw
+systemctl --user start $(systemd_unit)
 ```
 
 ### Bot not responding
@@ -257,7 +258,7 @@ systemctl --user start nanoclaw
 1. Auth exists: `test -f store/auth/creds.json`
 2. Connected: `grep "Connected to WhatsApp" logs/nanoclaw.log | tail -1`
 3. Channel wired: `pnpm exec tsx scripts/q.ts data/v2.db "SELECT mg.platform_id, mg.name FROM messaging_groups mg JOIN messaging_group_agents mga ON mg.id=mga.messaging_group_id WHERE mg.channel_type='whatsapp'"`
-4. Service running: `systemctl --user status nanoclaw`
+4. Service running: `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"`
 
 ### "conflict" disconnection
 

--- a/.claude/skills/convert-to-apple-container/SKILL.md
+++ b/.claude/skills/convert-to-apple-container/SKILL.md
@@ -173,7 +173,7 @@ Expected: Both operations succeed.
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 ```
 

--- a/.claude/skills/convert-to-apple-container/SKILL.md
+++ b/.claude/skills/convert-to-apple-container/SKILL.md
@@ -171,9 +171,11 @@ Expected: Both operations succeed.
 
 ### Full integration test
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 ```
 

--- a/.claude/skills/convert-to-apple-container/SKILL.md
+++ b/.claude/skills/convert-to-apple-container/SKILL.md
@@ -173,7 +173,8 @@ Expected: Both operations succeed.
 
 ```bash
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
 ```
 
 Send a message via WhatsApp and verify the agent responds.

--- a/.claude/skills/customize/SKILL.md
+++ b/.claude/skills/customize/SKILL.md
@@ -92,7 +92,7 @@ Always tell the user:
 ```bash
 # Rebuild and restart
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 # macOS:
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
 launchctl load ~/Library/LaunchAgents/$(launchd_label).plist

--- a/.claude/skills/customize/SKILL.md
+++ b/.claude/skills/customize/SKILL.md
@@ -88,11 +88,11 @@ Implementation:
 
 ## After Changes
 
-Always tell the user:
+Always tell the user — run from your NanoClaw project root:
 ```bash
 # Rebuild and restart
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 # macOS:
 launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
 launchctl load ~/Library/LaunchAgents/$(launchd_label).plist

--- a/.claude/skills/customize/SKILL.md
+++ b/.claude/skills/customize/SKILL.md
@@ -88,7 +88,10 @@ Implementation:
 
 ## After Changes
 
-Always tell the user — run from your NanoClaw project root:
+Always tell the user.
+
+Run from your NanoClaw project root:
+
 ```bash
 # Rebuild and restart
 pnpm run build

--- a/.claude/skills/customize/SKILL.md
+++ b/.claude/skills/customize/SKILL.md
@@ -92,11 +92,12 @@ Always tell the user:
 ```bash
 # Rebuild and restart
 pnpm run build
+source setup/lib/install-slug.sh
 # macOS:
-launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
-launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl unload ~/Library/LaunchAgents/$(launchd_label).plist
+launchctl load ~/Library/LaunchAgents/$(launchd_label).plist
 # Linux:
-# systemctl --user restart nanoclaw
+# systemctl --user restart $(systemd_unit)
 ```
 
 ## Example Interaction

--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -9,7 +9,7 @@ Stand up the first NanoClaw agent for a channel and verify end-to-end delivery b
 
 ## Prerequisites
 
-- **Service running.** Check: `launchctl list | grep nanoclaw` (macOS) or `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux). If stopped, tell the user to run `/setup` first.
+- **Service running.** Check: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) or `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux). Run from the project root so the slug helper resolves. If stopped, tell the user to run `/setup` first.
 - **Target channel installed.** At least one `/add-<channel>` skill has run, credentials are in `.env`, and the adapter is uncommented in `src/channels/index.ts`.
 - **Adapter connected.** Tail `logs/nanoclaw.log` — look for a recent `channel setup` / `adapter connected` line for the target channel.
 

--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -9,7 +9,7 @@ Stand up the first NanoClaw agent for a channel and verify end-to-end delivery b
 
 ## Prerequisites
 
-- **Service running.** Check: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) or `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux). Run from the project root so the slug helper resolves. If stopped, tell the user to run `/setup` first.
+- **Service running.** Check: `launchctl list | grep "$(. setup/lib/install-slug.sh && launchd_label)"` (macOS) or `systemctl --user status "$(. setup/lib/install-slug.sh && systemd_unit)"` (Linux). If stopped, tell the user to run `/setup` first.
 - **Target channel installed.** At least one `/add-<channel>` skill has run, credentials are in `.env`, and the adapter is uncommented in `src/channels/index.ts`.
 - **Adapter connected.** Tail `logs/nanoclaw.log` — look for a recent `channel setup` / `adapter connected` line for the target channel.
 

--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -9,7 +9,7 @@ Stand up the first NanoClaw agent for a channel and verify end-to-end delivery b
 
 ## Prerequisites
 
-- **Service running.** Check: `launchctl list | grep nanoclaw` (macOS) or `systemctl --user status nanoclaw` (Linux). If stopped, tell the user to run `/setup` first.
+- **Service running.** Check: `launchctl list | grep nanoclaw` (macOS) or `systemctl --user status "$(. setup/lib/install-slug.sh; systemd_unit)"` (Linux). If stopped, tell the user to run `/setup` first.
 - **Target channel installed.** At least one `/add-<channel>` skill has run, credentials are in `.env`, and the adapter is uncommented in `src/channels/index.ts`.
 - **Adapter connected.** Tail `logs/nanoclaw.log` — look for a recent `channel setup` / `adapter connected` line for the target channel.
 

--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -236,9 +236,9 @@ pnpm run build
 
 If build fails, diagnose and fix. Common issue: `@onecli-sh/sdk` not installed — run `pnpm install` first.
 
-Restart the service:
-- macOS (launchd): `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"`
-- Linux (systemd): `systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"`
+Restart the service (run from your NanoClaw project root so the slug helper resolves):
+- macOS (launchd): `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
+- Linux (systemd): `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`
 
 ## Phase 5: Verify

--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -236,7 +236,10 @@ pnpm run build
 
 If build fails, diagnose and fix. Common issue: `@onecli-sh/sdk` not installed — run `pnpm install` first.
 
-Restart the service, from your NanoClaw project root:
+Restart the service.
+
+Run from your NanoClaw project root:
+
 - macOS (launchd): `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
 - Linux (systemd): `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`

--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -236,7 +236,7 @@ pnpm run build
 
 If build fails, diagnose and fix. Common issue: `@onecli-sh/sdk` not installed — run `pnpm install` first.
 
-Restart the service (run from your NanoClaw project root so the slug helper resolves):
+Restart the service, from your NanoClaw project root:
 - macOS (launchd): `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
 - Linux (systemd): `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`

--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -237,8 +237,8 @@ pnpm run build
 If build fails, diagnose and fix. Common issue: `@onecli-sh/sdk` not installed — run `pnpm install` first.
 
 Restart the service:
-- macOS (launchd): `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
-- Linux (systemd): `systemctl --user restart nanoclaw`
+- macOS (launchd): `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"`
+- Linux (systemd): `systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`
 
 ## Phase 5: Verify

--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -44,7 +44,7 @@ npx tsx setup/index.ts --step mounts --force -- --empty
 Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`):
 
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -41,10 +41,10 @@ npx tsx setup/index.ts --step mounts --force -- --empty
 
 ## After Changes
 
-Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`):
+Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`). Run from your NanoClaw project root:
 
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 systemctl --user restart $(systemd_unit)              # Linux
 ```

--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -41,7 +41,9 @@ npx tsx setup/index.ts --step mounts --force -- --empty
 
 ## After Changes
 
-Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`). Run from your NanoClaw project root:
+Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`).
+
+Run from your NanoClaw project root:
 
 ```bash
 source setup/lib/install-slug.sh

--- a/.claude/skills/manage-mounts/SKILL.md
+++ b/.claude/skills/manage-mounts/SKILL.md
@@ -41,7 +41,10 @@ npx tsx setup/index.ts --step mounts --force -- --empty
 
 ## After Changes
 
-Restart the service so containers pick up the new config:
+Restart the service so containers pick up the new config (the unit/label names are per-install — see `setup/lib/install-slug.sh`):
 
-- macOS: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
-- Linux: `systemctl --user restart nanoclaw`
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
+```

--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -270,9 +270,9 @@ Show:
 Tell the user:
 - To rollback: `git reset --hard <backup-tag-from-step-1>`
 - Backup branch also exists: `backup/pre-update-<HASH>-<TIMESTAMP>`
-- Restart the service to apply changes. The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
+- Restart the service to apply changes (run from your NanoClaw project root so the slug helper resolves). The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
   - **macOS (Darwin)**: `source setup/lib/install-slug.sh && launchctl kickstart -k gui/$(id -u)/$(launchd_label)`
-  - **Linux**: `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (or, if you want to confirm the unit name first: `systemctl --user list-units --type=service | grep "$(. setup/lib/install-slug.sh; systemd_unit)"`)
+  - **Linux**: `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (or, if you want to confirm the unit name first: `systemctl --user list-units --type=service | grep "$(. setup/lib/install-slug.sh && systemd_unit)"`)
   - **Manual** (no service found): restart `pnpm run dev`
 
 

--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -270,7 +270,7 @@ Show:
 Tell the user:
 - To rollback: `git reset --hard <backup-tag-from-step-1>`
 - Backup branch also exists: `backup/pre-update-<HASH>-<TIMESTAMP>`
-- Restart the service to apply changes (run from your NanoClaw project root so the slug helper resolves). The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
+- Restart the service to apply changes, from your NanoClaw project root. The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
   - **macOS (Darwin)**: `source setup/lib/install-slug.sh && launchctl kickstart -k gui/$(id -u)/$(launchd_label)`
   - **Linux**: `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (or, if you want to confirm the unit name first: `systemctl --user list-units --type=service | grep "$(. setup/lib/install-slug.sh && systemd_unit)"`)
   - **Manual** (no service found): restart `pnpm run dev`

--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -270,7 +270,7 @@ Show:
 Tell the user:
 - To rollback: `git reset --hard <backup-tag-from-step-1>`
 - Backup branch also exists: `backup/pre-update-<HASH>-<TIMESTAMP>`
-- Restart the service to apply changes, from your NanoClaw project root. The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
+- Restart the service to apply changes. The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`. Run from your NanoClaw project root:
   - **macOS (Darwin)**: `source setup/lib/install-slug.sh && launchctl kickstart -k gui/$(id -u)/$(launchd_label)`
   - **Linux**: `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (or, if you want to confirm the unit name first: `systemctl --user list-units --type=service | grep "$(. setup/lib/install-slug.sh && systemd_unit)"`)
   - **Manual** (no service found): restart `pnpm run dev`

--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -270,9 +270,9 @@ Show:
 Tell the user:
 - To rollback: `git reset --hard <backup-tag-from-step-1>`
 - Backup branch also exists: `backup/pre-update-<HASH>-<TIMESTAMP>`
-- Restart the service to apply changes. Detect platform with `uname -s`:
-  - **macOS (Darwin)**: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
-  - **Linux**: detect the service name with `systemctl --user list-units --type=service | grep nanoclaw | awk '{print $1}'`, then `systemctl --user restart <detected-name>`
+- Restart the service to apply changes. The unit/label names are per-install — derive them with `setup/lib/install-slug.sh`:
+  - **macOS (Darwin)**: `source setup/lib/install-slug.sh && launchctl kickstart -k gui/$(id -u)/$(launchd_label)`
+  - **Linux**: `source setup/lib/install-slug.sh && systemctl --user restart $(systemd_unit)` (or, if you want to confirm the unit name first: `systemctl --user list-units --type=service | grep "$(. setup/lib/install-slug.sh; systemd_unit)"`)
   - **Manual** (no service found): restart `pnpm run dev`
 
 

--- a/.claude/skills/use-native-credential-proxy/SKILL.md
+++ b/.claude/skills/use-native-credential-proxy/SKILL.md
@@ -128,9 +128,9 @@ echo 'ANTHROPIC_API_KEY=<key>' >> .env
 pnpm run build
 ```
 
-Then restart the service:
-- macOS: `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"`
-- Linux: `systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"`
+Then restart the service (run from your NanoClaw project root so the slug helper resolves):
+- macOS: `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
+- Linux: `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`
 
 2. Check logs for successful proxy startup:

--- a/.claude/skills/use-native-credential-proxy/SKILL.md
+++ b/.claude/skills/use-native-credential-proxy/SKILL.md
@@ -128,7 +128,7 @@ echo 'ANTHROPIC_API_KEY=<key>' >> .env
 pnpm run build
 ```
 
-Then restart the service (run from your NanoClaw project root so the slug helper resolves):
+Then restart the service, from your NanoClaw project root:
 - macOS: `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
 - Linux: `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`

--- a/.claude/skills/use-native-credential-proxy/SKILL.md
+++ b/.claude/skills/use-native-credential-proxy/SKILL.md
@@ -128,7 +128,10 @@ echo 'ANTHROPIC_API_KEY=<key>' >> .env
 pnpm run build
 ```
 
-Then restart the service, from your NanoClaw project root:
+Then restart the service.
+
+Run from your NanoClaw project root:
+
 - macOS: `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh && launchd_label)"`
 - Linux: `systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`

--- a/.claude/skills/use-native-credential-proxy/SKILL.md
+++ b/.claude/skills/use-native-credential-proxy/SKILL.md
@@ -129,8 +129,8 @@ pnpm run build
 ```
 
 Then restart the service:
-- macOS: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
-- Linux: `systemctl --user restart nanoclaw`
+- macOS: `launchctl kickstart -k gui/$(id -u)/"$(. setup/lib/install-slug.sh; launchd_label)"`
+- Linux: `systemctl --user restart "$(. setup/lib/install-slug.sh; systemd_unit)"`
 - WSL/manual: stop and re-run `bash start-nanoclaw.sh`
 
 2. Check logs for successful proxy startup:

--- a/.claude/skills/x-integration/SKILL.md
+++ b/.claude/skills/x-integration/SKILL.md
@@ -49,7 +49,7 @@ pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/s
 
 # 3. Rebuild host and restart service
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 # Verify: launchctl list | grep "$(launchd_label)" (macOS) or systemctl --user status $(systemd_unit) (Linux)
@@ -273,14 +273,14 @@ cat data/x-auth.json  # Should show {"authenticated": true, ...}
 
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```
 
 **Verify success:**
 ```bash
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl list | grep "$(launchd_label)"  # macOS — should show PID and exit code 0 or -
 # Linux: systemctl --user status $(systemd_unit)
 ```
@@ -348,7 +348,7 @@ echo '{"content":"Test"}' | pnpm exec tsx .claude/skills/x-integration/scripts/p
 
 ```bash
 pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
-source setup/lib/install-slug.sh
+source setup/lib/install-slug.sh  # run from your NanoClaw project root
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```

--- a/.claude/skills/x-integration/SKILL.md
+++ b/.claude/skills/x-integration/SKILL.md
@@ -38,6 +38,8 @@ Before using this skill, ensure:
 
 ## Quick Start
 
+Run from your NanoClaw project root:
+
 ```bash
 # 1. Setup authentication (interactive)
 pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
@@ -49,7 +51,7 @@ pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/s
 
 # 3. Rebuild host and restart service
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 # Verify: launchctl list | grep "$(launchd_label)" (macOS) or systemctl --user status $(systemd_unit) (Linux)
@@ -271,16 +273,18 @@ cat data/x-auth.json  # Should show {"authenticated": true, ...}
 
 ### 4. Restart Service
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm run build
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```
 
-**Verify success:**
+**Verify success** — from your NanoClaw project root:
 ```bash
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl list | grep "$(launchd_label)"  # macOS — should show PID and exit code 0 or -
 # Linux: systemctl --user status $(systemd_unit)
 ```
@@ -346,9 +350,11 @@ echo '{"content":"Test"}' | pnpm exec tsx .claude/skills/x-integration/scripts/p
 
 ### Authentication Expired
 
+Run from your NanoClaw project root:
+
 ```bash
 pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
-source setup/lib/install-slug.sh  # run from your NanoClaw project root
+source setup/lib/install-slug.sh
 launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```

--- a/.claude/skills/x-integration/SKILL.md
+++ b/.claude/skills/x-integration/SKILL.md
@@ -282,7 +282,10 @@ launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 # Linux: systemctl --user restart $(systemd_unit)
 ```
 
-**Verify success** — from your NanoClaw project root:
+**Verify success.**
+
+Run from your NanoClaw project root:
+
 ```bash
 source setup/lib/install-slug.sh
 launchctl list | grep "$(launchd_label)"  # macOS — should show PID and exit code 0 or -

--- a/.claude/skills/x-integration/SKILL.md
+++ b/.claude/skills/x-integration/SKILL.md
@@ -49,9 +49,10 @@ pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/s
 
 # 3. Rebuild host and restart service
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
-# Verify: launchctl list | grep nanoclaw (macOS) or systemctl --user status nanoclaw (Linux)
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
+# Verify: launchctl list | grep "$(launchd_label)" (macOS) or systemctl --user status $(systemd_unit) (Linux)
 ```
 
 ## Configuration
@@ -272,14 +273,16 @@ cat data/x-auth.json  # Should show {"authenticated": true, ...}
 
 ```bash
 pnpm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
 ```
 
 **Verify success:**
 ```bash
-launchctl list | grep nanoclaw  # macOS — should show PID and exit code 0 or -
-# Linux: systemctl --user status nanoclaw
+source setup/lib/install-slug.sh
+launchctl list | grep "$(launchd_label)"  # macOS — should show PID and exit code 0 or -
+# Linux: systemctl --user status $(systemd_unit)
 ```
 
 ## Usage via WhatsApp
@@ -345,8 +348,9 @@ echo '{"content":"Test"}' | pnpm exec tsx .claude/skills/x-integration/scripts/p
 
 ```bash
 pnpm exec dotenv -e .env -- pnpm exec tsx .claude/skills/x-integration/scripts/setup.ts
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: systemctl --user restart nanoclaw
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+# Linux: systemctl --user restart $(systemd_unit)
 ```
 
 ### Browser Lock Files

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -21,6 +21,7 @@ import { formatResponse } from './format.js';
 import type { RequestFrame } from './frame.js';
 import { SocketTransport } from './socket-client.js';
 import type { Transport } from './transport.js';
+import { formatTransportError } from './transport-errors.js';
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
@@ -103,21 +104,6 @@ function printUsage(): void {
       '',
     ].join('\n'),
   );
-}
-
-function formatTransportError(e: unknown): string {
-  const msg = e instanceof Error ? e.message : String(e);
-  if (msg.includes('ENOENT') || msg.includes('ECONNREFUSED')) {
-    return [
-      `ncl: cannot reach NanoClaw host (${msg}).`,
-      `Is the host running? Start it with: pnpm run dev`,
-      `Or, if installed as a service:`,
-      `  macOS:  launchctl kickstart -k gui/$(id -u)/com.nanoclaw`,
-      `  Linux:  systemctl --user restart nanoclaw`,
-      ``,
-    ].join('\n');
-  }
-  return `ncl: transport error: ${msg}\n`;
 }
 
 main().catch((err) => {

--- a/src/cli/transport-errors.test.ts
+++ b/src/cli/transport-errors.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { getLaunchdLabel, getSystemdUnit } from '../install-slug.js';
+import { formatTransportError } from './transport-errors.js';
+
+describe('formatTransportError', () => {
+  it('renders per-install service names on ENOENT, not the bare v1 names', () => {
+    const out = formatTransportError(new Error('connect ENOENT /tmp/nanoclaw.sock'));
+
+    // Regression for #2484: pre-fix, this string was a hardcoded
+    // `com.nanoclaw` / `nanoclaw`, which doesn't match the actual
+    // v2 per-install slug-suffixed unit and label.
+    expect(out).toContain(`gui/$(id -u)/${getLaunchdLabel()}`);
+    expect(out).toContain(`systemctl --user restart ${getSystemdUnit()}`);
+    expect(out).not.toMatch(/gui\/\$\(id -u\)\/com\.nanoclaw\b(?!-v2)/);
+    expect(out).not.toMatch(/systemctl --user restart nanoclaw\b(?!-v2)/);
+  });
+
+  it('renders the same on ECONNREFUSED', () => {
+    const out = formatTransportError(new Error('connect ECONNREFUSED'));
+    expect(out).toContain(getLaunchdLabel());
+    expect(out).toContain(getSystemdUnit());
+  });
+
+  it('falls back to a generic transport error for other failures', () => {
+    const out = formatTransportError(new Error('some unrelated failure'));
+    expect(out).toBe('ncl: transport error: some unrelated failure\n');
+    expect(out).not.toContain('launchctl');
+    expect(out).not.toContain('systemctl');
+  });
+});

--- a/src/cli/transport-errors.ts
+++ b/src/cli/transport-errors.ts
@@ -1,0 +1,19 @@
+import { getLaunchdLabel, getSystemdUnit } from '../install-slug.js';
+
+export function formatTransportError(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  if (msg.includes('ENOENT') || msg.includes('ECONNREFUSED')) {
+    // `bin/ncl` cd's to the project root before exec'ing client.ts, so
+    // process.cwd() is the install dir — install-slug helpers pick up
+    // the right per-checkout suffix.
+    return [
+      `ncl: cannot reach NanoClaw host (${msg}).`,
+      `Is the host running? Start it with: pnpm run dev`,
+      `Or, if installed as a service:`,
+      `  macOS:  launchctl kickstart -k gui/$(id -u)/${getLaunchdLabel()}`,
+      `  Linux:  systemctl --user restart ${getSystemdUnit()}`,
+      ``,
+    ].join('\n');
+  }
+  return `ncl: transport error: ${msg}\n`;
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`com.nanoclaw` / `nanoclaw` are v1 service names. Under v2 every checkout gets a slug — `com.nanoclaw.<sha1(projectRoot)[:8]>` and `nanoclaw-<slug>.service` — so the old names don't match a real launchd label or systemd unit on the host. Anyone copy-pasting the commands in the `ncl` transport-error or the channel skill docs gets "no such service".

This sweep does two things:

1. **Source (#2484)** — extract `formatTransportError` from `src/cli/client.ts` into `src/cli/transport-errors.ts` so it can read `install-slug` at runtime, and call `getLaunchdLabel()` / `getSystemdUnit()` instead of writing the v1 names inline. Adds a regression test in `src/cli/transport-errors.test.ts` that asserts the error string contains the per-install names and **does not** contain the bare v1 names.

2. **Docs (#2485)** — replace hardcoded restart/status snippets across 26 skill files (`.claude/skills/**/SKILL.md` and a couple of `REMOVE.md` siblings) with the canonical pattern:

   ```bash
   source setup/lib/install-slug.sh
   launchctl kickstart -k gui/$(id -u)/$(launchd_label)   # macOS
   # systemctl --user restart $(systemd_unit)             # Linux
   ```

   For one-liners (inline backticks, troubleshooting bullets) I used the inline subshell form with `&&`, not `;`, so that a failed source propagates instead of being masked:

   ```
   "$(. setup/lib/install-slug.sh && systemd_unit)"
   ```

   Every restart bash block also got a standalone `Run from your NanoClaw project root:` line directly above it, so an agent following the skill sources the helper from the directory where it actually resolves. This replaced inline `# run from your NanoClaw project root` annotations from an earlier round of review.

   Status/health checks that grepped for `nanoclaw` (e.g. `launchctl list | grep nanoclaw` in `init-first-agent` and the `add-parallel` verify block) were updated to grep for the per-install label so they don't accidentally match a stale v1 install.

### What's deferred

- `add-macos-statusbar/add/src/statusbar.swift` references `com.nanoclaw` to control the main service. That's real broken behavior, but it's app code rather than docs and deserves its own issue rather than getting bundled into a docs sweep.
- `migrate-from-v1/SKILL.md`, `migrate-nanoclaw/SKILL.md`, `debug/SKILL.md` — references to old names that are intentional (documenting the source state of a migration, or filtering stale units).
- `add-teams/SKILL.md` — `com.nanoclaw.bot` is a Teams app package id, unrelated to the host service.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

---

**Confidence:** high. Fix is mechanical (string-substitution against the canonical helpers that already exist in `setup/lib/install-slug.sh`), typecheck and the new test pass, and the deferred-files list is justified. The one judgement call is leaving `statusbar.swift` for a separate fix; happy to roll it into this PR if you'd rather see it bundled.

Closes #2484
Closes #2485
