### PR TITLE
fix: forward host supplementary groups into agent containers (v2)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -441,6 +441,19 @@ async function buildContainerArgs(
   if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
     args.push('--user', `${hostUid}:${hostGid}`);
     args.push('-e', 'HOME=/home/node');
+
+    // Forward supplementary groups so bind-mounted files with group
+    // permissions (e.g. MEGAsync INBOX with umask 0660) are accessible.
+    // --user alone only sets primary uid:gid; supplementary group memberships
+    // are otherwise dropped inside the container.
+    const groups = process.getgroups?.();
+    if (groups) {
+      for (const gid of groups) {
+        if (gid !== hostUid && gid !== hostGid) {
+          args.push('--group-add', String(gid));
+        }
+      }
+    }
   }
 
   // Volume mounts


### PR DESCRIPTION
## Type of Change

- [x] **Fix** — bug fix to v2 source

## Description

v2 port of #1459. The bug is identical: `--user` only sets the primary uid:gid in `docker run`, so supplementary group memberships are dropped inside containers. Files bind-mounted with group-only read perms are then unreachable from the agent.

v2 lives in `src/container-runner.ts` (v1 lived in `src/v1/container-runner.ts`), so the fix is the same shape but lands in the new location: inside `buildContainerArgs`, just after `--user uid:gid` and the `HOME` env var are emitted, call `process.getgroups()` and append a `--group-add <gid>` for each supp gid, skipping the primary uid/gid that `--user` already set.

**Example:** a NanoClaw user (uid 1001) belongs to supplementary group 1000 (brent). Before this fix, the container only has gid 1001. After, it also gets `--group-add 1000`, and `/home/brent/INBOX/Bee` (mode 0660, owner `brent:brent`) becomes readable.

Only applies when `--user` is set (non-root, non-1000 uid). No-op when `process.getgroups` is unavailable (native Windows without WSL).

Confirmed live on a v2 install (2026-05-13): `docker inspect` shows `HostConfig.GroupAdd: ["114","1000"]` and inside the container `groups=1001,114,1000(node)`, with MEGAsync inbox reads now succeeding.

## Tests

No new tests in this PR — the v1 PR (#1459) added two tests for the same behavior in `src/v1/container-runner.test.ts`. If maintainers want equivalent coverage on the v2 path, happy to follow up.

## Related

- v1 PR: #1459 (still open) — same fix targeted at the v1 code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)