### PR TITLE
fix(platform-id): trust pre-prefixed ids regardless of channel key

### DIFF
--- a/src/platform-id.test.ts
+++ b/src/platform-id.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { namespacedPlatformId } from './platform-id.js';
+
+describe('namespacedPlatformId', () => {
+  it('prefixes bare ids with the channel key (legacy)', () => {
+    expect(namespacedPlatformId('telegram', '123456')).toBe('telegram:123456');
+    expect(namespacedPlatformId('discord', 'abc')).toBe('discord:abc');
+  });
+
+  it('leaves already-prefixed ids alone when prefix matches channel key', () => {
+    expect(namespacedPlatformId('telegram', 'telegram:123456')).toBe('telegram:123456');
+    expect(namespacedPlatformId('discord', 'discord:guild:chan')).toBe('discord:guild:chan');
+  });
+
+  it('trusts any <prefix>:<id> shape — channel key may differ from sdk-emitted prefix', () => {
+    // When one chat-sdk adapter is registered under multiple channel keys
+    // (e.g. a second Telegram bot under channel `telegram-2`), the sdk still
+    // emits `telegram:<id>`. The function must not double-prefix it into
+    // `telegram-2:telegram:<id>`.
+    expect(namespacedPlatformId('telegram-2', 'telegram:123456')).toBe('telegram:123456');
+  });
+
+  it('passes WhatsApp / iMessage JIDs through unchanged', () => {
+    expect(namespacedPlatformId('whatsapp', '15551234567@s.whatsapp.net')).toBe('15551234567@s.whatsapp.net');
+    expect(namespacedPlatformId('imessage', 'someone@example.com')).toBe('someone@example.com');
+  });
+
+  it('passes Signal phone numbers and group ids through unchanged', () => {
+    expect(namespacedPlatformId('signal', '+15551234567')).toBe('+15551234567');
+    expect(namespacedPlatformId('signal', 'group:abc123')).toBe('group:abc123');
+  });
+
+  it('leaves DeltaChat numeric ids unprefixed', () => {
+    expect(namespacedPlatformId('deltachat', '12')).toBe('12');
+  });
+});

--- a/src/platform-id.ts
+++ b/src/platform-id.ts
@@ -2,12 +2,13 @@
  * Determine whether a platform ID needs a channel-type prefix.
  *
  * Chat SDK adapters (Telegram, Discord, Slack, Teams, etc.) namespace their
- * platform IDs with a channel prefix: "telegram:123456", "discord:guild:chan".
- * The router stores channel_type and platform_id in separate columns, but
- * Chat SDK adapters send the prefixed form as the platform_id — so any code
- * that writes messaging_groups rows must produce the same shape the adapter
- * will later emit as event.platformId, or router lookups miss and messages
- * get silently dropped.
+ * platform IDs with a chat-sdk-side prefix: "telegram:123456", "discord:guild:chan".
+ * That prefix comes from the underlying chat-sdk adapter's name and is NOT
+ * necessarily the same as NanoClaw's channel registry key — if one chat-sdk
+ * adapter is registered under multiple channel keys (e.g. two Telegram bots
+ * on keys `telegram` and `telegram-2`), the underlying SDK still emits
+ * `telegram:<id>` for both. So any `<prefix>:<id>`-shaped value is trusted
+ * as-is; only bare ids get the channel prefix appended.
  *
  * Native adapters (Signal, WhatsApp, iMessage, DeltaChat) use their own ID
  * formats and send them as-is — no channel prefix. WhatsApp/iMessage emit
@@ -17,9 +18,9 @@
  * later emits.
  */
 export function namespacedPlatformId(channel: string, raw: string): string {
-  if (raw.startsWith(`${channel}:`)) return raw;
   if (raw.includes('@')) return raw;
   if (raw.startsWith('+') || raw.startsWith('group:')) return raw;
   if (channel === 'deltachat') return raw;
+  if (/^[a-z][a-z0-9_-]*:/i.test(raw)) return raw;
   return `${channel}:${raw}`;
 }


### PR DESCRIPTION
### What
`namespacedPlatformId()` now trusts any caller-supplied `<prefix>:<id>` value as the chat-sdk's already-encoded form, instead of only matching when the prefix equals the channel registry key.

### Why
When one chat-sdk adapter is registered under a channel key that differs from its SDK-side name (e.g. a second Telegram bot wired under channel `telegram-2`, whose underlying `@chat-adapter/telegram` still emits `telegram:<id>`), the previous logic prepended the channel key on top, producing `telegram-2:telegram:<id>`. That value never matches any real inbound platform_id, so messaging_groups created via `scripts/init-first-agent.ts` end up unreachable.

### How
- Drop the `raw.startsWith(`${channel}:`)` exact match.
- Add a regex check `^[a-z][a-z0-9_-]*:/i` so any `<lowercase-token>:…` shape is trusted as already-encoded.
- Native short-circuits preserved (`@`, `+`, `group:`, `deltachat`).

### Tests
Added `src/platform-id.test.ts` with 6 cases covering bare ids, channel-matching prefix, non-matching prefix (the bug), WhatsApp / iMessage JIDs, Signal phone numbers / group ids, and DeltaChat numeric ids.

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Full suite (`pnpm test`) — 338 passed, 0 failed. `pnpm run build` (tsc) — clean.

Refs #2653