### PR TITLE
fix(agent-runner): honor zero/negative transcript rotate-age override

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -257,8 +257,12 @@ function transcriptRotateBytes(): number {
  * non-positive value) disables the age check; size alone then governs.
  */
 function transcriptRotateAgeMs(): number {
-  const days = Number(process.env.CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS);
-  return Number.isFinite(days) && days > 0 ? days * 86_400_000 : 14 * 86_400_000;
+  const raw = process.env.CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS;
+  if (raw === undefined || raw.trim() === '') return 14 * 86_400_000;
+  const days = Number(raw);
+  if (!Number.isFinite(days)) return 14 * 86_400_000;
+  // Explicit non-positive override disables the age check; size alone governs.
+  return days > 0 ? days * 86_400_000 : Infinity;
 }
 
 function claudeProjectsDir(): string {


### PR DESCRIPTION
## What

`transcriptRotateAgeMs()` is documented so that setting `CLAUDE_TRANSCRIPT_ROTATE_AGE_DAYS=0` (or a negative value) disables age-based continuation rotation. It didn't — it routed any non-positive value into the same branch as an unset variable and returned the 14-day default.

## Why

Deployments that intentionally set `0` to keep long-lived sessions resumable were still having continuations rotated once they passed 14 days, causing unexpected session resets and context loss. Flagged by the codex review on #2586: https://github.com/nanocoai/nanoclaw/pull/2586#discussion_r3288816875

## How it works

Distinguish three cases the old single ternary collapsed into two:
- unset / blank / non-numeric → 14-day default (unchanged)
- explicit `0` or negative → `Infinity` (age check disabled; the byte-size cap alone governs, since the consumer does `ageMs > maxAgeMs`)
- positive → that many days

## How it was tested

Typechecked the container tsconfig (`tsc -p container/agent-runner/tsconfig.json --noEmit`) against the change. Pure tweak to an existing code path with no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)