### PR TITLE
feat(slack): add Socket Mode support to Slack adapter

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -44,7 +44,7 @@ import './slack.js';
 ### 4. Install the adapter package (pinned)
 
 ```bash
-pnpm install @chat-adapter/slack@4.26.0
+pnpm install @chat-adapter/slack@4.27.0
 ```
 
 ### 5. Build
@@ -55,30 +55,57 @@ pnpm run build
 
 ## Credentials
 
-### Create Slack App
+The adapter supports two delivery modes — pick one and follow the matching steps below.
+
+| Mode | When to use | What you need |
+|------|-------------|---------------|
+| **Socket Mode** (recommended for local installs) | Running NanoClaw on a laptop, NAS, or anywhere without a stable public URL. | `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` |
+| **Webhook Mode** | Running on a VPS or behind a stable public URL where Slack can POST events. | `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` |
+
+Mode is auto-detected from the env: if `SLACK_APP_TOKEN` is set, the adapter uses Socket Mode; otherwise it falls back to webhook mode.
+
+### Create Slack App (both modes)
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App** > **From scratch**
 2. Name it (e.g., "NanoClaw") and select your workspace
 3. Go to **OAuth & Permissions** and add Bot Token Scopes:
    - `chat:write`, `channels:history`, `groups:history`, `im:history`, `channels:read`, `groups:read`, `users:read`, `reactions:write`
 4. Click **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-...`)
-5. Go to **Basic Information** and copy the **Signing Secret**
 
-### Enable DMs
+### Enable DMs (both modes)
 
-6. Go to **App Home** and enable the **Messages Tab**
-7. Check **"Allow users to send Slash commands and messages from the messages tab"**
+5. Go to **App Home** and enable the **Messages Tab**
+6. Check **"Allow users to send Slash commands and messages from the messages tab"**
 
-### Event Subscriptions
+### Socket Mode setup
 
+7. Go to **Socket Mode** in the left sidebar and toggle **Enable Socket Mode**
+8. Slack will prompt you to create an **App-Level Token** — name it (e.g., "socket") and grant the `connections:write` scope. Copy the token (`xapp-...`)
+9. Go to **Event Subscriptions**, toggle **Enable Events**, and under **Subscribe to bot events** add:
+   - `message.channels`, `message.groups`, `message.im`, `app_mention`
+10. Click **Save Changes**
+11. Slack will show a banner asking you to **reinstall the app** — click it to apply the new event subscriptions
+
+Add to `.env`:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_APP_TOKEN=xapp-your-app-level-token
+```
+
+Sync to container: `mkdir -p data/env && cp .env data/env/env`
+
+No public URL or port forwarding required — the adapter opens an outbound WebSocket to Slack.
+
+### Webhook Mode setup
+
+7. Go to **Basic Information** and copy the **Signing Secret**
 8. Go to **Event Subscriptions** and toggle **Enable Events**
 9. Set the **Request URL** to `https://your-domain/webhook/slack` — Slack will send a verification challenge; it must pass before you can save
 10. Under **Subscribe to bot events**, add:
     - `message.channels`, `message.groups`, `message.im`, `app_mention`
 11. Click **Save Changes**
 12. Slack will show a banner asking you to **reinstall the app** — click it to apply the new event subscriptions
-
-### Configure environment
 
 Add to `.env`:
 
@@ -89,11 +116,9 @@ SLACK_SIGNING_SECRET=your-signing-secret
 
 Sync to container: `mkdir -p data/env && cp .env data/env/env`
 
-### Webhook server
-
 The Chat SDK bridge automatically starts a shared webhook server on port 3000 (configurable via `WEBHOOK_PORT` env var). The server handles `/webhook/slack` for Slack and other webhook-based adapters. This port must be publicly reachable from the internet for Slack to deliver events.
 
-If running locally, discuss options for exposing the server — e.g. ngrok (`ngrok http 3000`), Cloudflare Tunnel, or a reverse proxy on a VPS. The resulting public URL becomes the base for `https://your-domain/webhook/slack`.
+If running locally, discuss options for exposing the server — e.g. ngrok (`ngrok http 3000`), Cloudflare Tunnel, or a reverse proxy on a VPS. The resulting public URL becomes the base for `https://your-domain/webhook/slack`. (If you don't have a stable public URL, prefer Socket Mode above.)
 
 ## Next Steps
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1,6 +1,9 @@
 /**
  * Slack channel adapter (v2) — uses Chat SDK bridge.
  * Self-registers on import.
+ *
+ * Auto-detects socket mode when SLACK_APP_TOKEN is set; otherwise falls back
+ * to webhook mode using SLACK_SIGNING_SECRET.
  */
 import { createSlackAdapter } from '@chat-adapter/slack';
 
@@ -10,12 +13,18 @@ import { registerChannelAdapter } from './channel-registry.js';
 
 registerChannelAdapter('slack', {
   factory: () => {
-    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET']);
+    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET']);
     if (!env.SLACK_BOT_TOKEN) return null;
-    const slackAdapter = createSlackAdapter({
-      botToken: env.SLACK_BOT_TOKEN,
-      signingSecret: env.SLACK_SIGNING_SECRET,
-    });
+    const slackAdapter = env.SLACK_APP_TOKEN
+      ? createSlackAdapter({
+          mode: 'socket',
+          botToken: env.SLACK_BOT_TOKEN,
+          appToken: env.SLACK_APP_TOKEN,
+        })
+      : createSlackAdapter({
+          botToken: env.SLACK_BOT_TOKEN,
+          signingSecret: env.SLACK_SIGNING_SECRET,
+        });
     const bridge = createChatSdkBridge({ adapter: slackAdapter, concurrency: 'concurrent', supportsThreads: true });
     bridge.resolveChannelName = async (platformId: string) => {
       try {


### PR DESCRIPTION
## Summary

Adds Socket Mode support to the Slack channel adapter. Mode is auto-detected from env:

- If `SLACK_APP_TOKEN` is set → Socket Mode
- Otherwise → existing webhook flow using `SLACK_SIGNING_SECRET`

**Purely additive.** Existing webhook installs are byte-identical at runtime — no env change, no config change, same code path.

## Motivation

Webhook mode requires a stable, publicly reachable URL for Slack to POST events. For installs on a laptop, home NAS, or anything behind NAT, that means setting up ngrok / Cloudflare Tunnel / a reverse-proxy. Socket Mode opens an outbound WebSocket from the bot to Slack and removes the public-URL requirement entirely.

## What changed

- **`src/channels/slack.ts`** — adds an `env.SLACK_APP_TOKEN ? socket : webhook` branch around `createSlackAdapter`. Everything else (`resolveChannelName`, concurrency, thread support, bridge wiring) is unchanged.
- **`.claude/skills/add-slack/SKILL.md`** — adds a mode-comparison table at the top of the Credentials section and side-by-side step-by-step setup for each mode. Bumps the pinned install from `@chat-adapter/slack@4.26.0` → `4.27.0` because `mode: 'socket'` is not present in 4.26's `SlackAdapterConfig` type (added in 4.27).

## Test plan for review

- [ ] Confirm `@chat-adapter/slack@4.27.0` is acceptable as the new install pin (the current `^4.24.0` range allows it; `mode: 'socket'` is required for the new branch to typecheck).
- [ ] Webhook regression: existing installs without `SLACK_APP_TOKEN` continue to construct the adapter via the unchanged `signingSecret` path.
- [ ] Socket Mode: install with `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` (no signing secret, no public URL), follow Socket Mode setup steps in `SKILL.md`, verify events delivered for `message.channels`, `message.im`, `app_mention`.

## Compatibility

No breaking changes. No schema/DB changes. No host or container API surface changes. Single new optional env var.