### PR TITLE
feat: inherit parent agent permissions via OneCLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
-    "@onecli-sh/sdk": "^0.5.0",
+    "@onecli-sh/sdk": "^2.1.0",
     "better-sqlite3": "11.10.0",
     "chat": "^4.24.0",
     "cron-parser": "5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@onecli-sh/sdk':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^2.1.0
+        version: 2.1.0
       better-sqlite3:
         specifier: 11.10.0
         version: 11.10.0
@@ -303,8 +303,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@onecli-sh/sdk@0.5.0':
-    resolution: {integrity: sha512-oe5Yx9o98v6N1PgzcCR7nULHHqcqKWNJIDOHGOSNX+l20mLlZpFUqfKPeFmsojBNRQMoqbvZQKUlFMp6gVuYBA==}
+  '@onecli-sh/sdk@2.1.0':
+    resolution: {integrity: sha512-ohBtZJYz/gxDhlIco1WRImX+aTK+f+WgTNPmHsk4moKV26DYGNEQlj69N//65158p5vIKOytdzLKf8PhceBAVA==}
     engines: {node: '>=20'}
 
   '@oxc-project/types@0.124.0':
@@ -1665,7 +1665,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@onecli-sh/sdk@0.5.0': {}
+  '@onecli-sh/sdk@2.1.0': {}
 
   '@oxc-project/types@0.124.0': {}
 

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -105,7 +105,7 @@ function writeEnvOnecliUrl(url: string): void {
 // Last-known-good CLI release. Used only if BOTH the upstream installer
 // and the redirect-based version probe fail. Bump deliberately when a
 // new CLI release ships.
-const ONECLI_GATEWAY_VERSION = '1.23.0';
+const ONECLI_GATEWAY_VERSION = '1.30.0';
 const ONECLI_CLI_FALLBACK_VERSION = '1.3.0';
 const ONECLI_CLI_REPO = 'onecli/onecli-cli';
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -121,6 +121,15 @@ async function spawnContainer(session: Session): Promise<void> {
   }
   writeSessionRouting(agentGroup.id, session.id);
 
+  let parentIdentifier: string | undefined;
+  if (hasTable(getDb(), 'agent_destinations')) {
+    const { getDestinationByName } = await import('./modules/agent-to-agent/db/agent-destinations.js');
+    const parentDest = getDestinationByName(agentGroup.id, 'parent');
+    if (parentDest?.target_type === 'agent') {
+      parentIdentifier = parentDest.target_id;
+    }
+  }
+
   // Materialize container.json from DB — writes fresh file and returns
   // the config object, threaded through provider resolution, buildMounts,
   // and buildContainerArgs so we don't re-read.
@@ -144,6 +153,7 @@ async function spawnContainer(session: Session): Promise<void> {
     provider,
     contribution,
     agentIdentifier,
+    parentIdentifier,
   );
 
   log.info('Spawning container', { sessionId: session.id, agentGroup: agentGroup.name, containerName });
@@ -404,6 +414,7 @@ async function buildContainerArgs(
   provider: string,
   providerContribution: ProviderContainerContribution,
   agentIdentifier?: string,
+  parentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
 
@@ -424,7 +435,11 @@ async function buildContainerArgs(
   // The caller (router or host-sweep) catches the throw, leaves the inbound
   // message pending, and the next sweep tick retries.
   if (agentIdentifier) {
-    await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+    await onecli.ensureAgent({
+      name: agentGroup.name,
+      identifier: agentIdentifier,
+      ...(parentIdentifier && { parentIdentifier }),
+    });
   }
   const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
   if (!onecliApplied) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
When spawning a sub-agent, resolve the parent from agent_destinations and pass its identifier to OneCLI's ensureAgent. This enables child agents to inherit the parent's secretMode and credential assignments, preventing privilege escalation where a sub-agent could access credentials its parent was scoped away from.

    Changes:
    - Look up parent agent group ID from 'parent' destination at spawn time
    - Pass parentIdentifier to ensureAgent in buildContainerArgs
    - Update @onecli-sh/sdk to ^2.1.0 for parentIdentifier support

    Requires onecli/onecli API changes (parentIdentifier support on POST /v1/agents).

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
