### PR TITLE
fix(whatsapp): clear auth credentials immediately on 401 logout

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -529,6 +529,17 @@ registerChannelAdapter('whatsapp', {
             });
           } else {
             log.info('WhatsApp logged out');
+            // Delete auth credentials immediately. Keeping stale credentials
+            // causes the next service restart to attempt authentication with an
+            // invalidated session, producing a second 401 that can trigger
+            // WhatsApp's re-link cooldown ("can't link new devices now").
+            try {
+              fs.rmSync(authDir, { recursive: true, force: true });
+              fs.mkdirSync(authDir, { recursive: true });
+              log.info('WhatsApp auth cleared — set WHATSAPP_ENABLED=true and restart to re-link');
+            } catch (err) {
+              log.error('Failed to clear WhatsApp auth after logout', { err });
+            }
             if (rejectFirstOpen) {
               rejectFirstOpen(new Error('WhatsApp logged out'));
               rejectFirstOpen = undefined;


### PR DESCRIPTION
## Problem

When WhatsApp issues a forced logout (status 401), the auth credentials in `store/auth/` are left on disk. On the next service restart — including an unrelated system reboot — the adapter re-attempts authentication with those dead credentials, receives a second 401, and this repeated failed-auth pattern can trigger WhatsApp's temporary re-link cooldown: **"can't link new devices now. try again later"**, which blocks the operator from re-linking for hours.

## Fix

Delete `store/auth/` immediately when a 401 logout is received, and log a clear recovery message. On subsequent restarts, the existing guard at adapter startup (`!hasAuth && !WHATSAPP_ENABLED → return null`) keeps the adapter dormant until the operator explicitly sets `WHATSAPP_ENABLED=true` — no further auth attempts happen automatically.

## Behavior after this change

| Scenario | Before | After |
|---|---|---|
| Service restarts after 401 logout | Re-attempts dead auth → second 401 | Adapter stays dormant (no creds, no flag) |
| Operator ready to re-link | Must manually clear `store/auth/` | Auth already cleared; just set `WHATSAPP_ENABLED=true` and restart |

## Test plan

- [ ] Force a 401 (e.g. remove the linked device from the phone)
- [ ] Confirm `store/auth/` is empty after the adapter logs "WhatsApp logged out"
- [ ] Restart the service without `WHATSAPP_ENABLED` — confirm adapter does not start
- [ ] Set `WHATSAPP_ENABLED=true`, restart — confirm QR/pairing code appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)