### PR TITLE
fix(poll-loop): don't mistake </message> in body text for the end-of-message tag

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,7 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { isCorruptionError } from './poll-loop.js';
+import { findClosingMessageTag, isCorruptionError } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 
 beforeEach(() => {
@@ -376,6 +376,61 @@ describe('end-to-end with mock provider', () => {
     expect(outMessages).toHaveLength(1);
     expect(JSON.parse(outMessages[0].content).text).toBe('The answer is 4');
     expect(outMessages[0].in_reply_to).toBe('m1');
+  });
+});
+
+describe('findClosingMessageTag', () => {
+  // Helper: simulate the dispatch parser by finding <message to="..."> open,
+  // then looking up the matching close starting from the body.
+  function bodyOf(text: string): string {
+    const openRe = /<message\s+to="([^"]+)"\s*>/;
+    const m = openRe.exec(text);
+    if (!m) throw new Error('no open tag');
+    const bodyStart = m.index + m[0].length;
+    const close = findClosingMessageTag(text, bodyStart);
+    if (close === -1) return '<UNCLOSED>';
+    return text.slice(bodyStart, close);
+  }
+
+  it('matches the close of a plain message', () => {
+    expect(bodyOf('<message to="mark">hello</message>')).toBe('hello');
+  });
+
+  it('ignores </message> inside inline backticks', () => {
+    // Agent writing about NanoClaw destinations in prose
+    const text = '<message to="mark">routing example: `<message to="x">…</message>` covered</message>';
+    expect(bodyOf(text)).toBe('routing example: `<message to="x">…</message>` covered');
+  });
+
+  it('ignores </message> inside fenced code blocks', () => {
+    const text = [
+      '<message to="mark">here is the format:',
+      '```',
+      '<message to="name">body</message>',
+      '```',
+      'end</message>',
+    ].join('\n');
+    expect(bodyOf(text)).toBe(['here is the format:', '```', '<message to="name">body</message>', '```', 'end'].join('\n'));
+  });
+
+  it('returns -1 when the close tag is missing', () => {
+    expect(findClosingMessageTag('<message to="mark">no close here', 19)).toBe(-1);
+  });
+
+  it('treats inline-backtick close as unclosed when no other close follows', () => {
+    // Single `</message>` inside inline backticks with nothing after — outer is unclosed
+    const text = '<message to="mark">talking about `</message>` only';
+    expect(findClosingMessageTag(text, 19)).toBe(-1);
+  });
+
+  it('finds the outer close even when an inner close is inside a fenced block', () => {
+    // The inner </message> in the fence must NOT short-circuit the outer match.
+    const text = '<message to="mark">prefix\n```\n</message>\n```\nsuffix</message>';
+    const start = '<message to="mark">'.length;
+    const close = findClosingMessageTag(text, start);
+    // It should land on the outer </message>, not the fenced one
+    expect(close).toBeGreaterThan(text.indexOf('```\nsuffix'));
+    expect(text.slice(close)).toBe('</message>');
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -492,20 +492,31 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * blocks, even with a single destination. Bare text is scratchpad only.
  */
 function dispatchResultText(text: string, routing: RoutingContext): { sent: number; hasUnwrapped: boolean } {
-  const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
+  const OPEN_RE = /<message\s+to="([^"]+)"\s*>/g;
 
   let match: RegExpExecArray | null;
   let sent = 0;
   let lastIndex = 0;
   const scratchpadParts: string[] = [];
 
-  while ((match = MESSAGE_RE.exec(text)) !== null) {
+  while ((match = OPEN_RE.exec(text)) !== null) {
     if (match.index > lastIndex) {
       scratchpadParts.push(text.slice(lastIndex, match.index));
     }
     const toName = match[1];
-    const body = match[2].trim();
-    lastIndex = MESSAGE_RE.lastIndex;
+    const bodyStart = OPEN_RE.lastIndex;
+    // Find the matching </message>, ignoring any inside ``` fences or `inline`
+    // code spans so example tags in proposals/code don't truncate the body.
+    const closeIdx = findClosingMessageTag(text, bodyStart);
+    if (closeIdx === -1) {
+      // Unclosed — treat remainder as scratchpad and stop scanning
+      scratchpadParts.push(text.slice(match.index));
+      lastIndex = text.length;
+      break;
+    }
+    const body = text.slice(bodyStart, closeIdx).trim();
+    lastIndex = closeIdx + '</message>'.length;
+    OPEN_RE.lastIndex = lastIndex;
 
     const dest = findByName(toName);
     if (!dest) {
@@ -531,6 +542,37 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
     log(`WARNING: agent output had no <message to="..."> blocks — nothing was sent`);
   }
   return { sent, hasUnwrapped };
+}
+
+/**
+ * Find the next `</message>` close tag starting from `start`, ignoring any
+ * that appear inside ``` fenced blocks or single-line `inline` code spans.
+ * Returns the index of the `<` of `</message>`, or -1 if none found.
+ */
+function findClosingMessageTag(text: string, start: number): number {
+  const CLOSE = '</message>';
+  let i = start;
+  while (i < text.length) {
+    // Triple-backtick fence — skip to matching ```
+    if (text.startsWith('```', i)) {
+      const end = text.indexOf('```', i + 3);
+      if (end === -1) return -1; // unterminated fence — give up
+      i = end + 3;
+      continue;
+    }
+    // Inline backtick — skip to matching ` on the same line
+    if (text[i] === '`') {
+      const nl = text.indexOf('\n', i + 1);
+      const end = text.indexOf('`', i + 1);
+      if (end !== -1 && (nl === -1 || end < nl)) {
+        i = end + 1;
+        continue;
+      }
+    }
+    if (text.startsWith(CLOSE, i)) return i;
+    i++;
+  }
+  return -1;
 }
 
 function sendToDestination(dest: DestinationEntry, body: string, routing: RoutingContext): void {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -549,30 +549,35 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
  * that appear inside ``` fenced blocks or single-line `inline` code spans.
  * Returns the index of the `<` of `</message>`, or -1 if none found.
  *
+ * Jumps via `indexOf` between candidate close-tags and backticks so the cost
+ * is dominated by the (sparse) backtick spans rather than walking each char.
+ *
  * Exported for unit testing.
  */
 export function findClosingMessageTag(text: string, start: number): number {
   const CLOSE = '</message>';
   let i = start;
   while (i < text.length) {
-    // Triple-backtick fence — skip to matching ```
-    if (text.startsWith('```', i)) {
-      const end = text.indexOf('```', i + 3);
+    const close = text.indexOf(CLOSE, i);
+    if (close === -1) return -1;
+    const tick = text.indexOf('`', i);
+    if (tick === -1 || close < tick) return close;
+    // Tick comes first — figure out if it's a triple-backtick fence or an
+    // inline single-tick span, then skip past the matching close marker.
+    if (text.startsWith('```', tick)) {
+      const end = text.indexOf('```', tick + 3);
       if (end === -1) return -1; // unterminated fence — give up
       i = end + 3;
       continue;
     }
-    // Inline backtick — skip to matching ` on the same line
-    if (text[i] === '`') {
-      const nl = text.indexOf('\n', i + 1);
-      const end = text.indexOf('`', i + 1);
-      if (end !== -1 && (nl === -1 || end < nl)) {
-        i = end + 1;
-        continue;
-      }
+    const nl = text.indexOf('\n', tick + 1);
+    const inlineEnd = text.indexOf('`', tick + 1);
+    if (inlineEnd !== -1 && (nl === -1 || inlineEnd < nl)) {
+      i = inlineEnd + 1;
+    } else {
+      // Lone backtick with no closer on the same line — treat as plain text
+      i = tick + 1;
     }
-    if (text.startsWith(CLOSE, i)) return i;
-    i++;
   }
   return -1;
 }

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -548,8 +548,10 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
  * Find the next `</message>` close tag starting from `start`, ignoring any
  * that appear inside ``` fenced blocks or single-line `inline` code spans.
  * Returns the index of the `<` of `</message>`, or -1 if none found.
+ *
+ * Exported for unit testing.
  */
-function findClosingMessageTag(text: string, start: number): number {
+export function findClosingMessageTag(text: string, start: number): number {
   const CLOSE = '</message>';
   let i = start;
   while (i < text.length) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

### The bug

If an agent's reply contains `</message>` inside its body — e.g. in a
code example or while explaining the destination format to a user —
the parser mistakes it for the closing tag of the wrapping
`<message to="...">` block and silently drops everything after.

### Example

User asks Andy:

    How does the destination wrapping work?

Andy replies (full text):

    <message to="mark">
    Every reply lives inside a `<message to="name">…</message>` block.
    The "to" name picks which chat receives it.
    </message>

Before the fix: the user receives only

    Every reply lives inside a `<message to="name">…

— the parser hit the `</message>` inside the inline backticks and stopped
there, dropping the rest of the explanation.

After the fix: the user receives the full reply.

### The fix

Replace the non-greedy `([\s\S]*?)` regex in `dispatchResultText` with a
scanner that finds the opening tag, then walks forward looking for
`</message>` while skipping inline backtick spans and ``` fenced blocks.
Additive — same behavior for any input that doesn't contain `</message>`
inside code.

### Verification

- `bun test container/agent-runner/src/poll-loop.test.ts` — 6 new tests
  for `findClosingMessageTag` covering plain close, inline-backtick skip,
  fenced skip, outer-close-despite-inner-fenced-close, unclosed → -1,
  lone-backtick → -1. All 34 tests pass.
