### PR TITLE
fix(messaging-groups): rename channel destination on agent-name clash

### DIFF
--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -14,6 +14,7 @@ import {
   getDestinationByTarget,
   normalizeName,
 } from '../modules/agent-to-agent/db/agent-destinations.js';
+import { getAgentGroup } from './agent-groups.js';
 import { getDb, hasTable } from './connection.js';
 
 // ── Messaging Groups ──
@@ -173,11 +174,23 @@ export function createMessagingGroupAgent(mga: MessagingGroupAgent): void {
   const mg = getMessagingGroup(mga.messaging_group_id);
   if (!mg) return;
 
-  const base = normalizeName(mg.name || `${mg.channel_type}-${mga.messaging_group_id.slice(0, 8)}`);
-  let localName = base;
+  // Compute a default `local_name` for the destination. The mg's `name` is
+  // the natural starting point — operators usually pick something memorable.
+  // But it can collide with the agent's own identity (e.g., a Signal group
+  // called "homie" wired to the Homie agent produced a destination named
+  // "homie", and the agent treated `from="homie"` as a self-reference and
+  // failed to address its own chat). Detect that specific clash and fall
+  // back to a neutral `chat` (or `chat-2`, `chat-3` if multiple) name. The
+  // operator can still rename via the agent-network skill later.
+  const ag = getAgentGroup(mga.agent_group_id);
+  const agentNameSlug = ag ? normalizeName(ag.name) : '';
+  const mgNameSlug = normalizeName(mg.name || '');
+  const candidateBase = mgNameSlug && mgNameSlug !== agentNameSlug ? mgNameSlug : 'chat';
+  const fallbackBase = candidateBase || `${mg.channel_type}-${mga.messaging_group_id.slice(0, 8)}`;
+  let localName = fallbackBase;
   let suffix = 2;
   while (getDestinationByName(mga.agent_group_id, localName)) {
-    localName = `${base}-${suffix}`;
+    localName = `${fallbackBase}-${suffix}`;
     suffix++;
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** When `createMessagingGroupAgent` auto-creates an `agent_destinations` row whose `local_name` would collide with the agent's own name, fall back to `chat` (with `chat-2`, `chat-3` suffixes for additional wires) instead of using the colliding name. 

This comes up on chat apps like Signal where a 1:1 group is used by the operator to communicate directly with a specific agent; the group name typically will be the name of the agent, as it simulates DM.

**Why.** Hit in practice: a Signal group named `Agent X` was wired to the `Agent X` agent. The auto-created `agent_destinations` row got `local_name='agent-x'`, and the agent's outbound replies started going to its peer agent edge instead of the chat — because addressing `Agent X` (the group) from the agent named Agent X looked like a self-reference rather than a chat destination.

**How it works.** Compare the messaging group's slug to the agent's normalized name via the same `normalizeName` helper already used for destination naming, so any case/punctuation variant of the agent's name is caught. On collision, use `chat` as the destination's `local_name`. If `chat` is also taken (multiple wires), append `-2`, `-3`, etc.

The operator can still rename via the agent-network skill's edge tools later — this only affects the auto-default at wire time.

**How it was tested.** Reproduced by creating a messaging group with the same name as an agent; the group was default named to avoid collision, avoid the appearance of self-reference, and messages were delivered correctly.