### PR TITLE
feat(health-monitor): token status table + sweep all groups every 5 min

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -29,6 +29,7 @@ import { getDb, hasTable } from './db/connection.js';
 import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
+import { refreshOauthTokenIfNeeded } from './oauth-token-refresh.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
@@ -130,6 +131,15 @@ async function spawnContainer(session: Session): Promise<void> {
   // (extra mounts, env passthrough). Computed once and threaded through both
   // buildMounts and buildContainerArgs so side effects (mkdir, etc.) fire once.
   const { provider, contribution } = resolveProviderContribution(session, agentGroup, containerConfig);
+
+  // Refresh OAuth token before spawning if it's near expiry. This handles the
+  // shutdown case: token expired while the host was off, task fires on boot.
+  // buildMounts() still does a Keychain read afterward — the two don't conflict
+  // because this writes to both claude.json and Keychain first.
+  const claudeJsonPath = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, 'claude.json');
+  if (fs.existsSync(claudeJsonPath)) {
+    await refreshOauthTokenIfNeeded(claudeJsonPath, `[pre-spawn:${agentGroup.id}]`);
+  }
 
   const mounts = buildMounts(agentGroup, session, containerConfig, contribution);
   const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}`;
@@ -317,8 +327,9 @@ function buildMounts(
   if (!fs.existsSync(claudeJsonHostPath)) {
     const backupsDir = path.join(claudeDir, 'backups');
     if (fs.existsSync(backupsDir)) {
-      const backups = fs.readdirSync(backupsDir)
-        .filter(f => f.startsWith('.claude.json.backup.'))
+      const backups = fs
+        .readdirSync(backupsDir)
+        .filter((f) => f.startsWith('.claude.json.backup.'))
         .sort();
       if (backups.length > 0) {
         fs.copyFileSync(path.join(backupsDir, backups[backups.length - 1]), claudeJsonHostPath);
@@ -341,7 +352,10 @@ function buildMounts(
           const existing = JSON.parse(fs.readFileSync(claudeJsonHostPath, 'utf8'));
           existing.claudeAiOauth = freshOauth;
           fs.writeFileSync(claudeJsonHostPath, JSON.stringify(existing, null, 2));
-          log.debug('Refreshed OAuth token from Keychain', { agentGroupId: agentGroup.id, expiresAt: new Date(freshOauth.expiresAt).toISOString() });
+          log.debug('Refreshed OAuth token from Keychain', {
+            agentGroupId: agentGroup.id,
+            expiresAt: new Date(freshOauth.expiresAt).toISOString(),
+          });
         }
       }
     } catch {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -310,6 +310,46 @@ function buildMounts(
   // skill symlinks)
   mounts.push({ hostPath: claudeDir, containerPath: '/home/node/.claude', readonly: false });
 
+  // .claude.json lives at /home/node/.claude.json (parent of .claude/), not
+  // inside the mount above. Without a persistent bind mount it's lost on every
+  // container restart, causing "Invalid API key" on the next spawn.
+  const claudeJsonHostPath = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, 'claude.json');
+  if (!fs.existsSync(claudeJsonHostPath)) {
+    const backupsDir = path.join(claudeDir, 'backups');
+    if (fs.existsSync(backupsDir)) {
+      const backups = fs.readdirSync(backupsDir)
+        .filter(f => f.startsWith('.claude.json.backup.'))
+        .sort();
+      if (backups.length > 0) {
+        fs.copyFileSync(path.join(backupsDir, backups[backups.length - 1]), claudeJsonHostPath);
+      }
+    }
+  }
+  // Refresh OAuth token from macOS Keychain before every spawn. The token
+  // expires every ~8h and the container can't renew it — stale tokens cause
+  // silent 401s that appear as completed-but-empty processing_ack entries.
+  if (fs.existsSync(claudeJsonHostPath)) {
+    try {
+      const keychainRaw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', {
+        encoding: 'utf8',
+        timeout: 5000,
+      }).trim();
+      if (keychainRaw) {
+        const keychainData = JSON.parse(keychainRaw);
+        const freshOauth = keychainData?.claudeAiOauth;
+        if (freshOauth?.accessToken && freshOauth?.expiresAt) {
+          const existing = JSON.parse(fs.readFileSync(claudeJsonHostPath, 'utf8'));
+          existing.claudeAiOauth = freshOauth;
+          fs.writeFileSync(claudeJsonHostPath, JSON.stringify(existing, null, 2));
+          log.debug('Refreshed OAuth token from Keychain', { agentGroupId: agentGroup.id, expiresAt: new Date(freshOauth.expiresAt).toISOString() });
+        }
+      }
+    } catch {
+      // Non-macOS or Keychain unavailable — continue with whatever token is on disk
+    }
+    mounts.push({ hostPath: claudeJsonHostPath, containerPath: '/home/node/.claude.json', readonly: false });
+  }
+
   // Shared agent-runner source — read-only, same code for all groups.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
   mounts.push({ hostPath: agentRunnerSrc, containerPath: '/app/src', readonly: true });

--- a/src/db/migrations/016-token-status.ts
+++ b/src/db/migrations/016-token-status.ts
@@ -1,0 +1,21 @@
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration016: Migration = {
+  version: 16,
+  name: 'token-status',
+  up(db: Database.Database) {
+    db.prepare(
+      `
+      CREATE TABLE token_status (
+        agent_group_id TEXT PRIMARY KEY,
+        checked_at     INTEGER NOT NULL,
+        expires_at     INTEGER,
+        minutes_left   REAL,
+        status         TEXT NOT NULL,
+        refreshed_at   INTEGER
+      )
+    `,
+    ).run();
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-container-configs.js';
 import { migration015 } from './015-cli-scope.js';
+import { migration016 } from './016-token-status.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -35,6 +36,7 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migration016,
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/db/token-status.ts
+++ b/src/db/token-status.ts
@@ -1,0 +1,41 @@
+import { getDb } from './connection.js';
+
+export interface TokenStatusRow {
+  agent_group_id: string;
+  checked_at: number;
+  expires_at: number | null;
+  minutes_left: number | null;
+  status: 'ok' | 'refreshed' | 'failed' | 'no-token';
+  refreshed_at: number | null;
+}
+
+export function upsertTokenStatus(entry: {
+  agentGroupId: string;
+  checkedAt: number;
+  expiresAt: number | null;
+  minutesLeft: number | null;
+  status: 'ok' | 'refreshed' | 'failed' | 'no-token';
+}): void {
+  getDb()
+    .prepare(
+      `INSERT INTO token_status (agent_group_id, checked_at, expires_at, minutes_left, status, refreshed_at)
+       VALUES (@agentGroupId, @checkedAt, @expiresAt, @minutesLeft, @status, CASE WHEN @status = 'refreshed' THEN @checkedAt ELSE NULL END)
+       ON CONFLICT(agent_group_id) DO UPDATE SET
+         checked_at   = excluded.checked_at,
+         expires_at   = excluded.expires_at,
+         minutes_left = excluded.minutes_left,
+         status       = excluded.status,
+         refreshed_at = CASE WHEN excluded.status = 'refreshed' THEN excluded.checked_at ELSE token_status.refreshed_at END`,
+    )
+    .run({
+      agentGroupId: entry.agentGroupId,
+      checkedAt: entry.checkedAt,
+      expiresAt: entry.expiresAt,
+      minutesLeft: entry.minutesLeft,
+      status: entry.status,
+    });
+}
+
+export function getAllTokenStatuses(): TokenStatusRow[] {
+  return getDb().prepare('SELECT * FROM token_status ORDER BY agent_group_id').all() as TokenStatusRow[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,11 @@ async function main(): Promise<void> {
   // Idempotent — skips groups that already have a config row.
   backfillContainerConfigs();
 
+  // MODULE-HOOK:health-monitor:start
+  const { startHealthMonitor } = await import('./modules/health-monitor/index.js');
+  startHealthMonitor();
+  // MODULE-HOOK:health-monitor:end
+
   // 1c. One-time filesystem cutover — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
 

--- a/src/modules/health-monitor/alert.ts
+++ b/src/modules/health-monitor/alert.ts
@@ -1,0 +1,79 @@
+import https from 'https';
+
+import { getDb } from '../../db/connection.js';
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+import { resolveSession, writeSessionMessage } from '../../session-manager.js';
+import { wakeContainer } from '../../container-runner.js';
+
+export const HEALTH_MONITOR_AGENT_ID = 'health-monitor';
+const HEALTH_MONITOR_MG_ID = 'mg-health-monitor';
+
+export async function postAlert(message: string): Promise<void> {
+  const env = readEnvFile(['DISCORD_BOT_TOKEN', 'HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID']);
+  if (!env.DISCORD_BOT_TOKEN) {
+    log.warn('[health-monitor] No DISCORD_BOT_TOKEN — cannot post alert', { message });
+    return;
+  }
+  if (!env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID) {
+    log.warn('[health-monitor] No HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID — cannot post alert', { message });
+    return;
+  }
+
+  return new Promise((resolve) => {
+    const body = JSON.stringify({ content: message });
+    const req = https.request(
+      {
+        hostname: 'discord.com',
+        path: `/api/v10/channels/${env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID}/messages`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode >= 400) {
+          log.warn('[health-monitor] Discord alert HTTP error', { status: res.statusCode });
+        }
+        resolve();
+      },
+    );
+    req.on('error', (err) => {
+      log.warn('[health-monitor] Discord alert network error', { err });
+      resolve();
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function injectTask(prompt: string): Promise<void> {
+  try {
+    const agentGroup = getDb().prepare('SELECT id FROM agent_groups WHERE id = ?').get(HEALTH_MONITOR_AGENT_ID) as
+      | { id: string }
+      | undefined;
+
+    if (!agentGroup) {
+      log.warn('[health-monitor] Agent group not in DB — skipping task injection');
+      return;
+    }
+
+    const { session } = resolveSession(HEALTH_MONITOR_AGENT_ID, HEALTH_MONITOR_MG_ID, null, 'shared');
+    const messageId = `hm-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+    writeSessionMessage(HEALTH_MONITOR_AGENT_ID, session.id, {
+      id: messageId,
+      kind: 'task',
+      timestamp: new Date().toISOString(),
+      content: JSON.stringify({ prompt }),
+    });
+
+    await wakeContainer(session);
+    log.info('[health-monitor] Task injected', { sessionId: session.id });
+  } catch (err) {
+    log.error('[health-monitor] Failed to inject task', { err });
+  }
+}

--- a/src/modules/health-monitor/checks.ts
+++ b/src/modules/health-monitor/checks.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { DATA_DIR } from '../../config.js';
+import { isContainerRunning } from '../../container-runner.js';
+import { openOutboundDb } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+
+const TOKEN_WARN_MINUTES = 60;
+
+export interface TokenIssue {
+  agentGroupId: string;
+  minutesLeft: number;
+}
+
+export function checkTokenExpiry(): TokenIssue[] {
+  const issues: TokenIssue[] = [];
+  for (const group of getAllAgentGroups()) {
+    const claudeJsonPath = path.join(DATA_DIR, 'v2-sessions', group.id, 'claude.json');
+    if (!fs.existsSync(claudeJsonPath)) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+      const expiresAt = data?.claudeAiOauth?.expiresAt;
+      if (!expiresAt) continue;
+      const minutesLeft = Math.floor((expiresAt - Date.now()) / 60_000);
+      if (minutesLeft < TOKEN_WARN_MINUTES) {
+        issues.push({ agentGroupId: group.id, minutesLeft });
+      }
+    } catch {
+      // Ignore unreadable files
+    }
+  }
+  return issues;
+}
+
+/**
+ * Returns true when a session has recent completed processing_acks but produced
+ * zero messages_out in the same window — the signature of a silent 401 failure.
+ */
+export function checkSilentFail(session: Session): boolean {
+  // Skip the health-monitor itself, and skip sessions whose container is still alive
+  if (session.agent_group_id === 'health-monitor') return false;
+  if (isContainerRunning(session.id)) return false;
+
+  try {
+    const outDb = openOutboundDb(session.agent_group_id, session.id);
+    try {
+      const { count: ackCount } = outDb
+        .prepare(
+          "SELECT COUNT(*) as count FROM processing_ack WHERE status='completed' AND datetime(status_changed) > datetime('now', '-2 hours')",
+        )
+        .get() as { count: number };
+
+      if (ackCount === 0) return false;
+
+      const { count: outCount } = outDb
+        .prepare("SELECT COUNT(*) as count FROM messages_out WHERE datetime(timestamp) > datetime('now', '-2 hours')")
+        .get() as { count: number };
+
+      return outCount === 0;
+    } finally {
+      outDb.close();
+    }
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/health-monitor/index.ts
+++ b/src/modules/health-monitor/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Health monitor module.
+ *
+ * Runs every 5 minutes and checks for "can't run" level issues:
+ *   1. OAuth token near-expiry (belt-and-suspenders on top of pre-spawn refresh)
+ *   2. Silent-fail pattern: session completed processing but produced no output
+ *      — the signature of a 401 auth failure swallowed by the agent-runner
+ *
+ * On detection, posts a direct Discord alert to the keepalive channel and
+ * injects a diagnostic task into the health-monitor agent so Claude can
+ * investigate and report.
+ *
+ * Alert deduplication: each unique issue key is suppressed for 1 hour after
+ * the first alert so the channel isn't spammed on repeated sweeps.
+ */
+import { getActiveSessions } from '../../db/sessions.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { log } from '../../log.js';
+import { ensureHealthMonitorSetup } from './setup.js';
+import { checkTokenExpiry, checkSilentFail } from './checks.js';
+import { postAlert, injectTask } from './alert.js';
+
+const CHECK_INTERVAL_MS = 5 * 60 * 1_000;
+const ALERT_COOLDOWN_MS = 60 * 60 * 1_000;
+
+const alertedAt = new Map<string, number>();
+
+function shouldAlert(key: string): boolean {
+  const last = alertedAt.get(key) ?? 0;
+  if (Date.now() - last < ALERT_COOLDOWN_MS) return false;
+  alertedAt.set(key, Date.now());
+  return true;
+}
+
+async function runChecks(): Promise<void> {
+  // Check 1: OAuth token near-expiry
+  for (const { agentGroupId, minutesLeft } of checkTokenExpiry()) {
+    const key = `token:${agentGroupId}`;
+    if (!shouldAlert(key)) continue;
+    const msg =
+      `⚠️ **OAuth token expiring** — agent group \`${agentGroupId}\` expires in ${minutesLeft} min. ` +
+      `Pre-spawn refresh should handle it; alerting as belt-and-suspenders.`;
+    log.warn('[health-monitor] Token near-expiry', { agentGroupId, minutesLeft });
+    await postAlert(msg);
+    await injectTask(
+      `OAuth token for agent group "${agentGroupId}" expires in ${minutesLeft} minutes. ` +
+        `Verify the pre-spawn Keychain refresh is working: check the expiresAt in ` +
+        `data/v2-sessions/${agentGroupId}/claude.json against the current time. ` +
+        `If stale, read fresh token: security find-generic-password -s "Claude Code-credentials" -w`,
+    );
+  }
+
+  // Check 2: Silent-fail pattern per active session
+  for (const session of getActiveSessions()) {
+    if (!checkSilentFail(session)) continue;
+    const agentGroup = getAgentGroup(session.agent_group_id);
+    const groupName = agentGroup?.name ?? session.agent_group_id;
+    const key = `silent-fail:${session.id}`;
+    if (!shouldAlert(key)) continue;
+    const msg =
+      `🚨 **Silent task failure** — \`${groupName}\` (session \`${session.id.slice(-8)}\`) ` +
+      `completed processing in the last 2h but produced no output. ` +
+      `Likely cause: 401 auth error swallowed by agent-runner.`;
+    log.warn('[health-monitor] Silent fail detected', { sessionId: session.id, agentGroupId: session.agent_group_id });
+    await postAlert(msg);
+    await injectTask(
+      `Investigate silent task failure in agent "${groupName}" (session ID: ${session.id}). ` +
+        `The session shows completed processing_ack entries but zero messages_out in the last 2 hours. ` +
+        `Typical cause: OAuth 401 error — the container started, got auth failure, reported "completed" with no output. ` +
+        `Steps to diagnose:\n` +
+        `1. Check the most recent container logs: docker logs $(docker ps -a --filter "name=nanoclaw-v2-${agentGroup?.folder ?? session.agent_group_id}" --format "{{.Names}}" | head -1) 2>&1 | tail -30\n` +
+        `2. Check token status: python3 -c "import json,datetime,os; d=json.load(open('data/v2-sessions/${session.agent_group_id}/claude.json')); o=d.get('claudeAiOauth',{}); ts=o.get('expiresAt',0)/1000; print('expires:', datetime.datetime.utcfromtimestamp(ts), 'UTC', '— EXPIRED' if datetime.datetime.utcnow() > datetime.datetime.utcfromtimestamp(ts) else '— VALID')"\n` +
+        `3. Report findings and recommended action to this channel.`,
+    );
+  }
+}
+
+let timer: NodeJS.Timeout | null = null;
+
+function schedule(): void {
+  timer = setTimeout(async () => {
+    try {
+      await runChecks();
+    } catch (err) {
+      log.error('[health-monitor] Check error', { err });
+    }
+    schedule();
+  }, CHECK_INTERVAL_MS);
+}
+
+/**
+ * Called from src/index.ts after initDb() — must NOT be called at module
+ * import time since the central DB isn't open yet.
+ */
+export function startHealthMonitor(): void {
+  ensureHealthMonitorSetup();
+  schedule();
+  log.info('[health-monitor] Started (interval: 5 min)');
+}

--- a/src/modules/health-monitor/index.ts
+++ b/src/modules/health-monitor/index.ts
@@ -19,6 +19,7 @@ import { log } from '../../log.js';
 import { ensureHealthMonitorSetup } from './setup.js';
 import { checkTokenExpiry, checkSilentFail } from './checks.js';
 import { postAlert, injectTask } from './alert.js';
+import { tryRefreshOauthToken } from './token-refresh.js';
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1_000;
 const ALERT_COOLDOWN_MS = 60 * 60 * 1_000;
@@ -33,21 +34,35 @@ function shouldAlert(key: string): boolean {
 }
 
 async function runChecks(): Promise<void> {
-  // Check 1: OAuth token near-expiry
+  // Check 1: OAuth token near-expiry — attempt auto-refresh first, only alert if it fails
   for (const { agentGroupId, minutesLeft } of checkTokenExpiry()) {
     const key = `token:${agentGroupId}`;
     if (!shouldAlert(key)) continue;
-    const msg =
-      `⚠️ **OAuth token expiring** — agent group \`${agentGroupId}\` expires in ${minutesLeft} min. ` +
-      `Pre-spawn refresh should handle it; alerting as belt-and-suspenders.`;
-    log.warn('[health-monitor] Token near-expiry', { agentGroupId, minutesLeft });
-    await postAlert(msg);
-    await injectTask(
-      `OAuth token for agent group "${agentGroupId}" expires in ${minutesLeft} minutes. ` +
-        `Verify the pre-spawn Keychain refresh is working: check the expiresAt in ` +
-        `data/v2-sessions/${agentGroupId}/claude.json against the current time. ` +
-        `If stale, read fresh token: security find-generic-password -s "Claude Code-credentials" -w`,
-    );
+
+    log.warn('[health-monitor] Token near-expiry, attempting auto-refresh', { agentGroupId, minutesLeft });
+    const result = await tryRefreshOauthToken(agentGroupId);
+
+    const timeDesc =
+      minutesLeft < 0 ? `already expired ${Math.abs(minutesLeft)} min ago` : `expires in ${minutesLeft} min`;
+
+    if (result === 'refreshed') {
+      await postAlert(
+        `✅ **OAuth token auto-refreshed** — agent group \`${agentGroupId}\` (${timeDesc}). ` +
+          `New token written to claude.json and Keychain. No action needed.`,
+      );
+    } else {
+      // Cause is known: refresh_token expired or missing. No point asking the agent
+      // to investigate — just tell the user what to do.
+      const reason =
+        result === 'no-token'
+          ? 'no refresh token found in claude.json'
+          : 'refresh token rejected by Anthropic (likely expired)';
+      log.warn('[health-monitor] Token auto-refresh failed', { agentGroupId, result });
+      await postAlert(
+        `⚠️ **OAuth token expiring** — agent group \`${agentGroupId}\` ${timeDesc}. ` +
+          `Auto-refresh failed (${reason}). Run \`claude login\` on the host to re-authenticate.`,
+      );
+    }
   }
 
   // Check 2: Silent-fail pattern per active session

--- a/src/modules/health-monitor/index.ts
+++ b/src/modules/health-monitor/index.ts
@@ -1,25 +1,22 @@
 /**
  * Health monitor module.
  *
- * Runs every 5 minutes and checks for "can't run" level issues:
- *   1. OAuth token near-expiry (belt-and-suspenders on top of pre-spawn refresh)
- *   2. Silent-fail pattern: session completed processing but produced no output
- *      — the signature of a 401 auth failure swallowed by the agent-runner
+ * Runs every 5 minutes:
+ *   1. Token sweep — checks OAuth tokens for ALL agent groups, auto-refreshes
+ *      near-expiry ones, writes results to token_status table. Alerts only on
+ *      failure (refresh token rejected → manual claude login needed).
+ *   2. Silent-fail pattern — session completed processing but produced no
+ *      output, the signature of a 401 auth failure swallowed by agent-runner.
  *
- * On detection, posts a direct Discord alert to the keepalive channel and
- * injects a diagnostic task into the health-monitor agent so Claude can
- * investigate and report.
- *
- * Alert deduplication: each unique issue key is suppressed for 1 hour after
- * the first alert so the channel isn't spammed on repeated sweeps.
+ * Alert deduplication: each unique issue key is suppressed for 1 hour.
  */
 import { getActiveSessions } from '../../db/sessions.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { log } from '../../log.js';
 import { ensureHealthMonitorSetup } from './setup.js';
-import { checkTokenExpiry, checkSilentFail } from './checks.js';
+import { checkSilentFail } from './checks.js';
 import { postAlert, injectTask } from './alert.js';
-import { tryRefreshOauthToken } from './token-refresh.js';
+import { sweepAllTokens } from './token-sweep.js';
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1_000;
 const ALERT_COOLDOWN_MS = 60 * 60 * 1_000;
@@ -34,38 +31,36 @@ function shouldAlert(key: string): boolean {
 }
 
 async function runChecks(): Promise<void> {
-  // Check 1: OAuth token near-expiry — attempt auto-refresh first, only alert if it fails
-  for (const { agentGroupId, minutesLeft } of checkTokenExpiry()) {
+  // Check 1: token sweep — refresh all near-expiry groups, record to token_status
+  for (const { agentGroupId, status, minutesLeft } of await sweepAllTokens()) {
+    if (status === 'ok' || status === 'no-token') continue;
+
     const key = `token:${agentGroupId}`;
     if (!shouldAlert(key)) continue;
 
-    log.warn('[health-monitor] Token near-expiry, attempting auto-refresh', { agentGroupId, minutesLeft });
-    const result = await tryRefreshOauthToken(agentGroupId);
-
     const timeDesc =
-      minutesLeft < 0 ? `already expired ${Math.abs(minutesLeft)} min ago` : `expires in ${minutesLeft} min`;
+      minutesLeft === null
+        ? 'unknown expiry'
+        : minutesLeft < 0
+          ? `already expired ${Math.abs(minutesLeft)} min ago`
+          : `expires in ${minutesLeft} min`;
 
-    if (result === 'refreshed') {
+    if (status === 'refreshed') {
       await postAlert(
         `✅ **OAuth token auto-refreshed** — agent group \`${agentGroupId}\` (${timeDesc}). ` +
           `New token written to claude.json and Keychain. No action needed.`,
       );
     } else {
-      // Cause is known: refresh_token expired or missing. No point asking the agent
-      // to investigate — just tell the user what to do.
-      const reason =
-        result === 'no-token'
-          ? 'no refresh token found in claude.json'
-          : 'refresh token rejected by Anthropic (likely expired)';
-      log.warn('[health-monitor] Token auto-refresh failed', { agentGroupId, result });
+      log.warn('[health-monitor] Token auto-refresh failed', { agentGroupId, status });
       await postAlert(
         `⚠️ **OAuth token expiring** — agent group \`${agentGroupId}\` ${timeDesc}. ` +
-          `Auto-refresh failed (${reason}). Run \`claude login\` on the host to re-authenticate.`,
+          `Auto-refresh failed (refresh token rejected by Anthropic — likely expired). ` +
+          `Run \`claude login\` on the host to re-authenticate.`,
       );
     }
   }
 
-  // Check 2: Silent-fail pattern per active session
+  // Check 2: silent-fail pattern per active session
   for (const session of getActiveSessions()) {
     if (!checkSilentFail(session)) continue;
     const agentGroup = getAgentGroup(session.agent_group_id);

--- a/src/modules/health-monitor/setup.ts
+++ b/src/modules/health-monitor/setup.ts
@@ -1,0 +1,75 @@
+/**
+ * One-time idempotent setup for the health-monitor agent group.
+ * Creates agent group, messaging group for the keepalive channel, and wires them.
+ * Safe to call on every startup — skips rows that already exist.
+ *
+ * Required .env keys:
+ *   HEALTH_MONITOR_DISCORD_GUILD_ID    — Discord server (guild) ID
+ *   HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID — Channel ID for alert delivery
+ *
+ * If either key is missing, the agent group is still created but Discord
+ * wiring is skipped (alerts will be suppressed with a warning).
+ */
+import { getDb } from '../../db/connection.js';
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+import { HEALTH_MONITOR_AGENT_ID } from './alert.js';
+
+const HEALTH_MONITOR_MG_ID = 'mg-health-monitor';
+
+export function ensureHealthMonitorSetup(): void {
+  const db = getDb();
+
+  // Agent group
+  const existing = db.prepare('SELECT id FROM agent_groups WHERE id = ?').get(HEALTH_MONITOR_AGENT_ID);
+  if (!existing) {
+    db.prepare(
+      `INSERT INTO agent_groups (id, name, folder, agent_provider, created_at)
+       VALUES (?, ?, ?, NULL, datetime('now'))`,
+    ).run(HEALTH_MONITOR_AGENT_ID, 'Health Monitor', 'health-monitor');
+    log.info('[health-monitor] Created agent group');
+  }
+
+  const env = readEnvFile(['HEALTH_MONITOR_DISCORD_GUILD_ID', 'HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID']);
+  if (!env.HEALTH_MONITOR_DISCORD_GUILD_ID || !env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID) {
+    log.warn(
+      '[health-monitor] HEALTH_MONITOR_DISCORD_GUILD_ID or HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID not set in .env — Discord wiring skipped',
+    );
+    return;
+  }
+
+  // Messaging group for the keepalive Discord channel
+  const platformId = `discord:${env.HEALTH_MONITOR_DISCORD_GUILD_ID}:${env.HEALTH_MONITOR_KEEPALIVE_CHANNEL_ID}`;
+  const existingMg = db.prepare('SELECT id FROM messaging_groups WHERE id = ?').get(HEALTH_MONITOR_MG_ID);
+  if (!existingMg) {
+    db.prepare(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
+       VALUES (?, 'discord', ?, 'keepalive', 1, 'ignore', datetime('now'))`,
+    ).run(HEALTH_MONITOR_MG_ID, platformId);
+    log.info('[health-monitor] Created messaging group', { platformId });
+  }
+
+  // Wiring
+  const existingWiring = db
+    .prepare('SELECT 1 FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
+    .get(HEALTH_MONITOR_MG_ID, HEALTH_MONITOR_AGENT_ID);
+  if (!existingWiring) {
+    db.prepare(
+      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, session_mode, priority, created_at)
+       VALUES ('mga-health-monitor', ?, ?, 'shared', 0, datetime('now'))`,
+    ).run(HEALTH_MONITOR_MG_ID, HEALTH_MONITOR_AGENT_ID);
+    log.info('[health-monitor] Created wiring');
+  }
+
+  // Named destination so the agent can use <message to="keepalive"> in its output
+  const existingDest = db
+    .prepare("SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND local_name = 'keepalive'")
+    .get(HEALTH_MONITOR_AGENT_ID);
+  if (!existingDest) {
+    db.prepare(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES (?, 'keepalive', 'channel', ?, datetime('now'))`,
+    ).run(HEALTH_MONITOR_AGENT_ID, HEALTH_MONITOR_MG_ID);
+    log.info('[health-monitor] Created keepalive destination');
+  }
+}

--- a/src/modules/health-monitor/token-refresh.ts
+++ b/src/modules/health-monitor/token-refresh.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+
+import { DATA_DIR } from '../../config.js';
+import { refreshOauthTokenIfNeeded } from '../../oauth-token-refresh.js';
+
+export async function tryRefreshOauthToken(agentGroupId: string): Promise<'refreshed' | 'failed' | 'no-token'> {
+  const claudeJsonPath = path.join(DATA_DIR, 'v2-sessions', agentGroupId, 'claude.json');
+  const result = await refreshOauthTokenIfNeeded(claudeJsonPath, `[health-monitor:${agentGroupId}]`);
+  // Map 'not-needed' to 'refreshed' — from the caller's perspective, if token is healthy, nothing to do
+  return result === 'not-needed' ? 'refreshed' : result;
+}

--- a/src/modules/health-monitor/token-sweep.ts
+++ b/src/modules/health-monitor/token-sweep.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { upsertTokenStatus } from '../../db/token-status.js';
+import { DATA_DIR } from '../../config.js';
+import { refreshOauthTokenIfNeeded } from '../../oauth-token-refresh.js';
+
+export interface TokenSweepResult {
+  agentGroupId: string;
+  status: 'ok' | 'refreshed' | 'failed' | 'no-token';
+  minutesLeft: number | null;
+}
+
+function readMinutesLeft(claudeJsonPath: string): { minutesLeft: number | null; expiresAt: number | null } {
+  try {
+    const data = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+    const expiresAt = data?.claudeAiOauth?.expiresAt as number | undefined;
+    if (!expiresAt) return { minutesLeft: null, expiresAt: null };
+    return { minutesLeft: Math.floor((expiresAt - Date.now()) / 60_000), expiresAt };
+  } catch {
+    return { minutesLeft: null, expiresAt: null };
+  }
+}
+
+/**
+ * Checks OAuth tokens for all agent groups. Groups with tokens expiring
+ * within the threshold are refreshed automatically. Results are written
+ * to the token_status table and returned for alerting.
+ *
+ * Skips the health-monitor group itself (no claude.json).
+ */
+export async function sweepAllTokens(): Promise<TokenSweepResult[]> {
+  const results: TokenSweepResult[] = [];
+
+  for (const group of getAllAgentGroups()) {
+    if (group.id === 'health-monitor') continue;
+
+    const claudeJsonPath = path.join(DATA_DIR, 'v2-sessions', group.id, 'claude.json');
+
+    const raw = await refreshOauthTokenIfNeeded(claudeJsonPath, `[token-sweep:${group.id}]`);
+    const status: TokenSweepResult['status'] = raw === 'not-needed' ? 'ok' : raw;
+
+    const { minutesLeft, expiresAt } = readMinutesLeft(claudeJsonPath);
+
+    upsertTokenStatus({
+      agentGroupId: group.id,
+      checkedAt: Date.now(),
+      expiresAt,
+      minutesLeft,
+      status,
+    });
+
+    results.push({ agentGroupId: group.id, status, minutesLeft });
+  }
+
+  return results;
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -22,3 +22,4 @@ import './scheduling/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './health-monitor/index.js';

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+import { log } from './log.js';
+
+const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+// Refresh when access token expires within this many minutes.
+export const OAUTH_REFRESH_THRESHOLD_MINUTES = 60;
+
+interface OauthFields {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Attempts to refresh the OAuth access token stored in `claudeJsonPath`
+ * using the stored refresh_token. Updates both the file and macOS Keychain
+ * on success so subsequent reads (including pre-spawn Keychain reads) see
+ * the fresh token.
+ *
+ * Returns:
+ *   'refreshed'  — new token written, good to go
+ *   'failed'     — API call rejected (refresh token likely expired; user must re-run claude login)
+ *   'no-token'   — file not found or has no refreshToken field
+ *   'not-needed' — token is not near expiry, no refresh attempted
+ */
+export async function refreshOauthTokenIfNeeded(
+  claudeJsonPath: string,
+  logContext: string,
+): Promise<'refreshed' | 'failed' | 'no-token' | 'not-needed'> {
+  if (!fs.existsSync(claudeJsonPath)) return 'no-token';
+
+  let fileData: Record<string, unknown>;
+  let current: OauthFields | undefined;
+  try {
+    fileData = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+    current = fileData?.claudeAiOauth as OauthFields | undefined;
+  } catch {
+    return 'no-token';
+  }
+  if (!current?.refreshToken) return 'no-token';
+
+  const minutesLeft = (current.expiresAt - Date.now()) / 60_000;
+  if (minutesLeft >= OAUTH_REFRESH_THRESHOLD_MINUTES) return 'not-needed';
+
+  let resp: Response;
+  try {
+    resp = await fetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'claude-code/1.0' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: current.refreshToken,
+        client_id: CLIENT_ID,
+      }),
+    });
+  } catch (err) {
+    log.warn(`${logContext} Token refresh network error`, { err });
+    return 'failed';
+  }
+
+  if (!resp.ok) {
+    log.warn(`${logContext} Token refresh rejected`, { status: resp.status });
+    return 'failed';
+  }
+
+  let body: { access_token?: string; refresh_token?: string; expires_in?: number };
+  try {
+    body = (await resp.json()) as typeof body;
+  } catch {
+    return 'failed';
+  }
+  if (!body.access_token) return 'failed';
+
+  const newOauth: OauthFields = {
+    ...current,
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token ?? current.refreshToken,
+    expiresAt: Date.now() + (body.expires_in ?? 28_800) * 1_000,
+  };
+
+  fileData.claudeAiOauth = newOauth;
+  fs.writeFileSync(claudeJsonPath, JSON.stringify(fileData, null, 2));
+
+  // Update Keychain so the next pre-spawn Keychain read sees the fresh token.
+  // Pass the new JSON via env var to avoid shell-quoting issues with the token string.
+  try {
+    const keychainRaw = execSync(`security find-generic-password -s "${KEYCHAIN_SERVICE}" -w 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+    if (keychainRaw) {
+      const keychainData = JSON.parse(keychainRaw);
+      keychainData.claudeAiOauth = newOauth;
+      execSync(
+        `security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "${process.env.USER ?? 'files'}" -w "$KEYCHAIN_PWD" -U`,
+        { encoding: 'utf8', timeout: 5_000, env: { ...process.env, KEYCHAIN_PWD: JSON.stringify(keychainData) } },
+      );
+    }
+  } catch (err) {
+    log.warn(`${logContext} Keychain update after refresh failed`, { err });
+  }
+
+  log.info(`${logContext} OAuth token refreshed`, { newExpiresAt: new Date(newOauth.expiresAt).toISOString() });
+  return 'refreshed';
+}


### PR DESCRIPTION
## Summary

Extends the health-monitor (introduced in #2498) and the OAuth auto-refresh (introduced in #2505) with a persistent status record and a proactive sweep of **all** agent groups on every 5-minute cycle.

### Problem this solves

The original per-alert refresh had a blind spot: refreshing group A rotates the shared OAuth `refresh_token`, silently invalidating group B's cached token. Group B only gets caught when it also hits the 60-min alert threshold — by which point it may already be expired.

### Changes

**Migration 016** (`src/db/migrations/016-token-status.ts`) — new `token_status` table in v2.db:
| Column | Type | Description |
|---|---|---|
| `agent_group_id` | TEXT PK | |
| `checked_at` | INTEGER | Unix ms |
| `expires_at` | INTEGER | Unix ms, null if no-token |
| `minutes_left` | REAL | null if no-token |
| `status` | TEXT | `ok \| refreshed \| failed \| no-token` |
| `refreshed_at` | INTEGER | Unix ms of last successful refresh |

**`src/db/token-status.ts`** — `upsertTokenStatus()` + `getAllTokenStatuses()`

**`src/modules/health-monitor/token-sweep.ts`** — `sweepAllTokens()`:
- Iterates every agent group (skips health-monitor itself)
- Calls `refreshOauthTokenIfNeeded()` for each (from #2505)
- Writes result to `token_status`
- Returns array of results for alerting

**`src/modules/health-monitor/index.ts`** — replaces per-alert token refresh with `sweepAllTokens()`. Every group is now checked and proactively refreshed every 5 minutes regardless of whether any alert has fired.

### Query status

```bash
pnpm exec tsx scripts/q.ts data/v2.db \
  "SELECT agent_group_id, CAST(minutes_left AS INTEGER) as min_left, status FROM token_status"
```

### Depends on

- #2498 (health-monitor base module)
- #2505 (OAuth auto-refresh shared utility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)