### PR TITLE
fix(db): ensure container_configs row when creating an agent group

### DIFF
--- a/src/db/agent-groups.ts
+++ b/src/db/agent-groups.ts
@@ -1,5 +1,6 @@
 import type { AgentGroup } from '../types.js';
 import { getDb } from './connection.js';
+import { ensureContainerConfig } from './container-configs.js';
 
 export function createAgentGroup(group: AgentGroup): void {
   getDb()
@@ -8,6 +9,7 @@ export function createAgentGroup(group: AgentGroup): void {
        VALUES (@id, @name, @folder, @agent_provider, @created_at)`,
     )
     .run(group);
+  ensureContainerConfig(group.id);
 }
 
 export function getAgentGroup(id: string): AgentGroup | undefined {

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -6,6 +6,7 @@ import {
   runMigrations,
   createAgentGroup,
   getAgentGroup,
+  getContainerConfig,
   getAgentGroupByFolder,
   getAllAgentGroups,
   updateAgentGroup,
@@ -104,6 +105,13 @@ describe('agent groups', () => {
   it('should enforce unique folder', () => {
     createAgentGroup(ag());
     expect(() => createAgentGroup({ ...ag(), id: 'ag-dup' })).toThrow();
+  });
+
+  it('should create a default container_configs row', () => {
+    createAgentGroup(ag());
+    const config = getContainerConfig('ag-1');
+    expect(config).toBeDefined();
+    expect(config!.agent_group_id).toBe('ag-1');
   });
 });
 


### PR DESCRIPTION
## Summary
- `createAgentGroup` only inserted into `agent_groups`, leaving `spawnContainer` to throw `Container config not found for agent group: <id>` forever for any agent created via `ncl groups create`.
- Call the existing idempotent `ensureContainerConfig(group.id)` inline so a fresh group is immediately spawnable with sensible defaults.
- Added a unit test asserting a default `container_configs` row exists after `createAgentGroup`.

## How I hit this
Created a new agent group via `./bin/ncl groups create --name "Homey - Shopping" --folder shopping`, wired a WhatsApp group, sent a message. Host logged `wakeContainer failed` on every sweep with `Container config not found for agent group: 6aaeafe8-…`. Backfilling the row by calling `ensureContainerConfig` directly resolved it; this PR makes that happen on creation.

## Test plan
- [x] `pnpm exec vitest run src/db/db-v2.test.ts` — 33/33 pass, including new "should create a default container_configs row"
- [x] `pnpm run build` — clean tsc
- [x] Manual: created a fresh group via `ncl groups create`, confirmed `ncl groups config get --id <new>` returns a row immediately (no `No container config for group:` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)