### PR TITLE
fix(agent-runner): drop <messages> envelope so claude-agent-sdk calls API

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -51,14 +51,43 @@ describe('context timezone header', () => {
     expect(result).toContain(`<context timezone="${TIMEZONE}"`);
   });
 
-  it('header comes before the <messages> block', () => {
+  it('header comes before the first <message> block when multiple are present', () => {
     insertMessage('m1', 'chat', { sender: 'Alice', text: 'one' });
     insertMessage('m2', 'chat', { sender: 'Bob', text: 'two' });
     const result = formatMessages(getPendingMessages());
     const ctxIdx = result.indexOf('<context');
-    const msgsIdx = result.indexOf('<messages>');
+    const firstMsgIdx = result.indexOf('<message ');
     expect(ctxIdx).toBeGreaterThanOrEqual(0);
-    expect(msgsIdx).toBeGreaterThan(ctxIdx);
+    expect(firstMsgIdx).toBeGreaterThan(ctxIdx);
+  });
+});
+
+describe('multi-message chat batches', () => {
+  // Regression guard for #2555: an outer `<messages>` envelope around
+  // multiple chat messages caused the Claude Agent SDK to emit a synthetic
+  // `No response requested.` stub instead of calling the API. Each
+  // `<message>` block is self-contained; concatenating them is enough.
+  it('does NOT wrap multiple chat messages in an outer <messages> envelope', () => {
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'one' });
+    insertMessage('m2', 'chat', { sender: 'Bob', text: 'two' });
+    const result = formatMessages(getPendingMessages());
+    expect(result).not.toContain('<messages>');
+    expect(result).not.toContain('</messages>');
+  });
+
+  it('emits one <message> block per inbound row, in order', () => {
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'first' });
+    insertMessage('m2', 'chat', { sender: 'Bob', text: 'second' });
+    insertMessage('m3', 'chat', { sender: 'Carol', text: 'third' });
+    const result = formatMessages(getPendingMessages());
+    const matches = result.match(/<message [^>]*>/g) ?? [];
+    expect(matches.length).toBe(3);
+    const firstIdx = result.indexOf('first');
+    const secondIdx = result.indexOf('second');
+    const thirdIdx = result.indexOf('third');
+    expect(firstIdx).toBeGreaterThan(0);
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+    expect(thirdIdx).toBeGreaterThan(secondIdx);
   });
 });
 

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -155,16 +155,15 @@ export function formatMessages(messages: MessageInRow[]): string {
 }
 
 function formatChatMessages(messages: MessageInRow[]): string {
-  if (messages.length === 1) {
-    return formatSingleChat(messages[0]);
-  }
-
-  const lines = ['<messages>'];
-  for (const msg of messages) {
-    lines.push(formatSingleChat(msg));
-  }
-  lines.push('</messages>');
-  return lines.join('\n');
+  // Each `<message id="..." from="...">...</message>` block is self-contained;
+  // concatenating them reads to the agent as a sequence of distinct messages.
+  // Earlier revisions wrapped multi-message batches in an outer `<messages>`
+  // envelope, but the Claude Agent SDK responded to that shape with a
+  // synthetic stub (`model: "<synthetic>"`, `content: "No response
+  // requested."`) instead of calling the API — see #2555 for the full trace.
+  // The fix is simply to drop the wrapper; the single-message path (which
+  // already worked) is now just the N=1 case of the same code.
+  return messages.map(formatSingleChat).join('\n');
 }
 
 function formatSingleChat(msg: MessageInRow): string {


### PR DESCRIPTION
Fixes #2555.

## Summary

When 2+ pending chat messages were bundled into `<messages>...</messages>` at `container/agent-runner/src/formatter.ts:162-167`, the Claude Agent SDK (v2.1.128, native binary) responded with a synthetic stub — `model: \"<synthetic>\"`, `stop_reason: \"stop_sequence\"`, `content: \"No response requested.\"` — instead of calling the real API.

The poll loop never yielded a `result` event for the synthetic, so the inbound message was never marked completed, the container exited naturally, and the next sweep tick respawned it with the same batch. Same synthetic. The transcript grew with each retry until `tries=5 → failed`. From the outside this looked like \"transcript bloat\" or \"session corruption,\" but resetting the continuation alone didn't help — a fresh session given the same envelope shape hit the same synthetic immediately.

Single-message turns bypassed the wrapper entirely and worked normally, which is what tipped me off to the trigger being the envelope shape itself rather than the content.

## Fix

```diff
 function formatChatMessages(messages: MessageInRow[]): string {
-  if (messages.length === 1) {
-    return formatSingleChat(messages[0]);
-  }
-
-  const lines = ['<messages>'];
-  for (const msg of messages) {
-    lines.push(formatSingleChat(msg));
-  }
-  lines.push('</messages>');
-  return lines.join('\n');
+  return messages.map(formatSingleChat).join('\n');
 }
```

Each `<message id=\"...\" from=\"...\">...</message>` block is already self-contained, so concatenating them reads to the agent as a sequence of distinct messages. The N=1 case is now just a special case of the same code path that always worked.

## Test plan

- [x] Updated the existing `header comes before the <messages> block` test (which directly asserted on the envelope) to check ordering against the first `<message>` block instead.
- [x] Added two regression tests in a new `multi-message chat batches` block:
  - Negative: result does NOT contain `<messages>` / `</messages>` for a 2-message batch
  - Positive: a 3-message batch produces exactly 3 `<message>` blocks in input order
- [x] `bun test src/formatter.test.ts` → 18 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] Confirmed in a real install: two stuck lanes (`dev-react-launchmate`, `dev-supabase-launchmate`) recovered after applying this fix + wiping their continuations + reducing pending queues to 1 message. The wipe alone wasn't sufficient — without this fix, the fresh session hit the same synthetic loop on the very next 2-message batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)