### PR TITLE
fix(signal): replace silent restartService failure with explicit error

### DIFF
--- a/setup/channels/__tests__/signal.test.ts
+++ b/setup/channels/__tests__/signal.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for setup/channels/signal.ts:restartService — the bug surfaced in
+ * issue #2583. The previous implementation called `launchctl kickstart -k`
+ * with `stdio: 'ignore'`, ignored the exit code, then slept 5s and reported
+ * "NanoClaw restarted." When the plist had been unloaded (e.g. by
+ * setup/peer-cleanup.ts), kickstart silently no-op'd and the next step
+ * failed with a confusing `connect ENOENT data/cli.sock`.
+ *
+ * These tests verify the new probe-first behavior:
+ *   - When the service is loaded → use `kickstart -k`.
+ *   - When the service is unloaded → use `launchctl bootstrap`.
+ *   - When the socket never appears → throw a meaningful error.
+ *   - When `kickstart` / `bootstrap` returns non-zero → throw, not silent success.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock child_process.spawnSync so we can drive launchctl exit codes.
+const spawnSyncMock = vi.fn();
+vi.mock('child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+// Mock fs so we can control whether data/cli.sock appears.
+const statSyncMock = vi.fn();
+const existsSyncMock = vi.fn();
+vi.mock('fs', () => ({
+  default: {
+    statSync: (...args: unknown[]) => statSyncMock(...args),
+    existsSync: (...args: unknown[]) => existsSyncMock(...args),
+    // Stubbed but not exercised by restartService tests.
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    copyFileSync: vi.fn(),
+  },
+  statSync: (...args: unknown[]) => statSyncMock(...args),
+  existsSync: (...args: unknown[]) => existsSyncMock(...args),
+}));
+
+// Silence @clack/prompts spinner output during tests.
+vi.mock('@clack/prompts', () => ({
+  spinner: () => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+// Silence the setup log module.
+vi.mock('../../logs.js', () => ({
+  step: vi.fn(),
+  userInput: vi.fn(),
+  stepRawLog: vi.fn(() => '/tmp/raw.log'),
+}));
+
+// Use a fixed launchd label so we can match arguments exactly.
+vi.mock('../../../src/install-slug.js', () => ({
+  getLaunchdLabel: () => 'com.nanoclaw-v2-deadbeef',
+  getSystemdUnit: () => 'nanoclaw-v2-deadbeef',
+}));
+
+// Import AFTER mocks so the SUT sees the mocked modules.
+const { restartService, probeLaunchdLoaded } = await import('../signal.js');
+
+const ORIGINAL_PLATFORM = process.platform;
+
+function setDarwin(): void {
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+    configurable: true,
+  });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, 'platform', {
+    value: ORIGINAL_PLATFORM,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  statSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  setDarwin();
+  // getuid → 501 by default on darwin in real life; pin it so tests are deterministic.
+  Object.defineProperty(process, 'getuid', {
+    value: () => 501,
+    configurable: true,
+  });
+});
+
+describe('probeLaunchdLoaded', () => {
+  it('returns true when launchctl print exits 0', () => {
+    spawnSyncMock.mockReturnValue({ status: 0, error: undefined });
+    expect(probeLaunchdLoaded('gui/501/com.nanoclaw-v2-deadbeef')).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'launchctl',
+      ['print', 'gui/501/com.nanoclaw-v2-deadbeef'],
+      { stdio: 'ignore' },
+    );
+  });
+
+  it('returns false when launchctl print exits non-zero', () => {
+    spawnSyncMock.mockReturnValue({ status: 1, error: undefined });
+    expect(probeLaunchdLoaded('gui/501/com.nanoclaw-v2-deadbeef')).toBe(false);
+  });
+
+  it('returns false when spawnSync errors', () => {
+    spawnSyncMock.mockReturnValue({ status: null, error: new Error('ENOENT') });
+    expect(probeLaunchdLoaded('gui/501/com.nanoclaw-v2-deadbeef')).toBe(false);
+  });
+});
+
+describe('restartService — darwin', () => {
+  it('uses kickstart -k when the service is already loaded', async () => {
+    // 1st spawnSync = probe (loaded), 2nd = kickstart (success).
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, error: undefined }) // probe
+      .mockReturnValueOnce({ status: 0, error: undefined }); // kickstart
+    statSyncMock.mockReturnValue({} as never); // socket exists immediately
+
+    await restartService();
+
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      1,
+      'launchctl',
+      ['print', 'gui/501/com.nanoclaw-v2-deadbeef'],
+      { stdio: 'ignore' },
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'launchctl',
+      ['kickstart', '-k', 'gui/501/com.nanoclaw-v2-deadbeef'],
+      { stdio: 'ignore' },
+    );
+  });
+
+  it('bootstraps when the service is unloaded — this is the #2583 fix', async () => {
+    // probe → not loaded; existsSync(plist) → true; bootstrap → success.
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, error: undefined }) // probe (unloaded)
+      .mockReturnValueOnce({ status: 0, error: undefined }); // bootstrap
+    existsSyncMock.mockReturnValue(true);
+    statSyncMock.mockReturnValue({} as never); // socket exists
+
+    await restartService();
+
+    // Verify the 2nd call is `bootstrap`, not `kickstart`.
+    const secondCall = spawnSyncMock.mock.calls[1];
+    expect(secondCall[0]).toBe('launchctl');
+    expect(secondCall[1][0]).toBe('bootstrap');
+    expect(secondCall[1][1]).toBe('gui/501');
+    expect(secondCall[1][2]).toMatch(
+      /Library\/LaunchAgents\/com\.nanoclaw-v2-deadbeef\.plist$/,
+    );
+  });
+
+  it('throws a meaningful error when the plist file is missing', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 1, error: undefined }); // unloaded
+    existsSyncMock.mockReturnValue(false); // plist gone
+
+    await expect(restartService()).rejects.toThrow(/launchd plist missing/);
+  });
+
+  it('throws when kickstart returns non-zero (no more silent no-op)', async () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, error: undefined }) // probe: loaded
+      .mockReturnValueOnce({ status: 5, error: undefined }); // kickstart fails
+
+    await expect(restartService()).rejects.toThrow(/kickstart .* exited 5/);
+  });
+
+  it('throws when bootstrap returns non-zero', async () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, error: undefined }) // probe: unloaded
+      .mockReturnValueOnce({ status: 113, error: undefined }); // bootstrap fails
+    existsSyncMock.mockReturnValue(true);
+
+    await expect(restartService()).rejects.toThrow(/bootstrap .* exited 113/);
+  });
+
+  it('throws when data/cli.sock never appears within 5s', async () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, error: undefined }) // probe: loaded
+      .mockReturnValueOnce({ status: 0, error: undefined }); // kickstart OK
+    // Socket never appears — every statSync throws.
+    statSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    vi.useFakeTimers();
+    try {
+      const promise = restartService();
+      // Attach the rejection handler synchronously so vitest doesn't see an
+      // unhandled rejection while we advance the fake timers past the 5s
+      // socket-wait deadline.
+      const assertion = expect(promise).rejects.toThrow(
+        /data\/cli\.sock did not appear/,
+      );
+      await vi.advanceTimersByTimeAsync(6000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// Restore the original platform once the suite ends so other tests in the
+// same process aren't perturbed.
+restorePlatform();

--- a/setup/channels/signal.ts
+++ b/setup/channels/signal.ts
@@ -26,6 +26,7 @@
  */
 import { spawnSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import * as p from '@clack/prompts';
@@ -360,18 +361,79 @@ function writeSignalAccount(account: string): void {
   setupLog.userInput('signal_account', account);
 }
 
-async function restartService(): Promise<void> {
+/**
+ * Probe whether a launchd service is currently loaded in the given domain.
+ * `launchctl print <service-target>` exits 0 when loaded, non-zero otherwise.
+ */
+export function probeLaunchdLoaded(serviceTarget: string): boolean {
+  const r = spawnSync('launchctl', ['print', serviceTarget], { stdio: 'ignore' });
+  return !r.error && r.status === 0;
+}
+
+/** Wait up to `timeoutMs` for `data/cli.sock` to appear. Returns true if it did. */
+async function waitForCliSocket(timeoutMs: number): Promise<boolean> {
+  const sockPath = path.join(process.cwd(), 'data', 'cli.sock');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      fs.statSync(sockPath);
+      return true;
+    } catch {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  return false;
+}
+
+export async function restartService(): Promise<void> {
   const s = p.spinner();
   s.start('Restarting NanoClaw so it sees your Signal account…');
   const start = Date.now();
   const platform = process.platform;
   try {
     if (platform === 'darwin') {
-      spawnSync(
-        'launchctl',
-        ['kickstart', '-k', `gui/${process.getuid?.() ?? 501}/${getLaunchdLabel()}`],
-        { stdio: 'ignore' },
-      );
+      const uid = process.getuid?.() ?? 501;
+      const label = getLaunchdLabel();
+      const serviceTarget = `gui/${uid}/${label}`;
+      if (probeLaunchdLoaded(serviceTarget)) {
+        // Service is loaded — restart it in place.
+        const kick = spawnSync(
+          'launchctl',
+          ['kickstart', '-k', serviceTarget],
+          { stdio: 'ignore' },
+        );
+        if (kick.status !== 0) {
+          throw new Error(
+            `launchctl kickstart ${serviceTarget} exited ${kick.status ?? 'null'}`,
+          );
+        }
+      } else {
+        // Service is unloaded (likely from a prior `launchctl unload` in
+        // peer-cleanup) — bootstrap it back. `kickstart` would silently
+        // no-op here, leaving the wizard saying "restarted" while the
+        // next init-first-agent step fails with ENOENT data/cli.sock.
+        const plistPath = path.join(
+          os.homedir(),
+          'Library',
+          'LaunchAgents',
+          `${label}.plist`,
+        );
+        if (!fs.existsSync(plistPath)) {
+          throw new Error(
+            `launchd plist missing at ${plistPath} — run ncl install first`,
+          );
+        }
+        const boot = spawnSync(
+          'launchctl',
+          ['bootstrap', `gui/${uid}`, plistPath],
+          { stdio: 'ignore' },
+        );
+        if (boot.status !== 0) {
+          throw new Error(
+            `launchctl bootstrap gui/${uid} ${plistPath} exited ${boot.status ?? 'null'}`,
+          );
+        }
+      }
     } else if (platform === 'linux') {
       const unit = getSystemdUnit();
       const user = spawnSync('systemctl', ['--user', 'restart', unit], {
@@ -382,19 +444,30 @@ async function restartService(): Promise<void> {
       }
     }
     // Give the adapter a moment to connect to signal-cli before
-    // init-first-agent's welcome DM hits the delivery path.
-    await new Promise((r) => setTimeout(r, 5000));
+    // init-first-agent's welcome DM hits the delivery path. On darwin we
+    // also use this window to verify the socket actually appeared — that's
+    // the user-observable signal the service is alive.
+    if (platform === 'darwin') {
+      const sockUp = await waitForCliSocket(5000);
+      if (!sockUp) {
+        throw new Error(
+          'data/cli.sock did not appear within 5s — service may not have started',
+        );
+      }
+    } else {
+      await new Promise((r) => setTimeout(r, 5000));
+    }
     s.stop(`NanoClaw restarted. ${k.dim(`(${fmtDuration(Date.now() - start)})`)}`);
     setupLog.step('signal-restart', 'success', Date.now() - start, {
       PLATFORM: platform,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    s.stop(`Restart may have failed: ${message}`, 1);
+    s.stop(`Restart failed: ${message}`, 1);
     setupLog.step('signal-restart', 'failed', Date.now() - start, {
       ERROR: message,
     });
-    // Non-fatal — the user can restart manually if init-first-agent fails.
+    throw err;
   }
 }
 


### PR DESCRIPTION
Closes #2583.

## Problem
`setup/channels/signal.ts:restartService()` shells out via `launchctl kickstart -k` with `stdio: 'ignore'`. `kickstart` returns non-zero only when the plist is loaded; if a prior `launchctl unload` (or `setup/peer-cleanup.ts`) ran, the call silently no-ops, the wizard reports "NanoClaw restarted", and the next `init-first-agent` step fails with a confusing `connect ENOENT data/cli.sock`.

## Fix
Probe `launchctl print gui/<uid>/<label>` first (exit 0 = loaded). If loaded, keep current `kickstart -k`. If not loaded, use `launchctl bootstrap gui/<uid> <plist-path>` and verify `data/cli.sock` appears within the existing 5s settle window. Throw with a meaningful error on failure instead of returning success.

## Scope
Single function in `setup/channels/signal.ts`. The same pattern in `whatsapp.ts` and `setup/add-*.sh` is deferred to follow-up PRs per `CONTRIBUTING.md` (one-thing-per-PR).

## Verification
- `pnpm test setup/channels/__tests__/signal.test.ts` — **green (9/9)**
- `pnpm test` — **green (341/341 across 33 files)**
- `pnpm lint` — clean (scope of change; no new findings)
- `pnpm typecheck` — clean

🤖 AI disclosure: drafted with Claude (Opus 4.7).