### PR TITLE
fix(setup): re-probe systemd user session with derived env on su- entry

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -22,6 +22,7 @@ import {
   isWSL,
 } from './platform.js';
 import { emitStatus } from './status.js';
+import { computeUserSystemdEnv } from './systemd-user-env.js';
 
 export async function run(_args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -291,12 +292,34 @@ function setupSystemd(
     systemctlPrefix = 'systemctl';
     log.info('Running as root — installing system-level systemd unit');
   } else {
+    // pam_systemd normally exports XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS
+    // on login, but invocations via `su -`, `pct enter`, and other non-pam
+    // entry points skip that step. The user systemd manager is still running
+    // (linger keeps it alive across sessions), but the daemon-reload probe
+    // below can't reach it without the env vars. Re-derive them from on-disk
+    // state before probing so we don't false-negative into the nohup path
+    // when a real systemd user session is available. See #2482.
+    const envResult = computeUserSystemdEnv({
+      uid: process.getuid?.(),
+      user: process.env.USER || process.env.LOGNAME,
+      env: { XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR },
+      exists: fs.existsSync,
+    });
+    if (envResult.reason === 'populated') {
+      process.env.XDG_RUNTIME_DIR = envResult.XDG_RUNTIME_DIR;
+      process.env.DBUS_SESSION_BUS_ADDRESS = envResult.DBUS_SESSION_BUS_ADDRESS;
+      log.info('Populated systemd user env from linger state', {
+        XDG_RUNTIME_DIR: envResult.XDG_RUNTIME_DIR,
+      });
+    }
+
     // Check if user-level systemd session is available
     try {
       execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
     } catch {
       log.warn(
         'systemd user session not available — falling back to nohup wrapper',
+        { envProbeReason: envResult.reason },
       );
       setupNohupFallback(projectRoot, nodePath, homeDir);
       return;

--- a/setup/systemd-user-env.test.ts
+++ b/setup/systemd-user-env.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeUserSystemdEnv } from './systemd-user-env.js';
+
+function existsFrom(paths: Set<string>) {
+  return (p: string) => paths.has(p);
+}
+
+describe('computeUserSystemdEnv', () => {
+  it('populates env when linger is on and the runtime dir exists (#2482 repro)', () => {
+    const result = computeUserSystemdEnv({
+      uid: 1000,
+      user: 'nanoclaw',
+      env: {},
+      exists: existsFrom(
+        new Set(['/var/lib/systemd/linger/nanoclaw', '/run/user/1000']),
+      ),
+    });
+
+    expect(result).toEqual({
+      reason: 'populated',
+      XDG_RUNTIME_DIR: '/run/user/1000',
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus',
+    });
+  });
+
+  it('no-ops when XDG_RUNTIME_DIR is already set (SSH login path)', () => {
+    const result = computeUserSystemdEnv({
+      uid: 1000,
+      user: 'nanoclaw',
+      env: { XDG_RUNTIME_DIR: '/run/user/1000' },
+      exists: existsFrom(
+        new Set(['/var/lib/systemd/linger/nanoclaw', '/run/user/1000']),
+      ),
+    });
+
+    expect(result.reason).toBe('already_set');
+    expect(result.XDG_RUNTIME_DIR).toBeUndefined();
+    expect(result.DBUS_SESSION_BUS_ADDRESS).toBeUndefined();
+  });
+
+  it('returns no_linger when the linger marker is absent', () => {
+    const result = computeUserSystemdEnv({
+      uid: 1000,
+      user: 'nanoclaw',
+      env: {},
+      exists: existsFrom(new Set(['/run/user/1000'])),
+    });
+
+    expect(result.reason).toBe('no_linger');
+    expect(result.XDG_RUNTIME_DIR).toBeUndefined();
+  });
+
+  it('returns no_runtime_dir when linger is on but /run/user/<uid> is missing', () => {
+    // The defensive guard from #2482: without this we would point env vars
+    // at a non-existent socket and the daemon-reload probe would fail with a
+    // less recoverable error than the bare "No medium found".
+    const result = computeUserSystemdEnv({
+      uid: 1000,
+      user: 'nanoclaw',
+      env: {},
+      exists: existsFrom(new Set(['/var/lib/systemd/linger/nanoclaw'])),
+    });
+
+    expect(result.reason).toBe('no_runtime_dir');
+    expect(result.XDG_RUNTIME_DIR).toBeUndefined();
+  });
+
+  it('returns no_user when USER and LOGNAME are both missing', () => {
+    const result = computeUserSystemdEnv({
+      uid: 1000,
+      user: undefined,
+      env: {},
+      exists: existsFrom(new Set()),
+    });
+
+    expect(result.reason).toBe('no_user');
+  });
+
+  it('returns no_uid when process.getuid is unavailable', () => {
+    const result = computeUserSystemdEnv({
+      uid: undefined,
+      user: 'nanoclaw',
+      env: {},
+      exists: existsFrom(new Set()),
+    });
+
+    expect(result.reason).toBe('no_uid');
+  });
+});

--- a/setup/systemd-user-env.ts
+++ b/setup/systemd-user-env.ts
@@ -1,0 +1,38 @@
+export interface SystemdUserEnvDeps {
+  uid: number | undefined;
+  user: string | undefined;
+  env: { XDG_RUNTIME_DIR?: string };
+  exists: (path: string) => boolean;
+}
+
+export type SystemdUserEnvReason =
+  | 'already_set'
+  | 'no_user'
+  | 'no_uid'
+  | 'no_linger'
+  | 'no_runtime_dir'
+  | 'populated';
+
+export interface SystemdUserEnvResult {
+  reason: SystemdUserEnvReason;
+  XDG_RUNTIME_DIR?: string;
+  DBUS_SESSION_BUS_ADDRESS?: string;
+}
+
+export function computeUserSystemdEnv(
+  deps: SystemdUserEnvDeps,
+): SystemdUserEnvResult {
+  if (deps.env.XDG_RUNTIME_DIR) return { reason: 'already_set' };
+  if (!deps.user) return { reason: 'no_user' };
+  if (typeof deps.uid !== 'number') return { reason: 'no_uid' };
+  if (!deps.exists(`/var/lib/systemd/linger/${deps.user}`)) {
+    return { reason: 'no_linger' };
+  }
+  const runtimeDir = `/run/user/${deps.uid}`;
+  if (!deps.exists(runtimeDir)) return { reason: 'no_runtime_dir' };
+  return {
+    reason: 'populated',
+    XDG_RUNTIME_DIR: runtimeDir,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtimeDir}/bus`,
+  };
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`setup/service.ts` mis-detects "no systemd" whenever the wizard is invoked outside a pam_systemd session — `su -`, `pct enter`, headless containers, etc. The daemon-reload probe at line 296 runs without `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS`, hits "No medium found", and installs the nohup fallback even when the user manager is healthy on disk. Downstream the verify step then false-fails with `service: not_found` and any later `systemctl --user restart` against the slug-named unit is a silent no-op (it was never installed).

This PR is the targeted fix #2482 calls out under "Suggested fix":

1. **Pre-probe env hydration.** Before the daemon-reload probe, check `/var/lib/systemd/linger/<user>` and `/run/user/<uid>`. Both present → populate `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` on `process.env` so the probe (and every later `systemctl --user` call in the same setup run) inherits them via execSync. Neither present → fall through to the existing nohup path unchanged. The `/run/user/<uid>` guard is the defensive check from the issue: without it we'd point the env vars at a non-existent socket and the probe would fail with a less recoverable error than the bare "No medium found".

2. **Diagnostic on fallback.** The log line on probe failure now records the reason the pre-probe decided not to populate (`no_linger`, `no_runtime_dir`, `no_user`, `no_uid`, `already_set`) so the cause is visible at warn-level without grepping `setup.log`.

3. **Regression test.** The decision logic lives in `setup/systemd-user-env.ts` as a pure function so it can be exercised without spawning systemd. `setup/systemd-user-env.test.ts` covers the #2482 repro (linger + runtime dir → populate) plus every short-circuit branch.

### Scope notes

#2482 lists two adjacent defects (the nohup wrapper is written but never executed, `service: not_found` is ambiguous initial state) and two bundled small fixes (have verify surface the chosen service_type, rename the `wsl_no_systemd` constant). They're all legitimate but they're orthogonal to the env-detection fix — they belong in their own PRs so each can be reviewed and reverted independently. Happy to follow up on whichever you'd like to land first.

## Validation

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec vitest run setup/systemd-user-env.test.ts setup/service.test.ts` — 16/16 (6 new + 10 existing).
- Manual: not verified on a live Proxmox LXC. The decision function is exhaustively unit-tested; the integration point is a single 5-line wedge before the existing probe.

---

**Confidence:** high on correctness (decision logic is pure, exhaustively unit-tested, and matches the suggested fix in #2482 line-for-line). Medium on real-world hit rate — I haven't been able to repro on a fresh LXC myself, so there's a small chance the linger marker layout differs across distros (Debian 13 was the report; should be the same on Ubuntu/Fedora). If anyone has a CT handy a `bash nanoclaw.sh` smoke test from `su - nanoclaw` would close the loop.

Closes #1981
Closes #2482
