### PR TITLE
feat(chat-sdk-bridge): add channelType override + webhook routingPath

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -91,6 +91,41 @@ describe('createChatSdkBridge', () => {
     });
     expect(typeof bridge.subscribe).toBe('function');
   });
+
+  it('without channelType override, name and channelType default to adapter.name', () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'teams' }),
+      supportsThreads: true,
+    });
+    expect(bridge.name).toBe('teams');
+    expect(bridge.channelType).toBe('teams');
+  });
+
+  it('with channelType override, returned name and channelType reflect the override', () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'teams' }),
+      channelType: 'teams-alpha',
+      supportsThreads: true,
+    });
+    expect(bridge.name).toBe('teams-alpha');
+    expect(bridge.channelType).toBe('teams-alpha');
+  });
+
+  it('two bridges of the same adapter type get distinct channelTypes when overrides differ', () => {
+    const a = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'teams' }),
+      channelType: 'teams-alpha',
+      supportsThreads: true,
+    });
+    const b = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'teams' }),
+      channelType: 'teams-beta',
+      supportsThreads: true,
+    });
+    expect(a.channelType).toBe('teams-alpha');
+    expect(b.channelType).toBe('teams-beta');
+    expect(a.name).not.toBe(b.name);
+  });
 });
 
 describe('createChatSdkBridge.deliver — display cards (send_card)', () => {

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -74,6 +74,16 @@ export interface ChatSdkBridgeConfig {
    * and reactions still target the head of the reply.
    */
   maxTextLength?: number;
+  /**
+   * Override the channelType (and webhook path) for this bridge. Defaults to
+   * `adapter.name`. Used by channels that register multiple instances in one
+   * process — e.g. multi-workspace Slack, multi-bot Teams — so each instance
+   * gets a distinct channelType and a distinct `/webhook/<channelType>`
+   * routing path. The Chat SDK adapter's internal `.name` is unchanged, so
+   * `chat.webhooks[adapter.name]` lookup inside the webhook server still
+   * resolves correctly.
+   */
+  channelType?: string;
 }
 
 /**
@@ -192,9 +202,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     };
   }
 
+  const channelType = config.channelType ?? adapter.name;
+
   const bridge: ChannelAdapter = {
-    name: adapter.name,
-    channelType: adapter.name,
+    name: channelType,
+    channelType,
     supportsThreads: config.supportsThreads,
 
     async setup(hostConfig: ChannelSetup) {
@@ -358,8 +370,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         startGateway();
         log.info('Gateway listener started', { adapter: adapter.name });
       } else {
-        // Non-gateway adapters (Slack, Teams, GitHub, etc.) — register on the shared webhook server
-        registerWebhookAdapter(chat, adapter.name);
+        // Non-gateway adapters (Slack, Teams, GitHub, etc.) — register on the
+        // shared webhook server. Pass `channelType` as the routing path so
+        // multi-instance channels (e.g. multi-workspace Slack, multi-bot
+        // Teams) get distinct `/webhook/<channelType>` paths while sharing
+        // the same `adapter.name` key in `chat.webhooks`.
+        registerWebhookAdapter(chat, adapter.name, channelType);
       }
 
       log.info('Chat SDK bridge initialized', { adapter: adapter.name });

--- a/src/webhook-server.test.ts
+++ b/src/webhook-server.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Chat } from 'chat';
+
+import { registerWebhookAdapter, stopWebhookServer } from './webhook-server.js';
+
+// Pick a non-default port so the suite doesn't clash with a real running host.
+// WEBHOOK_PORT is read inside ensureServer() the first time a registration
+// triggers it, so the env must be set before the first registerWebhookAdapter
+// call in this suite.
+const TEST_PORT = 17389;
+
+beforeAll(() => {
+  process.env.WEBHOOK_PORT = String(TEST_PORT);
+});
+
+afterAll(async () => {
+  await stopWebhookServer();
+});
+
+function fakeChat(handlerMap: Record<string, (req: Request) => Promise<Response>>): Chat {
+  return { webhooks: handlerMap } as unknown as Chat;
+}
+
+describe('registerWebhookAdapter', () => {
+  it('without routingPath, the route equals adapterName', async () => {
+    const chat = fakeChat({
+      'default-route-adapter': async () => new Response('ok-default', { status: 200 }),
+    });
+    registerWebhookAdapter(chat, 'default-route-adapter');
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/default-route-adapter`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok-default');
+  });
+
+  it('with routingPath, the URL uses routingPath while handler lookup still uses adapterName', async () => {
+    let received = 0;
+    const chat = fakeChat({
+      // Note: keyed by the original adapter.name, not by the routing path.
+      'shared-adapter-A': async () => {
+        received++;
+        return new Response('ok-routed', { status: 200 });
+      },
+    });
+    registerWebhookAdapter(chat, 'shared-adapter-A', 'custom-path-A');
+
+    // The route URL is the routingPath ...
+    const routed = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/custom-path-A`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(routed.status).toBe(200);
+    expect(await routed.text()).toBe('ok-routed');
+    expect(received).toBe(1);
+
+    // ... and the bare adapter name does NOT resolve (no registration under it).
+    const bare = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/shared-adapter-A`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(bare.status).toBe(404);
+    expect(received).toBe(1);
+  });
+
+  it('two bridges sharing an adapterName but distinct routingPaths do not collide', async () => {
+    const chatA = fakeChat({
+      'shared-adapter-B': async () => new Response('alpha', { status: 200 }),
+    });
+    const chatB = fakeChat({
+      'shared-adapter-B': async () => new Response('beta', { status: 200 }),
+    });
+    registerWebhookAdapter(chatA, 'shared-adapter-B', 'instance-alpha');
+    registerWebhookAdapter(chatB, 'shared-adapter-B', 'instance-beta');
+
+    const resA = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/instance-alpha`, {
+      method: 'POST',
+      body: '{}',
+    });
+    const resB = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/instance-beta`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(await resA.text()).toBe('alpha');
+    expect(await resB.text()).toBe('beta');
+  });
+
+  it('returns 404 for an unregistered route', async () => {
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/webhook/never-registered-xyz`, {
+      method: 'POST',
+      body: '{}',
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -2,10 +2,12 @@
  * Minimal HTTP server for Chat SDK adapter webhooks.
  *
  * Starts lazily on first adapter registration. Routes requests by path:
- *   /webhook/{adapterName} → chat.webhooks[adapterName](request)
+ *   /webhook/{routingPath} → entry.chat.webhooks[entry.adapterName](request)
  *
- * Multiple Chat instances can register adapters — each adapter name maps
- * to its owning Chat instance.
+ * The routing path defaults to `adapterName` (single-instance channels).
+ * Multi-instance channels (e.g. multi-workspace Slack, multi-bot Teams)
+ * pass a distinct `routingPath` per registration so each instance gets its
+ * own URL while still resolving the same `chat.webhooks[adapterName]` handler.
  */
 import http from 'http';
 
@@ -69,11 +71,18 @@ async function fromWebResponse(webRes: Response, nodeRes: http.ServerResponse): 
 /**
  * Register a webhook adapter on the shared server.
  * Starts the server lazily on first call.
+ *
+ * `adapterName` is the key into `chat.webhooks` (the Chat SDK adapter's
+ * internal name). `routingPath`, when provided, becomes the URL path segment
+ * after `/webhook/`; otherwise it defaults to `adapterName`. Override
+ * `routingPath` when registering multiple bridges sharing the same Chat SDK
+ * adapter type under distinct URLs.
  */
-export function registerWebhookAdapter(chat: Chat, adapterName: string): void {
-  routes.set(adapterName, { chat, adapterName });
+export function registerWebhookAdapter(chat: Chat, adapterName: string, routingPath?: string): void {
+  const route = routingPath ?? adapterName;
+  routes.set(route, { chat, adapterName });
   ensureServer();
-  log.info('Webhook adapter registered', { adapter: adapterName, path: `/webhook/${adapterName}` });
+  log.info('Webhook adapter registered', { adapter: adapterName, path: `/webhook/${route}` });
 }
 
 function ensureServer(): void {
@@ -84,7 +93,7 @@ function ensureServer(): void {
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';
 
-    // Route: /webhook/{adapterName}
+    // Route: /webhook/{routingPath}
     const match = url.match(/^\/webhook\/([^/?]+)/);
     if (!match) {
       res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -92,11 +101,11 @@ function ensureServer(): void {
       return;
     }
 
-    const adapterName = match[1];
-    const entry = routes.get(adapterName);
+    const route = match[1];
+    const entry = routes.get(route);
     if (!entry) {
       res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end(`Unknown adapter: ${adapterName}`);
+      res.end(`Unknown route: ${route}`);
       return;
     }
 
@@ -112,14 +121,14 @@ function ensureServer(): void {
       });
       await fromWebResponse(webRes, res);
     } catch (err) {
-      log.error('Webhook handler error', { adapter: adapterName, url: req.url, err });
+      log.error('Webhook handler error', { route, adapter: entry.adapterName, url: req.url, err });
       res.writeHead(500, { 'Content-Type': 'text/plain' });
       res.end('Internal Server Error');
     }
   });
 
   server.listen(port, '0.0.0.0', () => {
-    log.info('Webhook server started', { port, adapters: [...routes.keys()] });
+    log.info('Webhook server started', { port, routes: [...routes.keys()] });
   });
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Two additive optional config knobs that remove the implicit coupling between webhook route, Chat SDK adapter name, and registry channelType:

- `ChatSdkBridgeConfig.channelType?: string` — when set, overrides the bridge's effective `.name`, `.channelType`, and webhook route. Defaults to `adapter.name` (current behavior).
- `registerWebhookAdapter(chat, adapterName, routingPath?)` — optional 3rd parameter. When set, the route URL becomes `/webhook/<routingPath>`; `chat.webhooks[adapterName]` lookup is unchanged.

### Why

`channel-registry.ts` keys live adapters by `adapter.channelType`; `chat-sdk-bridge.ts` hardcodes the webhook route to `adapter.name`. Two bridges sharing the same Chat SDK adapter type silently collide on both — the second registration overwrites the first in the registry, and both registrations target the same `/webhook/<adapter.name>` URL.

Removing the coupling unblocks any channel module that needs N bridges of the same Chat SDK adapter type on one host. #1804 documents the gap for multi-workspace Slack; the same primitive applies to multi-bot Teams and any future channel with the same shape.

### How

Both fields default to current behavior. The only call site of `registerWebhookAdapter` is inside `chat-sdk-bridge.ts`; all existing channel consumers of `createChatSdkBridge` continue to work identically. No semantic changes for single-instance channels.

Shape matches the prototype proposed on #1804 at https://github.com/davekim917/nanoclaw/commit/33274a91019216360648d56cdc0072658c5693a7 — adopting it verbatim so a single primitive landing unblocks Slack, Teams, and any other channel adopting the same pattern.

### How it was tested

- `pnpm test` — 339/339 pass, including 7 new tests:
  - `src/channels/chat-sdk-bridge.test.ts` — default behavior, override behavior, two bridges with distinct overrides.
  - `src/webhook-server.test.ts` — default routing, override routing with handler-lookup invariant, collision avoidance between bridges sharing an `adapterName` under distinct `routingPath`s, 404 for unregistered routes.
- `pnpm run typecheck` — clean.
- `pnpm run lint` — no new errors or warnings introduced (the pre-existing errors/warnings on `main` are unchanged).

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

Refs #1804.