### PR TITLE
fix: call initGroupFilesystem after ncl groups create

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -69,6 +69,8 @@ export interface ResourceDef {
   };
   /** Non-standard verbs (grant, revoke, add, remove, restart, etc.). */
   customOperations?: Record<string, CustomOperation>;
+  /** Called after a successful create with the inserted row values. */
+  afterCreate?: (result: Record<string, unknown>) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +160,7 @@ function genericCreate(def: ResourceDef) {
     getDb()
       .prepare(`INSERT INTO ${def.table} (${colNames.join(', ')}) VALUES (${placeholders.join(', ')})`)
       .run(values);
+    if (def.afterCreate) await def.afterCreate(values);
     return values;
   };
 }

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -9,6 +9,7 @@ import {
   updateContainerConfigScalars,
   updateContainerConfigJson,
 } from '../../db/container-configs.js';
+import { initGroupFilesystem } from '../../group-init.js';
 import type { ContainerConfigRow } from '../../types.js';
 import { registerResource } from '../crud.js';
 
@@ -62,6 +63,15 @@ registerResource({
   // DELETE violates FK constraints (see #2525). The cascading handler is
   // provided as `customOperations.delete` below.
   operations: { list: 'open', get: 'open', create: 'approval', update: 'approval' },
+  afterCreate: async (result) => {
+    initGroupFilesystem({
+      id: result.id as string,
+      name: result.name as string,
+      folder: result.folder as string,
+      agent_provider: null,
+      created_at: result.created_at as string,
+    });
+  },
   customOperations: {
     delete: {
       access: 'approval',


### PR DESCRIPTION
## Problem

`ncl groups create` inserts the `agent_groups` row but never calls `initGroupFilesystem`, so no `container_configs` row is created. When the host later tries to spawn a container for the new group, it fails with:

```
Container config not found for agent group: <id>
```

The host-sweep keeps retrying every 60 seconds but the container never starts.

## Fix

Add an optional `afterCreate` hook to `ResourceDef` in `crud.ts`. Resources can use it to run post-insert side-effects without duplicating the generic create logic.

Wire it in the groups resource to call `initGroupFilesystem`, which:
- Creates the group directory under `groups/<folder>/`
- Creates `CLAUDE.local.md`
- Inserts the `container_configs` row via `ensureContainerConfig`
- Creates the `.claude-shared/` directory and `settings.json`

## Testing

1. `ncl groups create --name test --folder test`
2. Send a message to the new group
3. Container spawns successfully (previously: would loop with "Container config not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)