### PR TITLE
fix(codex): bind-mount host auth.json so refreshed tokens reach future spawns

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -2,14 +2,16 @@
  * Host-side container config for the `codex` provider.
  *
  * Codex reads auth and MCP config from ~/.codex. We give each session its
- * own private copy of that directory so:
+ * own private codex dir for config.toml (which the in-container provider
+ * rewrites on every wake), but the host's auth.json is bind-mounted directly
+ * on top of it.
  *
- * - The user's host ~/.codex/auth.json reaches the container without us
- *   touching their host config.toml (which the host's own `codex` CLI
- *   might be using).
- * - The in-container provider can rewrite config.toml freely on every
- *   wake with container-appropriate MCP server paths, without racing
- *   other sessions or leaking per-session paths back to the host.
+ * Why bind-mount auth.json instead of copying it: ChatGPT OAuth uses
+ * single-use rotating refresh tokens. When a container refreshes its access
+ * token, the new refresh token has to reach the host file so the NEXT codex
+ * spawn picks it up — otherwise every subsequent spawn copies a stale auth
+ * and fails with `refresh_token_reused`. The mount lets the container's
+ * in-place writes propagate back to the host.
  *
  * Env passthrough covers the two knobs that are read at runtime:
  *   OPENAI_API_KEY  — fallback auth when auth.json isn't a subscription token
@@ -19,20 +21,27 @@
 import fs from 'fs';
 import path from 'path';
 
-import { registerProviderContainerConfig } from './provider-container-registry.js';
+import { registerProviderContainerConfig, type VolumeMount } from './provider-container-registry.js';
 
 registerProviderContainerConfig('codex', (ctx) => {
   const codexDir = path.join(ctx.sessionDir, 'codex');
   fs.mkdirSync(codexDir, { recursive: true });
 
-  // Copy the host's auth.json into the per-session dir if it exists.
-  // We only copy auth.json, not the full ~/.codex — config.toml would
-  // get clobbered by the container on every wake anyway.
+  const mounts: VolumeMount[] = [{ hostPath: codexDir, containerPath: '/home/node/.codex', readonly: false }];
+
+  // Bind-mount host's auth.json directly on top of the per-session codex dir.
+  // Docker requires the source file to exist; if the user hasn't run
+  // `codex login` yet there's nothing to mount and the container will fall
+  // back to OPENAI_API_KEY (or fail loudly if neither is configured).
   const hostHome = ctx.hostEnv.HOME;
   if (hostHome) {
     const hostAuth = path.join(hostHome, '.codex', 'auth.json');
     if (fs.existsSync(hostAuth)) {
-      fs.copyFileSync(hostAuth, path.join(codexDir, 'auth.json'));
+      mounts.push({
+        hostPath: hostAuth,
+        containerPath: '/home/node/.codex/auth.json',
+        readonly: false,
+      });
     }
   }
 
@@ -42,8 +51,5 @@ registerProviderContainerConfig('codex', (ctx) => {
     if (value) env[key] = value;
   }
 
-  return {
-    mounts: [{ hostPath: codexDir, containerPath: '/home/node/.codex', readonly: false }],
-    env,
-  };
+  return { mounts, env };
 });


### PR DESCRIPTION
## What

Changes `src/providers/codex.ts` to bind-mount the host's `~/.codex/auth.json` directly into each container instead of copying it at spawn time. The per-session codex dir is still mounted (for `config.toml`); the auth.json file mount sits on top of it.

## Why

ChatGPT OAuth uses single-use rotating refresh tokens. With the previous copy-based approach, once any codex session refreshed its token, the host's `auth.json` was left untouched — so every subsequent codex spawn copied a dead token and failed with `refresh_token_reused`. The failure is silent at the user level: `messages_in` get marked `completed`, no outbound row is written, and the operator just sees "the agent went quiet."

Hit in practice this week — a fresh codex agent spawned ~2.5h after the first one of the day stayed silent through three consecutive operator check-ins. Container logs showed the auth manager retrying `refresh_token_reused` on every poll.

## How it works

```diff
- fs.copyFileSync(hostAuth, path.join(codexDir, 'auth.json'));
+ mounts.push({
+   hostPath: hostAuth,
+   containerPath: '/home/node/.codex/auth.json',
+   readonly: false,
+ });
```

The container sees the same inode as the host. When codex refreshes its access token in-place, the new tokens are written back through the bind mount to the host file, and the next codex spawn picks them up.

The existing per-session codex dir mount is preserved so `config.toml` rewrites stay session-local (the container rewrites this on every wake with container-appropriate MCP server paths). The file mount overlays cleanly on top.

If the user hasn't run `codex login` yet (no host `auth.json`), the file mount is skipped and codex falls back to `OPENAI_API_KEY` — same behaviour as before for that case.

## How it was tested

- Triggered a fresh codex spawn after the patch
- Verified `/proc/mounts` inside the container shows both the dir mount and the file mount for `auth.json`
- Confirmed host and container see the same inode (`stat -c '%i' /home/adam/.codex/auth.json` vs `docker exec … stat -c '%i' /home/node/.codex/auth.json`)
- Container produced a normal agent reply with zero `refresh_token_reused` / `token_expired` entries in logs

Caveat I haven't been able to verify in a short test: a real token refresh propagating back to the host file requires waiting for the access token to expire (~1h). If codex ever switches to atomic-rename writes for `auth.json`, the file bind mount would silently regress to leaving the host file stale. Worth keeping an eye on if `refresh_token_reused` re-appears.

## Usage

No user-facing changes. Applies automatically to any agent group using `provider: codex`.