### PR TITLE
Use platform IDs for inbound message actions

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -194,6 +194,7 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
       tries          INTEGER DEFAULT 0,
       trigger        INTEGER NOT NULL DEFAULT 1,
       platform_id    TEXT,
+      platform_message_id TEXT,
       channel_type   TEXT,
       thread_id      TEXT,
       content        TEXT NOT NULL,

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -35,6 +35,7 @@ export interface MessageInRow {
   /** 1 = wake-eligible (default); 0 = accumulated context only */
   trigger: number;
   platform_id: string | null;
+  platform_message_id: string | null;
   channel_type: string | null;
   thread_id: string | null;
   content: string;
@@ -163,4 +164,3 @@ export function findQuestionResponse(questionId: string): MessageInRow | undefin
     inbound.close();
   }
 }
-

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -32,6 +32,11 @@ export interface WriteMessageOut {
   content: string;
 }
 
+export interface MessageTarget {
+  messageId: string;
+  source: 'inbound' | 'outbound';
+}
+
 /**
  * Write a new outbound message, auto-assigning an odd seq number.
  * Container uses odd seq (1, 3, 5...), host uses even (2, 4, 6...).
@@ -80,21 +85,32 @@ export function writeMessageOut(msg: WriteMessageOut): number {
  * Look up a message's platform ID by seq number.
  * Searches both inbound and outbound DBs since seq spans both.
  *
- * For inbound messages, the Chat SDK message ID is already the platform message ID
- * (e.g., "6037840640:42" for Telegram).
+ * For inbound messages, messages_in.id is NanoClaw's internal routed ID.
+ * messages_in.platform_message_id carries the raw platform ID when available.
  *
  * For outbound messages, the internal ID (msg-xxx) won't work for edits/reactions.
  * Instead, look up the platform_message_id from the delivered table (host writes this
  * after successful delivery).
  */
-export function getMessageIdBySeq(seq: number): string | null {
+export function getMessageTargetBySeq(seq: number): MessageTarget | null {
   const inbound = getInboundDb();
 
-  // Inbound messages: ID is already the platform message ID
-  const inRow = inbound.prepare('SELECT id FROM messages_in WHERE seq = ?').get(seq) as
-    | { id: string }
+  const inRow = inbound.prepare('SELECT id, platform_message_id FROM messages_in WHERE seq = ?').get(seq) as
+    | { id: string; platform_message_id: string | null }
     | undefined;
-  if (inRow) return inRow.id;
+  if (inRow) {
+    if (!inRow.platform_message_id) {
+      console.error(
+        JSON.stringify({
+          severity: 'warn',
+          component: 'messages-out',
+          event: 'missing_platform_message_id',
+          seq,
+        }),
+      );
+    }
+    return { messageId: inRow.platform_message_id ?? inRow.id, source: 'inbound' };
+  }
 
   // Outbound messages: look up platform message ID from delivered table
   const outRow = getOutboundDb().prepare('SELECT id FROM messages_out WHERE seq = ?').get(seq) as
@@ -106,10 +122,14 @@ export function getMessageIdBySeq(seq: number): string | null {
   const deliveredRow = inbound
     .prepare('SELECT platform_message_id FROM delivered WHERE message_out_id = ?')
     .get(outRow.id) as { platform_message_id: string | null } | undefined;
-  if (deliveredRow?.platform_message_id) return deliveredRow.platform_message_id;
+  if (deliveredRow?.platform_message_id) return { messageId: deliveredRow.platform_message_id, source: 'outbound' };
 
   // Fallback to internal ID (edits/reactions on undelivered messages won't work)
-  return outRow.id;
+  return { messageId: outRow.id, source: 'outbound' };
+}
+
+export function getMessageIdBySeq(seq: number): string | null {
+  return getMessageTargetBySeq(seq)?.messageId ?? null;
 }
 
 /**

--- a/container/agent-runner/src/mcp-tools/core.test.ts
+++ b/container/agent-runner/src/mcp-tools/core.test.ts
@@ -1,20 +1,21 @@
 /**
- * Tests for the core MCP tools' interaction with the per-batch routing
- * context. The agent-runner sets a current `inReplyTo` at the top of each
- * batch in poll-loop, and outbound writes from MCP tools (send_message,
- * send_file) must pick it up so a2a return-path routing on the host can
- * correlate replies back to the originating session.
+ * Tests for core MCP tool DB plumbing.
+ *
+ * The agent-runner sets a current `inReplyTo` at the top of each batch in
+ * poll-loop, and outbound writes from MCP tools must preserve that routing.
+ * Message action tools also resolve agent-facing numeric IDs to raw platform
+ * IDs before queuing edit/reaction operations.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
+import { setCurrentInReplyTo, clearCurrentInReplyTo } from '../current-batch.js';
 import { initTestSessionDb, closeSessionDb, getInboundDb } from '../db/connection.js';
 import { getUndeliveredMessages } from '../db/messages-out.js';
-import { setCurrentInReplyTo, clearCurrentInReplyTo } from '../current-batch.js';
-import { sendMessage } from './core.js';
+import { sendMessage, addReaction, editMessage } from './core.js';
 
 beforeEach(() => {
   initTestSessionDb();
-  // Seed a peer agent destination
+  // Seed a peer agent destination.
   getInboundDb()
     .prepare(
       `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
@@ -27,6 +28,31 @@ afterEach(() => {
   clearCurrentInReplyTo();
   closeSessionDb();
 });
+
+function insertInboundMessage(opts: {
+  seq: number;
+  id: string;
+  platformMessageId?: string | null;
+  channelType?: string | null;
+  platformId?: string | null;
+  threadId?: string | null;
+}): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (
+        id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, platform_message_id
+      )
+      VALUES (?, ?, 'chat', datetime('now'), 'pending', ?, ?, ?, '{}', ?)`,
+    )
+    .run(
+      opts.id,
+      opts.seq,
+      opts.platformId ?? '987654321098765432',
+      opts.channelType ?? 'discord',
+      opts.threadId ?? null,
+      opts.platformMessageId ?? null,
+    );
+}
 
 describe('send_message MCP tool — in_reply_to plumbing', () => {
   it('stamps current batch in_reply_to on outbound rows', async () => {
@@ -46,5 +72,40 @@ describe('send_message MCP tool — in_reply_to plumbing', () => {
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
     expect(out[0].in_reply_to).toBeNull();
+  });
+});
+
+describe('core message action tools', () => {
+  it('uses the raw platform message ID when reacting to a routed inbound message', async () => {
+    insertInboundMessage({
+      seq: 4,
+      id: '111122223333444455:ag-discord-test-agent',
+      platformMessageId: '111122223333444455',
+    });
+
+    const result = await addReaction.handler({ messageId: 4, emoji: 'clock3' });
+    expect(result.isError).toBeUndefined();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content)).toEqual({
+      operation: 'reaction',
+      messageId: '111122223333444455',
+      emoji: 'clock3',
+    });
+  });
+
+  it('rejects edits targeting inbound user messages', async () => {
+    insertInboundMessage({
+      seq: 4,
+      id: '111122223333444455:ag-discord-test-agent',
+      platformMessageId: '111122223333444455',
+    });
+
+    const result = await editMessage.handler({ messageId: 4, text: 'updated text' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Cannot edit inbound message #4');
+    expect(getUndeliveredMessages()).toHaveLength(0);
   });
 });

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { getCurrentInReplyTo } from '../current-batch.js';
 import { findByName, getAllDestinations } from '../destinations.js';
-import { getMessageIdBySeq, getRoutingBySeq, writeMessageOut } from '../db/messages-out.js';
+import { getMessageTargetBySeq, getRoutingBySeq, writeMessageOut } from '../db/messages-out.js';
 import { getSessionRouting } from '../db/session-routing.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
@@ -196,8 +196,9 @@ export const editMessage: McpToolDefinition = {
     const text = args.text as string;
     if (!seq || !text) return err('messageId and text are required');
 
-    const platformId = getMessageIdBySeq(seq);
-    if (!platformId) return err(`Message #${seq} not found`);
+    const target = getMessageTargetBySeq(seq);
+    if (!target) return err(`Message #${seq} not found`);
+    if (target.source === 'inbound') return err(`Cannot edit inbound message #${seq}`);
 
     const routing = getRoutingBySeq(seq);
     if (!routing || !routing.channel_type || !routing.platform_id) {
@@ -211,10 +212,10 @@ export const editMessage: McpToolDefinition = {
       platform_id: routing.platform_id,
       channel_type: routing.channel_type,
       thread_id: routing.thread_id,
-      content: JSON.stringify({ operation: 'edit', messageId: platformId, text }),
+      content: JSON.stringify({ operation: 'edit', messageId: target.messageId, text }),
     });
 
-    log(`edit_message: #${seq} → ${platformId}`);
+    log(`edit_message: #${seq} → ${target.messageId}`);
     return ok(`Message edit queued for #${seq}`);
   },
 };
@@ -237,8 +238,8 @@ export const addReaction: McpToolDefinition = {
     const emoji = args.emoji as string;
     if (!seq || !emoji) return err('messageId and emoji are required');
 
-    const platformId = getMessageIdBySeq(seq);
-    if (!platformId) return err(`Message #${seq} not found`);
+    const target = getMessageTargetBySeq(seq);
+    if (!target) return err(`Message #${seq} not found`);
 
     const routing = getRoutingBySeq(seq);
     if (!routing || !routing.channel_type || !routing.platform_id) {
@@ -252,10 +253,10 @@ export const addReaction: McpToolDefinition = {
       platform_id: routing.platform_id,
       channel_type: routing.channel_type,
       thread_id: routing.thread_id,
-      content: JSON.stringify({ operation: 'reaction', messageId: platformId, emoji }),
+      content: JSON.stringify({ operation: 'reaction', messageId: target.messageId, emoji }),
     });
 
-    log(`add_reaction: #${seq} → ${emoji} on ${platformId}`);
+    log(`add_reaction: #${seq} → ${emoji} on ${target.messageId}`);
     return ok(`Reaction queued for #${seq}`);
   },
 };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS messages_in (
   trigger        INTEGER NOT NULL DEFAULT 1,
                  -- 0 = accumulated context (don't wake), 1 = wake agent
   platform_id    TEXT,
+  platform_message_id TEXT,
   channel_type   TEXT,
   thread_id      TEXT,
   content        TEXT NOT NULL,

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -91,4 +91,56 @@ describe('migrateMessagesInTable', () => {
     expect(getInboundSourceSessionId(db, 'does-not-exist')).toBeNull();
     db.close();
   });
+
+  it('adds platform_message_id and only backfills routed Discord rows', () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+
+    const db = new Database(DB_PATH);
+    db.exec(`
+      CREATE TABLE messages_in (
+        id             TEXT PRIMARY KEY,
+        seq            INTEGER UNIQUE,
+        kind           TEXT NOT NULL,
+        timestamp      TEXT NOT NULL,
+        status         TEXT DEFAULT 'pending',
+        process_after  TEXT,
+        recurrence     TEXT,
+        series_id      TEXT,
+        tries          INTEGER DEFAULT 0,
+        trigger        INTEGER NOT NULL DEFAULT 1,
+        platform_id    TEXT,
+        channel_type   TEXT,
+        thread_id      TEXT,
+        content        TEXT NOT NULL
+      );
+    `);
+    db.prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, content)
+       VALUES (?, ?, 'chat', datetime('now'), 'pending', ?, ?, '{}')`,
+    ).run('111122223333444455:ag-discord-test-agent', 2, '987654321098765432', 'discord');
+    db.prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, content)
+       VALUES (?, ?, 'chat', datetime('now'), 'pending', ?, ?, '{}')`,
+    ).run('6037840640:42', 4, 'telegram-chat', 'telegram');
+
+    migrateMessagesInTable(db);
+    migrateMessagesInTable(db); // idempotent
+
+    const rows = db.prepare('SELECT id, platform_message_id FROM messages_in ORDER BY seq').all() as Array<{
+      id: string;
+      platform_message_id: string | null;
+    }>;
+    expect(rows).toEqual([
+      {
+        id: '111122223333444455:ag-discord-test-agent',
+        platform_message_id: '111122223333444455',
+      },
+      {
+        id: '6037840640:42',
+        platform_message_id: null,
+      },
+    ]);
+    db.close();
+  });
 });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -98,6 +98,7 @@ export function insertMessage(
     kind: string;
     timestamp: string;
     platformId: string | null;
+    platformMessageId?: string | null;
     channelType: string | null;
     threadId: string | null;
     content: string;
@@ -122,10 +123,11 @@ export function insertMessage(
   },
 ): void {
   db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
-     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)`,
+    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, platform_message_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
+     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @platformMessageId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)`,
   ).run({
     ...message,
+    platformMessageId: message.platformMessageId ?? null,
     trigger: message.trigger ?? 1,
     onWake: message.onWake ?? 0,
     sourceSessionId: message.sourceSessionId ?? null,
@@ -328,6 +330,19 @@ export function migrateMessagesInTable(db: Database.Database): void {
     // 1 = only deliver on the container's first poll (fresh start).
     // All existing rows are normal messages, so default 0.
     db.prepare('ALTER TABLE messages_in ADD COLUMN on_wake INTEGER NOT NULL DEFAULT 0').run();
+  }
+  if (!cols.has('platform_message_id')) {
+    db.prepare('ALTER TABLE messages_in ADD COLUMN platform_message_id TEXT').run();
+    db.prepare(
+      `UPDATE messages_in
+       SET platform_message_id =
+         CASE
+           WHEN instr(id, ':') > 0 THEN substr(id, 1, instr(id, ':') - 1)
+           ELSE id
+         END
+       WHERE channel_type = 'discord'
+         AND platform_message_id IS NULL`,
+    ).run();
   }
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -452,6 +452,7 @@ async function deliverToAgent(
     kind: event.message.kind,
     timestamp: event.message.timestamp,
     platformId: deliveryAddr.platformId,
+    platformMessageId: event.message.id || null,
     channelType: deliveryAddr.channelType,
     threadId: deliveryAddr.threadId,
     content: event.message.content,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -198,6 +198,7 @@ export function writeSessionMessage(
     kind: string;
     timestamp: string;
     platformId?: string | null;
+    platformMessageId?: string | null;
     channelType?: string | null;
     threadId?: string | null;
     content: string;
@@ -233,6 +234,7 @@ export function writeSessionMessage(
       kind: message.kind,
       timestamp: message.timestamp,
       platformId: message.platformId ?? null,
+      platformMessageId: message.platformMessageId ?? null,
       channelType: message.channelType ?? null,
       threadId: message.threadId ?? null,
       content,


### PR DESCRIPTION
## What

Fix inbound message actions to use the platform raw message ID instead of NanoClaw internal composite message IDs.

## Why

Some platform APIs require their own raw message identifier for message actions such as reactions. Composite IDs are useful internally, but they are not valid platform message IDs.

## How

Adds `messages_in.platform_message_id`, records the raw platform message ID during routing, and resolves inbound seq targets to that platform ID for message actions. Inbound edits are rejected because the agent can only edit messages it sent. Includes a platform-specific migration backfill for existing Discord inbound messages.

## Testing

- `bun test src/mcp-tools/core.test.ts`
- `pnpm exec vitest run src/db/session-db.test.ts`
- `cd container/agent-runner && bun test`
- `pnpm test`
- `pnpm run build`
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`
- `git diff --check`
