### PR TITLE
fix(container-runner): self-heal missing image before spawn

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -3,7 +3,7 @@
  * Spawns agent containers with session folder + agent group folder mounts.
  * The container runs the v2 agent-runner which polls the session DB.
  */
-import { ChildProcess, execSync, spawn } from 'child_process';
+import { ChildProcess, execSync, spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -22,7 +22,13 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  imageExists,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -61,6 +67,13 @@ const activeContainers = new Map<string, { process: ChildProcess; containerName:
  * racy double-replies.
  */
 const wakePromises = new Map<string, Promise<boolean>>();
+
+/**
+ * In-flight image rebuilds, keyed by tag. When multiple sessions wake
+ * concurrently after an external prune (e.g. Dokploy's daily cleanup), they
+ * all detect the same missing image — we want one shared rebuild, not N races.
+ */
+const imageRebuildLocks = new Map<string, Promise<void>>();
 
 export function getActiveContainerCount(): number {
   return activeContainers.size;
@@ -125,6 +138,14 @@ async function spawnContainer(session: Session): Promise<void> {
   // the config object, threaded through provider resolution, buildMounts,
   // and buildContainerArgs so we don't re-read.
   const containerConfig = materializeContainerJson(agentGroup.id);
+
+  // Self-heal if the image was deleted out from under us by an external
+  // tool. `docker run` with a missing tag would otherwise exit 125 every
+  // poll forever. `imageExists` is ~10ms when the image is present.
+  const imageTag = containerConfig.imageTag || CONTAINER_IMAGE;
+  if (!imageExists(imageTag)) {
+    await ensureImage(imageTag, agentGroup.id);
+  }
 
   // Resolve the effective provider + any host-side contribution it declares
   // (extra mounts, env passthrough). Computed once and threaded through both
@@ -462,6 +483,44 @@ async function buildContainerArgs(
   args.push('-c', 'exec bun run /app/src/index.ts');
 
   return args;
+}
+
+/**
+ * Rebuild a missing image, deduping concurrent callers via `imageRebuildLocks`.
+ * Per-group images FROM CONTAINER_IMAGE — if both are missing, base goes first.
+ */
+async function ensureImage(tag: string, agentGroupId: string): Promise<void> {
+  const existing = imageRebuildLocks.get(tag);
+  if (existing) return existing;
+  const promise = rebuildImage(tag, agentGroupId).finally(() => {
+    imageRebuildLocks.delete(tag);
+  });
+  imageRebuildLocks.set(tag, promise);
+  return promise;
+}
+
+async function rebuildImage(tag: string, agentGroupId: string): Promise<void> {
+  if (tag !== CONTAINER_IMAGE && !imageExists(CONTAINER_IMAGE)) {
+    await ensureImage(CONTAINER_IMAGE, agentGroupId);
+  }
+  if (tag === CONTAINER_IMAGE) {
+    log.warn('Base container image missing — running container/build.sh', { tag });
+    const projectRoot = path.dirname(DATA_DIR);
+    const result = spawnSync('bash', [path.join(projectRoot, 'container', 'build.sh')], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      timeout: 1_800_000,
+    });
+    if (result.status !== 0) {
+      const stderr = result.stderr?.toString() || '';
+      const stdout = result.stdout?.toString() || '';
+      throw new Error(`container/build.sh failed:\n${stderr || stdout}`);
+    }
+    log.info('Base container image rebuilt', { tag });
+    return;
+  }
+  log.warn('Per-group container image missing — rebuilding', { tag, agentGroupId });
+  await buildAgentGroupImage(agentGroupId);
 }
 
 /** Build a per-agent-group Docker image with custom packages. */

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import os from 'os';
 
 import { CONTAINER_INSTALL_LABEL } from './config.js';
@@ -23,6 +23,23 @@ export function hostGatewayArgs(): string[] {
 /** Returns CLI args for a readonly bind mount. */
 export function readonlyMountArgs(hostPath: string, containerPath: string): string[] {
   return ['-v', `${hostPath}:${containerPath}:ro`];
+}
+
+/**
+ * Check if a container image is present locally. Returns false on any failure
+ * — missing image, runtime not running, timeout. Cheap (~10ms when present).
+ *
+ * Used by the spawn path to self-heal when an external tool (e.g. Dokploy's
+ * "Daily Docker Cleanup", a stray `docker system prune -a`) deletes the
+ * agent image out from under us. Without this check the host crash-loops
+ * with code=125 until somebody re-runs `container/build.sh`.
+ */
+export function imageExists(tag: string): boolean {
+  const result = spawnSync(CONTAINER_RUNTIME_BIN, ['image', 'inspect', tag], {
+    stdio: 'pipe',
+    timeout: 10_000,
+  });
+  return result.status === 0;
 }
 
 /** Stop a container by name. Uses execFileSync to avoid shell injection. */


### PR DESCRIPTION
## What

Adds a `docker image inspect` check at the start of `spawnContainer`. When the agent image is missing, the host rebuilds it before issuing `docker run` instead of crash-looping.

## Why

Anyone running NanoClaw alongside [Dokploy](https://dokploy.com/) hits this — Dokploy ships with **"Daily Docker Cleanup" enabled by default** (Settings → Server). The cleanup runs, among others:

```
docker image prune --all --force
docker system prune --all --force
```

Both reap any tagged image whose containers aren't currently running. NanoClaw containers are `--rm` and short-lived, so the agent image is almost always evictable at cleanup time. Result: after Dokploy's nightly run, every wake exits with `code=125` (`Unable to find image '<tag>' locally`) and the host crash-loops forever until someone manually re-runs `container/build.sh`.

Same hazard for users who run `docker system prune -a` manually, have a separate cron, or hit Docker Desktop's disk-pressure GC.

Related: #2378 / #2379 already track "container image is a fragile assumption the host doesn't defend against" — this patch addresses both for the missing-image case.

## How it works

- `src/container-runtime.ts` — new `imageExists(tag)` helper using `docker image inspect`.
- `src/container-runner.ts`:
  - `ensureImage(tag, agentGroupId)` — per-tag mutex via `imageRebuildLocks` so concurrent wakes share one build.
  - `rebuildImage` — base image via `container/build.sh`, per-group via existing `buildAgentGroupImage`. If both are missing, base goes first.
  - One-line check in `spawnContainer` right after `containerConfig` is materialized.

Common case (image present): one extra `image inspect` per spawn (~10ms).
Missing case: synchronous rebuild, then spawn proceeds.

## How it was tested

End-to-end on macOS Docker Desktop with a real Dokploy-style prune:

1. Confirmed image present, host healthy
2. `docker rmi <agent-image>` to simulate Dokploy's cleanup
3. Sent a test iMessage
4. Logs:
   ```
   01:01:30.588  Base container image rebuilt
   01:01:30.624  Spawning container
   ...
   01:02:43.094  Message delivered
   ```

Build clean (`pnpm run build`), tests pass (`pnpm test` — 328/328).

## Known interaction (not caused by this patch)

The first spawn after rebuild was killed by host-sweep's `claim-stuck` check 5ms after spawn — because an orphan `processing_ack` claim from the previous (`code=125`-looping) container had been aging for 72s. Next sweep tick spawned cleanly and the message landed. This is a **pre-existing** bug: the host-sweep should treat a fresh spawn as a "reset" event for stale claims, but doesn't. The synchronous rebuild here just widens the window where it manifests.

Filing a separate issue for the host-sweep refinement — not in scope for this PR.

---

_— tenazas, here. lived this one front to back and reviewed the patch on the way through._
