### PR TITLE
docs(add-teams): document Teams CLI as an auto credentials path

### DIFF
--- a/.claude/skills/add-teams/SKILL.md
+++ b/.claude/skills/add-teams/SKILL.md
@@ -82,6 +82,12 @@ Requires Node.js 18+, a Microsoft 365 account with sideloading permissions, and 
      --endpoint "https://your-domain/api/webhooks/teams"
    ```
 
+   The CLI prints the credentials as `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID`. Map them to NanoClaw's env keys:
+
+   - `CLIENT_ID` → `TEAMS_APP_ID`
+   - `CLIENT_SECRET` → `TEAMS_APP_PASSWORD`
+   - `TENANT_ID` → `TEAMS_APP_TENANT_ID`
+
 4. Pick **Install in Teams** from the post-create menu and confirm in the Teams dialog.
 
 Continue to [Configure environment](#configure-environment).

--- a/.claude/skills/add-teams/SKILL.md
+++ b/.claude/skills/add-teams/SKILL.md
@@ -55,6 +55,41 @@ pnpm run build
 
 ## Credentials
 
+Two paths — manual (Azure Portal) or auto (Teams CLI).
+
+### Auto: Teams CLI
+
+Requires Node.js 18+, a Microsoft 365 account with sideloading permissions, and a public HTTPS endpoint (ngrok, Cloudflare Tunnel, or similar).
+
+1. Install the CLI:
+
+   ```bash
+   npm install -g @microsoft/teams.cli@preview
+   ```
+
+2. Sign in and verify:
+
+   ```bash
+   teams login
+   teams status
+   ```
+
+3. Create the Entra app, client secret, and bot registration:
+
+   ```bash
+   teams app create \
+     --name "NanoClaw" \
+     --endpoint "https://your-domain/api/webhooks/teams"
+   ```
+
+4. Pick **Install in Teams** from the post-create menu and confirm in the Teams dialog.
+
+Continue to [Configure environment](#configure-environment).
+
+---
+
+The steps below describe the **manual Azure Portal path**.
+
 ### Step 1: Create an Azure AD App Registration
 
 1. Go to [Azure Portal](https://portal.azure.com) > **App registrations** > **New registration**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [x] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What
Adds `@microsoft/teams.cli` as an "Auto" credential path in `.claude/skills/add-teams/SKILL.md`, alongside the existing Azure Portal manual path. Step 1–7 of the manual path are untouched.

### Why
The existing manual path requires three things from Azure that block users on locked-down corporate tenants:

1. An Azure subscription (the `N/A(tenant level account)` Entra-only placeholder isn't enough)
2. Contributor role on that subscription (or on a specific resource group)
3. The `Microsoft.BotService` resource provider registered on that subscription

For users issued an Entra identity without Azure RBAC (common in enterprise tenants), the manual path errors out at `az provider register --namespace Microsoft.BotService` with `AuthorizationFailed` and there's no documented alternative.

`@microsoft/teams.cli` registers the bot through the Teams Developer Portal instead of Azure Bot Service. It still produces an Entra app, client secret, and bot registration — the three values the existing Chat SDK Teams adapter consumes — but skips the Azure subscription requirement entirely.

### How
Two H3 sections under `## Credentials`:

- `### Auto: Teams CLI` — 4 imperative steps: install CLI, `teams login`, `teams app create`, `Install in Teams`. The CLI prints credentials as `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID`; the skill includes the mapping to NanoClaw's `TEAMS_APP_ID` / `TEAMS_APP_PASSWORD` / `TEAMS_APP_TENANT_ID` inline at step 3.
- Existing `### Step 1: ...` through `### Step 7: ...` headings unchanged. A short transition line above Step 1 marks them as the manual Azure Portal path.

Both paths hand off to the existing `### Configure environment` section to write `.env` and run the container sync.

### How it was tested
Verified end-to-end on a real Microsoft 365 corporate tenant with no Azure subscription (the exact scenario the manual path can't satisfy):

- `npm install -g @microsoft/teams.cli@preview` → `teams login` → `teams status` confirmed sideloading enabled
- `teams app create --name "NanoClaw" --endpoint "<tunnel>/api/webhooks/teams"` succeeded; CLI created the Entra app, generated a client secret, registered the bot, and printed `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` to stdout
- The printed values, mapped to `TEAMS_APP_*`, were written to `.env`; the existing `mkdir -p data/env && cp .env data/env/env` sync line worked unchanged
- Diff isolation verified: PR contains only `.claude/skills/add-teams/SKILL.md` (+41 / -0 across two commits)

Re-verified on a **fresh clone** at `~/nanoclaw-new` by running `/add-teams` in Claude Code on the PR branch:

- Install section executed: `git fetch origin channels`, copied `src/channels/teams.ts`, appended `import './teams.js'` to `src/channels/index.ts`, ran `pnpm install @chat-adapter/teams@4.26.0`
- Auto path executed: `teams app create --name "NanoClaw" --endpoint "https://<tunnel>/api/webhooks/teams"` provisioned a fresh Entra app + client secret + bot registration; the returned values were mapped per the SKILL.md to `TEAMS_APP_ID` / `TEAMS_APP_PASSWORD` / `TEAMS_APP_TENANT_ID` and written into `.env`; `mkdir -p data/env && cp .env data/env/env` synced to the container

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
