### PR TITLE
feat: add Codex provider

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -20,6 +20,7 @@ ARG INSTALL_CJK_FONTS=false
 # mean every rebuild silently picks up the latest and can break in lockstep
 # across all users.
 ARG CLAUDE_CODE_VERSION=2.1.128
+ARG CODEX_VERSION=0.129.0-alpha.15
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=52.2.1
 ARG BUN_VERSION=1.3.12
@@ -109,6 +110,9 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
 
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     pnpm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "@openai/codex@${CODEX_VERSION}"
 
 # ---- ncl CLI wrapper ----------------------------------------------------------
 # Actual script lives in the mounted source at /app/src/cli/ncl.ts.

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -181,7 +181,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
+      const result = await processQuery(
+        query,
+        routing,
+        processingIds,
+        config.providerName,
+        config.provider.supportsActivePush !== false,
+      );
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -262,6 +268,7 @@ async function processQuery(
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  canPushFollowUps: boolean,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
@@ -279,7 +286,7 @@ async function processQuery(
   let pollInFlight = false;
   let endedForCommand = false;
   const pollHandle = setInterval(() => {
-    if (done || pollInFlight || endedForCommand) return;
+    if (!canPushFollowUps || done || pollInFlight || endedForCommand) return;
     pollInFlight = true;
 
     void (async () => {

--- a/container/agent-runner/src/providers/codex.test.ts
+++ b/container/agent-runner/src/providers/codex.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildCodexArgs, buildCodexPrompt, CodexProvider, extractCodexSessionId } from './codex.js';
+
+describe('CodexProvider', () => {
+  it('does not advertise active push support', () => {
+    expect(new CodexProvider().supportsActivePush).toBe(false);
+  });
+
+  it('detects invalid resumed sessions', () => {
+    const provider = new CodexProvider();
+
+    expect(provider.isSessionInvalid(new Error('thread/resume failed: no rollout found for thread id abc'))).toBe(true);
+    expect(provider.isSessionInvalid(new Error('Failed to authenticate. API Error: 401'))).toBe(false);
+  });
+
+  it('builds fresh exec args', () => {
+    expect(buildCodexArgs(undefined, '/tmp/out.txt', 'gpt-5.4-mini')).toEqual([
+      'exec',
+      '--json',
+      '--skip-git-repo-check',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '-o',
+      '/tmp/out.txt',
+      '-m',
+      'gpt-5.4-mini',
+      '-C',
+      '/workspace/agent',
+      '-',
+    ]);
+  });
+
+  it('builds resume exec args', () => {
+    expect(buildCodexArgs('thread-123', '/tmp/out.txt')).toEqual([
+      'exec',
+      'resume',
+      '--json',
+      '--skip-git-repo-check',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '-o',
+      '/tmp/out.txt',
+      'thread-123',
+      '-',
+    ]);
+  });
+
+  it('extracts a session id from nested JSONL events', () => {
+    const jsonl = [
+      JSON.stringify({ event: 'start' }),
+      JSON.stringify({ msg: { thread_id: 'thread-abc' } }),
+    ].join('\n');
+
+    expect(extractCodexSessionId(jsonl)).toBe('thread-abc');
+  });
+
+  it('composes a prompt with NanoClaw and Codex context', () => {
+    const prompt = buildCodexPrompt({
+      prompt: 'hello',
+      systemContext: { instructions: 'system instructions' },
+    });
+
+    expect(prompt).toContain('system instructions');
+    expect(prompt).toContain('You are running inside NanoClaw using Codex as the active provider.');
+    expect(prompt).toContain('/workspace/agent/CLAUDE.local.md');
+    expect(prompt).toContain('/workspace/global/CLAUDE.md');
+    expect(prompt).toContain('hello');
+  });
+});

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -1,0 +1,239 @@
+import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+const CODEX_HOME = process.env.CODEX_HOME || '/home/node/.codex';
+const OUTPUT_DIR = '/tmp';
+
+const INVALID_SESSION_RE = /thread\/resume failed: no rollout found|no rollout found for thread id|session.*not found/i;
+
+function log(msg: string): void {
+  console.error(`[codex-provider] ${msg}`);
+}
+
+function readOptional(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findSessionId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ['thread_id', 'session_id', 'conversation_id']) {
+    if (typeof record[key] === 'string') return record[key];
+  }
+  for (const child of Object.values(record)) {
+    const id = findSessionId(child);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+export function extractCodexSessionId(jsonl: string): string | undefined {
+  for (const line of jsonl.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const id = findSessionId(JSON.parse(line));
+      if (id) return id;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+export function buildCodexPrompt(input: QueryInput): string {
+  const sections: string[] = [];
+
+  if (input.systemContext?.instructions) {
+    sections.push(input.systemContext.instructions);
+  }
+
+  sections.push(
+    'You are running inside NanoClaw using Codex as the active provider.',
+    'The agent group folder is /workspace/agent.',
+    'Group memory may be available in /workspace/agent/CLAUDE.local.md.',
+    'Global memory may be available in /workspace/global/CLAUDE.md and should be treated as read-only unless NanoClaw explicitly grants write access.',
+  );
+
+  const composed = readOptional('/workspace/agent/CLAUDE.md');
+  if (composed) sections.push('NanoClaw instructions:', composed);
+
+  const local = readOptional('/workspace/agent/CLAUDE.local.md');
+  if (local) sections.push('Group memory:', local);
+
+  const global = readOptional('/workspace/global/CLAUDE.md');
+  if (global) sections.push('Global memory:', global);
+
+  sections.push('User messages:', input.prompt);
+  return sections.join('\n\n');
+}
+
+export function buildCodexArgs(continuation: string | undefined, outputPath: string, model?: string): string[] {
+  const common = [
+    '--json',
+    '--skip-git-repo-check',
+    '--dangerously-bypass-approvals-and-sandbox',
+    '-o',
+    outputPath,
+  ];
+  if (model) common.push('-m', model);
+
+  if (continuation) {
+    return ['exec', 'resume', ...common, continuation, '-'];
+  }
+
+  return ['exec', ...common, '-C', '/workspace/agent', '-'];
+}
+
+interface ProcessResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+function runCodexProcess(
+  args: string[],
+  prompt: string,
+  env: Record<string, string | undefined>,
+  setChild: (child: ChildProcess) => void,
+): Promise<ProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('codex', args, {
+      cwd: '/workspace/agent',
+      env: {
+        ...env,
+        HOME: '/home/node',
+        CODEX_HOME,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    setChild(child);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code }));
+
+    child.stdin?.write(prompt);
+    child.stdin?.end();
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class CodexProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  readonly supportsActivePush = false;
+
+  private env: Record<string, string | undefined>;
+  private model?: string;
+  private child: ChildProcess | null = null;
+
+  constructor(options: ProviderOptions = {}) {
+    this.env = options.env ?? {};
+    this.model = options.model;
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return INVALID_SESSION_RE.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    let ended = false;
+    let aborted = false;
+
+    async function* eventsFor(provider: CodexProvider): AsyncGenerator<ProviderEvent> {
+      const outputPath = path.join(OUTPUT_DIR, `codex-output-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
+      const prompt = buildCodexPrompt(input);
+      let effectiveContinuation = input.continuation;
+      let args = buildCodexArgs(effectiveContinuation, outputPath, provider.model);
+      let promise = runCodexProcess(args, prompt, provider.env, (child) => {
+        provider.child = child;
+      });
+      while (true) {
+        const tick = sleep(1000).then(() => 'tick' as const);
+        const done = promise.then(() => 'done' as const, () => 'done' as const);
+        if ((await Promise.race([tick, done])) === 'done') break;
+        yield { type: 'activity' };
+      }
+      let result = await promise;
+
+      if (!aborted && effectiveContinuation && result.code !== 0 && provider.isSessionInvalid(result.stderr)) {
+        log(`Invalid continuation ${effectiveContinuation}; starting a fresh Codex thread`);
+        effectiveContinuation = undefined;
+        args = buildCodexArgs(undefined, outputPath, provider.model);
+        promise = runCodexProcess(args, prompt, provider.env, (child) => {
+          provider.child = child;
+        });
+        while (true) {
+          const tick = sleep(1000).then(() => 'tick' as const);
+          const done = promise.then(() => 'done' as const, () => 'done' as const);
+          if ((await Promise.race([tick, done])) === 'done') break;
+          yield { type: 'activity' };
+        }
+        result = await promise;
+      }
+
+      provider.child = null;
+      if (aborted) return;
+
+      yield { type: 'activity' };
+
+      if (result.code !== 0) {
+        throw new Error(`Codex exited with code ${result.code}: ${result.stderr.slice(-1000)}`);
+      }
+
+      const continuation = effectiveContinuation || extractCodexSessionId(result.stdout);
+      if (continuation) {
+        yield { type: 'init', continuation };
+      }
+
+      let text: string | null = null;
+      try {
+        text = fs.readFileSync(outputPath, 'utf8').trim() || null;
+      } catch {
+        text = null;
+      }
+      try {
+        fs.unlinkSync(outputPath);
+      } catch {}
+
+      yield { type: 'result', text };
+    }
+
+    return {
+      push: () => {
+        if (!ended) log('Ignoring push: Codex provider processes one prompt per query');
+      },
+      end: () => {
+        ended = true;
+      },
+      events: eventsFor(this),
+      abort: () => {
+        aborted = true;
+        this.child?.kill('SIGTERM');
+      },
+    };
+  }
+}
+
+registerProvider('codex', (opts) => new CodexProvider(opts));

--- a/container/agent-runner/src/providers/factory.test.ts
+++ b/container/agent-runner/src/providers/factory.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 
 import { createProvider, type ProviderName } from './factory.js';
 import { ClaudeProvider } from './claude.js';
+import { CodexProvider } from './codex.js';
 import { MockProvider } from './mock.js';
 
 describe('createProvider', () => {
@@ -11,6 +12,10 @@ describe('createProvider', () => {
 
   it('returns MockProvider for mock', () => {
     expect(createProvider('mock')).toBeInstanceOf(MockProvider);
+  });
+
+  it('returns CodexProvider for codex', () => {
+    expect(createProvider('codex')).toBeInstanceOf(CodexProvider);
   });
 
   it('throws for unknown name', () => {

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -3,4 +3,5 @@
 // level. Skills add a new provider by appending one import line below.
 
 import './claude.js';
+import './codex.js';
 import './mock.js';

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -6,6 +6,13 @@ export interface AgentProvider {
    */
   readonly supportsNativeSlashCommands: boolean;
 
+  /**
+   * True unless the provider can only process one complete prompt at a time.
+   * When false, the poll loop leaves new messages pending until the current
+   * query finishes instead of pushing them into an active query.
+   */
+  readonly supportsActivePush?: boolean;
+
   /** Start a new query. Returns a handle for streaming input and output. */
   query(input: QueryInput): AgentQuery;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,4 @@ The files in this directory are original design documents and developer referenc
 | [skills-as-branches.md](skills-as-branches.md) | [Skills system](https://docs.nanoclaw.dev/integrations/skills-system) |
 | [docker-sandboxes.md](docker-sandboxes.md) | [Docker Sandboxes](https://docs.nanoclaw.dev/advanced/docker-sandboxes) |
 | [APPLE-CONTAINER-NETWORKING.md](APPLE-CONTAINER-NETWORKING.md) | [Container runtime](https://docs.nanoclaw.dev/advanced/container-runtime) |
+| [codex-provider.md](codex-provider.md) | Codex provider |

--- a/docs/codex-provider.md
+++ b/docs/codex-provider.md
@@ -1,0 +1,65 @@
+# Codex Provider
+
+NanoClaw can run an agent group with Codex instead of Claude by selecting the
+`codex` provider in that group's container config.
+
+```sh
+ncl groups config update --id <group-id> --provider codex --model gpt-5.4-mini
+ncl groups restart --id <group-id> --rebuild
+```
+
+The default provider remains `claude`. Existing Claude sessions and `.claude`
+state are not converted.
+
+## Authentication
+
+The Codex provider mounts a provider-specific session directory at
+`/home/node/.codex`.
+
+Authentication is resolved in this order:
+
+1. `.env` or host environment value `CODEX_AUTH_JSON`
+2. host `~/.codex/auth.json`
+3. `.env` or host environment value `OPENAI_API_KEY`
+4. `.env` or host environment value `CODEX_ACCESS_TOKEN`
+
+When an auth JSON file is available, NanoClaw copies it into the session's
+`.codex` directory before starting the container. This keeps Codex state
+separate from Claude state.
+
+## Runtime Behavior
+
+The container image installs both Claude Code and Codex CLI. Codex is used only
+for groups whose effective provider is `codex`.
+
+The container-side provider runs:
+
+```sh
+codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox -C /workspace/agent -
+```
+
+For resumed conversations it runs `codex exec resume` with the stored Codex
+thread id. If Codex reports a missing rollout/thread, NanoClaw starts a fresh
+Codex thread and stores the new id.
+
+### In-Flight Prompts
+
+Codex CLI processes one complete prompt at a time in this provider. While Codex
+is running, NanoClaw leaves follow-up messages pending and includes them in the
+next turn instead of pushing them into the active process.
+
+Codex itself supports interactive steering, but this first adapter uses
+`codex exec` as a one-shot child process and does not have a stable
+programmatic handle for sending steer messages into an active rollout. The
+intended implementation is to switch `push()` to Codex steering when the
+provider uses a Codex API or SDK path that exposes active rollout control.
+
+## Memory Files
+
+The Codex provider reads existing NanoClaw memory files as prompt context:
+
+- `/workspace/agent/CLAUDE.md`
+- `/workspace/agent/CLAUDE.local.md`
+- `/workspace/global/CLAUDE.md`
+
+It does not rename, migrate, or rewrite those files as part of provider setup.

--- a/src/providers/codex.test.ts
+++ b/src/providers/codex.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import './codex.js';
+import { getProviderContainerConfig } from './provider-container-registry.js';
+
+describe('codex provider container config', () => {
+  it('mounts isolated Codex state and writes auth JSON', () => {
+    const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-codex-provider-'));
+    const config = getProviderContainerConfig('codex');
+
+    expect(config).toBeDefined();
+
+    const contribution = config!({
+      sessionDir,
+      agentGroupId: 'agent-1',
+      hostEnv: { CODEX_AUTH_JSON: '{"tokens":{"access_token":"token"}}' },
+    });
+
+    expect(contribution.env?.CODEX_HOME).toBe('/home/node/.codex');
+    expect(contribution.mounts).toEqual([
+      {
+        hostPath: path.join(sessionDir, '.codex'),
+        containerPath: '/home/node/.codex',
+        readonly: false,
+      },
+    ]);
+    expect(fs.readFileSync(path.join(sessionDir, '.codex', 'auth.json'), 'utf8')).toContain('access_token');
+  });
+
+  it('passes explicit API auth through env', () => {
+    const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-codex-provider-'));
+    const config = getProviderContainerConfig('codex')!;
+
+    const contribution = config({
+      sessionDir,
+      agentGroupId: 'agent-1',
+      hostEnv: {
+        OPENAI_API_KEY: 'sk-test',
+        CODEX_ACCESS_TOKEN: 'access-test',
+      },
+    });
+
+    expect(contribution.env?.OPENAI_API_KEY).toBe('sk-test');
+    expect(contribution.env?.CODEX_ACCESS_TOKEN).toBe('access-test');
+  });
+});

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { readEnvFile } from '../env.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+function readHostCodexAuthJson(hostEnv: NodeJS.ProcessEnv): string | undefined {
+  const dotenv = readEnvFile(['CODEX_AUTH_JSON']);
+  if (dotenv.CODEX_AUTH_JSON) return dotenv.CODEX_AUTH_JSON;
+  if (hostEnv.CODEX_AUTH_JSON) return hostEnv.CODEX_AUTH_JSON;
+
+  const authPath = path.join(os.homedir(), '.codex', 'auth.json');
+  return fs.existsSync(authPath) ? fs.readFileSync(authPath, 'utf8') : undefined;
+}
+
+registerProviderContainerConfig('codex', (ctx) => {
+  const codexDir = path.join(ctx.sessionDir, '.codex');
+  fs.mkdirSync(codexDir, { recursive: true });
+
+  const authJson = readHostCodexAuthJson(ctx.hostEnv);
+  if (authJson) {
+    JSON.parse(authJson);
+    fs.writeFileSync(path.join(codexDir, 'auth.json'), authJson);
+  }
+
+  const dotenv = readEnvFile(['OPENAI_API_KEY', 'CODEX_ACCESS_TOKEN']);
+  const env: Record<string, string> = {
+    CODEX_HOME: '/home/node/.codex',
+  };
+  const openAiApiKey = dotenv.OPENAI_API_KEY ?? ctx.hostEnv.OPENAI_API_KEY;
+  if (openAiApiKey) env.OPENAI_API_KEY = openAiApiKey;
+  const codexAccessToken = dotenv.CODEX_ACCESS_TOKEN ?? ctx.hostEnv.CODEX_ACCESS_TOKEN;
+  if (codexAccessToken) env.CODEX_ACCESS_TOKEN = codexAccessToken;
+
+  return {
+    mounts: [{ hostPath: codexDir, containerPath: '/home/node/.codex', readonly: false }],
+    env,
+  };
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,3 +4,4 @@
 // needs (claude, mock) don't appear here.
 //
 // Skills add a new provider by appending one import line below.
+import './codex.js';


### PR DESCRIPTION
## Summary

- add a Codex provider alongside the existing Claude provider
- mount isolated Codex state/auth into agent containers
- install pinned Codex CLI support in the agent container image
- document Codex runtime behavior, auth, memory handling, and in-flight prompt limitation

## Notes

This first implementation uses `codex exec --json` as a one-shot child process. Follow-up messages are queued for the next turn instead of pushed into an active rollout. The docs call out the intended future implementation: map NanoClaw `push()` to Codex steering once a Codex API/SDK path exposes active rollout control.

Existing Claude behavior remains the default and is not removed.

## Validation

- `pnpm run typecheck`
- `bun run typecheck`
- `pnpm test`
- `bun test`
- `pnpm exec eslint src/providers/codex.ts`

## Smoke Test

Ran a lightweight isolated container smoke test from a clean checkout.

Method:

- built a fresh image from this branch as `nanoclaw-codex-smoke:latest`
- created a temp workspace under `/private/tmp` with its own `inbound.db`, `outbound.db`, agent folder, global memory folder, and copied Codex auth
- mounted only those temp paths into a single detached container
- inserted one pending smoke message into the temp `inbound.db`
- verified the Codex provider processed it and wrote to the temp `outbound.db`
- stopped the container and deleted the temp workspace, including the copied auth file

Observed container log:

```text
[agent-runner] Starting v2 agent-runner (provider: codex)
[poll-loop] Processing 1 message(s), kinds: chat
[poll-loop] Session: 019e3474-5be4-72d1-b839-ef34961c6eef
[poll-loop] Result: <message to="smoke">codex smoke ok</message>
[poll-loop] Completed 1 message(s)
```

Observed outbound DB payload:

```json
{"text":"codex smoke ok"}
```