### PR TITLE
[security] fix(permissions): scope channel approval targets

### DIFF
--- a/src/modules/permissions/channel-approval.test.ts
+++ b/src/modules/permissions/channel-approval.test.ts
@@ -357,6 +357,87 @@ describe('unknown-channel registration flow', () => {
       .c;
     expect(stillPending).toBe(1);
   });
+
+  it('does not let a scoped admin connect an unknown channel to another agent group', async () => {
+    const { routeInbound } = await import('../../router.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { getDb } = await import('../../db/connection.js');
+
+    createAgentGroup({ id: 'ag-2', name: 'Betty', folder: 'betty', agent_provider: null, created_at: now() });
+    upsertUser({ id: 'telegram:scoped-admin', kind: 'telegram', display_name: 'Scoped Admin', created_at: now() });
+    grantRole({
+      user_id: 'telegram:scoped-admin',
+      role: 'admin',
+      agent_group_id: 'ag-1',
+      granted_by: 'telegram:owner',
+      granted_at: now(),
+    });
+    createMessagingGroup({
+      id: 'mg-dm-scoped-admin',
+      channel_type: 'telegram',
+      platform_id: 'dm-scoped-admin',
+      name: 'Scoped Admin DM',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    getDb()
+      .prepare(
+        `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+       VALUES (?, ?, ?, ?)`,
+      )
+      .run('telegram:scoped-admin', 'telegram', 'mg-dm-scoped-admin', now());
+
+    await routeInbound(groupMention('chat-scoped-cross-group'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const pending = getDb().prepare('SELECT messaging_group_id FROM pending_channel_approvals').get() as {
+      messaging_group_id: string;
+    };
+    expect(pending).toBeDefined();
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(deliverMock.mock.calls[0][1]).toBe('dm-scoped-admin');
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: pending.messaging_group_id,
+        value: 'choose_existing',
+        userId: 'scoped-admin',
+        channelType: 'telegram',
+        platformId: 'dm-scoped-admin',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    const followupPayload = JSON.parse(deliverMock.mock.calls[1][4] as string) as {
+      options: Array<{ label: string; value: string }>;
+    };
+    expect(followupPayload.options.map((option) => option.value)).toContain('connect:ag-1');
+    expect(followupPayload.options.map((option) => option.value)).not.toContain('connect:ag-2');
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: pending.messaging_group_id,
+        value: 'connect:ag-2',
+        userId: 'scoped-admin',
+        channelType: 'telegram',
+        platformId: 'dm-scoped-admin',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    const mgaCount = (
+      getDb()
+        .prepare('SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = ?')
+        .get(pending.messaging_group_id) as { c: number }
+    ).c;
+    expect(mgaCount).toBe(0);
+    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_channel_approvals').get() as { c: number })
+      .c;
+    expect(stillPending).toBe(1);
+  });
 });
 
 describe('no-owner / no-agent failure modes', () => {

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -55,6 +55,7 @@ import type { InboundEvent } from '../../channels/adapter.js';
 import type { AgentGroup } from '../../types.js';
 import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingChannelApproval, hasInFlightChannelApproval } from './db/pending-channel-approvals.js';
+import { hasAdminPrivilege } from './db/user-roles.js';
 
 // ── Value constants (response handler in index.ts parses these) ──
 
@@ -76,15 +77,24 @@ function toFolder(name: string): string {
 
 // ── Card builders ──
 
-function buildApprovalOptions(agentGroups: AgentGroup[]): RawOption[] {
+function visibleAgentGroupsForApprover(
+  agentGroups: AgentGroup[],
+  approverUserId: string | null | undefined,
+): AgentGroup[] {
+  if (!approverUserId) return agentGroups;
+  return agentGroups.filter((agentGroup) => hasAdminPrivilege(approverUserId, agentGroup.id));
+}
+
+function buildApprovalOptions(agentGroups: AgentGroup[], approverUserId?: string | null): RawOption[] {
+  const visibleAgentGroups = visibleAgentGroupsForApprover(agentGroups, approverUserId);
   const options: RawOption[] = [];
-  if (agentGroups.length === 1) {
+  if (visibleAgentGroups.length === 1) {
     options.push({
-      label: `Connect to ${agentGroups[0].name}`,
-      selectedLabel: `✅ Connected to ${agentGroups[0].name}`,
-      value: `${CONNECT_PREFIX}${agentGroups[0].id}`,
+      label: `Connect to ${visibleAgentGroups[0].name}`,
+      selectedLabel: `✅ Connected to ${visibleAgentGroups[0].name}`,
+      value: `${CONNECT_PREFIX}${visibleAgentGroups[0].id}`,
     });
-  } else {
+  } else if (visibleAgentGroups.length > 1) {
     options.push({
       label: 'Choose existing agent',
       selectedLabel: '📋 Choosing…',
@@ -194,7 +204,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
   const channelName = originMg?.name ?? null;
   const title = isGroup ? '📣 Bot mentioned in new channel' : '💬 New direct message';
   const question = buildQuestionText(isGroup, senderName, channelName, originChannelType);
-  const options = normalizeOptions(buildApprovalOptions(agentGroups));
+  const options = normalizeOptions(buildApprovalOptions(agentGroups, delivery.userId));
 
   createPendingChannelApproval({
     messaging_group_id: messagingGroupId,
@@ -241,8 +251,12 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
 /**
  * Build normalized options for the agent-selection follow-up card.
  */
-export function buildAgentSelectionOptions(agentGroups: AgentGroup[]): NormalizedOption[] {
-  const options: RawOption[] = agentGroups.map((ag) => ({
+export function buildAgentSelectionOptions(
+  agentGroups: AgentGroup[],
+  approverUserId?: string | null,
+): NormalizedOption[] {
+  const visibleAgentGroups = visibleAgentGroupsForApprover(agentGroups, approverUserId);
+  const options: RawOption[] = visibleAgentGroups.map((ag) => ({
     label: ag.name,
     selectedLabel: `✅ Connected to ${ag.name}`,
     value: `${CONNECT_PREFIX}${ag.id}`,

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -354,7 +354,7 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
     if (!adapter) return true;
 
     const agentGroups = getAllAgentGroups();
-    const options = buildAgentSelectionOptions(agentGroups);
+    const options = buildAgentSelectionOptions(agentGroups, approverId);
     const title = '📋 Choose an agent';
     updatePendingChannelApprovalCard(row.messaging_group_id, title, JSON.stringify(options));
 
@@ -436,6 +436,14 @@ async function handleChannelApprovalResponse(payload: ResponsePayload): Promise<
         targetAgentGroupId,
       });
       deletePendingChannelApproval(row.messaging_group_id);
+      return true;
+    }
+    if (!hasAdminPrivilege(approverId, targetAgentGroupId)) {
+      log.warn('Channel registration: target agent group rejected for unauthorized approver', {
+        messagingGroupId: row.messaging_group_id,
+        targetAgentGroupId,
+        approverId,
+      });
       return true;
     }
   } else {


### PR DESCRIPTION
## Summary

This PR tightens the channel-registration approval flow so scoped admins can only connect unknown channels to agent groups they are authorized to administer.

Before this change, the pending channel approval row used one agent group as the approval context, but the follow-up selection and final `connect:<agentGroupId>` response could point at a different target agent group. A scoped admin for the approval context could therefore attempt to register the unknown channel against an out-of-scope target group.

This patch fixes both sides of the boundary:

- the approval cards only show target agent groups visible to the actual approver
- the response handler re-checks target-group authorization before applying a pending channel registration
- regression coverage verifies that a scoped admin cannot connect a channel to another group by selecting or submitting an out-of-scope target

## Security issues covered

This PR covers one authorization issue:

| Issue | Boundary | Fix |
| --- | --- | --- |
| Scoped admin channel registration target authorization | A scoped admin may approve a channel registration for one group but must not be able to attach that channel to an unrelated group | Filter target options by approver scope and enforce target authorization at apply time |

## Before this PR

- The approval flow selected an approver based on a reference agent group.
- The initial and follow-up approval cards were built from all agent groups.
- The final `connect:<agentGroupId>` response checked that the clicker could approve the pending row, but did not also verify that the same clicker could administer the selected target group.
- A stale, hidden, or tampered response value could still reference an out-of-scope target group.

## After this PR

- Approval options are filtered through the approver identity.
- Agent-selection follow-up cards only include groups where the approver has admin privilege.
- The response handler rejects `connect:<agentGroupId>` if the approver is not authorized for that target group.
- Unauthorized target attempts leave the pending approval in place and do not create channel-to-agent-group wiring.

## Why this matters

Channel registration controls which external messaging channels can send into an agent group. Scoped admins are intentionally limited to the groups they administer. If the approval context and selected target group diverge, a scoped admin can cross that boundary and wire a channel into a group they should not control.

That can expose an out-of-scope agent group to messages from an unapproved channel and let a scoped administrator influence or observe behavior outside their delegated administrative scope.

## Attack flow

1. A scoped admin has admin rights for agent group `A`, but not agent group `B`.
2. An unknown messaging channel triggers the channel-registration approval flow using group `A` as the approval context.
3. The scoped admin receives the approval card.
4. The approval follow-up or callback value submits `connect:B`.
5. On vulnerable code, the handler accepts the target and creates the channel wiring for group `B`.
6. After this PR, `B` is not exposed in selectable options for that approver, and a forged or stale `connect:B` value is rejected before any wiring is created.

## Affected code

- `src/modules/permissions/channel-approval.ts`
  - builds initial approval options
  - builds agent-selection follow-up options
- `src/modules/permissions/index.ts`
  - handles pending channel approval responses
  - applies `connect:<agentGroupId>` target selection
- `src/modules/permissions/channel-approval.test.ts`
  - regression coverage for scoped-admin cross-group channel registration

## Root cause

- The pending approval authorization and target authorization were treated as the same decision.
- The approval row stored the reference group used to choose an approver, but a later response could select a different target group.
- Option generation did not take the approver identity into account.
- The final apply step did not re-check admin privilege for the selected target agent group.

## CVSS assessment

Issue: scoped admin channel registration target authorization bypass

CVSS v3.1: 6.4 Medium

Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N`

Rationale:

- Network-accessible channel approval callbacks can carry the selected target value.
- The attacker needs a scoped admin role for at least one group, so privileges are required.
- No victim user interaction is required beyond the attacker operating their own scoped-admin approval.
- Scope changes because a scoped admin can affect an agent group outside their delegated scope.
- Impact is bounded to channel registration/wiring, with potential confidentiality and integrity impact for the out-of-scope group.

## Safe reproduction steps

A safe local reproduction is included in the regression test:

1. Create two agent groups, `ag-1` and `ag-2`.
2. Grant `telegram:scoped-admin` admin rights only for `ag-1`.
3. Trigger an unknown-channel registration flow.
4. Handle the approval as `telegram:scoped-admin`.
5. Verify the follow-up options include `connect:ag-1` but not `connect:ag-2`.
6. Submit a forged/stale `connect:ag-2` response value.
7. Verify no `messaging_group_agents` row is created and the pending approval remains pending.

## Expected vulnerable behavior

On vulnerable code, the final `connect:ag-2` response can be accepted even though the approver only administers `ag-1`. That creates messaging-channel wiring for an out-of-scope target group.

## Changes in this PR

- Adds approver-aware filtering for channel approval option generation.
- Passes the actual approval delivery user into the initial card builder.
- Passes the approver ID into the agent-selection follow-up builder.
- Adds an apply-time authorization check before accepting `connect:<targetAgentGroupId>`.
- Adds regression coverage for the scoped-admin cross-group target case.

## Files changed

| File | What changed |
| --- | --- |
| `src/modules/permissions/channel-approval.ts` | Filters initial and follow-up target options by `hasAdminPrivilege(approverUserId, agentGroup.id)` |
| `src/modules/permissions/index.ts` | Passes approver identity into option generation and rejects unauthorized target groups at apply time |
| `src/modules/permissions/channel-approval.test.ts` | Adds scoped-admin regression coverage for out-of-scope target filtering and forged target rejection |

## Maintainer impact

This is intended to be a narrow authorization fix. It does not change the owner/global-admin flow, the pending approval schema, or the general unknown-channel registration behavior. It only scopes target selection to the approver's existing authorization and rejects target values that do not match that scope.

## Fix rationale

The approval flow has two separate security decisions:

1. whether the clicker is allowed to respond to the pending approval; and
2. whether the selected target agent group is within that clicker's administrative scope.

Both checks need to be enforced. Filtering options improves the normal UI path, while the response-handler check protects the server-side boundary against stale cards, hidden options, or direct callback/value submission.

## Type of change

- [x] Security fix
- [x] Regression test
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

Commands run locally:

```bash
pnpm vitest run src/modules/permissions/channel-approval.test.ts -t 'scoped admin'
pnpm vitest run src/modules/permissions/channel-approval.test.ts
pnpm format:check
pnpm typecheck
pnpm exec eslint src/modules/permissions/channel-approval.ts src/modules/permissions/index.ts src/modules/permissions/channel-approval.test.ts
pnpm test
git diff --check
```

Final validation passed after formatting the touched files. The focused channel-approval test file passed, and the full test suite passed locally.

## Disclosure notes

This PR is intentionally bounded to the scoped-admin channel-registration target authorization path. It does not claim a broader bypass of all approval flows or all permission checks. The fix is submitted directly as a defensive code change with regression coverage.