### PR TITLE
fix: detect reply-to-bot in Telegram extractReplyContext

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -38,13 +38,23 @@ async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5
   throw lastErr;
 }
 
+// Resolved once at setup via getMe; used to recognise reply-to-bot precisely.
+let resolvedBotUsername: string | null = null;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
   if (!raw.reply_to_message) return null;
   const reply = raw.reply_to_message;
+  // Reply-to-bot: the quoted message is from a bot. If we've resolved our own
+  // username, require an exact match; until then, any bot counts (our bot is
+  // the only one expected to post in wired chats).
+  const from = reply.from;
+  const isReplyToBot =
+    from?.is_bot === true && (resolvedBotUsername == null || from?.username === resolvedBotUsername);
   return {
     text: reply.text || reply.caption || '',
-    sender: reply.from?.first_name || reply.from?.username || 'Unknown',
+    sender: from?.first_name || from?.username || 'Unknown',
+    isReplyToBot,
   };
 }
 
@@ -214,6 +224,9 @@ registerChannelAdapter('telegram', {
     });
 
     const botUsernamePromise = fetchBotUsername(token);
+    void botUsernamePromise.then((u) => {
+      resolvedBotUsername = u;
+    });
 
     const wrapped: ChannelAdapter = {
       ...bridge,


### PR DESCRIPTION
### What
`extractReplyContext` for Telegram discarded the quoted message's author, so a reply to the bot's own message was indistinguishable from any other reply. This sets `ReplyContext.isReplyToBot` when the quoted message was authored by this bot.

### Why
A reply to the bot is a direct way to address it. With this flag, the router can engage on reply-to-bot (see companion trunk PR), so users can answer the bot without re-typing its name/@mention.

### How it works
- In `extractReplyContext`, `isReplyToBot = reply.from.is_bot && (username matches our resolved bot username, or unknown)`.
- The bot username is resolved once at setup via the existing `getMe` call and cached in module scope; until it resolves, any bot reply counts (our bot is the only one expected in wired chats).

### How it was tested
Verified live: replying to one of the bot's own messages in a Telegram group now engages the agent, while replies to other members don't.

> **Depends on nanocoai/nanoclaw#2643**, which adds the optional `isReplyToBot` field to `ReplyContext` and consumes it in the router. This branch won't typecheck until that change is in `channels`' base.