### PR TITLE
fix: engage pattern/mention wirings on direct address

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -39,6 +39,8 @@ interface GatewayAdapter extends Adapter {
 export interface ReplyContext {
   text: string;
   sender: string;
+  /** True when the quoted message was authored by this bot (reply-to-bot). */
+  isReplyToBot?: boolean;
 }
 
 /** Extract reply context from a platform-specific raw message. Return null if no reply. */

--- a/src/router.ts
+++ b/src/router.ts
@@ -143,7 +143,12 @@ export function setChannelRequestGate(fn: ChannelRequestGateFn): void {
   channelRequestGate = fn;
 }
 
-function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
+function safeParseContent(raw: string): {
+  text?: string;
+  sender?: string;
+  senderId?: string;
+  replyTo?: { isReplyToBot?: boolean };
+} {
   try {
     return JSON.parse(raw);
   } catch {
@@ -269,6 +274,11 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   //    avoids the extra await).
   const parsed = safeParseContent(event.message.content);
   const messageText = parsed.text ?? '';
+  // "Addressed" = the bot was directly engaged: @mention / DM (isMention) or a
+  // reply to one of the bot's own messages. Pattern/mention wirings treat this
+  // as a trigger in addition to their regex.
+  const replyToBot = parsed.replyTo?.isReplyToBot === true;
+  const addressed = isMention || replyToBot;
 
   let engagedCount = 0;
   let accumulatedCount = 0;
@@ -278,7 +288,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     const agentGroup = getAgentGroup(agent.agent_group_id);
     if (!agentGroup) continue;
 
-    const engages = evaluateEngage(agent, messageText, isMention, mg, event.threadId);
+    const engages = evaluateEngage(agent, messageText, addressed, mg, event.threadId);
 
     const accessOk = engages && (!accessGate || accessGate(event, userId, mg, agent.agent_group_id).allowed);
     const scopeOk = engages && (!senderScopeGate || senderScopeGate(event, userId, mg, agent).allowed);
@@ -364,7 +374,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
 function evaluateEngage(
   agent: MessagingGroupAgent,
   text: string,
-  isMention: boolean,
+  addressed: boolean,
   mg: MessagingGroup,
   threadId: string | null,
 ): boolean {
@@ -372,6 +382,9 @@ function evaluateEngage(
     case 'pattern': {
       const pat = agent.engage_pattern ?? '.';
       if (pat === '.') return true;
+      // Engage when directly addressed (mention / DM / reply-to-bot) OR when
+      // the message text matches the wiring's pattern (e.g. the agent's name).
+      if (addressed) return true;
       try {
         return new RegExp(pat).test(text);
       } catch {
@@ -380,9 +393,9 @@ function evaluateEngage(
       }
     }
     case 'mention':
-      return isMention;
+      return addressed;
     case 'mention-sticky': {
-      if (isMention) return true;
+      if (addressed) return true;
       // Sticky follow-up: session already exists for this (agent, mg, thread)
       // — the thread was activated before, keep firing.
       if (mg.is_group === 0) return false; // DMs never use mention-sticky sensibly


### PR DESCRIPTION
### What
In `evaluateEngage` (router), `pattern`-mode wirings only matched the message text against the regex. A wiring keyed on a keyword (e.g. the agent's name) therefore **ignored a direct @mention, DM, or reply-to-bot** when the text didn't also contain the keyword — the bot stayed silent even though it was addressed directly. Conversely, unrelated chatter that happened to contain the keyword engaged.

This treats being **directly addressed** (`isMention || reply-to-bot`) as an engagement trigger across `pattern` / `mention` / `mention-sticky`, and threads an optional `isReplyToBot` flag from the chat-sdk `ReplyContext` through the router so adapters can mark replies to the bot's own messages.

### Why
Being @mentioned / replied-to is the most explicit "I'm talking to you" signal a user can give; silently dropping it is surprising. This makes keyword wirings safe to use in shared group chats without losing direct addressing.

### How it works
- `ReplyContext` gains an optional `isReplyToBot?: boolean` (populated per-adapter; see the companion `channels` PR for Telegram).
- The router computes `addressed = isMention || parsed.replyTo?.isReplyToBot` and passes it to `evaluateEngage`.
- `pattern` engages on `addressed || regex.test(text)`; `mention` / `mention-sticky` use `addressed`. The `pattern === '.'` always-on shortcut is unchanged.

### How it was tested
Existing router/bridge tests pass (`vitest run`). Verified live on a Telegram group wiring keyed on the agent's name: plain chatter is now dropped, while the name keyword, an @mention of the bot, and a reply to the bot's message each engage.

This is the trunk half; the Telegram `extractReplyContext` change that sets `isReplyToBot` is a companion PR against the `channels` branch.