### PR TITLE
docs(changelog): add v2.0.64 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to NanoClaw will be documented in this file.
 
+## [2.0.64] - 2026-05-18
+
+- **`ncl destinations add` and `remove` through the approval flow now reach the receiver immediately.** Approved destinations weren't being projected into the receiving agent's local session state, so a freshly-added destination silently failed at `send_message` with `unknown destination`, and a removed destination stayed resolvable until the next container restart. Both now take effect the moment the approval executes. Direct (non-approval) calls were unaffected.
+
 ## [2.0.63] - 2026-05-15
 
 Rollup release covering v2.0.55 through v2.0.63 — everything merged since the v2.0.54 tag. Starting with this release, the goal is to publish a GitHub Release for every `package.json` version bump that lands on `main`; see [RELEASING.md](RELEASING.md).


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds the `CHANGELOG.md` entry for v2.0.64, documenting the fix from #2510 (closes #2465) in user-facing prose per [RELEASING.md](RELEASING.md).

Single-bullet release — no rollup opener since this is a clean one-bump cycle following v2.0.63. Once this lands, the v2.0.64 GitHub Release can be cut with its body mirroring this entry verbatim.

## Preview

```markdown
## [2.0.64] - 2026-05-18

- **`ncl destinations add` and `remove` through the approval flow now reach the receiver immediately.** Approved destinations weren't being projected into the receiving agent's local session state, so a freshly-added destination silently failed at `send_message` with `unknown destination`, and a removed destination stayed resolvable until the next container restart. Both now take effect the moment the approval executes. Direct (non-approval) calls were unaffected.
```