### PR TITLE
fix(signal-auth): read 'number' field from signal-cli 0.13+ listAccounts JSON

### DIFF
--- a/setup/signal-auth.ts
+++ b/setup/signal-auth.ts
@@ -36,6 +36,7 @@ const LINK_TIMEOUT_MS = 180_000;
 const DEFAULT_DEVICE_NAME = 'NanoClaw';
 
 interface SignalAccount {
+  number?: string;
   account?: string;
   registered?: boolean;
 }
@@ -59,7 +60,7 @@ function listAccounts(): string[] {
     const parsed = JSON.parse(res.stdout || '[]') as SignalAccount[];
     return parsed
       .filter((a) => a.registered !== false)
-      .map((a) => a.account ?? '')
+      .map((a) => a.number ?? a.account ?? '')
       .filter(Boolean);
   } catch {
     return [];


### PR DESCRIPTION
## Summary

`signal-auth` calls `signal-cli -o json listAccounts` to determine
whether the user is already linked, then maps the result to a list of
account identifiers. The code reads `a.account`, but signal-cli >= 0.13
emits the field as `a.number`. The "already-authenticated" skip path
is never taken on the version pinned in `setup/install-signal-cli.sh`
(0.14.3), so re-running setup always tries to start a fresh
`signal-cli link` — which fails when the data directory already exists.

Fixes #2581.

## Change

`setup/signal-auth.ts`: read `a.number` first, fall back to `a.account`
to keep older signal-cli versions working. Updated the `SignalAccount`
interface to include both fields.

## Verification

On signal-cli 0.14.3:

```
$ signal-cli -o json listAccounts
[{"number":"+15551234567"}]
```

Before:
```ts
listAccounts() // → []   (a.account is undefined)
```

After:
```ts
listAccounts() // → ["+15551234567"]
```

signal-auth then emits `STATUS=skipped, REASON=already-authenticated`
as intended, and `runSignalChannel` continues to `init-first-agent`.

## Test plan

- [x] Re-run setup on a system with an existing linked account — wizard
      skips the link prompt and proceeds to `init-first-agent`.
- [x] Re-run on a fresh system (no signal-cli accounts) — link path
      still works.