### PR TITLE
fix(cli): honor user-supplied --id in `ncl groups create` and friends

### DIFF
--- a/src/cli/__tests__/crud.test.ts
+++ b/src/cli/__tests__/crud.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #2390 — `genericCreate` must honor user-supplied
+ * `--id <slug>` instead of silently overriding with `randomUUID()`.
+ *
+ * Help text advertises `--id (auto)` and callers pass explicit slugs as
+ * the documented workaround for #2386 (OneCLI rejects raw UUIDs); before
+ * this fix the user value was discarded.
+ */
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const db = new Database(':memory:');
+db.prepare(
+  `CREATE TABLE widgets (
+     id TEXT PRIMARY KEY,
+     name TEXT NOT NULL,
+     created_at TEXT NOT NULL
+   )`,
+).run();
+
+vi.mock('../../db/connection.js', () => ({
+  getDb: () => db,
+}));
+
+// Capture the handler registered by registerResource.
+let createHandler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+vi.mock('../registry.js', () => ({
+  register: (cmd: { name: string; handler: (args: Record<string, unknown>) => Promise<unknown> }) => {
+    if (cmd.name === 'widgets-create') createHandler = cmd.handler;
+  },
+}));
+
+// Import AFTER mocks are in place so registerResource sees the mocked deps.
+const { registerResource } = await import('../crud.js');
+
+registerResource({
+  name: 'widget',
+  plural: 'widgets',
+  table: 'widgets',
+  description: 'Test resource for #2390.',
+  idColumn: 'id',
+  columns: [
+    { name: 'id', type: 'string', description: 'Slug.', generated: true },
+    { name: 'name', type: 'string', description: 'Display name.', required: true, updatable: true },
+    { name: 'created_at', type: 'string', description: 'Auto-set.', generated: true },
+  ],
+  operations: { create: 'open' },
+});
+
+beforeEach(() => {
+  db.prepare('DELETE FROM widgets').run();
+});
+
+afterEach(() => {
+  // no-op — table is reset in beforeEach
+});
+
+describe('genericCreate honors user-supplied --id (#2390)', () => {
+  it('uses the supplied id when valid', async () => {
+    expect(createHandler).toBeDefined();
+    const result = (await createHandler!({ id: 'daily-os', name: 'Daily OS' })) as Record<string, unknown>;
+    expect(result.id).toBe('daily-os');
+    const row = db.prepare('SELECT id, name FROM widgets WHERE id = ?').get('daily-os') as
+      | { id: string; name: string }
+      | undefined;
+    expect(row).toEqual({ id: 'daily-os', name: 'Daily OS' });
+  });
+
+  it('rejects invalid ids with a clear error', async () => {
+    expect(createHandler).toBeDefined();
+    await expect(createHandler!({ id: 'Bad ID!', name: 'x' })).rejects.toThrow(/--id must match/);
+    // Numeric-leading, uppercase, and over-length must all be rejected.
+    await expect(createHandler!({ id: '1abc', name: 'x' })).rejects.toThrow(/--id must match/);
+    await expect(createHandler!({ id: 'A-cap', name: 'x' })).rejects.toThrow(/--id must match/);
+    await expect(createHandler!({ id: 'a'.repeat(51), name: 'x' })).rejects.toThrow(/--id must match/);
+    // None of the failed attempts should have written a row.
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM widgets').get() as { c: number }).c;
+    expect(count).toBe(0);
+  });
+
+  it('auto-generates a UUID when --id is not supplied', async () => {
+    expect(createHandler).toBeDefined();
+    const result = (await createHandler!({ name: 'Auto' })) as Record<string, unknown>;
+    // RFC-4122 UUID v4 shape — same as randomUUID() produces.
+    expect(String(result.id)).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    const row = db.prepare('SELECT id FROM widgets').get() as { id: string };
+    expect(row.id).toBe(result.id);
+  });
+
+  it('treats empty --id as not supplied', async () => {
+    expect(createHandler).toBeDefined();
+    const result = (await createHandler!({ id: '', name: 'Empty' })) as Record<string, unknown>;
+    expect(String(result.id)).toMatch(/^[0-9a-f]{8}-/);
+  });
+});

--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -126,6 +126,15 @@ function genericGet(def: ResourceDef) {
   };
 }
 
+/**
+ * Slug validator for user-supplied resource IDs.
+ *
+ * Mirrors the lowercase-slug shape callers already use as workarounds for
+ * #2386 (OneCLI rejects raw UUIDs). 1-50 chars, must start with a letter,
+ * then letters / digits / hyphens. Anchored — no partial matches.
+ */
+const ID_SLUG_RE = /^[a-z][a-z0-9-]{0,49}$/;
+
 function genericCreate(def: ResourceDef) {
   return async (args: Record<string, unknown>) => {
     const values: Record<string, unknown> = {};
@@ -133,7 +142,21 @@ function genericCreate(def: ResourceDef) {
     for (const col of def.columns) {
       if (col.generated) {
         if (col.name === def.idColumn) {
-          values[col.name] = randomUUID();
+          // #2390: honor user-supplied --id. The help text advertises --id
+          // as `(auto)`, but a value passed explicitly is the user's intent
+          // and must not be silently overwritten by randomUUID().
+          const supplied = args[col.name];
+          if (supplied !== undefined && supplied !== '') {
+            const id = String(supplied);
+            if (!ID_SLUG_RE.test(id)) {
+              throw new Error(
+                `--id must match ${ID_SLUG_RE.source} (1-50 chars, lowercase letter then letters/digits/hyphens). Got: ${id}`,
+              );
+            }
+            values[col.name] = id;
+          } else {
+            values[col.name] = randomUUID();
+          }
         } else if (col.name.endsWith('_at')) {
           values[col.name] = new Date().toISOString();
         }


### PR DESCRIPTION
Closes #2390.

## Problem
The `--id` flag is documented as `(auto)` in the help text but `genericCreate` ignores user input — IDs are silently overridden by `randomUUID()`. Reporter demonstrated: `bin/ncl groups create --name x --folder x --id daily-os` returns a UUID with `daily-os` discarded. This breaks the CLI workaround for #2386 (UUID rejected by OneCLI) and surprises users who passed an explicit value.

## Fix
- When `--id` is supplied: validate against `^[a-z][a-z0-9-]{0,49}$` and use it; clear error on validation failure.
- When `--id` is NOT supplied: keep the existing auto-generation path (preserves the in-flight #2540 / #2543 UUID-format fixes).

## Coordination note
Touches `src/cli/crud.ts` `genericCreate`, the same function that in-flight PRs **#2540** and **#2543** modify. The changed branch is different (input-honored vs auto-generated), so the diffs are complementary, not conflicting. Both #2540 and #2543 were OPEN at the time of this fix. Happy to rebase if either lands first.

## Files
- `src/cli/crud.ts`
- `src/cli/__tests__/crud.test.ts` *(new — 4 regression tests covering valid id / invalid id / no id auto-UUID / empty-string id)*

## Verification
- `pnpm test src/cli/__tests__/crud.test.ts` — **green (4/4)**
- `pnpm test` — **green (336/336 across 33 files)**
- `pnpm typecheck` — clean
- `pnpm lint` — clean (scope of change)

🤖 AI disclosure: drafted with Claude (Opus 4.7).