### PR TITLE
feat(router): seed thread parent into fresh per-thread sessions

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -149,6 +149,24 @@ export interface ChannelAdapter {
   subscribe?(platformId: string, threadId: string): Promise<void>;
 
   /**
+   * Fetch the parent message of a thread for context-seeding on the first
+   * inbound that creates a per-thread session. Without this, the agent
+   * wakes in a brand-new session with no idea what message its user is
+   * replying to. Implementations should return the originating top-level
+   * message of the thread (not the most recent reply). Returns null when
+   * the parent can't be retrieved (deleted, missing scopes, transient
+   * platform error) — the router fails open and routes the reply with no
+   * extra context.
+   *
+   * Optional. Adapters that don't implement this leave the agent without
+   * parent-message context on fresh thread sessions.
+   */
+  fetchThreadParent?(
+    platformId: string,
+    threadId: string,
+  ): Promise<{ id: string; sender: string; text: string } | null>;
+
+  /**
    * Open (or fetch) a DM with this user, returning the platform_id of the
    * resulting DM channel. Called by the host on demand to initiate cold
    * DMs — approvals, pairing handshakes, host-initiated notifications — to

--- a/src/router.ts
+++ b/src/router.ts
@@ -270,6 +270,28 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   const parsed = safeParseContent(event.message.content);
   const messageText = parsed.text ?? '';
 
+  // Lazy, memoized parent-message fetch for thread context seeding. Only
+  // resolved when an agent's session creation actually needs it (see
+  // deliverToAgent). Cached so multiple agents wired to the same channel
+  // share one platform API call. Fail-open — never blocks routing.
+  let parentPromise: Promise<{ id: string; sender: string; text: string } | null> | null = null;
+  const getThreadParent = (): Promise<{ id: string; sender: string; text: string } | null> => {
+    if (parentPromise) return parentPromise;
+    if (!event.threadId || !adapter?.supportsThreads || !adapter.fetchThreadParent) {
+      parentPromise = Promise.resolve(null);
+      return parentPromise;
+    }
+    parentPromise = adapter.fetchThreadParent(event.platformId, event.threadId).catch((err) => {
+      log.warn('adapter.fetchThreadParent threw', {
+        channelType: event.channelType,
+        threadId: event.threadId,
+        err,
+      });
+      return null;
+    });
+    return parentPromise;
+  };
+
   let engagedCount = 0;
   let accumulatedCount = 0;
   let subscribed = false;
@@ -284,7 +306,16 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     const scopeOk = engages && (!senderScopeGate || senderScopeGate(event, userId, mg, agent).allowed);
 
     if (engages && accessOk && scopeOk) {
-      await deliverToAgent(agent, agentGroup, mg, event, userId, adapter?.supportsThreads === true, true);
+      await deliverToAgent(
+        agent,
+        agentGroup,
+        mg,
+        event,
+        userId,
+        adapter?.supportsThreads === true,
+        true,
+        getThreadParent,
+      );
       engagedCount++;
 
       // Mention-sticky: ask the adapter to subscribe the thread so the
@@ -315,7 +346,16 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
       // message (which also stages their attachments to disk via
       // writeSessionMessage → extractAttachmentFiles) is exactly what the
       // gate is meant to prevent.
-      await deliverToAgent(agent, agentGroup, mg, event, userId, adapter?.supportsThreads === true, false);
+      await deliverToAgent(
+        agent,
+        agentGroup,
+        mg,
+        event,
+        userId,
+        adapter?.supportsThreads === true,
+        false,
+        getThreadParent,
+      );
       accumulatedCount++;
     } else {
       log.debug('Message not engaged for agent (drop policy)', {
@@ -402,6 +442,7 @@ async function deliverToAgent(
   userId: string | null,
   adapterSupportsThreads: boolean,
   wake: boolean,
+  getThreadParent: () => Promise<{ id: string; sender: string; text: string } | null>,
 ): Promise<void> {
   // Apply the adapter thread policy: threaded adapter in a group chat →
   // per-thread session regardless of wiring. agent-shared preserved (it's
@@ -413,6 +454,38 @@ async function deliverToAgent(
   }
 
   const { session, created } = resolveSession(agent.agent_group_id, mg.id, event.threadId, effectiveSessionMode);
+
+  // Seed the thread-parent message into the inbound's `replyTo` when this
+  // is the first wake of a per-thread session and the inbound doesn't
+  // already carry one. The container's formatter renders `replyTo` as
+  // `<quoted_message>` inside the message tag, giving the agent the
+  // originating message it would otherwise have no view of. Fail-open:
+  // any error from the adapter fetch leaves the inbound unmodified.
+  let messageContent = event.message.content;
+  if (created && event.threadId && adapterSupportsThreads) {
+    let parsedContent: Record<string, unknown> | null = null;
+    try {
+      const candidate = JSON.parse(messageContent);
+      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+        parsedContent = candidate as Record<string, unknown>;
+      }
+    } catch {
+      // Non-JSON content (legacy/native adapters) — skip seeding.
+    }
+    if (parsedContent && parsedContent.replyTo == null) {
+      const parent = await getThreadParent();
+      if (parent && parent.id !== event.message.id) {
+        parsedContent.replyTo = { id: parent.id, sender: parent.sender, text: parent.text };
+        messageContent = JSON.stringify(parsedContent);
+        log.info('Seeded thread parent into fresh per-thread session', {
+          sessionId: session.id,
+          agentGroup: agent.agent_group_id,
+          threadId: event.threadId,
+          parentSender: parent.sender,
+        });
+      }
+    }
+  }
 
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source
@@ -454,7 +527,7 @@ async function deliverToAgent(
     platformId: deliveryAddr.platformId,
     channelType: deliveryAddr.channelType,
     threadId: deliveryAddr.threadId,
-    content: event.message.content,
+    content: messageContent,
     trigger: wake ? 1 : 0,
   });
 


### PR DESCRIPTION
## Summary

Adds an optional `fetchThreadParent` hook on `ChannelAdapter`, plus router wiring that calls it once per inbound event (memoized) when a fresh per-thread session is being created. The fetched parent message is stored on the inbound's `replyTo` field so the container's formatter renders it as `<quoted_message>` in the agent's view.

**Framework only.** No adapter implements `fetchThreadParent` in this PR — without an implementation the behavior is byte-identical to today. The Slack implementation lands in a follow-up PR against the `channels` branch that depends on this merging first.

## Motivation

Today, when a user starts a Slack/Discord thread by replying to some earlier message, and that thread's first reply triggers a new per-thread session, the agent wakes up with no view of what was being replied to. It sees only the reply text in isolation, with no context for why the user is saying it.

Seeding the originating top-level message into `replyTo` gives the agent the missing context on its very first turn, without changing anything for adapters that don't opt in.

## What changed

- **`src/channels/adapter.ts`** — adds optional `fetchThreadParent?(platformId, threadId): Promise<{id, sender, text} | null>` to the `ChannelAdapter` interface, with doc on fail-open semantics.
- **`src/router.ts`** — two pieces:
  1. **Memoized fetcher** at the top of `routeInbound`: lazy, cached per event, fail-open (a throw or `null` collapses to "no parent"). Avoids redundant platform API calls when multiple agents wired to the same channel each create a new session.
  2. **Seeding block** at the top of `deliverToAgent`: fires only when `created && event.threadId && adapterSupportsThreads`. Parses the inbound content as JSON; if it's not JSON or already has `replyTo`, skips. Otherwise sets `replyTo = {id, sender, text}` from the fetched parent, but only when the parent's id differs from the inbound's id (so single-message threads don't get a self-quote).

## Safety properties

| Condition | Behavior |
|-----------|----------|
| Adapter doesn't implement `fetchThreadParent` | No-op |
| Adapter throws | Logged warn, treated as `null` |
| Returns `null` | No seeding |
| Inbound is not JSON | Skipped (legacy/native adapters) |
| Inbound already has `replyTo` | Not overwritten |
| Parent id === inbound id | Not seeded (single-message thread) |
| Not the first message of the session (`created=false`) | Not seeded |
| Not a threaded adapter | Not seeded |
| Inbound has no `threadId` (DM) | Not seeded |

## Test plan for review

- [x] `pnpm run build` clean
- [x] `pnpm test` — 332/332 pass on this branch
- [ ] Reviewer: visual diff confirms `deliverToAgent` signature change is consistent at both call sites in `routeInbound` (`engaged` and `accumulate` paths both pass `getThreadParent`).
- [ ] Reviewer: confirm no adapter currently in trunk implements `fetchThreadParent` (it doesn't — channels live on the `channels` branch only).

## Follow-up PR

Slack implementation (`src/channels/slack-thread-parent.ts` + wiring in `src/channels/slack.ts`) against the `channels` branch. I'll open it as soon as this lands so reviewers can see the actual user-facing behavior end-to-end.

## Compatibility

No breaking changes. No schema/DB changes. No env changes. Interface addition is optional.