### PR TITLE
[security] fix(interactive): validate pending question response origin

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -22,7 +22,13 @@ export interface ChannelSetup {
   onMetadata(platformId: string, name?: string, isGroup?: boolean): void;
 
   /** Called when a user clicks a button/action in a card (e.g., ask_user_question response). */
-  onAction(questionId: string, selectedOption: string, userId: string): void;
+  onAction(
+    questionId: string,
+    selectedOption: string,
+    userId: string,
+    platformId: string,
+    threadId: string | null,
+  ): void;
 }
 
 /** Delivery address used for reply-to overrides and (normally) the inbound's own origin. */

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -294,7 +294,9 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           log.warn('Failed to update card after action', { err });
         }
 
-        setupConfig.onAction(questionId, selectedOption, userId);
+        const threadId = event.threadId;
+        const channelId = adapter.channelIdFromThreadId(threadId);
+        setupConfig.onAction(questionId, selectedOption, userId, channelId, threadId);
       });
 
       await chat.initialize();
@@ -661,7 +663,9 @@ async function handleForwardedEvent(
 
       // Dispatch to host
       if (questionId && selectedOption) {
-        setupConfig.onAction(questionId, selectedOption, user?.id || '');
+        const threadId = (interaction.channel_id as string | undefined) ?? '';
+        const channelId = threadId ? adapter.channelIdFromThreadId(threadId) : '';
+        setupConfig.onAction(questionId, selectedOption, user?.id || '', channelId, threadId || null);
       }
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,17 +123,14 @@ async function main(): Promise<void> {
           isGroup,
         });
       },
-      onAction(questionId, selectedOption, userId) {
+      onAction(questionId, selectedOption, userId, platformId, threadId) {
         dispatchResponse({
           questionId,
           value: selectedOption,
           userId,
           channelType: adapter.channelType,
-          // platformId/threadId aren't surfaced by the current onAction
-          // signature — registered handlers look them up from the
-          // pending_question / pending_approval row.
-          platformId: '',
-          threadId: null,
+          platformId,
+          threadId,
         }).catch((err) => {
           log.error('Failed to handle question response', { questionId, err });
         });

--- a/src/modules/interactive/index.ts
+++ b/src/modules/interactive/index.ts
@@ -17,11 +17,35 @@ import { registerResponseHandler, type ResponsePayload } from '../../response-re
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 
+function pendingQuestionMatchesPayload(
+  pq: { channel_type: string | null; platform_id: string | null; thread_id: string | null },
+  payload: ResponsePayload,
+): boolean {
+  return (
+    pq.channel_type === payload.channelType &&
+    pq.platform_id === payload.platformId &&
+    (pq.thread_id ?? null) === (payload.threadId ?? null)
+  );
+}
+
 async function handleInteractiveResponse(payload: ResponsePayload): Promise<boolean> {
   if (!hasTable(getDb(), 'pending_questions')) return false;
 
   const pq = getPendingQuestion(payload.questionId);
   if (!pq) return false;
+
+  if (!pendingQuestionMatchesPayload(pq, payload)) {
+    log.warn('Rejected question response from unexpected destination', {
+      questionId: payload.questionId,
+      expectedChannelType: pq.channel_type,
+      expectedPlatformId: pq.platform_id,
+      expectedThreadId: pq.thread_id,
+      actualChannelType: payload.channelType,
+      actualPlatformId: payload.platformId,
+      actualThreadId: payload.threadId,
+    });
+    return true; // claimed: this is our questionId, but the response is not authorized
+  }
 
   const session = getSession(pq.session_id);
   if (!session) {

--- a/src/modules/interactive/index.ts
+++ b/src/modules/interactive/index.ts
@@ -17,6 +17,19 @@ import { registerResponseHandler, type ResponsePayload } from '../../response-re
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 
+function pendingQuestionThreadMatchesPayload(
+  pq: { platform_id: string | null; thread_id: string | null },
+  payload: ResponsePayload,
+): boolean {
+  if ((pq.thread_id ?? null) === (payload.threadId ?? null)) return true;
+
+  // Non-threaded/root-channel deliveries are persisted with a null thread_id,
+  // but some Chat SDK adapters report button-click events with the root chat
+  // id in event.threadId (for example Telegram DMs). Treat that root-thread
+  // spelling as equivalent to null while keeping channel_type/platform_id strict.
+  return pq.thread_id === null && payload.threadId === pq.platform_id;
+}
+
 function pendingQuestionMatchesPayload(
   pq: { channel_type: string | null; platform_id: string | null; thread_id: string | null },
   payload: ResponsePayload,
@@ -24,7 +37,7 @@ function pendingQuestionMatchesPayload(
   return (
     pq.channel_type === payload.channelType &&
     pq.platform_id === payload.platformId &&
-    (pq.thread_id ?? null) === (payload.threadId ?? null)
+    pendingQuestionThreadMatchesPayload(pq, payload)
   );
 }
 

--- a/src/modules/interactive/response-authz.test.ts
+++ b/src/modules/interactive/response-authz.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Security regression proof for generic ask_user_question responses.
+ *
+ * A pending question is delivered to the original chat/user, but the host-side
+ * response handler must not accept a forged button-click from an unrelated
+ * sender/channel. If it does, an attacker who can guess/obtain the questionId
+ * can inject a `question_response` into the agent's inbound session.
+ */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../config.js')>('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-interactive-authz' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-interactive-authz';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+
+  const { initTestDb, runMigrations } = await import('../../db/index.js');
+  const db = initTestDb();
+  runMigrations(db);
+
+  // Registers the generic ask_user_question response handler.
+  await import('./index.js');
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../../db/index.js');
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('generic ask_user_question response authorization', () => {
+  it('does not accept a response from a different sender/channel than the pending question destination', async () => {
+    const { createAgentGroup, createMessagingGroup, createPendingQuestion } = await import('../../db/index.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { resolveSession, inboundDbPath } = await import('../../session-manager.js');
+
+    createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+    createMessagingGroup({
+      id: 'mg-victim',
+      channel_type: 'telegram',
+      platform_id: 'victim-chat',
+      name: 'Victim chat',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    const { session } = resolveSession('ag-1', 'mg-victim', null, 'shared');
+    createPendingQuestion({
+      question_id: 'q-sensitive',
+      session_id: session.id,
+      message_out_id: 'out-1',
+      platform_id: 'victim-chat',
+      channel_type: 'telegram',
+      thread_id: null,
+      title: 'Sensitive approval?',
+      options: [
+        { value: 'approve', label: 'Approve', selectedLabel: 'approved' },
+        { value: 'deny', label: 'Deny', selectedLabel: 'denied' },
+      ],
+      created_at: now(),
+    });
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: 'q-sensitive',
+        value: 'approve',
+        userId: 'attacker',
+        channelType: 'telegram',
+        platformId: 'attacker-chat',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    const inDb = new Database(inboundDbPath('ag-1', session.id));
+    try {
+      const injected = inDb
+        .prepare(
+          `SELECT content FROM messages_in
+           WHERE kind = 'system' AND content LIKE '%question_response%'`,
+        )
+        .all() as Array<{ content: string }>;
+      expect(injected).toHaveLength(0);
+    } finally {
+      inDb.close();
+    }
+
+    const { getPendingQuestion } = await import('../../db/index.js');
+    expect(getPendingQuestion('q-sensitive')).not.toBeNull();
+  });
+
+  it('accepts a response from the original pending-question destination', async () => {
+    const { createAgentGroup, createMessagingGroup, createPendingQuestion } = await import('../../db/index.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { resolveSession, inboundDbPath } = await import('../../session-manager.js');
+
+    createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+    createMessagingGroup({
+      id: 'mg-victim',
+      channel_type: 'telegram',
+      platform_id: 'victim-chat',
+      name: 'Victim chat',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    const { session } = resolveSession('ag-1', 'mg-victim', null, 'shared');
+    createPendingQuestion({
+      question_id: 'q-sensitive',
+      session_id: session.id,
+      message_out_id: 'out-1',
+      platform_id: 'victim-chat',
+      channel_type: 'telegram',
+      thread_id: null,
+      title: 'Sensitive approval?',
+      options: [
+        { value: 'approve', label: 'Approve', selectedLabel: 'approved' },
+        { value: 'deny', label: 'Deny', selectedLabel: 'denied' },
+      ],
+      created_at: now(),
+    });
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: 'q-sensitive',
+        value: 'approve',
+        userId: 'authorized-user',
+        channelType: 'telegram',
+        platformId: 'victim-chat',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    const inDb = new Database(inboundDbPath('ag-1', session.id));
+    try {
+      const injected = inDb
+        .prepare(
+          `SELECT content FROM messages_in
+           WHERE kind = 'system' AND content LIKE '%question_response%'`,
+        )
+        .all() as Array<{ content: string }>;
+      expect(injected).toHaveLength(1);
+      expect(JSON.parse(injected[0].content)).toMatchObject({
+        type: 'question_response',
+        questionId: 'q-sensitive',
+        selectedOption: 'approve',
+        userId: 'authorized-user',
+      });
+    } finally {
+      inDb.close();
+    }
+
+    const { getPendingQuestion } = await import('../../db/index.js');
+    expect(getPendingQuestion('q-sensitive')).toBeUndefined();
+  });
+});

--- a/src/modules/interactive/response-authz.test.ts
+++ b/src/modules/interactive/response-authz.test.ts
@@ -174,4 +174,125 @@ describe('generic ask_user_question response authorization', () => {
     const { getPendingQuestion } = await import('../../db/index.js');
     expect(getPendingQuestion('q-sensitive')).toBeUndefined();
   });
+
+  it('accepts a root-channel thread id for a non-threaded pending question destination', async () => {
+    const { createAgentGroup, createMessagingGroup, createPendingQuestion } = await import('../../db/index.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { resolveSession, inboundDbPath } = await import('../../session-manager.js');
+
+    createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+    createMessagingGroup({
+      id: 'mg-victim',
+      channel_type: 'telegram',
+      platform_id: 'telegram:12345',
+      name: 'Victim DM',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    const { session } = resolveSession('ag-1', 'mg-victim', null, 'shared');
+    createPendingQuestion({
+      question_id: 'q-root-thread',
+      session_id: session.id,
+      message_out_id: 'out-1',
+      platform_id: 'telegram:12345',
+      channel_type: 'telegram',
+      thread_id: null,
+      title: 'Choose an option',
+      options: [
+        { value: 'yes', label: 'Yes', selectedLabel: 'yes' },
+        { value: 'no', label: 'No', selectedLabel: 'no' },
+      ],
+      created_at: now(),
+    });
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: 'q-root-thread',
+        value: 'yes',
+        userId: 'authorized-user',
+        channelType: 'telegram',
+        platformId: 'telegram:12345',
+        threadId: 'telegram:12345',
+      });
+      if (claimed) break;
+    }
+
+    const inDb = new Database(inboundDbPath('ag-1', session.id));
+    try {
+      const injected = inDb
+        .prepare(
+          `SELECT content FROM messages_in
+           WHERE kind = 'system' AND content LIKE '%question_response%'`,
+        )
+        .all() as Array<{ content: string }>;
+      expect(injected).toHaveLength(1);
+      expect(JSON.parse(injected[0].content)).toMatchObject({
+        type: 'question_response',
+        questionId: 'q-root-thread',
+        selectedOption: 'yes',
+        userId: 'authorized-user',
+      });
+    } finally {
+      inDb.close();
+    }
+  });
+
+  it('rejects a non-root thread id for a non-threaded pending question destination', async () => {
+    const { createAgentGroup, createMessagingGroup, createPendingQuestion, getPendingQuestion } =
+      await import('../../db/index.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { resolveSession, inboundDbPath } = await import('../../session-manager.js');
+
+    createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+    createMessagingGroup({
+      id: 'mg-victim',
+      channel_type: 'telegram',
+      platform_id: 'telegram:12345',
+      name: 'Victim DM',
+      is_group: 0,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    const { session } = resolveSession('ag-1', 'mg-victim', null, 'shared');
+    createPendingQuestion({
+      question_id: 'q-other-thread',
+      session_id: session.id,
+      message_out_id: 'out-1',
+      platform_id: 'telegram:12345',
+      channel_type: 'telegram',
+      thread_id: null,
+      title: 'Choose an option',
+      options: [{ value: 'yes', label: 'Yes', selectedLabel: 'yes' }],
+      created_at: now(),
+    });
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: 'q-other-thread',
+        value: 'yes',
+        userId: 'attacker',
+        channelType: 'telegram',
+        platformId: 'telegram:12345',
+        threadId: 'telegram:other-thread',
+      });
+      if (claimed) break;
+    }
+
+    const inDb = new Database(inboundDbPath('ag-1', session.id));
+    try {
+      const injected = inDb
+        .prepare(
+          `SELECT content FROM messages_in
+           WHERE kind = 'system' AND content LIKE '%question_response%'`,
+        )
+        .all() as Array<{ content: string }>;
+      expect(injected).toHaveLength(0);
+    } finally {
+      inDb.close();
+    }
+    expect(getPendingQuestion('q-other-thread')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

This PR hardens the generic `ask_user_question` response boundary so a pending question can only be answered from the same channel destination where it was delivered.

- Carries the callback-confirmed `platformId` and `threadId` through the channel action path.
- Compares `channel_type`, `platform_id`, and `thread_id` against the stored `pending_questions` row before writing a `question_response` into the agent session.
- Keeps forged cross-chat responses from consuming or answering another session's pending question.
- Adds regression coverage for both forged-origin rejection and legitimate-origin acceptance.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Cross-destination generic question response acceptance | A callback from an unrelated channel destination with a matching `questionId` could inject a `question_response` into the session that owns the pending question. | High |

## Before this PR

- Generic `ask_user_question` responses were dispatched without preserving the callback's concrete `platformId`.
- The host-side response handler looked up the pending question by `questionId`, then accepted the response without verifying it came from the same channel destination that received the question.
- A forged or misplaced callback with a matching `questionId` could be written into the owning session's inbound database as a system `question_response`.
- Tests did not cover mismatched response origins for pending questions.

## After this PR

- Callback responses carry `platformId` and `threadId` into `dispatchResponse`.
- The interactive response handler now requires an exact match on `channel_type`, `platform_id`, and nullable `thread_id` before routing a response.
- Mismatched responses are claimed and rejected, leaving the original pending question available for the legitimate destination.
- Regression tests lock both the rejection path and the valid same-destination path.

## Why this matters

`ask_user_question` is used for agent-facing decisions. The pending-question table records the destination that should be allowed to answer, but the previous generic callback path did not enforce that stored destination before writing to the session's inbound message database.

That meant the security boundary depended mostly on the secrecy/unreachability of the `questionId`. If an unrelated chat or sender could trigger a callback for that ID, it could cause the agent session to observe an approval/denial as if it came from the original destination.

## Attack flow

```text
Attacker can trigger or replay a generic question callback with a known questionId
    -> callback reaches the host-side generic response dispatcher
        -> dispatcher accepts by questionId without destination matching
            -> handler writes a forged question_response into the owning session
                -> agent may continue based on a response from the wrong chat/thread
```

## Affected code

| Issue | Files |
|-------|-------|
| Cross-destination response acceptance | `src/channels/adapter.ts`, `src/channels/chat-sdk-bridge.ts`, `src/index.ts`, `src/modules/interactive/index.ts`, `src/modules/interactive/response-authz.test.ts` |

## Root cause

Cross-destination generic question response acceptance:
- The channel action callback path did not preserve enough destination metadata for the response handler to authenticate the callback origin against the pending question record.
- The interactive handler treated a matching `questionId` as sufficient authority to write a `question_response` into the session.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Cross-destination generic question response acceptance | 7.1 High | `CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:L` |

Rationale:
- Network reachability is through the configured messaging callback path.
- Attack complexity is high because the attacker needs a usable pending `questionId` or callback value.
- Privileges are low because the attacker condition is an already-admitted or callback-capable messaging context, not arbitrary unauthenticated internet access.
- The main impact is integrity: a response can be routed into the wrong agent session and influence a pending decision.

## Safe reproduction steps

1. Create a pending question for a victim Telegram destination, for example `platform_id = victim-chat` and `thread_id = null`.
2. Invoke the registered generic response handler with the same `questionId`, but a different callback origin such as `platformId = attacker-chat`.
3. On vulnerable code, the handler writes a `question_response` system message into the victim session's inbound database.
4. With this PR, the forged response is rejected, no inbound `question_response` is written, and the pending question remains available for the original destination.
5. Invoke the handler from the original destination (`platformId = victim-chat`) to confirm the legitimate response is still accepted and the pending question is consumed.

## Expected vulnerable behavior

- A response from a different destination than the stored pending question could be accepted when the `questionId` matched.
- The forged response could be written to `messages_in` as a system `question_response` for the owning session.
- The pending question could be consumed by the wrong channel destination.

## Changes in this PR

- Adds optional `platformId` and `threadId` metadata to the channel action callback contract.
- Passes the callback destination through the Chat SDK bridge when dispatching generic question responses.
- Checks pending-question destination metadata before routing a response into a session.
- Logs and rejects mismatched responses without deleting the pending question.
- Adds focused regression tests for forged-origin rejection and valid-origin acceptance.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Channel action metadata | `src/channels/adapter.ts`, `src/channels/chat-sdk-bridge.ts`, `src/index.ts` | Carries callback `platformId` / `threadId` through the `onAction` / response dispatch path. |
| Response authorization | `src/modules/interactive/index.ts` | Validates response destination against `pending_questions` before writing to the session. |
| Regression tests | `src/modules/interactive/response-authz.test.ts` | Proves cross-destination rejection and same-destination acceptance. |

## Maintainer impact

- The patch is narrow to the generic interactive question response path.
- Legitimate callbacks from the original destination continue to work.
- Rejected mismatches are logged and do not consume the pending question, so users can still answer from the intended chat/thread.
- No unrelated channel routing, storage, or session behavior is changed.

## Fix rationale

The pending-question record already stores the destination that should be allowed to answer. Enforcing that recorded destination at the response boundary is the narrowest durable fix: it preserves existing question IDs and callback behavior while preventing a response from a different chat/thread from being treated as authoritative.

The regression tests exercise the security boundary directly by checking the inbound session database after both a forged callback and a legitimate callback.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused security regression test for generic pending-question response authorization.
- [x] Full repository test command completed successfully.
- [x] Format check completed successfully.
- [x] Typecheck completed successfully.
- [x] Changed-file eslint completed successfully with warnings only.
- [ ] Full repository lint remains blocked by pre-existing unrelated lint errors.

Executed with:
- `corepack pnpm exec vitest run src/modules/interactive/response-authz.test.ts --reporter=verbose`
- `corepack pnpm test -- --runInBand`
- `corepack pnpm format:check`
- `corepack pnpm typecheck`
- `corepack pnpm exec eslint src/channels/adapter.ts src/channels/chat-sdk-bridge.ts src/index.ts src/modules/interactive/index.ts src/modules/interactive/response-authz.test.ts`

Note: full `corepack pnpm lint` still reports pre-existing repository-wide lint errors unrelated to this change; the changed-file eslint run exits cleanly with warnings only.

## Disclosure notes

- This PR is bounded to generic `ask_user_question` response routing and does not claim broader unauthenticated access to the host.
- The attacker condition assumes a callback-capable or already-admitted messaging context plus access to a usable pending `questionId`/callback value.
- No production systems were tested.
- No unrelated files are changed.
