### PR TITLE
fix(chat-sdk-bridge): apply transformOutboundText on ask_question and card paths

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -205,3 +205,109 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(msg.markdown).toBe('plain hello');
   });
 });
+
+describe('createChatSdkBridge.deliver — transformOutboundText wiring', () => {
+  // transformOutboundText is the adapter-specific outbound sanitizer
+  // (e.g. sanitizeTelegramLegacyMarkdown for the Telegram channel). It must
+  // be applied on every user-visible string before it reaches the underlying
+  // Chat SDK adapter — otherwise Telegram rejects approval cards and
+  // send_card payloads with `Bad Request: can't parse entities` whenever
+  // the source text contains unbalanced markdown special chars (e.g. a
+  // single `_` in an agent name like `repo_pilot`). The text branch
+  // already runs it; these tests pin the wiring for the two card branches
+  // that previously skipped it.
+
+  const tag = (t: string) => `«${t}»`;
+
+  // CardText nodes render as { type: 'text', content: '...' } inside the
+  // Chat SDK Card tree. Walk the tree and collect every text leaf so the
+  // tests can assert sanitization regardless of where the text lives.
+  function collectCardText(node: { type?: string; content?: string; children?: unknown[] } | undefined): string[] {
+    if (!node) return [];
+    const out: string[] = [];
+    if (node.type === 'text' && typeof node.content === 'string') out.push(node.content);
+    for (const child of node.children ?? []) {
+      out.push(...collectCardText(child as { type?: string; content?: string; children?: unknown[] }));
+    }
+    return out;
+  }
+
+  it('applies to ask_question title, question, and fallbackText', async () => {
+    const { calls, postMessage } = makePostCapture();
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ postMessage }),
+      supportsThreads: false,
+      transformOutboundText: tag,
+    });
+    await bridge.deliver('telegram:42', null, {
+      kind: 'chat-sdk',
+      content: {
+        type: 'ask_question',
+        questionId: 'q1',
+        title: 'Approve install_packages',
+        question: 'Agent "repo_pilot" wants to install gcc',
+        options: [
+          { label: 'Approve', value: 'approve' },
+          { label: 'Reject', value: 'reject' },
+        ],
+      },
+    });
+    expect(calls).toHaveLength(1);
+    const msg = calls[0].message as {
+      card?: { title?: string; children?: unknown[] };
+      fallbackText?: string;
+    };
+    expect(msg.card?.title).toBe(tag('Approve install_packages'));
+    const cardTexts = collectCardText(msg.card as Parameters<typeof collectCardText>[0]);
+    expect(cardTexts).toContain(tag('Agent "repo_pilot" wants to install gcc'));
+    // Button labels are SDK-controlled (not user content) — fine to leave raw.
+    expect(msg.fallbackText).toContain(tag('Approve install_packages'));
+    expect(msg.fallbackText).toContain(tag('Agent "repo_pilot" wants to install gcc'));
+  });
+
+  it('applies to send_card title, description, string children, and fallbackText', async () => {
+    const { calls, postMessage } = makePostCapture();
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ postMessage }),
+      supportsThreads: false,
+      transformOutboundText: tag,
+    });
+    await bridge.deliver('telegram:42', null, {
+      kind: 'chat-sdk',
+      content: {
+        type: 'card',
+        card: {
+          title: 'Daily',
+          description: 'Your plate today',
+          children: ['• item one', { text: '• item two' }],
+        },
+        fallbackText: 'Daily: your plate',
+      },
+    });
+    expect(calls).toHaveLength(1);
+    const msg = calls[0].message as {
+      card?: { title?: string; children?: unknown[] };
+      fallbackText?: string;
+    };
+    expect(msg.card?.title).toBe(tag('Daily'));
+    const cardTexts = collectCardText(msg.card as Parameters<typeof collectCardText>[0]);
+    expect(cardTexts).toEqual(expect.arrayContaining([tag('Your plate today'), tag('• item one'), tag('• item two')]));
+    expect(msg.fallbackText).toBe(tag('Daily: your plate'));
+  });
+
+  it('still applies to plain markdown messages (regression guard)', async () => {
+    const { calls, postMessage } = makePostCapture();
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ postMessage }),
+      supportsThreads: false,
+      transformOutboundText: tag,
+    });
+    await bridge.deliver('telegram:42', null, {
+      kind: 'chat-sdk',
+      content: { text: 'hello world' },
+    });
+    expect(calls).toHaveLength(1);
+    const msg = calls[0].message as { markdown?: string };
+    expect(msg.markdown).toBe(tag('hello world'));
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -393,10 +393,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           return;
         }
         const options: NormalizedOption[] = normalizeOptions(content.options as never);
+        const safeTitle = transformText(title);
+        const safeQuestion = transformText(question);
         const card = Card({
-          title,
+          title: safeTitle,
           children: [
-            CardText(question),
+            CardText(safeQuestion),
             Actions(
               // Encode button id/value with the option index rather than the
               // full value. Telegram caps callback_data at 64 bytes, and
@@ -411,7 +413,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         });
         const result = await adapter.postMessage(tid, {
           card,
-          fallbackText: `${title}\n\n${question}\nOptions: ${options.map((o) => o.label).join(', ')}`,
+          fallbackText: `${safeTitle}\n\n${safeQuestion}\nOptions: ${options.map((o) => o.label).join(', ')}`,
         });
         return result?.id;
       }
@@ -426,18 +428,18 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
 
         const cardChildren: CardChild[] = [];
         if (typeof cardSpec.description === 'string' && cardSpec.description) {
-          cardChildren.push(CardText(cardSpec.description));
+          cardChildren.push(CardText(transformText(cardSpec.description)));
         }
         if (Array.isArray(cardSpec.children)) {
           for (const child of cardSpec.children) {
             if (typeof child === 'string' && child) {
-              cardChildren.push(CardText(child));
+              cardChildren.push(CardText(transformText(child)));
             } else if (
               child &&
               typeof child === 'object' &&
               typeof (child as Record<string, unknown>).text === 'string'
             ) {
-              cardChildren.push(CardText((child as Record<string, string>).text));
+              cardChildren.push(CardText(transformText((child as Record<string, string>).text)));
             }
           }
         }
@@ -464,8 +466,8 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           return;
         }
 
-        const card = Card({ title, children: cardChildren });
-        const result = await adapter.postMessage(tid, { card, fallbackText });
+        const card = Card({ title: transformText(title), children: cardChildren });
+        const result = await adapter.postMessage(tid, { card, fallbackText: transformText(fallbackText) });
         return result?.id;
       }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #2522.

### The bug

`createChatSdkBridge` accepts a `transformOutboundText` config function — the adapter-specific outbound sanitizer (Telegram uses `sanitizeTelegramLegacyMarkdown`). It's wired into the bridge at `src/channels/chat-sdk-bridge.ts:124` and called on the normal text branch at `L474`, but the two card branches above it built `Card` / `CardText` components from raw, unsanitized text:

- `ask_question` (L399) — `CardText(question)` and the `Card({ title })` wrapper
- `send_card` (L429–468) — `CardText(cardSpec.description)`, `CardText(child)`, `CardText(child.text)`, `Card({ title })`, and `fallbackText`

The transform stayed plumbed but unused on exactly the paths that emit approval cards and `send_card` payloads — i.e. the messages most likely to embed markdown special chars from agent-controlled metadata. Telegram rejected with `Bad Request: can't parse entities` and the admin's DM never received the card, leaving the agent in a stuck "waiting for approval" state with no visible card to act on.

Reproducible with any agent group whose name contains an `_` — e.g. `repo_pilot` triggering `install_packages`. The question body `Agent "repo_pilot" is attempting to install...` has its single unbalanced `_` at byte offset 38, exactly where Telegram's legacy Markdown parser fails.

### The fix

Apply `transformText` to every user-visible string before constructing `Card` / `CardText` nodes, mirroring the existing text-branch pattern at `L474`:

- `ask_question`: sanitize `title`, `question`, and `fallbackText`
- `send_card`: sanitize `title`, `description`, string and `{text}` children, and `fallbackText`

Button labels are left raw — they come from `NormalizedOption.label`, which the SDK escapes appropriately, and they're echoed into `fallbackText` after sanitization just like the raw text would have been.

### Tests

`src/channels/chat-sdk-bridge.test.ts` gains a new `transformOutboundText wiring` describe block that supplies a tagging transform (`(t) => '«' + t + '»'`), captures the rendered `Card` via the existing `makePostCapture` helper, walks the Card tree with a small `collectCardText` traversal, and asserts that:

- ask_question's `title`, `question` (via CardText), and `fallbackText` are all tagged.
- send_card's `title`, `description`, string children, and `{text}`-object children are all tagged, plus `fallbackText`.
- plain markdown messages still apply the transform (regression guard for the path that wasn't broken).

Full suite: 31 files, 331 tests passing (15 of those in `chat-sdk-bridge.test.ts`).