### PR TITLE
docs(changelog): align v2.0.63 rollup line with RELEASING.md voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [2.0.63] - 2026-05-15
 
-Rollup release covering v2.0.55 through v2.0.63 — everything merged since the v2.0.54 tag. Starting with this release, NanoClaw publishes a GitHub Release on every `package.json` version bump; see [RELEASING.md](RELEASING.md).
+Rollup release covering v2.0.55 through v2.0.63 — everything merged since the v2.0.54 tag. Starting with this release, the goal is to publish a GitHub Release for every `package.json` version bump that lands on `main`; see [RELEASING.md](RELEASING.md).
 
 - [BREAKING] **Service names are now per-install.** On v2 installs the launchd label and systemd unit are slugged to your project root: `com.nanoclaw.<sha1(projectRoot)[:8]>` and `nanoclaw-<slug>.service`. The old `com.nanoclaw` / `nanoclaw.service` names no longer match a real service — update any copy-pasted restart or status commands. Find your install's names with `source setup/lib/install-slug.sh && launchd_label` (macOS) or `systemd_unit` (Linux). The `ncl` transport-error help text and 26 skill files now use the canonical helper-driven pattern; see [setup/lib/install-slug.sh](setup/lib/install-slug.sh).
 - **Compaction destination reminder placement fixed.** The reminder injected after SDK auto-compaction now appears at the end of the compaction summary so it isn't stripped during truncation. Replaces the placement shipped in v2.0.54.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Aligns the v2.0.63 CHANGELOG rollup line with the voice of `RELEASING.md` (landed in #2502). The two files were merged in opposite states:

- `RELEASING.md` framed the per-bump release policy as a goal cut manually by a maintainer ("the goal is to publish a GitHub Release for every `package.json` version bump that lands on `main`... releases are cut manually").
- The v2.0.63 CHANGELOG rollup line kept the stronger phrasing ("Starting with this release, NanoClaw **publishes** a GitHub Release on every `package.json` version bump").

The published v2.0.63 GitHub Release body already uses the softened wording. This PR brings `CHANGELOG.md` on `main` in line so the policy doc, release body, and changelog all say the same thing going forward.

### Why this didn't land in #2502

The reconciliation commit (`6418dda`) was pushed to the branch ~12 minutes after #2502 merged, so it ended up as an orphan commit on the still-open branch rather than part of the merge.

### Files

- **EDIT** `CHANGELOG.md` — one-line change to the v2.0.63 rollup paragraph.

The tagged v2.0.63 release commit is not changed by this PR (tags are immutable per `RELEASING.md`); only the changelog as it appears on `main` going forward is updated.

## Testing

- [x] Confirm the only diff in this PR is the rollup line in `CHANGELOG.md`.
- [x] Confirm the new wording matches the opening of `RELEASING.md` ("the goal is to publish... lands on `main`").