### PR TITLE
feat(providers): add ACP Client Protocol provider

### DIFF
--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -202,6 +202,7 @@ If a main Claude agent is already wired to this messaging group, ask the user wh
 
 **Option C — Dedicated channel**
 The user will use a separate chat or channel exclusively for this agent. No wiring needed now — when the dedicated channel is set up, use Option B for it.
+
 ## Running an ACP agent for testing
 
 ### Option A — Groq test agent (subprocess mode, no server needed)

--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -177,9 +177,12 @@ const db = require('./node_modules/better-sqlite3')('./data/v2.db');
 const row = db.prepare(
   'SELECT id, engage_pattern FROM messaging_group_agents WHERE agent_group_id = ?'
 ).get('YOUR-MAIN-AGENT-GROUP-ID');
-const updated = row.engage_pattern.replace(')', '|PREFIX:)');
-db.prepare('UPDATE messaging_group_agents SET engage_pattern = ? WHERE id = ?')
-  .run(updated, row.id);
+// Handle both: existing negative lookahead (append) or simple pattern (convert)
+const updated = row.engage_pattern && row.engage_pattern.includes('(?!')
+  ? row.engage_pattern.replace(/\\)$/, '|PREFIX:)')
+  : '^(?!PREFIX:)';
+db.prepare('UPDATE messaging_group_agents SET engage_mode = ?, engage_pattern = ? WHERE id = ?')
+  .run('pattern', updated, row.id);
 console.log('main agent pattern updated:', updated);
 "
 ```
@@ -201,7 +204,16 @@ console.log('wired as primary agent');
 "
 ```
 
-If an existing Claude agent is wired to this channel, ask the user whether to remove it or keep it at lower priority as a fallback.
+If an existing Claude agent is wired to this channel, it must be removed — the router fans out to ALL matching agents so both would reply. Ask the user to confirm, then delete its wiring:
+
+```bash
+node -e "
+const db = require('./node_modules/better-sqlite3')('./data/v2.db');
+db.prepare('DELETE FROM messaging_group_agents WHERE agent_group_id = ?')
+  .run('YOUR-MAIN-AGENT-GROUP-ID');
+console.log('removed main agent wiring');
+"
+```
 
 **Option C — Dedicated channel**
 The user will use a separate channel exclusively for this agent. No wiring needed now — use Option B when the channel is ready.

--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: add-acp-client-agent
+description: Route a NanoClaw agent group to any external AI agent that speaks the ACP Client Protocol (agentclientprotocol.com) — a JSON-RPC 2.0 protocol over TCP or stdio. NanoClaw acts as the editor/client. Works with Groq (free), any AI coding agent, or a custom server. Supports bidirectional file access so the agent can read/write workspace files. No npm dependencies, no container rebuild needed.
+---
+
+# ACP Client Protocol Provider
+
+Routes an agent group's conversations to any external AI agent that speaks the
+[ACP Client Protocol](https://agentclientprotocol.com) — JSON-RPC 2.0 over
+TCP or stdin/stdout. NanoClaw acts as the **editor/client**: it drives the
+agent through `initialize → session/new → session/prompt` and collects
+streaming `session/update` notifications.
+
+The agent can also call back into NanoClaw via `fs/read_text_file` and
+`fs/write_text_file` to read or write files in `/workspace`.
+
+Two connection modes:
+- **Subprocess**: NanoClaw spawns the agent as a child process (stdin/stdout)
+- **TCP**: NanoClaw connects to a running agent server
+
+No new npm dependencies. No container image rebuild required.
+
+## Install
+
+### Pre-flight
+
+Skip to **Configuration** if all of these are already present:
+
+- `src/providers/acp-client.ts`
+- `container/agent-runner/src/providers/acp-client.ts`
+- `import './acp-client.js';` in `src/providers/index.ts`
+- `import './acp-client.js';` in `container/agent-runner/src/providers/index.ts`
+
+All steps below are idempotent — safe to re-run.
+
+### 1. Fetch the providers branch
+
+```bash
+git fetch origin providers
+```
+
+### 2. Copy the provider source files
+
+```bash
+git show origin/providers:src/providers/acp-client.ts \
+  > src/providers/acp-client.ts
+
+git show origin/providers:container/agent-runner/src/providers/acp-client.ts \
+  > container/agent-runner/src/providers/acp-client.ts
+```
+
+### 3. Wire the self-registration imports
+
+Append to `src/providers/index.ts` if the line is not already present:
+
+```typescript
+import './acp-client.js';
+```
+
+Append to `container/agent-runner/src/providers/index.ts` if not already present:
+
+```typescript
+import './acp-client.js';
+```
+
+### 4. Build the host
+
+```bash
+pnpm run build
+```
+
+No container rebuild needed — `container/agent-runner/src/` is bind-mounted
+read-only into every container at spawn time.
+
+### 5. Verify
+
+```bash
+grep -q "'./acp-client.js'" src/providers/index.ts \
+  && echo "host barrel: OK" || echo "host barrel: MISSING"
+
+grep -q "'./acp-client.js'" container/agent-runner/src/providers/index.ts \
+  && echo "container barrel: OK" || echo "container barrel: MISSING"
+
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit \
+  && echo "container typecheck: OK"
+```
+
+## Configuration
+
+### 1. Create the agent group folder
+
+```bash
+mkdir -p groups/<folder>
+```
+
+### 2. Create acp-client.json
+
+**Subprocess mode** (NanoClaw spawns the agent — no server to manage):
+```json
+{ "command": ["python3", "/path/to/my-agent.py"] }
+```
+
+**TCP mode** (connect to a running agent server):
+```json
+{ "host": "host.docker.internal", "port": 7787 }
+```
+
+Per-group `acp-client.json` always wins over global env vars. Global fallback:
+`ACP_CLIENT_CMD`, `ACP_CLIENT_HOST`, `ACP_CLIENT_PORT` in `.env`.
+
+### 3. Create container.json
+
+```json
+{
+  "mcpServers": {},
+  "packages": { "apt": [], "npm": [] },
+  "additionalMounts": [],
+  "skills": "all",
+  "agentGroupId": "ag-GENERATED",
+  "groupName": "My ACP Client Agent",
+  "assistantName": "My ACP Client Agent",
+  "provider": "acp-client"
+}
+```
+
+Generate a unique `agentGroupId`:
+```bash
+node -e "console.log('ag-' + Date.now() + '-' + Math.random().toString(36).slice(2,8))"
+```
+
+### 4. Set the provider in the database
+
+```bash
+node -e "
+const db = require('./node_modules/better-sqlite3')('./data/v2.db');
+db.prepare('UPDATE agent_groups SET agent_provider = ? WHERE folder = ?')
+  .run('acp-client', 'YOUR-GROUP-FOLDER');
+console.log('updated:', db.prepare(
+  'SELECT folder, agent_provider FROM agent_groups WHERE folder = ?'
+).get('YOUR-GROUP-FOLDER'));
+"
+```
+
+### 5. Wire a trigger pattern (optional)
+
+To route messages with a specific prefix (e.g. `acp:`) to this group:
+
+```bash
+node -e "
+const db = require('./node_modules/better-sqlite3')('./data/v2.db');
+const ag = db.prepare('SELECT id FROM agent_groups WHERE folder = ?').get('YOUR-FOLDER');
+db.prepare(\`INSERT INTO messaging_group_agents
+  (id, messaging_group_id, agent_group_id, session_mode, priority,
+   created_at, engage_mode, engage_pattern, sender_scope, ignored_message_policy)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\`)
+  .run('mga-' + Date.now(), 'YOUR-MESSAGING-GROUP-ID', ag.id,
+       'per-thread', 20, new Date().toISOString(),
+       'pattern', '^acp:', 'all', 'drop');
+console.log('wired trigger: ^acp:');
+"
+```
+
+Then exclude the prefix from the main agent's pattern:
+
+```bash
+node -e "
+const db = require('./node_modules/better-sqlite3')('./data/v2.db');
+const row = db.prepare(
+  'SELECT id, engage_pattern FROM messaging_group_agents WHERE agent_group_id = ?'
+).get('YOUR-MAIN-AGENT-GROUP-ID');
+const updated = row.engage_pattern.replace(')', '|acp:)');
+db.prepare('UPDATE messaging_group_agents SET engage_pattern = ? WHERE id = ?')
+  .run(updated, row.id);
+console.log('main agent pattern updated:', updated);
+"
+```
+
+## Running an ACP agent for testing
+
+### Option A — Groq test agent (subprocess mode, no server needed)
+
+1. Get a free key at https://console.groq.com
+2. Add `GROQ_API_KEY=your_key` to `.env`
+3. Copy the test agent:
+
+```bash
+git show origin/providers:scripts/test-acp-client-server.py \
+  > scripts/test-acp-client-server.py
+```
+
+4. Set subprocess mode in `acp-client.json`:
+
+```json
+{ "command": ["python3", "scripts/test-acp-client-server.py"] }
+```
+
+NanoClaw will spawn this script automatically per session. No port, no
+terminal, no server to manage.
+
+### Option B — TCP server mode (Groq)
+
+```bash
+GROQ_API_KEY=$(grep GROQ_API_KEY .env | cut -d= -f2) \
+  nohup python3 scripts/test-acp-client-server.py --tcp 7787 \
+  > logs/acp-client.log 2>&1 &
+```
+
+In `acp-client.json`: `{ "host": "host.docker.internal", "port": 7787 }`
+
+### Option C — Echo mode (no API key)
+
+```json
+{ "command": ["python3", "scripts/test-acp-client-server.py", "--echo"] }
+```
+
+Returns `"Echo: <your message>"`. Useful for testing the protocol wiring without an API key.
+
+### Option D — Any ACP-compatible agent
+
+Any process that reads JSON-RPC 2.0 from stdin and writes to stdout. Minimum
+required methods: `initialize`, `session/new`, `session/prompt`.
+
+See `docs/acp-client-code-walkthrough.md` for a minimal Python implementation.
+
+## How it works
+
+1. NanoClaw opens a connection (subprocess or TCP) to the agent.
+2. Sends `initialize` (handshake + capabilities).
+3. Sends `session/new { cwd: "/workspace" }` — gets back a `sessionId`.
+4. Sends `session/prompt` with the user's message.
+5. While waiting, `session/update` notifications arrive with streaming text chunks.
+6. The agent may send `fs/read_text_file` or `fs/write_text_file` requests at
+   any time — NanoClaw serves these from `/workspace` (path-traversal protected).
+7. When `session/prompt` responds with `stopReason: "done"`, all chunks are
+   assembled and delivered to the user.
+8. Connection is closed. Each turn opens a fresh connection.
+
+## Troubleshooting
+
+**"ACP_CLIENT_CMD or ACP_CLIENT_HOST+ACP_CLIENT_PORT required" in container logs**
+The `acp-client.json` is missing or the database still has the old `agent_provider`.
+Check step 2 (config file) and step 4 (DB update).
+
+**"Failed to connect to ACP agent"**
+In TCP mode: the agent server is not running or not reachable. Use
+`host.docker.internal` (not `localhost`).
+In subprocess mode: the command path is wrong or the script has a syntax error.
+Test manually: `python3 scripts/test-acp-client-server.py --echo`
+
+**No response / timeout**
+The agent's `session/prompt` never responded with `stopReason: "done"`.
+Check the agent logs for errors. In subprocess mode, check the process
+didn't exit early.
+
+**"Path outside workspace" error**
+The agent sent an `fs/read_text_file` or `fs/write_text_file` for a path
+outside `/workspace`. This is a security guard — the agent cannot access host
+filesystem paths.
+
+See `docs/acp-client-code-walkthrough.md` for the full protocol and code walkthrough.

--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -141,9 +141,12 @@ console.log('updated:', db.prepare(
 "
 ```
 
-### 5. Wire a trigger pattern (optional)
+### 5. Choose routing mode
 
-To route messages with a specific prefix (e.g. `acp:`) to this group:
+Ask the user how they want messages routed to this agent, then run the matching commands.
+
+**Option A — Trigger prefix** (share a channel with the main agent)
+Only messages starting with a specific prefix go to this agent. Ask the user for their preferred prefix (e.g. `groq:`, `agent:`, `a2a:`).
 
 ```bash
 node -e "
@@ -155,8 +158,8 @@ db.prepare(\`INSERT INTO messaging_group_agents
   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\`)
   .run('mga-' + Date.now(), 'YOUR-MESSAGING-GROUP-ID', ag.id,
        'per-thread', 20, new Date().toISOString(),
-       'pattern', '^acp:', 'all', 'drop');
-console.log('wired trigger: ^acp:');
+       'pattern', '^PREFIX:', 'all', 'drop');
+console.log('wired trigger: ^PREFIX:');
 "
 ```
 
@@ -168,13 +171,35 @@ const db = require('./node_modules/better-sqlite3')('./data/v2.db');
 const row = db.prepare(
   'SELECT id, engage_pattern FROM messaging_group_agents WHERE agent_group_id = ?'
 ).get('YOUR-MAIN-AGENT-GROUP-ID');
-const updated = row.engage_pattern.replace(')', '|acp:)');
+const updated = row.engage_pattern.replace(')', '|PREFIX:)');
 db.prepare('UPDATE messaging_group_agents SET engage_pattern = ? WHERE id = ?')
   .run(updated, row.id);
 console.log('main agent pattern updated:', updated);
 "
 ```
 
+**Option B — Default agent** (this agent handles all messages in the channel)
+No prefix needed. Wire with `engage_mode = 'always'`.
+
+```bash
+node -e "
+const db = require('./node_modules/better-sqlite3')('./data/v2.db');
+const ag = db.prepare('SELECT id FROM agent_groups WHERE folder = ?').get('YOUR-FOLDER');
+db.prepare(\`INSERT INTO messaging_group_agents
+  (id, messaging_group_id, agent_group_id, session_mode, priority,
+   created_at, engage_mode, engage_pattern, sender_scope, ignored_message_policy)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\`)
+  .run('mga-' + Date.now(), 'YOUR-MESSAGING-GROUP-ID', ag.id,
+       'per-thread', 20, new Date().toISOString(),
+       'always', null, 'all', 'drop');
+console.log('wired as default agent');
+"
+```
+
+If a main Claude agent is already wired to this messaging group, ask the user whether to remove it or keep it at a lower priority as a fallback.
+
+**Option C — Dedicated channel**
+The user will use a separate chat or channel exclusively for this agent. No wiring needed now — when the dedicated channel is set up, use Option B for it.
 ## Running an ACP agent for testing
 
 ### Option A — Groq test agent (subprocess mode, no server needed)

--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -145,10 +145,14 @@ console.log('updated:', db.prepare(
 
 ### 5. Choose routing mode
 
-Ask the user how they want messages routed to this agent, then run the matching commands.
+**Ask the user two questions before continuing:**
+
+1. *"Should this ACP agent be the primary agent for the channel (handles all messages), or share the channel with your existing Claude agent using a trigger prefix?"*
+2. If sharing: *"What prefix should trigger it? (e.g. `acp:`, `agent:`, `code:`)"*
+
+Then run the matching commands below.
 
 **Option A — Trigger prefix** (share a channel with the main agent)
-Only messages starting with a specific prefix go to this agent. Ask the user for their preferred prefix (e.g. `groq:`, `agent:`, `a2a:`).
 
 ```bash
 node -e "
@@ -180,8 +184,7 @@ console.log('main agent pattern updated:', updated);
 "
 ```
 
-**Option B — Default agent** (this agent handles all messages in the channel)
-No prefix needed. Wire with `engage_mode = 'always'`.
+**Option B — Primary agent** (handles all messages in the channel)
 
 ```bash
 node -e "
@@ -194,74 +197,14 @@ db.prepare(\`INSERT INTO messaging_group_agents
   .run('mga-' + Date.now(), 'YOUR-MESSAGING-GROUP-ID', ag.id,
        'per-thread', 20, new Date().toISOString(),
        'always', null, 'all', 'drop');
-console.log('wired as default agent');
+console.log('wired as primary agent');
 "
 ```
 
-If a main Claude agent is already wired to this messaging group, ask the user whether to remove it or keep it at a lower priority as a fallback.
+If an existing Claude agent is wired to this channel, ask the user whether to remove it or keep it at lower priority as a fallback.
 
 **Option C — Dedicated channel**
-The user will use a separate chat or channel exclusively for this agent. No wiring needed now — when the dedicated channel is set up, use Option B for it.
-
-## Running an ACP agent for testing
-
-### Option A — Groq test agent (subprocess mode, no server needed)
-
-1. Get a free key at https://console.groq.com
-2. Add `GROQ_API_KEY=your_key` to `.env`
-3. Copy the test agent:
-
-```bash
-git show origin/providers:scripts/test-acp-client-server.py \
-  > scripts/test-acp-client-server.py
-```
-
-4. Set subprocess mode in `acp-client.json`:
-
-```json
-{ "command": ["python3", "scripts/test-acp-client-server.py"] }
-```
-
-NanoClaw will spawn this script automatically per session. No port, no
-terminal, no server to manage.
-
-### Option B — TCP server mode (Groq)
-
-```bash
-GROQ_API_KEY=$(grep GROQ_API_KEY .env | cut -d= -f2) \
-  nohup python3 scripts/test-acp-client-server.py --tcp 7787 \
-  > logs/acp-client.log 2>&1 &
-```
-
-In `acp-client.json`: `{ "host": "host.docker.internal", "port": 7787 }`
-
-### Option C — Echo mode (no API key)
-
-```json
-{ "command": ["python3", "scripts/test-acp-client-server.py", "--echo"] }
-```
-
-Returns `"Echo: <your message>"`. Useful for testing the protocol wiring without an API key.
-
-### Option D — Any ACP-compatible agent
-
-Any process that reads JSON-RPC 2.0 from stdin and writes to stdout. Minimum
-required methods: `initialize`, `session/new`, `session/prompt`.
-
-See `docs/acp-client-code-walkthrough.md` for a minimal Python implementation.
-
-## How it works
-
-1. NanoClaw opens a connection (subprocess or TCP) to the agent.
-2. Sends `initialize` (handshake + capabilities).
-3. Sends `session/new { cwd: "/workspace" }` — gets back a `sessionId`.
-4. Sends `session/prompt` with the user's message.
-5. While waiting, `session/update` notifications arrive with streaming text chunks.
-6. The agent may send `fs/read_text_file` or `fs/write_text_file` requests at
-   any time — NanoClaw serves these from `/workspace` (path-traversal protected).
-7. When `session/prompt` responds with `stopReason: "done"`, all chunks are
-   assembled and delivered to the user.
-8. Connection is closed. Each turn opens a fresh connection.
+The user will use a separate channel exclusively for this agent. No wiring needed now — use Option B when the channel is ready.
 
 ## Troubleshooting
 
@@ -273,16 +216,11 @@ Check step 2 (config file) and step 4 (DB update).
 In TCP mode: the agent server is not running or not reachable. Use
 `host.docker.internal` (not `localhost`).
 In subprocess mode: the command path is wrong or the script has a syntax error.
-Test manually: `python3 scripts/test-acp-client-server.py --echo`
 
 **No response / timeout**
-The agent's `session/prompt` never responded with `stopReason: "done"`.
-Check the agent logs for errors. In subprocess mode, check the process
-didn't exit early.
+The agent's `session/prompt` never returned a result.
+Check the agent logs. In subprocess mode, check the process didn't exit early.
 
 **"Path outside workspace" error**
-The agent sent an `fs/read_text_file` or `fs/write_text_file` for a path
-outside `/workspace`. This is a security guard — the agent cannot access host
-filesystem paths.
-
-See `docs/acp-client-code-walkthrough.md` for the full protocol and code walkthrough.
+The agent sent an `fs/` request for a path outside `/workspace`.
+This is a security guard — the agent cannot escape the container boundary.

--- a/.claude/skills/add-acp-client-agent/SKILL.md
+++ b/.claude/skills/add-acp-client-agent/SKILL.md
@@ -130,6 +130,8 @@ node -e "console.log('ag-' + Date.now() + '-' + Math.random().toString(36).slice
 
 ### 4. Set the provider in the database
 
+Run this from the **project root** (the directory containing `data/` and `node_modules/`):
+
 ```bash
 node -e "
 const db = require('./node_modules/better-sqlite3')('./data/v2.db');

--- a/container/agent-runner/src/providers/acp-client.test.ts
+++ b/container/agent-runner/src/providers/acp-client.test.ts
@@ -48,7 +48,7 @@ function autoScript(
 
 const initResult = { protocolVersion: 1, agentCapabilities: {}, meta: { name: 'test', version: '0' }, authenticationMethods: [] };
 
-/** Collect events from a provider query, up to maxEvents. */
+/** Collect all events from a provider query until the generator ends. */
 async function collectEvents(provider: AcpClientProvider, input: QueryInput, maxEvents = 30): Promise<ProviderEvent[]> {
   const q = provider.query(input);
   const events: ProviderEvent[] = [];
@@ -176,14 +176,12 @@ beforeEach(() => {
   process.env.ACP_CLIENT_CMD = JSON.stringify(['fake-agent']);
   delete process.env.ACP_CLIENT_HOST;
   delete process.env.ACP_CLIENT_PORT;
-  delete process.env.ACP_CLIENT_IDLE_TIMEOUT_MS;
 });
 
 afterEach(() => {
   delete process.env.ACP_CLIENT_CMD;
   delete process.env.ACP_CLIENT_HOST;
   delete process.env.ACP_CLIENT_PORT;
-  delete process.env.ACP_CLIENT_IDLE_TIMEOUT_MS;
 });
 
 // ── AcpClientProvider — constructor ─────────────────────────────────────────
@@ -246,12 +244,7 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
     expect(events.find(e => e.type === 'init')).toMatchObject({ type: 'init', continuation: 'sess-1' });
   });
 
@@ -267,12 +260,7 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
     expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Hello from agent!' });
   });
 
@@ -285,12 +273,7 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
     expect(events.some(e => e.type === 'activity')).toBe(true);
   });
 
@@ -307,12 +290,7 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
     const result = events.find(e => e.type === 'result') as { type: 'result'; text: string } | undefined;
     expect(result?.text).toBe('Part1 Part2');
   });
@@ -326,12 +304,7 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
     expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Inline answer' });
   });
 });
@@ -405,10 +378,7 @@ describe('AcpClientProvider: fs/ request handling', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    for await (const e of q.events) {
-      if (e.type === 'result') { q.end(); }
-    }
+    await collectEvents(new AcpClientProvider(), baseInput);
 
     // Wait for fs/ response to be written (async handler)
     await new Promise(r => setTimeout(r, 10));
@@ -432,10 +402,7 @@ describe('AcpClientProvider: fs/ request handling', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    for await (const e of q.events) {
-      if (e.type === 'result') { q.end(); }
-    }
+    await collectEvents(new AcpClientProvider(), baseInput);
     await new Promise(r => setTimeout(r, 10));
 
     const termResp = transport.writes
@@ -458,12 +425,7 @@ describe('AcpClientProvider.query(): session resume', () => {
     _test.createTransport = async () => transport;
 
     const input: QueryInput = { prompt: 'follow up', cwd: '/workspace', continuation: 'existing-sess' };
-    const q = new AcpClientProvider().query(input);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') { q.end(); }
-    }
+    const events = await collectEvents(new AcpClientProvider(), input);
 
     // init should reflect the resumed sessionId
     expect(events.find(e => e.type === 'init')).toMatchObject({ continuation: 'existing-sess' });
@@ -495,10 +457,7 @@ describe('AcpClientProvider.query(): systemContext forwarding', () => {
       cwd: '/workspace',
       systemContext: { instructions: 'You are a helpful assistant.' },
     };
-    const q = new AcpClientProvider().query(input);
-    for await (const e of q.events) {
-      if (e.type === 'result') { q.end(); }
-    }
+    await collectEvents(new AcpClientProvider(), input);
 
     const promptMsg = transport.writes
       .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
@@ -518,156 +477,11 @@ describe('AcpClientProvider.query(): systemContext forwarding', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const q = new AcpClientProvider().query(baseInput);
-    for await (const e of q.events) {
-      if (e.type === 'result') { q.end(); }
-    }
+    await collectEvents(new AcpClientProvider(), baseInput);
 
     const promptMsg = transport.writes
       .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
       .find(w => w.method === 'session/prompt');
     expect(promptMsg?.params?.content?.[0]?.text).toBe('Hello agent');
-  });
-});
-
-// ── AcpClientProvider — multi-turn (push) ────────────────────────────────────
-
-describe('AcpClientProvider.query(): multi-turn via push()', () => {
-  it('sends a second session/prompt on push() without reconnecting', async () => {
-    const transport = createMockTransport();
-    autoScript(transport, [
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'mt-sess' } })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Turn 1' }], stopReason: 'done' } })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Turn 2' }], stopReason: 'done' } })),
-    ]);
-    _test.createTransport = async () => transport;
-
-    const q = new AcpClientProvider().query(baseInput);
-    const results: string[] = [];
-
-    for await (const e of q.events) {
-      if (e.type === 'result') {
-        results.push((e as { type: 'result'; text: string | null }).text ?? '');
-        if (results.length === 1) {
-          q.push('follow-up message');
-        } else {
-          q.end();
-        }
-      }
-    }
-
-    expect(results).toEqual(['Turn 1', 'Turn 2']);
-
-    // Exactly 2 session/prompt calls on the same transport
-    const promptCalls = transport.writes
-      .map(w => JSON.parse(w) as { method?: string })
-      .filter(w => w.method === 'session/prompt');
-    expect(promptCalls).toHaveLength(2);
-  });
-
-  it('second turn uses the same sessionId', async () => {
-    const transport = createMockTransport();
-    autoScript(transport, [
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'shared-sess' } })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
-    ]);
-    _test.createTransport = async () => transport;
-
-    const q = new AcpClientProvider().query(baseInput);
-    let turn = 0;
-    for await (const e of q.events) {
-      if (e.type === 'result') {
-        turn++;
-        if (turn === 1) q.push('turn 2');
-        else q.end();
-      }
-    }
-
-    const promptMsgs = transport.writes
-      .map(w => JSON.parse(w) as { method?: string; params?: { sessionId?: string } })
-      .filter(w => w.method === 'session/prompt');
-    expect(promptMsgs[0]?.params?.sessionId).toBe('shared-sess');
-    expect(promptMsgs[1]?.params?.sessionId).toBe('shared-sess');
-  });
-
-  it('second turn chunks are independent from first turn', async () => {
-    const transport = createMockTransport();
-    autoScript(transport, [
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'chunk-sess' } })),
-      id => {
-        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'First' }] } } } }));
-        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
-      },
-      id => {
-        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'Second' }] } } } }));
-        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
-      },
-    ]);
-    _test.createTransport = async () => transport;
-
-    const q = new AcpClientProvider().query(baseInput);
-    const results: (string | null)[] = [];
-    for await (const e of q.events) {
-      if (e.type === 'result') {
-        results.push((e as { type: 'result'; text: string | null }).text);
-        if (results.length === 1) q.push('turn 2');
-        else q.end();
-      }
-    }
-
-    // Each turn should only have its own chunks, not accumulated from prior turns
-    expect(results[0]).toBe('First');
-    expect(results[1]).toBe('Second');
-  });
-});
-
-// ── AcpClientProvider — abort ────────────────────────────────────────────────
-
-describe('AcpClientProvider.query(): abort()', () => {
-  it('abort() while waiting for push stops the generator cleanly', async () => {
-    const transport = createMockTransport();
-    autoScript(transport, [
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'ab-sess' } })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
-    ]);
-    _test.createTransport = async () => transport;
-
-    const q = new AcpClientProvider().query(baseInput);
-    const events: ProviderEvent[] = [];
-    for await (const e of q.events) {
-      events.push(e);
-      if (e.type === 'result') {
-        // Abort instead of push/end — generator should exit without error
-        q.abort();
-      }
-    }
-
-    expect(events.some(e => e.type === 'result')).toBe(true);
-    expect(events.filter(e => e.type === 'error')).toHaveLength(0);
-  });
-});
-
-// ── AcpClientProvider — idle timeout ────────────────────────────────────────
-
-describe('AcpClientProvider.query(): idle timeout', () => {
-  it('closes connection and emits error after ACP_CLIENT_IDLE_TIMEOUT_MS of silence', async () => {
-    process.env.ACP_CLIENT_IDLE_TIMEOUT_MS = '50'; // very short for test
-
-    const transport = createMockTransport();
-    autoScript(transport, [
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
-      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'timeout-sess' } })),
-      // session/prompt step: respond very slowly (simulated by not responding — idle timer fires)
-      _id => { /* no response — timeout will close transport */ },
-    ]);
-    _test.createTransport = async () => transport;
-
-    const events = await collectEvents(new AcpClientProvider(), baseInput, 20);
-    expect(events.some(e => e.type === 'error')).toBe(true);
   });
 });

--- a/container/agent-runner/src/providers/acp-client.test.ts
+++ b/container/agent-runner/src/providers/acp-client.test.ts
@@ -460,9 +460,9 @@ describe('AcpClientProvider.query(): systemContext forwarding', () => {
     await collectEvents(new AcpClientProvider(), input);
 
     const promptMsg = transport.writes
-      .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
+      .map(w => JSON.parse(w) as { method?: string; params?: { prompt?: Array<{ text?: string }> } })
       .find(w => w.method === 'session/prompt');
-    const text = promptMsg?.params?.content?.[0]?.text ?? '';
+    const text = promptMsg?.params?.prompt?.[0]?.text ?? '';
     expect(text).toContain('<system>');
     expect(text).toContain('You are a helpful assistant.');
     expect(text).toContain('Hello');
@@ -480,8 +480,8 @@ describe('AcpClientProvider.query(): systemContext forwarding', () => {
     await collectEvents(new AcpClientProvider(), baseInput);
 
     const promptMsg = transport.writes
-      .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
+      .map(w => JSON.parse(w) as { method?: string; params?: { prompt?: Array<{ text?: string }> } })
       .find(w => w.method === 'session/prompt');
-    expect(promptMsg?.params?.content?.[0]?.text).toBe('Hello agent');
+    expect(promptMsg?.params?.prompt?.[0]?.text).toBe('Hello agent');
   });
 });

--- a/container/agent-runner/src/providers/acp-client.test.ts
+++ b/container/agent-runner/src/providers/acp-client.test.ts
@@ -176,12 +176,14 @@ beforeEach(() => {
   process.env.ACP_CLIENT_CMD = JSON.stringify(['fake-agent']);
   delete process.env.ACP_CLIENT_HOST;
   delete process.env.ACP_CLIENT_PORT;
+  delete process.env.ACP_CLIENT_IDLE_TIMEOUT_MS;
 });
 
 afterEach(() => {
   delete process.env.ACP_CLIENT_CMD;
   delete process.env.ACP_CLIENT_HOST;
   delete process.env.ACP_CLIENT_PORT;
+  delete process.env.ACP_CLIENT_IDLE_TIMEOUT_MS;
 });
 
 // ── AcpClientProvider — constructor ─────────────────────────────────────────
@@ -244,7 +246,12 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
     expect(events.find(e => e.type === 'init')).toMatchObject({ type: 'init', continuation: 'sess-1' });
   });
 
@@ -260,7 +267,12 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
     expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Hello from agent!' });
   });
 
@@ -273,7 +285,12 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
     expect(events.some(e => e.type === 'activity')).toBe(true);
   });
 
@@ -290,7 +307,12 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
     const result = events.find(e => e.type === 'result') as { type: 'result'; text: string } | undefined;
     expect(result?.text).toBe('Part1 Part2');
   });
@@ -304,7 +326,12 @@ describe('AcpClientProvider.query(): successful turn', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
     expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Inline answer' });
   });
 });
@@ -378,7 +405,10 @@ describe('AcpClientProvider: fs/ request handling', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    for await (const e of q.events) {
+      if (e.type === 'result') { q.end(); }
+    }
 
     // Wait for fs/ response to be written (async handler)
     await new Promise(r => setTimeout(r, 10));
@@ -402,12 +432,242 @@ describe('AcpClientProvider: fs/ request handling', () => {
     ]);
     _test.createTransport = async () => transport;
 
-    await collectEvents(new AcpClientProvider(), baseInput);
+    const q = new AcpClientProvider().query(baseInput);
+    for await (const e of q.events) {
+      if (e.type === 'result') { q.end(); }
+    }
     await new Promise(r => setTimeout(r, 10));
 
     const termResp = transport.writes
       .map(w => JSON.parse(w) as { id?: number; error?: { code: number } })
       .find(w => w.id === 88);
     expect(termResp?.error?.code).toBe(-32601);
+  });
+});
+
+// ── AcpClientProvider — session resume (continuation) ───────────────────────
+
+describe('AcpClientProvider.query(): session resume', () => {
+  it('skips session/new and uses continuation as sessionId', async () => {
+    const transport = createMockTransport();
+    // Only 2 requests: initialize + session/prompt (no session/new)
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Resumed!' }], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const input: QueryInput = { prompt: 'follow up', cwd: '/workspace', continuation: 'existing-sess' };
+    const q = new AcpClientProvider().query(input);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') { q.end(); }
+    }
+
+    // init should reflect the resumed sessionId
+    expect(events.find(e => e.type === 'init')).toMatchObject({ continuation: 'existing-sess' });
+    expect(events.find(e => e.type === 'result')).toMatchObject({ text: 'Resumed!' });
+
+    // Verify session/new was never sent
+    const methods = transport.writes
+      .map(w => (JSON.parse(w) as { method?: string }).method)
+      .filter(Boolean);
+    expect(methods).not.toContain('session/new');
+    expect(methods).toContain('session/prompt');
+  });
+});
+
+// ── AcpClientProvider — systemContext forwarding ─────────────────────────────
+
+describe('AcpClientProvider.query(): systemContext forwarding', () => {
+  it('prepends system instructions to the prompt content', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'sys-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const input: QueryInput = {
+      prompt: 'Hello',
+      cwd: '/workspace',
+      systemContext: { instructions: 'You are a helpful assistant.' },
+    };
+    const q = new AcpClientProvider().query(input);
+    for await (const e of q.events) {
+      if (e.type === 'result') { q.end(); }
+    }
+
+    const promptMsg = transport.writes
+      .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
+      .find(w => w.method === 'session/prompt');
+    const text = promptMsg?.params?.content?.[0]?.text ?? '';
+    expect(text).toContain('<system>');
+    expect(text).toContain('You are a helpful assistant.');
+    expect(text).toContain('Hello');
+  });
+
+  it('sends plain prompt when no systemContext', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'plain-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const q = new AcpClientProvider().query(baseInput);
+    for await (const e of q.events) {
+      if (e.type === 'result') { q.end(); }
+    }
+
+    const promptMsg = transport.writes
+      .map(w => JSON.parse(w) as { method?: string; params?: { content?: Array<{ text?: string }> } })
+      .find(w => w.method === 'session/prompt');
+    expect(promptMsg?.params?.content?.[0]?.text).toBe('Hello agent');
+  });
+});
+
+// ── AcpClientProvider — multi-turn (push) ────────────────────────────────────
+
+describe('AcpClientProvider.query(): multi-turn via push()', () => {
+  it('sends a second session/prompt on push() without reconnecting', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'mt-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Turn 1' }], stopReason: 'done' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Turn 2' }], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const q = new AcpClientProvider().query(baseInput);
+    const results: string[] = [];
+
+    for await (const e of q.events) {
+      if (e.type === 'result') {
+        results.push((e as { type: 'result'; text: string | null }).text ?? '');
+        if (results.length === 1) {
+          q.push('follow-up message');
+        } else {
+          q.end();
+        }
+      }
+    }
+
+    expect(results).toEqual(['Turn 1', 'Turn 2']);
+
+    // Exactly 2 session/prompt calls on the same transport
+    const promptCalls = transport.writes
+      .map(w => JSON.parse(w) as { method?: string })
+      .filter(w => w.method === 'session/prompt');
+    expect(promptCalls).toHaveLength(2);
+  });
+
+  it('second turn uses the same sessionId', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'shared-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const q = new AcpClientProvider().query(baseInput);
+    let turn = 0;
+    for await (const e of q.events) {
+      if (e.type === 'result') {
+        turn++;
+        if (turn === 1) q.push('turn 2');
+        else q.end();
+      }
+    }
+
+    const promptMsgs = transport.writes
+      .map(w => JSON.parse(w) as { method?: string; params?: { sessionId?: string } })
+      .filter(w => w.method === 'session/prompt');
+    expect(promptMsgs[0]?.params?.sessionId).toBe('shared-sess');
+    expect(promptMsgs[1]?.params?.sessionId).toBe('shared-sess');
+  });
+
+  it('second turn chunks are independent from first turn', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'chunk-sess' } })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'First' }] } } } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
+      },
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'Second' }] } } } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
+      },
+    ]);
+    _test.createTransport = async () => transport;
+
+    const q = new AcpClientProvider().query(baseInput);
+    const results: (string | null)[] = [];
+    for await (const e of q.events) {
+      if (e.type === 'result') {
+        results.push((e as { type: 'result'; text: string | null }).text);
+        if (results.length === 1) q.push('turn 2');
+        else q.end();
+      }
+    }
+
+    // Each turn should only have its own chunks, not accumulated from prior turns
+    expect(results[0]).toBe('First');
+    expect(results[1]).toBe('Second');
+  });
+});
+
+// ── AcpClientProvider — abort ────────────────────────────────────────────────
+
+describe('AcpClientProvider.query(): abort()', () => {
+  it('abort() while waiting for push stops the generator cleanly', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'ab-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const q = new AcpClientProvider().query(baseInput);
+    const events: ProviderEvent[] = [];
+    for await (const e of q.events) {
+      events.push(e);
+      if (e.type === 'result') {
+        // Abort instead of push/end — generator should exit without error
+        q.abort();
+      }
+    }
+
+    expect(events.some(e => e.type === 'result')).toBe(true);
+    expect(events.filter(e => e.type === 'error')).toHaveLength(0);
+  });
+});
+
+// ── AcpClientProvider — idle timeout ────────────────────────────────────────
+
+describe('AcpClientProvider.query(): idle timeout', () => {
+  it('closes connection and emits error after ACP_CLIENT_IDLE_TIMEOUT_MS of silence', async () => {
+    process.env.ACP_CLIENT_IDLE_TIMEOUT_MS = '50'; // very short for test
+
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'timeout-sess' } })),
+      // session/prompt step: respond very slowly (simulated by not responding — idle timer fires)
+      _id => { /* no response — timeout will close transport */ },
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput, 20);
+    expect(events.some(e => e.type === 'error')).toBe(true);
   });
 });

--- a/container/agent-runner/src/providers/acp-client.test.ts
+++ b/container/agent-runner/src/providers/acp-client.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { LineReader, JsonRpcDispatcher, AcpClientProvider, _test } from './acp-client.js';
+import type { AcpTransport } from './acp-client.js';
+import type { QueryInput, ProviderEvent } from './types.js';
+
+// ── Mock transport ────────────────────────────────────────────────────────────
+
+interface MockTransport extends AcpTransport {
+  writes: string[];
+  enqueue(line: string): void;
+  terminate(): void;
+}
+
+function createMockTransport(): MockTransport {
+  const writes: string[] = [];
+  const reader = new LineReader();
+  return {
+    writes,
+    write(msg) { writes.push(msg); },
+    readLine: () => reader.readLine(),
+    close() { reader.end(); },
+    enqueue(line) { reader.feed(line + '\n'); },
+    terminate() { reader.end(); },
+  };
+}
+
+/**
+ * Intercept transport.write so that only outgoing requests (which have a
+ * `method` field) increment the step counter. Responses we send back to
+ * the agent (which have `id` + `result`/`error` but no `method`) are
+ * forwarded unchanged without affecting step.
+ */
+function autoScript(
+  transport: MockTransport,
+  steps: Array<(id: number) => void>,
+): void {
+  let step = 0;
+  const orig = transport.write.bind(transport);
+  transport.write = (msg: string) => {
+    orig(msg);
+    const parsed = JSON.parse(msg) as { id?: number; method?: string };
+    // Only count outgoing requests (have both id AND method)
+    if (!parsed.id || !parsed.method) return;
+    const handler = steps[step++];
+    handler?.(parsed.id);
+  };
+}
+
+const initResult = { protocolVersion: 1, agentCapabilities: {}, meta: { name: 'test', version: '0' }, authenticationMethods: [] };
+
+/** Collect events from a provider query, up to maxEvents. */
+async function collectEvents(provider: AcpClientProvider, input: QueryInput, maxEvents = 30): Promise<ProviderEvent[]> {
+  const q = provider.query(input);
+  const events: ProviderEvent[] = [];
+  for await (const e of q.events) {
+    events.push(e);
+    if (events.length >= maxEvents) { q.abort(); break; }
+  }
+  return events;
+}
+
+const baseInput: QueryInput = { prompt: 'Hello agent', cwd: '/workspace' };
+
+// ── LineReader ────────────────────────────────────────────────────────────────
+
+describe('LineReader', () => {
+  it('yields complete lines', async () => {
+    const lr = new LineReader();
+    lr.feed('hello\nworld\n');
+    expect(await lr.readLine()).toBe('hello');
+    expect(await lr.readLine()).toBe('world');
+  });
+
+  it('buffers incomplete lines across chunks', async () => {
+    const lr = new LineReader();
+    lr.feed('hel');
+    lr.feed('lo\n');
+    expect(await lr.readLine()).toBe('hello');
+  });
+
+  it('skips blank lines', async () => {
+    const lr = new LineReader();
+    lr.feed('\n\nhello\n\n');
+    expect(await lr.readLine()).toBe('hello');
+  });
+
+  it('returns null immediately when called after end() with no queued lines', async () => {
+    const lr = new LineReader();
+    lr.end();
+    expect(await lr.readLine()).toBeNull();
+  });
+
+  it('resolves waiting readers with null on end()', async () => {
+    const lr = new LineReader();
+    const p = lr.readLine(); // reader is waiting
+    lr.end();
+    expect(await p).toBeNull();
+  });
+});
+
+// ── JsonRpcDispatcher ────────────────────────────────────────────────────────
+
+describe('JsonRpcDispatcher', () => {
+  it('resolves request when matching response arrives', async () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+    rpc.pumpLoop().catch(() => {});
+
+    const result = rpc.request('initialize', { protocolVersion: 1 });
+    const sent = JSON.parse(transport.writes[0]) as { id: number };
+    transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: { ok: true } }));
+
+    expect(await result).toEqual({ ok: true });
+  });
+
+  it('rejects request when error response arrives', async () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+    rpc.pumpLoop().catch(() => {});
+
+    const result = rpc.request('session/new', {});
+    const sent = JSON.parse(transport.writes[0]) as { id: number };
+    transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id: sent.id, error: { code: -32001, message: 'Not found' } }));
+
+    await expect(result).rejects.toThrow('Not found');
+  });
+
+  it('fires notification handler on notification', () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+    const received: unknown[] = [];
+    rpc.onNotification('session/update', p => received.push(p));
+
+    rpc.dispatch(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { update: { kind: 'agent_message_chunk' } } }));
+    expect(received).toHaveLength(1);
+  });
+
+  it('calls request handler and sends result for incoming server requests', async () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+    rpc.onRequest('fs/read_text_file', async () => ({ content: 'file content' }));
+
+    rpc.dispatch(JSON.stringify({ jsonrpc: '2.0', id: 99, method: 'fs/read_text_file', params: { uri: 'file:///workspace/foo.ts' } }));
+    await new Promise(r => setTimeout(r, 0)); // let async handler run
+
+    const resp = JSON.parse(transport.writes[0]) as { id: number; result: unknown };
+    expect(resp.id).toBe(99);
+    expect(resp.result).toEqual({ content: 'file content' });
+  });
+
+  it('sends -32601 for unhandled incoming requests', () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+
+    rpc.dispatch(JSON.stringify({ jsonrpc: '2.0', id: 42, method: 'terminal/create', params: {} }));
+    const resp = JSON.parse(transport.writes[0]) as { error: { code: number } };
+    expect(resp.error.code).toBe(-32601);
+  });
+
+  it('rejects all pending when transport closes', async () => {
+    const transport = createMockTransport();
+    const rpc = new JsonRpcDispatcher(transport);
+    const pump = rpc.pumpLoop();
+
+    const p = rpc.request('session/new', {});
+    transport.terminate(); // close transport
+    await pump.catch(() => {});
+
+    await expect(p).rejects.toThrow('Connection closed');
+  });
+});
+
+// ── AcpClientProvider — setup ────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.ACP_CLIENT_CMD = JSON.stringify(['fake-agent']);
+  delete process.env.ACP_CLIENT_HOST;
+  delete process.env.ACP_CLIENT_PORT;
+});
+
+afterEach(() => {
+  delete process.env.ACP_CLIENT_CMD;
+  delete process.env.ACP_CLIENT_HOST;
+  delete process.env.ACP_CLIENT_PORT;
+});
+
+// ── AcpClientProvider — constructor ─────────────────────────────────────────
+
+describe('AcpClientProvider constructor', () => {
+  it('constructs with ACP_CLIENT_CMD', () => {
+    expect(() => new AcpClientProvider()).not.toThrow();
+  });
+
+  it('constructs with ACP_CLIENT_HOST + ACP_CLIENT_PORT', () => {
+    delete process.env.ACP_CLIENT_CMD;
+    process.env.ACP_CLIENT_HOST = 'localhost';
+    process.env.ACP_CLIENT_PORT = '7777';
+    expect(() => new AcpClientProvider()).not.toThrow();
+  });
+
+  it('throws when neither CMD nor HOST+PORT is set', () => {
+    delete process.env.ACP_CLIENT_CMD;
+    expect(() => new AcpClientProvider()).toThrow('ACP_CLIENT_CMD or ACP_CLIENT_HOST');
+  });
+
+  it('supportsNativeSlashCommands is false', () => {
+    expect(new AcpClientProvider().supportsNativeSlashCommands).toBe(false);
+  });
+});
+
+// ── AcpClientProvider — isSessionInvalid ────────────────────────────────────
+
+describe('AcpClientProvider.isSessionInvalid()', () => {
+  const p = () => new AcpClientProvider();
+
+  it('returns true for "session not found"', () => {
+    expect(p().isSessionInvalid(new Error('session abc not found'))).toBe(true);
+  });
+
+  it('returns true for "invalid state"', () => {
+    expect(p().isSessionInvalid(new Error('invalid state'))).toBe(true);
+  });
+
+  it('returns true for "connection closed"', () => {
+    expect(p().isSessionInvalid(new Error('connection closed'))).toBe(true);
+  });
+
+  it('returns false for network errors (retryable, not stale)', () => {
+    expect(p().isSessionInvalid(new Error('ECONNREFUSED'))).toBe(false);
+  });
+});
+
+// ── AcpClientProvider — happy path ──────────────────────────────────────────
+
+describe('AcpClientProvider.query(): successful turn', () => {
+  it('emits init with sessionId as continuation token', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'sess-1' } })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
+      },
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    expect(events.find(e => e.type === 'init')).toMatchObject({ type: 'init', continuation: 'sess-1' });
+  });
+
+  it('emits result with streamed text from session/update chunks', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'sess-2' } })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: 'sess-2', update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'Hello from agent!' }] } } } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
+      },
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Hello from agent!' });
+  });
+
+  it('emits at least one activity event', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'sess-3' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    expect(events.some(e => e.type === 'activity')).toBe(true);
+  });
+
+  it('merges multiple streamed chunks into one result', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'multi' } })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: 'multi', update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'Part1 ' }] } } } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: 'multi', update: { kind: 'agent_message_chunk', content: { content: [{ type: 'text', text: 'Part2' }] } } } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } }));
+      },
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const result = events.find(e => e.type === 'result') as { type: 'result'; text: string } | undefined;
+    expect(result?.text).toBe('Part1 Part2');
+  });
+
+  it('includes inline text from final prompt response when no stream chunks', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'inline' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'Inline answer' }], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    expect(events.find(e => e.type === 'result')).toMatchObject({ type: 'result', text: 'Inline answer' });
+  });
+});
+
+// ── AcpClientProvider — error paths ─────────────────────────────────────────
+
+describe('AcpClientProvider.query(): error paths', () => {
+  it('emits retryable error when transport connection fails', async () => {
+    _test.createTransport = async () => { throw new Error('ECONNREFUSED'); };
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const err = events.find(e => e.type === 'error') as { type: 'error'; retryable: boolean; message: string } | undefined;
+    expect(err?.retryable).toBe(true);
+    expect(err?.message).toContain('ECONNREFUSED');
+  });
+
+  it('emits retryable error when initialize RPC fails', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, error: { code: -32603, message: 'Internal error' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const err = events.find(e => e.type === 'error') as { type: 'error'; retryable: boolean } | undefined;
+    expect(err).toBeDefined();
+    expect(err?.retryable).toBe(true);
+  });
+
+  it('emits non-retryable error when prompt is cancelled', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'cancel-sess' } })),
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'cancelled' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    const err = events.find(e => e.type === 'error') as { type: 'error'; retryable: boolean; message: string } | undefined;
+    expect(err?.retryable).toBe(false);
+    expect(err?.message).toContain('cancelled');
+  });
+
+  it('emits error when transport closes mid-session', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      _id => transport.terminate(), // close before session/new responds
+    ]);
+    _test.createTransport = async () => transport;
+
+    const events = await collectEvents(new AcpClientProvider(), baseInput);
+    expect(events.some(e => e.type === 'error')).toBe(true);
+  });
+});
+
+// ── AcpClientProvider — fs/ request handling ────────────────────────────────
+
+describe('AcpClientProvider: fs/ request handling', () => {
+  it('rejects fs/read_text_file for paths outside /workspace', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'sec-sess' } }));
+        // Agent immediately tries to read /etc/passwd
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id: 77, method: 'fs/read_text_file', params: { uri: 'file:///etc/passwd' } }));
+      },
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    await collectEvents(new AcpClientProvider(), baseInput);
+
+    // Wait for fs/ response to be written (async handler)
+    await new Promise(r => setTimeout(r, 10));
+
+    const secResp = transport.writes
+      .map(w => JSON.parse(w) as { id?: number; error?: { message: string } })
+      .find(w => w.id === 77);
+    expect(secResp?.error).toBeDefined();
+    expect(secResp?.error?.message).toContain('outside workspace');
+  });
+
+  it('sends -32601 for terminal/create (capability not declared)', async () => {
+    const transport = createMockTransport();
+    autoScript(transport, [
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: initResult })),
+      id => {
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { sessionId: 'term-sess' } }));
+        transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id: 88, method: 'terminal/create', params: {} }));
+      },
+      id => transport.enqueue(JSON.stringify({ jsonrpc: '2.0', id, result: { content: [], stopReason: 'done' } })),
+    ]);
+    _test.createTransport = async () => transport;
+
+    await collectEvents(new AcpClientProvider(), baseInput);
+    await new Promise(r => setTimeout(r, 10));
+
+    const termResp = transport.writes
+      .map(w => JSON.parse(w) as { id?: number; error?: { code: number } })
+      .find(w => w.id === 88);
+    expect(termResp?.error?.code).toBe(-32601);
+  });
+});

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -5,13 +5,23 @@
  * NanoClaw acts as the client, spawning an AI agent subprocess and
  * communicating over stdin/stdout, or connecting to one over TCP.
  *
- * Per-turn flow: initialize → session/new → session/prompt → collect
- * session/update notifications → session/prompt response (stopReason=done)
+ * Per-turn flow: initialize → session/new (or resume) → turn loop:
+ *   session/prompt → collect session/update notifications → result
+ *
+ * Multi-turn: push() queues follow-up prompts; the connection stays open
+ * and session/prompt is called again on the same sessionId.
+ *
+ * Session resume: if input.continuation is set, session/new is skipped and
+ * the existing sessionId is reused. Works for TCP (stateful server); in
+ * subprocess mode the new process won't know the old session, so the agent
+ * will return an error and isSessionInvalid() will cause the poll-loop to
+ * retry fresh.
  *
  * Config (injected by host-side src/providers/acp-client.ts):
- *   ACP_CLIENT_CMD   — JSON array: command + args for subprocess mode
- *   ACP_CLIENT_HOST  — hostname for TCP mode
- *   ACP_CLIENT_PORT  — port for TCP mode (used with ACP_CLIENT_HOST)
+ *   ACP_CLIENT_CMD            — JSON array: command + args for subprocess mode
+ *   ACP_CLIENT_HOST           — hostname for TCP mode
+ *   ACP_CLIENT_PORT           — port for TCP mode (used with ACP_CLIENT_HOST)
+ *   ACP_CLIENT_IDLE_TIMEOUT_MS — ms with no session/update before closing (default 60000)
  */
 import fs from 'fs';
 import path from 'path';
@@ -195,6 +205,7 @@ export class JsonRpcDispatcher {
       if (handler) {
         handler(msg.params).then(respond).catch(e => respondErr(-32603, e instanceof Error ? e.message : String(e)));
       } else {
+        // Capability not declared in initialize — -32601 is correct per JSON-RPC 2.0 spec
         respondErr(-32601, `Method not found: ${msg.method}`);
       }
     } else {
@@ -228,6 +239,13 @@ function resolveWorkspacePath(uri: string): string | null {
   const resolved = path.resolve(filePath);
   if (resolved !== WORKSPACE && !resolved.startsWith(WORKSPACE + path.sep)) return null;
   return resolved;
+}
+
+// ── Prompt builder ──────────────────────────────────────────────────────────
+
+function buildPromptText(prompt: string, systemInstructions?: string): string {
+  if (!systemInstructions) return prompt;
+  return `<system>\n${systemInstructions}\n</system>\n\n${prompt}`;
 }
 
 // ── Injectable transport factory (overridden in tests) ──────────────────────
@@ -270,7 +288,14 @@ export class AcpClientProvider implements AgentProvider {
 
   query(input: QueryInput): AgentQuery {
     let aborted = false;
+    const pending: string[] = [input.prompt];
+    let waitKick: (() => void) | null = null;
+    let ended = false;
+    let activeTransport: AcpTransport | null = null;
+
     const { cmd, host, port } = this;
+    const systemInstructions = input.systemContext?.instructions;
+    const IDLE_TIMEOUT_MS = Number(process.env.ACP_CLIENT_IDLE_TIMEOUT_MS) || 60_000;
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
       if (aborted) return;
@@ -283,6 +308,7 @@ export class AcpClientProvider implements AgentProvider {
         yield { type: 'error', message: `Failed to connect to ACP agent: ${e instanceof Error ? e.message : String(e)}`, retryable: true };
         return;
       }
+      activeTransport = transport;
 
       const rpc = new JsonRpcDispatcher(transport);
 
@@ -303,9 +329,12 @@ export class AcpClientProvider implements AgentProvider {
         return {};
       });
 
-      // Accumulate streamed message chunks from session/update notifications
-      const chunks: string[] = [];
+      // Per-turn state: reset before each session/prompt call
+      let currentChunks: string[] = [];
+      let lastEventAt = Date.now();
+
       rpc.onNotification('session/update', (params) => {
+        lastEventAt = Date.now();
         const p = params as { update?: { kind: string; content?: unknown } };
         if (p?.update?.kind !== 'agent_message_chunk') return;
         const c = p.update.content as { content?: Array<{ type: string; text?: string }> } | undefined;
@@ -313,15 +342,15 @@ export class AcpClientProvider implements AgentProvider {
           .filter(b => b.type === 'text')
           .map(b => b.text ?? '')
           .join('');
-        if (text) chunks.push(text);
+        if (text) currentChunks.push(text);
       });
 
-      // Start pump loop — runs concurrently with the request awaits below
+      // Start pump loop — runs concurrently with all request awaits below
       rpc.pumpLoop().catch(() => {});
 
       try {
         // ── initialize ────────────────────────────────────────────────────
-        if (aborted) { transport.close(); return; }
+        if (aborted) return;
         yield { type: 'activity' };
 
         await rpc.request('initialize', {
@@ -335,37 +364,73 @@ export class AcpClientProvider implements AgentProvider {
           authenticationMethods: [],
         });
 
-        // ── session/new ───────────────────────────────────────────────────
-        if (aborted) { transport.close(); return; }
+        // ── session: resume or new ────────────────────────────────────────
+        if (aborted) return;
 
-        const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
-        const sessionId = sessionResult.sessionId;
-        log(`session created: ${sessionId}`);
+        let sessionId: string;
+        if (input.continuation) {
+          sessionId = input.continuation;
+          log(`resuming session: ${sessionId}`);
+        } else {
+          const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
+          sessionId = sessionResult.sessionId;
+          log(`session created: ${sessionId}`);
+        }
         yield { type: 'init', continuation: sessionId };
 
-        // ── session/prompt ────────────────────────────────────────────────
-        if (aborted) { transport.close(); return; }
-        yield { type: 'activity' };
+        // ── Turn loop ─────────────────────────────────────────────────────
+        while (!aborted) {
+          // Wait for a pending prompt or end signal
+          while (pending.length === 0 && !ended && !aborted) {
+            await new Promise<void>(resolve => { waitKick = resolve; });
+            waitKick = null;
+          }
 
-        const promptResult = (await rpc.request('session/prompt', {
-          sessionId,
-          content: [{ type: 'text', text: input.prompt }],
-        })) as { content?: Array<{ type: string; text?: string }>; stopReason: string };
+          if (aborted) return;
+          if (pending.length === 0 && ended) return;
 
-        if (promptResult.stopReason === 'cancelled') {
-          yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
-          return;
+          const promptText = pending.shift()!;
+          yield { type: 'activity' };
+
+          // Reset per-turn state
+          currentChunks = [];
+          lastEventAt = Date.now();
+
+          // Idle timeout: close the transport if the agent goes silent mid-turn.
+          // Check interval is at most 5s but capped to the timeout so short
+          // timeouts (e.g. in tests) fire without waiting the full 5s.
+          const idleCheckInterval = Math.min(5000, IDLE_TIMEOUT_MS);
+          const idleCheck = setInterval(() => {
+            if (Date.now() - lastEventAt > IDLE_TIMEOUT_MS) {
+              log(`ACP idle timeout (${IDLE_TIMEOUT_MS}ms) — closing connection`);
+              transport.close();
+            }
+          }, idleCheckInterval);
+
+          try {
+            const promptResult = (await rpc.request('session/prompt', {
+              sessionId,
+              content: [{ type: 'text', text: buildPromptText(promptText, systemInstructions) }],
+            })) as { content?: Array<{ type: string; text?: string }>; stopReason: string };
+
+            if (promptResult.stopReason === 'cancelled') {
+              yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
+              return;
+            }
+
+            // Merge streamed chunks + any inline text in the final response
+            const inlineText = (promptResult.content ?? [])
+              .filter(b => b.type === 'text')
+              .map(b => b.text ?? '')
+              .join('');
+
+            const fullText = [...currentChunks, inlineText].join('').trim() || null;
+            log(`session ${sessionId} turn done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
+            yield { type: 'result', text: fullText };
+          } finally {
+            clearInterval(idleCheck);
+          }
         }
-
-        // Merge streamed chunks + any inline text in the final response
-        const inlineText = (promptResult.content ?? [])
-          .filter(b => b.type === 'text')
-          .map(b => b.text ?? '')
-          .join('');
-
-        const fullText = [...chunks, inlineText].join('').trim() || null;
-        log(`session ${sessionId} done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
-        yield { type: 'result', text: fullText };
       } catch (e) {
         if (!aborted) {
           yield {
@@ -375,15 +440,23 @@ export class AcpClientProvider implements AgentProvider {
           };
         }
       } finally {
+        activeTransport = null;
         transport.close();
       }
     }
 
     return {
-      push: () => { log('push() no-op on acp-client (single-turn per session)'); },
-      end: () => {},
+      push: (message: string) => {
+        pending.push(message);
+        waitKick?.();
+      },
+      end: () => { ended = true; waitKick?.(); },
       events: gen(),
-      abort: () => { aborted = true; },
+      abort: () => {
+        aborted = true;
+        activeTransport?.close();
+        waitKick?.();
+      },
     };
   }
 }

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -5,23 +5,17 @@
  * NanoClaw acts as the client, spawning an AI agent subprocess and
  * communicating over stdin/stdout, or connecting to one over TCP.
  *
- * Per-turn flow: initialize → session/new (or resume) → turn loop:
- *   session/prompt → collect session/update notifications → result
- *
- * Multi-turn: push() queues follow-up prompts; the connection stays open
- * and session/prompt is called again on the same sessionId.
+ * Per-turn flow: initialize → session/new (or resume) → session/prompt →
+ *   collect session/update notifications → result
  *
  * Session resume: if input.continuation is set, session/new is skipped and
- * the existing sessionId is reused. Works for TCP (stateful server); in
- * subprocess mode the new process won't know the old session, so the agent
- * will return an error and isSessionInvalid() will cause the poll-loop to
- * retry fresh.
+ * the existing sessionId is reused. Falls back to session/new if the agent
+ * no longer knows the session (e.g. server restarted).
  *
  * Config (injected by host-side src/providers/acp-client.ts):
- *   ACP_CLIENT_CMD            — JSON array: command + args for subprocess mode
- *   ACP_CLIENT_HOST           — hostname for TCP mode
- *   ACP_CLIENT_PORT           — port for TCP mode (used with ACP_CLIENT_HOST)
- *   ACP_CLIENT_IDLE_TIMEOUT_MS — ms with no session/update before closing (default 60000)
+ *   ACP_CLIENT_CMD   — JSON array: command + args for subprocess mode
+ *   ACP_CLIENT_HOST  — hostname for TCP mode
+ *   ACP_CLIENT_PORT  — port for TCP mode (used with ACP_CLIENT_HOST)
  */
 import fs from 'fs';
 import path from 'path';
@@ -205,11 +199,9 @@ export class JsonRpcDispatcher {
       if (handler) {
         handler(msg.params).then(respond).catch(e => respondErr(-32603, e instanceof Error ? e.message : String(e)));
       } else {
-        // Capability not declared in initialize — -32601 is correct per JSON-RPC 2.0 spec
         respondErr(-32601, `Method not found: ${msg.method}`);
       }
     } else {
-      // Notification (no id, has method)
       const p = msg as RpcNotification;
       if ('method' in p) this.notifHandlers.get(p.method)?.(p.params);
     }
@@ -232,21 +224,21 @@ export class JsonRpcDispatcher {
 
 const WORKSPACE = '/workspace';
 
-function resolveWorkspacePath(uri: string): string | null {
-  let filePath = uri;
-  if (filePath.startsWith('file://')) filePath = decodeURIComponent(filePath.slice(7));
-  if (!path.isAbsolute(filePath)) filePath = path.join(WORKSPACE, filePath);
-  const resolved = path.resolve(filePath);
+function resolveWorkspacePath(filePath: string): string | null {
+  // Support both spec field name ("path") and legacy "uri" (file:// or plain path)
+  let p = filePath;
+  if (p.startsWith('file://')) p = decodeURIComponent(p.slice(7));
+  if (!path.isAbsolute(p)) p = path.join(WORKSPACE, p);
+  const resolved = path.resolve(p);
   if (resolved !== WORKSPACE && !resolved.startsWith(WORKSPACE + path.sep)) return null;
   return resolved;
 }
 
-// ── Prompt builder ──────────────────────────────────────────────────────────
+// ── stopReason classification ───────────────────────────────────────────────
 
-function buildPromptText(prompt: string, systemInstructions?: string): string {
-  if (!systemInstructions) return prompt;
-  return `<system>\n${systemInstructions}\n</system>\n\n${prompt}`;
-}
+// Reasons that mean the agent produced output and is done — treat as result.
+// "done" is not in the spec but our test server uses it for compat.
+const STOP_REASON_SUCCESS = new Set(['end_turn', 'done', 'max_tokens', 'max_turn_requests']);
 
 // ── Injectable transport factory (overridden in tests) ──────────────────────
 
@@ -308,29 +300,42 @@ export class AcpClientProvider implements AgentProvider {
 
       const rpc = new JsonRpcDispatcher(transport);
 
-      // Serve fs/ requests from /workspace
+      // Serve fs/ requests from /workspace — accept both "path" (spec) and
+      // "uri" (legacy) so both compliant agents and our test server work.
       rpc.onRequest('fs/read_text_file', async (params) => {
-        const { uri } = params as { uri: string };
-        const resolved = resolveWorkspacePath(uri);
-        if (!resolved) throw new Error(`Path outside workspace: ${uri}`);
-        return { content: fs.readFileSync(resolved, 'utf-8') };
+        const p = params as { sessionId?: string; path?: string; uri?: string; line?: number; limit?: number };
+        const filePath = p.path ?? p.uri ?? '';
+        const resolved = resolveWorkspacePath(filePath);
+        if (!resolved) throw new Error(`Path outside workspace: ${filePath}`);
+        const raw = fs.readFileSync(resolved, 'utf-8');
+        // Apply optional line/limit slicing
+        if (p.line !== undefined || p.limit !== undefined) {
+          const lines = raw.split('\n');
+          const start = Math.max(0, (p.line ?? 1) - 1);
+          const slice = p.limit !== undefined ? lines.slice(start, start + p.limit) : lines.slice(start);
+          return { content: slice.join('\n') };
+        }
+        return { content: raw };
       });
 
       rpc.onRequest('fs/write_text_file', async (params) => {
-        const { uri, content } = params as { uri: string; content: string };
-        const resolved = resolveWorkspacePath(uri);
-        if (!resolved) throw new Error(`Path outside workspace: ${uri}`);
+        const p = params as { sessionId?: string; path?: string; uri?: string; content: string };
+        const filePath = p.path ?? p.uri ?? '';
+        const resolved = resolveWorkspacePath(filePath);
+        if (!resolved) throw new Error(`Path outside workspace: ${filePath}`);
         fs.mkdirSync(path.dirname(resolved), { recursive: true });
-        fs.writeFileSync(resolved, content, 'utf-8');
-        return {};
+        fs.writeFileSync(resolved, p.content, 'utf-8');
+        return null;
       });
 
-      // Accumulate streamed message chunks from session/update notifications
+      // Accumulate streamed message chunks. Accept both "sessionUpdate" (spec)
+      // and "kind" (legacy test server) as the discriminator field name.
       const chunks: string[] = [];
       rpc.onNotification('session/update', (params) => {
-        const p = params as { update?: { kind: string; content?: unknown } };
-        if (p?.update?.kind !== 'agent_message_chunk') return;
-        const c = p.update.content as { content?: Array<{ type: string; text?: string }> } | undefined;
+        const p = params as { update?: { sessionUpdate?: string; kind?: string; content?: unknown } };
+        const updateType = p?.update?.sessionUpdate ?? p?.update?.kind;
+        if (updateType !== 'agent_message_chunk') return;
+        const c = p.update!.content as { content?: Array<{ type: string; text?: string }> } | undefined;
         const text = (c?.content ?? [])
           .filter(b => b.type === 'text')
           .map(b => b.text ?? '')
@@ -338,7 +343,6 @@ export class AcpClientProvider implements AgentProvider {
         if (text) chunks.push(text);
       });
 
-      // Start pump loop — runs concurrently with the request awaits below
       rpc.pumpLoop().catch(() => {});
 
       try {
@@ -346,16 +350,20 @@ export class AcpClientProvider implements AgentProvider {
         if (aborted) { transport.close(); return; }
         yield { type: 'activity' };
 
-        await rpc.request('initialize', {
+        const initResult = (await rpc.request('initialize', {
           protocolVersion: 1,
-          clientInfo: { name: 'nanoclaw', version: '1.0.0' },
-          capabilities: {
-            fileSystem: { readTextFile: true, writeTextFile: true },
-            terminal: { create: false, output: false, waitForExit: false, kill: false, release: false },
-            prompts: { audio: false, image: false, embeddedContext: false },
+          clientInfo: { name: 'nanoclaw', title: 'NanoClaw', version: '1.0.0' },
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            terminal: false,
           },
-          authenticationMethods: [],
-        });
+          authMethods: [],
+        })) as { protocolVersion?: number; agentCapabilities?: unknown };
+
+        if (initResult.protocolVersion !== undefined && initResult.protocolVersion !== 1) {
+          yield { type: 'error', message: `ACP agent uses unsupported protocol version ${initResult.protocolVersion}`, retryable: false };
+          return;
+        }
 
         // ── session: resume or new ────────────────────────────────────────
         if (aborted) { transport.close(); return; }
@@ -365,7 +373,10 @@ export class AcpClientProvider implements AgentProvider {
           sessionId = input.continuation;
           log(`resuming session: ${sessionId}`);
         } else {
-          const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
+          const sessionResult = (await rpc.request('session/new', {
+            cwd: WORKSPACE,
+            mcpServers: [],
+          })) as { sessionId: string };
           sessionId = sessionResult.sessionId;
           log(`session created: ${sessionId}`);
         }
@@ -375,43 +386,65 @@ export class AcpClientProvider implements AgentProvider {
         if (aborted) { transport.close(); return; }
         yield { type: 'activity' };
 
+        const promptText = systemInstructions
+          ? `<system>\n${systemInstructions}\n</system>\n\n${input.prompt}`
+          : input.prompt;
+
         let promptResult: { content?: Array<{ type: string; text?: string }>; stopReason: string };
         try {
           promptResult = (await rpc.request('session/prompt', {
             sessionId,
-            content: [{ type: 'text', text: buildPromptText(input.prompt, systemInstructions) }],
+            prompt: [{ type: 'text', text: promptText }],
           })) as typeof promptResult;
         } catch (e) {
-          // Stale continuation — server restarted and lost the session.
-          // Fall back transparently to a fresh session.
+          // Stale continuation — agent lost the session (e.g. server restarted).
+          // Transparently create a fresh session and retry.
           if (input.continuation && e instanceof Error && /session.*not found|no conversation/i.test(e.message)) {
-            log(`session ${sessionId} not found on server — creating fresh session`);
-            const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
+            log(`session ${sessionId} not found — creating fresh session`);
+            const sessionResult = (await rpc.request('session/new', {
+              cwd: WORKSPACE,
+              mcpServers: [],
+            })) as { sessionId: string };
             sessionId = sessionResult.sessionId;
-            log(`fresh session created: ${sessionId}`);
             yield { type: 'init', continuation: sessionId };
             promptResult = (await rpc.request('session/prompt', {
               sessionId,
-              content: [{ type: 'text', text: buildPromptText(input.prompt, systemInstructions) }],
+              prompt: [{ type: 'text', text: promptText }],
             })) as typeof promptResult;
           } else {
             throw e;
           }
         }
 
-        if (promptResult.stopReason === 'cancelled') {
+        const { stopReason } = promptResult;
+
+        if (stopReason === 'cancelled') {
           yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
           return;
         }
 
-        // Merge streamed chunks + any inline text in the final response
+        if (stopReason === 'refusal') {
+          yield { type: 'error', message: 'ACP agent refused to respond', retryable: false };
+          return;
+        }
+
+        // All other stopReasons (end_turn, done, max_tokens, max_turn_requests)
+        // mean the agent produced output — return whatever we collected.
+        if (!STOP_REASON_SUCCESS.has(stopReason)) {
+          log(`Unknown stopReason: ${stopReason} — treating as result`);
+        }
+
         const inlineText = (promptResult.content ?? [])
           .filter(b => b.type === 'text')
           .map(b => b.text ?? '')
           .join('');
 
         const fullText = [...chunks, inlineText].join('').trim() || null;
-        log(`session ${sessionId} done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
+        log(`session ${sessionId} done (${stopReason}), ${fullText?.length ?? 0} chars`);
+
+        // ── session/close — best-effort, don't block on it ────────────────
+        rpc.request('session/close', { sessionId }).catch(() => {});
+
         yield { type: 'result', text: fullText };
       } catch (e) {
         if (!aborted) {
@@ -428,7 +461,7 @@ export class AcpClientProvider implements AgentProvider {
     }
 
     return {
-      push: () => { log('push() is a no-op on acp-client — each turn opens a fresh connection'); },
+      push: () => { log('push() is a no-op on acp-client — single-turn per connection'); },
       end: () => {},
       events: gen(),
       abort: () => {

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -288,14 +288,10 @@ export class AcpClientProvider implements AgentProvider {
 
   query(input: QueryInput): AgentQuery {
     let aborted = false;
-    const pending: string[] = [input.prompt];
-    let waitKick: (() => void) | null = null;
-    let ended = false;
     let activeTransport: AcpTransport | null = null;
 
     const { cmd, host, port } = this;
     const systemInstructions = input.systemContext?.instructions;
-    const IDLE_TIMEOUT_MS = Number(process.env.ACP_CLIENT_IDLE_TIMEOUT_MS) || 60_000;
 
     async function* gen(): AsyncGenerator<ProviderEvent> {
       if (aborted) return;
@@ -329,12 +325,9 @@ export class AcpClientProvider implements AgentProvider {
         return {};
       });
 
-      // Per-turn state: reset before each session/prompt call
-      let currentChunks: string[] = [];
-      let lastEventAt = Date.now();
-
+      // Accumulate streamed message chunks from session/update notifications
+      const chunks: string[] = [];
       rpc.onNotification('session/update', (params) => {
-        lastEventAt = Date.now();
         const p = params as { update?: { kind: string; content?: unknown } };
         if (p?.update?.kind !== 'agent_message_chunk') return;
         const c = p.update.content as { content?: Array<{ type: string; text?: string }> } | undefined;
@@ -342,15 +335,15 @@ export class AcpClientProvider implements AgentProvider {
           .filter(b => b.type === 'text')
           .map(b => b.text ?? '')
           .join('');
-        if (text) currentChunks.push(text);
+        if (text) chunks.push(text);
       });
 
-      // Start pump loop — runs concurrently with all request awaits below
+      // Start pump loop — runs concurrently with the request awaits below
       rpc.pumpLoop().catch(() => {});
 
       try {
         // ── initialize ────────────────────────────────────────────────────
-        if (aborted) return;
+        if (aborted) { transport.close(); return; }
         yield { type: 'activity' };
 
         await rpc.request('initialize', {
@@ -365,7 +358,7 @@ export class AcpClientProvider implements AgentProvider {
         });
 
         // ── session: resume or new ────────────────────────────────────────
-        if (aborted) return;
+        if (aborted) { transport.close(); return; }
 
         let sessionId: string;
         if (input.continuation) {
@@ -378,59 +371,48 @@ export class AcpClientProvider implements AgentProvider {
         }
         yield { type: 'init', continuation: sessionId };
 
-        // ── Turn loop ─────────────────────────────────────────────────────
-        while (!aborted) {
-          // Wait for a pending prompt or end signal
-          while (pending.length === 0 && !ended && !aborted) {
-            await new Promise<void>(resolve => { waitKick = resolve; });
-            waitKick = null;
-          }
+        // ── session/prompt ────────────────────────────────────────────────
+        if (aborted) { transport.close(); return; }
+        yield { type: 'activity' };
 
-          if (aborted) return;
-          if (pending.length === 0 && ended) return;
-
-          const promptText = pending.shift()!;
-          yield { type: 'activity' };
-
-          // Reset per-turn state
-          currentChunks = [];
-          lastEventAt = Date.now();
-
-          // Idle timeout: close the transport if the agent goes silent mid-turn.
-          // Check interval is at most 5s but capped to the timeout so short
-          // timeouts (e.g. in tests) fire without waiting the full 5s.
-          const idleCheckInterval = Math.min(5000, IDLE_TIMEOUT_MS);
-          const idleCheck = setInterval(() => {
-            if (Date.now() - lastEventAt > IDLE_TIMEOUT_MS) {
-              log(`ACP idle timeout (${IDLE_TIMEOUT_MS}ms) — closing connection`);
-              transport.close();
-            }
-          }, idleCheckInterval);
-
-          try {
-            const promptResult = (await rpc.request('session/prompt', {
+        let promptResult: { content?: Array<{ type: string; text?: string }>; stopReason: string };
+        try {
+          promptResult = (await rpc.request('session/prompt', {
+            sessionId,
+            content: [{ type: 'text', text: buildPromptText(input.prompt, systemInstructions) }],
+          })) as typeof promptResult;
+        } catch (e) {
+          // Stale continuation — server restarted and lost the session.
+          // Fall back transparently to a fresh session.
+          if (input.continuation && e instanceof Error && /session.*not found|no conversation/i.test(e.message)) {
+            log(`session ${sessionId} not found on server — creating fresh session`);
+            const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
+            sessionId = sessionResult.sessionId;
+            log(`fresh session created: ${sessionId}`);
+            yield { type: 'init', continuation: sessionId };
+            promptResult = (await rpc.request('session/prompt', {
               sessionId,
-              content: [{ type: 'text', text: buildPromptText(promptText, systemInstructions) }],
-            })) as { content?: Array<{ type: string; text?: string }>; stopReason: string };
-
-            if (promptResult.stopReason === 'cancelled') {
-              yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
-              return;
-            }
-
-            // Merge streamed chunks + any inline text in the final response
-            const inlineText = (promptResult.content ?? [])
-              .filter(b => b.type === 'text')
-              .map(b => b.text ?? '')
-              .join('');
-
-            const fullText = [...currentChunks, inlineText].join('').trim() || null;
-            log(`session ${sessionId} turn done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
-            yield { type: 'result', text: fullText };
-          } finally {
-            clearInterval(idleCheck);
+              content: [{ type: 'text', text: buildPromptText(input.prompt, systemInstructions) }],
+            })) as typeof promptResult;
+          } else {
+            throw e;
           }
         }
+
+        if (promptResult.stopReason === 'cancelled') {
+          yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
+          return;
+        }
+
+        // Merge streamed chunks + any inline text in the final response
+        const inlineText = (promptResult.content ?? [])
+          .filter(b => b.type === 'text')
+          .map(b => b.text ?? '')
+          .join('');
+
+        const fullText = [...chunks, inlineText].join('').trim() || null;
+        log(`session ${sessionId} done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
+        yield { type: 'result', text: fullText };
       } catch (e) {
         if (!aborted) {
           yield {
@@ -446,16 +428,12 @@ export class AcpClientProvider implements AgentProvider {
     }
 
     return {
-      push: (message: string) => {
-        pending.push(message);
-        waitKick?.();
-      },
-      end: () => { ended = true; waitKick?.(); },
+      push: () => { log('push() is a no-op on acp-client — each turn opens a fresh connection'); },
+      end: () => {},
       events: gen(),
       abort: () => {
         aborted = true;
         activeTransport?.close();
-        waitKick?.();
       },
     };
   }

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -240,6 +240,23 @@ function resolveWorkspacePath(filePath: string): string | null {
 // "done" is not in the spec but our test server uses it for compat.
 const STOP_REASON_SUCCESS = new Set(['end_turn', 'done', 'max_tokens', 'max_turn_requests']);
 
+// ── XML stripping ──────────────────────────────────────────────────────────
+// NanoClaw formats conversation history as XML for Claude. External ACP agents
+// are not Claude — strip to plain text so they see a clean conversation.
+function stripXmlMessages(prompt: string): string {
+  if (!prompt.includes('<message') && !prompt.includes('<context')) return prompt;
+  const lines: string[] = [];
+  const messageRe = /<message[^>]*\ssender="([^"]*)"[^>]*>([\s\S]*?)<\/message>/g;
+  let match: RegExpExecArray | null;
+  while ((match = messageRe.exec(prompt)) !== null) {
+    const text = match[2].replace(/<[^>]+>/g, '').trim();
+    if (text) lines.push(text);
+  }
+  if (lines.length === 0) return prompt;
+  const TRIGGER_RE = /^[a-z][a-z0-9_-]*:\s*/i;
+  return lines.map((l) => l.replace(TRIGGER_RE, '')).join('\n');
+}
+
 // ── Injectable transport factory (overridden in tests) ──────────────────────
 
 export const _test = {
@@ -347,7 +364,7 @@ export class AcpClientProvider implements AgentProvider {
         if (text) chunks.push(text);
       });
 
-      rpc.pumpLoop().catch(() => {});
+      rpc.pumpLoop().catch(e => log(`pumpLoop closed: ${e instanceof Error ? e.message : String(e)}`));
 
       try {
         // ── initialize ────────────────────────────────────────────────────
@@ -369,6 +386,9 @@ export class AcpClientProvider implements AgentProvider {
           return;
         }
 
+        // We serve fs/ requests regardless of what the agent declares — the agent
+        // calls US for file access, not the other way around. Warn if the agent
+        // didn't advertise fs support so unexpected rejections are easier to diagnose.
         const agentCaps = initResult.agentCapabilities as { fs?: { readTextFile?: boolean; writeTextFile?: boolean } } | undefined;
         if (agentCaps && !agentCaps.fs?.readTextFile && !agentCaps.fs?.writeTextFile) {
           log('Warning: agent did not declare fs capabilities — fs/ calls may be rejected');
@@ -377,9 +397,21 @@ export class AcpClientProvider implements AgentProvider {
         // ── session: resume or new ────────────────────────────────────────
         if (aborted) { transport.close(); return; }
 
+        // Strip NanoClaw XML conversation format — external agents are not Claude
+        // and don't understand the XML wrapper. System instructions are injected
+        // as a plain <system> block that the test server (and real agents) can parse.
+        const cleanPrompt = stripXmlMessages(input.prompt);
+        const promptText = systemInstructions
+          ? `<system>\n${systemInstructions}\n</system>\n\n${cleanPrompt}`
+          : cleanPrompt;
+
+        // ── session: resume or new ────────────────────────────────────────
+        if (aborted) { transport.close(); return; }
+
         let sessionId: string;
-        if (input.continuation) {
-          sessionId = input.continuation;
+        const isResume = !!input.continuation;
+        if (isResume) {
+          sessionId = input.continuation!;
           log(`resuming session: ${sessionId}`);
         } else {
           const sessionResult = (await rpc.request('session/new', {
@@ -388,16 +420,14 @@ export class AcpClientProvider implements AgentProvider {
           })) as { sessionId: string };
           sessionId = sessionResult.sessionId;
           log(`session created: ${sessionId}`);
+          // Emit init immediately so the poll-loop persists the sessionId even
+          // if the container dies before the prompt response arrives.
+          yield { type: 'init', continuation: sessionId };
         }
-        yield { type: 'init', continuation: sessionId };
 
         // ── session/prompt ────────────────────────────────────────────────
         if (aborted) { transport.close(); return; }
         yield { type: 'activity' };
-
-        const promptText = systemInstructions
-          ? `<system>\n${systemInstructions}\n</system>\n\n${input.prompt}`
-          : input.prompt;
 
         let promptResult: { content?: Array<{ type: string; text?: string }>; stopReason: string };
         try {
@@ -405,10 +435,12 @@ export class AcpClientProvider implements AgentProvider {
             sessionId,
             prompt: [{ type: 'text', text: promptText }],
           })) as typeof promptResult;
+          // Resume succeeded — emit init with the resumed session id.
+          if (isResume) yield { type: 'init', continuation: sessionId };
         } catch (e) {
           // Stale continuation — agent lost the session (e.g. server restarted).
-          // Transparently create a fresh session and retry.
-          if (input.continuation && e instanceof Error && /session.*not found|no conversation/i.test(e.message)) {
+          // Transparently create a fresh session and retry without surfacing an error.
+          if (isResume && e instanceof Error && /session.*not found|no conversation/i.test(e.message)) {
             log(`session ${sessionId} not found — creating fresh session`);
             const sessionResult = (await rpc.request('session/new', {
               cwd: WORKSPACE,
@@ -451,7 +483,8 @@ export class AcpClientProvider implements AgentProvider {
         const fullText = [...chunks, inlineText].join('').trim() || null;
         log(`session ${sessionId} done (${stopReason}), ${fullText?.length ?? 0} chars`);
 
-        // ── session/close — best-effort, don't block on it ────────────────
+        // Best-effort close: transport shuts down immediately after, so the
+        // agent may not receive this if it's slow. Intentional — we don't block.
         rpc.request('session/close', { sessionId }).catch(() => {});
 
         yield { type: 'result', text: fullText };

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -1,0 +1,391 @@
+/**
+ * Agent Client Protocol (ACP) provider.
+ *
+ * ACP (https://agentclientprotocol.com) is a JSON-RPC 2.0 protocol where
+ * NanoClaw acts as the client, spawning an AI agent subprocess and
+ * communicating over stdin/stdout, or connecting to one over TCP.
+ *
+ * Per-turn flow: initialize → session/new → session/prompt → collect
+ * session/update notifications → session/prompt response (stopReason=done)
+ *
+ * Config (injected by host-side src/providers/acp-client.ts):
+ *   ACP_CLIENT_CMD   — JSON array: command + args for subprocess mode
+ *   ACP_CLIENT_HOST  — hostname for TCP mode
+ *   ACP_CLIENT_PORT  — port for TCP mode (used with ACP_CLIENT_HOST)
+ */
+import fs from 'fs';
+import path from 'path';
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+// ── JSON-RPC 2.0 types ──────────────────────────────────────────────────────
+
+interface RpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface RpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+interface RpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+type RpcMessage = RpcRequest | RpcNotification | RpcResponse;
+
+function isRpcResponse(msg: RpcMessage): msg is RpcResponse {
+  return 'id' in msg && ('result' in msg || 'error' in msg) && !('method' in msg);
+}
+
+function isRpcRequest(msg: RpcMessage): msg is RpcRequest {
+  return 'id' in msg && 'method' in msg;
+}
+
+// ── Line reader ─────────────────────────────────────────────────────────────
+
+export class LineReader {
+  private buf = '';
+  private lines: string[] = [];
+  private waiters: Array<(line: string | null) => void> = [];
+  private ended = false;
+
+  feed(chunk: string): void {
+    this.buf += chunk;
+    const parts = this.buf.split('\n');
+    this.buf = parts.pop()!;
+    for (const line of parts) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (this.waiters.length > 0) this.waiters.shift()!(trimmed);
+      else this.lines.push(trimmed);
+    }
+  }
+
+  end(): void {
+    this.ended = true;
+    for (const w of this.waiters) w(null);
+    this.waiters = [];
+  }
+
+  readLine(): Promise<string | null> {
+    if (this.lines.length > 0) return Promise.resolve(this.lines.shift()!);
+    if (this.ended) return Promise.resolve(null);
+    return new Promise(resolve => this.waiters.push(resolve));
+  }
+}
+
+// ── Transport interface ─────────────────────────────────────────────────────
+
+export interface AcpTransport {
+  write(msg: string): void;
+  readLine(): Promise<string | null>;
+  close(): void;
+}
+
+// ── Subprocess transport ────────────────────────────────────────────────────
+
+export async function connectSubprocess(cmd: string[]): Promise<AcpTransport> {
+  const [prog, ...args] = cmd;
+  const proc = Bun.spawn([prog, ...args], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const reader = new LineReader();
+  const dec = new TextDecoder();
+
+  (async () => {
+    const r = proc.stdout.getReader();
+    try {
+      while (true) {
+        const { value, done } = await r.read();
+        if (done) break;
+        reader.feed(dec.decode(value));
+      }
+    } finally {
+      reader.end();
+    }
+  })().catch(() => reader.end());
+
+  return {
+    write(msg) {
+      proc.stdin.write(msg + '\n');
+      proc.stdin.flush();
+    },
+    readLine: () => reader.readLine(),
+    close() { try { proc.kill(); } catch { /* already dead */ } },
+  };
+}
+
+// ── TCP transport ───────────────────────────────────────────────────────────
+
+export async function connectTcp(host: string, port: number): Promise<AcpTransport> {
+  const reader = new LineReader();
+  const dec = new TextDecoder();
+
+  return new Promise<AcpTransport>((resolve, reject) => {
+    Bun.connect({
+      hostname: host,
+      port,
+      socket: {
+        open(socket) {
+          resolve({
+            write(msg) { socket.write(msg + '\n'); },
+            readLine: () => reader.readLine(),
+            close() { try { socket.end(); } catch { /* ignore */ } },
+          });
+        },
+        data(_socket, data) { reader.feed(dec.decode(data)); },
+        close() { reader.end(); },
+        error(_socket, err) { reader.end(); reject(err); },
+      },
+    }).catch(reject);
+  });
+}
+
+// ── JSON-RPC dispatcher ─────────────────────────────────────────────────────
+
+export class JsonRpcDispatcher {
+  private idSeq = 1;
+  private pending = new Map<number, { resolve: (r: unknown) => void; reject: (e: unknown) => void }>();
+  private notifHandlers = new Map<string, (params: unknown) => void>();
+  private reqHandlers = new Map<string, (params: unknown) => Promise<unknown>>();
+
+  constructor(private transport: AcpTransport) {}
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    const id = this.idSeq++;
+    this.transport.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
+    return new Promise((resolve, reject) => this.pending.set(id, { resolve, reject }));
+  }
+
+  onNotification(method: string, handler: (params: unknown) => void): void {
+    this.notifHandlers.set(method, handler);
+  }
+
+  onRequest(method: string, handler: (params: unknown) => Promise<unknown>): void {
+    this.reqHandlers.set(method, handler);
+  }
+
+  dispatch(line: string): void {
+    let msg: RpcMessage;
+    try { msg = JSON.parse(line) as RpcMessage; } catch { return; }
+
+    if (isRpcResponse(msg)) {
+      const p = this.pending.get(msg.id);
+      if (!p) return;
+      this.pending.delete(msg.id);
+      msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+    } else if (isRpcRequest(msg)) {
+      const handler = this.reqHandlers.get(msg.method);
+      const respond = (result: unknown) =>
+        this.transport.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result }));
+      const respondErr = (code: number, message: string) =>
+        this.transport.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code, message } }));
+      if (handler) {
+        handler(msg.params).then(respond).catch(e => respondErr(-32603, e instanceof Error ? e.message : String(e)));
+      } else {
+        respondErr(-32601, `Method not found: ${msg.method}`);
+      }
+    } else {
+      // Notification (no id, has method)
+      const p = msg as RpcNotification;
+      if ('method' in p) this.notifHandlers.get(p.method)?.(p.params);
+    }
+  }
+
+  async pumpLoop(): Promise<void> {
+    while (true) {
+      const line = await this.transport.readLine();
+      if (line === null) {
+        for (const { reject } of this.pending.values()) reject(new Error('Connection closed'));
+        this.pending.clear();
+        return;
+      }
+      this.dispatch(line);
+    }
+  }
+}
+
+// ── Workspace path guard ────────────────────────────────────────────────────
+
+const WORKSPACE = '/workspace';
+
+function resolveWorkspacePath(uri: string): string | null {
+  let filePath = uri;
+  if (filePath.startsWith('file://')) filePath = decodeURIComponent(filePath.slice(7));
+  if (!path.isAbsolute(filePath)) filePath = path.join(WORKSPACE, filePath);
+  const resolved = path.resolve(filePath);
+  if (resolved !== WORKSPACE && !resolved.startsWith(WORKSPACE + path.sep)) return null;
+  return resolved;
+}
+
+// ── Injectable transport factory (overridden in tests) ──────────────────────
+
+export const _test = {
+  createTransport: async (cmd: string[] | null, host: string | null, port: number | null): Promise<AcpTransport> => {
+    if (cmd) return connectSubprocess(cmd);
+    return connectTcp(host!, port!);
+  },
+};
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+function log(msg: string): void {
+  console.error(`[acp-client-provider] ${msg}`);
+}
+
+export class AcpClientProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private readonly cmd: string[] | null;
+  private readonly host: string | null;
+  private readonly port: number | null;
+
+  constructor(_options: ProviderOptions = {}) {
+    const cmdEnv = process.env.ACP_CLIENT_CMD;
+    this.cmd = cmdEnv ? (JSON.parse(cmdEnv) as string[]) : null;
+    this.host = process.env.ACP_CLIENT_HOST || null;
+    this.port = process.env.ACP_CLIENT_PORT ? parseInt(process.env.ACP_CLIENT_PORT, 10) : null;
+
+    if (!this.cmd && !(this.host && this.port)) {
+      throw new Error('ACP_CLIENT_CMD or ACP_CLIENT_HOST+ACP_CLIENT_PORT required for acp-client provider');
+    }
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return /session.*not found|invalid state|connection closed/i.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    let aborted = false;
+    const { cmd, host, port } = this;
+
+    async function* gen(): AsyncGenerator<ProviderEvent> {
+      if (aborted) return;
+
+      // ── Connect ──────────────────────────────────────────────────────────
+      let transport: AcpTransport;
+      try {
+        transport = await _test.createTransport(cmd, host, port);
+      } catch (e) {
+        yield { type: 'error', message: `Failed to connect to ACP agent: ${e instanceof Error ? e.message : String(e)}`, retryable: true };
+        return;
+      }
+
+      const rpc = new JsonRpcDispatcher(transport);
+
+      // Serve fs/ requests from /workspace
+      rpc.onRequest('fs/read_text_file', async (params) => {
+        const { uri } = params as { uri: string };
+        const resolved = resolveWorkspacePath(uri);
+        if (!resolved) throw new Error(`Path outside workspace: ${uri}`);
+        return { content: fs.readFileSync(resolved, 'utf-8') };
+      });
+
+      rpc.onRequest('fs/write_text_file', async (params) => {
+        const { uri, content } = params as { uri: string; content: string };
+        const resolved = resolveWorkspacePath(uri);
+        if (!resolved) throw new Error(`Path outside workspace: ${uri}`);
+        fs.mkdirSync(path.dirname(resolved), { recursive: true });
+        fs.writeFileSync(resolved, content, 'utf-8');
+        return {};
+      });
+
+      // Accumulate streamed message chunks from session/update notifications
+      const chunks: string[] = [];
+      rpc.onNotification('session/update', (params) => {
+        const p = params as { update?: { kind: string; content?: unknown } };
+        if (p?.update?.kind !== 'agent_message_chunk') return;
+        const c = p.update.content as { content?: Array<{ type: string; text?: string }> } | undefined;
+        const text = (c?.content ?? [])
+          .filter(b => b.type === 'text')
+          .map(b => b.text ?? '')
+          .join('');
+        if (text) chunks.push(text);
+      });
+
+      // Start pump loop — runs concurrently with the request awaits below
+      rpc.pumpLoop().catch(() => {});
+
+      try {
+        // ── initialize ────────────────────────────────────────────────────
+        if (aborted) { transport.close(); return; }
+        yield { type: 'activity' };
+
+        await rpc.request('initialize', {
+          protocolVersion: 1,
+          clientInfo: { name: 'nanoclaw', version: '1.0.0' },
+          capabilities: {
+            fileSystem: { readTextFile: true, writeTextFile: true },
+            terminal: { create: false, output: false, waitForExit: false, kill: false, release: false },
+            prompts: { audio: false, image: false, embeddedContext: false },
+          },
+          authenticationMethods: [],
+        });
+
+        // ── session/new ───────────────────────────────────────────────────
+        if (aborted) { transport.close(); return; }
+
+        const sessionResult = (await rpc.request('session/new', { cwd: WORKSPACE })) as { sessionId: string };
+        const sessionId = sessionResult.sessionId;
+        log(`session created: ${sessionId}`);
+        yield { type: 'init', continuation: sessionId };
+
+        // ── session/prompt ────────────────────────────────────────────────
+        if (aborted) { transport.close(); return; }
+        yield { type: 'activity' };
+
+        const promptResult = (await rpc.request('session/prompt', {
+          sessionId,
+          content: [{ type: 'text', text: input.prompt }],
+        })) as { content?: Array<{ type: string; text?: string }>; stopReason: string };
+
+        if (promptResult.stopReason === 'cancelled') {
+          yield { type: 'error', message: 'ACP session prompt was cancelled', retryable: false };
+          return;
+        }
+
+        // Merge streamed chunks + any inline text in the final response
+        const inlineText = (promptResult.content ?? [])
+          .filter(b => b.type === 'text')
+          .map(b => b.text ?? '')
+          .join('');
+
+        const fullText = [...chunks, inlineText].join('').trim() || null;
+        log(`session ${sessionId} done (${promptResult.stopReason}), ${fullText?.length ?? 0} chars`);
+        yield { type: 'result', text: fullText };
+      } catch (e) {
+        if (!aborted) {
+          yield {
+            type: 'error',
+            message: `ACP client error: ${e instanceof Error ? e.message : String(e)}`,
+            retryable: true,
+          };
+        }
+      } finally {
+        transport.close();
+      }
+    }
+
+    return {
+      push: () => { log('push() no-op on acp-client (single-turn per session)'); },
+      end: () => {},
+      events: gen(),
+      abort: () => { aborted = true; },
+    };
+  }
+}
+
+registerProvider('acp-client', (opts) => new AcpClientProvider(opts));

--- a/container/agent-runner/src/providers/acp-client.ts
+++ b/container/agent-runner/src/providers/acp-client.ts
@@ -334,7 +334,11 @@ export class AcpClientProvider implements AgentProvider {
       rpc.onNotification('session/update', (params) => {
         const p = params as { update?: { sessionUpdate?: string; kind?: string; content?: unknown } };
         const updateType = p?.update?.sessionUpdate ?? p?.update?.kind;
-        if (updateType !== 'agent_message_chunk') return;
+        if (updateType !== 'agent_message_chunk') {
+          // plan, tool_call, tool_call_update — log but do not error
+          if (updateType) log(`session/update: ${updateType} (not collected)`);
+          return;
+        }
         const c = p.update!.content as { content?: Array<{ type: string; text?: string }> } | undefined;
         const text = (c?.content ?? [])
           .filter(b => b.type === 'text')
@@ -363,6 +367,11 @@ export class AcpClientProvider implements AgentProvider {
         if (initResult.protocolVersion !== undefined && initResult.protocolVersion !== 1) {
           yield { type: 'error', message: `ACP agent uses unsupported protocol version ${initResult.protocolVersion}`, retryable: false };
           return;
+        }
+
+        const agentCaps = initResult.agentCapabilities as { fs?: { readTextFile?: boolean; writeTextFile?: boolean } } | undefined;
+        if (agentCaps && !agentCaps.fs?.readTextFile && !agentCaps.fs?.writeTextFile) {
+          log('Warning: agent did not declare fs capabilities — fs/ calls may be rejected');
         }
 
         // ── session: resume or new ────────────────────────────────────────

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -2,6 +2,7 @@
 // Each import triggers the provider module's registerProvider() call at top
 // level. Skills add a new provider by appending one import line below.
 
+import './acp-client.js';
 import './claude.js';
 import './codex.js';
 import './mock.js';

--- a/src/providers/acp-client.test.ts
+++ b/src/providers/acp-client.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-type ConfigCallback = (ctx: { agentGroupId: string; hostEnv: Record<string, string> }) => { env: Record<string, string> };
+type ConfigCallback = (ctx: { agentGroupId: string; hostEnv: Record<string, string> }) => {
+  env: Record<string, string>;
+};
 
 // vi.hoisted runs in the hoisted scope so the reference is available when vi.mock factories run
 const captured = vi.hoisted(() => ({ callback: null as ConfigCallback | null }));
@@ -13,8 +15,14 @@ vi.mock('./provider-container-registry.js', () => ({
   }),
 }));
 vi.mock('fs', () => ({
-  default: { readFileSync: vi.fn(() => { throw new Error('ENOENT'); }) },
-  readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+  default: {
+    readFileSync: vi.fn(() => {
+      throw new Error('ENOENT');
+    }),
+  },
+  readFileSync: vi.fn(() => {
+    throw new Error('ENOENT');
+  }),
 }));
 
 // Import module — triggers registerProviderContainerConfig side-effect
@@ -29,7 +37,9 @@ const ctx = (hostEnv: Record<string, string> = {}, agentGroupId = 'grp-1') => ({
 
 beforeEach(() => {
   vi.mocked(getAgentGroup).mockReturnValue(undefined as any);
-  vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+  vi.mocked(fs.readFileSync).mockImplementation(() => {
+    throw new Error('ENOENT');
+  });
 });
 
 describe('acp-client host-side container config', () => {
@@ -74,9 +84,7 @@ describe('acp-client host-side container config', () => {
 describe('acp-client host-side: group config (acp-client.json)', () => {
   it('uses command from group config over env var', () => {
     vi.mocked(getAgentGroup).mockReturnValue({ folder: 'my-group' } as any);
-    vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify({ command: ['group-agent', '--mode', 'fast'] }) as any,
-    );
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ command: ['group-agent', '--mode', 'fast'] }) as any);
 
     const env = captured.callback!(ctx({ ACP_CLIENT_CMD: '["env-agent"]' })).env;
     expect(env.ACP_CLIENT_CMD).toBe(JSON.stringify(['group-agent', '--mode', 'fast']));
@@ -84,9 +92,7 @@ describe('acp-client host-side: group config (acp-client.json)', () => {
 
   it('uses host+port from group config over env var', () => {
     vi.mocked(getAgentGroup).mockReturnValue({ folder: 'grp' } as any);
-    vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify({ host: 'group-host', port: 9999 }) as any,
-    );
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ host: 'group-host', port: 9999 }) as any);
 
     const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'env-host', ACP_CLIENT_PORT: '1111' })).env;
     expect(env.ACP_CLIENT_HOST).toBe('group-host');

--- a/src/providers/acp-client.test.ts
+++ b/src/providers/acp-client.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type ConfigCallback = (ctx: { agentGroupId: string; hostEnv: Record<string, string> }) => { env: Record<string, string> };
+
+// vi.hoisted runs in the hoisted scope so the reference is available when vi.mock factories run
+const captured = vi.hoisted(() => ({ callback: null as ConfigCallback | null }));
+
+vi.mock('../db/agent-groups.js', () => ({ getAgentGroup: vi.fn() }));
+vi.mock('../config.js', () => ({ GROUPS_DIR: '/groups' }));
+vi.mock('./provider-container-registry.js', () => ({
+  registerProviderContainerConfig: vi.fn((_name: string, cb: ConfigCallback) => {
+    captured.callback = cb;
+  }),
+}));
+vi.mock('fs', () => ({
+  default: { readFileSync: vi.fn(() => { throw new Error('ENOENT'); }) },
+  readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+}));
+
+// Import module — triggers registerProviderContainerConfig side-effect
+import './acp-client.js';
+import { getAgentGroup } from '../db/agent-groups.js';
+import fs from 'fs';
+
+const ctx = (hostEnv: Record<string, string> = {}, agentGroupId = 'grp-1') => ({
+  agentGroupId,
+  hostEnv,
+});
+
+beforeEach(() => {
+  vi.mocked(getAgentGroup).mockReturnValue(undefined as any);
+  vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+});
+
+describe('acp-client host-side container config', () => {
+  it('registers with provider name "acp-client"', async () => {
+    const { registerProviderContainerConfig } = await import('./provider-container-registry.js');
+    expect(vi.mocked(registerProviderContainerConfig)).toHaveBeenCalledWith('acp-client', expect.any(Function));
+  });
+
+  it('injects ACP_CLIENT_CMD from env when no group config', () => {
+    const env = captured.callback!(ctx({ ACP_CLIENT_CMD: '["my-agent","--flag"]' })).env;
+    expect(env.ACP_CLIENT_CMD).toBe('["my-agent","--flag"]');
+  });
+
+  it('injects ACP_CLIENT_HOST and ACP_CLIENT_PORT from env when no group config', () => {
+    const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'localhost', ACP_CLIENT_PORT: '7777' })).env;
+    expect(env.ACP_CLIENT_HOST).toBe('localhost');
+    expect(env.ACP_CLIENT_PORT).toBe('7777');
+  });
+
+  it('injects empty env when no config and no env vars', () => {
+    const env = captured.callback!(ctx({})).env;
+    expect(Object.keys(env)).toHaveLength(0);
+  });
+
+  it('adds NO_PROXY for host to bypass OneCLI proxy', () => {
+    const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'localhost', ACP_CLIENT_PORT: '7777' })).env;
+    expect(env.NO_PROXY).toContain('localhost');
+    expect(env.no_proxy).toContain('localhost');
+  });
+
+  it('appends to existing NO_PROXY rather than overwriting', () => {
+    const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'myhost', NO_PROXY: '172.17.0.1' })).env;
+    expect(env.NO_PROXY).toBe('172.17.0.1,myhost');
+  });
+
+  it('does not add NO_PROXY in subprocess mode (no host)', () => {
+    const env = captured.callback!(ctx({ ACP_CLIENT_CMD: '["agent"]' })).env;
+    expect(env.NO_PROXY).toBeUndefined();
+  });
+});
+
+describe('acp-client host-side: group config (acp-client.json)', () => {
+  it('uses command from group config over env var', () => {
+    vi.mocked(getAgentGroup).mockReturnValue({ folder: 'my-group' } as any);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ command: ['group-agent', '--mode', 'fast'] }) as any,
+    );
+
+    const env = captured.callback!(ctx({ ACP_CLIENT_CMD: '["env-agent"]' })).env;
+    expect(env.ACP_CLIENT_CMD).toBe(JSON.stringify(['group-agent', '--mode', 'fast']));
+  });
+
+  it('uses host+port from group config over env var', () => {
+    vi.mocked(getAgentGroup).mockReturnValue({ folder: 'grp' } as any);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ host: 'group-host', port: 9999 }) as any,
+    );
+
+    const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'env-host', ACP_CLIENT_PORT: '1111' })).env;
+    expect(env.ACP_CLIENT_HOST).toBe('group-host');
+    expect(env.ACP_CLIENT_PORT).toBe('9999');
+  });
+
+  it('falls back to env vars when group config file is missing', () => {
+    vi.mocked(getAgentGroup).mockReturnValue({ folder: 'grp' } as any);
+    // fs.readFileSync throws by default (see beforeEach)
+
+    const env = captured.callback!(ctx({ ACP_CLIENT_HOST: 'fallback', ACP_CLIENT_PORT: '5555' })).env;
+    expect(env.ACP_CLIENT_HOST).toBe('fallback');
+    expect(env.ACP_CLIENT_PORT).toBe('5555');
+  });
+});

--- a/src/providers/acp-client.ts
+++ b/src/providers/acp-client.ts
@@ -1,0 +1,74 @@
+/**
+ * Host-side container config for the `acp-client` provider.
+ *
+ * Resolves ACP client connection details per agent group and injects them
+ * as env vars so the container-side AcpClientProvider can connect to the
+ * right ACP-speaking agent.
+ *
+ * Per-group config (takes precedence):
+ *   groups/<folder>/acp-client.json  —  one of:
+ *     { "command": ["my-acp-agent", "--flag"] }     — subprocess mode
+ *     { "host": "localhost", "port": 7777 }          — TCP mode
+ *
+ * Global fallback (.env or env vars):
+ *   ACP_CLIENT_CMD   — JSON-serialised string array for subprocess mode
+ *   ACP_CLIENT_HOST  — hostname for TCP mode
+ *   ACP_CLIENT_PORT  — port for TCP mode
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { getAgentGroup } from '../db/agent-groups.js';
+import { GROUPS_DIR } from '../config.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+interface AcpClientGroupConfig {
+  command?: string[];
+  host?: string;
+  port?: number;
+}
+
+function readGroupConfig(agentGroupId: string): AcpClientGroupConfig {
+  try {
+    const ag = getAgentGroup(agentGroupId);
+    if (!ag) return {};
+    const configPath = path.join(GROUPS_DIR, ag.folder, 'acp-client.json');
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    return {
+      command: Array.isArray(raw.command) ? (raw.command as string[]) : undefined,
+      host: typeof raw.host === 'string' ? raw.host : undefined,
+      port: typeof raw.port === 'number' ? raw.port : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+registerProviderContainerConfig('acp-client', (ctx) => {
+  const group = readGroupConfig(ctx.agentGroupId);
+  const env: Record<string, string> = {};
+
+  // Subprocess mode: command array → JSON-serialised env var
+  const cmd = group.command;
+  if (cmd?.length) {
+    env.ACP_CLIENT_CMD = JSON.stringify(cmd);
+  } else if (ctx.hostEnv.ACP_CLIENT_CMD) {
+    env.ACP_CLIENT_CMD = ctx.hostEnv.ACP_CLIENT_CMD;
+  }
+
+  // TCP mode
+  const host = group.host ?? ctx.hostEnv.ACP_CLIENT_HOST;
+  const port = group.port ?? (ctx.hostEnv.ACP_CLIENT_PORT ? parseInt(ctx.hostEnv.ACP_CLIENT_PORT, 10) : undefined);
+  if (host) env.ACP_CLIENT_HOST = host;
+  if (port) env.ACP_CLIENT_PORT = String(port);
+
+  // Bypass OneCLI proxy for local ACP servers
+  if (host) {
+    const existing = ctx.hostEnv.NO_PROXY || ctx.hostEnv.no_proxy || '';
+    const noProxy = existing ? `${existing},${host}` : host;
+    env.NO_PROXY = noProxy;
+    env.no_proxy = noProxy;
+  }
+
+  return { env };
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,5 +5,6 @@
 //
 // Skills add a new provider by appending one import line below.
 
+import './acp-client.js';
 import './codex.js';
 import './opencode.js';


### PR DESCRIPTION
## Summary

Adds an **ACP Client Protocol** provider that lets NanoClaw act as the
editor/client side of the [Agent Client Protocol](https://agentclientprotocol.com)
(JSON-RPC 2.0 over TCP or stdio). Any external AI coding agent that speaks
ACP can be wired to an agent group — no container image rebuild required.

## Protocol overview

ACP Client Protocol defines a JSON-RPC 2.0 exchange between an **editor**
(NanoClaw) and an **agent** (any ACP-compliant AI). The wire format is one
JSON object per line (`\n`-delimited), over either a TCP socket or stdin/stdout.

### Handshake

editor → agent:  initialize
         ← agent: { protocolVersion, agentCapabilities, meta, authMethods }

editor → agent:  session/new  { cwd, mcpServers }
         ← agent: { sessionId }

### Per-message flow

editor → agent:  session/prompt  { sessionId, prompt: [{ type: "text", text }] }
         ← agent: session/update (notification, 0..N)
                   { method: "session/update",
                     params: { sessionId, update: { sessionUpdate: "agent_message_chunk",
                               content: { role, content: [{ type, text }] } } } }
         ← agent: { content: [], stopReason: "end_turn" }   (RPC response)

NanoClaw collects all `agent_message_chunk` text blocks, joins them, and delivers
the assembled message back through the originating channel.

### File callbacks (optional)

If the agent declares `agentCapabilities.fs.readTextFile / writeTextFile`,
it may call back into NanoClaw mid-prompt:

agent → editor (RPC request):  fs/read_text_file  { path }
                ← editor:  { content: "..." }

agent → editor (RPC request):  fs/write_text_file  { path, content }
                ← editor:  {}

All paths are resolved under `/workspace`; requests outside that boundary
are rejected.

### Session resume

`sessionId` is stored in `outbound.db` after each successful exchange.
On the next message NanoClaw sends the same `sessionId` in `session/prompt`.
If the agent returns a session-not-found error, NanoClaw automatically opens
a new session and retries transparently.

### Connection modes

| Mode       | Config key      | How it works |
|------------|-----------------|--------------|
| Subprocess | `command`       | NanoClaw spawns the agent as a child process; JSON-RPC over stdin/stdout |
| TCP        | `host` + `port` | NanoClaw connects to a running agent server |

## Files

| File | Purpose |
|------|---------|
| `container/agent-runner/src/providers/acp-client.ts` | Core provider: transport, dispatcher, session lifecycle |
| `container/agent-runner/src/providers/acp-client.test.ts` | 33 unit tests (bun:test) |
| `src/providers/acp-client.ts` | Host-side config reader — injects env vars into the agent container |
| `.claude/skills/add-acp-client-agent/SKILL.md` | Install + wiring skill |

## Example configuration

**Subprocess mode** (`groups/my-acp-agent/acp-client.json`):
```json
{ "command": ["python3", "/path/to/my-agent.py"] }

TCP mode:
{ "host": "host.docker.internal", "port": 7787 }

container.json (set "provider": "acp-client"):
{
  "provider": "acp-client",
  "groupName": "My ACP Agent",
  "assistantName": "My ACP Agent",
  "agentGroupId": "ag-..."
}
```
## Testing

All 33 container tests pass:
cd container/agent-runner && bun test src/providers/acp-client.test.ts

A minimal echo-mode test server (scripts/test-acp-client-server.py) is
included for manual end-to-end verification — run it untracked alongside
a live NanoClaw instance.
