### PR TITLE
feat(agent-runner): surface context-window usage to the agent

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -95,11 +95,23 @@ async function main(): Promise<void> {
     effort: config.effort,
   });
 
+  // Context-window override: lets operators retarget the
+  // `Current context usage: X / Y (Z%)` denominator when running with a
+  // non-default window (e.g. 1M-context Sonnet beta). Falls back to the
+  // poll-loop's DEFAULT_CONTEXT_WINDOW_TOKENS when unset or unparseable.
+  const contextWindowEnv = process.env.CLAUDE_CODE_CONTEXT_WINDOW;
+  const parsedContextWindow = contextWindowEnv ? Number.parseInt(contextWindowEnv, 10) : NaN;
+  const contextWindowTokens = Number.isFinite(parsedContextWindow) && parsedContextWindow > 0 ? parsedContextWindow : undefined;
+  if (contextWindowTokens !== undefined) {
+    log(`Context-window override: ${contextWindowTokens.toLocaleString()} tokens`);
+  }
+
   await runPollLoop({
     provider,
     providerName,
     cwd: CWD,
     systemContext: { instructions },
+    contextWindowTokens,
   });
 }
 

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,6 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
+import { detectEffortOverride } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 
 beforeEach(() => {
@@ -216,7 +217,13 @@ describe('origin metadata (from= attribute)', () => {
       .run(name, name, channelType, platformId);
   }
 
-  function insertWithRouting(id: string, kind: string, content: object, channelType: string | null, platformId: string | null): void {
+  function insertWithRouting(
+    id: string,
+    kind: string,
+    content: object,
+    channelType: string | null,
+    platformId: string | null,
+  ): void {
     getInboundDb()
       .prepare(
         `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, content)
@@ -373,5 +380,49 @@ describe('end-to-end with mock provider', () => {
     expect(outMessages).toHaveLength(1);
     expect(JSON.parse(outMessages[0].content).text).toBe('The answer is 4');
     expect(outMessages[0].in_reply_to).toBe('m1');
+  });
+});
+
+describe('detectEffortOverride', () => {
+  it('returns undefined for a plain chat batch', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: 'hey what is up' });
+    insertMessage('m2', 'chat', { sender: 'M', text: 'follow-up question' });
+    expect(detectEffortOverride(getPendingMessages())).toBeUndefined();
+  });
+
+  it('returns "max" when any chat starts with /council', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: 'background context' });
+    insertMessage('m2', 'chat', { sender: 'M', text: '/council should we ship?' });
+    expect(detectEffortOverride(getPendingMessages())).toBe('max');
+  });
+
+  it('returns "max" for /build', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: '/build the feature now' });
+    expect(detectEffortOverride(getPendingMessages())).toBe('max');
+  });
+
+  it('returns "max" for /think', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: '/think about the tradeoffs' });
+    expect(detectEffortOverride(getPendingMessages())).toBe('max');
+  });
+
+  it('is case-insensitive (matches /Council just like /council)', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: '/Council weigh in' });
+    expect(detectEffortOverride(getPendingMessages())).toBe('max');
+  });
+
+  it('does not trigger for non-heavy passthrough commands', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: '/research topic xyz' });
+    expect(detectEffortOverride(getPendingMessages())).toBeUndefined();
+  });
+
+  it('does not trigger for admin commands like /clear', () => {
+    insertMessage('m1', 'chat', { sender: 'M', text: '/clear' });
+    expect(detectEffortOverride(getPendingMessages())).toBeUndefined();
+  });
+
+  it('ignores non-chat messages (task rows never carry slash commands)', () => {
+    insertMessage('m1', 'task', { prompt: '/council pretend this is heavy' });
+    expect(detectEffortOverride(getPendingMessages())).toBeUndefined();
   });
 });

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,7 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { detectEffortOverride } from './poll-loop.js';
+import { buildDynamicSystemContext, detectEffortOverride } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 
 beforeEach(() => {
@@ -424,5 +424,47 @@ describe('detectEffortOverride', () => {
   it('ignores non-chat messages (task rows never carry slash commands)', () => {
     insertMessage('m1', 'task', { prompt: '/council pretend this is heavy' });
     expect(detectEffortOverride(getPendingMessages())).toBeUndefined();
+  });
+});
+
+describe('buildDynamicSystemContext', () => {
+  const usage = {
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheCreationTokens: 4000,
+    cacheReadTokens: 35000,
+    totalContextTokens: 40000,
+  };
+
+  it('returns the base context unchanged when no usage is available yet', () => {
+    const base = { instructions: 'base instructions' };
+    expect(buildDynamicSystemContext(base, undefined, 200000)).toBe(base);
+  });
+
+  it('returns undefined when neither base nor usage is provided', () => {
+    expect(buildDynamicSystemContext(undefined, undefined, 200000)).toBeUndefined();
+  });
+
+  it('appends a context-usage line to existing instructions', () => {
+    const out = buildDynamicSystemContext({ instructions: 'base instructions' }, usage, 200000);
+    expect(out?.instructions).toContain('base instructions');
+    expect(out?.instructions).toContain('Current context usage: 40,000 / 200,000 tokens (20.0%)');
+  });
+
+  it('creates instructions when base is empty', () => {
+    const out = buildDynamicSystemContext(undefined, usage, 200000);
+    expect(out?.instructions).toBe(
+      "Current context usage: 40,000 / 200,000 tokens (20.0%) as of the prior turn's API response.",
+    );
+  });
+
+  it('honors a non-default context window', () => {
+    const out = buildDynamicSystemContext(undefined, usage, 1000000);
+    expect(out?.instructions).toContain('40,000 / 1,000,000 tokens (4.0%)');
+  });
+
+  it('survives a zero-window edge case without dividing by zero', () => {
+    const out = buildDynamicSystemContext(undefined, usage, 0);
+    expect(out?.instructions).toContain('(0.0%)');
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -471,10 +471,15 @@ function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {
  * (including <internal>...</internal>) is scratchpad — logged but not sent.
  *
  * The agent must always wrap output in <message to="name">...</message>
- * blocks, even with a single destination. Bare text is scratchpad only.
+ * blocks. For multi-destination groups, unwrapped text is scratchpad only.
+ * For single-destination groups, unwrapped text falls back to the sole
+ * destination — routing is unambiguous and silent drops cost the user
+ * conversation continuity (see qwibitai/nanoclaw#2325).
  */
 function dispatchResultText(text: string, routing: RoutingContext): void {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
+  const ORPHAN_OPEN_RE = /<message\s+to="[^"]*"\s*>/g;
+  const ORPHAN_CLOSE_RE = /<\/message>/g;
 
   let match: RegExpExecArray | null;
   let sent = 0;
@@ -502,7 +507,26 @@ function dispatchResultText(text: string, routing: RoutingContext): void {
     scratchpadParts.push(text.slice(lastIndex));
   }
 
-  const scratchpad = stripInternalTags(scratchpadParts.join(''));
+  let scratchpad = stripInternalTags(scratchpadParts.join(''));
+
+  // Single-destination fallback: when no valid <message to="…">…</message>
+  // block matched (typically because the model emitted an opening tag
+  // without ever closing it, a known post-compaction failure mode), still
+  // deliver the text to the sole destination. Orphan open/close tags are
+  // stripped so the user never sees the wrapper. Multi-destination groups
+  // intentionally have no fallback — routing is ambiguous there.
+  if (sent === 0 && scratchpad) {
+    const destinations = getAllDestinations();
+    if (destinations.length === 1) {
+      const cleaned = scratchpad.replace(ORPHAN_OPEN_RE, '').replace(ORPHAN_CLOSE_RE, '').trim();
+      if (cleaned) {
+        log(`Single-destination fallback: routing unwrapped output to "${destinations[0].name}"`);
+        sendToDestination(destinations[0], cleaned, routing);
+        sent++;
+        scratchpad = '';
+      }
+    }
+  }
 
   if (scratchpad) {
     log(`[scratchpad] ${scratchpad.slice(0, 500)}${scratchpad.length > 500 ? '…' : ''}`);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -18,6 +18,18 @@ import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
 
+/**
+ * Slash commands that warrant the highest reasoning-effort tier for the
+ * turn they appear in. Single static container effort is wasteful when most
+ * turns are quick chat replies but a few — multi-agent council synthesis,
+ * deliberate reasoning runs, multi-file build orchestration — genuinely
+ * benefit from `max`. If any message in the current batch starts with one
+ * of these, the poll-loop hands `effortOverride: 'max'` to the provider so
+ * the SDK reasoning budget scales for that turn only. All other turns fall
+ * back to the group's configured default.
+ */
+const HEAVY_EFFORT_COMMANDS = new Set(['/council', '/build', '/think']);
+
 function log(msg: string): void {
   console.error(`[poll-loop] ${msg}`);
 }
@@ -165,13 +177,18 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // provider natively handles slash commands), others get XML.
     const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
 
-    log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
+    const effortOverride = detectEffortOverride(keep);
+    log(
+      `Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}` +
+        (effortOverride ? ` (effort override: ${effortOverride})` : ''),
+    );
 
     const query = config.provider.query({
       prompt,
       continuation,
       cwd: config.cwd,
       systemContext: config.systemContext,
+      effortOverride,
     });
 
     // Process the query while concurrently polling for new messages
@@ -251,6 +268,27 @@ function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommand
   }
 
   return parts.join('\n\n');
+}
+
+/**
+ * Walk the kept-batch messages, classify each chat slash-command via the
+ * shared formatter, and if any command is in HEAVY_EFFORT_COMMANDS, return
+ * `'max'` as the override. Returns `undefined` when no heavy command is
+ * present, so the provider falls through to its constructor-time effort.
+ *
+ * Conservative on purpose: any single heavy command in the batch lifts the
+ * whole turn, since the kept messages are already merged into one prompt
+ * and the SDK applies one effort per query.
+ */
+export function detectEffortOverride(messages: MessageInRow[]): string | undefined {
+  for (const msg of messages) {
+    if (msg.kind !== 'chat' && msg.kind !== 'chat-sdk') continue;
+    const info = categorizeMessage(msg);
+    if (info.category === 'passthrough' && HEAVY_EFFORT_COMMANDS.has(info.command)) {
+      return 'max';
+    }
+  }
+  return undefined;
 }
 
 interface QueryResult {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -13,10 +13,20 @@ import {
   stripInternalTags,
   type RoutingContext,
 } from './formatter.js';
-import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types.js';
+import type { AgentProvider, AgentQuery, ContextUsage, ProviderEvent } from './providers/types.js';
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
+
+/**
+ * Default context-window size assumed when no `CLAUDE_CODE_CONTEXT_WINDOW`
+ * override is provided by the bootstrap. Matches the Claude 4.x family's
+ * standard 200K window. The auto-compact trigger
+ * (`CLAUDE_CODE_AUTO_COMPACT_WINDOW`, default 165K) lives in the Claude
+ * provider — this constant is the *display denominator*, not the compaction
+ * threshold.
+ */
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200000;
 
 /**
  * Slash commands that warrant the highest reasoning-effort tier for the
@@ -50,6 +60,38 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /**
+   * Total context-window size in tokens, used as the denominator for the
+   * `Current context usage: X / Y (Z%)` line injected into each turn's
+   * system prompt. Defaults to {@link DEFAULT_CONTEXT_WINDOW_TOKENS}. Set
+   * this when the provider is configured for a non-default window (e.g.,
+   * the 1M-context Sonnet beta) so the displayed percentage matches the
+   * model's actual budget.
+   */
+  contextWindowTokens?: number;
+}
+
+/**
+ * Append a `Current context usage:` line to the per-turn system-prompt
+ * instructions so the agent sees the same signal Claude Code surfaces in
+ * its UI footer. The line is built from the most recent `result` event's
+ * `usage` field, so it reports the context fill at the *end of the prior
+ * turn* — the standard one-turn lag inherent to any post-hoc API-usage
+ * read. On the first turn (no prior usage), the base instructions pass
+ * through unchanged.
+ */
+export function buildDynamicSystemContext(
+  base: { instructions?: string } | undefined,
+  usage: ContextUsage | undefined,
+  windowTokens: number,
+): { instructions?: string } | undefined {
+  if (!usage) return base;
+  const total = usage.totalContextTokens;
+  const pct = windowTokens > 0 ? ((total / windowTokens) * 100).toFixed(1) : '0.0';
+  const line = `Current context usage: ${total.toLocaleString()} / ${windowTokens.toLocaleString()} tokens (${pct}%) as of the prior turn's API response.`;
+  const existing = base?.instructions?.trim();
+  const combined = existing ? `${existing}\n\n${line}` : line;
+  return { instructions: combined };
 }
 
 /**
@@ -77,6 +119,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
   // Clear leftover 'processing' acks from a previous crashed container.
   // This lets the new container re-process those messages.
   clearStaleProcessingAcks();
+
+  const contextWindowTokens = config.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+
+  // Most recent token-usage snapshot reported by the provider on a `result`
+  // event. Used to compose the `Current context usage:` line appended to the
+  // next turn's system prompt. Stays undefined until the first turn completes.
+  let lastContextUsage: ContextUsage | undefined;
 
   let pollCount = 0;
   let isFirstPoll = true;
@@ -183,11 +232,17 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         (effortOverride ? ` (effort override: ${effortOverride})` : ''),
     );
 
+    const dynamicSystemContext = buildDynamicSystemContext(
+      config.systemContext,
+      lastContextUsage,
+      contextWindowTokens,
+    );
+
     const query = config.provider.query({
       prompt,
       continuation,
       cwd: config.cwd,
-      systemContext: config.systemContext,
+      systemContext: dynamicSystemContext,
       effortOverride,
     });
 
@@ -202,6 +257,11 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
+      }
+      if (result.usage) {
+        lastContextUsage = result.usage;
+        const pct = ((result.usage.totalContextTokens / contextWindowTokens) * 100).toFixed(1);
+        log(`Context usage: ${result.usage.totalContextTokens.toLocaleString()}/${contextWindowTokens.toLocaleString()} (${pct}%)`);
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -293,6 +353,14 @@ export function detectEffortOverride(messages: MessageInRow[]): string | undefin
 
 interface QueryResult {
   continuation?: string;
+  /**
+   * Latest token-usage snapshot reported during the query. The outer loop
+   * carries this forward into the next turn's system-prompt injection so
+   * the agent sees a `Current context usage:` line matching what the SDK
+   * reported on the prior turn's API response. Undefined if no `result`
+   * event with a usage payload arrived (e.g., stream closed early).
+   */
+  usage?: ContextUsage;
 }
 
 async function processQuery(
@@ -302,6 +370,7 @@ async function processQuery(
   providerName: string,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
+  let latestUsage: ContextUsage | undefined;
   let done = false;
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
@@ -413,6 +482,9 @@ async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        if (event.usage) {
+          latestUsage = event.usage;
+        }
         if (event.text) {
           dispatchResultText(event.text, routing);
         }
@@ -440,7 +512,7 @@ async function processQuery(
     clearInterval(pollHandle);
   }
 
-  return { continuation: queryContinuation };
+  return { continuation: queryContinuation, usage: latestUsage };
 }
 
 function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -299,7 +299,7 @@ export class ClaudeProvider implements AgentProvider {
         env: this.env,
         model: this.model,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        effort: this.effort as any,
+        effort: (input.effortOverride ?? this.effort) as any,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
         settingSources: ['project', 'user'],

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -328,7 +328,27 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
           const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
-          yield { type: 'result', text };
+          const sdkUsage = (message as {
+            usage?: {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_creation_input_tokens?: number | null;
+              cache_read_input_tokens?: number | null;
+            };
+          }).usage;
+          const usage = sdkUsage
+            ? {
+                inputTokens: sdkUsage.input_tokens ?? 0,
+                outputTokens: sdkUsage.output_tokens ?? 0,
+                cacheCreationTokens: sdkUsage.cache_creation_input_tokens ?? 0,
+                cacheReadTokens: sdkUsage.cache_read_input_tokens ?? 0,
+                totalContextTokens:
+                  (sdkUsage.input_tokens ?? 0) +
+                  (sdkUsage.cache_creation_input_tokens ?? 0) +
+                  (sdkUsage.cache_read_input_tokens ?? 0),
+              }
+            : undefined;
+          yield { type: 'result', text, usage };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -57,6 +57,16 @@ export interface QueryInput {
   systemContext?: {
     instructions?: string;
   };
+
+  /**
+   * Per-query reasoning-effort override. When set, takes precedence over the
+   * provider's constructor-time `effort`. The poll-loop sets this when a
+   * batch contains a heavy-lift command (`/council`, `/build`, `/think`) so
+   * that one container can serve both light and heavy turns without
+   * burning `max` effort on every reply. If omitted, the provider's default
+   * effort applies.
+   */
+  effortOverride?: string;
 }
 
 export interface McpServerConfig {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -89,9 +89,29 @@ export interface AgentQuery {
   abort(): void;
 }
 
+/**
+ * Per-turn token usage reported by the provider's underlying SDK. The
+ * poll-loop reads this off `result` events and surfaces a context-usage
+ * line into the next turn's system prompt — same signal Claude Code's
+ * "Context: X/Y (Z%)" footer uses, so the agent gets the same self-awareness
+ * users have. `totalContextTokens` sums input + cache_read + cache_creation,
+ * which approximates the context window's current fill at the moment of the
+ * API call. Output tokens are tracked separately for cost telemetry but
+ * intentionally excluded from `totalContextTokens` — the next turn re-reads
+ * the assistant message from the transcript, where it's already counted
+ * under input on the next call.
+ */
+export interface ContextUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalContextTokens: number;
+}
+
 export type ProviderEvent =
   | { type: 'init'; continuation: string }
-  | { type: 'result'; text: string | null }
+  | { type: 'result'; text: string | null; usage?: ContextUsage }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }
   | { type: 'progress'; message: string }
   /**


### PR DESCRIPTION
## Motivation

The model has no introspection into its own context fill — Claude Code's
"Context: X / Y (Z%)" footer is the *client* tracking it from API
responses, not the model knowing. Inside a NanoClaw container the agent
never saw that number, so it couldn't pace work against the budget the
way a Claude Code user can. After-the-fact "I should've checkpointed
earlier" reasoning is too late.

## What changed

Wire the same signal Claude Code uses through the agent-runner:

- **Providers** emit a `ContextUsage` snapshot on every `result` event,
  extracted from the SDK's `usage` field
  (`input_tokens + cache_creation_input_tokens + cache_read_input_tokens`).
- **Poll-loop** carries the latest usage forward and rebuilds the
  `systemContext.instructions` per query, appending one line:

  > `Current context usage: 47,318 / 200,000 tokens (23.7%) as of the prior turn's API response.`

  It rides on the existing `claude_code` preset's `append` field — same
  surface already used for the destinations addendum.
- **One-turn lag** is inherent to any post-hoc API-usage read; the first
  turn passes through unchanged. The line is explicit about the lag so
  the agent can reason about it.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `CLAUDE_CODE_CONTEXT_WINDOW` | `200000` | Denominator for the display line. Lets operators retarget for non-default windows (e.g. 1M Sonnet beta) without touching auto-compact. |
| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `165000` (unchanged) | Separate concern; left alone. |

## Tests

- 6 new unit tests for `buildDynamicSystemContext` covering no-usage
  passthrough, append-to-existing-instructions, empty-base, non-default
  windows, and the zero-window edge case.
- All 36 existing poll-loop tests still pass.
- `tsc --noEmit` clean.

## Out of scope

- No change to the auto-compact threshold or its semantics.
- No active polling of `Query.getContextUsage()` — passive tracking from
  `result.usage` is sufficient and matches the source of truth the
  Claude Code UI uses.