### PR TITLE
Fix/whatsapp self destruct and shutdown auth wipe

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -577,12 +577,12 @@ registerChannelAdapter('whatsapp', {
                 });
               }, RECONNECT_DELAY_MS);
             });
-          } else {
+          } else if (reason === DisconnectReason.loggedOut) {
+            // Server-side logout (account unlinked, 401, etc.). Clear auth so
+            // the next start prompts for a fresh pair — stale creds would
+            // 401 again and risk WhatsApp's "can't link new devices now"
+            // cooldown.
             log.info('WhatsApp logged out');
-            // Delete auth credentials immediately. Keeping stale credentials
-            // causes the next service restart to attempt authentication with an
-            // invalidated session, producing a second 401 that can trigger
-            // WhatsApp's re-link cooldown ("can't link new devices now").
             try {
               fs.rmSync(authDir, { recursive: true, force: true });
               fs.mkdirSync(authDir, { recursive: true });
@@ -592,6 +592,18 @@ registerChannelAdapter('whatsapp', {
             }
             if (rejectFirstOpen) {
               rejectFirstOpen(new Error('WhatsApp logged out'));
+              rejectFirstOpen = undefined;
+              resolveFirstOpen = undefined;
+            }
+          } else {
+            // Clean shutdown (shuttingDown=true) or a non-loggedOut disconnect
+            // that won't auto-reconnect. KEEP AUTH — the next process boot
+            // must be able to restore the session. Wiping here turned every
+            // `systemctl restart` into a forced re-pair, which is catastrophic
+            // when the bot phone is not in reach.
+            log.info('WhatsApp adapter stopped (auth preserved)');
+            if (rejectFirstOpen) {
+              rejectFirstOpen(new Error('WhatsApp adapter shutdown'));
               rejectFirstOpen = undefined;
               resolveFirstOpen = undefined;
             }

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -516,8 +516,18 @@ registerChannelAdapter('whatsapp', {
         },
       });
 
-      // Request pairing code if phone number is set and not yet registered
-      if (phoneNumber && !state.creds.registered) {
+      // Request pairing code only when there's no paired account yet.
+      //
+      // We can't use `state.creds.registered` here: Baileys 7.x doesn't
+      // reliably flip that flag back to `true` after the post-pair stream
+      // restart (statusCode 515). An already-paired socket would then see
+      // `registered=false` and request a *new* pairing code 3s after the
+      // restart, which the WhatsApp server rejects with 401 and the adapter
+      // wipes the auth directory — re-pair from scratch every restart.
+      //
+      // `state.creds.me` is set as part of the QR / pairing-code handshake
+      // and is the authoritative "this socket has an account" signal.
+      if (phoneNumber && !state.creds.me) {
         setTimeout(async () => {
           try {
             const code = await sock.requestPairingCode(phoneNumber);


### PR DESCRIPTION
# fix(whatsapp): two structural bugs that destroy paired sessions on Baileys 7.x

## Summary

Fixes a pair of structural bugs in `src/channels/whatsapp.ts` that combine to make
WhatsApp installs with `WHATSAPP_PHONE_NUMBER` set unreliable on Baileys 7.x:

1. **The adapter self-destructs its own paired session 3 seconds after a stream restart.**
   Baileys 7.x does not reliably re-set `state.creds.registered` to `true` after the
   post-pair stream restart (statusCode 515). The check at line 520 then triggers a
   fresh `requestPairingCode()` on an already-paired socket. The server rejects with
   401, the adapter wipes `authDir`, and the bot is offline until manual re-pair.

2. **`systemctl restart` wipes the auth directory.** The cleanup branch at line ~575 runs
   whenever `shouldReconnect === false`, which is `true` for both
   `DisconnectReason.loggedOut` *and* `shuttingDown === true`. So every clean shutdown
   wipes the auth — and combined with bug #1, every restart forces a fresh QR / pair-code
   flow with a human at the bot phone.

These reproduce reliably on Baileys 7.0.0-rc.9 and `WHATSAPP_PHONE_NUMBER` set
(the recommended config for dedicated-number bots).

## Root cause diagnosis

The two bugs interact in a way that masks each other:

- Without bug #2, bug #1 would only fire on the *first* restart after a pair — once
  bug #2 wipes auth, bug #1 fires on every subsequent restart too.
- Without bug #1, bug #2 alone would force a re-pair after every restart but at least
  the re-pair flow would complete.

Together they create the symptom users see: "WhatsApp keeps going offline and needs
the bot phone re-paired, sometimes succeeding for a few hours, then dying again."

The trail of `Connected to WhatsApp` → `pairing code: …` → `connection closed reason=401`
→ `auth cleared` shows up consistently in production logs.

## Fix

- Bug #1: Use `state.creds.me` instead of `state.creds.registered`. `me` is set during
  pair handshake and is the authoritative "this socket has an account" signal. It does
  not toggle on stream restarts.
- Bug #2: Split the cleanup branch so `authDir` is only wiped when the disconnect
  reason is actually `DisconnectReason.loggedOut`. On clean shutdown, log
  `WhatsApp adapter stopped (auth preserved)` and exit cleanly. The next process boot
  picks up the preserved auth via `useMultiFileAuthState`.

## Verification

Deployed both fixes on a production install (Baileys 7.0.0-rc.9, dedicated phone
number, ~15h previous outage window). After the patches:

- `systemctl restart nanoclaw` now produces:
  ```
  WhatsApp adapter stopped (auth preserved)
  ... (~3s) ...
  Connected to WhatsApp
  WhatsApp adapter initialized
  ```
- No `pairing code` log after `Connected` (was the bug-#1 regression signature).
- No `auth cleared` log on clean shutdown (was the bug-#2 regression signature).
- `store/auth/` survives restarts at full file count (~830 files).
- End-to-end roundtrip (Michael → WhatsApp → routed → container reply → delivered
  back to Michael's WhatsApp with real `platformMsgId`) works after every restart
  without human intervention.

Stability watched for >15 minutes post-fix across two restart cycles, no
regression of either signature.

## Test plan

- [ ] CI passes
- [ ] Existing WA adapter tests still pass
- [ ] Manual: start a fresh install with `WHATSAPP_PHONE_NUMBER` set, pair via QR or
      pairing-code, `systemctl restart`, verify auth survives + adapter reconnects
      transparently
- [ ] Manual: force a real `DisconnectReason.loggedOut` (e.g. remove the linked
      device from the bot phone), verify auth IS cleared as before — the logout path
      should still wipe properly

## Notes

- The codebase comment at line 553-555 ("a parallel connectSocket() initializes
  useMultiFileAuthState which can truncate creds.json mid-write") explains the rule
  that we don't auto-reconnect during shutdown. That rule is still correct and
  unchanged. Bug #2 was that the *cleanup branch* also fired during shutdown.
- Considered: should we keep the auth-clear on loggedOut, or only clear creds.json
  selectively? Kept the full-wipe to preserve the original "avoid re-link cooldown"
  intent — only changed *when* the wipe fires.
