### PR TITLE
[codex] Add street wind shadow map

### DIFF
--- a/winds/.gitignore
+++ b/winds/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.DS_Store
+coverage
+.vercel

--- a/winds/.vercelignore
+++ b/winds/.vercelignore
@@ -1,0 +1,4 @@
+aligment
+node_modules
+dist
+.DS_Store

--- a/winds/README.md
+++ b/winds/README.md
@@ -1,0 +1,79 @@
+# Street Wind & Shadow Map
+
+Interactive Vite app for exploring projected building shadows and approximate street wind around a city block. The default view starts near Nevsky Prospect in Saint Petersburg.
+
+## Run locally
+
+```bash
+npm install
+npm run dev
+```
+
+Then open the local Vite URL printed in the terminal. Useful checks:
+
+```bash
+npm test
+npm run build
+```
+
+## Data sources
+
+- Basemap tiles, building footprints, road geometries, and most building height tags come from [OpenStreetMap](https://www.openstreetmap.org/).
+- Buildings and roads are fetched live from the [Overpass API](https://overpass-api.de/).
+- Current 10 m wind speed and wind direction are fetched live from [Open-Meteo](https://open-meteo.com/).
+- Place search uses [Nominatim](https://nominatim.org/). Coordinate input also accepts `lat, lng`.
+
+The app keeps fetched OSM responses in memory by nearby area while the tab stays open. It queries a deliberately small bounding box around the selected map center.
+
+## What is modeled
+
+### Shadows
+
+Each OSM building footprint gets a height from:
+
+1. `height` or `building:height`;
+2. `building:levels * 3 m`;
+3. a 12 m default.
+
+Sun position comes from SunCalc for the selected date, time, and map center. Direct shadow length uses:
+
+```text
+shadowLength = buildingHeight / tan(sunAltitude)
+```
+
+When the sun is below the horizon the app reports that direct shadows are unavailable.
+
+### Street wind
+
+The wind layer is intentionally approximate. A road is split into small segments. Each segment gets:
+
+- its Turf bearing;
+- the current Open-Meteo wind vector projected onto that street alignment;
+- a canyon boost when tall nearby buildings appear on both sides;
+- a shelter reduction when a tall nearby building sits upwind.
+
+The road tooltip exposes the estimated speed, base weather wind, road bearing, heuristic multiplier, and confidence label. This is not CFD and should not be used for safety decisions.
+
+## Failure behavior
+
+Live APIs are the main path. If Overpass or Open-Meteo fails in development, the UI shows a clear error and temporarily swaps in a tiny local fallback dataset so geometry work remains inspectable offline. Production mode does not silently replace live API data.
+
+## Project layout
+
+- `src/api/overpass.ts` - live OSM building and road fetch, height parsing, cache.
+- `src/api/weather.ts` - Open-Meteo current wind fetch.
+- `src/api/geocoding.ts` - coordinate parsing and Nominatim search.
+- `src/utils/geometry.ts` - bbox, bearing, distance, and segment helpers.
+- `src/utils/shadows.ts` - SunCalc conversion and projected shadow polygons.
+- `src/utils/wind.ts` - road wind projection and urban-canyon heuristics.
+- `src/components/MapView.tsx` - Leaflet layers and tooltips.
+- `src/components/ControlsPanel.tsx` - location, time, toggles, and wind readout.
+- `src/components/Legend.tsx` - wind and shadow legends.
+
+## Future improvements
+
+- Read OSM multipolygon building relations and richer height formats.
+- Use building facade distance and road width tags where available.
+- Add wind direction variability, gusts, and terrain or water exposure.
+- Move heavy geometry work into a worker for larger areas.
+- Replace the convex projected shadow hull with a more exact footprint sweep.

--- a/winds/api/overpass.ts
+++ b/winds/api/overpass.ts
@@ -1,0 +1,88 @@
+import { endpointName, OVERPASS_ENDPOINTS } from "../src/api/endpoints.js";
+
+const OVERPASS_PROXY_TIMEOUT_MS = 12_000;
+
+function sendJson(response: { status: (code: number) => { json: (payload: unknown) => void } }, status: number, payload: unknown) {
+  response.status(status).json(payload);
+}
+
+async function postToEndpoint(endpoint: string, query: string) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OVERPASS_PROXY_TIMEOUT_MS);
+
+  try {
+    return await fetch(endpoint, {
+      signal: controller.signal,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "User-Agent": "StreetWindShadowMap/0.1 (+https://winds-beta.vercel.app)",
+      },
+      body: new URLSearchParams({ data: query }),
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export default async function handler(
+  request: { method?: string; body?: { query?: string } | string },
+  response: { status: (code: number) => { json: (payload: unknown) => void } },
+) {
+  if (request.method !== "POST") {
+    return sendJson(response, 405, { error: "Method not allowed." });
+  }
+
+  let query = "";
+
+  if (typeof request.body === "string") {
+    try {
+      query = ((JSON.parse(request.body) as { query?: string }).query ?? "").trim();
+    } catch {
+      return sendJson(response, 400, { error: "Expected JSON body with query." });
+    }
+  } else {
+    query = request.body?.query?.trim() ?? "";
+  }
+
+  if (!query.includes("[out:json]") || query.length > 8_000) {
+    return sendJson(response, 400, { error: "Invalid Overpass query." });
+  }
+
+  const errors: string[] = [];
+
+  for (const endpoint of OVERPASS_ENDPOINTS) {
+    let upstreamResponse: Response;
+
+    try {
+      upstreamResponse = await postToEndpoint(endpoint, query);
+    } catch (error) {
+      errors.push(`${endpointName(endpoint)}: ${error instanceof Error ? error.message : String(error)}`);
+      continue;
+    }
+
+    if (!upstreamResponse.ok) {
+      const detail = await upstreamResponse.text().catch(() => "");
+      const suffix = detail ? ` ${detail.replace(/\s+/g, " ").slice(0, 180)}` : "";
+      errors.push(`${endpointName(endpoint)}: HTTP ${upstreamResponse.status}${suffix}`);
+      continue;
+    }
+
+    const text = await upstreamResponse.text();
+
+    try {
+      return sendJson(response, 200, {
+        endpoint,
+        errors,
+        payload: JSON.parse(text),
+      });
+    } catch {
+      errors.push(`${endpointName(endpoint)}: invalid JSON response`);
+    }
+  }
+
+  return sendJson(response, 502, {
+    error: "All Overpass endpoints failed.",
+    errors,
+  });
+}

--- a/winds/index.html
+++ b/winds/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Street Wind & Shadow Map</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/winds/package-lock.json
+++ b/winds/package-lock.json
@@ -1,0 +1,4659 @@
+{
+  "name": "street-wind-shadow-map",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "street-wind-shadow-map",
+      "version": "0.1.0",
+      "dependencies": {
+        "@turf/turf": "^7.2.0",
+        "leaflet": "^1.9.4",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-leaflet": "^5.0.0",
+        "suncalc": "^1.9.0"
+      },
+      "devDependencies": {
+        "@types/leaflet": "^1.9.20",
+        "@types/node": "^24.0.0",
+        "@types/react": "^19.1.6",
+        "@types/react-dom": "^19.1.5",
+        "@types/suncalc": "^1.9.2",
+        "@vitejs/plugin-react": "^4.5.1",
+        "typescript": "~5.8.3",
+        "vite": "^6.3.5",
+        "vitest": "^3.1.4"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turf/along": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.5.tgz",
+      "integrity": "sha512-Ee4AHV9j2Bnlm/5nm4ChY7nkwpaaMffSez9nsJ9HcMbzG+GgTkt0F5pn9d02U7YvuWqckM5lfr3kBI+w2uTz+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.5.tgz",
+      "integrity": "sha512-+c3UZfkL1nNacfpLkj89rRreIlKM5UALeeWpcw7hCEK4MycXCBmITkyLLXOzoQaRBc/7ua4PV0Ov13Y6Ck9PzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.5.tgz",
+      "integrity": "sha512-sSn80wPT7XfBIDN3vurCPxhk9W4U8ozS/XImSqeLN8qveTICOxzZkhsGDMp0CuncaN+plWut4a2TdNM7mzZB6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.5.tgz",
+      "integrity": "sha512-FuADTCBfRwdzJb2gFawDGnD1jKlUOfsWcu5Uv8iyEgu9JLuLAIYtI/l9xVF76BAoAvSkLgMfUvrPQ4SXCSUrVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.5.tgz",
+      "integrity": "sha512-Cs9Laej8zfSY51kORM9UcbY4Uf/7X3OIZr/LydbrmmARFSpYH/FZsEQjAGi1S1Q0aYbibVqjEUReHN3ZVsV5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.5.tgz",
+      "integrity": "sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.5.tgz",
+      "integrity": "sha512-54qnreNRvV9BeTGz2YXJyma+m8HMusuXWw3AkG0bIJGtqJMHqFKC/rWOcYxVj1VM2ScoTgglFxvq7GtSna+KMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.5.tgz",
+      "integrity": "sha512-VpDIpTKBjH4oPbzx1ns18TWcosi+qCRtgU1HIJHLj4NWyLNr7TX86DvomCvZRPfsFxkYYgkFlqHBG1a29dcyqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.5.tgz",
+      "integrity": "sha512-CHrmnEww43CAwEPszrKtLjM13hWDmsFZe0eCocxOtXLMspj+LCheB0bjMfcoBYfoTsvOPXxnoLTK9n4xuWBRSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.5.tgz",
+      "integrity": "sha512-P4JUAHgvJkD+8ybQ6d1OHp9TBsGsjJxF5lWeXJgp0k4+Hd/D0CVy4/mhLkZdNa6QdljVdwNcfU0CTqy1WsSQig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.5.tgz",
+      "integrity": "sha512-o4Gmb2gbPl4j7810ZrT9GZsGigY+HRwcOI9pkkKH6BJ4ewSlQCPzP4JFruZp0+mIXS6NnPv7+Lw3J8LN3kYw1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-equal": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.5.tgz",
+      "integrity": "sha512-Pz1GGUC6iL6xGVqhyo+fYg35kl4j/HONMEoC1voN3DcBOCcVlzq+ljvMpvE+oQiR7Q38xLhIxZneLCqMp5YrQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.5.tgz",
+      "integrity": "sha512-xjSFi/BpxBY5tDDuSbixIRVq2AnDGcdLL8XOHzZtJWZjSa6tAi6afxSiMbQTGIhYfwwcB/sJcIUUffBaIQ2BiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.5.tgz",
+      "integrity": "sha512-Z6GPYjozrmTuzWQD0x7o8RPm+4HC7hz9q23hdB3U1+Qahesv8Mtc+wo82tO4CG6/NRnJ9u79DlEhmR1DxUU4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.5.tgz",
+      "integrity": "sha512-DUeiPVqFSTjW79erPbo780pRcKCRad59NcscVsTYkZD/92peF/4rQvHbvAUpUDPZaQCxe+mvfeDHfUFmfVKCGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-overlap": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.5.tgz",
+      "integrity": "sha512-+shvGYFUx1vPQRPNeKiJcHtLAf9fl3mzAl9tBx2z+dU0IZDKz76/MAaDYSrMya/BYilFZ0E4RCEVq1X3s+AfkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.5.tgz",
+      "integrity": "sha512-GwD0gmbV1p+EFHojBjaa1cwGMybayOZUDLj562RlAAoexC8ownrW7W6oMAlM2VCxk4gq6CLx3hss9pONuQcKjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.5.tgz",
+      "integrity": "sha512-ZezJCgFJS0JRJfj6fVSI1idcifTaWFW70NYRCUur9926DHLvSkfbtEF5i63yPQt2Zxx00FTUJPcHRzdgOiwECA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-crosses": "7.3.5",
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/boolean-overlap": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.5.tgz",
+      "integrity": "sha512-FsZhkAoi9KU2F0D5dyOQ38A7y9Bk8XTmUfLKAJa12xHN0QtXZEYH86YdVlrI1XgfFB9gmUddJPFX+bJATy6rxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.5.tgz",
+      "integrity": "sha512-TGls3nYtWzviKHT00XVBfHKa7Z2oIZKqiHN7R0xErGwMSAR7YhxVROhxq/iyIsWZjl1SlPwweZZIxWILQuxpZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.5.tgz",
+      "integrity": "sha512-eub5/Kfdmn89ZqwCONHI7astmTDEtN5M6+JfOkgoSyhKKFhUJYNxUyH1F/vCtIP7j1K369Vs4L9TYiuGapvIKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.5.tgz",
+      "integrity": "sha512-8IpS7zUZg0fuUpN9ViqT4gR6YMjSR1R1kHysaDxhP1zMrTJ84U5lGG+VQC7HpHqybOnuwkXZrV970h9Ni78n6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.5.tgz",
+      "integrity": "sha512-e+NeDKyZzIzSTA0qd9cwIuguCnDQSc6TLd1MjkHKTd37PCaPSc40TMEIBX1x+kJRwOxzmUgpubfHUG9zfjdtyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.5.tgz",
+      "integrity": "sha512-eEzx4YKxUP55Apdjt7XXuQ906KKx4uSQWLxJw5OHE0rKOSN/qYTSdu0s7nQBAmGgAqeSC2538vuN7wEqMfYMvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/convex": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
+      "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.5.tgz",
+      "integrity": "sha512-Tse7GJrx0rxaQ5BdY6pHZ9HFPrZwRMry2yaqq94UsUyonhy1m7U2icB3Zp4M8o4XjHIGTCq9i2BYcGJram51Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.5.tgz",
+      "integrity": "sha512-e0ZTqVWiQaCI/b8EFb+HAS8lCDomWafAKxQuIv0IYks0GwOlVTDWTwsY2RX2685j2Y+QssqOsyHsPZCtAjc3YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.5.tgz",
+      "integrity": "sha512-ZYQSCxElarAaG4azNieZ0ylX1sietkHIVAZv6H5JfSz/EXbAekQIom/isoynfDl/jVyNonDT7UrDZdCIjKQ2Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.5.tgz",
+      "integrity": "sha512-xdc0ccv2fyiUSWrJYJFE6RTluf8oVCB0/aCOdUD/ZvtG3eyqGIXMRMzAR1PujQHjBWtI+ndD4Eq+DqiGukGK+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.5.tgz",
+      "integrity": "sha512-MnKymdmL7vy4TR5CLkcNkNgsJP8ZBEiWkqnRYBJLq/hFoppTvXxKvkRzftWtLfkIWb5oQ2XMvBh8BgALN22d5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.5.tgz",
+      "integrity": "sha512-ddcBDdnM2Rwjfedxsbjvb7Zhoqo6uCTcnaHvu3ej/g+Z9iJ/K2wkRWhEUVAg/wppso5io6qEPmmPpNlefePt+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.5.tgz",
+      "integrity": "sha512-olQH6WmLl3XAalbpiz7RSRr4/mogan38gvgDlo37ypW1ckeBUi+2TX5HgJUZq4wxa2gMlny72QYkqY9zW4Jw+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.5.tgz",
+      "integrity": "sha512-T496U4K5mXsJXTKjnf7eW+4SYoDP0bXWhpcfpWuCAaDJy8n1Q8Dbslj7wqrWd2lqIhulVRF+3zWAh0bJS34L5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/tin": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.5.tgz",
+      "integrity": "sha512-d/pq86he+/GB/2ObuBHapeT15QFsCPhhGab3uE4YjogLMbD8qtu0sRGF+cvvPRDNuCLycOBL/xgFLnf9SteYlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.5.tgz",
+      "integrity": "sha512-x6ylChhOlIbucRSw7wF6z2gSEqqQl+dE0nSH5AL/ojZkqqGYahiw+2P4A8ZMuDM6rzH+FIqRYDes0o4nSArZCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.5.tgz",
+      "integrity": "sha512-iDyWYCvgS3vgB8W1ai2cvfJaTq9bOt1QghiVkCNIyccF97CgtYJzenREVVUlp8qU9lJlbQ/ameyKvXPA1uOAlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/directional-mean": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/directional-mean/-/directional-mean-7.3.5.tgz",
+      "integrity": "sha512-Fm3rVgX7xiCL8Ed68dZpUl5NEAgEpaUdkAaZLvhedfUmKcuXcfBwX8RebHwNWctxcvKVOhoAMSlogpV33JnKdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.5.tgz",
+      "integrity": "sha512-6kZTc8rbGuBqxWW8iK1sJZC8r7vr5uWdv7nsMJ0eX8/g0mTKNgSGXo14hYqp2GN4bE7JzpAgpFeSX8Xu1psxlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.5.tgz",
+      "integrity": "sha512-GpV2h5ZkbWMdUFe5BWm9lfeLFMnYR8CRj6HiguZBLesarSub6I0UNO1u8UhkRGi26YLGnFlBh7c4KyaakNx1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.5.tgz",
+      "integrity": "sha512-C478LrdvUkjwIVGN6PoYsFp27PuT+W2IH4ZOVt9sd4359hRPFhJ2m+f8jSPfS6rdamdvc/O+h7vNmOIBRP/TeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/transform-rotate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.5.tgz",
+      "integrity": "sha512-0Sc2AVx0JZ3MaQ0k6+khplU3wO7bwc1qAQ6Fd+Q4RhIVPY2JKstBdq5ftU1T/BHNf8KK+9y4qbSV2u8hnw/PqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.5.tgz",
+      "integrity": "sha512-Qdd7ehX5AF0DdpJl+JJyxws7jEmsZBRV35wTm+Lyhapuc3yLHU7tN5EqJ+2lVV7RkUgBXEFQV+34pmPLPGQn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.5.tgz",
+      "integrity": "sha512-4dDAyoY8wf4UCIJ2lH3JbypmEeqyuRFExHEPu6eJeaOybdpOV9kn3LqB0lsWArizFjJWQNS+0qpv08jD85jSPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.5.tgz",
+      "integrity": "sha512-qDSBFqo5+8yE5gfBCsQZxgj0bGRx6abQg6TgYvg1wvYYHtUJL/0VS+QdDTmxZiYm8N46uNAv9pKvun9MGK+elA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.5.tgz",
+      "integrity": "sha512-VAio6hwPJIheSzrvsMkLDMHkCfHyOi4H4r1Y2ynb2oMiGiqZjkQ7jIFlRYBcTyO2RnwEOgwM/d3kwRImAwMVBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "arc": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.5.tgz",
+      "integrity": "sha512-sPtYXqbNvUxt8h4NzspcoFAVotd/75LgrLxxI84LGIVPCN+fsK1uWwr4a6MAlzfSbWbOYOq7OSWMSSXzHoQzJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.5.tgz",
+      "integrity": "sha512-rl5LwK85etpvbSW1VEXp/I85kzgiGviXInrvvhQxzEF9xGKvs1ed/6dc1uy1LsczSr4wUnbdGATzZTF9lFYjIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/hex-grid": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@turf/triangle-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.5.tgz",
+      "integrity": "sha512-v11Do9ySbsE08ffiwboQeFKvYByyxzvAz0ls837A9T3rSC+8vKMmK815S+C5v8CBMLNhuBCSgqnOIV3zonNICQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.5.tgz",
+      "integrity": "sha512-WX6vpPkM8O8SY7hsijOtj4owVXP24nU33Q0eMhWdZ+YiDmAHgEOQcDhPJLvp0mIbyYj81mU73hdnilf3q9tk/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.5.tgz",
+      "integrity": "sha512-n5QUX1/Z/PuPVpTUrKhYcKF95L5+nKF8hWznYtG/GsiMXfRqMeAEjTCqgKIgF8T65H4LrvcpLyq8VPQSi7aISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.5.tgz",
+      "integrity": "sha512-dPW8d4vs1v8WMobjyq/TVqajjPwkMsl94IF58yp1UYlmJDQrW4iNRUmI9fFzww+fl7epCKNwY+jZhXf1DRi93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.5.tgz",
+      "integrity": "sha512-Bi+vEP54wt1ly3BRcCOP0nd2kGTYEhGk6haQxTpkrqr3XtmqDh8c3NowSgseN2cegIZRjwCOEC8eSsZ0JemJdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.5.tgz",
+      "integrity": "sha512-XrPicIoN7XCtiJ7e7ELje7GjMZrBw/nuJnz0mQoCwwHwmX8Oz9oRfb6uaiS8NeR4WBzUVdkmVR/ro0kW4lypog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.5.tgz",
+      "integrity": "sha512-z5/EBv79oyNXMYFpFIsA9gw/7TAKoJ9a/Ijo/jBeO47Fr1mV3JLtE3aB2i/nqLTYZWMU7K3Lnzwqt2Rn5Gri/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/line-slice-along": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.5.tgz",
+      "integrity": "sha512-7tNI+4xKFOTQj720aJI7vuRMyTC+4hAqd7N8AnnZ0EpzH+sBfyrt8rNI/Vf3+d/iY0c9ZNbhU9Qhyb0ckJUdsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.5.tgz",
+      "integrity": "sha512-7lZMWYHuzM6EMlL5pIIi/Nh7GLsM7ilW8/jVyHP1yGfQ0c0YAUoJd/Xy3J2+9v8OkYiZW/t2LdwVoTmCEJLWxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.5.tgz",
+      "integrity": "sha512-BGw5N4UvjH691J/z1P2S+hWBgCcvbl2/HXaqGvKTijXw5i1vzsZ9m07wLl/qH+i38OJDRMJ/+FkNZnrKpsoXLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.5.tgz",
+      "integrity": "sha512-zLOU9mGFXJdbPvA3/zXpDsBmXY2paA7eD6/p0iYiP9OASYO0GDcarwY5K/E0uuEdLrMf8G8YA2cJDcEl9gRgFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.5.tgz",
+      "integrity": "sha512-PNWDN1B0nJRlgA4DAXeYEf53OZSWwsu/rtDB4wxe/1NwfM9zlDVElQ/mtgDPtZpwC2aDKV5+B0vTXfKR/MMIfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.5.tgz",
+      "integrity": "sha512-zs9bBtdANOsSkG7xiLFYforeI2nszXu0QwPv3vkaX747oEVdcyd0nSW81aQRmSWw/fvhXja++8duIVXOIYr4ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.5.tgz",
+      "integrity": "sha512-y92O2YDDBkZp7jAUuUPgof/HiXHjJSkKjEtQRjWXZcjTlzHd/Fqg6/twarY2wNkENK2EuaaiV9MDy74FeRG2Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.5.tgz",
+      "integrity": "sha512-l/FgZkgPzwAsdj7rtKYWv2rxeTy+Tv8NMk6qSEwKqB4eHqn1TYHcTASWRcZIyipH4LtOJJOl77n7FmKcaDBtSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.5.tgz",
+      "integrity": "sha512-6vnSqt7OH8zTPdvUxCYnnN86Ci8VS5G3q2G1UrAcrnjTH7DbJ4KvIkRQlv4y6hj53G+bm9cA6TjeJuyP2jAOcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.5.tgz",
+      "integrity": "sha512-qcsbj9fo5CYhGeIDaJORoqiZyjNGu2+Te31MVaFoTTxqqkXypxp9e6HJGvUi2zPd1Zk3oAWXhvm1a+UXw2G56w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.5.tgz",
+      "integrity": "sha512-O27A9dFAqDYBRPhhoLP82Da7Q6rd0fXRR/jwQcBiycjTGdsXJmzxywuR08aDvWiARbJAmohEzdYzk4f9/eWXhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.5.tgz",
+      "integrity": "sha512-+hjECX1hDbol8psuG6iYSwcZHQ+RPJqFIBh3pXKc/pa0cdjZyB/L6q1d8ahnFrQBEpuoO3XVvo2hHN49VOEPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.5.tgz",
+      "integrity": "sha512-aEPnqj/4C9ejNz4uCJKgk6Flux6SxnqxjQHAYPIP5C7ooAB1xRAT1NMnCzxUjjUq1SMtgdZ6skoNfvKNK4Rzrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.5.tgz",
+      "integrity": "sha512-Y7W+JZJCmm9Qq93NHpk4dVhzAtAk2Uyau2Uk1ttCJ2Jsnuu4dwSjOurpmgDmMUe7yPmzihAUYhMFDumpAja8ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.5.tgz",
+      "integrity": "sha512-mR1NAIX+JfpYAJQ9u3gpIV37QzYvBOefDP+/16uBCAOM8Fp12goT8l7WdenT0dvB4wPibbqM2+2kyEl5u9XJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.5.tgz",
+      "integrity": "sha512-SQPhAlfiuCkIIFos/OPCxtt8iR3BlZqGKzKXLYqt6z8iaICaf2SjMyn4Zsr1oFO+Gy2K1rqandR+kuLTIo8Eqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.5.tgz",
+      "integrity": "sha512-TRyVY5Xlx6j72sNIyBaHZNgTbILs2iUDevX5lnCFTiThkzp25BIBBQ77tv2VPilYH+v7+9/0T/pLO37SaVhsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.5.tgz",
+      "integrity": "sha512-dc/dlYFqVBcel6d5HM5tBANh1HfWbJ89lSVLR7YhRX+Y/UABTvbtJCWwxBBiFxFBeRmW7B45nv3jytHUYxQUOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.5.tgz",
+      "integrity": "sha512-3/TtCQlXc2Lrgzb+LjwqbtILWan7lRD6P9Nn3edm2xGAZw5WY17+yZfpeySJPfcZhOWten9dXkOwDvSZF5uyWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-within": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.5.tgz",
+      "integrity": "sha512-Mat5tvJcW3grpXCNFcMvjHL3d8hO4eoIgF3qYpXj25BHx/S7SJUOgyCV5x3arC0rCfM/cB71VmNDm9k57ec7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.5.tgz",
+      "integrity": "sha512-pD3Zv/392sLlZVKRGUrJ4CKLN/Im+TO6wMCOfm/uiq4F9pEL5R+HPvXTcwEyxbhEPKYn3cylGKt21Wq0OfNQDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/envelope": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.5.tgz",
+      "integrity": "sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.5.tgz",
+      "integrity": "sha512-e5Am3cJuiP43f89Xv7n9cv3Z4P0I17zBvQPvhj6UowpRbiYoD4TKHfOr2PWHLYUkXjQ+vKY5CwiWvCYbfj3BIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/random": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.5.tgz",
+      "integrity": "sha512-Fid43jfmQpvrpr/wrUaW9hr66ukPqfZPuwzEt3gfCx6mAVpFWbCPx2yRuVlLNiRkMgmKTphFfh6267UCPOSnCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.5.tgz",
+      "integrity": "sha512-SVtXOJIz7FYaRUinxb0HfE/GNSJU6eU9tlKQaERDo/vG7wjPoTCDvnH8p4BdE5GRdXZMjvBUhtNdMj+M3rGRjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.5.tgz",
+      "integrity": "sha512-4AZdDh55JeCoKWLS5AC6MuXqAvoqSpj2WigtowtA3JIJ/1J4SclRrV6BGq/Xemwm5yKtRePHazBVUmG5uU75og==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.5.tgz",
+      "integrity": "sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.5.tgz",
+      "integrity": "sha512-znICdPBtZq5EKh/Qu0TkiMyNhqiYfM2VUlFOWa7iegCWe1E+X7q/f6rlZ5TcmYVyLZ95XZ6eciDNmgVmpHVWaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.5.tgz",
+      "integrity": "sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.5.tgz",
+      "integrity": "sha512-ayl/QlDAkqIDJjbzcBeAsMzFmIDanQP4xXdNKZmnYg83FhvH/Sgu7mMNNhrYwCVMWrmOicviDHu3xKuJ6jVnMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.5.tgz",
+      "integrity": "sha512-9mtBorGPZfbZI2MoI0nkN5ogmbCz/NLpHdEM0UwwWiOW430iPhwZ649DXH32lDGerfzREX10vpamX8v1P9YVrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-arc": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.5.tgz",
+      "integrity": "sha512-RmrfdDVTuBsHDNr88tGMRmIdJNFTdna3nQWRF8yFsgKR9LhZ4MWqebL24eQFn2hkyclL7O6lyPpOEJJtQxvcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/clean-coords": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/transform-scale": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.5.tgz",
+      "integrity": "sha512-9wzxlRA+0yNALeqyXNHFgj+8ebsg2aKdMrWRiSMS+ZqbiknZ/mCARiDYqM2Qz8TgTqdrNt53ze4o1vS6WeJrJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.5.tgz",
+      "integrity": "sha512-zUh9cxlZ4bPkSK2XynY26JSLDVy8oUss94mXACqSGrGjv308q3Voj4dzvfeh0E/Q3PQ3D8GJRZECXdCB/PU78Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.5.tgz",
+      "integrity": "sha512-mcwefBumsO3nwRG4nPfmXsq7YqHOsa71Z3h4JwWQn/XOrhV/8l1/QX3IAIx1qUWC2RqRMOImt3et5mlc+g2SxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/rectangle-grid": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.5.tgz",
+      "integrity": "sha512-CIJaQ61bjmxxqi5CpRLWAwxnbeHcG6e7esK2IX2DXBIE/7p/F7Sk9F2GOAL6vt1o29GnmzU2APHZvTX/YKcLbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.5",
+        "@turf/ellipse": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/points-within-polygon": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.5.tgz",
+      "integrity": "sha512-jwLOP7ZFfOcMPbK+0puT0SMOs0urSKYSYax7G4LDtZ9oPFAicVJtr2K0OB/rgmdoTK4VfUwb2nVZUdYAVnXtAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.5.tgz",
+      "integrity": "sha512-MI+pSkehJyZmbl2L5/43B9DlD6MEDcr63pW/LDSXYRDoRUXtSGY/NAAibIQ0gMAr8VxsimGCZKSuGMNUZdsuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.5.tgz",
+      "integrity": "sha512-70747SmLQttt+ywq+NmMqmkHdXsinO57SjHNFKX6G6qHuvxUu48vN7Kf3zjkqGAp2kQnu38OOqB4QPus6RdUqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.5.tgz",
+      "integrity": "sha512-WXkteI0DihwCukZesVXVVYpsoyftYoiBtq1b+u1Dz4HyATK25zfEeWChlgRtApbiePF6uqG7bSQS+K8vjC4c0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.5.tgz",
+      "integrity": "sha512-eAmey/LtJVT6WlCMULsnd+sCAOwCezG6lVP67qN5HARZ8ft+b7yBiU4FC+IGXbVsrdRcCRLSzoQc6K0fROoo2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.5.tgz",
+      "integrity": "sha512-OMQLOFLIjqeDNARaa2kdh1AgvWKFgq41/I6k3CAaj1UcB4javpVFMlcjRJY+pL2oZtMRZRcUZxhO+zSNl6p83Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.5.tgz",
+      "integrity": "sha512-oiwtTm+yqZwuODOSEyLSQSFaZFyjC6kgftUFFW6kLGQtm+Fw1GjxwS7QjiY55GRWxgfgbg2l1iNZNgfsCiPQWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.5.tgz",
+      "integrity": "sha512-l5Z1ZFEizN9p5GxX3mzUGf+i4t7AP3YpWcNdf9+kIzJcQD3eYuGBabj2hLrfrluqFJ+uxsuo4RgPtortQ9Dwpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.5",
+        "@turf/angle": "7.3.5",
+        "@turf/area": "7.3.5",
+        "@turf/bbox": "7.3.5",
+        "@turf/bbox-clip": "7.3.5",
+        "@turf/bbox-polygon": "7.3.5",
+        "@turf/bearing": "7.3.5",
+        "@turf/bezier-spline": "7.3.5",
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/boolean-concave": "7.3.5",
+        "@turf/boolean-contains": "7.3.5",
+        "@turf/boolean-crosses": "7.3.5",
+        "@turf/boolean-disjoint": "7.3.5",
+        "@turf/boolean-equal": "7.3.5",
+        "@turf/boolean-intersects": "7.3.5",
+        "@turf/boolean-overlap": "7.3.5",
+        "@turf/boolean-parallel": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/boolean-touches": "7.3.5",
+        "@turf/boolean-valid": "7.3.5",
+        "@turf/boolean-within": "7.3.5",
+        "@turf/buffer": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/center-mean": "7.3.5",
+        "@turf/center-median": "7.3.5",
+        "@turf/center-of-mass": "7.3.5",
+        "@turf/centroid": "7.3.5",
+        "@turf/circle": "7.3.5",
+        "@turf/clean-coords": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/clusters": "7.3.5",
+        "@turf/clusters-dbscan": "7.3.5",
+        "@turf/clusters-kmeans": "7.3.5",
+        "@turf/collect": "7.3.5",
+        "@turf/combine": "7.3.5",
+        "@turf/concave": "7.3.5",
+        "@turf/convex": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/difference": "7.3.5",
+        "@turf/directional-mean": "7.3.5",
+        "@turf/dissolve": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/distance-weight": "7.3.5",
+        "@turf/ellipse": "7.3.5",
+        "@turf/envelope": "7.3.5",
+        "@turf/explode": "7.3.5",
+        "@turf/flatten": "7.3.5",
+        "@turf/flip": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/great-circle": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/hex-grid": "7.3.5",
+        "@turf/interpolate": "7.3.5",
+        "@turf/intersect": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/isobands": "7.3.5",
+        "@turf/isolines": "7.3.5",
+        "@turf/kinks": "7.3.5",
+        "@turf/length": "7.3.5",
+        "@turf/line-arc": "7.3.5",
+        "@turf/line-chunk": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-offset": "7.3.5",
+        "@turf/line-overlap": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/line-slice": "7.3.5",
+        "@turf/line-slice-along": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@turf/line-to-polygon": "7.3.5",
+        "@turf/mask": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/midpoint": "7.3.5",
+        "@turf/moran-index": "7.3.5",
+        "@turf/nearest-neighbor-analysis": "7.3.5",
+        "@turf/nearest-point": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/nearest-point-to-line": "7.3.5",
+        "@turf/planepoint": "7.3.5",
+        "@turf/point-grid": "7.3.5",
+        "@turf/point-on-feature": "7.3.5",
+        "@turf/point-to-line-distance": "7.3.5",
+        "@turf/point-to-polygon-distance": "7.3.5",
+        "@turf/points-within-polygon": "7.3.5",
+        "@turf/polygon-smooth": "7.3.5",
+        "@turf/polygon-tangents": "7.3.5",
+        "@turf/polygon-to-line": "7.3.5",
+        "@turf/polygonize": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@turf/quadrat-analysis": "7.3.5",
+        "@turf/random": "7.3.5",
+        "@turf/rectangle-grid": "7.3.5",
+        "@turf/rewind": "7.3.5",
+        "@turf/rhumb-bearing": "7.3.5",
+        "@turf/rhumb-destination": "7.3.5",
+        "@turf/rhumb-distance": "7.3.5",
+        "@turf/sample": "7.3.5",
+        "@turf/sector": "7.3.5",
+        "@turf/shortest-path": "7.3.5",
+        "@turf/simplify": "7.3.5",
+        "@turf/square": "7.3.5",
+        "@turf/square-grid": "7.3.5",
+        "@turf/standard-deviational-ellipse": "7.3.5",
+        "@turf/tag": "7.3.5",
+        "@turf/tesselate": "7.3.5",
+        "@turf/tin": "7.3.5",
+        "@turf/transform-rotate": "7.3.5",
+        "@turf/transform-scale": "7.3.5",
+        "@turf/transform-translate": "7.3.5",
+        "@turf/triangle-grid": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@turf/union": "7.3.5",
+        "@turf/unkink-polygon": "7.3.5",
+        "@turf/voronoi": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "@types/kdbush": "^3.0.5",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.5.tgz",
+      "integrity": "sha512-/FSKhl+LX4+M7L/Trmiln0CDPWS8vCneGnQktt1o5XbCY/zIpH1JdxHEBFXhFZg4beAyXCz0uuxRyW9N/DH+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.5.tgz",
+      "integrity": "sha512-7MwKCm7sPHVF4xBO/3s08/DtA/09UEBXaLNnm8/RUq3abS5zZ9PnakLsd36J18IHDscM6RmH7IZPLSwYh4TLcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.5.tgz",
+      "integrity": "sha512-v51D9H+er/K5lP+rBs7jIBEXTFhl0FQOZn4mfhb7brN5sGGDmnfEFOaxIYOiJN4Qco1GtFD2Tq0NgZ8+dmJmEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/kdbush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-3.0.5.tgz",
+      "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/suncalc": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.9.2.tgz",
+      "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/arc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
+      "integrity": "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.2.tgz",
+      "integrity": "sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/winds/package.json
+++ b/winds/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "street-wind-shadow-map",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@turf/turf": "^7.2.0",
+    "leaflet": "^1.9.4",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-leaflet": "^5.0.0",
+    "suncalc": "^1.9.0"
+  },
+  "devDependencies": {
+    "@types/leaflet": "^1.9.20",
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@types/suncalc": "^1.9.2",
+    "@vitejs/plugin-react": "^4.5.1",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.5",
+    "vitest": "^3.1.4"
+  }
+}

--- a/winds/src/App.tsx
+++ b/winds/src/App.tsx
@@ -1,0 +1,297 @@
+import * as turf from "@turf/turf";
+import { useEffect, useMemo, useState } from "react";
+import { findLocation } from "./api/geocoding";
+import { fetchOSMData } from "./api/overpass";
+import { fetchWeather } from "./api/weather";
+import ControlsPanel from "./components/ControlsPanel";
+import Legend from "./components/Legend";
+import MapView from "./components/MapView";
+import type {
+  LatLng,
+  LayerRenderStats,
+  LayerToggles,
+  OSMData,
+  ShadowFeature,
+  WeatherData,
+} from "./types";
+import { shadowForBuilding, sunForDate } from "./utils/shadows";
+import { estimateRoadWind, windArrowForSegment } from "./utils/wind";
+
+const DEFAULT_CENTER = {
+  lat: 59.93476,
+  lng: 30.32649,
+};
+
+function initialLocation() {
+  const parameters = new URLSearchParams(window.location.search);
+  const lat = Number.parseFloat(parameters.get("lat") ?? "");
+  const lng = Number.parseFloat(parameters.get("lng") ?? "");
+
+  if (Number.isFinite(lat) && Number.isFinite(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180) {
+    return {
+      center: { lat, lng },
+      label: `${lat.toFixed(5)}, ${lng.toFixed(5)}`,
+    };
+  }
+
+  return {
+    center: DEFAULT_CENTER,
+    label: "Nevsky Prospect, Saint Petersburg",
+  };
+}
+
+const EMPTY_OSM: OSMData = {
+  fallback: false,
+  source: "error",
+  counts: {
+    buildingsReturned: 0,
+    roadsReturned: 0,
+    buildingsRendered: 0,
+    roadsRendered: 0,
+  },
+  buildings: turf.featureCollection([]),
+  roads: turf.featureCollection([]),
+};
+
+function localDateTimeValue(date: Date) {
+  const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return offsetDate.toISOString().slice(0, 16);
+}
+
+function fallbackFrom(error: unknown) {
+  if (error && typeof error === "object" && "fallback" in error) {
+    return error.fallback;
+  }
+
+  return undefined;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+export default function App() {
+  const [center, setCenter] = useState<LatLng>(() => initialLocation().center);
+  const [locationLabel, setLocationLabel] = useState(() => initialLocation().label);
+  const [dateTime, setDateTime] = useState(() => localDateTimeValue(new Date()));
+  const [layers, setLayers] = useState<LayerToggles>({
+    buildings: true,
+    shadows: true,
+    windArrows: true,
+    roadWind: true,
+  });
+  const [osmData, setOSMData] = useState<OSMData>(EMPTY_OSM);
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [loadingOSM, setLoadingOSM] = useState(true);
+  const [loadingWeather, setLoadingWeather] = useState(true);
+  const [dataMessage, setDataMessage] = useState<string>();
+  const [weatherMessage, setWeatherMessage] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+
+    setLoadingOSM(true);
+    setDataMessage(undefined);
+
+    fetchOSMData(center)
+      .then((data) => {
+        if (!active) {
+          return;
+        }
+
+        setOSMData(data);
+        setDataMessage(data.warning);
+        console.info("[OSM data]", {
+          source: data.source,
+          endpoint: data.endpoint,
+          counts: data.counts,
+          warning: data.warning,
+          errors: data.errors,
+        });
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+
+        const fallback = fallbackFrom(error);
+
+        if (fallback) {
+          setOSMData(fallback as OSMData);
+        }
+
+        setDataMessage(
+          `${errorMessage(error)} ${
+            fallback ? "Using the small development fallback." : "No map data loaded."
+          }`,
+        );
+      })
+      .finally(() => {
+        if (active) {
+          setLoadingOSM(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [center]);
+
+  useEffect(() => {
+    let active = true;
+
+    setLoadingWeather(true);
+    setWeatherMessage(undefined);
+
+    fetchWeather(center)
+      .then((reading) => {
+        if (active) {
+          setWeather(reading);
+        }
+      })
+      .catch((error) => {
+        if (!active) {
+          return;
+        }
+
+        const fallback = fallbackFrom(error);
+
+        if (fallback) {
+          setWeather(fallback as WeatherData);
+        } else {
+          setWeather(null);
+        }
+
+        setWeatherMessage(
+          `${errorMessage(error)} ${
+            fallback ? "Using the small development fallback." : "No wind reading loaded."
+          }`,
+        );
+      })
+      .finally(() => {
+        if (active) {
+          setLoadingWeather(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [center]);
+
+  const selectedDate = useMemo(() => new Date(dateTime), [dateTime]);
+  const sun = useMemo(() => sunForDate(selectedDate, center), [center, selectedDate]);
+  const shadows = useMemo(
+    () =>
+      turf.featureCollection(
+        osmData.buildings.features
+          .map((building) => shadowForBuilding(building, sun.altitude, sun.shadowBearing))
+          .filter((shadow): shadow is ShadowFeature => Boolean(shadow)),
+      ),
+    [osmData.buildings.features, sun.altitude, sun.shadowBearing],
+  );
+  const windSegments = useMemo(
+    () =>
+      turf.featureCollection(
+        weather
+          ? estimateRoadWind(
+              osmData.roads.features,
+              osmData.buildings.features,
+              weather.windSpeed,
+              weather.windDirection,
+            )
+          : [],
+      ),
+    [osmData.buildings.features, osmData.roads.features, weather],
+  );
+  const arrows = useMemo(
+    () => {
+      const arrowStride = Math.max(1, Math.ceil(windSegments.features.length / 360));
+
+      return turf.featureCollection(
+        windSegments.features
+          .filter((_, index) => index % arrowStride === 0)
+          .map(windArrowForSegment),
+      );
+    },
+    [windSegments.features],
+  );
+  const renderStats: LayerRenderStats = useMemo(
+    () => ({
+      shadowPolygons: shadows.features.length,
+      windSegments: windSegments.features.length,
+      windArrows: arrows.features.length,
+    }),
+    [arrows.features.length, shadows.features.length, windSegments.features.length],
+  );
+
+  async function search(query: string) {
+    const location = await findLocation(query);
+    setLocationLabel(location.label);
+    setCenter(location.center);
+  }
+
+  function useCurrentLocation() {
+    if (!navigator.geolocation) {
+      setDataMessage("Geolocation is not available in this browser.");
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        setLocationLabel("Current location");
+        setCenter({ lat: coords.latitude, lng: coords.longitude });
+      },
+      () => setDataMessage("Current location could not be read."),
+      { enableHighAccuracy: false, maximumAge: 120_000, timeout: 10_000 },
+    );
+  }
+
+  function updateCenterFromMap(nextCenter: LatLng) {
+    setCenter((current) =>
+      Math.abs(current.lat - nextCenter.lat) > 0.002 ||
+      Math.abs(current.lng - nextCenter.lng) > 0.003
+        ? nextCenter
+        : current,
+    );
+  }
+
+  return (
+    <div className="app-shell">
+      <MapView
+        arrows={arrows}
+        buildings={osmData.buildings}
+        center={center}
+        layers={layers}
+        onAreaChange={updateCenterFromMap}
+        shadows={shadows}
+        windSegments={windSegments}
+      />
+      <ControlsPanel
+        center={center}
+        dataMessage={dataMessage}
+        dateTime={dateTime}
+        layers={layers}
+        loadingOSM={loadingOSM}
+        loadingWeather={loadingWeather}
+        locationLabel={locationLabel}
+        osmData={osmData}
+        onDateTimeChange={setDateTime}
+        onSearch={search}
+        onToggle={(layer) => setLayers((current) => ({ ...current, [layer]: !current[layer] }))}
+        onUseLocation={useCurrentLocation}
+        renderStats={renderStats}
+        sunMessage={
+          sun.altitude <= 0
+            ? "Sun below horizon - no direct shadows."
+            : `Sun altitude ${sun.altitudeDegrees.toFixed(1)} deg, shadow bearing ${Math.round(
+                sun.shadowBearing,
+              )} deg.`
+        }
+        weather={weather}
+        weatherMessage={weatherMessage}
+      />
+      <Legend sunBelowHorizon={sun.altitude <= 0} />
+    </div>
+  );
+}

--- a/winds/src/api/endpoints.ts
+++ b/winds/src/api/endpoints.ts
@@ -1,0 +1,15 @@
+export const OVERPASS_ENDPOINTS = [
+  "https://overpass-api.de/api/interpreter",
+  "https://lz4.overpass-api.de/api/interpreter",
+  "https://z.overpass-api.de/api/interpreter",
+  "https://overpass.openstreetmap.ru/api/interpreter",
+  "https://overpass.private.coffee/api/interpreter",
+  "https://overpass.kumi.systems/api/interpreter",
+  "https://api.openstreetmap.fr/oapi/interpreter",
+  "https://overpass.osm.vi-di.fr/api/interpreter",
+  "https://overpass.osm.rambler.ru/cgi/interpreter",
+];
+
+export function endpointName(endpoint: string) {
+  return new URL(endpoint).hostname;
+}

--- a/winds/src/api/geocoding.ts
+++ b/winds/src/api/geocoding.ts
@@ -1,0 +1,62 @@
+import type { LatLng } from "../types";
+
+type NominatimResult = {
+  lat: string;
+  lon: string;
+  display_name: string;
+};
+
+function parseCoordinates(query: string): LatLng | null {
+  const parts = query
+    .split(/[,\s]+/)
+    .map((part) => Number.parseFloat(part.trim()))
+    .filter((part) => Number.isFinite(part));
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [lat, lng] = parts;
+
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+    return null;
+  }
+
+  return { lat, lng };
+}
+
+export async function findLocation(query: string) {
+  const coordinates = parseCoordinates(query);
+
+  if (coordinates) {
+    return {
+      center: coordinates,
+      label: `${coordinates.lat.toFixed(5)}, ${coordinates.lng.toFixed(5)}`,
+    };
+  }
+
+  const parameters = new URLSearchParams({
+    q: query,
+    format: "jsonv2",
+    limit: "1",
+  });
+  const response = await fetch(`https://nominatim.openstreetmap.org/search?${parameters}`);
+
+  if (!response.ok) {
+    throw new Error(`Location search returned ${response.status}.`);
+  }
+
+  const [result] = (await response.json()) as NominatimResult[];
+
+  if (!result) {
+    throw new Error("No matching location found.");
+  }
+
+  return {
+    center: {
+      lat: Number.parseFloat(result.lat),
+      lng: Number.parseFloat(result.lon),
+    },
+    label: result.display_name,
+  };
+}

--- a/winds/src/api/overpass.ts
+++ b/winds/src/api/overpass.ts
@@ -1,5 +1,6 @@
 import * as turf from "@turf/turf";
 import { demoOSMData } from "../data/offlineDemo";
+import { endpointName, OVERPASS_ENDPOINTS } from "./endpoints";
 import type {
   BuildingFeature,
   HeightSource,
@@ -14,7 +15,7 @@ type OverpassElement = {
   type: "way";
   id: number;
   tags?: Record<string, string>;
-  geometry?: Array<{ lat: number; lon: number }>;
+  geometry?: Array<{ lat: number; lon: number } | null>;
 };
 
 type OverpassResponse = {
@@ -26,14 +27,6 @@ const resolvedOverpassCache = new Map<string, OSMData>();
 const MAX_RENDER_BUILDINGS = 650;
 const MAX_RENDER_ROADS = 240;
 const OVERPASS_TIMEOUT_MS = 14_000;
-const OVERPASS_ENDPOINTS = [
-  "https://overpass-api.de/api/interpreter",
-  "https://overpass.private.coffee/api/interpreter",
-  "https://overpass.kumi.systems/api/interpreter",
-  "https://api.openstreetmap.fr/oapi/interpreter",
-  "https://overpass.osm.vi-di.fr/api/interpreter",
-  "https://overpass.osm.rambler.ru/cgi/interpreter",
-];
 
 function parseMetricHeight(raw?: string) {
   if (!raw) {
@@ -69,7 +62,9 @@ export function resolveBuildingHeight(tags: Record<string, string>) {
 }
 
 function positions(element: OverpassElement) {
-  return (element.geometry ?? []).map(({ lon, lat }) => [lon, lat]);
+  return (element.geometry ?? [])
+    .filter((point): point is { lat: number; lon: number } => Boolean(point))
+    .map(({ lon, lat }) => [lon, lat]);
 }
 
 function closeRing(coordinates: number[][]) {
@@ -132,7 +127,7 @@ function queryFor(center: LatLng) {
   way["building"](${bbox});
   way["highway"]["area"!="yes"]["highway"!~"footway|path|steps|cycleway|track|corridor|construction|proposed"](${bbox});
 );
-out tags geom;`;
+out tags geom(${bbox});`;
 }
 
 async function postToOverpass(endpoint: string, query: string) {
@@ -151,10 +146,6 @@ async function postToOverpass(endpoint: string, query: string) {
   } finally {
     window.clearTimeout(timeout);
   }
-}
-
-function endpointName(endpoint: string) {
-  return new URL(endpoint).hostname;
 }
 
 function emptyErrorData(warning: string, errors: string[]): OSMData {
@@ -221,6 +212,11 @@ function parseOverpassPayload(payload: OverpassResponse, endpoint: string, error
 async function fetchFromOverpass(center: LatLng): Promise<OSMData> {
   const query = queryFor(center);
   const errors: string[] = [];
+  const proxiedData = await fetchFromProxy(query, errors);
+
+  if (proxiedData) {
+    return proxiedData;
+  }
 
   for (const endpoint of OVERPASS_ENDPOINTS) {
     let response: Response;
@@ -233,7 +229,9 @@ async function fetchFromOverpass(center: LatLng): Promise<OSMData> {
     }
 
     if (!response.ok) {
-      errors.push(`${endpointName(endpoint)}: HTTP ${response.status}`);
+      const detail = await response.text().catch(() => "");
+      const suffix = detail ? ` ${detail.replace(/\s+/g, " ").slice(0, 180)}` : "";
+      errors.push(`${endpointName(endpoint)}: HTTP ${response.status}${suffix}`);
       continue;
     }
 
@@ -248,6 +246,55 @@ async function fetchFromOverpass(center: LatLng): Promise<OSMData> {
   }
 
   throw Object.assign(new Error("All Overpass endpoints failed."), { errors });
+}
+
+async function fetchFromProxy(query: string, errors: string[]) {
+  try {
+    const response = await fetch("/api/overpass", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query }),
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      endpoint?: string;
+      errors?: string[];
+      payload?: OverpassResponse;
+    };
+
+    if (data.errors?.length) {
+      errors.push(...data.errors.map((error) => `proxy ${error}`));
+    }
+
+    if (!response.ok || !data.endpoint || !data.payload) {
+      errors.push(`proxy: HTTP ${response.status}`);
+      if (import.meta.env.PROD) {
+        throw Object.assign(new Error("Overpass proxy failed."), { errors });
+      }
+      return null;
+    }
+
+    const parsed = parseOverpassPayload(data.payload, data.endpoint, errors);
+
+    if (parsed.counts.buildingsReturned === 0 && parsed.counts.roadsReturned === 0) {
+      errors.push(`proxy ${endpointName(data.endpoint)}: empty OSM response for this bbox`);
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    errors.push(`proxy: ${error instanceof Error ? error.message : String(error)}`);
+    if (import.meta.env.PROD) {
+      throw Object.assign(new Error("Overpass proxy failed."), { errors });
+    }
+    return null;
+  }
 }
 
 export function fetchOSMData(center: LatLng) {

--- a/winds/src/api/overpass.ts
+++ b/winds/src/api/overpass.ts
@@ -1,0 +1,311 @@
+import * as turf from "@turf/turf";
+import { demoOSMData } from "../data/offlineDemo";
+import type {
+  BuildingFeature,
+  HeightSource,
+  LatLng,
+  OSMData,
+  OSMDataCounts,
+  RoadFeature,
+} from "../types";
+import { bboxAround, bboxCacheKey, simplifyPolygon } from "../utils/geometry";
+
+type OverpassElement = {
+  type: "way";
+  id: number;
+  tags?: Record<string, string>;
+  geometry?: Array<{ lat: number; lon: number }>;
+};
+
+type OverpassResponse = {
+  elements?: OverpassElement[];
+};
+
+const pendingOverpassCache = new Map<string, Promise<OSMData>>();
+const resolvedOverpassCache = new Map<string, OSMData>();
+const MAX_RENDER_BUILDINGS = 650;
+const MAX_RENDER_ROADS = 240;
+const OVERPASS_TIMEOUT_MS = 14_000;
+const OVERPASS_ENDPOINTS = [
+  "https://overpass-api.de/api/interpreter",
+  "https://overpass.private.coffee/api/interpreter",
+  "https://overpass.kumi.systems/api/interpreter",
+  "https://api.openstreetmap.fr/oapi/interpreter",
+  "https://overpass.osm.vi-di.fr/api/interpreter",
+  "https://overpass.osm.rambler.ru/cgi/interpreter",
+];
+
+function parseMetricHeight(raw?: string) {
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number.parseFloat(raw.replace(",", "."));
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return raw.includes("'") || raw.toLowerCase().includes("ft") ? parsed * 0.3048 : parsed;
+}
+
+export function resolveBuildingHeight(tags: Record<string, string>) {
+  const exact = parseMetricHeight(tags.height ?? tags["building:height"]);
+
+  if (exact) {
+    return { height: exact, heightSource: "exact" as HeightSource };
+  }
+
+  const levels = parseMetricHeight(tags["building:levels"]);
+
+  if (levels) {
+    return {
+      height: levels * 3,
+      heightSource: "levels-estimated" as HeightSource,
+    };
+  }
+
+  return { height: 12, heightSource: "default" as HeightSource };
+}
+
+function positions(element: OverpassElement) {
+  return (element.geometry ?? []).map(({ lon, lat }) => [lon, lat]);
+}
+
+function closeRing(coordinates: number[][]) {
+  const first = coordinates[0];
+  const last = coordinates.at(-1);
+
+  if (!first || !last || (first[0] === last[0] && first[1] === last[1])) {
+    return coordinates;
+  }
+
+  return [...coordinates, first];
+}
+
+function buildingFromWay(element: OverpassElement): BuildingFeature | null {
+  const ring = closeRing(positions(element));
+
+  if (ring.length < 4) {
+    return null;
+  }
+
+  const { height, heightSource } = resolveBuildingHeight(element.tags ?? {});
+  const feature = turf.polygon([ring], {
+    id: `building-${element.id}`,
+    height,
+    heightSource,
+    name: element.tags?.name,
+  }) as BuildingFeature;
+
+  return ring.length > 70 ? (simplifyPolygon(feature, 0.000004) as BuildingFeature) : feature;
+}
+
+function roadFromWay(element: OverpassElement): RoadFeature | null {
+  const coordinates = positions(element);
+
+  if (coordinates.length < 2) {
+    return null;
+  }
+
+  const feature = turf.lineString(coordinates, {
+    id: `road-${element.id}`,
+    highway: element.tags?.highway ?? "road",
+    name: element.tags?.name,
+  }) as RoadFeature;
+
+  return coordinates.length > 6
+    ? (turf.simplify(feature, {
+        highQuality: false,
+        mutate: false,
+        tolerance: 0.000006,
+      }) as RoadFeature)
+    : feature;
+}
+
+function queryFor(center: LatLng) {
+  const { south, west, north, east } = bboxAround(center);
+  const bbox = `${south},${west},${north},${east}`;
+
+  return `[out:json][timeout:20];
+(
+  way["building"](${bbox});
+  way["highway"]["area"!="yes"]["highway"!~"footway|path|steps|cycleway|track|corridor|construction|proposed"](${bbox});
+);
+out tags geom;`;
+}
+
+async function postToOverpass(endpoint: string, query: string) {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), OVERPASS_TIMEOUT_MS);
+
+  try {
+    return await fetch(endpoint, {
+      signal: controller.signal,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+      },
+      body: new URLSearchParams({ data: query }),
+    });
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function endpointName(endpoint: string) {
+  return new URL(endpoint).hostname;
+}
+
+function emptyErrorData(warning: string, errors: string[]): OSMData {
+  return {
+    fallback: false,
+    source: "error",
+    warning,
+    errors,
+    counts: {
+      buildingsReturned: 0,
+      roadsReturned: 0,
+      buildingsRendered: 0,
+      roadsRendered: 0,
+    },
+    buildings: turf.featureCollection([]),
+    roads: turf.featureCollection([]),
+  };
+}
+
+function cachedData(data: OSMData, warning?: string): OSMData {
+  return {
+    ...data,
+    source: "cache",
+    warning: warning ?? data.warning,
+  };
+}
+
+function parseOverpassPayload(payload: OverpassResponse, endpoint: string, errors: string[]): OSMData {
+  const elements = payload.elements ?? [];
+  const buildings = elements
+    .filter((element) => Boolean(element.tags?.building))
+    .map(buildingFromWay)
+    .filter((building): building is BuildingFeature => Boolean(building));
+  const roads = elements
+    .filter((element) => Boolean(element.tags?.highway))
+    .map(roadFromWay)
+    .filter((road): road is RoadFeature => Boolean(road));
+  const trimmedBuildings = buildings.slice(0, MAX_RENDER_BUILDINGS);
+  const trimmedRoads = roads.slice(0, MAX_RENDER_ROADS);
+  const counts: OSMDataCounts = {
+    buildingsReturned: buildings.length,
+    roadsReturned: roads.length,
+    buildingsRendered: trimmedBuildings.length,
+    roadsRendered: trimmedRoads.length,
+  };
+  const wasTrimmed = trimmedBuildings.length < buildings.length || trimmedRoads.length < roads.length;
+  const warning =
+    wasTrimmed
+      ? `Large area response: ${buildings.length} buildings and ${roads.length} roads. Rendering a nearby subset for responsiveness.`
+      : undefined;
+
+  return {
+    fallback: false,
+    source: "live",
+    endpoint,
+    warning,
+    errors,
+    counts,
+    buildings: turf.featureCollection(trimmedBuildings),
+    roads: turf.featureCollection(trimmedRoads),
+  };
+}
+
+async function fetchFromOverpass(center: LatLng): Promise<OSMData> {
+  const query = queryFor(center);
+  const errors: string[] = [];
+
+  for (const endpoint of OVERPASS_ENDPOINTS) {
+    let response: Response;
+
+    try {
+      response = await postToOverpass(endpoint, query);
+    } catch (error) {
+      errors.push(`${endpointName(endpoint)}: ${error instanceof Error ? error.message : String(error)}`);
+      continue;
+    }
+
+    if (!response.ok) {
+      errors.push(`${endpointName(endpoint)}: HTTP ${response.status}`);
+      continue;
+    }
+
+    const data = parseOverpassPayload((await response.json()) as OverpassResponse, endpoint, errors);
+
+    if (data.counts.buildingsReturned === 0 && data.counts.roadsReturned === 0) {
+      errors.push(`${endpointName(endpoint)}: empty OSM response for this bbox`);
+      continue;
+    }
+
+    return data;
+  }
+
+  throw Object.assign(new Error("All Overpass endpoints failed."), { errors });
+}
+
+export function fetchOSMData(center: LatLng) {
+  const cacheKey = bboxCacheKey(center);
+  const cached = resolvedOverpassCache.get(cacheKey);
+
+  if (cached) {
+    return Promise.resolve(cachedData(cached));
+  }
+
+  const pending = pendingOverpassCache.get(cacheKey);
+
+  if (pending) {
+    return pending;
+  }
+
+  const request = fetchFromOverpass(center)
+    .then((data) => {
+      resolvedOverpassCache.set(cacheKey, data);
+      return data;
+    })
+    .catch((error) => {
+      const errors =
+        error && typeof error === "object" && "errors" in error && Array.isArray(error.errors)
+          ? error.errors
+          : [error instanceof Error ? error.message : String(error)];
+      const cachedAfterFailure = resolvedOverpassCache.get(cacheKey);
+
+      if (cachedAfterFailure) {
+        return cachedData(
+          cachedAfterFailure,
+          `Live OpenStreetMap / Overpass fetch failed. Using cached data for this area. ${errors.join(
+            " | ",
+          )}`,
+        );
+      }
+
+      if (import.meta.env.DEV) {
+        return {
+          ...demoOSMData,
+          warning: `Live OpenStreetMap / Overpass fetch failed. Using the small development fallback. ${errors.join(
+            " | ",
+          )}`,
+          errors,
+        };
+      }
+
+      return emptyErrorData(
+        `Live OpenStreetMap / Overpass fetch failed. No cached data is available. ${errors.join(
+          " | ",
+        )}`,
+        errors,
+      );
+    })
+    .finally(() => {
+      pendingOverpassCache.delete(cacheKey);
+    });
+
+  pendingOverpassCache.set(cacheKey, request);
+  return request;
+}

--- a/winds/src/api/weather.ts
+++ b/winds/src/api/weather.ts
@@ -1,0 +1,52 @@
+import { demoWeatherData } from "../data/offlineDemo";
+import type { LatLng, WeatherData } from "../types";
+
+type WeatherResponse = {
+  current?: {
+    time?: string;
+    wind_speed_10m?: number;
+    wind_direction_10m?: number;
+  };
+};
+
+export async function fetchWeather(center: LatLng): Promise<WeatherData> {
+  const parameters = new URLSearchParams({
+    latitude: center.lat.toString(),
+    longitude: center.lng.toString(),
+    current: "wind_speed_10m,wind_direction_10m",
+    wind_speed_unit: "ms",
+    timezone: "auto",
+  });
+
+  try {
+    const response = await fetch(`https://api.open-meteo.com/v1/forecast?${parameters}`);
+
+    if (!response.ok) {
+      throw new Error(`Open-Meteo returned ${response.status}.`);
+    }
+
+    const payload = (await response.json()) as WeatherResponse;
+    const windSpeed = payload.current?.wind_speed_10m;
+    const windDirection = payload.current?.wind_direction_10m;
+
+    if (typeof windSpeed !== "number" || typeof windDirection !== "number") {
+      throw new Error("Open-Meteo did not include current wind values.");
+    }
+
+    return {
+      windSpeed,
+      windDirection,
+      observedAt: payload.current?.time ?? new Date().toISOString(),
+      fallback: false,
+    };
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      throw Object.assign(new Error("Live Open-Meteo wind fetch failed."), {
+        cause: error,
+        fallback: demoWeatherData,
+      });
+    }
+
+    throw error;
+  }
+}

--- a/winds/src/components/ControlsPanel.tsx
+++ b/winds/src/components/ControlsPanel.tsx
@@ -1,0 +1,202 @@
+import type { FormEvent } from "react";
+import { useState } from "react";
+import type { LatLng, LayerRenderStats, LayerToggles, OSMData, WeatherData } from "../types";
+
+type ControlsPanelProps = {
+  center: LatLng;
+  dateTime: string;
+  locationLabel: string;
+  layers: LayerToggles;
+  loadingOSM: boolean;
+  loadingWeather: boolean;
+  osmData: OSMData;
+  renderStats: LayerRenderStats;
+  weather: WeatherData | null;
+  sunMessage: string;
+  dataMessage?: string;
+  weatherMessage?: string;
+  onDateTimeChange: (value: string) => void;
+  onSearch: (query: string) => Promise<void>;
+  onUseLocation: () => void;
+  onToggle: (layer: keyof LayerToggles) => void;
+};
+
+export default function ControlsPanel({
+  center,
+  dateTime,
+  locationLabel,
+  layers,
+  loadingOSM,
+  loadingWeather,
+  osmData,
+  renderStats,
+  weather,
+  sunMessage,
+  dataMessage,
+  weatherMessage,
+  onDateTimeChange,
+  onSearch,
+  onUseLocation,
+  onToggle,
+}: ControlsPanelProps) {
+  const [query, setQuery] = useState("Nevsky Prospect, Saint Petersburg");
+  const [searchState, setSearchState] = useState<"idle" | "searching">("idle");
+  const [searchError, setSearchError] = useState<string>();
+
+  async function submitSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!query.trim()) {
+      return;
+    }
+
+    setSearchState("searching");
+    setSearchError(undefined);
+
+    try {
+      await onSearch(query.trim());
+    } catch (error) {
+      setSearchError(error instanceof Error ? error.message : "Location search failed.");
+    } finally {
+      setSearchState("idle");
+    }
+  }
+
+  return (
+    <aside className="controls-panel">
+      <header className="panel-header">
+        <p className="eyebrow">Street model</p>
+        <h1>Wind & Shadow Map</h1>
+        <p className="location-label">{locationLabel}</p>
+      </header>
+
+      <form className="search-form" onSubmit={submitSearch}>
+        <label htmlFor="location-search">Location</label>
+        <div className="input-row">
+          <input
+            id="location-search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Place or lat, lng"
+          />
+          <button disabled={searchState === "searching"} type="submit">
+            {searchState === "searching" ? "..." : "Go"}
+          </button>
+        </div>
+        <button className="secondary-button" onClick={onUseLocation} type="button">
+          Use my location
+        </button>
+        <p className="coordinates">
+          {center.lat.toFixed(5)}, {center.lng.toFixed(5)}
+        </p>
+        {searchError ? <p className="inline-error">{searchError}</p> : null}
+      </form>
+
+      <section className="panel-section">
+        <label htmlFor="shadow-time">Date and time</label>
+        <input
+          id="shadow-time"
+          type="datetime-local"
+          value={dateTime}
+          onChange={(event) => onDateTimeChange(event.target.value)}
+        />
+        <p className="sun-readout">{sunMessage}</p>
+      </section>
+
+      <section className="panel-section layer-controls">
+        {(
+          [
+            ["buildings", "Buildings"],
+            ["shadows", "Shadows"],
+            ["windArrows", "Wind arrows"],
+            ["roadWind", "Road wind heatmap"],
+          ] as const
+        ).map(([layer, label]) => (
+          <label className="toggle-row" key={layer}>
+            <span>{label}</span>
+            <input
+              checked={layers[layer]}
+              onChange={() => onToggle(layer)}
+              type="checkbox"
+            />
+          </label>
+        ))}
+      </section>
+
+      <section className="panel-section weather-panel">
+        <div className="section-heading">
+          <h2>Wind feed</h2>
+          {loadingWeather ? <span>Loading</span> : null}
+        </div>
+        {weather ? (
+          <dl>
+            <div>
+              <dt>Speed</dt>
+              <dd>{weather.windSpeed.toFixed(1)} m/s</dd>
+            </div>
+            <div>
+              <dt>Direction</dt>
+              <dd>{Math.round(weather.windDirection)} deg</dd>
+            </div>
+            <div>
+              <dt>Observed</dt>
+              <dd>{weather.observedAt.replace("T", " ")}</dd>
+            </div>
+          </dl>
+        ) : (
+          <p>No wind reading yet.</p>
+        )}
+        {weather?.fallback ? <p className="fallback-chip">Development fallback wind</p> : null}
+      </section>
+
+      <section className="panel-section notices">
+        <div className="section-heading">
+          <h2>Data</h2>
+          {loadingOSM ? <span>Loading</span> : null}
+        </div>
+        <dl className="data-stats">
+          <div>
+            <dt>Source</dt>
+            <dd>{osmData.source}</dd>
+          </div>
+          <div>
+            <dt>Buildings returned</dt>
+            <dd>{osmData.counts.buildingsReturned}</dd>
+          </div>
+          <div>
+            <dt>Roads returned</dt>
+            <dd>{osmData.counts.roadsReturned}</dd>
+          </div>
+          <div>
+            <dt>Buildings rendered</dt>
+            <dd>{osmData.counts.buildingsRendered}</dd>
+          </div>
+          <div>
+            <dt>Roads rendered</dt>
+            <dd>{osmData.counts.roadsRendered}</dd>
+          </div>
+          <div>
+            <dt>Shadow polygons</dt>
+            <dd>{renderStats.shadowPolygons}</dd>
+          </div>
+          <div>
+            <dt>Wind heat segments</dt>
+            <dd>{renderStats.windSegments}</dd>
+          </div>
+          <div>
+            <dt>Wind arrows</dt>
+            <dd>{renderStats.windArrows}</dd>
+          </div>
+        </dl>
+        {osmData.endpoint ? <p className="data-endpoint">{new URL(osmData.endpoint).hostname}</p> : null}
+        {dataMessage ? <p className="inline-error">{dataMessage}</p> : null}
+        {weatherMessage ? <p className="inline-error">{weatherMessage}</p> : null}
+        <p>
+          Shadows use OSM footprints and tagged or estimated heights. Street wind is a fast
+          urban-canyon approximation from weather wind, road alignment, and nearby buildings,
+          not CFD.
+        </p>
+      </section>
+    </aside>
+  );
+}

--- a/winds/src/components/ControlsPanel.tsx
+++ b/winds/src/components/ControlsPanel.tsx
@@ -42,6 +42,11 @@ export default function ControlsPanel({
   const [query, setQuery] = useState("Nevsky Prospect, Saint Petersburg");
   const [searchState, setSearchState] = useState<"idle" | "searching">("idle");
   const [searchError, setSearchError] = useState<string>();
+  const noRenderedOsmData =
+    !loadingOSM &&
+    osmData.counts.buildingsRendered === 0 &&
+    osmData.counts.roadsRendered === 0;
+  const noWindModel = !loadingOSM && !loadingWeather && renderStats.windSegments === 0;
 
   async function submitSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -104,6 +109,17 @@ export default function ControlsPanel({
       </section>
 
       <section className="panel-section layer-controls">
+        {noRenderedOsmData ? (
+          <p className="status-warning">
+            OSM data did not load for this area. Wind and shadows need live building and road
+            geometry.
+          </p>
+        ) : null}
+        {noWindModel && !noRenderedOsmData ? (
+          <p className="status-warning">
+            Wind model has no road segments yet. Check weather and OSM counts below.
+          </p>
+        ) : null}
         {(
           [
             ["buildings", "Buildings"],

--- a/winds/src/components/Legend.tsx
+++ b/winds/src/components/Legend.tsx
@@ -1,0 +1,37 @@
+import { windColor } from "../utils/wind";
+
+const strengthBands = [
+  ["Weak", "< 0.8", 0.4],
+  ["Light", "0.8-2", 1.2],
+  ["Moderate", "2-4", 3],
+  ["Strong", "4-6", 5],
+  ["Very strong", "> 6", 7],
+] as const;
+
+type LegendProps = {
+  sunBelowHorizon: boolean;
+};
+
+export default function Legend({ sunBelowHorizon }: LegendProps) {
+  return (
+    <div className="map-legends" aria-label="Map legends">
+      <section className="legend-block">
+        <h2>Wind strength along road</h2>
+        {strengthBands.map(([label, range, value]) => (
+          <div className="legend-row" key={label}>
+            <span className="legend-swatch wind" style={{ background: windColor(value) }} />
+            <span>{label}</span>
+            <strong>{range} m/s</strong>
+          </div>
+        ))}
+      </section>
+      <section className="legend-block compact">
+        <h2>Shadow layer</h2>
+        <div className="legend-row">
+          <span className="legend-swatch shadow" />
+          <span>{sunBelowHorizon ? "No direct sun" : "Projected shadow"}</span>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/winds/src/components/MapView.tsx
+++ b/winds/src/components/MapView.tsx
@@ -1,0 +1,214 @@
+import L, { type Layer } from "leaflet";
+import { useEffect } from "react";
+import {
+  GeoJSON,
+  MapContainer,
+  Marker,
+  Pane,
+  TileLayer,
+  useMap,
+  useMapEvents,
+} from "react-leaflet";
+import type { FeatureCollection, GeoJsonObject, LineString, Point, Polygon } from "geojson";
+import type {
+  ArrowProperties,
+  BuildingProperties,
+  LatLng,
+  LayerToggles,
+  ShadowProperties,
+  WindSegmentProperties,
+} from "../types";
+import { windColor } from "../utils/wind";
+
+type MapViewProps = {
+  center: LatLng;
+  layers: LayerToggles;
+  buildings: FeatureCollection<Polygon, BuildingProperties>;
+  shadows: FeatureCollection<Polygon, ShadowProperties>;
+  windSegments: FeatureCollection<LineString, WindSegmentProperties>;
+  arrows: FeatureCollection<Point, ArrowProperties>;
+  onAreaChange: (center: LatLng) => void;
+};
+
+function RefreshMapCenter({ center }: { center: LatLng }) {
+  const map = useMap();
+
+  useEffect(() => {
+    const current = map.getCenter();
+
+    if (Math.abs(current.lat - center.lat) > 0.0002 || Math.abs(current.lng - center.lng) > 0.0002) {
+      map.flyTo([center.lat, center.lng], map.getZoom(), {
+        duration: 0.65,
+      });
+    }
+  }, [center, map]);
+
+  return null;
+}
+
+function ReportMapCenter({ onAreaChange }: { onAreaChange: (center: LatLng) => void }) {
+  useMapEvents({
+    moveend(event) {
+      const center = event.target.getCenter();
+      onAreaChange({ lat: center.lat, lng: center.lng });
+    },
+  });
+
+  return null;
+}
+
+function buildingTooltip(properties: BuildingProperties) {
+  return `Height: ${properties.height.toFixed(1)} m
+Source: ${properties.heightSource}`;
+}
+
+function windTooltip(properties: WindSegmentProperties) {
+  return `Estimated street wind: ${properties.speed.toFixed(1)} m/s
+Base wind: ${properties.baseSpeed.toFixed(1)} m/s at ${Math.round(properties.baseDirection)} deg
+Road bearing: ${Math.round(properties.bearing)} deg
+Canyon multiplier: ${properties.canyonMultiplier.toFixed(2)}x
+Confidence: ${properties.confidence}`;
+}
+
+function bindBuildingTooltip(_feature: GeoJSON.Feature, layer: Layer) {
+  const properties = _feature.properties as BuildingProperties;
+  const details = buildingTooltip(properties);
+  layer.bindTooltip(details, {
+    className: "map-tooltip",
+    direction: "top",
+    sticky: true,
+  });
+  layer.bindPopup(details.replace(/\n/g, "<br />"), {
+    className: "map-popup",
+  });
+}
+
+function bindShadowTooltip(_feature: GeoJSON.Feature, layer: Layer) {
+  const properties = _feature.properties as ShadowProperties;
+  const details = `Shadow length: ${properties.shadowLength.toFixed(1)} m`;
+  layer.bindTooltip(details, {
+    className: "map-tooltip",
+    direction: "top",
+    sticky: true,
+  });
+  layer.bindPopup(details, {
+    className: "map-popup",
+  });
+}
+
+function bindWindTooltip(_feature: GeoJSON.Feature, layer: Layer) {
+  const properties = _feature.properties as WindSegmentProperties;
+  const details = windTooltip(properties);
+  layer.bindTooltip(details, {
+    className: "map-tooltip",
+    direction: "top",
+    sticky: true,
+  });
+  layer.bindPopup(details.replace(/\n/g, "<br />"), {
+    className: "map-popup",
+  });
+}
+
+function arrowIcon(properties: ArrowProperties) {
+  return L.divIcon({
+    className: "wind-arrow-shell",
+    html: `<span aria-hidden="true" class="wind-arrow" style="--bearing:${properties.localDirection}deg;--wind-color:${windColor(
+      properties.speed,
+    )}"></span>`,
+    iconAnchor: [14, 14],
+    iconSize: [28, 28],
+  });
+}
+
+export default function MapView({
+  center,
+  layers,
+  buildings,
+  shadows,
+  windSegments,
+  arrows,
+  onAreaChange,
+}: MapViewProps) {
+  return (
+    <main className="map-shell">
+      <MapContainer center={[center.lat, center.lng]} zoom={16} minZoom={13}>
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <RefreshMapCenter center={center} />
+        <ReportMapCenter onAreaChange={onAreaChange} />
+        <Pane name="shadow-pane" style={{ zIndex: 410 }}>
+          {layers.shadows ? (
+            <GeoJSON
+              data={shadows as GeoJsonObject}
+              key={`shadows-${shadows.features.length}-${center.lat}-${center.lng}`}
+              onEachFeature={bindShadowTooltip}
+              pane="shadow-pane"
+              style={{
+                color: "#12151a",
+                fillColor: "#12151a",
+                fillOpacity: 0.52,
+                opacity: 0.28,
+                weight: 1.2,
+              }}
+            />
+          ) : null}
+        </Pane>
+        <Pane name="building-pane" style={{ zIndex: 430 }}>
+          {layers.buildings ? (
+            <GeoJSON
+              data={buildings as GeoJsonObject}
+              key={`buildings-${buildings.features.length}-${center.lat}-${center.lng}`}
+              onEachFeature={bindBuildingTooltip}
+              pane="building-pane"
+              style={{
+                color: "#fff7dc",
+                fillColor: "#117f86",
+                fillOpacity: 0.56,
+                opacity: 1,
+                weight: 1.8,
+              }}
+            />
+          ) : null}
+        </Pane>
+        <Pane name="road-wind-pane" style={{ zIndex: 455 }}>
+          {layers.roadWind ? (
+            <GeoJSON
+              data={windSegments as GeoJsonObject}
+              key={`wind-${windSegments.features.length}-${center.lat}-${center.lng}`}
+              onEachFeature={bindWindTooltip}
+              pane="road-wind-pane"
+              style={(feature) => {
+                const properties = feature?.properties as WindSegmentProperties | undefined;
+
+                return {
+                  color: windColor(properties?.speed ?? 0),
+                  dashArray: "10 8",
+                  lineCap: "butt",
+                  opacity: 0.48,
+                  weight: 4,
+                };
+              }}
+            />
+          ) : null}
+        </Pane>
+        <Pane name="wind-arrow-pane" style={{ zIndex: 650 }}>
+          {layers.windArrows
+            ? arrows.features.map((arrow) => (
+                <Marker
+                  alt=""
+                  icon={arrowIcon(arrow.properties)}
+                  interactive={false}
+                  key={arrow.properties.id}
+                  keyboard={false}
+                  pane="wind-arrow-pane"
+                  position={[arrow.geometry.coordinates[1], arrow.geometry.coordinates[0]]}
+                />
+              ))
+            : null}
+        </Pane>
+      </MapContainer>
+    </main>
+  );
+}

--- a/winds/src/main.tsx
+++ b/winds/src/main.tsx
@@ -1,0 +1,11 @@
+import "leaflet/dist/leaflet.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/winds/src/styles.css
+++ b/winds/src/styles.css
@@ -1,0 +1,462 @@
+:root {
+  color: #eef1f5;
+  background: #111317;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+  letter-spacing: 0;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+.app-shell {
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.map-shell,
+.leaflet-container {
+  height: 100%;
+  width: 100%;
+}
+
+.leaflet-container {
+  background: #c8d2d0;
+  color: #12161d;
+}
+
+.leaflet-control-attribution {
+  max-width: min(58vw, 520px);
+}
+
+.controls-panel {
+  backdrop-filter: blur(16px);
+  background:
+    linear-gradient(180deg, rgb(20 24 31 / 96%), rgb(13 16 22 / 94%)),
+    #151920;
+  border: 1px solid rgb(246 240 231 / 14%);
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgb(0 0 0 / 28%);
+  display: grid;
+  gap: 14px;
+  left: 18px;
+  max-height: calc(100vh - 36px);
+  overflow-y: auto;
+  padding: 18px;
+  position: absolute;
+  scrollbar-width: thin;
+  top: 18px;
+  width: min(370px, calc(100vw - 36px));
+  z-index: 800;
+}
+
+.panel-header {
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
+  padding-bottom: 14px;
+}
+
+.eyebrow {
+  color: #f2bb68;
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin: 0 0 7px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  color: #fbf7ef;
+  font-size: 1.5rem;
+  line-height: 1.12;
+  margin-bottom: 8px;
+}
+
+h2 {
+  color: #fbf7ef;
+  font-size: 0.92rem;
+  margin-bottom: 0;
+}
+
+.location-label {
+  color: #b8c5d1;
+  line-height: 1.35;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.search-form,
+.panel-section {
+  background: rgb(255 255 255 / 5%);
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: 8px;
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+}
+
+label {
+  color: #dbe2e9;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+input {
+  background: #0e1218;
+  border: 1px solid #344150;
+  border-radius: 6px;
+  color: #f6f2ea;
+  min-height: 40px;
+  min-width: 0;
+  outline: none;
+  padding: 0 11px;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+  width: 100%;
+}
+
+input:focus {
+  border-color: #6ad0c5;
+  box-shadow: 0 0 0 3px rgb(106 208 197 / 18%);
+}
+
+.input-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 48px;
+}
+
+.input-row button,
+.secondary-button {
+  border-radius: 6px;
+  min-height: 40px;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.input-row button {
+  background: #f2bb68;
+  color: #1b160d;
+  font-weight: 800;
+}
+
+.input-row button:hover,
+.secondary-button:hover {
+  transform: translateY(-1px);
+}
+
+.input-row button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+}
+
+.secondary-button {
+  background: #24303c;
+  color: #e8f0f5;
+  justify-self: start;
+  padding: 0 12px;
+}
+
+.secondary-button:hover {
+  background: #2e4050;
+}
+
+.coordinates,
+.sun-readout {
+  color: #9fb0c0;
+  font-size: 0.83rem;
+  margin: 0;
+}
+
+.layer-controls {
+  gap: 1px;
+}
+
+.toggle-row {
+  align-items: center;
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  min-height: 38px;
+  padding: 0 6px;
+  transition: background 160ms ease;
+}
+
+.toggle-row:hover {
+  background: rgb(255 255 255 / 6%);
+}
+
+.toggle-row input {
+  accent-color: #6ad0c5;
+  height: 18px;
+  min-height: 18px;
+  width: 18px;
+}
+
+.section-heading {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+}
+
+.section-heading span {
+  color: #f2bb68;
+  font-size: 0.78rem;
+}
+
+.weather-panel dl,
+.data-stats {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+}
+
+.weather-panel dl div,
+.data-stats div {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+dt {
+  color: #aebdcc;
+  font-size: 0.83rem;
+}
+
+dd {
+  color: #f6f2ea;
+  font-size: 0.86rem;
+  font-weight: 700;
+  margin: 0;
+  text-align: right;
+}
+
+.fallback-chip {
+  background: rgb(242 187 104 / 15%);
+  border: 1px solid rgb(242 187 104 / 28%);
+  border-radius: 6px;
+  color: #ffd38f;
+  font-size: 0.79rem;
+  margin-bottom: 0;
+  padding: 6px 8px;
+}
+
+.data-stats {
+  background: rgb(0 0 0 / 16%);
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.data-stats dt,
+.data-stats dd {
+  font-size: 0.78rem;
+}
+
+.data-stats dd {
+  color: #9fe8de;
+}
+
+.data-endpoint {
+  color: #8fa5b5;
+  font-size: 0.78rem;
+  margin: -2px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.inline-error {
+  background: rgb(230 84 100 / 14%);
+  border: 1px solid rgb(230 84 100 / 26%);
+  border-radius: 6px;
+  color: #ffc0c7;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  margin-bottom: 0;
+  padding: 7px 8px;
+}
+
+.notices p:last-child,
+.weather-panel p:last-child {
+  color: #bfccd7;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  margin-bottom: 0;
+}
+
+.map-legends {
+  bottom: 24px;
+  display: grid;
+  gap: 10px;
+  pointer-events: none;
+  position: absolute;
+  right: 18px;
+  width: min(256px, calc(100vw - 36px));
+  z-index: 790;
+}
+
+.legend-block {
+  backdrop-filter: blur(14px);
+  background: rgb(15 18 24 / 92%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 8px;
+  box-shadow: 0 14px 36px rgb(0 0 0 / 22%);
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+
+.legend-block.compact {
+  justify-self: end;
+  width: fit-content;
+}
+
+.legend-row {
+  align-items: center;
+  color: #dae4ec;
+  display: grid;
+  font-size: 0.8rem;
+  gap: 8px;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  min-height: 14px;
+}
+
+.legend-row strong {
+  color: #f6f2ea;
+  font-size: 0.78rem;
+}
+
+.legend-block.compact .legend-row {
+  grid-template-columns: 14px auto;
+}
+
+.legend-swatch {
+  border: 1px solid rgb(255 255 255 / 18%);
+  display: inline-block;
+  height: 10px;
+  width: 14px;
+}
+
+.legend-swatch.wind {
+  border-radius: 999px;
+}
+
+.legend-swatch.shadow {
+  background: rgb(27 28 34 / 78%);
+}
+
+.map-tooltip,
+.map-popup .leaflet-popup-content-wrapper {
+  background: rgb(15 18 24 / 94%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 6px;
+  box-shadow: 0 10px 24px rgb(0 0 0 / 24%);
+  color: #f7f1e7;
+  line-height: 1.35;
+  padding: 7px 9px;
+  white-space: pre-line;
+}
+
+.leaflet-tooltip-top.map-tooltip::before {
+  border-top-color: rgb(15 18 24 / 94%);
+}
+
+.map-popup .leaflet-popup-tip {
+  background: rgb(15 18 24 / 94%);
+}
+
+.map-popup .leaflet-popup-content {
+  margin: 8px 10px;
+}
+
+.wind-arrow-shell {
+  background: transparent;
+  border: 0;
+}
+
+.wind-arrow {
+  align-items: center;
+  color: var(--wind-color);
+  display: flex;
+  filter:
+    drop-shadow(0 0 1px rgb(255 255 255 / 70%))
+    drop-shadow(0 1px 2px rgb(0 0 0 / 75%));
+  height: 22px;
+  justify-content: center;
+  opacity: 0.82;
+  position: relative;
+  transform: rotate(var(--bearing));
+  width: 22px;
+}
+
+.wind-arrow::before {
+  background: currentcolor;
+  border-radius: 999px;
+  content: "";
+  height: 16px;
+  position: absolute;
+  top: 5px;
+  width: 4px;
+}
+
+.wind-arrow::after {
+  border-bottom: 8px solid currentcolor;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  content: "";
+  position: absolute;
+  top: 0;
+}
+
+@media (max-width: 760px) {
+  .controls-panel {
+    bottom: 14px;
+    left: 12px;
+    max-height: min(64vh, 640px);
+    padding: 14px;
+    top: auto;
+    width: calc(100vw - 24px);
+  }
+
+  .map-legends {
+    bottom: auto;
+    right: 12px;
+    top: 12px;
+    width: min(228px, calc(100vw - 24px));
+  }
+
+  .legend-block.compact {
+    justify-self: stretch;
+    width: auto;
+  }
+}

--- a/winds/src/styles.css
+++ b/winds/src/styles.css
@@ -203,6 +203,17 @@ input:focus {
   gap: 1px;
 }
 
+.status-warning {
+  background: rgb(242 187 104 / 14%);
+  border: 1px solid rgb(242 187 104 / 30%);
+  border-radius: 6px;
+  color: #ffd99f;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  margin: 0 0 7px;
+  padding: 8px;
+}
+
 .toggle-row {
   align-items: center;
   border-radius: 6px;

--- a/winds/src/types.ts
+++ b/winds/src/types.ts
@@ -1,0 +1,98 @@
+import type {
+  Feature,
+  FeatureCollection,
+  LineString,
+  Point,
+  Polygon,
+  Position,
+} from "geojson";
+
+export type LatLng = {
+  lat: number;
+  lng: number;
+};
+
+export type HeightSource = "exact" | "levels-estimated" | "default";
+
+export type BuildingProperties = {
+  id: string;
+  height: number;
+  heightSource: HeightSource;
+  name?: string;
+};
+
+export type RoadProperties = {
+  id: string;
+  highway: string;
+  name?: string;
+};
+
+export type BuildingFeature = Feature<Polygon, BuildingProperties>;
+export type RoadFeature = Feature<LineString, RoadProperties>;
+
+export type ShadowProperties = BuildingProperties & {
+  shadowLength: number;
+};
+
+export type ShadowFeature = Feature<Polygon, ShadowProperties>;
+
+export type Confidence = "low" | "medium" | "high";
+
+export type WindSegmentProperties = RoadProperties & {
+  bearing: number;
+  localDirection: number;
+  speed: number;
+  baseSpeed: number;
+  baseDirection: number;
+  canyonMultiplier: number;
+  confidence: Confidence;
+  nearbyBuildings: number;
+};
+
+export type WindSegmentFeature = Feature<LineString, WindSegmentProperties>;
+
+export type ArrowProperties = WindSegmentProperties & {
+  midpoint: Position;
+};
+
+export type ArrowFeature = Feature<Point, ArrowProperties>;
+
+export type OSMDataSource = "live" | "cache" | "fallback" | "error";
+
+export type OSMDataCounts = {
+  buildingsReturned: number;
+  roadsReturned: number;
+  buildingsRendered: number;
+  roadsRendered: number;
+};
+
+export type OSMData = {
+  buildings: FeatureCollection<Polygon, BuildingProperties>;
+  roads: FeatureCollection<LineString, RoadProperties>;
+  warning?: string;
+  endpoint?: string;
+  errors?: string[];
+  fallback: boolean;
+  source: OSMDataSource;
+  counts: OSMDataCounts;
+};
+
+export type LayerRenderStats = {
+  shadowPolygons: number;
+  windSegments: number;
+  windArrows: number;
+};
+
+export type WeatherData = {
+  windSpeed: number;
+  windDirection: number;
+  observedAt: string;
+  fallback: boolean;
+};
+
+export type LayerToggles = {
+  buildings: boolean;
+  shadows: boolean;
+  windArrows: boolean;
+  roadWind: boolean;
+};

--- a/winds/src/utils/geometry.test.ts
+++ b/winds/src/utils/geometry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { angleDifference, lineBearing } from "./geometry";
+
+describe("geometry helpers", () => {
+  it("calculates a map bearing from north", () => {
+    expect(lineBearing([0, 0], [1, 0])).toBeCloseTo(90, 4);
+  });
+
+  it("uses the shortest angle difference around north", () => {
+    expect(angleDifference(350, 10)).toBe(20);
+    expect(angleDifference(40, 220)).toBe(180);
+  });
+});

--- a/winds/src/utils/geometry.ts
+++ b/winds/src/utils/geometry.ts
@@ -1,0 +1,94 @@
+import * as turf from "@turf/turf";
+import type { Feature, LineString, Point, Polygon, Position } from "geojson";
+import type { BuildingFeature, LatLng, RoadFeature } from "../types";
+
+export const OVERPASS_HALF_SPAN = {
+  lat: 0.0029,
+  lng: 0.0046,
+};
+
+export function normalizeBearing(value: number) {
+  return ((value % 360) + 360) % 360;
+}
+
+export function angleDifference(first: number, second: number) {
+  const difference = Math.abs(normalizeBearing(first) - normalizeBearing(second));
+  return Math.min(difference, 360 - difference);
+}
+
+export function lineBearing(start: Position, end: Position) {
+  return normalizeBearing(turf.bearing(turf.point(start), turf.point(end)));
+}
+
+export function bboxAround(center: LatLng) {
+  return {
+    south: center.lat - OVERPASS_HALF_SPAN.lat,
+    west: center.lng - OVERPASS_HALF_SPAN.lng,
+    north: center.lat + OVERPASS_HALF_SPAN.lat,
+    east: center.lng + OVERPASS_HALF_SPAN.lng,
+  };
+}
+
+export function bboxCacheKey(center: LatLng) {
+  return `${center.lat.toFixed(3)}:${center.lng.toFixed(3)}`;
+}
+
+export function midpointOnLine(line: Feature<LineString>) {
+  const length = turf.length(line, { units: "kilometers" });
+  return turf.along(line, length / 2, { units: "kilometers" });
+}
+
+export function roadSegments(roads: RoadFeature[]) {
+  return roads.flatMap((road) =>
+    road.geometry.coordinates.slice(0, -1).flatMap((start, index) => {
+      const end = road.geometry.coordinates[index + 1];
+
+      if (!end || turf.distance(turf.point(start), turf.point(end), { units: "meters" }) < 5) {
+        return [];
+      }
+
+      return [
+        turf.lineString([start, end], {
+          ...road.properties,
+          id: `${road.properties.id}:${index}`,
+        }),
+      ];
+    }),
+  );
+}
+
+export function centroidOfBuilding(building: BuildingFeature) {
+  return turf.centroid(building);
+}
+
+export function distanceToBuildingMeters(point: Feature<Point>, building: BuildingFeature) {
+  if (turf.booleanPointInPolygon(point, building)) {
+    return 0;
+  }
+
+  const outline = turf.polygonToLine(building) as Feature<LineString>;
+  const nearest = turf.nearestPointOnLine(outline, point, { units: "meters" });
+  return nearest.properties.dist ?? turf.distance(point, nearest, { units: "meters" });
+}
+
+export function sideOfLine(start: Position, end: Position, point: Position) {
+  const segmentX = end[0] - start[0];
+  const segmentY = end[1] - start[1];
+  const pointX = point[0] - start[0];
+  const pointY = point[1] - start[1];
+  const cross = segmentX * pointY - segmentY * pointX;
+
+  if (Math.abs(cross) < Number.EPSILON) {
+    return "center";
+  }
+
+  return cross > 0 ? "left" : "right";
+}
+
+export function simplifyPolygon(feature: Feature<Polygon>, tolerance: number) {
+  return turf.simplify(feature, {
+    highQuality: false,
+    mutate: false,
+    tolerance,
+  }) as Feature<Polygon>;
+}

--- a/winds/src/utils/shadows.test.ts
+++ b/winds/src/utils/shadows.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { shadowLengthMeters } from "./shadows";
+
+describe("shadow helpers", () => {
+  it("calculates the length from height and sun altitude", () => {
+    expect(shadowLengthMeters(12, Math.PI / 4)).toBeCloseTo(12, 6);
+  });
+
+  it("returns no direct shadow below the horizon", () => {
+    expect(shadowLengthMeters(12, -0.1)).toBe(0);
+  });
+});

--- a/winds/src/utils/shadows.ts
+++ b/winds/src/utils/shadows.ts
@@ -1,0 +1,67 @@
+import * as turf from "@turf/turf";
+import SunCalc from "suncalc";
+import type { Position } from "geojson";
+import type { BuildingFeature, LatLng, ShadowFeature } from "../types";
+import { normalizeBearing } from "./geometry";
+
+const RADIANS_TO_DEGREES = 180 / Math.PI;
+
+export function shadowLengthMeters(heightMeters: number, sunAltitudeRadians: number) {
+  if (sunAltitudeRadians <= 0) {
+    return 0;
+  }
+
+  // A taller building or lower sun makes a longer shadow: height / tan(altitude).
+  return heightMeters / Math.tan(sunAltitudeRadians);
+}
+
+export function sunForDate(date: Date, center: LatLng) {
+  const position = SunCalc.getPosition(date, center.lat, center.lng);
+
+  // SunCalc azimuth starts at south and rotates westward. Map bearings start north.
+  const sunBearing = normalizeBearing(position.azimuth * RADIANS_TO_DEGREES + 180);
+
+  return {
+    altitude: position.altitude,
+    altitudeDegrees: position.altitude * RADIANS_TO_DEGREES,
+    sunBearing,
+    shadowBearing: normalizeBearing(sunBearing + 180),
+  };
+}
+
+function projectCoordinate(coordinate: Position, lengthMeters: number, bearing: number) {
+  return turf.destination(turf.point(coordinate), lengthMeters / 1000, bearing, {
+    units: "kilometers",
+  }).geometry.coordinates;
+}
+
+export function shadowForBuilding(
+  building: BuildingFeature,
+  sunAltitudeRadians: number,
+  shadowBearing: number,
+): ShadowFeature | null {
+  const length = shadowLengthMeters(building.properties.height, sunAltitudeRadians);
+
+  if (!Number.isFinite(length) || length <= 0) {
+    return null;
+  }
+
+  const footprint = building.geometry.coordinates[0];
+  const shadowPoints = footprint.flatMap((coordinate) => [
+    turf.point(coordinate),
+    turf.point(projectCoordinate(coordinate, length, shadowBearing)),
+  ]);
+  const hull = turf.convex(turf.featureCollection(shadowPoints));
+
+  if (!hull || hull.geometry.type !== "Polygon") {
+    return null;
+  }
+
+  return {
+    ...hull,
+    properties: {
+      ...building.properties,
+      shadowLength: length,
+    },
+  };
+}

--- a/winds/src/utils/wind.test.ts
+++ b/winds/src/utils/wind.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { windComponentAlongRoad } from "./wind";
+
+describe("wind helpers", () => {
+  it("keeps wind strength for a parallel street", () => {
+    expect(windComponentAlongRoad(4, 90, 90)).toBeCloseTo(4, 6);
+  });
+
+  it("drops the along-road component for a cross street", () => {
+    expect(windComponentAlongRoad(4, 0, 90)).toBeCloseTo(0, 6);
+  });
+});

--- a/winds/src/utils/wind.ts
+++ b/winds/src/utils/wind.ts
@@ -1,0 +1,198 @@
+import * as turf from "@turf/turf";
+import type { Feature, LineString } from "geojson";
+import type {
+  ArrowFeature,
+  BuildingFeature,
+  Confidence,
+  RoadFeature,
+  WindSegmentFeature,
+} from "../types";
+import {
+  angleDifference,
+  centroidOfBuilding,
+  distanceToBuildingMeters,
+  lineBearing,
+  midpointOnLine,
+  normalizeBearing,
+  roadSegments,
+  sideOfLine,
+} from "./geometry";
+
+const CLOSE_BUILDING_METERS = 34;
+const UPWIND_SHELTER_METERS = 58;
+const TALL_BUILDING_METERS = 18;
+
+export function windComponentAlongRoad(
+  baseWindSpeed: number,
+  roadBearing: number,
+  windFlowBearing: number,
+) {
+  // Wind parallel to a street keeps its strength; crosswind contributes less.
+  const difference = angleDifference(roadBearing, windFlowBearing);
+  return baseWindSpeed * Math.abs(Math.cos((difference * Math.PI) / 180));
+}
+
+export function windFlowBearing(windDirectionFrom: number) {
+  return normalizeBearing(windDirectionFrom + 180);
+}
+
+export function localStreetDirection(roadBearing: number, windFlow: number) {
+  return angleDifference(roadBearing, windFlow) <= 90
+    ? roadBearing
+    : normalizeBearing(roadBearing + 180);
+}
+
+export function windColor(speed: number) {
+  if (speed < 0.8) {
+    return "#92a5b3";
+  }
+
+  if (speed < 2) {
+    return "#52c6b4";
+  }
+
+  if (speed < 4) {
+    return "#e5ce5b";
+  }
+
+  if (speed < 6) {
+    return "#ef8e43";
+  }
+
+  return "#e65464";
+}
+
+function confidenceForSegment(
+  nearbyBuildings: BuildingFeature[],
+  hasLeftWall: boolean,
+  hasRightWall: boolean,
+): Confidence {
+  const hasMeasuredHeight = nearbyBuildings.some(
+    (building) => building.properties.heightSource !== "default",
+  );
+
+  if (hasLeftWall && hasRightWall && hasMeasuredHeight) {
+    return "high";
+  }
+
+  if (nearbyBuildings.length >= 2) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function multiplierForSegment(
+  segment: Feature<LineString>,
+  buildings: BuildingFeature[],
+  flowBearing: number,
+) {
+  const midpoint = midpointOnLine(segment);
+  const [start, end] = segment.geometry.coordinates;
+  const nearby = buildings
+    .map((building) => ({
+      building,
+      centroid: centroidOfBuilding(building),
+    }))
+    .filter(
+      ({ centroid }) =>
+        turf.distance(midpoint, centroid, { units: "meters" }) <= UPWIND_SHELTER_METERS + 90,
+    )
+    .map(({ building, centroid }) => ({
+      building,
+      centroid,
+      distance: distanceToBuildingMeters(midpoint, building),
+    }))
+    .filter(({ distance }) => distance <= UPWIND_SHELTER_METERS);
+
+  const tallClose = nearby.filter(
+    ({ building, distance }) =>
+      building.properties.height >= TALL_BUILDING_METERS && distance <= CLOSE_BUILDING_METERS,
+  );
+  const hasLeftWall = tallClose.some(
+    ({ centroid }) => sideOfLine(start, end, centroid.geometry.coordinates) === "left",
+  );
+  const hasRightWall = tallClose.some(
+    ({ centroid }) => sideOfLine(start, end, centroid.geometry.coordinates) === "right",
+  );
+  const streetBearing = lineBearing(start, end);
+  const alignment = Math.abs(Math.cos((angleDifference(streetBearing, flowBearing) * Math.PI) / 180));
+  const canyonBoost = hasLeftWall && hasRightWall ? 1.2 + alignment * 0.4 : 1;
+  const upwindBearing = normalizeBearing(flowBearing + 180);
+  const shelter = nearby
+    .filter(({ building, centroid }) => {
+      if (building.properties.height < TALL_BUILDING_METERS) {
+        return false;
+      }
+
+      const bearingToBuilding = lineBearing(midpoint.geometry.coordinates, centroid.geometry.coordinates);
+      return angleDifference(bearingToBuilding, upwindBearing) <= 42;
+    })
+    .reduce((reduction, { distance }) => {
+      const distanceFactor = Math.min(distance / UPWIND_SHELTER_METERS, 1);
+      return Math.min(reduction, 0.5 + distanceFactor * 0.3);
+    }, 1);
+
+  return {
+    multiplier: canyonBoost * shelter,
+    nearbyBuildings: nearby.map(({ building }) => building),
+    confidence: confidenceForSegment(
+      nearby.map(({ building }) => building),
+      hasLeftWall,
+      hasRightWall,
+    ),
+  };
+}
+
+export function estimateRoadWind(
+  roads: RoadFeature[],
+  buildings: BuildingFeature[],
+  baseWindSpeed: number,
+  windDirectionFrom: number,
+) {
+  const flowBearing = windFlowBearing(windDirectionFrom);
+  const segments = roadSegments(roads);
+
+  return segments.map((segment) => {
+    const [start, end] = segment.geometry.coordinates;
+    const bearing = lineBearing(start, end);
+    const { multiplier, nearbyBuildings, confidence } = multiplierForSegment(
+      segment,
+      buildings,
+      flowBearing,
+    );
+    const localDirection = localStreetDirection(bearing, flowBearing);
+    const speed = windComponentAlongRoad(baseWindSpeed, bearing, flowBearing) * multiplier;
+
+    return {
+      ...segment,
+      properties: {
+        ...segment.properties,
+        bearing,
+        localDirection,
+        speed,
+        baseSpeed: baseWindSpeed,
+        baseDirection: windDirectionFrom,
+        canyonMultiplier: multiplier,
+        confidence,
+        nearbyBuildings: nearbyBuildings.length,
+      },
+    } as WindSegmentFeature;
+  });
+}
+
+export function windArrowForSegment(segment: WindSegmentFeature): ArrowFeature {
+  const midpoint = midpointOnLine(segment);
+
+  return {
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: midpoint.geometry.coordinates,
+    },
+    properties: {
+      ...segment.properties,
+      midpoint: midpoint.geometry.coordinates,
+    },
+  };
+}

--- a/winds/src/vite-env.d.ts
+++ b/winds/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/winds/tsconfig.app.json
+++ b/winds/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/winds/tsconfig.json
+++ b/winds/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/winds/tsconfig.node.json
+++ b/winds/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/winds/vite.config.ts
+++ b/winds/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Add the Street Wind & Shadow Map Vite/React app under `winds/`
- Add live OSM/Overpass building and road loading, Open-Meteo wind data, shadow projection, and wind visualization
- Fix Overpass loading through a Vercel proxy, clipped geometry, fallback endpoint diagnostics, and null geometry handling

## Validation
- `npm test` in `winds/`
- `npm run build` in `winds/`
- Production Vercel deployment verified at https://winds-beta.vercel.app/?lat=48.71123&lng=44.85910
