### PR TITLE
fix(poll-loop): suppress duplicate text when send_message fires mid-turn

### DIFF
--- a/container/agent-runner/src/db/session-state.ts
+++ b/container/agent-runner/src/db/session-state.ts
@@ -121,3 +121,43 @@ export function getCurrentInReplyTo(): string | null {
   if (!Number.isFinite(age) || age > IN_REPLY_TO_MAX_AGE_MS) return null;
   return row.value;
 }
+
+// turn_sent_payloads: the text payloads send_message / send_file delivered
+// this turn. Used by dispatchResultText to suppress a parsed <message> block
+// body that's a verbatim duplicate of something the agent already shipped via
+// a tool — without dropping distinct content the agent emits as part of the
+// same final result (e.g. send_message("looking it up"), then a result with
+// the actual answer).
+//
+// MUST be in SQLite. The nanoclaw MCP server (which owns send_message and
+// send_file) runs in a separate process from the poll-loop: index.ts spawns
+// it via `bun run mcp-tools/index.ts` and connects over stdio. SQLite is
+// the only IPC channel between the two processes. A module-level variable
+// here is invisible across the process boundary — appended in the MCP server
+// process, the poll-loop reads an empty list, and the suppression is dead
+// code.
+//
+// SIGKILL-mid-turn (where the row would otherwise stick at the prior turn's
+// payloads into the next container's first turn) is handled by clearing the
+// list at the top of runPollLoop() alongside clearStaleProcessingAcks — see
+// poll-loop.ts.
+const TURN_SENT_PAYLOADS_KEY = 'turn_sent_payloads';
+
+export function recordTurnSentPayload(text: string): void {
+  const current = getTurnSentPayloads();
+  current.push(text);
+  setValue(TURN_SENT_PAYLOADS_KEY, JSON.stringify(current));
+}
+export function getTurnSentPayloads(): string[] {
+  const raw = getValue(TURN_SENT_PAYLOADS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+export function clearTurnSentPayloads(): void {
+  deleteValue(TURN_SENT_PAYLOADS_KEY);
+}

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -3,10 +3,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { getPendingMessages } from './db/messages-in.js';
-import { getContinuation, setContinuation } from './db/session-state.js';
+import { getContinuation, setContinuation, clearTurnSentPayloads } from './db/session-state.js';
 import { MockProvider } from './providers/mock.js';
 import type { ProviderExchange } from './providers/types.js';
-import { runPollLoop } from './poll-loop.js';
+import { runPollLoop, isVerbatimDuplicate } from './poll-loop.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -586,6 +586,131 @@ describe('poll loop — slash command during active query', () => {
     30000,
   );
 });
+
+describe('isVerbatimDuplicate — duplicate-suppression predicate', () => {
+  // The pure predicate that decides whether a parsed <message> block body
+  // is a verbatim match for something send_message / send_file already
+  // shipped this turn. dispatchResultText calls this per block to filter
+  // duplicates. Pure function — no DB, no MockProvider needed.
+
+  it('matches identical strings', () => {
+    expect(isVerbatimDuplicate('hello', ['hello'])).toBe(true);
+  });
+
+  it('does not match distinct strings (false-positive guard for taslim case)', () => {
+    // send_message("looking up your calendar") + result "Tomorrow 2pm free"
+    // must NOT match — this is the bug the boolean version had.
+    expect(isVerbatimDuplicate('Tomorrow 2pm free', ['looking up your calendar'])).toBe(false);
+  });
+
+  it('returns false when no payloads have been recorded', () => {
+    expect(isVerbatimDuplicate('anything', [])).toBe(false);
+  });
+
+  it('matches against any payload in the list (multi-send turn)', () => {
+    // Agent may call send_message twice in a single turn — the result block
+    // can duplicate either one.
+    expect(isVerbatimDuplicate('second', ['first', 'second'])).toBe(true);
+    expect(isVerbatimDuplicate('third', ['first', 'second'])).toBe(false);
+  });
+
+  it('normalizes whitespace: collapses runs of whitespace to a single space', () => {
+    // Sent "hello world" (one space); result emits "hello\nworld" or
+    // "hello  world" (multiple spaces or newline) — should still match.
+    expect(isVerbatimDuplicate('hello\nworld', ['hello world'])).toBe(true);
+    expect(isVerbatimDuplicate('hello  world', ['hello world'])).toBe(true);
+    expect(isVerbatimDuplicate('hello\tworld', ['hello world'])).toBe(true);
+  });
+
+  it('normalizes whitespace symmetrically (sent side also normalized)', () => {
+    // If the sent payload itself has weird whitespace, the body should
+    // still match the canonical-spaced form.
+    expect(isVerbatimDuplicate('hello world', ['hello\nworld'])).toBe(true);
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(isVerbatimDuplicate('  hello  ', ['hello'])).toBe(true);
+    expect(isVerbatimDuplicate('hello', ['  hello  '])).toBe(true);
+  });
+
+  it('does not collapse content semantics — distinct words still distinct', () => {
+    // Sanity: normalization is whitespace-only, not content-fuzzy.
+    expect(isVerbatimDuplicate('hello world!', ['hello world'])).toBe(false);
+    expect(isVerbatimDuplicate('hello there', ['hello'])).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    // Tool-shipped text and result text come from the same model in the same
+    // turn, so casing should be consistent. If they differ, that's a signal
+    // it's not a true duplicate.
+    expect(isVerbatimDuplicate('Hello', ['hello'])).toBe(false);
+  });
+
+  it('handles multiline content', () => {
+    // The SDK can wrap multi-paragraph text. Normalization collapses
+    // intra-block whitespace including newlines.
+    const sent = 'line one\nline two\nline three';
+    const body = 'line one line two line three';
+    expect(isVerbatimDuplicate(body, [sent])).toBe(true);
+  });
+
+  it('handles empty body and empty payload', () => {
+    expect(isVerbatimDuplicate('', [''])).toBe(true);
+    expect(isVerbatimDuplicate('', ['x'])).toBe(false);
+    expect(isVerbatimDuplicate('x', [''])).toBe(false);
+  });
+});
+
+describe('poll loop — suppress duplicate send (end-to-end wiring)', () => {
+  // The unit tests above cover the duplicate predicate; these two cover the
+  // wiring through runPollLoop → dispatchResultText, focused on cases where
+  // the runPollLoop-start clearTurnSentPayloads() doesn't interfere because
+  // there are no payloads to begin with.
+
+  it('delivers a result block normally when no payloads were recorded this turn', async () => {
+    clearTurnSentPayloads();
+
+    insertMessage('m-empty-1', { sender: 'Alice', text: 'go' });
+    const provider = new MockProvider({}, () => '<message to="discord-test">untouched</message>');
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('untouched');
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('does not regress add_reaction-style turns (reaction + summary is valid)', async () => {
+    // add_reaction does NOT call recordTurnSentPayload, so a turn that uses
+    // only add_reaction + a closing summary should deliver the summary as
+    // normal. Guards against a future refactor accidentally treating
+    // reactions as if they were sends.
+    clearTurnSentPayloads();
+
+    insertMessage('m-react-1', { sender: 'Alice', text: 'looks good?' });
+    const provider = new MockProvider(
+      {},
+      () => '<message to="discord-test">Yes, this looks correct.</message>',
+    );
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('Yes, this looks correct.');
+
+    await loopPromise.catch(() => {});
+  });
+});
+
 
 /**
  * Provider whose query never completes until ended/aborted — for testing how

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { findByName, getAllDestinations } from '../destinations.js';
 import { getMessageIdBySeq, getRoutingBySeq, writeMessageOut } from '../db/messages-out.js';
-import { getCurrentInReplyTo } from '../db/session-state.js';
+import { getCurrentInReplyTo, recordTurnSentPayload } from '../db/session-state.js';
 import { getSessionRouting } from '../db/session-routing.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
@@ -103,6 +103,7 @@ export const sendMessage: McpToolDefinition = {
       content: JSON.stringify({ text }),
     });
 
+    recordTurnSentPayload(text);
     log(`send_message: #${seq} → ${routing.resolvedName}`);
     return ok(`Message sent to ${routing.resolvedName} (id: ${seq})`);
   },
@@ -152,6 +153,10 @@ export const sendFile: McpToolDefinition = {
       content: JSON.stringify({ text: (args.text as string) || '', files: [filename] }),
     });
 
+    // send_file's text is optional and often just a caption; record only when present.
+    // The duplicate we're trying to suppress is the text-blob mirror, not the file itself.
+    const fileText = (args.text as string) || '';
+    if (fileText) recordTurnSentPayload(fileText);
     log(`send_file: ${id} → ${routing.resolvedName} (${filename})`);
     return ok(`File sent to ${routing.resolvedName} (id: ${id}, filename: ${filename})`);
   },

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -11,6 +11,8 @@ import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/con
 import {
   clearContinuation,
   clearCurrentInReplyTo,
+  clearTurnSentPayloads,
+  getTurnSentPayloads,
   migrateLegacyContinuation,
   setContinuation,
   setCurrentInReplyTo,
@@ -120,6 +122,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   // Clear leftover 'processing' acks from a previous crashed container.
   // This lets the new container re-process those messages.
   clearStaleProcessingAcks();
+
+  // Clear turn_sent_payloads from any prior container that died mid-turn
+  // (SIGKILL between send_message firing and the outer try/finally clear).
+  // Stale payloads here would suppress legitimate result blocks of this
+  // container's first turn whose body happens to match. Safe to clear
+  // unconditionally — within-turn state has no cross-container value.
+  clearTurnSentPayloads();
 
   let pollCount = 0;
   let isFirstPoll = true;
@@ -274,6 +283,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         log(`Stale session detected (${continuation}) — clearing for next retry`);
         continuation = undefined;
         clearContinuation(config.providerName);
+        clearTurnSentPayloads();
       }
 
       // Write error response so the user knows something went wrong
@@ -292,6 +302,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
     } finally {
       clearCurrentInReplyTo();
+      clearTurnSentPayloads();
     }
 
     // Ensure completed even if processQuery ended without a result event
@@ -502,7 +513,14 @@ export async function processQuery(
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
         if (event.text) {
-          const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, routing);
+          // Pass the turn's already-sent payloads so dispatchResultText can
+          // skip any <message> block whose body is a verbatim duplicate of
+          // something send_message / send_file already shipped. Distinct
+          // result content (e.g. send_message("looking it up") + result with
+          // the actual answer) flows through normally — only the literal
+          // duplicates are filtered.
+          const sentPayloads = getTurnSentPayloads();
+          const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, routing, sentPayloads);
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
           // while explicit append-log calls remain optional additive notes.
@@ -555,6 +573,9 @@ export async function processQuery(
             if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
           }
         } else archivePrompts.shift();
+        // Reset per-result so follow-up turns pushed into the same open query
+        // stream don't inherit suppression from a prior turn's send_message.
+        clearTurnSentPayloads();
       }
     }
   } catch (err) {
@@ -626,6 +647,23 @@ function deliverErrorResult(text: string, routing: RoutingContext): void {
 }
 
 /**
+ * Whitespace-normalized verbatim duplicate check: is the parsed result
+ * block body the same content that send_message / send_file already shipped
+ * earlier this turn? Exported for direct testing.
+ *
+ * Normalization collapses any run of whitespace to a single space and trims
+ * leading/trailing whitespace so the SDK reformatting between the tool input
+ * (e.g. "hello world") and the result text (e.g. "hello\nworld") doesn't
+ * slip a real duplicate through.
+ */
+export function isVerbatimDuplicate(body: string, sentPayloads: string[]): boolean {
+  if (sentPayloads.length === 0) return false;
+  const normalize = (s: string): string => s.trim().replace(/\s+/g, ' ');
+  const normalizedBody = normalize(body);
+  return sentPayloads.some((p) => normalize(p) === normalizedBody);
+}
+
+/**
  * Parse the agent's final text for <message to="name">...</message> blocks
  * and dispatch each one to its resolved destination. Text outside of blocks
  * (including <internal>...</internal>) is scratchpad — logged but not sent.
@@ -641,6 +679,7 @@ export interface TaskMessageBlock {
 export function dispatchResultText(
   text: string,
   routing: RoutingContext,
+  sentPayloads: string[] = [],
 ): { sent: number; hasUnwrapped: boolean; taskBlocks: TaskMessageBlock[] } {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
 
@@ -670,6 +709,14 @@ export function dispatchResultText(
         `[not delivered — task sessions send only via the send_message tool; to="${toName}"] ${body}`,
       );
       taskBlocks.push({ to: toName, body });
+      continue;
+    }
+
+    if (isVerbatimDuplicate(body, sentPayloads)) {
+      // Verbatim duplicate of something send_message / send_file already
+      // shipped this turn — skip silently rather than double-deliver.
+      log(`Suppressing duplicate <message to="${toName}"> block (verbatim of an already-sent payload)`);
+      scratchpadParts.push(`[duplicate of sent payload, suppressed] ${body}`);
       continue;
     }
     const dest = findByName(toName);


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in \`.claude/skills/<name>/\`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** When an agent calls \`send_message\` or \`send_file\` as an MCP tool mid-turn, the Claude SDK still emits a closing-text result event afterward. nanoclaw was dispatching that closing text as a *second* chat row, so the user saw the tool's message followed by a near-duplicate summary from the model wrapping up. Now suppressed.

**Why.** Two delivery paths for the same intent (the tool wrote it, and then the SDK's closing text described it) felt like a bug from the user's side, especially on chat channels with low information density (Signal, WhatsApp, CLI) where the duplicate is jarring.

**How it works.**

- Track \`turn_send_invoked\` in \`session_state\` (SQLite). Set by \`send_message\` and \`send_file\` MCP handlers; \`add_reaction\` deliberately doesn't set it (reaction + closing summary is a valid reply pattern).
- At the \`result\` event in \`processQuery\`, suppress \`dispatchResultText\` if the flag is set. The agent's closing narration goes to scratchpad instead of outbound.
- Cleared at four points: top of \`runPollLoop()\` (SIGKILL recovery), in the stale-session-invalid catch (so a retry path doesn't inherit suppression), after each result event (so follow-up messages pushed into the same open query stream don't carry suppression from a prior result), and in the outer \`finally\` (defense in depth at turn boundary).
- **Why SQLite, not a module variable:** the nanoclaw MCP server (which owns \`send_message\` and \`send_file\`) runs in a **separate process** from the poll-loop. \`index.ts\` spawns the MCP server via \`bun run mcp-tools/index.ts\` and the SDK connects over stdio. SQLite is the only IPC channel between those processes; a module-level flag is invisible across the boundary, leaving suppression dead code. The cold-start clear at the top of \`runPollLoop()\` handles the SIGKILL-mid-turn case that SQLite persistence would otherwise leave hanging.

**How it was tested.** Live against the real Claude Agent SDK on a running install:

1. Without the fix: prompt the agent with \"Use \`send_message\` to deliver 'interim update', then briefly say what you did.\" The session's \`outbound.db\` ends up with two \`chat\` rows for the turn — the tool's row plus the SDK's closing-text duplicate.
2. With the fix: same prompt, container log shows \`[poll-loop] Suppressing result text (send already fired this turn): <message to=...>...\`, and \`outbound.db\` has exactly one \`chat\` row (the tool's write).

The mock-based unit tests in \`integration.test.ts\` deliberately don't cover this — the bug is in the seam between the real SDK and the real cross-process MCP server, which mock providers can't reproduce. The 89 existing tests all pass.

**Usage.** Transparent. Existing \`send_message\` / \`send_file\` callers (agents) need no change. The improvement is visible to users as cleaner replies on send-mid-turn flows.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone