### PR TITLE
fix: load per-group CLAUDE.local.md by adding 'local' to settingSources

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -411,7 +411,7 @@ export class ClaudeProvider implements AgentProvider {
         effort: this.effort as any,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
-        settingSources: ['project', 'user'],
+        settingSources: ['project', 'user', 'local'],
         mcpServers: this.mcpServers,
         hooks: {
           PreToolUse: [{ hooks: [preToolUseHook] }],


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — Add `'local'` to the agent-runner's Agent SDK `settingSources` so each group's `CLAUDE.local.md` is loaded into the agent's context.

```diff
-        settingSources: ['project', 'user'],
+        settingSources: ['project', 'user', 'local'],
```

`container/agent-runner/src/providers/claude.ts`

**Why** — Per the [Agent SDK docs](https://code.claude.com/docs/en/agent-sdk/claude-code-features), the three setting sources load different files:

| Source | What it loads |
| :-- | :-- |
| `'project'` | Project `CLAUDE.md`, `.claude/rules/*.md`, skills, hooks, `settings.json` |
| `'user'` | User `CLAUDE.md`, user settings |
| `'local'` | **`CLAUDE.local.md`**, `.claude/settings.local.json` |

> Omitting `settingSources` is equivalent to `["user", "project", "local"]`.

The agent-runner passes `settingSources: ['project', 'user']`, which omits `'local'`. Because `CLAUDE.local.md` is loaded only by the `'local'` source (`'project'` loads `CLAUDE.md`, not `CLAUDE.local.md`), every group's `CLAUDE.local.md` is silently never read.

This breaks the convention the codebase tells agents to rely on. `container/CLAUDE.md` instructs every agent: *"CLAUDE.local.md in your workspace is your per-group memory. Record things there that you'll want to remember in future sessions."* Today those writes never load back, so per-group memory and persona edits are dropped.

Reported in #2185. An import-based alternative was explored in #2567; this takes the `settingSources` route the docs point to, so no composer/`@import` change is needed.

**How it works** — Including `'local'` restores the SDK's documented default set (`['user', 'project', 'local']`) for the one file the agent already writes to. One line, no other changes.

**How tested** — Verified against the SDK docs table above: `'local'` is the source that loads `CLAUDE.local.md`, and an explicit `settingSources` array excludes any source not listed. Reviewer repro (from #2185): add `Always reply with the word PINEAPPLE first.` to a group's `CLAUDE.local.md`, then message the agent — ignored before this change, obeyed after.

Closes #2185.
