### PR TITLE
[security] fix(session-manager): confine target inbox roots

### DIFF
--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -189,6 +189,29 @@ describe('session manager', () => {
     expect(fs.existsSync(path.join(evilTarget, 'photo.png'))).toBe(false);
   });
 
+  it('should reject inbound attachment writes when the session inbox root is a symlink', () => {
+    initSessionFolder('ag-1', 'sess-test');
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const inboxRoot = path.join(sessionDir('ag-1', session.id), 'inbox');
+    const escapedRoot = path.join(TEST_DIR, 'escaped-inbox-root');
+    fs.rmSync(inboxRoot, { recursive: true, force: true });
+    fs.mkdirSync(escapedRoot, { recursive: true });
+    fs.symlinkSync(escapedRoot, inboxRoot, 'dir');
+
+    writeSessionMessage('ag-1', session.id, {
+      id: 'msg-root-sym',
+      kind: 'chat',
+      timestamp: now(),
+      content: JSON.stringify({
+        text: 'root-sym',
+        attachments: [{ name: 'photo.png', data: Buffer.from('PNGBYTES').toString('base64'), size: 8 }],
+      }),
+    });
+
+    expect(fs.existsSync(path.join(escapedRoot, 'msg-root-sym', 'photo.png'))).toBe(false);
+  });
+
   it('should refuse to follow a pre-existing symlink at the inbound attachment path', () => {
     initSessionFolder('ag-1', 'sess-test');
     const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');

--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -386,6 +386,48 @@ describe('routeAgentMessage return-path', () => {
     expect(JSON.parse(s2Rows[0].content).text).toBe('self-note');
   });
 
+  it('file forwarding: refuses to plant a persistent Claude skill through a symlinked target inbox root', async () => {
+    const filename = 'SKILL.md';
+    const skillBody = [
+      '---',
+      'name: planted-skill',
+      'description: proves target inbox root symlink escape',
+      '---',
+      '',
+      '# Planted skill',
+      '',
+      'INBOX_ROOT_SYMLINK_SKILL_CHAIN',
+      '',
+    ].join('\n');
+
+    const outboxDir = path.join(sessionDir(A, S1.id), 'outbox', 'self-file-msg');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, filename), skillBody);
+
+    const skillsDir = path.join(TEST_DIR, 'v2-sessions', A, '.claude-shared', 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+    for (const targetSession of [S1, S2]) {
+      const inboxRoot = path.join(sessionDir(A, targetSession.id), 'inbox');
+      fs.rmSync(inboxRoot, { recursive: true, force: true });
+      fs.symlinkSync('../.claude-shared/skills', inboxRoot, 'dir');
+    }
+
+    await routeAgentMessage(
+      {
+        id: 'self-file-msg',
+        platform_id: A,
+        content: JSON.stringify({ text: 'self file', files: [filename] }),
+        in_reply_to: null,
+      },
+      S1,
+    );
+
+    const plantedSkillFiles = fs
+      .readdirSync(skillsDir, { recursive: true })
+      .filter((entry) => entry.toString().endsWith('/SKILL.md'));
+    expect(plantedSkillFiles).toEqual([]);
+  });
+
   it('BUG: no volume cap on a2a routing — unbounded ping-pong is allowed (#2063)', async () => {
     // Two agents can exchange unlimited messages with no rate limit or loop
     // detection. This test documents the gap — it should FAIL once #2063 lands.

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -27,7 +27,13 @@ import { getInboundSourceSessionId, getMostRecentPeerSourceSessionId } from '../
 import { getSession } from '../../db/sessions.js';
 import { wakeContainer } from '../../container-runner.js';
 import { log } from '../../log.js';
-import { openInboundDb, resolveSession, sessionDir, writeSessionMessage } from '../../session-manager.js';
+import {
+  openInboundDb,
+  resolveSafeInboxDir,
+  resolveSession,
+  sessionDir,
+  writeSessionMessage,
+} from '../../session-manager.js';
 import type { Session } from '../../types.js';
 import { hasDestination } from './db/agent-destinations.js';
 
@@ -66,8 +72,15 @@ export function forwardAttachedFiles(
     return [];
   }
 
-  const targetInboxDir = path.join(sessionDir(target.agentGroupId, target.sessionId), 'inbox', target.messageId);
-  fs.mkdirSync(targetInboxDir, { recursive: true });
+  const safeInbox = resolveSafeInboxDir(target.agentGroupId, target.sessionId, target.messageId);
+  if (!safeInbox) {
+    log.warn('agent-route: rejecting unsafe target inbox, no files forwarded', {
+      targetMsgId: target.messageId,
+      targetSessionId: target.sessionId,
+    });
+    return [];
+  }
+  const targetInboxDir = safeInbox.inboxDir;
 
   const attachments: ForwardedAttachment[] = [];
   for (const filename of source.filenames) {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -43,6 +43,77 @@ function isPathInside(parent: string, child: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function resolveSafeInboxRoot(
+  agentGroupId: string,
+  sessionId: string,
+): { inboxRoot: string; realInboxRoot: string } | null {
+  const dir = sessionDir(agentGroupId, sessionId);
+  const inboxRoot = path.join(dir, 'inbox');
+
+  try {
+    if (fs.existsSync(inboxRoot)) {
+      const stat = fs.lstatSync(inboxRoot);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        log.warn('Rejecting unsafe inbox root', { agentGroupId, sessionId, inboxRoot });
+        return null;
+      }
+    } else {
+      fs.mkdirSync(inboxRoot, { recursive: true });
+    }
+
+    const realSessionDir = fs.realpathSync(dir);
+    const realInboxRoot = fs.realpathSync(inboxRoot);
+    if (!isPathInside(realSessionDir, realInboxRoot)) {
+      log.warn('Inbox root escaped session directory', { agentGroupId, sessionId, inboxRoot });
+      return null;
+    }
+    return { inboxRoot, realInboxRoot };
+  } catch (err) {
+    log.warn('Failed to inspect inbox root', { agentGroupId, sessionId, inboxRoot, err });
+    return null;
+  }
+}
+
+export function resolveSafeInboxDir(
+  agentGroupId: string,
+  sessionId: string,
+  messageId: string,
+): { inboxDir: string; realInboxDir: string } | null {
+  if (!isSafeAttachmentName(messageId)) {
+    log.warn('Rejecting unsafe inbound message id', { messageId });
+    return null;
+  }
+
+  const root = resolveSafeInboxRoot(agentGroupId, sessionId);
+  if (!root) return null;
+
+  const inboxDir = path.join(root.inboxRoot, messageId);
+
+  try {
+    // Refuse to mkdir through a symlink that the container may have pre placed
+    // at inboxDir. With recursive:true, mkdirSync would silently no op on a
+    // pre existing symlink and the subsequent writeFileSync would follow it.
+    if (fs.existsSync(inboxDir)) {
+      const stat = fs.lstatSync(inboxDir);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        log.warn('Rejecting unsafe inbox directory', { messageId, inboxDir });
+        return null;
+      }
+    }
+    fs.mkdirSync(inboxDir, { recursive: true });
+
+    const realInboxDir = fs.realpathSync(inboxDir);
+    if (!isPathInside(root.realInboxRoot, realInboxDir)) {
+      log.warn('Inbox directory escaped session inbox root', { messageId, inboxDir });
+      return null;
+    }
+    return { inboxDir, realInboxDir };
+  } catch (err) {
+    log.warn('Failed to inspect inbox directory', { messageId, inboxDir, err });
+    return null;
+  }
+}
+
 /** Root directory for all session data. */
 export function sessionsBaseDir(): string {
   return path.join(DATA_DIR, 'v2-sessions');
@@ -283,14 +354,13 @@ function extractAttachmentFiles(
   const attachments = parsed.attachments as Array<Record<string, unknown>> | undefined;
   if (!Array.isArray(attachments)) return contentStr;
 
-  if (!isSafeAttachmentName(messageId)) {
-    log.warn('Rejecting unsafe inbound message id', { messageId });
-    return contentStr;
-  }
-
+  let safeInbox: ReturnType<typeof resolveSafeInboxDir> | null = null;
   let changed = false;
   for (const att of attachments) {
     if (typeof att.data !== 'string') continue;
+
+    safeInbox ??= resolveSafeInboxDir(agentGroupId, sessionId, messageId);
+    if (!safeInbox) return contentStr;
 
     const rawName = deriveAttachmentName(att);
     const filename = isSafeAttachmentName(rawName) ? rawName : `attachment-${Date.now()}`;
@@ -302,34 +372,7 @@ function extractAttachmentFiles(
       });
     }
 
-    const inboxDir = path.join(sessionDir(agentGroupId, sessionId), 'inbox', messageId);
-
-    // Refuse to mkdir through a symlink that the container may have pre placed
-    // at inboxDir. With recursive:true, mkdirSync would silently no op on a
-    // pre existing symlink and the subsequent writeFileSync would follow it.
-    if (fs.existsSync(inboxDir)) {
-      const stat = fs.lstatSync(inboxDir);
-      if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        log.warn('Rejecting unsafe inbox directory', { messageId, inboxDir });
-        continue;
-      }
-    }
-    fs.mkdirSync(inboxDir, { recursive: true });
-
-    let realInboxDir: string;
-    try {
-      realInboxDir = fs.realpathSync(inboxDir);
-    } catch (err) {
-      log.warn('Failed to resolve inbox directory', { messageId, err });
-      continue;
-    }
-    const inboxRoot = path.join(sessionDir(agentGroupId, sessionId), 'inbox');
-    if (!isPathInside(fs.realpathSync(inboxRoot), realInboxDir)) {
-      log.warn('Inbox directory escaped session inbox root', { messageId, inboxDir });
-      continue;
-    }
-
-    const filePath = path.join(inboxDir, filename);
+    const filePath = path.join(safeInbox.inboxDir, filename);
     try {
       // wx = exclusive create. Refuses to follow a pre existing symlink or
       // overwrite any existing file. The host expects to be the sole writer


### PR DESCRIPTION
## Summary

This PR hardens NanoClaw's inbound attachment sink so the host refuses to write through a symlinked session `inbox` root.

Previous hardening covered unsafe `inbox/<messageId>` directories and file-path targets, but both channel-inbound attachment extraction and agent-to-agent file forwarding still trusted the top-level session `inbox` directory as the containment root. Because the session directory is writable from the agent container, a compromised or prompt-injected agent could replace `/workspace/inbox` with a symlink and wait for host-side attachment writes to land outside the intended session inbox.

This patch introduces a shared safe-inbox resolver and uses it for both inbound attachment extraction and agent-to-agent target file forwarding.

## Security issues covered

| Issue | Impact | Fixed by |
| --- | --- | --- |
| Symlinked session inbox root | Host-side inbound attachment writes can escape the intended `session/inbox` tree | `lstat` rejection of the inbox root before mkdir/write plus realpath containment under the session directory |
| Agent-to-agent target inbox root escape | A source agent can self-route or route a file so the host copies bytes through a target session's symlinked `inbox` root | Reusing the safe-inbox resolver in `forwardAttachedFiles(...)` before the copy sink |
| Persistent Claude skill planting chain | A self-routed attachment can be written under `.claude-shared/skills/<a2a-message-id>/SKILL.md` when `inbox` points to `../.claude-shared/skills` | Refusing symlinked inbox roots prevents host writes from reaching the shared Claude skills directory |

## Before this PR

- `extractAttachmentFiles(...)` checked `inbox/<messageId>` but did not reject `inbox` itself when it was a symlink.
- `forwardAttachedFiles(...)` created `inbox/<a2a-message-id>` with `mkdirSync(..., { recursive: true })` and copied files into it without validating the target inbox root.
- A container with `/workspace` write access could replace `inbox` with a relative symlink such as `../.claude-shared/skills`.
- A later host-side attachment write or agent-to-agent copy would follow that root symlink.

## After this PR

- `resolveSafeInboxDir(...)` validates the message id as a safe path segment.
- The top-level session `inbox` path is inspected with `lstatSync` and rejected if it is a symlink or non-directory.
- The resolved inbox root must remain under the resolved session directory.
- The per-message inbox directory still rejects symlinks/non-directories and must remain under the resolved inbox root.
- `extractAttachmentFiles(...)` and `forwardAttachedFiles(...)` both use the same target-side safe-inbox resolver before writing files.

## Why this matters

The session directory is intentionally writable by the agent container:

```ts
mounts.push({ hostPath: sessDir, containerPath: '/workspace', readonly: false });
```

That writable mount is expected for agent workspace state, but host-side file writes must not treat container-controlled directory entries as trusted containment roots.

The impact is especially important for agent-to-agent self-routing because NanoClaw also mounts the per-group Claude config directory back into the agent runtime:

```ts
const claudeDir = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, '.claude-shared');
mounts.push({ hostPath: claudeDir, containerPath: '/home/node/.claude', readonly: false });
```

If a compromised container replaces its session `inbox` with a relative symlink to `../.claude-shared/skills`, a self-routed attachment named `SKILL.md` can make the host create:

```text
data/v2-sessions/<agentGroupId>/.claude-shared/skills/<a2a-message-id>/SKILL.md
```

That path is later visible inside the agent as:

```text
/home/node/.claude/skills/<a2a-message-id>/SKILL.md
```

This turns a target-side path-confusion bug into persistent agent skill/config planting within the same agent group.

## How this differs from #2001, #2053, and #2468

This is the same host/container filesystem-boundary family, but it is a different path component and sink:

- #2001 hardened outbound attachment reads and outbox cleanup in `src/session-manager.ts`.
- #2053 described inbound-side hardening for message ids, attachment filenames, per-message inbox dirs, and file targets.
- #2468 hardens the source side of agent-to-agent forwarding so the host does not copy symlinked source attachments out of a source outbox.

This PR focuses on the **target inbox root** itself. Even with safe message ids, safe filenames, safe per-message dirs, and safe source attachments, the host can still escape if the trusted root `session/inbox` is already a symlink. Both fixes are needed because source-file validation does not protect the destination tree, and per-message validation does not protect the root that per-message directories are created under.

## Attack flow

```text
1. A compromised or prompt-injected agent container has write access to /workspace.
2. The container replaces /workspace/inbox with a relative symlink:
   inbox -> ../.claude-shared/skills
3. The agent writes outbox/<message-id>/SKILL.md and sends an agent-to-agent message to itself with files: ["SKILL.md"].
4. Host-side routeAgentMessage(...) resolves a target a2a message id and calls forwardAttachedFiles(...).
5. Vulnerable code creates inbox/<a2a-message-id>/ and copies SKILL.md through the symlinked inbox root.
6. The host writes the file under .claude-shared/skills/<a2a-message-id>/SKILL.md.
7. Future agent runs see that directory through /home/node/.claude/skills.
```

## Affected code

| File | Area |
| --- | --- |
| `src/session-manager.ts` | Inbound attachment extraction and shared safe-inbox target resolution |
| `src/modules/agent-to-agent/agent-route.ts` | Agent-to-agent target attachment copy sink |
| `src/host-core.test.ts` | Regression coverage for symlinked session inbox root during inbound attachment extraction |
| `src/modules/agent-to-agent/agent-route.test.ts` | Regression coverage for self-routed attachment skill-planting chain |

## Root cause

- The session directory is writable by the agent container.
- The host used `session/inbox` as a trusted root without validating the filesystem object at that path.
- `mkdirSync(..., { recursive: true })` follows or accepts existing symlinked ancestors instead of proving the target tree is inside the intended namespace.
- Existing checks were applied one level too low: they protected `inbox/<messageId>` but not `inbox` itself.

## CVSS assessment

Issue: host/container inbox-root path confinement bypass with persistent agent config planting

CVSS v3.1: 8.5 High

Vector: `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`

Rationale: exploitation requires control of an agent container or equivalent prompt-injected ability to write under `/workspace`, but once that precondition is met the host process can be made to write attacker-controlled attachment bytes outside the intended session inbox. The demonstrated chain crosses from container-writable session state into the host-managed per-group Claude configuration/skills directory, which is mounted into future agent runs.

## Safe reproduction steps

A safe local proof uses temporary NanoClaw data directories and sentinel bytes only:

1. Create an agent group with two active sessions and initialize their session folders.
2. Create `data/v2-sessions/<group>/.claude-shared/skills/`.
3. Replace each candidate target session's `inbox` with a relative symlink to `../.claude-shared/skills`.
4. Create a source outbox file `outbox/self-file-msg/SKILL.md` containing a sentinel string.
5. Call `routeAgentMessage(...)` with `platform_id` equal to the same agent group and `content` containing `files: ["SKILL.md"]`.
6. On vulnerable code, inspect `.claude-shared/skills/` for `<a2a-message-id>/SKILL.md` containing the sentinel.

The new regression test encodes this flow without using real secrets or user data.

## Expected vulnerable behavior

On vulnerable code:

- channel-inbound attachment extraction can write through a symlinked `session/inbox` root into an escaped directory;
- agent-to-agent self-routing can plant `SKILL.md` under `.claude-shared/skills/<a2a-message-id>/`;
- `forwardedFileCount` reports a copied file because the host followed the symlinked target root.

After this patch:

- symlinked inbox roots are logged and rejected;
- no escaped files are written;
- agent-to-agent file forwarding skips the unsafe target inbox and routes the accompanying message without forwarded attachments.

## Changes in this PR

- Adds `resolveSafeInboxDir(...)` in `src/session-manager.ts`.
- Rejects symlinked/non-directory session `inbox` roots before creating per-message inbox directories.
- Requires the resolved inbox root to remain under the resolved session directory.
- Preserves the existing per-message inbox directory symlink/non-directory rejection.
- Reuses the safe-inbox resolver from both channel-inbound attachment extraction and agent-to-agent target forwarding.
- Adds regression tests for the root symlink escape and the self-routed skill-planting chain.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Runtime hardening | `src/session-manager.ts` | Added shared safe-inbox resolver and applied it to inbound attachment writes |
| Runtime hardening | `src/modules/agent-to-agent/agent-route.ts` | Validates the target inbox tree before copying forwarded files |
| Regression tests | `src/host-core.test.ts` | Verifies channel-inbound attachments do not write through a symlinked inbox root |
| Regression tests | `src/modules/agent-to-agent/agent-route.test.ts` | Verifies self-routed `SKILL.md` attachments cannot be planted through a symlinked inbox root |

## Maintainer impact

- Normal inbound attachments and agent-to-agent forwarded attachments continue to use `inbox/<messageId>/<filename>`.
- Unsafe target inbox roots cause attachments to be skipped rather than aborting the whole message route.
- This intentionally rejects a session `inbox` path if a container has replaced it with a symlink or non-directory.
- This PR does not change source outbox validation beyond reusing the existing source behavior; source-side symlink handling is a separate adjacent hardening surface.

## Fix rationale

The host-side file sink is the correct boundary to enforce. Container-side checks are not sufficient because `/workspace` is writable by design, and a compromised container can replace directory entries after initialization.

Validating the root before constructing per-message paths prevents the host from treating a container-controlled symlink as a trusted namespace. The same resolver is shared across channel-inbound and agent-to-agent paths so future inbox writes use the same confinement rules.

## Type of change

- [x] **Fix** - bug fix or security fix to source code
- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Test plan

Red/green validation:

```bash
corepack pnpm exec vitest run src/host-core.test.ts -t "session inbox root is a symlink|symlinked target inbox root" src/modules/agent-to-agent/agent-route.test.ts --reporter=verbose
```

- Before the fix: failed as expected with two vulnerable writes observed.
- After the fix: passed, 2 tests passed / 48 skipped.

Final local validation:

```bash
corepack pnpm exec vitest run src/modules/agent-to-agent/agent-route.test.ts src/host-core.test.ts --reporter=default
corepack pnpm run typecheck
corepack pnpm exec prettier --check src/session-manager.ts src/host-core.test.ts src/modules/agent-to-agent/agent-route.ts src/modules/agent-to-agent/agent-route.test.ts
corepack pnpm exec eslint src/session-manager.ts src/host-core.test.ts src/modules/agent-to-agent/agent-route.ts src/modules/agent-to-agent/agent-route.test.ts
git diff --check
corepack pnpm test -- --run src/modules/agent-to-agent/agent-route.test.ts src/host-core.test.ts
corepack pnpm run build
```

Results:

- Focused `agent-route` + `host-core`: 50 tests passed.
- TypeScript typecheck: passed.
- Prettier check: passed.
- ESLint on touched files: passed with existing catch-all warnings only.
- Diff whitespace check: passed.
- Full `pnpm test` command as run by the repo script: 32 files / 334 tests passed.
- Build: passed.

## Disclosure notes

This PR is intentionally bounded to target-side inbox root confinement for host-side attachment writes. It does not claim a Docker runtime breakout, host namespace escape, or direct arbitrary command execution. The demonstrated impact is a NanoClaw host/container confused-deputy path where a container-controlled symlink can make the host write attacker-controlled attachment bytes into a host-managed per-group Claude configuration surface.
