### PR TITLE
feat(formatter): add from-channel and from-type to XML message attributes

### DIFF
--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -189,7 +189,10 @@ function formatSingleChat(msg: MessageInRow): string {
  */
 function originAttr(msg: MessageInRow): string {
   const fromDest = findByRouting(msg.channel_type, msg.platform_id);
-  if (fromDest) return ` from="${escapeXml(fromDest.name)}"`;
+  if (fromDest) {
+    const channelAttr = fromDest.channelType ? ` from-channel="${escapeXml(fromDest.channelType)}"` : '';
+    return ` from="${escapeXml(fromDest.name)}"${channelAttr} from-type="${fromDest.type}"`;
+  }
   if (msg.channel_type || msg.platform_id) {
     return ` from="unknown:${escapeXml(msg.channel_type || '')}:${escapeXml(msg.platform_id || '')}"`;
   }


### PR DESCRIPTION
Hey 

I run a multi-channel setup (Telegram + Discord) and built a small monitoring dashboard that parses the `.jsonl` transcripts. To display channel icons I needed to know the origin channel — and realized `fromDest.channelType` was already resolved in `findByRouting()` but not emitted in the XML.

This PR exposes it as two optional attributes on `<message>`:

- `from-channel` — normalized channel type (`"telegram"`, `"discord"`, `"slack"`, …); omitted when null (agent-to-agent messages)
- `from-type` — `"channel"` or `"agent"`; always present when `fromDest` is resolved

\`\`\`xml
<!-- before -->
<message from="Telegram - @pierre" ...>

<!-- after -->
<message from="Telegram - @pierre" from-channel="telegram" from-type="channel" ...>
\`\`\`

Non-breaking: unknown attributes are silently ignored by XML parsers, and existing sessions without these attributes continue to work.

Pierre