### PR TITLE
feat(health): restore /health endpoint (port from v1)

### DIFF
--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -118,6 +118,11 @@ export function startSweepDeliveryPoll(): void {
   pollSweep();
 }
 
+/** Whether both delivery polls are currently enabled. Read by the health snapshot. */
+export function getDeliveryPollsRunning(): boolean {
+  return activePolling && sweepPolling;
+}
+
 async function pollActive(): Promise<void> {
   if (!activePolling) return;
 

--- a/src/health-server.test.ts
+++ b/src/health-server.test.ts
@@ -1,0 +1,100 @@
+import http from 'http';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import type { HealthData } from './health.js';
+import { startHealthServer } from './health-server.js';
+
+const healthyData: HealthData = {
+  uptimeSeconds: 3600,
+  channels: [{ name: 'whatsapp', connected: true }],
+  messageLoopRunning: true,
+  queue: { active: 1, max: 5, waiting: 0 },
+  registeredGroupCount: 4,
+  activeSessionCount: 2,
+  lastMessageTimestamp: '2026-05-22T10:00:00Z',
+  lastMessageAge: '5m ago',
+  tasks: {
+    activeCount: 3,
+    pausedCount: 1,
+    nextRunTime: '2026-05-22T10:10:00Z',
+    recentFailures: 0,
+  },
+  healthy: true,
+};
+
+const unhealthyData: HealthData = {
+  ...healthyData,
+  channels: [{ name: 'whatsapp', connected: false }],
+  healthy: false,
+};
+
+function fetch(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+async function listenOnEphemeralPort(getter: () => HealthData): Promise<http.Server> {
+  const server = startHealthServer(0, getter);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  return server;
+}
+
+describe('health-server', () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('returns 200 with JSON when healthy', async () => {
+    server = await listenOnEphemeralPort(() => healthyData);
+    const port = (server.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.healthy).toBe(true);
+    expect(data.uptimeSeconds).toBe(3600);
+    expect(data.channels).toHaveLength(1);
+  });
+
+  it('returns 503 when unhealthy', async () => {
+    server = await listenOnEphemeralPort(() => unhealthyData);
+    const port = (server.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(503);
+    const data = JSON.parse(res.body);
+    expect(data.healthy).toBe(false);
+  });
+
+  it('returns 404 for other paths', async () => {
+    server = await listenOnEphemeralPort(() => healthyData);
+    const port = (server.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/other`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when health provider throws', async () => {
+    server = await listenOnEphemeralPort(() => {
+      throw new Error('broken');
+    });
+    const port = (server.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(res.status).toBe(500);
+    const data = JSON.parse(res.body);
+    expect(data.error).toBe('broken');
+  });
+});

--- a/src/health-server.ts
+++ b/src/health-server.ts
@@ -1,0 +1,40 @@
+/**
+ * HTTP `/health` endpoint.
+ *
+ * Ported from v1 (`src/health-server.ts`). Binds 127.0.0.1 only — the
+ * webhook server on 0.0.0.0:3000 is what's exposed via Funnel; `/health`
+ * stays loopback (probes + `/status` command, no public surface).
+ */
+import http from 'http';
+
+import type { HealthData } from './health.js';
+import { log } from './log.js';
+
+export function startHealthServer(port: number, getHealth: () => HealthData): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      try {
+        const data = getHealth();
+        const status = data.healthy ? 200 : 503;
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }
+    } else {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    }
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    log.info('Health server listening', { port });
+  });
+
+  return server;
+}

--- a/src/health-snapshot.ts
+++ b/src/health-snapshot.ts
@@ -1,0 +1,102 @@
+/**
+ * Composes a fresh HealthData snapshot from runtime state.
+ *
+ * Extracted from `src/index.ts` so host-side commands can call it without
+ * pulling the entry-point module into their import graph. The pure assembly
+ * lives in `health.ts` (`collectHealth`); this module supplies the I/O
+ * (channel registry, delivery loops, DB, per-session inbound DBs).
+ */
+import { MAX_CONCURRENT_CONTAINERS } from './config.js';
+import { getDb } from './db/connection.js';
+import { getDeliveryPollsRunning } from './delivery.js';
+import { isHostSweepRunning } from './host-sweep.js';
+import { collectHealth, type HealthData } from './health.js';
+import { getActiveContainerCount } from './container-runner.js';
+import { getAllAgentGroups } from './db/agent-groups.js';
+import { getActiveSessions } from './db/sessions.js';
+import { openInboundDb } from './session-manager.js';
+import { getActiveAdapters } from './channels/channel-registry.js';
+import { log } from './log.js';
+
+export function snapshotHealth(): HealthData {
+  const adapters = getActiveAdapters();
+
+  // SQLite's MAX(last_active) is stored timezoneless; append 'Z' so formatAge
+  // reads it as UTC. Empty string when no sessions exist yet.
+  let lastMessageTimestamp = '';
+  try {
+    const row = getDb().prepare('SELECT MAX(last_active) AS m FROM sessions').get() as { m: string | null };
+    if (row.m) {
+      const isoish = row.m.includes('T') ? row.m : row.m.replace(' ', 'T');
+      const withZ = /[zZ]|[+-]\d{2}:?\d{2}$/.test(isoish) ? isoish : isoish + 'Z';
+      lastMessageTimestamp = withZ;
+    }
+  } catch (err) {
+    log.warn('Failed to read sessions.last_active for health snapshot', { err });
+  }
+
+  // Walk active session inbound DBs once for task counts. Activated/paused/
+  // failed live as `messages_in` rows with kind='task'; v2 has no central
+  // task table.
+  let activeTasks = 0;
+  let pausedTasks = 0;
+  let recentTaskFailures = 0;
+  let nextTaskRunTime: string | null = null;
+
+  for (const session of getActiveSessions()) {
+    let inDb;
+    try {
+      inDb = openInboundDb(session.agent_group_id, session.id);
+    } catch {
+      continue;
+    }
+    try {
+      const counts = inDb
+        .prepare(
+          `SELECT
+             SUM(CASE WHEN kind = 'task' AND status = 'pending' THEN 1 ELSE 0 END) AS active,
+             SUM(CASE WHEN kind = 'task' AND status = 'paused' THEN 1 ELSE 0 END) AS paused,
+             SUM(CASE WHEN kind = 'task' AND status = 'failed'
+                       AND timestamp >= datetime('now', '-1 day') THEN 1 ELSE 0 END) AS failures
+           FROM messages_in`,
+        )
+        .get() as { active: number | null; paused: number | null; failures: number | null };
+      activeTasks += counts.active ?? 0;
+      pausedTasks += counts.paused ?? 0;
+      recentTaskFailures += counts.failures ?? 0;
+
+      const nextRow = inDb
+        .prepare(
+          `SELECT MIN(process_after) AS next FROM messages_in
+           WHERE kind = 'task' AND status = 'pending' AND process_after IS NOT NULL`,
+        )
+        .get() as { next: string | null };
+      if (nextRow.next) {
+        const isoish = nextRow.next.includes('T') ? nextRow.next : nextRow.next.replace(' ', 'T');
+        const withZ = /[zZ]|[+-]\d{2}:?\d{2}$/.test(isoish) ? isoish : isoish + 'Z';
+        if (!nextTaskRunTime || withZ < nextTaskRunTime) {
+          nextTaskRunTime = withZ;
+        }
+      }
+    } catch (err) {
+      log.warn('Failed to read task counts for health snapshot', { sessionId: session.id, err });
+    } finally {
+      inDb.close();
+    }
+  }
+
+  return collectHealth({
+    channels: adapters.map((a) => ({ name: a.channelType, isConnected: () => a.isConnected() })),
+    messageLoopRunning: getDeliveryPollsRunning() && isHostSweepRunning(),
+    queueActiveCount: getActiveContainerCount(),
+    queueWaitingCount: 0,
+    maxConcurrentContainers: MAX_CONCURRENT_CONTAINERS,
+    registeredGroupCount: getAllAgentGroups().length,
+    activeSessionCount: getActiveSessions().length,
+    lastMessageTimestamp,
+    activeTasks,
+    pausedTasks,
+    nextTaskRunTime,
+    recentTaskFailures,
+  });
+}

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+
+import { collectHealth, formatAge, formatHealthText, type HealthDeps } from './health.js';
+
+function makeDeps(overrides: Partial<HealthDeps> = {}): HealthDeps {
+  return {
+    channels: [
+      { name: 'whatsapp', isConnected: () => true },
+      { name: 'slack', isConnected: () => true },
+    ],
+    messageLoopRunning: true,
+    queueActiveCount: 1,
+    queueWaitingCount: 0,
+    maxConcurrentContainers: 5,
+    registeredGroupCount: 4,
+    activeSessionCount: 2,
+    lastMessageTimestamp: new Date(Date.now() - 120_000).toISOString(),
+    activeTasks: 3,
+    pausedTasks: 1,
+    nextTaskRunTime: new Date(Date.now() + 600_000).toISOString(),
+    recentTaskFailures: 0,
+    ...overrides,
+  };
+}
+
+describe('formatAge', () => {
+  it('returns "never" for empty string', () => {
+    expect(formatAge('')).toBe('never');
+  });
+
+  it('returns "unknown" for invalid date', () => {
+    expect(formatAge('not-a-date')).toBe('unknown');
+  });
+
+  it('returns seconds for recent timestamps', () => {
+    const ts = new Date(Date.now() - 30_000).toISOString();
+    expect(formatAge(ts)).toBe('30s ago');
+  });
+
+  it('returns minutes for timestamps a few minutes old', () => {
+    const ts = new Date(Date.now() - 180_000).toISOString();
+    expect(formatAge(ts)).toBe('3m ago');
+  });
+
+  it('returns hours for timestamps hours old', () => {
+    const ts = new Date(Date.now() - 7_200_000).toISOString();
+    expect(formatAge(ts)).toBe('2h ago');
+  });
+
+  it('returns days for timestamps days old', () => {
+    const ts = new Date(Date.now() - 172_800_000).toISOString();
+    expect(formatAge(ts)).toBe('2d ago');
+  });
+
+  it('returns "in the future" for future timestamps', () => {
+    const ts = new Date(Date.now() + 60_000).toISOString();
+    expect(formatAge(ts)).toBe('in the future');
+  });
+});
+
+describe('collectHealth', () => {
+  it('reports healthy when all channels connected and loop running', () => {
+    const data = collectHealth(makeDeps());
+    expect(data.healthy).toBe(true);
+    expect(data.messageLoopRunning).toBe(true);
+    expect(data.channels).toHaveLength(2);
+    expect(data.channels[0]).toEqual({ name: 'whatsapp', connected: true });
+  });
+
+  it('reports unhealthy when a channel is disconnected', () => {
+    const data = collectHealth(
+      makeDeps({
+        channels: [
+          { name: 'whatsapp', isConnected: () => true },
+          { name: 'slack', isConnected: () => false },
+        ],
+      }),
+    );
+    expect(data.healthy).toBe(false);
+    expect(data.channels[1].connected).toBe(false);
+  });
+
+  it('reports unhealthy when message loop is stopped', () => {
+    const data = collectHealth(makeDeps({ messageLoopRunning: false }));
+    expect(data.healthy).toBe(false);
+  });
+
+  it('reports unhealthy when no channels exist', () => {
+    const data = collectHealth(makeDeps({ channels: [] }));
+    expect(data.healthy).toBe(false);
+  });
+
+  it('includes queue state', () => {
+    const data = collectHealth(makeDeps({ queueActiveCount: 3, queueWaitingCount: 2 }));
+    expect(data.queue).toEqual({ active: 3, max: 5, waiting: 2 });
+  });
+
+  it('includes task health', () => {
+    const data = collectHealth(makeDeps({ activeTasks: 5, pausedTasks: 2, recentTaskFailures: 1 }));
+    expect(data.tasks.activeCount).toBe(5);
+    expect(data.tasks.pausedCount).toBe(2);
+    expect(data.tasks.recentFailures).toBe(1);
+  });
+
+  it('includes uptime from process.uptime()', () => {
+    const data = collectHealth(makeDeps());
+    expect(data.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it('formats last message age', () => {
+    const data = collectHealth(
+      makeDeps({
+        lastMessageTimestamp: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    );
+    expect(data.lastMessageAge).toBe('2m ago');
+  });
+
+  it('handles empty last message timestamp', () => {
+    const data = collectHealth(makeDeps({ lastMessageTimestamp: '' }));
+    expect(data.lastMessageAge).toBe('never');
+  });
+});
+
+describe('formatHealthText', () => {
+  it('produces expected sections', () => {
+    const data = collectHealth(makeDeps());
+    const text = formatHealthText(data);
+
+    expect(text).toContain('*NanoClaw Status*');
+    expect(text).toContain('Message loop: running');
+    expect(text).toContain('*Channels*');
+    expect(text).toContain('whatsapp: connected');
+    expect(text).toContain('slack: connected');
+    expect(text).toContain('*Containers*');
+    expect(text).toContain('Active: 1/5');
+    expect(text).toContain('*Groups & Sessions*');
+    expect(text).toContain('Registered: 4');
+    expect(text).toContain('Sessions: 2');
+    expect(text).toContain('*Message Cursor*');
+    expect(text).toContain('*Scheduled Tasks*');
+    expect(text).toContain('Active: 3 | Paused: 1');
+    expect(text).toContain('Failures (24h): 0');
+  });
+
+  it('shows STOPPED when message loop is down', () => {
+    const data = collectHealth(makeDeps({ messageLoopRunning: false }));
+    const text = formatHealthText(data);
+    expect(text).toContain('Message loop: STOPPED');
+  });
+
+  it('shows DISCONNECTED for offline channels', () => {
+    const data = collectHealth(
+      makeDeps({
+        channels: [{ name: 'telegram', isConnected: () => false }],
+      }),
+    );
+    const text = formatHealthText(data);
+    expect(text).toContain('telegram: DISCONNECTED');
+  });
+
+  it('shows "(none connected)" when no channels', () => {
+    const data = collectHealth(makeDeps({ channels: [] }));
+    const text = formatHealthText(data);
+    expect(text).toContain('(none connected)');
+  });
+
+  it('shows "never" when no messages processed', () => {
+    const data = collectHealth(makeDeps({ lastMessageTimestamp: '' }));
+    const text = formatHealthText(data);
+    expect(text).toContain('Last: never');
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,170 @@
+/**
+ * Health snapshot — pure-function collector + formatters.
+ *
+ * Ported from v1 (`src/health.ts`). Same shape, same formatters; the data
+ * sources differ (v2's split modules instead of v1's monolithic state).
+ * Call sites build a HealthDeps and pass it to collectHealth — the function
+ * itself has no I/O so it's trivially testable.
+ */
+
+export interface ChannelHealth {
+  name: string;
+  connected: boolean;
+}
+
+export interface QueueHealth {
+  active: number;
+  max: number;
+  waiting: number;
+}
+
+export interface TaskHealth {
+  activeCount: number;
+  pausedCount: number;
+  nextRunTime: string | null;
+  recentFailures: number;
+}
+
+export interface HealthData {
+  uptimeSeconds: number;
+  channels: ChannelHealth[];
+  messageLoopRunning: boolean;
+  queue: QueueHealth;
+  registeredGroupCount: number;
+  activeSessionCount: number;
+  lastMessageTimestamp: string;
+  lastMessageAge: string;
+  tasks: TaskHealth;
+  healthy: boolean;
+}
+
+export interface HealthDeps {
+  channels: Array<{ name: string; isConnected(): boolean }>;
+  /**
+   * v2's "message loop" equivalent — all polling loops running. The composer
+   * sets this to (active delivery poll) && (sweep delivery poll) && (host
+   * sweep). v1 had a single message loop; v2 has three cooperating loops, so
+   * "all three on" is the right boolean.
+   */
+  messageLoopRunning: boolean;
+  queueActiveCount: number;
+  queueWaitingCount: number;
+  maxConcurrentContainers: number;
+  registeredGroupCount: number;
+  activeSessionCount: number;
+  lastMessageTimestamp: string;
+  activeTasks: number;
+  pausedTasks: number;
+  nextTaskRunTime: string | null;
+  recentTaskFailures: number;
+}
+
+export function formatAge(isoTimestamp: string): string {
+  if (!isoTimestamp) return 'never';
+
+  const then = new Date(isoTimestamp).getTime();
+  if (isNaN(then)) return 'unknown';
+
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return 'in the future';
+
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function collectHealth(deps: HealthDeps): HealthData {
+  const allChannelsConnected = deps.channels.length > 0 && deps.channels.every((ch) => ch.isConnected());
+
+  const healthy = allChannelsConnected && deps.messageLoopRunning;
+
+  return {
+    uptimeSeconds: Math.floor(process.uptime()),
+    channels: deps.channels.map((ch) => ({
+      name: ch.name,
+      connected: ch.isConnected(),
+    })),
+    messageLoopRunning: deps.messageLoopRunning,
+    queue: {
+      active: deps.queueActiveCount,
+      max: deps.maxConcurrentContainers,
+      waiting: deps.queueWaitingCount,
+    },
+    registeredGroupCount: deps.registeredGroupCount,
+    activeSessionCount: deps.activeSessionCount,
+    lastMessageTimestamp: deps.lastMessageTimestamp,
+    lastMessageAge: formatAge(deps.lastMessageTimestamp),
+    tasks: {
+      activeCount: deps.activeTasks,
+      pausedCount: deps.pausedTasks,
+      nextRunTime: deps.nextTaskRunTime,
+      recentFailures: deps.recentTaskFailures,
+    },
+    healthy,
+  };
+}
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(' ');
+}
+
+export function formatHealthText(data: HealthData): string {
+  const lines: string[] = [];
+
+  lines.push('*NanoClaw Status*');
+  lines.push('');
+  lines.push(`Uptime: ${formatUptime(data.uptimeSeconds)}`);
+  lines.push(`Message loop: ${data.messageLoopRunning ? 'running' : 'STOPPED'}`);
+  lines.push('');
+
+  lines.push('*Channels*');
+  if (data.channels.length === 0) {
+    lines.push('  (none connected)');
+  } else {
+    for (const ch of data.channels) {
+      lines.push(`  ${ch.name}: ${ch.connected ? 'connected' : 'DISCONNECTED'}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('*Containers*');
+  lines.push(`  Active: ${data.queue.active}/${data.queue.max} | Waiting: ${data.queue.waiting}`);
+  lines.push('');
+
+  lines.push('*Groups & Sessions*');
+  lines.push(`  Registered: ${data.registeredGroupCount} | Sessions: ${data.activeSessionCount}`);
+  lines.push('');
+
+  lines.push('*Message Cursor*');
+  if (data.lastMessageTimestamp) {
+    lines.push(`  Last: ${data.lastMessageAge} (${data.lastMessageTimestamp})`);
+  } else {
+    lines.push('  Last: never');
+  }
+  lines.push('');
+
+  lines.push('*Scheduled Tasks*');
+  lines.push(`  Active: ${data.tasks.activeCount} | Paused: ${data.tasks.pausedCount}`);
+  if (data.tasks.nextRunTime) {
+    lines.push(`  Next run: ${formatAge(data.tasks.nextRunTime).replace(' ago', '')}`);
+  }
+  lines.push(`  Failures (24h): ${data.tasks.recentFailures}`);
+
+  return lines.join('\n');
+}

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -129,6 +129,11 @@ export function stopHostSweep(): void {
   running = false;
 }
 
+/** Whether the host sweep loop is currently enabled. Read by the health snapshot. */
+export function isHostSweepRunning(): boolean {
+  return running;
+}
+
 async function sweep(): Promise<void> {
   if (!running) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
+import http from 'http';
 import path from 'path';
 
 import { backfillContainerConfigs } from './backfill-container-configs.js';
@@ -17,6 +18,8 @@ import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, st
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
+import { snapshotHealth } from './health-snapshot.js';
+import { startHealthServer } from './health-server.js';
 
 // Response + shutdown registries live in response-registry.ts to break the
 // circular import cycle: src/index.ts imports src/modules/index.js for side
@@ -45,6 +48,9 @@ async function dispatchResponse(payload: ResponsePayload): Promise<void> {
   }
   log.warn('Unclaimed response', { questionId: payload.questionId, value: payload.value });
 }
+
+let healthServer: http.Server | null = null;
+const DEFAULT_HEALTH_PORT = 3002;
 
 // Channel barrel — each enabled channel self-registers on import.
 // Channel skills uncomment lines in channels/index.ts to enable them.
@@ -177,12 +183,20 @@ async function main(): Promise<void> {
   // 7. Start the `ncl` CLI socket server (data/ncl.sock).
   await startCliServer();
 
+  // 8. Start the /health HTTP endpoint (loopback only).
+  const healthPort = parseInt(process.env.HEALTH_PORT || String(DEFAULT_HEALTH_PORT), 10);
+  healthServer = startHealthServer(healthPort, snapshotHealth);
+
   log.info('NanoClaw running');
 }
 
 /** Graceful shutdown. */
 async function shutdown(signal: string): Promise<void> {
   log.info('Shutdown signal received', { signal });
+  if (healthServer) {
+    await new Promise<void>((resolve) => healthServer!.close(() => resolve()));
+    healthServer = null;
+  }
   for (const cb of getShutdownCallbacks()) {
     try {
       await cb();


### PR DESCRIPTION
## Summary

Restores v1's `/health` endpoint that was dropped in the v2 rewrite. Loopback-only HTTP probe — no public surface — composing channel/queue/task/cursor-age status from existing runtime state. Production-hardened on my fork (multi-hour uptime). Closer to a regression fix than a new feature.

## What's in the PR

**New host modules:**

- `src/health.ts` — pure-function snapshot composer (`collectHealth`) plus a text formatter (`formatHealthText`) that's useful for any host-side status command. Takes injected dependencies (`HealthDeps`) so the pure-assembly half is trivially unit-testable.
- `src/health-snapshot.ts` — supplies the runtime I/O (channel registry, delivery/sweep loop state, central DB, per-session inbound DBs) and hands it to `collectHealth`. v2 has no central task table, so it walks each active session's `inbound.db` once per request, counting `kind='task'` rows for active/paused/recent-failures and minimum `process_after` for the next scheduled run. Trivially fast at single-digit session counts.
- `src/health-server.ts` — `http.createServer` bound to `127.0.0.1`. Returns 200/503 from `snapshot.healthy`, no caching. Port from `HEALTH_PORT` env var, default `3002`.

**Modified host modules (additive only):**

- `src/index.ts` — wires `startHealthServer(port, snapshotHealth)` after the CLI socket server in `main()` and tears it down at the top of `shutdown()`. No other lifecycle changes.
- `src/host-sweep.ts` — adds `isHostSweepRunning(): boolean` (5 LOC). Pure accessor for the existing `running` module flag, read by the snapshot so it can report `messageLoopRunning` honestly.
- `src/delivery.ts` — adds `getDeliveryPollsRunning(): boolean` (5 LOC). Pure accessor for the existing `activePolling && sweepPolling` flags.

## Why loopback-only

The webhook server on `0.0.0.0:3000` is the only externally reachable surface; `/health` is for local probes (process supervisor, systemd, future host-side status commands) and intentionally never public. Binding `127.0.0.1` makes that explicit at the kernel level rather than relying on documentation.

## Stats

```
 src/delivery.ts           |   5 ++
 src/health-server.test.ts | 100 +++++++++++++++++++++++++++
 src/health-server.ts      |  40 +++++++++++
 src/health-snapshot.ts    | 102 +++++++++++++++++++++++++++
 src/health.test.ts        | 173 ++++++++++++++++++++++++++++++++++++++++++++++
 src/health.ts             | 170 +++++++++++++++++++++++++++++++++++++++++++++
 src/host-sweep.ts         |   5 ++
 src/index.ts              |  14 ++++
 8 files changed, 609 insertions(+)
```

## Tests

- 21 tests in `src/health.test.ts` (snapshot composition, age formatter, text formatter, edge cases)
- 4 tests in `src/health-server.test.ts` (200 OK, 503 unhealthy, 404 non-`/health`, 500 on snapshot throw)
- Full host suite: **34 test files, 357 tests, all passing** on this branch
- `pnpm exec tsc --noEmit`: clean

## Paired-but-not-included: systemd watchdog

On my fork this commit was bundled with a `src/watchdog.ts` module that sends `sd_notify` `READY=1` / `WATCHDOG=1` / `STOPPING=1`, and a `setup/service.ts` change adding `Type=notify` + `WatchdogSec=30s` to the systemd unit. I'm **deliberately not** upstreaming that half:

- The watchdog is a no-op without the unit-file change.
- The unit-file change would push every installer onto systemd-notify semantics whether or not they're on systemd in the first place.

Whether to add `sd_notify` support is a separate design decision — it should land (or not) as its own PR with the unit-file change attached.