### PR TITLE
feat: mount external symlink targets for per-group skills

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -320,6 +320,35 @@ function buildMounts(
     mounts.push({ hostPath: skillsSrc, containerPath: '/app/skills', readonly: true });
   }
 
+  // External symlink mounts — per-group skills may be symlinks pointing outside
+  // the group directory (e.g., to a personal marketplace). Inside the container
+  // only /workspace/agent/ is mounted, so the symlink targets are unreachable.
+  // Fix: resolve each external symlink and mount its real path at the same
+  // absolute path so the container symlink resolves correctly.
+  const groupSkillsDir = path.join(groupDir, 'skills');
+  if (fs.existsSync(groupSkillsDir)) {
+    const seenRealPaths = new Set<string>();
+    for (const entry of fs.readdirSync(groupSkillsDir)) {
+      const entryPath = path.join(groupSkillsDir, entry);
+      try {
+        if (!fs.lstatSync(entryPath).isSymbolicLink()) continue;
+        const realPath = fs.realpathSync(entryPath);
+        // Only mount if it points outside the group dir (i.e., it's an external dep)
+        if (realPath.startsWith(groupDir + path.sep) || realPath === groupDir) continue;
+        if (seenRealPaths.has(realPath)) continue;
+        seenRealPaths.add(realPath);
+        mounts.push({ hostPath: realPath, containerPath: realPath, readonly: true });
+        log.debug('Mounting external skill symlink target', {
+          group: agentGroup.name,
+          skill: entry,
+          realPath,
+        });
+      } catch {
+        /* skip unreadable entries */
+      }
+    }
+  }
+
   // Additional mounts from container config
   if (containerConfig.additionalMounts && containerConfig.additionalMounts.length > 0) {
     const validated = validateAdditionalMounts(containerConfig.additionalMounts, agentGroup.name);


### PR DESCRIPTION
## Problem

Per-group skills under `groups/<group>/skills/` can be symlinks pointing
outside the group directory (e.g. to a shared skill library on the host).
Only `/workspace/agent/` is mounted into the container, so such symlinks
resolve to paths that don't exist inside the container — the skill
silently fails to load with no error message.

## Fix

`buildMounts()` now scans the group skills directory at spawn time. For
any entry that is a symlink resolving outside the group directory,
it bind-mounts the real target at the same absolute path (read-only).
The in-container symlink then resolves correctly.

- Deduplicates shared targets (multiple skills pointing to the same dir)
- Skips unreadable entries silently
- Only applies to external symlinks; internal ones (pointing within the
  group dir) are already covered by the `/workspace/agent/` mount

## Test plan

- [ ] Skill that is a normal directory: no change in behavior
- [ ] Skill that is an internal symlink: no change in behavior
- [ ] Skill that is an external symlink: target is mounted and skill loads correctly inside container
- [ ] Two skills pointing to the same external target: deduplicated (single mount)