### PR TITLE
feat: add HTTP/SSE MCP server support

### DIFF
--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -74,11 +74,9 @@ export interface QueryInput {
   };
 }
 
-export interface McpServerConfig {
-  command: string;
-  args: string[];
-  env: Record<string, string>;
-}
+export type McpServerConfig =
+  | { command: string; args?: string[]; env?: Record<string, string>; instructions?: string }
+  | { type: 'http' | 'sse'; url: string; headers?: Record<string, string> };
 
 export interface AgentQuery {
   /** Push a follow-up message into the active query. */

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -98,10 +98,11 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   // MCP server fragments — inline instructions from container.json for
   // user-added external MCP servers.
   for (const [name, mcp] of Object.entries(mcpServers)) {
-    if (mcp.instructions) {
+    const instructions = 'instructions' in mcp ? mcp.instructions : undefined;
+    if (instructions) {
       desired.set(`mcp-${name}.md`, {
         type: 'inline',
-        content: mcp.instructions,
+        content: instructions,
       });
     }
   }

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -257,24 +257,37 @@ registerResource({
       access: 'approval',
       description:
         'Add an MCP server to a group. Requires `ncl groups restart` to take effect. ' +
-        'Use --id <group-id> --name <server-name> --command <cmd> [--args <json-array>] [--env <json-object>].',
+        'Stdio: --id <group-id> --name <server-name> --command <cmd> [--args <json-array>] [--env <json-object>]. ' +
+        'HTTP/SSE: --id <group-id> --name <server-name> --type http|sse --url <url> [--headers <json-object>].',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
         const name = args.name as string;
         if (!name) throw new Error('--name is required');
-        const command = args.command as string;
-        if (!command) throw new Error('--command is required');
 
         const row = getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const servers = JSON.parse(row.mcp_servers) as Record<string, McpServerConfig>;
-        servers[name] = {
-          command,
-          args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
-          env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
-        };
+        const type = args.type as string | undefined;
+
+        if (type === 'http' || type === 'sse') {
+          const url = args.url as string;
+          if (!url) throw new Error('--url is required for HTTP/SSE servers');
+          servers[name] = {
+            type,
+            url,
+            headers: args.headers ? (JSON.parse(args.headers as string) as Record<string, string>) : undefined,
+          };
+        } else {
+          const command = args.command as string;
+          if (!command) throw new Error('--command is required for stdio servers');
+          servers[name] = {
+            command,
+            args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
+            env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
+          };
+        }
         updateContainerConfigJson(id, 'mcp_servers', servers);
 
         return { added: name, servers };

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -16,12 +16,9 @@ import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
-export interface McpServerConfig {
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-  instructions?: string;
-}
+export type McpServerConfig =
+  | { command: string; args?: string[]; env?: Record<string, string>; instructions?: string }
+  | { type: 'http' | 'sse'; url: string; headers?: Record<string, string> };
 
 export interface AdditionalMountConfig {
   hostPath: string;


### PR DESCRIPTION
## Problem

`McpServerConfig` only supported stdio-based MCP servers. HTTP and SSE
transports (increasingly common for hosted/remote MCP servers) could not
be configured via `ncl groups config add-mcp-server`.

## Changes

Extends `McpServerConfig` from a single stdio interface to a union type:

```ts
type McpServerConfig =
  | { command: string; args?: string[]; env?: Record<string, string>; instructions?: string }
  | { type: 'http' | 'sse'; url: string; headers?: Record<string, string> }
```

- **`src/container-config.ts`** — `McpServerConfig` is now a union type
- **`container/agent-runner/src/providers/types.ts`** — same union type mirrored in the agent-runner
- **`src/cli/resources/groups.ts`** — `ncl groups config add-mcp-server` now accepts:
  - `--type http|sse --url <url> [--headers <json-object>]` for HTTP/SSE servers
  - existing `--command --args --env` flags for stdio (unchanged, `--command` is now required only for stdio)
- **`src/claude-md-compose.ts`** — guard `instructions` access with `'instructions' in mcp` before reading, required by the new union type

## Test plan

- [ ] Existing stdio MCP server config: no behavior change
- [ ] `ncl groups config add-mcp-server --type http --url https://...`: adds HTTP server to container config
- [ ] `ncl groups config add-mcp-server --type sse --url https://... --headers '{"Authorization":"Bearer tok"}'`: headers are stored
- [ ] Groups with HTTP MCP servers: `claude-md-compose` does not crash on `instructions` access