### PR TITLE
feat(telegram): enable message_reaction + callback_query in allowedUpdates

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -203,6 +203,16 @@ registerChannelAdapter('telegram', {
     const telegramAdapter = createTelegramAdapter({
       botToken: token,
       mode: 'polling',
+      longPolling: {
+        // Reactions and callback queries are not included in Telegram's
+        // default allowed_updates set — once we set this list explicitly,
+        // all wanted update types must be enumerated. message + edited_message
+        // are the existing baseline; message_reaction unlocks 👍/👎 ingestion
+        // (Chat SDK already routes via processReaction); callback_query is
+        // included pre-emptively so future inline-keyboard work doesn't need
+        // another config edit.
+        allowedUpdates: ['message', 'edited_message', 'callback_query', 'message_reaction'],
+      },
     });
     const bridge = createChatSdkBridge({
       adapter: telegramAdapter,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

<!-- This PR is a small enhancement to an existing channel adapter (not a new
     skill, not a fix, not a refactor, not docs). None of the template
     checkboxes fit cleanly — please apply `PR: Feature` manually if it's
     the right category. -->

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Without explicitly setting `allowedUpdates`, Telegram excludes update types it considers "advanced" from the polling response by default, including `message_reaction` (added in Bot API 7.0, Feb 2024) and `callback_query`. Once any explicit list is provided, all wanted types must be enumerated.

This passes `longPolling.allowedUpdates` with the existing default pair (`message`, `edited_message`) plus `callback_query` and `message_reaction`. The Chat SDK's `processReaction` handler is already wired end-to-end — this commit just asks Telegram to deliver the events. `callback_query` is added pre-emptively so future inline-keyboard adopters don't need another config edit.

Behavior for groups that don't consume reactions or callback queries is unchanged — they simply receive update types they ignore (same as today they receive `edited_message` updates that most don't act on).

## Diff

```ts
// src/channels/telegram.ts, around line 205 inside createTelegramAdapter({ ... })
longPolling: {
  allowedUpdates: ['message', 'edited_message', 'callback_query', 'message_reaction'],
},
```

## Test plan

- [ ] Re-run `/add-telegram` skill, observe groups created on this branch receive 👍/👎 reaction events via the existing `processReaction` handler
- [ ] Confirm groups with reactions disabled still ignore the events (no behavior change for non-consumers)
- [ ] Verify `edited_message` and `message` baseline behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)