### PR TITLE
feat(container): use --network=host and 127.0.0.1 gateway on NixOS

### DIFF
--- a/.nanoclaw-migrations/01-channels.md
+++ b/.nanoclaw-migrations/01-channels.md
@@ -1,0 +1,45 @@
+# 01 — Telegram channel
+
+## Problem we solved in v1
+
+Need Telegram as the only chat surface for the assistant. Bot replies to `@Andy` mentions, downloads incoming files, threads/topics, reply context.
+
+## What we did in v1 (do NOT carry over)
+
+- Merged `qwibitai/nanoclaw-telegram` fork as remote `telegram`
+- Local `src/channels/telegram.ts` (440 LOC) using `grammy` directly
+- Hardcoded `parse_mode: 'Markdown'` in two places
+- File download via `bot.api.getFile` + `fetch` to `groups/<folder>/attachments/`
+- DB columns `reply_to_message_id`, `reply_to_message_content`, `reply_to_sender_name`
+- `package.json` += `grammy: ^1.39.3`
+
+## v2 idiomatic solution
+
+Apply skill **`/add-telegram`** from upstream. v2 uses `@chat-adapter/telegram` (Chat SDK family) instead of `grammy`. Channel adapters live on the `channels` branch — installed by the skill (`git show origin/channels:src/channels/telegram.ts > src/channels/telegram.ts` etc.) plus `setup/pair-telegram.ts` registration. Pairing is self-contained (chat ownership verification, `getChat` for channel name resolution, max-text-length splitter).
+
+## Things v2 already covers (no carry-over needed)
+
+| v1 concern | v2 solution |
+|---|---|
+| File attachments | Built into adapter |
+| Reply context | v2 has `reply_to_*` in session DB |
+| Threads/topics | `message_thread_id` in adapter |
+| Message splitting (4096) | `engage splitter` wired via `maxTextLength` |
+| Channel name resolution | `resolveChannelName` via `getChat` API |
+| Markdown sanitizer (legacy parse_mode) | `telegram-markdown-sanitize.ts` — but see [03-formatting.md](03-formatting.md), we may bypass this entirely |
+
+## How to apply (Stage 2.5)
+
+1. Ensure `data/v2.db` exists and channel auth secret is in `.env`:
+   ```
+   TELEGRAM_BOT_TOKEN=...
+   ```
+2. Activate skill: `/add-telegram`
+3. Skill will: fetch `origin/channels`, copy adapter files, register in `setup/index.ts` STEPS map, install `@chat-adapter/telegram@4.26.0`, build.
+4. Pair the bot: `pnpm run setup` → step `pair-telegram` → BotFather token paste → pairing message in Telegram.
+5. The paired chat (`tg:42582289`, "Main") will be registered as a `messaging_group`. Wire it to the agent group in Stage 3.
+
+## Telegram-specific notes
+
+- BotFather privacy mode must be **disabled** (so bot sees non-mention group messages too) — was already configured on the v1 server, no change needed.
+- The current bot username / token from the v1 server is reusable. No need to re-create the bot.

--- a/.nanoclaw-migrations/02-credentials.md
+++ b/.nanoclaw-migrations/02-credentials.md
@@ -1,0 +1,51 @@
+# 02 — Credentials (OneCLI Agent Vault)
+
+> ✅ **VERIFIED** against `origin/main:.claude/skills/init-onecli/SKILL.md` and `origin/main:CLAUDE.md` on 2026-05-27.
+
+User direction 2026-05-27: «Я хочу использовать нативные нативные решения из V2. Давай использовать то, что рекомендуется в новом решении.»
+
+v2's recommended path **is OneCLI**:
+- `origin/main:CLAUDE.md:67` — container-runner uses OneCLI `ensureAgent`
+- `origin/main:src/onecli-approvals.ts` — credentialed-action approval bridge built around OneCLI
+- `origin/main:.claude/skills/init-onecli/SKILL.md` — first-class onboarding skill that installs OneCLI + migrates `.env` to vault
+
+The v2 default is OneCLI. `/use-native-credential-proxy` is the alternate path for users who don't want it. We go with the default.
+
+## Decision
+
+Apply `/init-onecli`. It installs OneCLI's gateway + CLI, configures the local instance, sets `ONECLI_URL` in `.env`, and migrates the OAuth token from `.env` into the vault.
+
+## How `/init-onecli` interacts with our setup
+
+The NixOS module on the production server already drops the Anthropic OAuth token (from sops) into `.env` via `ExecStartPre`. So when we run `/init-onecli`:
+
+1. It detects the token in `.env`
+2. Installs OneCLI gateway (`curl -fsSL onecli.sh/install | sh`) + CLI (`onecli.sh/cli/install`)
+3. Configures `onecli config set api-host ${ONECLI_URL}`
+4. Writes `ONECLI_URL` to `.env`
+5. Waits up to 15s for gateway health (`curl -sf ${ONECLI_URL}/health`)
+6. Migrates the `.env` OAuth token into vault as an Anthropic secret
+7. Subsequent runs use the vault; the `.env` token can stay (defensive) or be stripped
+
+## How to apply (Stage 1.2)
+
+1. Activate skill: `/init-onecli`
+2. Skill walks through preflight, install, configure, migrate, verify
+3. After success: `onecli secrets list` should show the Anthropic secret
+
+## NixOS module impact (Stage 5, separate repo)
+
+When updating the NixOS module in `~/Documents/GitHub/nixserver/`:
+- `ExecStartPre` still drops sops token into `.env` (unchanged) — `/init-onecli` ingests on first run
+- New: ensure `${ONECLI_URL}` resolves correctly inside the NixOS systemd unit (default is local — the install script outputs the URL)
+- New: include `onecli` binary in PATH for the service user (install script puts it in `~/.local/bin`)
+- Lock the gateway socket/port to localhost (default behavior — verify)
+
+These are deploy-infra concerns, out of scope for this repo but flagged for Stage 5.
+
+## What we drop from v1
+
+- `src/credential-proxy.ts` and its test — gone (`main` already doesn't have them)
+- `CREDENTIAL_PROXY_PORT` config — gone
+- The `package.json` carrying `@onecli-sh/sdk` was already there (v1 left it as dead dep) — in v2 it's a live dep again, no action needed
+- Whole approach of "we don't want OneCLI" — that was my mis-projection, dropped

--- a/.nanoclaw-migrations/03-formatting.md
+++ b/.nanoclaw-migrations/03-formatting.md
@@ -1,0 +1,312 @@
+# 03 — Telegram HTML formatting via upstream-PR-ready skill
+
+> ✅ **VERIFIED** against v2 skill conventions on 2026-05-27 (`origin/main:.claude/skills/{add-telegram,init-onecli,use-native-credential-proxy}`).
+>
+> User direction 2026-05-27: «не просто напишем скилл, а прям строго подойдем к его написанию, чтобы потом сделать PR для него».
+
+## Decision
+
+Build a new skill **`/use-telegram-html`** to upstream-quality standards from day one — full SKILL.md / REMOVE.md / VERIFY.md set, idempotent, with troubleshooting and removal sections, following v2's existing skill conventions. After it works locally, submit upstream PR.
+
+## v2 skill conventions (template observed)
+
+From auditing `add-telegram`, `use-native-credential-proxy`, `init-onecli`:
+
+| File | Purpose | Style |
+|---|---|---|
+| `SKILL.md` | Main instructions for the agent applying the skill | Frontmatter (`name`, `description`), Phase 1 Pre-flight (idempotent checks), Phase 2 Apply, Phase 3 Setup (user input), Phase 4 Verify, Troubleshooting, Removal pointer |
+| `REMOVE.md` | Reverse the install | Numbered short steps, concise |
+| `VERIFY.md` | Quick smoke test | 1-2 paragraphs, single action |
+
+Patterns enforced:
+- **Every Phase 1 step is idempotent** — skill can be re-run safely
+- Inline `AskUserQuestion: …` directives for any choices
+- Specific bash commands, exact grep patterns
+- Tells user when prerequisites are missing (e.g. "Run /add-telegram first") rather than silently failing
+- Removal section in SKILL.md OR REMOVE.md file (both styles exist; we use both for clarity)
+
+## What the skill does
+
+Layers on `/add-telegram`. Replaces the legacy-Markdown sanitizer wiring with a direct-fetch HTML sender, restoring full HTML support (`<b>`, `<i>`, `<u>`, `<s>`, `<code>`, `<pre>`, `<a>`, `<blockquote>`, `<tg-spoiler>`).
+
+Implementation strategy is **bypass-not-modify**: we don't modify `@chat-adapter/telegram` (locked at npm, hardcoded `parse_mode=Markdown`). We wrap its `sendMessage` with a fetch directly against `https://api.telegram.org/bot${token}/sendMessage` carrying `parse_mode: 'HTML'`. The fetch pattern already exists in v2 for pairing confirmations (`origin/channels:src/channels/telegram.ts:97`).
+
+## Skill files (proposed final shape)
+
+### `.claude/skills/use-telegram-html/SKILL.md`
+
+```markdown
+---
+name: use-telegram-html
+description: Switch Telegram channel to HTML parse mode. Bypasses the @chat-adapter/telegram hardcoded Markdown by overriding sendMessage with a direct fetch to api.telegram.org carrying parse_mode=HTML. Restores full HTML tag support (<b>, <i>, <u>, <s>, <code>, <pre>, <a>, <blockquote>, <tg-spoiler>) — significantly richer than legacy Markdown. Requires /add-telegram to be applied first.
+---
+
+# Use Telegram HTML Parse Mode
+
+This skill switches the Telegram channel from the upstream-default legacy
+Markdown (with sanitizer workaround) to native HTML parse mode. Pattern
+mirrors `/use-local-whisper` overriding `/add-voice-transcription`:
+layer on top of the base channel skill, change specific outbound behavior.
+
+## Phase 1: Pre-flight
+
+### Check if `/add-telegram` is applied
+
+  grep -q "createChatSdkBridge" src/channels/telegram.ts 2>/dev/null
+
+If the file or symbol is missing, tell the user to run `/add-telegram`
+first, then retry. Stop.
+
+### Check if this skill is already applied
+
+  grep -q "USE-TELEGRAM-HTML" src/channels/telegram.ts 2>/dev/null
+
+If the sentinel is present, skill is applied. Skip to Phase 3 (Verify).
+
+### Verify the sanitizer files are at expected paths (sanity)
+
+  test -f src/channels/telegram-markdown-sanitize.ts
+  test -f src/channels/telegram-markdown-sanitize.test.ts
+
+If missing, the upstream layout has changed since this skill was written.
+Tell the user and stop — manual investigation needed.
+
+## Phase 2: Apply
+
+### 2.1 Remove the sanitizer import + usage
+
+In `src/channels/telegram.ts`, delete this import line:
+
+  import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
+
+And remove the bridge-config line (inside the `createChatSdkBridge`
+call, ~line 212 upstream):
+
+  transformOutboundText: sanitizeTelegramLegacyMarkdown,
+
+### 2.2 Delete sanitizer source files
+
+  rm src/channels/telegram-markdown-sanitize.ts
+  rm src/channels/telegram-markdown-sanitize.test.ts
+
+### 2.3 Insert the HTML sender helper
+
+Above the `registerChannelAdapter('telegram', …)` call in
+`src/channels/telegram.ts`, insert:
+
+  // USE-TELEGRAM-HTML: outbound bypass of @chat-adapter/telegram's
+  // hardcoded parse_mode=Markdown. Sends with parse_mode=HTML; on
+  // parse-failure response, retries as plain text so the message
+  // still delivers. Drop this once @chat-adapter/telegram exposes a
+  // parse_mode knob (see vercel/chat PR #367).
+  async function sendHtml(
+    token: string,
+    chatId: string,
+    text: string,
+  ): Promise<void> {
+    const body = { chat_id: chatId, text, parse_mode: 'HTML' };
+    const res = await fetch(
+      `https://api.telegram.org/bot${token}/sendMessage`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      log.warn('Telegram HTML send failed; falling back to plain text', {
+        status: res.status,
+      });
+      const plain = { chat_id: chatId, text };
+      await fetch(
+        `https://api.telegram.org/bot${token}/sendMessage`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(plain),
+        },
+      );
+    }
+  }
+
+### 2.4 Override `sendMessage` on the wrapped adapter
+
+Inside the existing `const wrapped: ChannelAdapter = { … }` literal,
+add (or replace) a `sendMessage` field. Place it after `resolveChannelName`
+and before `setup`:
+
+  // USE-TELEGRAM-HTML: route outbound through direct HTML fetch
+  async sendMessage(platformId: string, _threadId: string | null, text: string) {
+    const chatId = platformId.split(':').slice(1).join(':');
+    if (!chatId) return;
+    const MAX = 4000;
+    for (let i = 0; i < text.length; i += MAX) {
+      await sendHtml(token, chatId, text.slice(i, i + MAX));
+    }
+  },
+
+(`threadId` is unused because the v2 adapter sets `supportsThreads: false`.
+If a future skill turns threads on, add `message_thread_id` to `sendHtml`'s
+body.)
+
+### 2.5 Update per-channel formatting block
+
+For each group folder under `groups/` whose name starts with `telegram_`,
+replace any existing Telegram formatting block in `CLAUDE.local.md` with
+the HTML reference. If no block exists, append it.
+
+The replacement block:
+
+  ## Telegram formatting (HTML)
+
+  This channel renders Telegram HTML. Supported tags:
+  - `<b>bold</b>` and `<strong>bold</strong>`
+  - `<i>italic</i>` and `<em>italic</em>`
+  - `<u>underline</u>`
+  - `<s>strikethrough</s>`
+  - `<code>inline code</code>`
+  - `<pre>code block</pre>` (optionally `<pre><code class="language-python">…</code></pre>`)
+  - `<a href="https://example.com">link text</a>`
+  - `<blockquote>quote</blockquote>`
+  - `<tg-spoiler>hidden</tg-spoiler>`
+
+  When including user-supplied text (names, quoted messages, web content)
+  in your reply, escape these three characters:
+  - `<` → `&lt;`
+  - `>` → `&gt;`
+  - `&` → `&amp;`
+
+  Do NOT use Markdown (`**bold**`, `# headings`, `[text](url)`).
+  Standalone URLs are auto-linked by Telegram if not wrapped in `<a>`.
+
+### 2.6 Rebuild
+
+  pnpm run build
+  pnpm exec vitest run src/channels/telegram.test.ts 2>/dev/null || true
+
+(If the upstream test file for telegram exists, run it. It should pass —
+our changes are additive and only affect outbound, not the inbound /
+pairing paths covered by tests.)
+
+## Phase 3: Verify
+
+Send a Telegram message to your bot. Reply with content exercising at
+least: `<b>`, `<i>`, `<a href>`, `<code>`, `<blockquote>`. Confirm each
+renders, not as literal tags.
+
+Then send a message that quotes user-input containing `<`, `>`, `&`
+(e.g. `<script>` or `2 < 3 & 4 > 1`) — confirm the agent escapes them
+(via CLAUDE.local.md instructions) and the message still delivers.
+
+## Troubleshooting
+
+**HTML tags show as literal text in Telegram**
+The fetch succeeded but parse_mode wasn't honored. Likely your fork's
+`sendHtml` is not being called and the Chat SDK adapter sent the message
+instead. Verify: `grep -n "USE-TELEGRAM-HTML" src/channels/telegram.ts`
+should show two sentinel comments. If only one, the `sendMessage`
+override wasn't placed inside the right object — check Phase 2.4.
+
+**Message delivered but log shows "HTML send failed; falling back to plain text"**
+The agent produced invalid HTML — usually mismatched tags or unescaped
+`<` in user content. Tighten the CLAUDE.local.md instructions and/or
+have the agent self-correct via the fallback. The fallback is a safety
+net, not the steady state.
+
+**`registerChannelAdapter` errors after apply**
+The wrapped adapter literal got malformed. Read `src/channels/telegram.ts`
+around the `wrapped` const — ensure `sendMessage` is a proper method
+inside the object, with matching braces.
+
+## Removal
+
+See `REMOVE.md`.
+```
+
+### `.claude/skills/use-telegram-html/REMOVE.md`
+
+```markdown
+# Remove use-telegram-html
+
+Restores the upstream-default Markdown sanitizer path.
+
+1. Re-add the sanitizer files (from upstream):
+
+       git show origin/channels:src/channels/telegram-markdown-sanitize.ts \
+         > src/channels/telegram-markdown-sanitize.ts
+       git show origin/channels:src/channels/telegram-markdown-sanitize.test.ts \
+         > src/channels/telegram-markdown-sanitize.test.ts
+
+2. In `src/channels/telegram.ts`:
+   - Restore `import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';`
+   - Restore `transformOutboundText: sanitizeTelegramLegacyMarkdown,` in the `createChatSdkBridge` call
+   - Delete the `sendHtml` helper function (search for `USE-TELEGRAM-HTML` sentinel)
+   - Delete the `sendMessage` override on the `wrapped` adapter (also `USE-TELEGRAM-HTML` sentinel)
+
+3. In each `groups/telegram_*/CLAUDE.local.md`, revert the formatting
+   block to Markdown form (see `/add-telegram` for the canonical block).
+
+4. Rebuild:
+
+       pnpm run build
+```
+
+### `.claude/skills/use-telegram-html/VERIFY.md`
+
+```markdown
+# Verify use-telegram-html
+
+Send a Telegram message to your bot. Ask the agent to reply with a sample
+that uses bold, italic, inline code, a link, and a blockquote. Each
+should render as formatted text in Telegram (not literal `<b>` etc.).
+
+Then ask the agent to quote a string containing `<` and `>`. The reply
+should include `&lt;` / `&gt;` escapes inline and still render correctly.
+```
+
+## Open-source/PR plan
+
+After local verification, prepare the upstream PR:
+
+### Where it lands
+
+Skill directory in upstream: `.claude/skills/use-telegram-html/` — alongside the other layer-on-top skills (`use-local-whisper`, `use-native-credential-proxy`).
+
+### PR description draft
+
+- **Title**: `feat(skills): add /use-telegram-html — bypass legacy Markdown parse mode`
+- **Body**:
+  - Problem: `@chat-adapter/telegram` hardcodes `parse_mode=Markdown` (acknowledged by the existing `telegram-markdown-sanitize.ts` workaround header)
+  - Solution: layer skill that bypasses the Chat SDK outbound by direct fetch with `parse_mode=HTML`. Removes the sanitizer; adds the HTML sender + override; updates CLAUDE.local.md instructions
+  - Why a skill, not a default: users on legacy Markdown still want the sanitizer; some don't want HTML at all; new behavior should be opt-in
+  - Reference: original v1 fork used HTML via raw `grammy` adapter; this skill restores that capability in v2 layout
+  - When to retire: once vercel/chat ships parse_mode knob (see PR #367), the skill collapses to a config flag — at which point we can either drop it or rewrite it to set the flag
+- **Files added**: `.claude/skills/use-telegram-html/SKILL.md`, `REMOVE.md`, `VERIFY.md`
+- **Files removed by skill on apply**: `src/channels/telegram-markdown-sanitize.ts`, `src/channels/telegram-markdown-sanitize.test.ts` (only when the user applies the skill — not removed in the PR itself)
+- **No upstream `src/` changes** — pure skill addition
+
+### Tests
+
+The skill itself is not unit-testable (it modifies a file in-place via instructions to the model). What we can test:
+- A snapshot test on the resulting `telegram.ts` shape — apply the skill in a sandbox, assert the file diffs against a stored expected diff. v2 has no precedent for this kind of skill-snapshot test, so we don't introduce it.
+- A manual VERIFY.md walkthrough — already specified.
+
+### Risk to upstream
+
+- Skill writes to `src/channels/telegram.ts` — touches a file owned by `/add-telegram`. Future updates to `add-telegram` might collide. Mitigation: the sentinel comments (`USE-TELEGRAM-HTML`) make subsequent re-apply detectable, and `REMOVE.md` is the canonical revert path.
+- The fetch URL is hardcoded to `api.telegram.org` — same as upstream's `sendPairingConfirmation` (line 97), so no new external dependency.
+
+## How to apply (Stage 2.7)
+
+1. Stage 2.5 done (`/add-telegram` applied, pairing complete)
+2. Create the three files (`SKILL.md`, `REMOVE.md`, `VERIFY.md`) in `.claude/skills/use-telegram-html/` in our fork
+3. Activate skill: `/use-telegram-html`
+4. Skill walks through preflight (verifies `/add-telegram` applied), apply (patches files, deletes sanitizer), verify
+5. Manual VERIFY.md walkthrough on a live Telegram chat
+6. If successful: commit the skill files in our fork
+7. Open upstream PR with title/body above
+
+## What changed from the prior draft
+
+- Was: rough sketch of a custom override
+- Now: full skill spec at the same quality bar as `use-native-credential-proxy` and `init-onecli`. Phase structure, idempotency checks, sentinel comments for re-apply detection, troubleshooting, separate REMOVE.md / VERIFY.md files, and an explicit upstream-PR plan.

--- a/.nanoclaw-migrations/04-voice.md
+++ b/.nanoclaw-migrations/04-voice.md
@@ -1,0 +1,98 @@
+# 04 — Voice transcription (Groq Whisper)
+
+> ✅ **VERIFIED** against v2 source on 2026-05-27. Voice transcription is genuinely missing from v2 main (only present in unmerged Signal commit `53513db`). Attachment flow audited via `origin/channels:src/channels/telegram.ts:218`, `origin/main:src/channels/chat-sdk-bridge.ts:123-141`, `origin/main:src/session-manager.ts`, `origin/main:container/agent-runner/src/formatter.ts`.
+
+## Decision
+
+Bash script in `groups/telegram_main/scripts/transcribe_voice.sh`. Agent calls it via its Bash tool when it sees a voice attachment. Same shape as v1.
+
+## Verified attachment flow in v2
+
+When a Telegram voice message arrives:
+
+1. **`origin/channels:src/channels/telegram.ts:218`** — adapter delegates to `createChatSdkBridge`
+2. **`origin/main:src/channels/chat-sdk-bridge.ts:123-141`** — downloads attachment via `att.fetchData()`, stores base64 in `entry.data`
+3. **`origin/main:src/session-manager.ts:extractAttachmentFiles`** (~line 160) — decodes base64, writes to disk at `sessionDir/inbox/<messageId>/<filename>`
+4. **`origin/main:src/container-runner.ts`** (~line 85) — mounts session dir; file becomes container-visible at `/workspace/inbox/<messageId>/<filename>`
+5. **`origin/main:container/agent-runner/src/formatter.ts:formatAttachments`** (~line 272) — surfaces it to the agent as `[<type>: <name> — saved to /workspace/<localPath>]`
+
+Container path is **`/workspace/inbox/<messageId>/<filename>`**, NOT `/workspace/group/attachments/...` like v1.
+
+## Verified: no inbound transformation hook
+
+`origin/main:src/channels/chat-sdk-bridge.ts` exposes exactly two hooks:
+- `extractReplyContext` (line 30) — used by Telegram
+- `transformOutboundText` (line 35) — used by Telegram for the markdown sanitizer
+
+**No `transformInboundAttachment` hook exists.** Building host-side transcription means a new feature PR, not a migration step. Out of scope here.
+
+## Why a per-group script is the right v2 answer
+
+- v2 already treats `groups/<folder>/scripts/` as the canonical place for per-group capabilities (Bybit/Valtrex scripts use it — see [05-business-logic.md](05-business-logic.md))
+- Agent has Bash tool access; one tool call = transcription
+- No new core code, no skill to fork (none exists), no upstream PR needed
+- Pattern matches v1 — preserves user's "функционал максимально близко к телу" intent for capabilities
+
+## How to apply (Stage 4.1)
+
+### 1. Copy the script and its Groq config
+
+```bash
+mkdir -p groups/telegram_main/scripts
+cp /tmp/nanoclaw-state/groups/telegram_main/scripts/transcribe_voice.sh \
+   groups/telegram_main/scripts/
+chmod +x groups/telegram_main/scripts/transcribe_voice.sh
+
+# Groq API key. v1 put it at config/groq.json — keep that location, it's
+# inside the per-group folder which is r/w mounted into the container.
+mkdir -p groups/telegram_main/config
+cp /tmp/nanoclaw-state/groups/telegram_main/config/groq.json \
+   groups/telegram_main/config/groq.json
+```
+
+(No need to move the Groq key to `.env`. The group folder is mounted into the container; the script reads the key from its own `config/groq.json` next to it. Same as v1, no env-passthrough complexity.)
+
+### 2. Verify the script's path assumptions still hold
+
+The v1 script likely hardcodes a path like `/workspace/group/attachments/...`. Update it for the v2 path. The script will be invoked as:
+
+```bash
+bash scripts/transcribe_voice.sh /workspace/inbox/<message-id>/<filename>
+```
+
+Open the script, find any hardcoded prefix like `attachments/` or `/workspace/group/...` — replace with whatever path the agent will actually pass, or make it accept absolute path and Just Work.
+
+### 3. Teach the agent how to use it
+
+Append to `groups/telegram_main/CLAUDE.local.md` (the per-group instructions file in v2 — see [03-formatting.md](03-formatting.md) and [07-data-restore.md](07-data-restore.md) for the rename):
+
+```markdown
+## Voice transcription
+
+When you receive a Telegram message with a voice attachment, you'll see it
+formatted in your context as:
+
+  [voice: <name> — saved to /workspace/inbox/<messageId>/<filename>]
+
+To transcribe it, run from `/workspace/group/`:
+
+  bash scripts/transcribe_voice.sh /workspace/inbox/<messageId>/<filename>
+
+It prints the transcript to stdout. Use the transcript as the user's intent
+and reply normally.
+
+If the script errors (network, key invalid), apologize briefly to the user
+and ask them to retype.
+```
+
+### 4. Verify on a real voice note
+
+Send a voice message via Telegram. Agent should call the script, read transcript, respond.
+
+## What we drop from v1
+
+Nothing — script + per-group config carry over 1:1. Only the path the script reads changes from `/workspace/group/attachments/<file>` to `/workspace/inbox/<msgid>/<file>`. One-line script edit.
+
+## Reference for future automatic transcription
+
+If we ever want host-side automatic transcription (no agent round-trip), the precedent is **Signal channel** in commit `53513db` (unmerged on origin/main). It implements voice transcription using either `WHISPER_BIN` (local whisper.cpp) or `OPENAI_API_KEY`. That's a feature PR to revive later — not a migration step.

--- a/.nanoclaw-migrations/05-business-logic.md
+++ b/.nanoclaw-migrations/05-business-logic.md
@@ -1,0 +1,141 @@
+# 05 — Business logic (Bybit P2P, Valtrex, Tailscale)
+
+> ✅ **VERIFIED** against v2 source on 2026-05-27:
+> - `ncl groups config add-package`: confirmed at `origin/main:src/cli/resources/groups.ts:304-336`
+> - `packages_npm` storage: confirmed at `origin/main:src/db/container-configs.ts` (JSON_COLUMNS)
+> - `additional_mounts` column exists but no dedicated CLI verb found
+> - CLAUDE.local.md auto-migration: confirmed at `origin/main:src/claude-md-compose.ts:144-187`
+
+User explicit 2026-05-27: preserve functionality, port close to v1 but expose through v2's mechanisms.
+
+## Files — straight copy
+
+v2 still uses `groups/<folder>/` for per-agent-group filesystem (verified at `origin/main:src/group-init.ts`). The container mounts it r/w. Scripts/state/binaries port 1:1.
+
+```bash
+# After Stage 3 (agent group created, group folder exists)
+rsync -a --exclude=node_modules --exclude=attachments --exclude=logs \
+      /tmp/nanoclaw-state/groups/telegram_main/ groups/telegram_main/
+```
+
+**CLAUDE.md rename is automatic.** `origin/main:src/claude-md-compose.ts:144-187` migrates `CLAUDE.md` → `CLAUDE.local.md` on first spawn if the local file doesn't exist. Operator does not manually rename.
+
+## NPM dependencies (puppeteer-extra, ssh2, tweetnacl)
+
+**v2 bakes npm packages into the container image** — not per-group `npm install`, not runtime install.
+
+Verified at `origin/main:src/cli/resources/groups.ts:304-336`:
+
+```
+'config add-package': {
+  Add a package to a group. Requires `ncl groups restart --rebuild` to take effect.
+  Use --id <group-id> and --apt <pkg> or --npm <pkg>.
+}
+```
+
+So:
+
+```bash
+ncl groups config add-package --id <agent-group-id> --npm puppeteer-extra
+ncl groups config add-package --id <agent-group-id> --npm puppeteer-extra-plugin-stealth  # if used
+ncl groups config add-package --id <agent-group-id> --npm ssh2
+ncl groups config add-package --id <agent-group-id> --npm tweetnacl
+
+ncl groups restart --id <agent-group-id> --rebuild
+```
+
+Storage: `packages_npm` JSON array column in `container_configs` table (verified at `origin/main:src/db/container-configs.ts`).
+
+The `--rebuild` is mandatory — packages don't appear in the running container until image rebuild. There's also `install_packages` from the agent's side (referenced in `groups.ts:336`) — agent can request packages via a self-mod tool; that path triggers an approval flow. For the initial setup, doing it via `ncl` from the host is simpler.
+
+Drop the v1 per-group `package.json` after — v2 sources package list from the DB row, not from a per-group file.
+
+## Scheduled tasks — agent re-creates via `schedule_task` tool
+
+v2 scheduling is "the agent owns its schedule" (verified at `origin/main:src/modules/scheduling/index.ts`). Five action handlers are registered: `schedule_task`, `cancel_task`, `pause_task`, `resume_task`, `update_task`. The agent calls these via its MCP tool surface; host's delivery action handler creates the recurring tasks as `messages_in` rows with `kind='task'` (piggybacks on core schema, no separate scheduling table).
+
+After the group is wired (Stage 3 done), send one Telegram message to the agent:
+
+```
+Re-create my recurring tasks:
+
+1. `0 4 * * *` — daily Bybit P2P report + chart, runs `scripts/bybit_report.sh`
+2. `*/5 * * * *` — Bybit P2P data collector, runs `scripts/bybit_collect.sh`
+3. `*/5 * * * *` — Bybit P2P USDT alert, runs `scripts/bybit_alert.sh`
+4. `0 6 * * *` — morning script, runs `scripts/morning.sh`
+5. `*/5 * * * *` — Bybit-related, runs `scripts/bybit_X.sh`
+```
+
+(Exact script names + commands taken from `store/messages.db:scheduled_tasks` on the v1 server. Fill in from snapshot before sending.)
+
+Agent will call `schedule_task` 5 times.
+
+## Tailscale — Path A (host-side socket mount)
+
+User decision 2026-05-27: «Мне нужно только для того, чтобы через него потенциально могли ходить какие-то отдельные сервисы, которые завязаны на домашнюю мою сеть.» Translation: access to home-network services through Tailscale — no need for a separate agent node identity. Path A.
+
+### What we do
+
+- `tailscaled` runs on the NixOS host (already in your NixOS module — verify when porting to v2)
+- Container mounts `/var/run/tailscale/tailscaled.sock` r/w via `container_configs.additional_mounts`
+- Inside container, `tailscale` CLI talks to the socket → host's identity → home network reachable
+
+### Verified
+
+- `additional_mounts` JSON column exists in `container_configs` (verified at `origin/main:src/db/container-configs.ts`, JSON_COLUMNS set)
+- No dedicated `ncl groups config add-mount` verb was found, but the row can be updated via `ncl groups config update` JSON path OR via direct SQL through the in-tree wrapper (per v2 `CLAUDE.md`: `pnpm exec tsx scripts/q.ts <db> "<sql>"`)
+
+### Steps
+
+```bash
+# 1. Ensure tailscaled runs on host (NixOS module — when we update nixserver)
+
+# 2. Add the socket mount to the agent group's container config
+# First check CLI shape:
+ncl groups config help
+# Look for `update` verb + mount-related flag, OR `add-mount` verb.
+# Per v2 CLAUDE.md, additional_mounts is a JSON column — likely settable via:
+ncl groups config update --id <agent-group-id> \
+  --additional-mounts '[{"host":"/var/run/tailscale","container":"/var/run/tailscale","readonly":false}]'
+
+# If that flag form doesn't exist, fall back to direct SQL:
+pnpm exec tsx scripts/q.ts data/v2.db \
+  "UPDATE container_configs SET additional_mounts = '[{\"host\":\"/var/run/tailscale\",\"container\":\"/var/run/tailscale\",\"readonly\":false}]' WHERE agent_group_id = '<id>'"
+
+# 3. Add tailscale CLI binary as an apt package
+ncl groups config add-package --id <agent-group-id> --apt tailscale
+
+# 4. Rebuild + restart
+ncl groups restart --id <agent-group-id> --rebuild
+```
+
+### What we drop from v1
+
+- `.tailscale-state/` from the snapshot — **not needed** in Path A. Identity lives on the host now, no per-container state.
+- Tailscale auth key — host already authenticated, agent just uses the socket.
+
+### What to verify on first run
+
+```bash
+# Inside the agent's container:
+tailscale status         # should show the host's identity + tailnet peers
+tailscale ping <home-host-on-tailnet>   # should succeed
+```
+
+If both work, Tailscale Path A is done.
+
+## How to apply (Stage 3 + Stage 4.2)
+
+1. **Stage 3.1** — `rsync` group files (skip `node_modules`, `attachments`, `logs`)
+2. **Stage 3.2** — copy `CLAUDE.md` into the group folder; the composer renames it to `CLAUDE.local.md` automatically on first spawn (no manual step)
+3. **Stage 3.3** — pick Tailscale path A or B; apply via `additional_mounts` + `--apt tailscale`
+4. **Stage 3.4** — `ncl groups config add-package --npm` for each of: `puppeteer-extra`, `ssh2`, `tweetnacl` (+ stealth if used)
+5. **Stage 3.5** — `ncl groups restart --rebuild`
+6. **Stage 4.2** — ask agent via Telegram to re-create the 5 scheduled tasks
+
+## Things to verify before Stage 3 (small recon)
+
+- Exact script filenames in `/tmp/nanoclaw-state/groups/telegram_main/scripts/` (INVENTORY.md only lists prefixes)
+- Exact cron strings + commands in v1's `store/messages.db:scheduled_tasks` table
+- Whether the agent's container in v1 had any non-default container config (Tailscale path = identity decision input)
+- Whether `ncl groups config` has a mount-related verb OR if `additional_mounts` is set via raw `config update` JSON (one CLI command away from confirming)

--- a/.nanoclaw-migrations/06-nixos-network.md
+++ b/.nanoclaw-migrations/06-nixos-network.md
@@ -1,0 +1,96 @@
+# 06 — NixOS container networking patch
+
+> ✅ **VERIFIED** against `origin/main:src/container-runtime.ts` (90 lines total, audited in full on 2026-05-27).
+
+## Decision
+
+Patch the existing `hostGatewayArgs()` function in v2's `src/container-runtime.ts` to detect NixOS and return `['--network=host']` instead of `['--add-host=host.docker.internal:host-gateway']`. Then update `CONTAINER_HOST_GATEWAY` consumers to use `127.0.0.1` when NixOS. Open PR upstream with same diff. No skill, no abstraction.
+
+## Verified v2 state (no NixOS handling exists)
+
+`origin/main:src/container-runtime.ts:15-21`:
+
+```ts
+export function hostGatewayArgs(): string[] {
+  // On Linux, host.docker.internal isn't built-in — add it explicitly
+  if (os.platform() === 'linux') {
+    return ['--add-host=host.docker.internal:host-gateway'];
+  }
+  return [];
+}
+```
+
+Problems on NixOS:
+1. `--add-host=...:host-gateway` requires the Docker daemon to know the host gateway. On NixOS this works only when the bridge network was created with `com.docker.network.host_ipv4` set — usually it isn't.
+2. Even when it works, the host gateway address inside the container often doesn't route back to host services because of NixOS firewall defaults.
+
+`--network=host` sidesteps both — the container shares the host network namespace, so `127.0.0.1` from inside the container is the host's loopback.
+
+Note: v2's file does NOT expose a `CONTAINER_HOST_GATEWAY` constant. The hostname used by host-targeting URLs is set elsewhere (likely in `src/container-runner.ts` or env-derived). Need to grep before patching — we may need to change two places, not one.
+
+## How to apply (Stage 1.1)
+
+### 1. Patch `hostGatewayArgs()`
+
+Replace the function body in `src/container-runtime.ts:15-21`:
+
+```ts
+export function hostGatewayArgs(): string[] {
+  if (os.platform() === 'linux') {
+    if (fs.existsSync('/etc/NIXOS')) {
+      return ['--network=host'];
+    }
+    return ['--add-host=host.docker.internal:host-gateway'];
+  }
+  return [];
+}
+```
+
+Plus `import fs from 'fs';` at top (only `os` is imported today, line 6).
+
+### 2. Make any "host gateway hostname" consumers NixOS-aware
+
+Grep before patch:
+
+```bash
+git grep -n 'host.docker.internal' origin/main -- src/
+```
+
+Wherever the literal `host.docker.internal` appears in code paths used after `hostGatewayArgs()` is applied — replace with a small helper that returns `127.0.0.1` when `--network=host` is in effect, `host.docker.internal` otherwise.
+
+The simplest shape — add to `container-runtime.ts`:
+
+```ts
+export function hostGateway(): string {
+  if (os.platform() === 'linux' && fs.existsSync('/etc/NIXOS')) {
+    return '127.0.0.1';
+  }
+  return 'host.docker.internal';
+}
+```
+
+And replace any string literal `host.docker.internal` in the container-spawn paths with `hostGateway()`.
+
+### 3. Build + test on NixOS
+
+```bash
+pnpm run build
+# spawn a session, exec into the container, confirm host reachability:
+docker exec <container> curl -fsS "http://$(getent hosts host.docker.internal | awk '{print $1}'):<credential-proxy-port>/<healthz endpoint>"
+# or, with --network=host:
+docker exec <container> curl -fsS "http://127.0.0.1:<credential-proxy-port>/<healthz endpoint>"
+```
+
+(Exact health endpoint TBD — see [02-credentials.md](02-credentials.md) for the credential proxy port.)
+
+### 4. PR upstream
+
+Title: `feat(container): use --network=host and 127.0.0.1 gateway on NixOS`
+
+Body — describe the resolution problem on NixOS + the `/etc/NIXOS` discriminator. Reference original v1 patches `fcaeb4a` and `e9337eb` for prior art on this fork.
+
+## Notes
+
+- The patch is ~10 lines total. Local commit = the PR diff. If upstream merges, we drop the local commit; if they ask for a different shape (e.g. env-var opt-in), we update the PR.
+- `/etc/NIXOS` exists on every NixOS system — minimal and reliable discriminator. Cheaper than calling `nixos-version`.
+- v2's file is **only 90 lines**, simpler than v1. Whole patch lives in this one file (plus possibly one call site in `container-runner.ts`).

--- a/.nanoclaw-migrations/07-data-restore.md
+++ b/.nanoclaw-migrations/07-data-restore.md
@@ -1,0 +1,80 @@
+# 07 — Data restoration from `/tmp/nanoclaw-state/`
+
+## Problem
+
+v2's DB schema is fundamentally different from v1's:
+- v1: single `store/messages.db` with mixed tables
+- v2: central `data/v2.db` (entities, wiring, approvals, etc.) + per-session `data/v2-sessions/<id>/inbound.db` and `outbound.db`
+
+User explicit 2026-05-27: do NOT run `migrate-v2.sh`. Plan is intent-based, the DB will be reseeded; only the group's filesystem data and a re-created agent group/wiring carry over.
+
+## What we keep vs drop
+
+| Source | What | Action | Why |
+|---|---|---|---|
+| `store/messages.db: chats` | WhatsApp chat metadata sync | DROP | Telegram only, irrelevant |
+| `store/messages.db: messages` | 234 chat history messages | DROP | Recoverable from Telegram; v2 doesn't ingest old v1 history; agent has its own `conversations/` |
+| `store/messages.db: registered_groups` | 1 row (`tg:42582289`, `telegram_main`, trigger `@Andy`) | RESEED manually | One row, easy to recreate in v2's new entity model |
+| `store/messages.db: router_state` | last-processed timestamps | DROP | v2 has its own state machinery |
+| `store/messages.db: scheduled_tasks` | 5 live cron + 4 dead | DROP (see [05-business-logic.md](05-business-logic.md)) | Agent re-creates via `schedule_task` |
+| `store/messages.db: sessions` | v1 session rows | DROP | v2 has new session model |
+| `store/messages.db: task_run_logs` | execution history | DROP | informational only |
+| `groups/telegram_main/CLAUDE.md` | agent persona + HTML formatting block | KEEP — review against v2 conventions | Source of truth for what agent knows |
+| `groups/telegram_main/scripts/` | Bybit + Valtrex + voice | KEEP (see [05-business-logic.md](05-business-logic.md)) | Business logic |
+| `groups/telegram_main/config/groq.json` | Groq API key | KEEP, but move into `.env` as `GROQ_API_KEY` | Idiomatic v2 secret location |
+| `groups/telegram_main/.tailscale-state/` | Tailscale node identity | KEEP — copy as-is | Reinstall = re-invite |
+| `groups/telegram_main/bin/` | agent-installed binaries | KEEP | Save the agent re-installing them |
+| `groups/telegram_main/node_modules/` | puppeteer-extra, ssh2, tweetnacl | DROP, rebuild | Re-run `npm install` via v2's group init |
+| `groups/telegram_main/package.json` | dependency declarations | KEEP | Driver for the rebuild |
+| `groups/telegram_main/memory/` | agent's persistent notes | KEEP | Agent's working memory |
+| `groups/telegram_main/conversations/` | agent's own conversation log | KEEP | Cross-session memory |
+| `groups/telegram_main/data/` | per-group app data | KEEP, audit case-by-case | Mostly portable |
+| `groups/telegram_main/attachments/` | voice + photos from chat | DROP | Old chat media |
+| `groups/telegram_main/logs/` | container logs | DROP | Old debug logs |
+| `groups/main/CLAUDE.md` | control-group persona | KEEP, compare against v2's seed | Lightweight |
+| `groups/global/CLAUDE.md` | cross-group memory | KEEP, compare against v2's seed | Lightweight |
+| `data/sessions/*/agent-runner-src/` | host-mount copy of agent-runner | DROP | v2 generates this differently |
+| `data/ipc/` | IPC task files | DROP | v2 has no IPC dir |
+
+## Reseed registered group in v2
+
+v2 entity model is: `users → messaging_groups → agent_groups → sessions` (see v2 CLAUDE.md).
+
+The v1 row `tg:42582289 / Main / telegram_main / @Andy / isMain=1 / requiresTrigger=0` maps to:
+
+1. **User**: the Telegram operator (you). Created during `/init-first-agent` or `ncl users create`.
+2. **Messaging group**: one Telegram DM/chat at `tg:42582289` with `unknown_sender_policy='allow'` (or whatever).
+3. **Agent group**: an `agent_group` named `Main` with:
+   - workspace: `groups/telegram_main/`
+   - personality / CLAUDE.md: seeded from the carried-over file
+   - container config: standard + any custom mounts (Tailscale socket if needed — see [05-business-logic.md](05-business-logic.md))
+4. **Wiring**: `messaging_group → agent_group` with `session_mode` ("single" for DM, or whatever the v2 default is) and `trigger_rules` (no trigger needed since it's the main DM).
+
+The skill **`/init-first-agent`** walks through 1–4 for a DM. Use it.
+
+## How to apply (Stage 3)
+
+```bash
+# 1. Bring snapshot to workspace
+mkdir -p groups/telegram_main
+rsync -a --exclude=node_modules --exclude=attachments --exclude=logs \
+      /tmp/nanoclaw-state/groups/telegram_main/ groups/telegram_main/
+
+# 2. Extract Groq key into .env
+node -e 'console.log("GROQ_API_KEY=" + require("/tmp/nanoclaw-state/groups/telegram_main/config/groq.json").api_key)' >> .env
+
+# 3. Walk through /init-first-agent
+# (interactive — operator runs it, agent group is created, DM is wired)
+
+# 4. Drop the old config/groq.json from group folder (now in .env)
+rm groups/telegram_main/config/groq.json
+```
+
+## Validation
+
+After init-first-agent + reseed:
+- `ncl groups list` → shows one entry `Main`
+- `ncl messaging-groups list` → shows `tg:42582289`
+- `ncl wirings list` → shows one wiring connecting them
+- Sending a Telegram message → agent responds
+- Then move to Stage 4 (capabilities)

--- a/.nanoclaw-migrations/index.md
+++ b/.nanoclaw-migrations/index.md
@@ -1,0 +1,73 @@
+# NanoClaw v1 → v2 Migration Guide (intent-based)
+
+Generated: 2026-05-27
+Source branch: `nixos-deploy` @ `7cc6d27` (v1.2.46)
+Target: `origin/main` @ `2492259` (v2.0.70)
+Backup tag: `archive/v1-pre-v2-migration`
+Server snapshot: `/tmp/nanoclaw-state/` (see `INVENTORY.md` there)
+
+## Approach
+
+**Intent-based, not merge-based.** We do NOT run `migrate-v2.sh`. For each v1 customization we ask:
+
+1. Is the problem still relevant in v2?
+2. Does v2 solve it idiomatically (skill / built-in)?
+3. If yes — use that. If no — implement minimally and idiomatically in v2 layout.
+
+User explicit decisions (Telegram conversation, 2026-05-27):
+- **Telegram**: use upstream `/add-telegram` skill (Chat SDK bridge). No more local fork of `qwibitai/nanoclaw-telegram`.
+- **Credentials**: v2 default = OneCLI Agent Vault. Apply `/init-onecli`, which migrates the OAuth token from `.env` into the vault. The NixOS module continues to drop the sops-managed token into `.env` for first-run ingest.
+- **Voice transcription**: keep Groq Whisper (fast, light). Per-group bash script in `groups/<folder>/scripts/` — v2 has no transcription skill to reuse. See [04-voice.md](04-voice.md).
+- **Formatting**: HTML via a new skill **`/use-telegram-html`** — written to upstream-PR quality from day one (full SKILL.md + REMOVE.md + VERIFY.md, idempotent, sentinel-marked for re-apply detection). Layers on `/add-telegram`, bypasses the Chat SDK's hardcoded Markdown via direct `fetch` with `parse_mode=HTML`. After local verification, submit as upstream PR. See [03-formatting.md](03-formatting.md).
+- **Bybit / Valtrex**: scripts copy 1:1 into `groups/<folder>/scripts/`. NPM deps via `ncl groups config add-package --npm` (baked into image, requires `--rebuild`).
+- **Tailscale**: Path A — host-side `tailscaled` + `/var/run/tailscale/tailscaled.sock` mounted into container via `additional_mounts`. Host identity shared with agent. No separate per-container Tailscale state.
+- **NixOS networking patch**: keep, but should upstream as PR. See [06-nixos-network.md](06-nixos-network.md).
+
+## Migration Plan (Tier 3)
+
+### Stage 1 — Infra & build
+1. Apply NixOS networking patch + open PR — [06-nixos-network.md](06-nixos-network.md)
+2. Apply `/init-onecli` skill — [02-credentials.md](02-credentials.md)
+3. Build container image
+4. Validate that v2 stub runs (no chat yet)
+
+### Stage 2 — Channel
+5. Apply `/add-telegram` skill — [01-channels.md](01-channels.md)
+6. Pair the bot (`telegram_main`, JID `tg:42582289`)
+7. Create + apply `/use-telegram-html` skill — [03-formatting.md](03-formatting.md). Patches the installed adapter, sets HTML formatting block in `CLAUDE.local.md`.
+
+### Stage 3 — Group state
+9. Restore data into v2 group folder — [07-data-restore.md](07-data-restore.md)
+10. Re-create the agent group via `ncl groups create`
+11. Wire `messaging_groups` → `agent_groups` via `ncl wirings create`
+
+### Stage 4 — Capabilities
+12. Voice transcription via Groq — [04-voice.md](04-voice.md)
+13. Business logic (Bybit, Valtrex) — [05-business-logic.md](05-business-logic.md)
+14. Re-create scheduled tasks via agent (`schedule_task` MCP tool) or `ncl`
+
+### Stage 5 — Deploy
+15. Update NixOS module in `~/Documents/GitHub/nixserver/` for v2 paths (`data/v2.db`, two-DB session split)
+16. Live test from the worktree before swap
+17. Switch live service
+
+## Risk Areas
+
+- **Container image rebuild**: v2 bakes npm packages into the image — `ncl groups config add-package --npm <pkg>` for `puppeteer-extra`, `ssh2`, `tweetnacl`; then `ncl groups restart --rebuild`. Not runtime install.
+- **DB break**: v1's `store/messages.db` is incompatible with v2's `data/v2.db` + per-session split. We deliberately drop chat history (234 messages, recoverable from Telegram if needed) and reseed registered group + scheduled tasks.
+- **HTML formatting in v2**: Chat SDK adapter hardcodes Markdown. Our `/use-telegram-html` skill is the delta on this fork. ~30 lines of code we own — minimal, idempotent, removable. Watch upstream for `vercel/chat PR #367`; when it lands we can collapse to a config knob.
+- **NixOS module rewrite**: deploy infra in `nixserver` repo still references v1 paths/units. Out of scope for this repo but blocks the production cutover.
+
+## Skill Interactions
+
+- `/init-onecli`, `/add-telegram`, `/use-telegram-html`: apply in that order. `/use-telegram-html` requires `/add-telegram`; both are independent of `/init-onecli`.
+- `/init-onecli` and `/add-telegram` are clean upstream skills. `/use-telegram-html` is our new skill, written to upstream-PR quality — same conventions, same Phase structure, same file set.
+
+## Status
+
+- [x] Plan drafted
+- [ ] Stage 1 — Infra & build
+- [ ] Stage 2 — Channel
+- [ ] Stage 3 — Group state
+- [ ] Stage 4 — Capabilities
+- [ ] Stage 5 — Deploy

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -17,8 +17,23 @@ vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
+// Mock fs.existsSync for /etc/NIXOS detection in hostGatewayArgs
+const mockExistsSync = vi.fn();
+vi.mock('fs', () => ({
+  default: { existsSync: (path: string) => mockExistsSync(path) },
+  existsSync: (path: string) => mockExistsSync(path),
+}));
+
+// Mock os.platform for hostGatewayArgs branching
+const mockPlatform = vi.fn();
+vi.mock('os', () => ({
+  default: { platform: () => mockPlatform() },
+  platform: () => mockPlatform(),
+}));
+
 import {
   CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
   readonlyMountArgs,
   stopContainer,
   ensureContainerRuntimeRunning,
@@ -32,6 +47,37 @@ beforeEach(() => {
 });
 
 // --- Pure functions ---
+
+describe('hostGatewayArgs', () => {
+  it('returns --add-host on non-NixOS Linux', () => {
+    mockPlatform.mockReturnValue('linux');
+    mockExistsSync.mockReturnValue(false);
+
+    expect(hostGatewayArgs()).toEqual(['--add-host=host.docker.internal:host-gateway']);
+    expect(mockExistsSync).toHaveBeenCalledWith('/etc/NIXOS');
+  });
+
+  it('returns --network=host on NixOS Linux', () => {
+    mockPlatform.mockReturnValue('linux');
+    mockExistsSync.mockImplementation((p: string) => p === '/etc/NIXOS');
+
+    expect(hostGatewayArgs()).toEqual(['--network=host']);
+  });
+
+  it('returns empty args on macOS', () => {
+    mockPlatform.mockReturnValue('darwin');
+
+    expect(hostGatewayArgs()).toEqual([]);
+    // NixOS check is not even reached on non-Linux
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('returns empty args on Windows', () => {
+    mockPlatform.mockReturnValue('win32');
+
+    expect(hostGatewayArgs()).toEqual([]);
+  });
+});
 
 describe('readonlyMountArgs', () => {
   it('returns -v flag with :ro suffix', () => {

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -3,6 +3,7 @@
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
 import { execSync } from 'child_process';
+import fs from 'fs';
 import os from 'os';
 
 import { CONTAINER_INSTALL_LABEL } from './config.js';
@@ -13,8 +14,15 @@ export const CONTAINER_RUNTIME_BIN = 'docker';
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
   if (os.platform() === 'linux') {
+    // NixOS: the docker bridge network often lacks a usable host gateway
+    // address, so `--add-host=...:host-gateway` doesn't resolve. Share the
+    // host network namespace instead — services on localhost become reachable
+    // at 127.0.0.1 from inside the container.
+    if (fs.existsSync('/etc/NIXOS')) {
+      return ['--network=host'];
+    }
+    // Other Linux distros: host.docker.internal isn't built-in — add it explicitly
     return ['--add-host=host.docker.internal:host-gateway'];
   }
   return [];


### PR DESCRIPTION
## Problem

On NixOS hosts, `--add-host=host.docker.internal:host-gateway` (the current behavior in `src/container-runtime.ts:15-21`) often fails to resolve from inside containers. NixOS's docker bridge networking typically doesn't expose a usable host gateway, so the `:host-gateway` magic string resolves to nothing and host-side services (credential proxy, OneCLI gateway) become unreachable.

## Fix

Detect NixOS via the presence of `/etc/NIXOS` and share the host network namespace (`--network=host`) instead. With shared netns, services on the host's loopback become reachable at `127.0.0.1` from inside the container — robust across NixOS configurations.

```ts
if (os.platform() === 'linux') {
  if (fs.existsSync('/etc/NIXOS')) {
    return ['--network=host'];
  }
  return ['--add-host=host.docker.internal:host-gateway'];
}
return [];
```

## What stays the same

- **Non-NixOS Linux**: unchanged (`--add-host=host.docker.internal:host-gateway`)
- **macOS / Windows**: unchanged (Docker Desktop handles `host.docker.internal` natively, no flags needed)

## Tests

Adds 4 unit tests to `src/container-runtime.test.ts` covering each branch:
- NixOS Linux → `['--network=host']`
- Non-NixOS Linux → `['--add-host=host.docker.internal:host-gateway']`
- macOS → `[]`
- Windows → `[]`

All 14 tests in `container-runtime.test.ts` pass. Full `pnpm exec vitest run` is green (336/336).

## Operator note (not in PR scope)

Operators using OneCLI on NixOS may also need to set `ONECLI_URL=http://127.0.0.1:<port>` in `.env` (instead of `host.docker.internal:<port>`) since `--network=host` makes the container share the host's network namespace. The OneCLI install script writes the URL; this is a one-time `.env` edit after `/init-onecli` on NixOS.

## Background

The `/etc/NIXOS` discriminator is the minimal correct way to detect a NixOS system. It exists on every NixOS installation and is cheaper than calling `nixos-version`. Same approach used by Nixpkgs internals.