### PR TITLE
ci: bump Node 20 actions to v5 ahead of June 2026 deprecation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,11 +16,11 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - name: Bump patch version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -17,7 +17,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## What

Bumps the three GitHub Actions still pinned to Node 20 runtimes up to their first Node 24 major (`@v5`):

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `pnpm/action-setup@v4` → `@v5`

Across `ci.yml`, `bump-version.yml`, and `update-tokens.yml`.

## Why

CI runs currently emit the deprecation annotation:

> Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`v5` is the first major of each action that ships on Node 24, so this clears the warning ahead of the forced cutover.

## Unchanged

- `oven-sh/setup-bun@v2` already runs on Node 24.
- `node-version: 20` in `ci.yml` is the project *build* runtime, not the action runtime — left as-is.
- `actions/create-github-app-token@v1` was not flagged (already Node 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)