### PR TITLE
feat(health-monitor): host-side silent-fail detection and operator alerting

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -310,6 +310,46 @@ function buildMounts(
   // skill symlinks)
   mounts.push({ hostPath: claudeDir, containerPath: '/home/node/.claude', readonly: false });
 
+  // .claude.json lives at /home/node/.claude.json (parent of .claude/), not
+  // inside the mount above. Without a persistent bind mount it's lost on every
+  // container restart, causing "Invalid API key" on the next spawn.
+  const claudeJsonHostPath = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, 'claude.json');
+  if (!fs.existsSync(claudeJsonHostPath)) {
+    const backupsDir = path.join(claudeDir, 'backups');
+    if (fs.existsSync(backupsDir)) {
+      const backups = fs.readdirSync(backupsDir)
+        .filter(f => f.startsWith('.claude.json.backup.'))
+        .sort();
+      if (backups.length > 0) {
+        fs.copyFileSync(path.join(backupsDir, backups[backups.length - 1]), claudeJsonHostPath);
+      }
+    }
+  }
+  // Refresh OAuth token from macOS Keychain before every spawn. The token
+  // expires every ~8h and the container can't renew it — stale tokens cause
+  // silent 401s that appear as completed-but-empty processing_ack entries.
+  if (fs.existsSync(claudeJsonHostPath)) {
+    try {
+      const keychainRaw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', {
+        encoding: 'utf8',
+        timeout: 5000,
+      }).trim();
+      if (keychainRaw) {
+        const keychainData = JSON.parse(keychainRaw);
+        const freshOauth = keychainData?.claudeAiOauth;
+        if (freshOauth?.accessToken && freshOauth?.expiresAt) {
+          const existing = JSON.parse(fs.readFileSync(claudeJsonHostPath, 'utf8'));
+          existing.claudeAiOauth = freshOauth;
+          fs.writeFileSync(claudeJsonHostPath, JSON.stringify(existing, null, 2));
+          log.debug('Refreshed OAuth token from Keychain', { agentGroupId: agentGroup.id, expiresAt: new Date(freshOauth.expiresAt).toISOString() });
+        }
+      }
+    } catch {
+      // Non-macOS or Keychain unavailable — continue with whatever token is on disk
+    }
+    mounts.push({ hostPath: claudeJsonHostPath, containerPath: '/home/node/.claude.json', readonly: false });
+  }
+
   // Shared agent-runner source — read-only, same code for all groups.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
   mounts.push({ hostPath: agentRunnerSrc, containerPath: '/app/src', readonly: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,11 @@ async function main(): Promise<void> {
   // Idempotent — skips groups that already have a config row.
   backfillContainerConfigs();
 
+  // MODULE-HOOK:health-monitor:start
+  const { startHealthMonitor } = await import('./modules/health-monitor/index.js');
+  startHealthMonitor();
+  // MODULE-HOOK:health-monitor:end
+
   // 1c. One-time filesystem cutover — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
 

--- a/src/modules/health-monitor/alert.ts
+++ b/src/modules/health-monitor/alert.ts
@@ -1,0 +1,79 @@
+import https from 'https';
+
+import { getDb } from '../../db/connection.js';
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+import { resolveSession, writeSessionMessage } from '../../session-manager.js';
+import { wakeContainer } from '../../container-runner.js';
+
+export const HEALTH_MONITOR_AGENT_ID = 'health-monitor';
+const HEALTH_MONITOR_MG_ID = 'mg-health-monitor';
+
+export async function postAlert(message: string): Promise<void> {
+  const env = readEnvFile(['DISCORD_BOT_TOKEN', 'HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID']);
+  if (!env.DISCORD_BOT_TOKEN) {
+    log.warn('[health-monitor] No DISCORD_BOT_TOKEN — cannot post alert', { message });
+    return;
+  }
+  if (!env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID) {
+    log.warn('[health-monitor] No HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID — cannot post alert', { message });
+    return;
+  }
+
+  return new Promise((resolve) => {
+    const body = JSON.stringify({ content: message });
+    const req = https.request(
+      {
+        hostname: 'discord.com',
+        path: `/api/v10/channels/${env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID}/messages`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode >= 400) {
+          log.warn('[health-monitor] Discord alert HTTP error', { status: res.statusCode });
+        }
+        resolve();
+      },
+    );
+    req.on('error', (err) => {
+      log.warn('[health-monitor] Discord alert network error', { err });
+      resolve();
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function injectTask(prompt: string): Promise<void> {
+  try {
+    const agentGroup = getDb().prepare('SELECT id FROM agent_groups WHERE id = ?').get(HEALTH_MONITOR_AGENT_ID) as
+      | { id: string }
+      | undefined;
+
+    if (!agentGroup) {
+      log.warn('[health-monitor] Agent group not in DB — skipping task injection');
+      return;
+    }
+
+    const { session } = resolveSession(HEALTH_MONITOR_AGENT_ID, HEALTH_MONITOR_MG_ID, null, 'shared');
+    const messageId = `hm-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+    writeSessionMessage(HEALTH_MONITOR_AGENT_ID, session.id, {
+      id: messageId,
+      kind: 'task',
+      timestamp: new Date().toISOString(),
+      content: JSON.stringify({ prompt }),
+    });
+
+    await wakeContainer(session);
+    log.info('[health-monitor] Task injected', { sessionId: session.id });
+  } catch (err) {
+    log.error('[health-monitor] Failed to inject task', { err });
+  }
+}

--- a/src/modules/health-monitor/checks.ts
+++ b/src/modules/health-monitor/checks.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { DATA_DIR } from '../../config.js';
+import { isContainerRunning } from '../../container-runner.js';
+import { openOutboundDb } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+
+const TOKEN_WARN_MINUTES = 60;
+
+export interface TokenIssue {
+  agentGroupId: string;
+  minutesLeft: number;
+}
+
+export function checkTokenExpiry(): TokenIssue[] {
+  const issues: TokenIssue[] = [];
+  for (const group of getAllAgentGroups()) {
+    const claudeJsonPath = path.join(DATA_DIR, 'v2-sessions', group.id, 'claude.json');
+    if (!fs.existsSync(claudeJsonPath)) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+      const expiresAt = data?.claudeAiOauth?.expiresAt;
+      if (!expiresAt) continue;
+      const minutesLeft = Math.floor((expiresAt - Date.now()) / 60_000);
+      if (minutesLeft < TOKEN_WARN_MINUTES) {
+        issues.push({ agentGroupId: group.id, minutesLeft });
+      }
+    } catch {
+      // Ignore unreadable files
+    }
+  }
+  return issues;
+}
+
+/**
+ * Returns true when a session has recent completed processing_acks but produced
+ * zero messages_out in the same window — the signature of a silent 401 failure.
+ */
+export function checkSilentFail(session: Session): boolean {
+  // Skip the health-monitor itself, and skip sessions whose container is still alive
+  if (session.agent_group_id === 'health-monitor') return false;
+  if (isContainerRunning(session.id)) return false;
+
+  try {
+    const outDb = openOutboundDb(session.agent_group_id, session.id);
+    try {
+      const { count: ackCount } = outDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM processing_ack WHERE status='completed' AND datetime(status_changed) > datetime('now', '-2 hours')",
+        )
+        .get() as { count: number };
+
+      if (ackCount === 0) return false;
+
+      const { count: outCount } = outDb
+        .prepare("SELECT COUNT(*) as count FROM messages_out WHERE datetime(timestamp) > datetime('now', '-2 hours')")
+        .get() as { count: number };
+
+      return outCount === 0;
+    } finally {
+      outDb.close();
+    }
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/health-monitor/index.ts
+++ b/src/modules/health-monitor/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Health monitor module.
+ *
+ * Runs every 5 minutes and checks for "can't run" level issues:
+ *   1. OAuth token near-expiry (belt-and-suspenders on top of pre-spawn refresh)
+ *   2. Silent-fail pattern: session completed processing but produced no output
+ *      — the signature of a 401 auth failure swallowed by the agent-runner
+ *
+ * On detection, posts a direct Discord alert to the keepalive channel and
+ * injects a diagnostic task into the health-monitor agent so Claude can
+ * investigate and report.
+ *
+ * Alert deduplication: each unique issue key is suppressed for 1 hour after
+ * the first alert so the channel isn't spammed on repeated sweeps.
+ */
+import { getActiveSessions } from '../../db/sessions.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { log } from '../../log.js';
+import { ensureHealthMonitorSetup } from './setup.js';
+import { checkTokenExpiry, checkSilentFail } from './checks.js';
+import { postAlert, injectTask } from './alert.js';
+
+const CHECK_INTERVAL_MS = 5 * 60 * 1_000;
+const ALERT_COOLDOWN_MS = 60 * 60 * 1_000;
+
+const alertedAt = new Map<string, number>();
+
+function shouldAlert(key: string): boolean {
+  const last = alertedAt.get(key) ?? 0;
+  if (Date.now() - last < ALERT_COOLDOWN_MS) return false;
+  alertedAt.set(key, Date.now());
+  return true;
+}
+
+async function runChecks(): Promise<void> {
+  // Check 1: OAuth token near-expiry
+  for (const { agentGroupId, minutesLeft } of checkTokenExpiry()) {
+    const key = `token:${agentGroupId}`;
+    if (!shouldAlert(key)) continue;
+    const msg =
+      `⚠️ **OAuth token expiring** — agent group \`${agentGroupId}\` expires in ${minutesLeft} min. ` +
+      `Pre-spawn refresh should handle it; alerting as belt-and-suspenders.`;
+    log.warn('[health-monitor] Token near-expiry', { agentGroupId, minutesLeft });
+    await postAlert(msg);
+    await injectTask(
+      `OAuth token for agent group "${agentGroupId}" expires in ${minutesLeft} minutes. ` +
+        `Verify the pre-spawn Keychain refresh is working: check the expiresAt in ` +
+        `data/v2-sessions/${agentGroupId}/claude.json against the current time. ` +
+        `If stale, read fresh token: security find-generic-password -s "Claude Code-credentials" -w`,
+    );
+  }
+
+  // Check 2: Silent-fail pattern per active session
+  for (const session of getActiveSessions()) {
+    if (!checkSilentFail(session)) continue;
+    const agentGroup = getAgentGroup(session.agent_group_id);
+    const groupName = agentGroup?.name ?? session.agent_group_id;
+    const key = `silent-fail:${session.id}`;
+    if (!shouldAlert(key)) continue;
+    const msg =
+      `🚨 **Silent task failure** — \`${groupName}\` (session \`${session.id.slice(-8)}\`) ` +
+      `completed processing in the last 2h but produced no output. ` +
+      `Likely cause: 401 auth error swallowed by agent-runner.`;
+    log.warn('[health-monitor] Silent fail detected', { sessionId: session.id, agentGroupId: session.agent_group_id });
+    await postAlert(msg);
+    await injectTask(
+      `Investigate silent task failure in agent "${groupName}" (session ID: ${session.id}). ` +
+        `The session shows completed processing_ack entries but zero messages_out in the last 2 hours. ` +
+        `Typical cause: OAuth 401 error — the container started, got auth failure, reported "completed" with no output. ` +
+        `Steps to diagnose:\n` +
+        `1. Check the most recent container logs: docker logs $(docker ps -a --filter "name=nanoclaw-v2-${agentGroup?.folder ?? session.agent_group_id}" --format "{{.Names}}" | head -1) 2>&1 | tail -30\n` +
+        `2. Check token status: python3 -c "import json,datetime,os; d=json.load(open('data/v2-sessions/${session.agent_group_id}/claude.json')); o=d.get('claudeAiOauth',{}); ts=o.get('expiresAt',0)/1000; print('expires:', datetime.datetime.utcfromtimestamp(ts), 'UTC', '— EXPIRED' if datetime.datetime.utcnow() > datetime.datetime.utcfromtimestamp(ts) else '— VALID')"\n` +
+        `3. Report findings and recommended action to this channel.`,
+    );
+  }
+}
+
+let timer: NodeJS.Timeout | null = null;
+
+function schedule(): void {
+  timer = setTimeout(async () => {
+    try {
+      await runChecks();
+    } catch (err) {
+      log.error('[health-monitor] Check error', { err });
+    }
+    schedule();
+  }, CHECK_INTERVAL_MS);
+}
+
+/**
+ * Called from src/index.ts after initDb() — must NOT be called at module
+ * import time since the central DB isn't open yet.
+ */
+export function startHealthMonitor(): void {
+  ensureHealthMonitorSetup();
+  schedule();
+  log.info('[health-monitor] Started (interval: 5 min)');
+}

--- a/src/modules/health-monitor/setup.ts
+++ b/src/modules/health-monitor/setup.ts
@@ -1,0 +1,75 @@
+/**
+ * One-time idempotent setup for the health-monitor agent group.
+ * Creates agent group, messaging group for the keepalive channel, and wires them.
+ * Safe to call on every startup — skips rows that already exist.
+ *
+ * Required .env keys:
+ *   HEALTH_MONITOR_DISCORD_GUILD_ID    — Discord server (guild) ID
+ *   HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID — Channel ID for alert delivery
+ *
+ * If either key is missing, the agent group is still created but Discord
+ * wiring is skipped (alerts will be suppressed with a warning).
+ */
+import { getDb } from '../../db/connection.js';
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+import { HEALTH_MONITOR_AGENT_ID } from './alert.js';
+
+const HEALTH_MONITOR_MG_ID = 'mg-health-monitor';
+
+export function ensureHealthMonitorSetup(): void {
+  const db = getDb();
+
+  // Agent group
+  const existing = db.prepare('SELECT id FROM agent_groups WHERE id = ?').get(HEALTH_MONITOR_AGENT_ID);
+  if (!existing) {
+    db.prepare(
+      `INSERT INTO agent_groups (id, name, folder, agent_provider, created_at)
+       VALUES (?, ?, ?, NULL, datetime('now'))`,
+    ).run(HEALTH_MONITOR_AGENT_ID, 'Health Monitor', 'health-monitor');
+    log.info('[health-monitor] Created agent group');
+  }
+
+  const env = readEnvFile(['HEALTH_MONITOR_DISCORD_GUILD_ID', 'HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID']);
+  if (!env.HEALTH_MONITOR_DISCORD_GUILD_ID || !env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID) {
+    log.warn(
+      '[health-monitor] HEALTH_MONITOR_DISCORD_GUILD_ID or HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID not set in .env — Discord wiring skipped',
+    );
+    return;
+  }
+
+  // Messaging group for the keepalive Discord channel
+  const platformId = `discord:${env.HEALTH_MONITOR_DISCORD_GUILD_ID}:${env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID}`;
+  const existingMg = db.prepare('SELECT id FROM messaging_groups WHERE id = ?').get(HEALTH_MONITOR_MG_ID);
+  if (!existingMg) {
+    db.prepare(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
+       VALUES (?, 'discord', ?, 'keepalive', 1, 'ignore', datetime('now'))`,
+    ).run(HEALTH_MONITOR_MG_ID, platformId);
+    log.info('[health-monitor] Created messaging group', { platformId });
+  }
+
+  // Wiring
+  const existingWiring = db
+    .prepare('SELECT 1 FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
+    .get(HEALTH_MONITOR_MG_ID, HEALTH_MONITOR_AGENT_ID);
+  if (!existingWiring) {
+    db.prepare(
+      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, session_mode, priority, created_at)
+       VALUES ('mga-health-monitor', ?, ?, 'shared', 0, datetime('now'))`,
+    ).run(HEALTH_MONITOR_MG_ID, HEALTH_MONITOR_AGENT_ID);
+    log.info('[health-monitor] Created wiring');
+  }
+
+  // Named destination so the agent can use <message to="keepalive"> in its output
+  const existingDest = db
+    .prepare("SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND local_name = 'keepalive'")
+    .get(HEALTH_MONITOR_AGENT_ID);
+  if (!existingDest) {
+    db.prepare(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES (?, 'keepalive', 'channel', ?, datetime('now'))`,
+    ).run(HEALTH_MONITOR_AGENT_ID, HEALTH_MONITOR_MG_ID);
+    log.info('[health-monitor] Created keepalive destination');
+  }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -22,3 +22,4 @@ import './scheduling/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './health-monitor/index.js';


### PR DESCRIPTION
## Summary

- Adds `src/modules/health-monitor/` module: 5-min timer that detects silent task failures and posts direct Discord alerts
- Adds pre-spawn OAuth token refresh from macOS Keychain in `buildMounts()`

## Problem

Stuck-container detection catches *hung* containers but misses containers that complete with zero output — the silent 401 auth failure pattern:

1. Token expires → container spawns → Claude binary 401
2. Agent-runner writes `processing_ack = completed` (processed the message, result was empty)
3. Container idles → 30 min later `absolute-ceiling` kills it
4. Operator has no idea. Scheduled task looks like it ran.

## Changes

**`src/modules/health-monitor/`** (new module):
- `setup.ts` — idempotent DB bootstrap (agent group + messaging group + wiring + named destination)
- `checks.ts` — `checkSilentFail()` (ack with no output in 2h window, container stopped) + `checkTokenExpiry()`
- `alert.ts` — direct Discord REST to configurable keepalive channel (bypasses routing — works even if routing is broken) + task injection into health-monitor session
- `index.ts` — 5-min timer, 1h dedup per issue key, `startHealthMonitor()` called after `initDb()` via MODULE-HOOK

**`src/container-runner.ts`**: pre-spawn Keychain token refresh in `buildMounts()`. try/catch, no-op on non-macOS.

**`src/index.ts` + `src/modules/index.ts`**: MODULE-HOOK wiring.

## Test plan

- [x] Service starts cleanly, `[health-monitor] Started` in logs
- [x] DB rows created on startup (idempotent)
- [x] Health-monitor container spawns and delivers `<message to="keepalive">` to Discord
- [x] `pnpm run build` passes

## Related upstream issues

- nanocoai/nanoclaw#730 — OAuth token expiry (macOS Keychain details added to comment)
- nanocoai/nanoclaw#2492 — health-monitor feature proposal to upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)