### PR TITLE
fix(reactions): align MCP add_reaction schema with channel reality + Slack bridge translation

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -20,7 +20,7 @@ Use `mcp__nanoclaw__send_file({ path, text?, filename?, to? })` to deliver a fil
 
 ### Reacting to messages (`add_reaction`)
 
-Use `mcp__nanoclaw__add_reaction({ messageId, emoji })` to react to a specific inbound message by its `#N` id — pass `messageId` as an integer (e.g. `22`, not `"22"`). Good for lightweight acknowledgment (`eyes` = seen, `white_check_mark` = done) when a full reply would be noise. `emoji` is the shortcode name (e.g. `thumbs_up`, `heart`), not the raw character.
+Use `mcp__nanoclaw__add_reaction({ messageId, emoji })` to react to a specific inbound message by its `#N` id — pass `messageId` as an integer (e.g. `22`, not `"22"`). Good for lightweight acknowledgment (`👀` = seen, `✅` = done) when a full reply would be noise. `emoji` is the unicode character itself (e.g. `👍`, `❤️`, `✅`) — shortcode names like `thumbs_up` only render on Slack and silently fail on WhatsApp, Discord, Telegram, Teams, and Google Chat.
 
 ### Internal thoughts
 

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -227,7 +227,11 @@ export const addReaction: McpToolDefinition = {
       type: 'object' as const,
       properties: {
         messageId: { type: 'integer', description: 'Message ID (the numeric id shown in messages)' },
-        emoji: { type: 'string', description: 'Emoji name (e.g., thumbs_up, heart, check)' },
+        emoji: {
+          type: 'string',
+          description:
+            'Emoji character (e.g. "👍", "❤️", "✅"). Pass the unicode character itself — shortcode names like "thumbs_up" only render on Slack and do NOT render on WhatsApp, Discord, Telegram, Teams, or Google Chat.',
+        },
       },
       required: ['messageId', 'emoji'],
     },

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -205,3 +205,67 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(msg.markdown).toBe('plain hello');
   });
 });
+
+describe('createChatSdkBridge.deliver — reactions (issue #2569 part 1)', () => {
+  // The MCP add_reaction tool now asks agents for a unicode emoji (e.g. "👍"),
+  // which is what WhatsApp / Discord / Telegram / Teams / Google Chat expect.
+  // Slack is the outlier — it expects a shortcode name. The bridge translates
+  // unicode → shortcode for the Slack adapter only; every other adapter must
+  // see the raw unicode unchanged.
+
+  function makeReactionCapture() {
+    const calls: Array<{ threadId: string; messageId: string; emoji: string }> = [];
+    const addReaction = async (threadId: string, messageId: string, emoji: string): Promise<void> => {
+      calls.push({ threadId, messageId, emoji });
+    };
+    return { calls, addReaction };
+  }
+
+  it('translates unicode → Slack shortcode for the Slack adapter', async () => {
+    const { calls, addReaction } = makeReactionCapture();
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'slack', addReaction }),
+      supportsThreads: true,
+    });
+    await bridge.deliver('slack:C123', 'slack:C123:thread', {
+      kind: 'chat-sdk',
+      content: { operation: 'reaction', messageId: 'platform-msg-1', emoji: '👍' },
+    });
+    expect(calls).toHaveLength(1);
+    // The chat SDK's defaultEmojiResolver maps "👍" → "thumbs_up" → first Slack
+    // format. Both "+1" and "thumbsup" are valid Slack names — assert against
+    // either rather than overfitting to the resolver's tie-breaker, which is
+    // an internal contract of the chat SDK and may shift between versions.
+    expect(['+1', 'thumbsup']).toContain(calls[0].emoji);
+  });
+
+  it('passes unicode through unchanged for every non-Slack adapter', async () => {
+    for (const adapterName of ['discord', 'telegram', 'whatsapp', 'teams', 'gchat']) {
+      const { calls, addReaction } = makeReactionCapture();
+      const bridge = createChatSdkBridge({
+        adapter: stubAdapter({ name: adapterName, addReaction }),
+        supportsThreads: false,
+      });
+      await bridge.deliver(`${adapterName}:chan`, null, {
+        kind: 'chat-sdk',
+        content: { operation: 'reaction', messageId: 'platform-msg-1', emoji: '👍' },
+      });
+      expect(calls, `adapter ${adapterName} should pass unicode through`).toHaveLength(1);
+      expect(calls[0].emoji, `adapter ${adapterName} mangled unicode`).toBe('👍');
+    }
+  });
+
+  it('round-trips unknown emoji unchanged on Slack (resolver fallback is verbatim)', async () => {
+    const { calls, addReaction } = makeReactionCapture();
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'slack', addReaction }),
+      supportsThreads: false,
+    });
+    await bridge.deliver('slack:C123', null, {
+      kind: 'chat-sdk',
+      content: { operation: 'reaction', messageId: 'platform-msg-1', emoji: 'custom_workspace_emoji' },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].emoji).toBe('custom_workspace_emoji');
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -13,6 +13,7 @@ import {
   Actions,
   Button,
   LinkButton,
+  defaultEmojiResolver,
   type CardChild,
   type Adapter,
   type ConcurrencyStrategy,
@@ -379,7 +380,17 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       }
 
       if (content.operation === 'reaction' && content.messageId && content.emoji) {
-        await adapter.addReaction(tid, content.messageId as string, content.emoji as string);
+        // The MCP add_reaction tool asks agents for unicode characters (e.g. "👍"),
+        // which is what WhatsApp / Discord / Telegram / Teams / Google Chat all
+        // expect. Slack is the outlier: it expects a shortcode name ("+1",
+        // "thumbsup"). Translate via the SDK's emoji map so a single unicode
+        // character renders correctly on every channel. Unknown emoji round-trip
+        // unchanged (fromGChat returns the raw value when unmapped, and toSlack
+        // returns the name verbatim when no Slack format exists).
+        const rawEmoji = content.emoji as string;
+        const emoji =
+          adapter.name === 'slack' ? defaultEmojiResolver.toSlack(defaultEmojiResolver.fromGChat(rawEmoji)) : rawEmoji;
+        await adapter.addReaction(tid, content.messageId as string, emoji);
         return;
       }
 


### PR DESCRIPTION
Closes #2569 (Part 1).

## Problem
The MCP `add_reaction.emoji` parameter docstring asks for shortcode names (`thumbs_up`); the handler passes the parameter verbatim. Most channels (WhatsApp/Discord/Telegram/Teams/GChat) expect unicode; only Slack expects shortcodes. So reactions silently fail to render on most channels — and the agent often retries with prose ("reacted with 👍"), doubling noise.

## Scope (Part 1 only)
Per `CONTRIBUTING.md` one-thing-per-PR — this PR ships:
1. `core.ts`: rewrite the parameter description to specify unicode characters with examples; note shortcodes only render on Slack.
2. `core.instructions.md`: mirror the wording.
3. `chat-sdk-bridge.ts`: when `adapter.name === 'slack'`, translate unicode to shortcode via `defaultEmojiResolver`. All other adapters unchanged.

Part 2 (WhatsApp host `fromMe` and other channel-specific normalization) is deferred to a follow-up PR.

Adapts the reporter's reference commits `0de2a7d` and `0fac791`.

## Files
- `container/agent-runner/src/mcp-tools/core.ts`
- `container/agent-runner/src/mcp-tools/core.instructions.md`
- `src/channels/chat-sdk-bridge.ts`
- `src/channels/chat-sdk-bridge.test.ts` *(extended; tests live next to source in this repo, not under `__tests__/`)*

## Verification
- `pnpm test src/channels/chat-sdk-bridge.test.ts` — **15/15 green** (3 new reaction-translation tests + 12 existing)
- `pnpm test` — **335/335 green across 32 test files**
- `pnpm typecheck` — clean
- `pnpm lint` — no new errors or warnings introduced (repo baseline on `main` has 13 pre-existing errors in unrelated files; the diff itself is lint-clean)

🤖 AI disclosure: drafted with Claude (Opus 4.7).