### PR TITLE
docs: add v2.0.63 CHANGELOG entry and RELEASING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to NanoClaw will be documented in this file.
 
-For detailed release notes, see the [full changelog on the documentation site](https://docs.nanoclaw.dev/changelog).
-
 ## [2.0.63] - 2026-05-15
 
 Rollup release covering v2.0.55 through v2.0.63 — everything merged since the v2.0.54 tag. Starting with this release, NanoClaw publishes a GitHub Release on every `package.json` version bump; see [RELEASING.md](RELEASING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to NanoClaw will be documented in this file.
 
 For detailed release notes, see the [full changelog on the documentation site](https://docs.nanoclaw.dev/changelog).
 
+## [2.0.63] - 2026-05-15
+
+Rollup release covering v2.0.55 through v2.0.63 — everything merged since the v2.0.54 tag. Starting with this release, NanoClaw publishes a GitHub Release on every `package.json` version bump; see [RELEASING.md](RELEASING.md).
+
+- [BREAKING] **Service names are now per-install.** On v2 installs the launchd label and systemd unit are slugged to your project root: `com.nanoclaw.<sha1(projectRoot)[:8]>` and `nanoclaw-<slug>.service`. The old `com.nanoclaw` / `nanoclaw.service` names no longer match a real service — update any copy-pasted restart or status commands. Find your install's names with `source setup/lib/install-slug.sh && launchd_label` (macOS) or `systemd_unit` (Linux). The `ncl` transport-error help text and 26 skill files now use the canonical helper-driven pattern; see [setup/lib/install-slug.sh](setup/lib/install-slug.sh).
+- **Compaction destination reminder placement fixed.** The reminder injected after SDK auto-compaction now appears at the end of the compaction summary so it isn't stripped during truncation. Replaces the placement shipped in v2.0.54.
+- **Stronger message-wrapping enforcement.** The poll loop nudges the agent when its output lacks `<message>` wrapping, and `CLAUDE.md` core instructions now require wrapping even for single-destination agents. The welcome flow no longer double-greets.
+- **OneCLI credentials after MCP install.** MCP servers added through `add_mcp_server` now inherit OneCLI gateway routing — fixes the case where the agent kept asking for API keys after installing a new server.
+- **CLI scope hardening.** `scopeField` now fails closed when scope is missing, and `sessions get` is guarded against cross-group oracle access from group-scoped agents.
+- **gmail/gcal skills aligned with v2.** `/add-gmail-tool` and `/add-gcal-tool` now reflect the v2 container-config model — DB-backed mounts, no dead `TOOL_ALLOWLIST` edits, no `container.json` writes that get clobbered on next spawn. Manual sqlite3/JSON1 invocations corrected.
+- **Repo-rename cleanup.** Remaining `qwibitai/nanoclaw` references swept to `nanocoai/nanoclaw` across code and docs; CI workflow guards updated so they no longer no-op after the rename.
+- Slack scope checklist now includes `files:read` and `files:write` for skills that read or post attachments.
+- The internal-tag description in destination instructions no longer mentions scratchpads (which confused agents into routing them incorrectly).
+- Container startup is now graceful when the `on_wake` column is missing on older sessions DBs.
+
 ## [2.0.54] - 2026-05-10
 
 - **Per-group model and effort overrides.** Agent groups can now run a specific Claude model and effort level, set via `ncl groups config update --model <model> --effort <level>`. Defaults to the host-configured model when unset.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing NanoClaw
 
-Starting with v2.0.63, NanoClaw publishes a GitHub Release on every `package.json` version bump. Each release ships:
+Starting with v2.0.63, the goal is to publish a GitHub Release for every `package.json` version bump that lands on `main`. Releases are cut manually by a maintainer, so there can be lag between a bump merging and its release being published. The intent is *timeliness*, not strict 1:1 correlation with every bump.
+
+Each release ships:
 
 - A tagged commit on `main` (`vX.Y.Z`).
 - A `CHANGELOG.md` entry under `## [<version>] - <YYYY-MM-DD>`.
@@ -8,7 +10,7 @@ Starting with v2.0.63, NanoClaw publishes a GitHub Release on every `package.jso
 
 ## When to cut a release
 
-A release is cut whenever `package.json` is bumped on `main`. Maintainers bump the version on whatever cadence the work justifies — there is no fixed schedule. Cutting more frequently is better than batching: smaller releases are easier to read, pin, and revert.
+A release is cut by a maintainer publishing it. The trigger is a `package.json` bump on `main`, but the publish step is manual — there is no fixed schedule, and bumps that land back-to-back may be rolled into a single release (as v2.0.55 through v2.0.63 were). Cutting more frequently is preferable to batching: smaller releases are easier to read, pin, and revert.
 
 ## What goes in a release
 
@@ -35,6 +37,14 @@ A release is cut whenever `package.json` is bumped on `main`. Maintainers bump t
 
 If multiple `package.json` bumps land between two GitHub Releases (as happened between v2.0.54 and v2.0.63), the next release is a rollup: its CHANGELOG entry covers everything merged since the last released tag, and the body opens with a one-line "Rollup release covering vX.Y.Z through vX.Y.W." note. After the catchup, return to one release per bump.
 
-## Pinning
+## Channels and stability
 
-Packagers and forks pin to any tagged release. The tag is the source of truth — the GitHub Release's `target_commitish` always points to a tagged commit.
+NanoClaw currently ships a single channel: every published release is a stable release.
+
+- **Latest** — the most recent release on `main`, shown as "Latest release" on the GitHub Releases page. Consumers that want auto-bump follow GitHub's `/releases/latest` pointer.
+- **Stable** — currently identical to latest. NanoClaw has no separate stable branch and no pre-release/RC channel.
+- **Pinned** — any tagged release. Reproducible and the recommended choice for packagers and forks; published tags are not moved or retracted.
+
+If a pre-release channel is introduced later (e.g. `vX.Y.Z-rc.N`), those releases will be marked "Pre-release" on GitHub so they do not become the `latest` pointer, and this section will be updated to describe the promotion path.
+
+The tag is the source of truth — a GitHub Release's `target_commitish` always points to a tagged commit.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,40 @@
+# Releasing NanoClaw
+
+Starting with v2.0.63, NanoClaw publishes a GitHub Release on every `package.json` version bump. Each release ships:
+
+- A tagged commit on `main` (`vX.Y.Z`).
+- A `CHANGELOG.md` entry under `## [<version>] - <YYYY-MM-DD>`.
+- A GitHub Release whose body mirrors the CHANGELOG entry plus a contributors section.
+
+## When to cut a release
+
+A release is cut whenever `package.json` is bumped on `main`. Maintainers bump the version on whatever cadence the work justifies — there is no fixed schedule. Cutting more frequently is better than batching: smaller releases are easier to read, pin, and revert.
+
+## What goes in a release
+
+`CHANGELOG.md` is the canonical record of user-visible change. The release body on GitHub mirrors it. Aim for:
+
+- **Bold lead-ins** per major feature or fix, then a sentence-case prose explanation.
+- **`[BREAKING]` prefix** for any change that requires user action. Always include the workaround inline — never link to a separate doc for the fix.
+- **Doc links** for major features (relative paths into the repo, e.g. `[setup/lib/install-slug.sh](setup/lib/install-slug.sh)`).
+- **Inline commands** for actionable steps, in backticks.
+- **Minor items** as single plain bullets at the bottom of the entry, no bold lead-in.
+- **No PR numbers** in the user-facing prose. PR references can live in the GitHub Release's `## Contributors` section.
+
+## Publishing the release
+
+1. Bump `package.json` and add a `CHANGELOG.md` entry in the same commit (commit message: `chore: bump version to vX.Y.Z`).
+2. Once the bump commit lands on `main`, open a draft GitHub Release:
+   - **Tag:** `vX.Y.Z`, target `main`.
+   - **Title:** `vX.Y.Z` (bare version — descriptive content lives in the body, matching the CHANGELOG header pattern).
+   - **Body:** copy the CHANGELOG entry verbatim. Append a `## Contributors` section listing every PR author who landed work in the release window. Append a `**Full Changelog**: https://github.com/nanocoai/nanoclaw/compare/<prev-tag>...vX.Y.Z` line at the bottom.
+3. If anyone in the window opened their first NanoClaw PR, add a `## New Contributors` section above `## Contributors`, with each first-timer's first PR link and an invite to Discord.
+4. Publish (not just save draft).
+
+## Rollup releases
+
+If multiple `package.json` bumps land between two GitHub Releases (as happened between v2.0.54 and v2.0.63), the next release is a rollup: its CHANGELOG entry covers everything merged since the last released tag, and the body opens with a one-line "Rollup release covering vX.Y.Z through vX.Y.W." note. After the catchup, return to one release per bump.
+
+## Pinning
+
+Packagers and forks pin to any tagged release. The tag is the source of truth — the GitHub Release's `target_commitish` always points to a tagged commit.


### PR DESCRIPTION
## Summary

- Add CHANGELOG.md rollup entry for v2.0.63 covering everything merged since v2.0.54.
- Add RELEASING.md documenting the release policy that starts with v2.0.63.

## CHANGELOG voice match

The new entry follows the existing CHANGELOG conventions:

- Bold lead-ins per major change, sentence-case prose body.
- `[BREAKING]` prefix on the service-name change, with the workaround inline (no link-out for the fix).
- Doc link uses a relative path: `[setup/lib/install-slug.sh](setup/lib/install-slug.sh)`.
- Minor items collapsed to plain bullets at the bottom (Slack scope addition, scratchpad clause, `on_wake` graceful startup).
- No PR numbers in the user-facing prose.

## RELEASING.md contents

Covers:

- **Goal-framed policy** — the goal is to publish a GitHub Release for every `package.json` bump that lands on `main`, with releases cut manually by a maintainer. Acknowledges lag between bump and release; intent is timeliness, not strict 1:1.
- **What goes in a release** — bold lead-ins, `[BREAKING]` prefix conventions, doc-link style, no PR numbers in prose.
- **Publishing workflow** — bump + CHANGELOG in one commit, draft Release with bare-version title, body mirrors CHANGELOG plus Contributors / New Contributors / Full Changelog.
- **Rollup releases** — handling for catchup windows like v2.0.54..v2.0.63, with a one-line "Rollup release covering ..." note in the body.
- **Channels and stability** — explicit single-channel model today (every release is stable), with latest/stable/pinned definitions and a placeholder for a future pre-release channel.

## Commits

1. Initial CHANGELOG entry + RELEASING.md skeleton.
2. Follow-up: soften the per-bump policy and add the "Channels and stability" section, based on review feedback.

## Follow-up

Once this lands on `main`, the v2.0.63 draft GitHub Release body should be updated to mirror the CHANGELOG entry verbatim and link to RELEASING.md at the new relative path. The release body draft is staged at `release-v2.0.63/release-body.md` in the maintainer's workspace.

If/when [#2403](https://github.com/nanocoai/nanoclaw/pull/2403) (Release workflow) lands, RELEASING.md should be updated in that PR to reference the workflow and its gates.

## Test plan

- [x] Confirm CHANGELOG.md renders cleanly on GitHub with the new entry above v2.0.54.
- [x] Confirm RELEASING.md relative link from CHANGELOG.md resolves on GitHub.
- [x] Confirm doc link `[setup/lib/install-slug.sh](setup/lib/install-slug.sh)` resolves.
- [x] Maintainer reviews voice match against prior CHANGELOG entries.