### PR TITLE
fix(add-telegram): pin chat-adapter to 4.26.0 to match installed chat

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -58,7 +58,7 @@ In `setup/index.ts`, add this entry to the `STEPS` map (right after the `registe
 ### 5. Install the adapter package (pinned)
 
 ```bash
-pnpm install @chat-adapter/telegram@4.27.0
+pnpm install @chat-adapter/telegram@4.26.0
 ```
 
 ### 6. Build


### PR DESCRIPTION
## Summary

The `/add-telegram` skill in `main` instructs `pnpm install @chat-adapter/telegram@4.27.0`, but that version has a strict `peerDependency` on `chat@4.27.0`. The root `package.json` pins `chat` at `^4.24.0`, which currently resolves to `4.26.0` (in part due to the `minimumReleaseAge: 4320` policy in `pnpm-workspace.yaml`). The mismatch breaks `pnpm run build` immediately after the skill runs.

## Repro

1. Clean checkout of `main` (currently `3601a8a`, v2.0.71).
2. Run `/add-telegram`.
3. After step 5 (`pnpm install @chat-adapter/telegram@4.27.0`), step 6 (`pnpm run build`) fails:

```
src/channels/telegram.ts(208,7): error TS2322: Type 'TelegramAdapter' is not assignable to type 'Adapter<unknown, unknown>'.
  Types of property 'initialize' are incompatible.
    Type '(chat: chat@4.27.0.ChatInstance) => Promise<void>'
      is not assignable to
    Type '(chat: chat@4.26.0.ChatInstance) => Promise<void>'.
      Property 'processOptionsLoad' is missing in type 'chat@4.26.0.ChatInstance'
      but required in type 'chat@4.27.0.ChatInstance'.
```

The `TelegramAdapter` was built against `chat@4.27.0`'s `ChatInstance` (with `processOptionsLoad`), while the host's `chat-sdk-bridge` is consuming `chat@4.26.0` from the resolved tree.

## Root cause

The skill files diverged between branches:

- `upstream/channels` — `package.json` pins `@chat-adapter/telegram` at `4.26.0`, and `.claude/skills/add-telegram/SKILL.md` step 5 says `4.26.0`.
- `upstream/main` — `.claude/skills/add-telegram/SKILL.md` step 5 says `4.27.0` (this PR).

The `main`-branch copy of the skill was bumped to `4.27.0` without a coordinated bump of `chat` (or the matching `package.json` in `channels`), making the skill produce a broken install on a fresh `main` checkout.

## Fix

Revert step 5 in the `main`-branch skill from `4.27.0` to `4.26.0` to match the `channels` branch's `package.json`. After the change, `pnpm run build` succeeds and the Telegram adapter loads cleanly (`Channel adapter started channel="telegram" type="telegram"` in `logs/nanoclaw.log`).

A coordinated upgrade to `4.27.0`+ later would need to bump `chat` in `package.json` (or rely on its `^4.24.0` floor resolving forward) and bump `@chat-adapter/telegram` in the `channels` branch `package.json` in the same change.

## Test plan

- [x] `/add-telegram` on a fresh checkout of `main` runs cleanly end-to-end (install + build pass).
- [x] Service restart loads the adapter (`Channel adapter started channel="telegram" type="telegram"`).
- [x] Inbound and outbound Telegram messages route to the wired agent group.