### PR TITLE
feat: add /add-early-compact-nudge feature skill

### DIFF
--- a/.claude/skills/add-early-compact-nudge/SKILL.md
+++ b/.claude/skills/add-early-compact-nudge/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: add-early-compact-nudge
-description: Inject a one-shot system-reminder before the next user turn when context usage crosses a configurable fraction of the SDK auto-compact ceiling. Suggests the agent run /compact at a natural pause instead of letting the SDK auto-compact mid-task.
+description: Push a one-shot system-reminder into the active SDK query when context usage crosses a configurable fraction of the auto-compact ceiling. The agent must acknowledge and reply, so it verbalizes whether to run /compact at a natural pause point or stay on task.
 ---
 
 # Add Early Compaction Nudge
 
 When the Claude Agent SDK's `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is configured, the SDK will auto-compact history once effective context exceeds the ceiling. Auto-compaction picks an arbitrary point — frequently mid-task — and the resulting summary tends to drop load-bearing details of the work in progress.
 
-This skill installs an opt-in nudge: when effective context (input + cache_read + cache_creation) crosses a configurable ratio of the ceiling (default 75%), the next user prompt is prefixed with a `<system-reminder>` block that tells the agent it's near the ceiling and suggests running `/compact` at a natural pause. One-shot per compact cycle; resets automatically when the SDK auto-compacts.
+This skill installs an opt-in nudge: when effective context (input + cache_read + cache_creation) crosses a configurable ratio of the ceiling (default 75%), a `<system-reminder>` block is pushed into the active SDK query as a synthetic user message. The reminder suggests running `/compact` at a natural pause point and strongly recommends passing an `instructions` argument so load-bearing details survive the boundary. One-shot per compact cycle; resets automatically when the SDK auto-compacts.
 
-This is structurally different from PR #2327, which pushed a synthetic message into a live query. The agent treated it as a user turn and replied to it. This implementation attaches the reminder as plain context on the *next* `provider.query()` call, so the agent reads it as system context and can act on it (or ignore it) without round-tripping.
+The push is deliberate: delivering the nudge as a user message forces the agent to acknowledge it and verbalize whether the current moment is a natural pause point or whether it's mid-task. That surfaces the compaction decision in the conversation rather than letting the agent silently ignore a context note. The latch + post-compact reset keep it to one nudge per cycle.
 
 ## Install
 
@@ -81,21 +81,21 @@ export COMPACT_NUDGE_RATIO=0
 ## How it works
 
 1. The Claude provider emits a `usage` event after every assistant turn, carrying `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from the SDK.
-2. The poll loop's nudge tracker sums those into effective context. If it crosses `ceiling * ratio` for the first time in the current compact cycle, the latch arms.
-3. Before the *next* `provider.query()` call, the tracker is drained: the reminder text is prepended to the prompt as plain context — not pushed mid-stream, not formatted as a user message.
+2. The poll loop's nudge tracker sums those into effective context. If it crosses `ceiling * ratio` for the first time in the current compact cycle, the tracker returns the reminder text from `onUsage()`.
+3. The poll loop pushes that text into the active SDK query via `query.push(text)`. The SDK delivers it as a synthetic user message in the same turn — the agent acknowledges it and decides aloud whether to `/compact` or stay on task.
 4. When the SDK auto-compacts, the Claude provider emits a `compact_boundary` event. The tracker resets, ready to arm again if usage climbs back over the threshold.
 
-State machine and reminder text live in `container/agent-runner/src/compact-nudge.ts`. Unit tests in `compact-nudge.test.ts` cover threshold arming, one-shot semantics, and post-compact re-arming. Integration tests in `integration.test.ts` cover the wiring through the poll loop.
+State machine and reminder text live in `container/agent-runner/src/compact-nudge.ts`. Unit tests in `compact-nudge.test.ts` cover threshold arming, one-shot semantics, and post-compact re-arming. Integration tests in `integration.test.ts` cover the push wiring through the poll loop.
 
 ## Verify
 
 After install, the next time context approaches the ceiling you should see this in container logs:
 
 ```
-[poll-loop] Prepended early-compaction nudge to prompt
+[poll-loop] Pushing early-compaction nudge into active query
 ```
 
-And in the next assistant turn, the prompt the SDK received will start with the `<system-reminder>` block.
+In the next assistant message you will see the agent acknowledge the reminder and either invoke `/compact` (typically with an `instructions` payload) or explicitly say it's mid-task and will compact at the next pause.
 
 ## Uninstall
 

--- a/.claude/skills/add-early-compact-nudge/SKILL.md
+++ b/.claude/skills/add-early-compact-nudge/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: add-early-compact-nudge
+description: Inject a one-shot system-reminder before the next user turn when context usage crosses a configurable fraction of the SDK auto-compact ceiling. Suggests the agent run /compact at a natural pause instead of letting the SDK auto-compact mid-task.
+---
+
+# Add Early Compaction Nudge
+
+When the Claude Agent SDK's `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is configured, the SDK will auto-compact history once effective context exceeds the ceiling. Auto-compaction picks an arbitrary point — frequently mid-task — and the resulting summary tends to drop load-bearing details of the work in progress.
+
+This skill installs an opt-in nudge: when effective context (input + cache_read + cache_creation) crosses a configurable ratio of the ceiling (default 75%), the next user prompt is prefixed with a `<system-reminder>` block that tells the agent it's near the ceiling and suggests running `/compact` at a natural pause. One-shot per compact cycle; resets automatically when the SDK auto-compacts.
+
+This is structurally different from PR #2327, which pushed a synthetic message into a live query. The agent treated it as a user turn and replied to it. This implementation attaches the reminder as plain context on the *next* `provider.query()` call, so the agent reads it as system context and can act on it (or ignore it) without round-tripping.
+
+## Install
+
+This is a branch-based feature skill. The code lives on `skill/early-compact-nudge`.
+
+### Pre-flight (idempotent)
+
+Skip to **Configure** if all of these are already in place:
+
+- `container/agent-runner/src/compact-nudge.ts` exists
+- `container/agent-runner/src/poll-loop.ts` imports from `./compact-nudge.js`
+- `container/agent-runner/src/providers/types.ts` has `usage` and `compact_boundary` in the `ProviderEvent` union
+
+Otherwise continue.
+
+### 1. Fetch the skill branch
+
+```bash
+git fetch origin skill/early-compact-nudge
+```
+
+### 2. Merge
+
+```bash
+git merge --no-ff origin/skill/early-compact-nudge -m "Install /add-early-compact-nudge"
+```
+
+If a customized fork has touched `poll-loop.ts`, `providers/types.ts`, or `providers/claude.ts`, resolve conflicts by hand. The changes are small (added imports, a new event type, two new event handlers) and isolated to those three files.
+
+### 3. Rebuild the container image
+
+```bash
+./container/build.sh
+```
+
+### 4. Restart any running containers so they pick up the new code
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux
+systemctl --user restart nanoclaw
+```
+
+## Configure
+
+Two environment variables, both optional. Both must be set on the host (they're forwarded into the container via the existing env-pass-through).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `165000` | The SDK's auto-compact ceiling. Already read by the Claude Agent SDK itself; the nudge reads the same value so it stays in sync. |
+| `COMPACT_NUDGE_RATIO` | `0.75` | Fraction of the ceiling that arms the nudge. Set to `0` or `>= 1` to disable the nudge entirely. |
+
+Example: a 200k ceiling with a 70% trigger:
+
+```bash
+# In your host shell rc, .envrc, or service unit
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000
+export COMPACT_NUDGE_RATIO=0.7
+```
+
+To disable without uninstalling:
+
+```bash
+export COMPACT_NUDGE_RATIO=0
+```
+
+## How it works
+
+1. The Claude provider emits a `usage` event after every assistant turn, carrying `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from the SDK.
+2. The poll loop's nudge tracker sums those into effective context. If it crosses `ceiling * ratio` for the first time in the current compact cycle, the latch arms.
+3. Before the *next* `provider.query()` call, the tracker is drained: the reminder text is prepended to the prompt as plain context — not pushed mid-stream, not formatted as a user message.
+4. When the SDK auto-compacts, the Claude provider emits a `compact_boundary` event. The tracker resets, ready to arm again if usage climbs back over the threshold.
+
+State machine and reminder text live in `container/agent-runner/src/compact-nudge.ts`. Unit tests in `compact-nudge.test.ts` cover threshold arming, one-shot semantics, and post-compact re-arming. Integration tests in `integration.test.ts` cover the wiring through the poll loop.
+
+## Verify
+
+After install, the next time context approaches the ceiling you should see this in container logs:
+
+```
+[poll-loop] Prepended early-compaction nudge to prompt
+```
+
+And in the next assistant turn, the prompt the SDK received will start with the `<system-reminder>` block.
+
+## Uninstall
+
+```bash
+git revert -m 1 <merge-commit-sha>
+./container/build.sh
+```
+
+Or set `COMPACT_NUDGE_RATIO=0` to disable without removing the code.

--- a/container/agent-runner/src/compact-nudge.test.ts
+++ b/container/agent-runner/src/compact-nudge.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'bun:test';
+
+import { createNudgeTracker, effectiveContext, readNudgeConfig, buildNudgeReminder } from './compact-nudge.js';
+
+describe('readNudgeConfig', () => {
+  it('uses 165k ceiling and 0.75 ratio when env is unset', () => {
+    const cfg = readNudgeConfig({});
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.ceiling).toBe(165_000);
+    expect(cfg.ratio).toBe(0.75);
+    expect(cfg.threshold).toBe(Math.floor(165_000 * 0.75));
+  });
+
+  it('reads CLAUDE_CODE_AUTO_COMPACT_WINDOW for the ceiling', () => {
+    const cfg = readNudgeConfig({ CLAUDE_CODE_AUTO_COMPACT_WINDOW: '200000' });
+    expect(cfg.ceiling).toBe(200_000);
+    expect(cfg.threshold).toBe(150_000);
+  });
+
+  it('reads COMPACT_NUDGE_RATIO for the ratio', () => {
+    const cfg = readNudgeConfig({ COMPACT_NUDGE_RATIO: '0.5', CLAUDE_CODE_AUTO_COMPACT_WINDOW: '200000' });
+    expect(cfg.ratio).toBe(0.5);
+    expect(cfg.threshold).toBe(100_000);
+  });
+
+  it('disables when ratio is 0', () => {
+    const cfg = readNudgeConfig({ COMPACT_NUDGE_RATIO: '0' });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('disables when ratio is >= 1', () => {
+    const cfg = readNudgeConfig({ COMPACT_NUDGE_RATIO: '1' });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('disables when ratio cannot be parsed', () => {
+    const cfg = readNudgeConfig({ COMPACT_NUDGE_RATIO: 'banana' });
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('falls back to default ceiling when CLAUDE_CODE_AUTO_COMPACT_WINDOW cannot be parsed', () => {
+    const cfg = readNudgeConfig({ CLAUDE_CODE_AUTO_COMPACT_WINDOW: 'notanumber' });
+    expect(cfg.ceiling).toBe(165_000);
+  });
+});
+
+describe('effectiveContext', () => {
+  it('sums input + cache_read + cache_creation', () => {
+    expect(effectiveContext({ inputTokens: 100, cacheReadInputTokens: 50, cacheCreationInputTokens: 25 })).toBe(175);
+  });
+
+  it('treats missing fields as zero', () => {
+    expect(effectiveContext({ inputTokens: 100, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).toBe(100);
+  });
+});
+
+describe('buildNudgeReminder', () => {
+  it('wraps the message in a system-reminder block', () => {
+    const text = buildNudgeReminder(150_000, 200_000);
+    expect(text.startsWith('<system-reminder>')).toBe(true);
+    expect(text.endsWith('</system-reminder>')).toBe(true);
+  });
+
+  it('mentions the used and ceiling token counts', () => {
+    const text = buildNudgeReminder(150_000, 200_000);
+    expect(text).toContain('150,000');
+    expect(text).toContain('200,000');
+  });
+
+  it('tells the agent to ignore if mid-task and is explicit it is one-shot per cycle', () => {
+    const text = buildNudgeReminder(150_000, 200_000);
+    expect(text).toContain('natural pause');
+    expect(text).toContain('mid-task');
+    expect(text).toContain('next compaction cycle');
+  });
+});
+
+describe('createNudgeTracker', () => {
+  const cfg = { enabled: true, ceiling: 200_000, threshold: 150_000, ratio: 0.75 };
+
+  it('does not arm before the threshold', () => {
+    const t = createNudgeTracker(cfg);
+    t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).toBeNull();
+  });
+
+  it('arms exactly once at the threshold and consumes the reminder', () => {
+    const t = createNudgeTracker(cfg);
+    t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 50_000, cacheCreationInputTokens: 0 });
+    const reminder = t.consumePending();
+    expect(reminder).not.toBeNull();
+    expect(reminder).toContain('<system-reminder>');
+    // Second consume yields nothing — already drained.
+    expect(t.consumePending()).toBeNull();
+  });
+
+  it('does not re-arm on further usage in the same compact cycle', () => {
+    const t = createNudgeTracker(cfg);
+    t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).not.toBeNull();
+    // Another assistant turn pushes usage even higher — must NOT re-arm.
+    t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).toBeNull();
+  });
+
+  it('re-arms after a compact_boundary if usage crosses again', () => {
+    const t = createNudgeTracker(cfg);
+    t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).not.toBeNull();
+    t.onCompactBoundary();
+    // Post-compact, usage drops, climbs again, crosses the threshold again.
+    t.onUsage({ inputTokens: 50_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).toBeNull();
+    t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).not.toBeNull();
+  });
+
+  it('is inert when disabled', () => {
+    const disabled = { ...cfg, enabled: false };
+    const t = createNudgeTracker(disabled);
+    t.onUsage({ inputTokens: 1_000_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.consumePending()).toBeNull();
+  });
+
+  it('reports state for inspection', () => {
+    const t = createNudgeTracker(cfg);
+    t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(t.state()).toEqual({ lastEffective: 160_000, pending: true, sent: true });
+    t.consumePending();
+    expect(t.state()).toEqual({ lastEffective: 160_000, pending: false, sent: true });
+    t.onCompactBoundary();
+    expect(t.state()).toEqual({ lastEffective: 0, pending: false, sent: false });
+  });
+});

--- a/container/agent-runner/src/compact-nudge.test.ts
+++ b/container/agent-runner/src/compact-nudge.test.ts
@@ -67,11 +67,17 @@ describe('buildNudgeReminder', () => {
     expect(text).toContain('200,000');
   });
 
-  it('tells the agent to ignore if mid-task and is explicit it is one-shot per cycle', () => {
+  it('mentions /compact and the instructions argument', () => {
+    const text = buildNudgeReminder(150_000, 200_000);
+    expect(text).toContain('/compact');
+    expect(text).toContain('instructions');
+  });
+
+  it('tells the agent to ignore if mid-task and is explicit it is one-shot', () => {
     const text = buildNudgeReminder(150_000, 200_000);
     expect(text).toContain('natural pause');
     expect(text).toContain('mid-task');
-    expect(text).toContain('next compaction cycle');
+    expect(text).toContain('one-shot');
   });
 });
 
@@ -80,55 +86,45 @@ describe('createNudgeTracker', () => {
 
   it('does not arm before the threshold', () => {
     const t = createNudgeTracker(cfg);
-    t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).toBeNull();
+    const result = t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
+    expect(result).toBeNull();
   });
 
-  it('arms exactly once at the threshold and consumes the reminder', () => {
+  it('returns reminder text exactly once when crossing the threshold', () => {
     const t = createNudgeTracker(cfg);
-    t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 50_000, cacheCreationInputTokens: 0 });
-    const reminder = t.consumePending();
+    const reminder = t.onUsage({ inputTokens: 100_000, cacheReadInputTokens: 50_000, cacheCreationInputTokens: 0 });
     expect(reminder).not.toBeNull();
     expect(reminder).toContain('<system-reminder>');
-    // Second consume yields nothing — already drained.
-    expect(t.consumePending()).toBeNull();
+    expect(reminder).toContain('/compact');
   });
 
   it('does not re-arm on further usage in the same compact cycle', () => {
     const t = createNudgeTracker(cfg);
-    t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).not.toBeNull();
+    expect(t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).not.toBeNull();
     // Another assistant turn pushes usage even higher — must NOT re-arm.
-    t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).toBeNull();
+    expect(t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).toBeNull();
   });
 
   it('re-arms after a compact_boundary if usage crosses again', () => {
     const t = createNudgeTracker(cfg);
-    t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).not.toBeNull();
+    expect(t.onUsage({ inputTokens: 150_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).not.toBeNull();
     t.onCompactBoundary();
     // Post-compact, usage drops, climbs again, crosses the threshold again.
-    t.onUsage({ inputTokens: 50_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).toBeNull();
-    t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).not.toBeNull();
+    expect(t.onUsage({ inputTokens: 50_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).toBeNull();
+    expect(t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).not.toBeNull();
   });
 
   it('is inert when disabled', () => {
     const disabled = { ...cfg, enabled: false };
     const t = createNudgeTracker(disabled);
-    t.onUsage({ inputTokens: 1_000_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.consumePending()).toBeNull();
+    expect(t.onUsage({ inputTokens: 1_000_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 })).toBeNull();
   });
 
   it('reports state for inspection', () => {
     const t = createNudgeTracker(cfg);
     t.onUsage({ inputTokens: 160_000, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
-    expect(t.state()).toEqual({ lastEffective: 160_000, pending: true, sent: true });
-    t.consumePending();
-    expect(t.state()).toEqual({ lastEffective: 160_000, pending: false, sent: true });
+    expect(t.state()).toEqual({ lastEffective: 160_000, sent: true });
     t.onCompactBoundary();
-    expect(t.state()).toEqual({ lastEffective: 0, pending: false, sent: false });
+    expect(t.state()).toEqual({ lastEffective: 0, sent: false });
   });
 });

--- a/container/agent-runner/src/compact-nudge.ts
+++ b/container/agent-runner/src/compact-nudge.ts
@@ -1,16 +1,16 @@
 // Early-compaction nudge: when effective context crosses a configurable ratio
-// of the SDK auto-compact ceiling, schedule a one-shot <system-reminder> to
-// prepend to the *next* user prompt. The reminder asks the agent to consider
-// running /compact at a natural pause point — never mid-task.
+// of the SDK auto-compact ceiling, push a one-shot reminder into the active
+// SDK query as a synthetic user message. The reminder asks the agent to
+// consider running /compact at a natural pause point, and strongly suggests
+// passing an `instructions` payload so load-bearing details survive the
+// compaction boundary.
 //
-// Why a separate state machine: PR #2327 tried injecting a reminder into the
-// live query post-compact via `query.push()`. The SDK treated it as a synthetic
-// user turn and the agent replied to it. The fix is to attach the reminder as
-// context on the *next user prompt*, before the next `provider.query()` call —
-// not pushed into an active stream.
-//
-// One-shot per compact cycle: latch on usage, clear on observed compact_boundary
-// so a session that grows past the ratio again gets re-nudged.
+// Why push as a user message instead of attaching as plain context: pushing
+// makes the agent acknowledge and reply, which surfaces its reasoning about
+// whether this is a natural pause point or it's mid-task. A silent context
+// note lets the agent ignore the question entirely. PR #2327's mechanism is
+// reused here deliberately — a one-shot latch + post-compact reset keep it
+// from spamming the conversation.
 
 export interface NudgeConfig {
   enabled: boolean;
@@ -51,57 +51,54 @@ export function effectiveContext(u: UsageSample): number {
   return (u.inputTokens || 0) + (u.cacheReadInputTokens || 0) + (u.cacheCreationInputTokens || 0);
 }
 
-/**
- * The reminder text. Framed as plain context for the next turn — never as a
- * synthetic user message. The agent should ignore it if mid-task; act on it
- * at a natural pause point.
- */
 export function buildNudgeReminder(used: number, ceiling: number): string {
+  const usedStr = used.toLocaleString();
+  const ceilingStr = ceiling.toLocaleString();
   return [
     '<system-reminder>',
-    `Context usage is at ~${used.toLocaleString()} tokens of ~${ceiling.toLocaleString()} before auto-compaction. `,
-    'If you are at a natural pause point, consider running /compact to summarize history before the SDK auto-compacts at an arbitrary point. ',
-    'If you are mid-task, ignore this — it will not be repeated until the next compaction cycle.',
+    `Context usage is now ${usedStr} tokens (auto-compact ceiling: ${ceilingStr}). `,
+    'If you are at a natural pause point (between tasks, after a deliverable, not mid-edit or mid-investigation), ',
+    'consider running `/compact` now — and STRONGLY PREFER passing an instructions argument so load-bearing details survive ',
+    '(specific identifiers, exact phrasing, the open question, the next pending step). ',
+    "Ignore if you're mid-task; this nudge is one-shot per compact cycle.",
     '</system-reminder>',
   ].join('');
 }
 
 export interface NudgeTracker {
-  onUsage(sample: UsageSample): void;
+  /**
+   * Record a usage sample. Returns the reminder text to push into the active
+   * query when usage first crosses the threshold in the current compact
+   * cycle; returns null otherwise (under threshold, already fired, or
+   * disabled).
+   */
+  onUsage(sample: UsageSample): string | null;
+  /** Reset the latch — call when the SDK emits a `compact_boundary` event. */
   onCompactBoundary(): void;
-  /** Returns reminder text if one is pending, then clears the pending flag. */
-  consumePending(): string | null;
   /** Test/inspection accessor. */
-  state(): { lastEffective: number; pending: boolean; sent: boolean };
+  state(): { lastEffective: number; sent: boolean };
 }
 
 export function createNudgeTracker(config: NudgeConfig = readNudgeConfig()): NudgeTracker {
   let lastEffective = 0;
-  let pending = false;
   let sent = false;
 
   return {
     onUsage(sample) {
-      if (!config.enabled) return;
+      if (!config.enabled) return null;
       const used = effectiveContext(sample);
       if (used > lastEffective) lastEffective = used;
-      if (!sent && used >= config.threshold) {
-        pending = true;
-        sent = true;
-      }
+      if (sent) return null;
+      if (used < config.threshold) return null;
+      sent = true;
+      return buildNudgeReminder(used, config.ceiling);
     },
     onCompactBoundary() {
       sent = false;
-      pending = false;
       lastEffective = 0;
     },
-    consumePending() {
-      if (!pending) return null;
-      pending = false;
-      return buildNudgeReminder(lastEffective, config.ceiling);
-    },
     state() {
-      return { lastEffective, pending, sent };
+      return { lastEffective, sent };
     },
   };
 }

--- a/container/agent-runner/src/compact-nudge.ts
+++ b/container/agent-runner/src/compact-nudge.ts
@@ -1,0 +1,107 @@
+// Early-compaction nudge: when effective context crosses a configurable ratio
+// of the SDK auto-compact ceiling, schedule a one-shot <system-reminder> to
+// prepend to the *next* user prompt. The reminder asks the agent to consider
+// running /compact at a natural pause point — never mid-task.
+//
+// Why a separate state machine: PR #2327 tried injecting a reminder into the
+// live query post-compact via `query.push()`. The SDK treated it as a synthetic
+// user turn and the agent replied to it. The fix is to attach the reminder as
+// context on the *next user prompt*, before the next `provider.query()` call —
+// not pushed into an active stream.
+//
+// One-shot per compact cycle: latch on usage, clear on observed compact_boundary
+// so a session that grows past the ratio again gets re-nudged.
+
+export interface NudgeConfig {
+  enabled: boolean;
+  ceiling: number;
+  threshold: number;
+  ratio: number;
+}
+
+const DEFAULT_RATIO = 0.75;
+const DEFAULT_CEILING = 165_000;
+
+export function readNudgeConfig(env: NodeJS.ProcessEnv = process.env): NudgeConfig {
+  const ratio = parseRatio(env.COMPACT_NUDGE_RATIO);
+  const ceiling = parseCeiling(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW);
+  const enabled = ratio > 0 && ratio < 1 && ceiling > 0;
+  return { enabled, ratio, ceiling, threshold: Math.floor(ceiling * ratio) };
+}
+
+function parseRatio(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_RATIO;
+  const v = Number(raw);
+  return Number.isFinite(v) ? v : 0;
+}
+
+function parseCeiling(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_CEILING;
+  const v = Number(raw);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_CEILING;
+}
+
+export interface UsageSample {
+  inputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+}
+
+export function effectiveContext(u: UsageSample): number {
+  return (u.inputTokens || 0) + (u.cacheReadInputTokens || 0) + (u.cacheCreationInputTokens || 0);
+}
+
+/**
+ * The reminder text. Framed as plain context for the next turn — never as a
+ * synthetic user message. The agent should ignore it if mid-task; act on it
+ * at a natural pause point.
+ */
+export function buildNudgeReminder(used: number, ceiling: number): string {
+  return [
+    '<system-reminder>',
+    `Context usage is at ~${used.toLocaleString()} tokens of ~${ceiling.toLocaleString()} before auto-compaction. `,
+    'If you are at a natural pause point, consider running /compact to summarize history before the SDK auto-compacts at an arbitrary point. ',
+    'If you are mid-task, ignore this — it will not be repeated until the next compaction cycle.',
+    '</system-reminder>',
+  ].join('');
+}
+
+export interface NudgeTracker {
+  onUsage(sample: UsageSample): void;
+  onCompactBoundary(): void;
+  /** Returns reminder text if one is pending, then clears the pending flag. */
+  consumePending(): string | null;
+  /** Test/inspection accessor. */
+  state(): { lastEffective: number; pending: boolean; sent: boolean };
+}
+
+export function createNudgeTracker(config: NudgeConfig = readNudgeConfig()): NudgeTracker {
+  let lastEffective = 0;
+  let pending = false;
+  let sent = false;
+
+  return {
+    onUsage(sample) {
+      if (!config.enabled) return;
+      const used = effectiveContext(sample);
+      if (used > lastEffective) lastEffective = used;
+      if (!sent && used >= config.threshold) {
+        pending = true;
+        sent = true;
+      }
+    },
+    onCompactBoundary() {
+      sent = false;
+      pending = false;
+      lastEffective = 0;
+    },
+    consumePending() {
+      if (!pending) return null;
+      pending = false;
+      return buildNudgeReminder(lastEffective, config.ceiling);
+    },
+    state() {
+      return { lastEffective, pending, sent };
+    },
+  };
+}

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -6,6 +6,7 @@ import { getPendingMessages } from './db/messages-in.js';
 import { getContinuation, setContinuation } from './db/session-state.js';
 import { MockProvider } from './providers/mock.js';
 import { runPollLoop } from './poll-loop.js';
+import type { AgentProvider, ProviderEvent } from './providers/types.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -298,12 +299,13 @@ describe('poll loop integration', () => {
 });
 
 // Helper: run poll loop until aborted or timeout
-async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
+async function runPollLoopWithTimeout(provider: AgentProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
   return Promise.race([
     runPollLoop({
       provider,
       providerName: 'mock',
       cwd: '/tmp',
+      signal,
     }),
     new Promise<void>((_, reject) => {
       signal.addEventListener('abort', () => reject(new Error('aborted')));
@@ -462,3 +464,158 @@ class InvalidSessionProvider {
     };
   }
 }
+
+// ── Early-compaction nudge ──────────────────────────────────────────────────
+//
+// A scripted provider that lets each test queue per-call event scripts and
+// captures the prompt string each query was started with. Used to prove that
+// once a `usage` event crosses the threshold, the *next* prompt has the nudge
+// prepended, and that a `compact_boundary` event re-arms the latch.
+
+type ScriptedEvent =
+  | { type: 'usage'; inputTokens: number; cacheReadInputTokens?: number; cacheCreationInputTokens?: number }
+  | { type: 'compact_boundary' }
+  | { type: 'result'; text: string };
+
+class ScriptedProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  readonly receivedPrompts: string[] = [];
+  private scripts: ScriptedEvent[][];
+  private callCount = 0;
+
+  constructor(scripts: ScriptedEvent[][]) {
+    this.scripts = scripts;
+  }
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query(input: { prompt: string }): {
+    push: (m: string) => void;
+    end: () => void;
+    abort: () => void;
+    events: AsyncIterable<ProviderEvent>;
+  } {
+    this.receivedPrompts.push(input.prompt);
+    const script = this.scripts[this.callCount] ?? this.scripts[this.scripts.length - 1] ?? [];
+    this.callCount++;
+
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'activity' };
+        yield { type: 'init', continuation: `scripted-${Date.now()}` };
+        for (const ev of script) {
+          yield { type: 'activity' };
+          if (ev.type === 'usage') {
+            yield {
+              type: 'usage',
+              inputTokens: ev.inputTokens,
+              cacheReadInputTokens: ev.cacheReadInputTokens ?? 0,
+              cacheCreationInputTokens: ev.cacheCreationInputTokens ?? 0,
+            };
+          } else if (ev.type === 'compact_boundary') {
+            yield { type: 'compact_boundary' };
+          } else if (ev.type === 'result') {
+            yield { type: 'result', text: ev.text };
+          }
+        }
+      },
+    };
+
+    return { push() {}, end() {}, abort() {}, events };
+  }
+}
+
+describe('poll loop — early-compaction nudge', () => {
+  async function waitForPrompts(provider: ScriptedProvider, n: number, timeoutMs: number): Promise<void> {
+    const start = Date.now();
+    while (provider.receivedPrompts.length < n) {
+      if (Date.now() - start > timeoutMs) throw new Error(`waitForPrompts(${n}) timeout — got ${provider.receivedPrompts.length}`);
+      await sleep(20);
+    }
+  }
+
+  it('prepends the nudge to the second prompt after a usage event crosses the threshold', async () => {
+    // 150k usage exceeds the default-ratio threshold of either 165k or 200k ceilings.
+    const provider = new ScriptedProvider([
+      // First turn: usage at 150k crosses the threshold → arm the nudge.
+      [
+        { type: 'usage', inputTokens: 150_000 },
+        { type: 'result', text: '<message to="discord-test">one</message>' },
+      ],
+      // Second turn: agent doesn't matter, we just want to inspect its prompt.
+      [{ type: 'result', text: '<message to="discord-test">two</message>' }],
+    ]);
+
+    insertMessage('m1', { sender: 'Alice', text: 'first' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 4000);
+
+    try {
+      await waitForPrompts(provider, 1, 2000);
+      insertMessage('m2', { sender: 'Alice', text: 'second' }, { platformId: 'chan-1', channelType: 'discord' });
+      await waitForPrompts(provider, 2, 3000);
+    } finally {
+      controller.abort();
+      await loopPromise.catch(() => {});
+    }
+
+    // First prompt: no nudge (latch wasn't armed yet).
+    expect(provider.receivedPrompts[0]).not.toContain('<system-reminder>');
+    // Second prompt: nudge prepended, then the actual user content.
+    expect(provider.receivedPrompts[1]).toContain('<system-reminder>');
+    expect(provider.receivedPrompts[1]).toContain('150,000');
+    expect(provider.receivedPrompts[1]).toContain('second');
+  }, 8000);
+
+  it('one-shot per cycle and re-arms after compact_boundary', async () => {
+    const provider = new ScriptedProvider([
+      // Turn 1: cross threshold → arm.
+      [
+        { type: 'usage', inputTokens: 150_000 },
+        { type: 'result', text: '<message to="discord-test">one</message>' },
+      ],
+      // Turn 2: usage even higher, but already-sent — must NOT re-arm. Then compact_boundary fires (mid-stream auto-compact). Latch resets.
+      [
+        { type: 'usage', inputTokens: 160_000 },
+        { type: 'compact_boundary' },
+        { type: 'result', text: '<message to="discord-test">two</message>' },
+      ],
+      // Turn 3: post-compact usage well above threshold → arm again.
+      [
+        { type: 'usage', inputTokens: 150_000 },
+        { type: 'result', text: '<message to="discord-test">three</message>' },
+      ],
+      // Turn 4: nothing — we just need the prompt.
+      [{ type: 'result', text: '<message to="discord-test">four</message>' }],
+    ]);
+
+    insertMessage('m1', { sender: 'Alice', text: 'first' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 12000);
+
+    try {
+      await waitForPrompts(provider, 1, 2000);
+      insertMessage('m2', { sender: 'Alice', text: 'second' }, { platformId: 'chan-1', channelType: 'discord' });
+      await waitForPrompts(provider, 2, 3000);
+      insertMessage('m3', { sender: 'Alice', text: 'third' }, { platformId: 'chan-1', channelType: 'discord' });
+      await waitForPrompts(provider, 3, 3000);
+      insertMessage('m4', { sender: 'Alice', text: 'fourth' }, { platformId: 'chan-1', channelType: 'discord' });
+      await waitForPrompts(provider, 4, 3000);
+    } finally {
+      controller.abort();
+      await loopPromise.catch(() => {});
+    }
+
+    // Prompt 2 has the nudge (armed by turn 1's usage).
+    expect(provider.receivedPrompts[1]).toContain('<system-reminder>');
+    // Prompt 3 does NOT have a nudge — already sent once.
+    expect(provider.receivedPrompts[2]).not.toContain('<system-reminder>');
+    // Prompt 4 has the nudge again — turn 3's post-compact usage(150k) crossed
+    // the freshly-reset threshold (compact_boundary in turn 2 reset the latch).
+    expect(provider.receivedPrompts[3]).toContain('<system-reminder>');
+  }, 18000);
+});

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -467,19 +467,27 @@ class InvalidSessionProvider {
 
 // ── Early-compaction nudge ──────────────────────────────────────────────────
 //
-// A scripted provider that lets each test queue per-call event scripts and
-// captures the prompt string each query was started with. Used to prove that
-// once a `usage` event crosses the threshold, the *next* prompt has the nudge
-// prepended, and that a `compact_boundary` event re-arms the latch.
+// A scripted provider that lets each test queue per-call event scripts,
+// captures the prompt string each query was started with, AND records every
+// follow-up `push()` made into the active query. Used to prove that when a
+// `usage` event crosses the threshold the tracker pushes a reminder into the
+// live query (so the agent must verbalize whether to compact), and that a
+// `compact_boundary` event re-arms the latch.
 
 type ScriptedEvent =
   | { type: 'usage'; inputTokens: number; cacheReadInputTokens?: number; cacheCreationInputTokens?: number }
   | { type: 'compact_boundary' }
   | { type: 'result'; text: string };
 
+interface PushedMessage {
+  callIndex: number;
+  text: string;
+}
+
 class ScriptedProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
   readonly receivedPrompts: string[] = [];
+  readonly pushed: PushedMessage[] = [];
   private scripts: ScriptedEvent[][];
   private callCount = 0;
 
@@ -497,10 +505,12 @@ class ScriptedProvider implements AgentProvider {
     abort: () => void;
     events: AsyncIterable<ProviderEvent>;
   } {
+    const callIndex = this.callCount;
     this.receivedPrompts.push(input.prompt);
-    const script = this.scripts[this.callCount] ?? this.scripts[this.scripts.length - 1] ?? [];
+    const script = this.scripts[callIndex] ?? this.scripts[this.scripts.length - 1] ?? [];
     this.callCount++;
 
+    const pushed = this.pushed;
     const events: AsyncIterable<ProviderEvent> = {
       async *[Symbol.asyncIterator]() {
         yield { type: 'activity' };
@@ -523,7 +533,14 @@ class ScriptedProvider implements AgentProvider {
       },
     };
 
-    return { push() {}, end() {}, abort() {}, events };
+    return {
+      push(text: string) {
+        pushed.push({ callIndex, text });
+      },
+      end() {},
+      abort() {},
+      events,
+    };
   }
 }
 
@@ -536,16 +553,21 @@ describe('poll loop — early-compaction nudge', () => {
     }
   }
 
-  it('prepends the nudge to the second prompt after a usage event crosses the threshold', async () => {
+  async function waitForPushes(provider: ScriptedProvider, n: number, timeoutMs: number): Promise<void> {
+    const start = Date.now();
+    while (provider.pushed.length < n) {
+      if (Date.now() - start > timeoutMs) throw new Error(`waitForPushes(${n}) timeout — got ${provider.pushed.length}`);
+      await sleep(20);
+    }
+  }
+
+  it('pushes the nudge into the active query when usage crosses the threshold', async () => {
     // 150k usage exceeds the default-ratio threshold of either 165k or 200k ceilings.
     const provider = new ScriptedProvider([
-      // First turn: usage at 150k crosses the threshold → arm the nudge.
       [
         { type: 'usage', inputTokens: 150_000 },
         { type: 'result', text: '<message to="discord-test">one</message>' },
       ],
-      // Second turn: agent doesn't matter, we just want to inspect its prompt.
-      [{ type: 'result', text: '<message to="discord-test">two</message>' }],
     ]);
 
     insertMessage('m1', { sender: 'Alice', text: 'first' }, { platformId: 'chan-1', channelType: 'discord' });
@@ -555,41 +577,41 @@ describe('poll loop — early-compaction nudge', () => {
 
     try {
       await waitForPrompts(provider, 1, 2000);
-      insertMessage('m2', { sender: 'Alice', text: 'second' }, { platformId: 'chan-1', channelType: 'discord' });
-      await waitForPrompts(provider, 2, 3000);
+      await waitForPushes(provider, 1, 2000);
     } finally {
       controller.abort();
       await loopPromise.catch(() => {});
     }
 
-    // First prompt: no nudge (latch wasn't armed yet).
+    // The first prompt itself is clean — the nudge is delivered as a push, not a prefix.
     expect(provider.receivedPrompts[0]).not.toContain('<system-reminder>');
-    // Second prompt: nudge prepended, then the actual user content.
-    expect(provider.receivedPrompts[1]).toContain('<system-reminder>');
-    expect(provider.receivedPrompts[1]).toContain('150,000');
-    expect(provider.receivedPrompts[1]).toContain('second');
+    // Exactly one push into the active query carrying the nudge.
+    expect(provider.pushed.length).toBe(1);
+    expect(provider.pushed[0].callIndex).toBe(0);
+    expect(provider.pushed[0].text).toContain('<system-reminder>');
+    expect(provider.pushed[0].text).toContain('150,000');
+    expect(provider.pushed[0].text).toContain('/compact');
   }, 8000);
 
   it('one-shot per cycle and re-arms after compact_boundary', async () => {
     const provider = new ScriptedProvider([
-      // Turn 1: cross threshold → arm.
+      // Turn 1: cross threshold → push nudge into THIS query.
       [
         { type: 'usage', inputTokens: 150_000 },
         { type: 'result', text: '<message to="discord-test">one</message>' },
       ],
-      // Turn 2: usage even higher, but already-sent — must NOT re-arm. Then compact_boundary fires (mid-stream auto-compact). Latch resets.
+      // Turn 2: usage even higher, already-sent — must NOT push again. Then
+      // compact_boundary fires (mid-stream auto-compact). Latch resets.
       [
         { type: 'usage', inputTokens: 160_000 },
         { type: 'compact_boundary' },
         { type: 'result', text: '<message to="discord-test">two</message>' },
       ],
-      // Turn 3: post-compact usage well above threshold → arm again.
+      // Turn 3: post-compact usage well above threshold → push again.
       [
         { type: 'usage', inputTokens: 150_000 },
         { type: 'result', text: '<message to="discord-test">three</message>' },
       ],
-      // Turn 4: nothing — we just need the prompt.
-      [{ type: 'result', text: '<message to="discord-test">four</message>' }],
     ]);
 
     insertMessage('m1', { sender: 'Alice', text: 'first' }, { platformId: 'chan-1', channelType: 'discord' });
@@ -599,23 +621,24 @@ describe('poll loop — early-compaction nudge', () => {
 
     try {
       await waitForPrompts(provider, 1, 2000);
+      await waitForPushes(provider, 1, 2000);
       insertMessage('m2', { sender: 'Alice', text: 'second' }, { platformId: 'chan-1', channelType: 'discord' });
       await waitForPrompts(provider, 2, 3000);
       insertMessage('m3', { sender: 'Alice', text: 'third' }, { platformId: 'chan-1', channelType: 'discord' });
       await waitForPrompts(provider, 3, 3000);
-      insertMessage('m4', { sender: 'Alice', text: 'fourth' }, { platformId: 'chan-1', channelType: 'discord' });
-      await waitForPrompts(provider, 4, 3000);
+      // After turn 3's usage event the latch should arm and push again.
+      await waitForPushes(provider, 2, 3000);
     } finally {
       controller.abort();
       await loopPromise.catch(() => {});
     }
 
-    // Prompt 2 has the nudge (armed by turn 1's usage).
-    expect(provider.receivedPrompts[1]).toContain('<system-reminder>');
-    // Prompt 3 does NOT have a nudge — already sent once.
-    expect(provider.receivedPrompts[2]).not.toContain('<system-reminder>');
-    // Prompt 4 has the nudge again — turn 3's post-compact usage(150k) crossed
-    // the freshly-reset threshold (compact_boundary in turn 2 reset the latch).
-    expect(provider.receivedPrompts[3]).toContain('<system-reminder>');
+    // Exactly two nudge pushes total — one per compact cycle.
+    const nudgePushes = provider.pushed.filter((p) => p.text.includes('<system-reminder>'));
+    expect(nudgePushes.length).toBe(2);
+    // First push happened during call 0 (the first query).
+    expect(nudgePushes[0].callIndex).toBe(0);
+    // Second push happened during call 2 (post-compact_boundary), not call 1.
+    expect(nudgePushes[1].callIndex).toBe(2);
   }, 18000);
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -174,18 +174,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
-    let prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
-
-    // Early-compaction nudge: if the prior turn's usage crossed the threshold,
-    // attach a one-shot <system-reminder> to this prompt before sending. The
-    // reminder is plain context for the next user turn — NOT a synthetic user
-    // message and NOT pushed into a live query (see PR #2327 for why those
-    // failed).
-    const nudge = nudgeTracker.consumePending();
-    if (nudge) {
-      prompt = `${nudge}\n\n${prompt}`;
-      log('Prepended early-compaction nudge to prompt');
-    }
+    const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
@@ -389,11 +378,15 @@ async function processQuery(
       touchHeartbeat();
 
       if (event.type === 'usage') {
-        nudgeTracker.onUsage({
+        const nudge = nudgeTracker.onUsage({
           inputTokens: event.inputTokens,
           cacheReadInputTokens: event.cacheReadInputTokens,
           cacheCreationInputTokens: event.cacheCreationInputTokens,
         });
+        if (nudge) {
+          log('Pushing early-compaction nudge into active query');
+          query.push(nudge);
+        }
       } else if (event.type === 'compact_boundary') {
         nudgeTracker.onCompactBoundary();
       } else if (event.type === 'init') {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -14,6 +14,7 @@ import {
   type RoutingContext,
 } from './formatter.js';
 import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
+import { createNudgeTracker, type NudgeTracker } from './compact-nudge.js';
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
@@ -38,6 +39,12 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * Optional abort signal for clean shutdown. Production never sets this
+   * (the loop runs until the process is killed). Tests use it so leaked
+   * loops don't compete with the next test's messages.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -66,9 +73,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   // This lets the new container re-process those messages.
   clearStaleProcessingAcks();
 
+  const nudgeTracker = createNudgeTracker();
+
   let pollCount = 0;
   let isFirstPoll = true;
   while (true) {
+    if (config.signal?.aborted) return;
+
     // Skip system messages — they're responses for MCP tools (e.g., ask_user_question)
     const messages = getPendingMessages(isFirstPoll).filter((m) => m.kind !== 'system');
     isFirstPoll = false;
@@ -163,7 +174,18 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
-    const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
+    let prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
+
+    // Early-compaction nudge: if the prior turn's usage crossed the threshold,
+    // attach a one-shot <system-reminder> to this prompt before sending. The
+    // reminder is plain context for the next user turn — NOT a synthetic user
+    // message and NOT pushed into a live query (see PR #2327 for why those
+    // failed).
+    const nudge = nudgeTracker.consumePending();
+    if (nudge) {
+      prompt = `${nudge}\n\n${prompt}`;
+      log('Prepended early-compaction nudge to prompt');
+    }
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
@@ -180,8 +202,12 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
+    // Forward an external abort (test-only signal) into the active query so a
+    // long-lived MockProvider stream actually ends when the test tears down.
+    const abortListener = () => query.abort();
+    config.signal?.addEventListener('abort', abortListener, { once: true });
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
+      const result = await processQuery(query, routing, processingIds, config.providerName, nudgeTracker);
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -210,6 +236,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       });
     } finally {
       clearCurrentInReplyTo();
+      config.signal?.removeEventListener('abort', abortListener);
     }
 
     // Ensure completed even if processQuery ended without a result event
@@ -262,6 +289,7 @@ async function processQuery(
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  nudgeTracker: NudgeTracker,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
@@ -360,7 +388,15 @@ async function processQuery(
       handleEvent(event, routing);
       touchHeartbeat();
 
-      if (event.type === 'init') {
+      if (event.type === 'usage') {
+        nudgeTracker.onUsage({
+          inputTokens: event.inputTokens,
+          cacheReadInputTokens: event.cacheReadInputTokens,
+          cacheCreationInputTokens: event.cacheCreationInputTokens,
+        });
+      } else if (event.type === 'compact_boundary') {
+        nudgeTracker.onCompactBoundary();
+      } else if (event.type === 'init') {
         queryContinuation = event.continuation;
         // Persist immediately so a mid-turn container crash still lets the
         // next wake resume the conversation. Without this, the session id

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -326,6 +326,19 @@ export class ClaudeProvider implements AgentProvider {
 
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
+        } else if (message.type === 'assistant') {
+          // Surface per-turn token usage so poll-loop can drive the early
+          // compaction nudge. SDK assistant messages carry a `usage` object;
+          // absent on partial/streaming chunks — skip those silently.
+          const usage = (message as { message?: { usage?: { input_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number } } }).message?.usage;
+          if (usage) {
+            yield {
+              type: 'usage',
+              inputTokens: usage.input_tokens ?? 0,
+              cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+              cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
+            };
+          }
         } else if (message.type === 'result') {
           const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
           yield { type: 'result', text };
@@ -334,6 +347,7 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {
           yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
+          yield { type: 'compact_boundary' };
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
           const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';
           yield { type: 'result', text: `Context compacted${detail}.` };

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -89,4 +89,19 @@ export type ProviderEvent =
    * event (tool call, thinking, partial message, anything) so the
    * poll-loop's idle timer stays honest during long tool runs.
    */
-  | { type: 'activity' };
+  | { type: 'activity' }
+  /**
+   * Per-turn token accounting from the underlying SDK. Optional — providers
+   * that don't surface usage simply never emit this. Consumed by the
+   * early-compaction nudge in poll-loop to compare against the auto-compact
+   * ceiling. All fields are absolute (not deltas) and represent the input
+   * cost of the assistant turn that produced them.
+   */
+  | { type: 'usage'; inputTokens: number; cacheReadInputTokens: number; cacheCreationInputTokens: number }
+  /**
+   * The underlying SDK auto-compacted history. Re-arms anything latched on a
+   * usage threshold (the nudge tracker, primarily). Distinct from the
+   * Claude-provider's existing remap of compact_boundary into a synthetic
+   * `result` text event — that path is preserved for backwards compatibility.
+   */
+  | { type: 'compact_boundary' };


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

## What

A feature skill that pushes a one-shot `<system-reminder>` into the active SDK query when effective context crosses a configurable fraction of the auto-compact ceiling. The reminder asks the agent to consider running `/compact` (with an `instructions` argument) at a natural pause point.

## Why — dynamic compaction, not a static prompt

The SDK already has a static compact prompt baked in. The problem with anything static — whether the built-in or a custom per-project override — is that it cannot know what the conversation is actually about *right now*. It produces a generic summary and drops the specific identifiers, exact phrasing, open question, and pending next step that the work depends on.

This skill is dynamic in a different sense: it doesn't replace the compact prompt at all. Instead, it nudges the agent to invoke `/compact <instructions>` itself, with an instructions payload it just wrote — informed by the conversation context it's still holding. Because the agent generates that payload from live context, the preservation rules are tailored to whatever the session is doing in that moment.

A natural follow-up is whether the nudge needs to vary between projects, workspaces, or sessions. It doesn't. The nudge text is constant; the *instructions the agent ends up passing to `/compact`* are what change, and those are produced from the agent's view of the live conversation. There's no per-project prompt to maintain.

A secondary benefit of pushing the reminder as a user message (rather than a silent context prefix) is that the agent has to acknowledge it and verbalize the decision — say whether this is a natural pause or it's mid-task — instead of being free to ignore it.

## How it works

- The Claude provider yields a new `usage` event after every assistant turn (`input_tokens + cache_read + cache_creation`).
- A pure state machine (`compact-nudge.ts`) tracks effective context. When it crosses `ceiling * ratio` for the first time in the current compact cycle, `onUsage()` returns the reminder text.
- The poll loop pushes that text into the active query via `query.push(...)`.
- The Claude provider also yields a new `compact_boundary` event; the tracker resets so the latch can re-arm if usage climbs again post-compact.

## Prior art — #2327

PR #2327 tried the same delivery mechanism — push a reminder into the active query — and was closed. This PR reuses the mechanism deliberately, with the safety rails the earlier attempt lacked:

- **One-shot per compact cycle.** A latch ensures exactly one push between compact boundaries. The earlier approach would have fired repeatedly as usage hovered near the threshold.
- **Auto-reset on `compact_boundary`.** The SDK's compaction event resets the latch so the nudge can arm again next cycle.
- **Configurable threshold + disable switch.** `COMPACT_NUDGE_RATIO` (default `0.75`) and `=0` to opt out entirely.
- **Dynamic instructions payload.** The reminder explicitly tells the agent to pass `instructions` to `/compact`, so the preserved details are written from live context rather than left to the static built-in summary.
- **Test coverage.** 19 unit + 2 integration tests around arming, one-shot semantics, post-compact re-arm, and the push wiring.

The fact that the agent treats the push as a user turn and replies to it is a feature here, not a bug — the reply surfaces the agent's compaction decision in the conversation.

## Configuration

Two env vars, both optional:

| Variable | Default | Effect |
|---|---|---|
| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `165000` | The SDK's auto-compact ceiling (already read by the SDK). |
| `COMPACT_NUDGE_RATIO` | `0.75` | Fraction of the ceiling that arms the nudge. `0` or `>= 1` disables it. |

## How it was tested

- `bun test` — 110 agent-runner tests pass (19 unit + 16 integration + the prior 75).
- `bun run typecheck` clean.
- Unit tests cover config parsing, threshold arming, one-shot semantics, and post-compact re-arming.
- Integration tests script `usage` and `compact_boundary` events through the poll loop and assert the nudge is pushed into the active query exactly once per compact cycle.

## Usage

```
/add-early-compact-nudge
```

Merges the `skill/early-compact-nudge` branch, rebuilds the container, restarts the service. Disable later without uninstalling by setting `COMPACT_NUDGE_RATIO=0`.
