### PR TITLE
fix(container-runtime): rootless-podman two-gotcha

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,7 +22,13 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  readonlyMountArgs,
+  stopContainer,
+  userNamespaceArgs,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -434,6 +440,9 @@ async function buildContainerArgs(
 
   // Host gateway
   args.push(...hostGatewayArgs());
+
+  // User namespace (rootless podman: keep-id so --user lands at host uid)
+  args.push(...userNamespaceArgs());
 
   // User mapping
   const hostUid = process.getuid?.();

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -11,13 +11,46 @@ import { log } from './log.js';
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';
 
+let cachedIsPodman: boolean | null = null;
+
+/** Whether the active runtime is rootless Podman (e.g. via a docker-shim). */
+export function isPodman(): boolean {
+  if (cachedIsPodman !== null) return cachedIsPodman;
+  try {
+    const out = execSync(`${CONTAINER_RUNTIME_BIN} --version`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    cachedIsPodman = /podman/i.test(out);
+  } catch {
+    cachedIsPodman = false;
+  }
+  return cachedIsPodman;
+}
+
+/**
+ * Rootless Podman: keep host uid mapped to itself so `--user $hostUid:$hostGid`
+ * makes the container process run as the host user. Without this, the
+ * container's uid lands in a subuid range and writes to host-owned bind
+ * mounts fail with SQLite "attempt to write a readonly database". No-op
+ * on Docker.
+ */
+export function userNamespaceArgs(): string[] {
+  return isPodman() ? ['--userns=keep-id'] : [];
+}
+
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
-  if (os.platform() === 'linux') {
-    return ['--add-host=host.docker.internal:host-gateway'];
+  if (os.platform() !== 'linux') return [];
+  if (isPodman()) {
+    // Rootless podman: slirp4netns + allow_host_loopback makes the host's
+    // loopback-bound services reachable at the slirp gateway IP (10.0.2.2).
+    // Plain --add-host=host-gateway resolves to the host's primary interface,
+    // where OneCLI (bound to 127.0.0.1) isn't listening — so requests fail.
+    return ['--network=slirp4netns:allow_host_loopback=true', '--add-host=host.docker.internal:10.0.2.2'];
   }
-  return [];
+  return ['--add-host=host.docker.internal:host-gateway'];
 }
 
 /** Returns CLI args for a readonly bind mount. */


### PR DESCRIPTION
Two compounding bugs prevent agent containers from working under rootless Podman; both must be fixed, and bug 1 hides bug 2.

(1) Under rootless Podman, --user $hostUid:$hostGid lands the
    container process in the user's subuid range, not at the host
    uid. Writes to host-owned bind mounts (incl. the session SQLite
    DB) fail with "attempt to write a readonly database". Fix:
    --userns=keep-id keeps host uid mapped 1:1 into the container.
    No-op on Docker (added userNamespaceArgs()).

(2) --add-host=host.docker.internal:host-gateway in a rootless
    container resolves to the host's primary outbound interface
    rather than loopback. Host services bound to 127.0.0.1
    (e.g. OneCLI) are unreachable. Fix: when isPodman(), use
    --network=slirp4netns:allow_host_loopback=true +
    --add-host=host.docker.internal:10.0.2.2 (the slirp gateway).

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
