### PR TITLE
test(agent-runner): update formatter test for dropped <messages> envelope

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -37,13 +37,15 @@ describe('formatter', () => {
     expect(prompt).toContain('Hello world');
   });
 
-  it('should format multiple chat messages as XML block', () => {
+  it('should format multiple chat messages as distinct <message> blocks', () => {
     insertMessage('m1', 'chat', { sender: 'John', text: 'Hello' });
     insertMessage('m2', 'chat', { sender: 'Jane', text: 'Hi there' });
     const messages = getPendingMessages();
     const prompt = formatMessages(messages);
-    expect(prompt).toContain('<messages>');
-    expect(prompt).toContain('</messages>');
+    // The <messages> envelope was dropped in fe2e881b (#2556) so the SDK calls
+    // the API; each message is now its own self-contained <message> block.
+    expect(prompt).not.toContain('<messages>');
+    expect(prompt.match(/<message /g) ?? []).toHaveLength(2);
     expect(prompt).toContain('sender="John"');
     expect(prompt).toContain('sender="Jane"');
   });


### PR DESCRIPTION
## What

Update `poll-loop.test.ts` so the multi-message formatter test matches the current formatter output.

## Why

`fe2e881b` (#2556) dropped the `<messages>` envelope from `formatChatMessages` — multiple chat messages are now emitted as consecutive self-contained `<message …>` blocks (so the Claude Agent SDK calls the API instead of returning a synthetic "No response requested." stub). The test was never updated and still asserted `toContain('<messages>')` / `'</messages>'`, so it has failed on **every** PR built against `main` since 2026-05-19.

## How it works

Assert the current shape instead: no `<messages>` envelope, and one `<message ` block per message (2 here). Sender assertions are unchanged.

## How it was tested

`bun test` in `container/agent-runner/` — full suite now 95 pass / 0 fail (was 94 / 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)