### PR TITLE
fix: prefix generated resource IDs to satisfy OneCLI identifier rules

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -52,6 +52,8 @@ export interface ResourceDef {
   description: string;
   /** Primary key column name. */
   idColumn: string;
+  /** Prefix prepended to generated primary-key UUIDs (e.g. 'ag-' for OneCLI compatibility). */
+  idPrefix?: string;
   /**
    * Column that carries the agent group ID for group-scope enforcement.
    * Required on every resource in the CLI whitelist (groups, sessions,
@@ -133,7 +135,7 @@ function genericCreate(def: ResourceDef) {
     for (const col of def.columns) {
       if (col.generated) {
         if (col.name === def.idColumn) {
-          values[col.name] = randomUUID();
+          values[col.name] = (def.idPrefix ?? '') + randomUUID();
         } else if (col.name.endsWith('_at')) {
           values[col.name] = new Date().toISOString();
         }

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -38,6 +38,7 @@ registerResource({
   description:
     'Agent group — a logical agent identity. Each group has its own workspace folder (CLAUDE.md, skills, container config), conversation history, and container image. Multiple messaging groups can be wired to one agent group.',
   idColumn: 'id',
+  idPrefix: 'ag-',
   scopeField: 'id',
   columns: [
     { name: 'id', type: 'string', description: 'UUID.', generated: true },

--- a/src/cli/resources/messaging-groups.ts
+++ b/src/cli/resources/messaging-groups.ts
@@ -7,6 +7,7 @@ registerResource({
   description:
     'Messaging group — one chat or channel on one platform (a Telegram DM, a Discord channel, a Slack thread root, an email address). Identity is the (channel_type, platform_id) pair, which must be unique.',
   idColumn: 'id',
+  idPrefix: 'mg-',
   columns: [
     { name: 'id', type: 'string', description: 'UUID.', generated: true },
     {

--- a/src/cli/resources/wirings.ts
+++ b/src/cli/resources/wirings.ts
@@ -7,6 +7,7 @@ registerResource({
   description:
     'Wiring — connects a messaging group to an agent group. Determines which agent handles messages from which chat. The same messaging group can be wired to multiple agents; the same agent can be wired to multiple messaging groups.',
   idColumn: 'id',
+  idPrefix: 'mga-',
   columns: [
     { name: 'id', type: 'string', description: 'UUID.', generated: true },
     {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Fixes #2386.

`ncl groups create` was generating bare UUIDs (e.g. `7469d38e-…`) as agent group IDs. OneCLI rejects identifiers that start with a digit ("must start with a letter"), which affects ~1 in 16 groups created via the CLI.

This adds an optional `idPrefix` field to `ResourceDef` in `src/cli/crud.ts`. When set, the prefix is prepended to the generated UUID. Applied to:

- `groups` → `ag-` (fixes the OneCLI rejection)
- `messaging-groups` → `mg-` (consistency)
- `wirings` → `mga-` (consistency with the pattern already used in `src/modules/permissions/index.ts` and test fixtures)

Resulting IDs like `ag-<uuid>` are 39 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens — fully valid for OneCLI.

Co-authored-by: ss-sonic <ss-sonic@users.noreply.github.com>