### PR TITLE
fix: open outbound DB with write access in writeOutboundDirect

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -391,7 +391,7 @@ export function writeOutboundDirect(
     content: string;
   },
 ): void {
-  const db = openOutboundDb(agentGroupId, sessionId);
+  const db = openOutboundDbRw(agentGroupId, sessionId);
   try {
     db.prepare(
       `INSERT OR IGNORE INTO messages_out (id, seq, timestamp, kind, platform_id, channel_type, thread_id, content)


### PR DESCRIPTION
## Problem

`writeOutboundDirect()` in `src/session-manager.ts` calls `openOutboundDb()`, which opens the database with `readonly: true`. The subsequent INSERT always fails silently with `SQLITE_READONLY`, so command-gate deny responses are never delivered to the user.

When the command gate in `router.ts:437` denies an admin command, it calls `writeOutboundDirect()` to send a "Permission denied" response. Because the write silently fails, the user sees no response at all.

## Fix

Change `openOutboundDb` to `openOutboundDbRw` on line 394 of `session-manager.ts`. The function was designed for direct writes (per its doc comment and INSERT statement), but uses the wrong opener.

## Verification

- `tsc --noEmit` passes
- `eslint src/session-manager.ts` clean (0 errors, pre-existing warnings only)

Closes #2495