### PR TITLE
fix(webhook-server): default-bind to loopback instead of 0.0.0.0

### DIFF
--- a/src/webhook-server.test.ts
+++ b/src/webhook-server.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveListenConfig } from './webhook-server.js';
+
+describe('webhook-server resolveListenConfig', () => {
+  it('defaults to loopback so the port is not exposed to the LAN', () => {
+    expect(resolveListenConfig({})).toEqual({ port: 3000, bind: '127.0.0.1' });
+  });
+
+  it('honors WEBHOOK_PORT when set', () => {
+    expect(resolveListenConfig({ WEBHOOK_PORT: '4500' })).toEqual({ port: 4500, bind: '127.0.0.1' });
+  });
+
+  it('honors WEBHOOK_BIND for opt-in external exposure', () => {
+    expect(resolveListenConfig({ WEBHOOK_BIND: '0.0.0.0' })).toEqual({ port: 3000, bind: '0.0.0.0' });
+  });
+
+  it('honors WEBHOOK_BIND for binding to a specific interface', () => {
+    expect(resolveListenConfig({ WEBHOOK_BIND: '10.0.0.5' })).toEqual({
+      port: 3000,
+      bind: '10.0.0.5',
+    });
+  });
+
+  it('treats an empty WEBHOOK_BIND as unset (falls back to loopback)', () => {
+    // An accidental `WEBHOOK_BIND=` in a dotenv file should not silently bind
+    // to all interfaces — empty string is falsy and should hit the safe default.
+    expect(resolveListenConfig({ WEBHOOK_BIND: '' })).toEqual({ port: 3000, bind: '127.0.0.1' });
+  });
+
+  it('combines WEBHOOK_PORT and WEBHOOK_BIND independently', () => {
+    expect(resolveListenConfig({ WEBHOOK_PORT: '8080', WEBHOOK_BIND: '0.0.0.0' })).toEqual({
+      port: 8080,
+      bind: '0.0.0.0',
+    });
+  });
+});

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -14,6 +14,7 @@ import type { Chat } from 'chat';
 import { log } from './log.js';
 
 const DEFAULT_PORT = 3000;
+const DEFAULT_BIND = '127.0.0.1';
 
 interface WebhookEntry {
   chat: Chat;
@@ -22,6 +23,20 @@ interface WebhookEntry {
 
 const routes = new Map<string, WebhookEntry>();
 let server: http.Server | null = null;
+
+/**
+ * Resolve the listen address from the environment.
+ *
+ * Defaults to loopback so the webhook port is not exposed to the LAN. Set
+ * `WEBHOOK_BIND=0.0.0.0` (or a specific interface IP) to opt into external
+ * exposure — typically you want a reverse proxy in front instead.
+ */
+export function resolveListenConfig(env: NodeJS.ProcessEnv): { port: number; bind: string } {
+  const portRaw = env.WEBHOOK_PORT;
+  const port = portRaw ? parseInt(portRaw, 10) : DEFAULT_PORT;
+  const bind = env.WEBHOOK_BIND || DEFAULT_BIND;
+  return { port, bind };
+}
 
 /** Convert Node.js IncomingMessage to a Web API Request. */
 async function toWebRequest(req: http.IncomingMessage): Promise<Request> {
@@ -79,7 +94,7 @@ export function registerWebhookAdapter(chat: Chat, adapterName: string): void {
 function ensureServer(): void {
   if (server) return;
 
-  const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
+  const { port, bind } = resolveListenConfig(process.env);
 
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';
@@ -118,8 +133,8 @@ function ensureServer(): void {
     }
   });
 
-  server.listen(port, '0.0.0.0', () => {
-    log.info('Webhook server started', { port, adapters: [...routes.keys()] });
+  server.listen(port, bind, () => {
+    log.info('Webhook server started', { port, bind, adapters: [...routes.keys()] });
   });
 }
 


### PR DESCRIPTION
## Summary

- Extract `resolveListenConfig(env)` so the webhook listen address is environment-driven and unit-testable.
- Default `bind` to `127.0.0.1` so the webhook port (default `3000`) is not exposed to the LAN. `WEBHOOK_BIND=0.0.0.0` (or a specific interface IP) opts back into external exposure — typically a reverse proxy in front is preferable.
- Use the helper in the `server.listen` call and include `bind` in the startup log line.
- Add `src/webhook-server.test.ts` covering the loopback default, port + bind env overrides, the empty-string fallback, a specific-interface bind, and combined env vars.

## Why

`server.listen(port, '0.0.0.0', ...)` at `src/webhook-server.ts:121` binds the webhook to all interfaces. The webhook handles inbound callbacks for any adapter that registers via `registerWebhookAdapter` (Telegram, Slack via Chat SDK proxy, etc.). There's no auth at the HTTP layer — the adapter handlers trust the request shape — so anything on the LAN that can reach the host port can hit the webhook routes directly.

Defaulting to loopback closes that exposure for installs where the bot doesn't need to receive callbacks from outside the box. Installs that *do* need external callbacks (a real Telegram webhook from `api.telegram.org`, or a Slack event-subscription URL) will typically front the webhook with a reverse proxy / tunnel anyway; for the rare cases where you want the bot to listen on a LAN IP directly, `WEBHOOK_BIND=<ip>` (or `0.0.0.0`) preserves the prior behavior.

## Compatibility

This changes the default listen address from `0.0.0.0` to `127.0.0.1`. For most installs (where Telegram polling is used, or a reverse proxy fronts the webhook) this is transparent. Installs that relied on direct LAN access to the webhook port need either:
- A reverse proxy fronting it (recommended), or
- `WEBHOOK_BIND=0.0.0.0` set explicitly (preserves prior behavior).

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm test src/webhook-server.test.ts` — 6/6 pass; full suite 334/334 pass
- [ ] Manual: with no env vars set, start the host and verify `ss -ltn` shows `127.0.0.1:3000` (not `0.0.0.0:3000`)
- [ ] Manual: set `WEBHOOK_BIND=0.0.0.0`, restart, verify the listen address goes back to all-interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)