### PR TITLE
fix(cli): ncl groups delete cascades + auto-IDs survive OneCLI validation

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -69,6 +69,21 @@ export interface ResourceDef {
   };
   /** Non-standard verbs (grant, revoke, add, remove, restart, etc.). */
   customOperations?: Record<string, CustomOperation>;
+  /**
+   * Override the default DELETE for this resource. Use when the row has
+   * dependents that aren't covered by ON DELETE CASCADE — e.g. agent_groups
+   * has FK references from sessions/wirings/members/roles that need to be
+   * walked in one transaction. Called with the validated `id`; returns the
+   * number of rows removed from the primary table (0 means "not found").
+   */
+  customDelete?: (id: string) => number;
+  /**
+   * Prefix prepended to auto-generated IDs. Use when downstream systems
+   * constrain the ID format — e.g. OneCLI requires agent identifiers to
+   * start with a letter, so groups uses `ag-` to keep `randomUUID()` output
+   * valid. Resources without a prefix still get a raw UUID.
+   */
+  idPrefix?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +148,11 @@ function genericCreate(def: ResourceDef) {
     for (const col of def.columns) {
       if (col.generated) {
         if (col.name === def.idColumn) {
-          values[col.name] = randomUUID();
+          // Honor an explicit --id if the caller provides one; otherwise
+          // auto-generate. The prefix lets resources (e.g. groups) keep
+          // auto-IDs compatible with downstream identifier constraints.
+          const provided = args[col.name];
+          values[col.name] = provided !== undefined ? String(provided) : `${def.idPrefix ?? ''}${randomUUID()}`;
         } else if (col.name.endsWith('_at')) {
           values[col.name] = new Date().toISOString();
         }
@@ -201,8 +220,10 @@ function genericDelete(def: ResourceDef) {
   return async (args: Record<string, unknown>) => {
     const id = args.id as string;
     if (!id) throw new Error(`${def.name} id is required`);
-    const result = getDb().prepare(`DELETE FROM ${def.table} WHERE ${def.idColumn} = ?`).run(id);
-    if (result.changes === 0) throw new Error(`${def.name} not found: ${id}`);
+    const changes = def.customDelete
+      ? def.customDelete(id)
+      : getDb().prepare(`DELETE FROM ${def.table} WHERE ${def.idColumn} = ?`).run(id).changes;
+    if (changes === 0) throw new Error(`${def.name} not found: ${id}`);
     return { deleted: id };
   };
 }

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -9,6 +9,7 @@ import {
   updateContainerConfigJson,
 } from '../../db/container-configs.js';
 import type { ContainerConfigRow } from '../../types.js';
+import { deleteAgentGroup } from '../../db/agent-groups.js';
 import { registerResource } from '../crud.js';
 
 /** Deserialize JSON columns for display. */
@@ -58,6 +59,8 @@ registerResource({
     { name: 'created_at', type: 'string', description: 'Auto-set.', generated: true },
   ],
   operations: { list: 'open', get: 'open', create: 'approval', update: 'approval', delete: 'approval' },
+  customDelete: deleteAgentGroup,
+  idPrefix: 'ag-',
   customOperations: {
     restart: {
       access: 'approval',

--- a/src/db/agent-groups.ts
+++ b/src/db/agent-groups.ts
@@ -39,6 +39,26 @@ export function updateAgentGroup(id: string, updates: Partial<Pick<AgentGroup, '
     .run(values);
 }
 
-export function deleteAgentGroup(id: string): void {
-  getDb().prepare('DELETE FROM agent_groups WHERE id = ?').run(id);
+/**
+ * Deletes the agent group and all rows that reference it. The original FK
+ * declarations were authored without ON DELETE CASCADE, so this function
+ * walks every dependent table in one transaction. An agent group with a
+ * dangling session/wiring/member/role row is unusable anyway — the container,
+ * inbound/outbound DBs, and routing config are all gone.
+ */
+export function deleteAgentGroup(id: string): number {
+  const db = getDb();
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM sessions WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM messaging_group_agents WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM agent_group_members WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM user_roles WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM agent_destinations WHERE agent_group_id = ?').run(id);
+    db.prepare('UPDATE pending_approvals SET agent_group_id = NULL WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM unregistered_senders WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM pending_sender_approvals WHERE agent_group_id = ?').run(id);
+    db.prepare('DELETE FROM pending_channel_approvals WHERE agent_group_id = ?').run(id);
+    return db.prepare('DELETE FROM agent_groups WHERE id = ?').run(id).changes as number;
+  });
+  return tx() as number;
 }

--- a/src/db/db-v2.test.ts
+++ b/src/db/db-v2.test.ts
@@ -105,6 +105,48 @@ describe('agent groups', () => {
     createAgentGroup(ag());
     expect(() => createAgentGroup({ ...ag(), id: 'ag-dup' })).toThrow();
   });
+
+  it('cascades through sessions and wirings on delete', () => {
+    createAgentGroup(ag());
+    createMessagingGroup({
+      id: 'mg-1',
+      channel_type: 'discord',
+      platform_id: 'chan-1',
+      name: 'Gen',
+      is_group: 1,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    createMessagingGroupAgent({
+      id: 'mga-1',
+      messaging_group_id: 'mg-1',
+      agent_group_id: 'ag-1',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: now(),
+    });
+    createSession({
+      id: 'sess-1',
+      agent_group_id: 'ag-1',
+      messaging_group_id: 'mg-1',
+      thread_id: null,
+      agent_provider: null,
+      status: 'active',
+      container_status: 'stopped',
+      last_active: now(),
+      created_at: now(),
+    });
+
+    // Without cascade, the session FK alone would block this.
+    expect(() => deleteAgentGroup('ag-1')).not.toThrow();
+    expect(getAgentGroup('ag-1')).toBeUndefined();
+    expect(getSession('sess-1')).toBeUndefined();
+    expect(getMessagingGroupAgents('mg-1')).toHaveLength(0);
+  });
 });
 
 // ── Messaging Groups ──


### PR DESCRIPTION
## Summary
Two coupled bugs that surface together the moment you create a brand-new agent group via \`ncl groups create\` and try to clean it up.

### 1. \`ncl groups delete\` always fails with FOREIGN KEY constraint failed
\`genericDelete\` in \`src/cli/crud.ts\` ran \`DELETE FROM \${table}\` directly. That's fine for leaf rows, but \`agent_groups\` has FK references with no \`ON DELETE CASCADE\` from \`sessions\`, \`messaging_group_agents\`, \`agent_group_members\`, \`user_roles\`, \`agent_destinations\`, and a few pending-approval tables. Result: once a session row exists for the group, \`ncl groups delete\` errors forever and there's no \`ncl\` verb to clean it up.

Fix:
- New optional \`customDelete?: (id: string) => number\` hook on \`ResourceDef\`.
- \`groups\` resource wires it to \`deleteAgentGroup\`, which walks every dependent table in a single transaction (delete sessions/wirings/members/roles/destinations/pending sender + channel approvals; null-out \`pending_approvals.agent_group_id\`; then delete the group).
- \`genericDelete\` falls back to the raw SQL when \`customDelete\` is not set — every other resource is unchanged.

### 2. Auto-generated agent group IDs are rejected by OneCLI
\`genericCreate\` generates IDs via \`randomUUID()\`. UUIDs start with a digit ~62% of the time. OneCLI's \`POST /api/agents\` validates \`identifier\` against \`^[a-z][a-z0-9-]{0,49}$\` and returns 400 Bad Request. The host's first wakeContainer call then fails forever:
\`\`\`
OneCLIRequestError: [URL=…/api/agents] [StatusCode=400] OneCLI returned 400 Bad Request
\`\`\`
Repro: \`./bin/ncl groups create --name Foo --folder foo\` — any UUID starting with a digit. Symptom is silent — the host just keeps retrying on every sweep.

Fix:
- New optional \`idPrefix?: string\` on \`ResourceDef\`. Auto-generated IDs become \`\${idPrefix}\${randomUUID()}\`.
- \`groups\` resource sets \`idPrefix: 'ag-'\` so auto-IDs are always OneCLI-safe.
- \`genericCreate\` now also honors an explicit \`--id\` if the caller provides one (previously \`generated: true\` silently dropped user input), so you can pass \`--id ag-shopping\` for a readable identifier.

## Test plan
- [x] Added \`cascades through sessions and wirings on delete\` test — creates an agent group, messaging group, wiring, and session; calls \`deleteAgentGroup\`; asserts they're all gone.
- [x] \`pnpm exec vitest run src/db/db-v2.test.ts\` — 33/33 pass.
- [x] \`pnpm run build\` — clean tsc.
- [x] Manual end-to-end:
  - \`ncl groups create --id ag-shopping --name "Homey - Shopping" --folder shopping\` → group created with the literal ID
  - Wired a WhatsApp messaging group, host spawned the container on the first message (no more 400 from OneCLI).
  - \`ncl groups delete --id <id>\` on a group with active sessions + wiring → clean delete, no FK error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)