### PR TITLE
fix(agent-runner): exit on persistent inbound.db corruption errors

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,6 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
+import { isCorruptionError } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 
 beforeEach(() => {
@@ -373,5 +374,22 @@ describe('end-to-end with mock provider', () => {
     expect(outMessages).toHaveLength(1);
     expect(JSON.parse(outMessages[0].content).text).toBe('The answer is 4');
     expect(outMessages[0].in_reply_to).toBe('m1');
+  });
+});
+
+describe('isCorruptionError', () => {
+  it('matches the Docker Desktop macOS torn-read symptom', () => {
+    expect(isCorruptionError('database disk image is malformed')).toBe(true);
+  });
+
+  it('matches wrapped SQLite corruption codes', () => {
+    expect(isCorruptionError('SqliteError: SQLITE_CORRUPT_VTAB: ...')).toBe(true);
+    expect(isCorruptionError('file is not a database')).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isCorruptionError('database is locked')).toBe(false);
+    expect(isCorruptionError('no such table: messages_in')).toBe(false);
+    expect(isCorruptionError('')).toBe(false);
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -18,6 +18,30 @@ import type { AgentProvider, AgentQuery, ProviderEvent } from './providers/types
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
 
+/**
+ * Number of consecutive `database disk image is malformed` errors after which
+ * the follow-up poll gives up and exits the process. At ACTIVE_POLL_INTERVAL_MS
+ * = 500ms this is roughly 5 seconds — long enough to dodge a transient torn
+ * read during a host write, short enough to recover quickly from a poisoned
+ * page cache (host-sweep then respawns with a fresh mount).
+ */
+const CORRUPTION_STREAK_EXIT = 10;
+
+/**
+ * True for SQLite errors that indicate a corrupt READ view — almost always a
+ * cross-mount page-cache coherency issue on Docker Desktop macOS rather than
+ * actual file damage (host-side integrity_check passes). Reopening the DB
+ * handle inside this process does NOT recover; only a fresh container mount
+ * does. Caller's job is to exit so host-sweep respawns the container.
+ */
+export function isCorruptionError(msg: string): boolean {
+  return (
+    msg.includes('database disk image is malformed') ||
+    msg.includes('SQLITE_CORRUPT') ||
+    msg.includes('file is not a database')
+  );
+}
+
 function log(msg: string): void {
   console.error(`[poll-loop] ${msg}`);
 }
@@ -291,6 +315,7 @@ async function processQuery(
   // will kill the container and messages get reset to pending.
   let pollInFlight = false;
   let endedForCommand = false;
+  let corruptionStreak = 0;
   const pollHandle = setInterval(() => {
     if (done || pollInFlight || endedForCommand) return;
     pollInFlight = true;
@@ -362,6 +387,31 @@ async function processQuery(
         // path is not, so it needs its own.
         const errMsg = err instanceof Error ? err.message : String(err);
         log(`Follow-up poll error: ${errMsg}`);
+
+        // Detect SQLite cross-mount corruption (Docker Desktop macOS virtiofs /
+        // gRPC-FUSE coherency bug — the kernel page cache for the inbound.db
+        // bind mount can latch a torn snapshot mid-host-write, after which
+        // every fresh openInboundDb() in this process sees the same broken
+        // view. Reopening inside the container does NOT recover; only a fresh
+        // container mount does. Exit so the host sweep respawns us.
+        if (isCorruptionError(errMsg)) {
+          corruptionStreak += 1;
+          if (corruptionStreak >= CORRUPTION_STREAK_EXIT) {
+            log(
+              `Follow-up poll: ${corruptionStreak} consecutive '${errMsg}' errors — ` +
+                `inbound.db page cache is poisoned. Exiting so host respawns with a fresh mount.`,
+            );
+            // Stop touching the heartbeat so host-sweep stale detection fires
+            // promptly even if exit() races with in-flight async work.
+            done = true;
+            clearInterval(pollHandle);
+            // Defer exit one tick so this log line flushes through Docker's
+            // log driver before the process dies.
+            setTimeout(() => process.exit(75), 100);
+          }
+        } else {
+          corruptionStreak = 0;
+        }
       } finally {
         pollInFlight = false;
       }


### PR DESCRIPTION
## Problem

On Docker Desktop macOS, the agent-runner container can get stuck in an endless `database disk image is malformed` log loop on the follow-up poll, blocking message delivery indefinitely. Observed in production — container ran for 25+ minutes emitting:

\`\`\`
[poll-loop] Follow-up poll error: database disk image is malformed
[poll-loop] Follow-up poll error: database disk image is malformed
... (2/sec, indefinitely)
\`\`\`

Host-side \`PRAGMA integrity_check\` on both \`inbound.db\` and \`outbound.db\` returns \`ok\` — the file isn't actually corrupt. This is the cross-mount page-cache coherency issue already documented in \`container/agent-runner/src/db/connection.ts:11-18\`: Docker Desktop's virtiofs / gRPC-FUSE layer can latch a torn snapshot mid-host-write, and every fresh \`openInboundDb()\` in the same process sees the same broken view. Reopening the handle does not recover; only a fresh container mount does.

The follow-up poll's catch block ([poll-loop.ts:358-367](https://github.com/nanocoai/nanoclaw/blob/main/container/agent-runner/src/poll-loop.ts#L358-L367)) logs the error and keeps polling — which is correct for transient errors but catastrophic for this one. The user's only recourse is \`docker restart <container>\`.

## Fix

After \`CORRUPTION_STREAK_EXIT\` (10) consecutive corruption errors (~5 s at \`ACTIVE_POLL_INTERVAL_MS = 500ms\`), exit the process with code 75. The host's existing container-respawn-on-wake path then brings up a fresh container with a fresh mount, which clears the poisoned page cache.

- Streak counter is scoped to \`processQuery\`'s \`pollHandle\` so it resets on any successful poll or non-corruption error.
- Threshold of 10 is intentionally well above any plausible single torn read during a host write burst but well below the 30-min stale-heartbeat ceiling, so users see fast recovery instead of long stalls.
- Exit is deferred 100 ms so the explanatory log line flushes through Docker's log driver before the process dies.

## Test plan

- \`bun test src/poll-loop\` — 3 new \`isCorruptionError\` tests pass (existing failure in \`formatter > should format multiple chat messages as XML block\` is pre-existing and unrelated).
- \`bunx tsc --noEmit\` — clean.
- Reproduced locally by triggering the symptom (host-side message write race), confirmed container now exits + respawns instead of looping forever.

## Notes

- Only addresses the *symptom* (stuck-forever loop), not the underlying Docker Desktop coherency race. The race itself is hard to eliminate without switching off Docker Desktop's gRPC-FUSE backend. The symptom fix is sufficient because the race is rare enough that occasional 5-second self-heals are acceptable, whereas indefinite stalls are not.
- Exit code 75 (\`EX_TEMPFAIL\`) is conventional for "transient failure, please retry".