### PR TITLE
fix(setup): correct OneCLI default URL from app to api subdomain

### DIFF
--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -70,8 +70,8 @@ export const CONFIG: Entry[] = [
     surface: 'flag+ui',
     group: 'OneCLI',
     type: 'url',
-    default: 'https://app.onecli.sh',
-    placeholder: 'https://app.onecli.sh',
+    default: 'https://api.onecli.sh',
+    placeholder: 'https://api.onecli.sh',
     validate: httpUrl,
   },
   {


### PR DESCRIPTION
  <!-- contributing-guide: v1 -->
  ## Type of Change                                                                 
   
  - [ ] **Feature skill** - adds a channel or integration (source code changes +    
  SKILL.md)                                                                       
  - [ ] **Utility skill** - adds a standalone tool (code files in
  `.claude/skills/<name>/`, no source changes)
  - [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md
  only, no source changes)                                                          
  - [x] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code                      
  - [ ] **Documentation** - docs, README, or CONTRIBUTING changes only            
                                                                                    
  ## Description
                                                                                    
  Corrects the default and placeholder URL for `ONECLI_URL` in the setup config from
   `https://app.onecli.sh` to `https://api.onecli.sh`.
                                                                                    
  ## For Skills                                                                   

  N/A