### PR TITLE
fix: import CLAUDE.local.md so per-group memory reaches the agent

### DIFF
--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Override GROUPS_DIR so composition writes into a throwaway dir, not the repo.
+// Literal duplicated below (vi.mock is hoisted above const initialization).
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, GROUPS_DIR: '/tmp/nanoclaw-test-compose/groups' };
+});
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import { initTestDb, closeDb, runMigrations } from './db/index.js';
+import type { AgentGroup } from './types.js';
+
+const TEST_GROUPS_DIR = '/tmp/nanoclaw-test-compose/groups';
+
+const group: AgentGroup = {
+  id: 'ag-test',
+  name: 'Test Agent',
+  folder: 'test-group',
+  agent_provider: null,
+  created_at: new Date().toISOString(),
+};
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_GROUPS_DIR)) fs.rmSync(TEST_GROUPS_DIR, { recursive: true });
+  fs.mkdirSync(TEST_GROUPS_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_GROUPS_DIR)) fs.rmSync(TEST_GROUPS_DIR, { recursive: true });
+});
+
+describe('composeGroupClaudeMd', () => {
+  it('imports CLAUDE.local.md so per-group memory reaches the agent', () => {
+    composeGroupClaudeMd(group);
+
+    const composed = fs.readFileSync(path.join(TEST_GROUPS_DIR, group.folder, 'CLAUDE.md'), 'utf8');
+
+    expect(composed).toContain('@./CLAUDE.local.md');
+  });
+});

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -7,7 +7,7 @@
  *   - optional per-skill fragments (skills that ship `instructions.md`)
  *   - optional per-MCP-server fragments (inline `instructions` field in
  *     `container.json`)
- *   - per-group agent memory (`CLAUDE.local.md`, auto-loaded by Claude Code)
+ *   - per-group agent memory (`CLAUDE.local.md`, imported last so it overrides)
  *
  * Runs on every spawn from `container-runner.buildMounts()`. Deterministic —
  * same inputs produce the same CLAUDE.md, and stale fragments are pruned.
@@ -121,18 +121,26 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
     }
   }
 
+  // Per-group memory file — create empty if missing so the @-import below
+  // always resolves to a real file.
+  const localFile = path.join(groupDir, 'CLAUDE.local.md');
+  if (!fs.existsSync(localFile)) {
+    fs.writeFileSync(localFile, '');
+  }
+
   // Composed entry — imports only.
   const imports = ['@./.claude-shared.md'];
   for (const name of [...desired.keys()].sort()) {
     imports.push(`@./.claude-fragments/${name}`);
   }
+  // Per-group memory imported last so it can override shared/module guidance.
+  // The agent SDK (settingSources: ['project', 'user']) does not auto-load a
+  // group's CLAUDE.local.md from cwd the way the Claude Code CLI does, so it
+  // must be imported explicitly — otherwise per-group persona edits are
+  // silently dropped from the agent's system prompt.
+  imports.push('@./CLAUDE.local.md');
   const body = [COMPOSED_HEADER, ...imports, ''].join('\n');
   writeAtomic(path.join(groupDir, 'CLAUDE.md'), body);
-
-  const localFile = path.join(groupDir, 'CLAUDE.local.md');
-  if (!fs.existsSync(localFile)) {
-    fs.writeFileSync(localFile, '');
-  }
 }
 
 /**


### PR DESCRIPTION
## Bug

The composed `groups/<folder>/CLAUDE.md` imports the shared base (`.claude-shared.md`) and the skill/MCP fragments under `.claude-fragments/`, but it never `@`-imports the sibling `CLAUDE.local.md`. Comments in the codebase claimed `CLAUDE.local.md` is "auto-loaded by Claude Code" — that's true for the Claude Code CLI, but the agent SDK runs with `settingSources: ['project', 'user']` and does **not** auto-load `CLAUDE.local.md` from `cwd`.

Result: every per-group persona edit (behaviour rules, identity, custom workflows) written to `CLAUDE.local.md` is silently dropped from the agent's system prompt.

Fixes #2185.

## Repro

1. Edit `groups/<any-group>/CLAUDE.local.md` to add an obvious instruction (e.g. *"Always reply with the word PINEAPPLE first."*).
2. Message the agent.
3. The instruction is ignored — and the composed `CLAUDE.md` shows only `.claude-shared.md` + fragments, no path that reaches `CLAUDE.local.md`.

## Fix

In `composeGroupClaudeMd()`:
- Append `@./CLAUDE.local.md` to the import list **last**, so per-group memory overrides shared/module guidance.
- Create the (empty) `CLAUDE.local.md` *before* composing the entry file so the import always resolves to a real file.
- Correct the stale "auto-loaded by Claude Code" docstring.

## Test

Adds `src/claude-md-compose.test.ts` asserting the composed `CLAUDE.md` imports `@./CLAUDE.local.md`. Verified it fails before the fix and passes after. Full suite: 329 passing, no regressions. `tsc --noEmit`, prettier, and eslint all clean.