### PR TITLE
Provider failure recovery: rollback, replay, in-turn ack, friendly fallback

### DIFF
--- a/container/agent-runner/src/db/session-state.ts
+++ b/container/agent-runner/src/db/session-state.ts
@@ -77,3 +77,46 @@ export function setContinuation(providerName: string, id: string): void {
 export function clearContinuation(providerName: string): void {
   deleteValue(continuationKey(providerName));
 }
+
+const FAILED_TURN_KEY = 'failed_turn';
+
+export interface FailedTurnRecord {
+  /** The prompt that was sent to the provider on the failed turn. Used to
+   *  reconstruct what the user asked when we replay context on the next
+   *  turn — the inbound row has been markCompleted'd by then. */
+  prompt: string;
+  /** The error message we surfaced to the user. The next turn tells the
+   *  agent about it so it can acknowledge the failure rather than acting
+   *  as if the previous message never happened. */
+  error: string;
+  /** Wall-clock when we recorded the failure. Lets the next turn render a
+   *  rough "a few seconds ago" hint if desired. */
+  recorded_at: number;
+}
+
+/** Persist a failed-turn record. Called when a turn surfaces an error to
+ *  the user (either via the unsurfacedError path or by throwing after
+ *  stale-session retry is exhausted). Read once on the next turn so the
+ *  agent has visibility into what was lost.
+ *
+ *  Pairs with the continuation rollback in processQuery: when we revert
+ *  to the prior good session id, the resumed transcript has no record of
+ *  the failed message or its error. This row carries that context across
+ *  turns instead. */
+export function setFailedTurn(record: FailedTurnRecord): void {
+  setValue(FAILED_TURN_KEY, JSON.stringify(record));
+}
+
+export function getFailedTurn(): FailedTurnRecord | undefined {
+  const raw = getValue(FAILED_TURN_KEY);
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as FailedTurnRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearFailedTurn(): void {
+  deleteValue(FAILED_TURN_KEY);
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -265,19 +265,25 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         clearContinuation(config.providerName);
       }
 
-      // Write error response so the user knows something went wrong
-      writeMessageOut({
-        id: generateId(),
-        kind: 'chat',
-        platform_id: routing.platformId,
-        channel_type: routing.channelType,
-        thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
-      });
       try {
         setFailedTurn({ prompt, error: errMsg, recorded_at: Date.now() });
       } catch (e) {
         log(`Failed to persist failed-turn record: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      const ack = await tryAcknowledgeFailure(config, routing, continuation, errMsg, undefined);
+      if (ack.continuation && ack.continuation !== continuation) {
+        continuation = ack.continuation;
+        setContinuation(config.providerName, continuation);
+      }
+      if (!ack.delivered) {
+        writeMessageOut({
+          id: generateId(),
+          kind: 'chat',
+          platform_id: routing.platformId,
+          channel_type: routing.channelType,
+          thread_id: routing.threadId,
+          content: JSON.stringify({ text: `Error: ${errMsg}` }),
+        });
       }
     } finally {
       clearCurrentInReplyTo();
@@ -343,6 +349,65 @@ function renderFailedTurnReplay(failed: { prompt: string; error: string; recorde
     `<note>The provider rejected the previous turn with the error above. The user was already told their message was not processed. You have no transcript of it because the session was rolled back to its last good state. Acknowledge the failure briefly when relevant; do not silently retry the failed action.</note>`,
     `</previous_turn_failed>`,
   ].join('\n');
+}
+
+interface AcknowledgeResult {
+  /** True when the agent emitted at least one user-visible message
+   *  during the ack turn — caller skips the static error fallback. */
+  delivered: boolean;
+  /** New continuation if the ack turn cleanly produced one, so the
+   *  outer loop can persist it for the next user turn. */
+  continuation?: string;
+}
+
+/**
+ * Best-effort in-turn acknowledgment of a provider failure.
+ *
+ * Pairs with the continuation rollback in processQuery: after a turn
+ * dies, we restore the prior good session id and run this short
+ * follow-up so the agent can tell the user what happened in its own
+ * voice. The user-supplied prompt that triggered the failure is
+ * intentionally NOT included — content-filter style failures would
+ * just repeat.
+ *
+ * Single query call, no recursion. If it also fails (throws or returns
+ * its own unsurfacedError) the caller falls back to a static error
+ * message; nothing here calls setFailedTurn so a busted ack never
+ * poisons the next turn's replay.
+ */
+async function tryAcknowledgeFailure(
+  config: PollLoopConfig,
+  routing: RoutingContext,
+  ackContinuation: string | undefined,
+  errorMessage: string,
+  errorClassification: string | undefined,
+): Promise<AcknowledgeResult> {
+  const tag = errorClassification ? ` (${errorClassification})` : '';
+  const ackPrompt = [
+    `<system>`,
+    `The user's most recent message could not be processed because the model provider returned an error${tag}:`,
+    ``,
+    errorMessage,
+    ``,
+    `Briefly (one or two short sentences) tell the user that their message failed and, if useful, quote the most relevant phrase from the error verbatim so they can act on it. Do not retry the failed action. Do not speculate about causes beyond what the error literally says. Do not apologize at length.`,
+    `</system>`,
+  ].join('\n');
+
+  log('Generating in-turn acknowledgment of provider error');
+  try {
+    const query = config.provider.query({
+      prompt: ackPrompt,
+      continuation: ackContinuation,
+      cwd: config.cwd,
+      systemContext: config.systemContext,
+    });
+    const result = await processQuery(query, routing, [], config.providerName, ackContinuation);
+    return { delivered: true, continuation: result.continuation };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log(`Acknowledgment turn threw: ${errMsg}`);
+    return { delivered: false };
+  }
 }
 
 interface QueryResult {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -270,11 +270,11 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       } catch (e) {
         log(`Failed to persist failed-turn record: ${e instanceof Error ? e.message : String(e)}`);
       }
-      const ack = await tryAcknowledgeFailure(config, routing, continuation, errMsg, undefined);
-      if (ack.continuation && ack.continuation !== continuation) {
-        continuation = ack.continuation;
-        setContinuation(config.providerName, continuation);
-      }
+      const ack = await tryAcknowledgeFailure(config, routing, errMsg, undefined);
+      // Intentionally do NOT persist ack.continuation — the ack runs
+      // in a fresh one-shot session with no real conversation state;
+      // the user's next turn should resume the rolled-back
+      // `continuation` we already have.
       if (!ack.delivered) {
         writeMessageOut({
           id: generateId(),
@@ -282,7 +282,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
           platform_id: routing.platformId,
           channel_type: routing.channelType,
           thread_id: routing.threadId,
-          content: JSON.stringify({ text: `Error: ${errMsg}` }),
+          content: JSON.stringify({ text: friendlyProviderErrorFallback(errMsg) }),
         });
       }
     } finally {
@@ -355,30 +355,43 @@ interface AcknowledgeResult {
   /** True when the agent emitted at least one user-visible message
    *  during the ack turn — caller skips the static error fallback. */
   delivered: boolean;
-  /** New continuation if the ack turn cleanly produced one, so the
-   *  outer loop can persist it for the next user turn. */
-  continuation?: string;
+}
+
+/**
+ * Static fallback message used only when both the agent's normal turn
+ * AND the in-turn ack failed. Pulls the human-readable message out of
+ * Claude Code-style API errors so the user gets one short line instead
+ * of a wall of JSON. Best-effort — if extraction misses, returns a
+ * generic message and drops the raw error entirely (the user can't act
+ * on it anyway).
+ */
+function friendlyProviderErrorFallback(errMsg: string): string {
+  // Match either `"message":"..."` (JSON-escaped) or a bare error line
+  // anywhere in the string. The first capture wins.
+  const jsonMatch = errMsg.match(/"message"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"/);
+  if (jsonMatch) {
+    const quoted = jsonMatch[1].replace(/\\"/g, '"').replace(/\\n/g, ' ').trim();
+    if (quoted) return `Your message couldn't be processed: "${quoted}". You may want to rephrase and try again.`;
+  }
+  return "Your message couldn't be processed due to a provider error. You may want to rephrase and try again.";
 }
 
 /**
  * Best-effort in-turn acknowledgment of a provider failure.
  *
- * Pairs with the continuation rollback in processQuery: after a turn
- * dies, we restore the prior good session id and run this short
- * follow-up so the agent can tell the user what happened in its own
- * voice. The user-supplied prompt that triggered the failure is
- * intentionally NOT included — content-filter style failures would
- * just repeat.
+ * Runs in a FRESH session (no continuation) so whatever context tripped
+ * the failure (e.g. a content-filter trigger in the rolled-back
+ * transcript) can't immediately re-trip it. The user-supplied prompt is
+ * also intentionally NOT included for the same reason.
  *
  * Single query call, no recursion. If it also fails (throws or returns
- * its own unsurfacedError) the caller falls back to a static error
+ * its own unsurfacedError) the caller falls back to a short static
  * message; nothing here calls setFailedTurn so a busted ack never
  * poisons the next turn's replay.
  */
 async function tryAcknowledgeFailure(
   config: PollLoopConfig,
   routing: RoutingContext,
-  ackContinuation: string | undefined,
   errorMessage: string,
   errorClassification: string | undefined,
 ): Promise<AcknowledgeResult> {
@@ -393,16 +406,20 @@ async function tryAcknowledgeFailure(
     `</system>`,
   ].join('\n');
 
+  // Always use a fresh session (no continuation). The rolled-back
+  // transcript still carries whatever content tripped the filter, so
+  // re-asking the model there often trips it again. The ack only needs
+  // the error string itself — no conversation context required.
   log('Generating in-turn acknowledgment of provider error');
   try {
     const query = config.provider.query({
       prompt: ackPrompt,
-      continuation: ackContinuation,
+      continuation: undefined,
       cwd: config.cwd,
       systemContext: config.systemContext,
     });
-    const result = await processQuery(query, routing, [], config.providerName, ackContinuation);
-    return { delivered: true, continuation: result.continuation };
+    await processQuery(query, routing, [], config.providerName, undefined);
+    return { delivered: true };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log(`Acknowledgment turn threw: ${errMsg}`);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -232,7 +232,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
+      const result = await processQuery(query, routing, processingIds, config.providerName, continuation);
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -313,8 +313,10 @@ async function processQuery(
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  priorContinuation: string | undefined,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
+  let resultSeen = false;
   let done = false;
   let unwrappedNudged = false;
 
@@ -447,6 +449,7 @@ async function processQuery(
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
       } else if (event.type === 'result') {
+        resultSeen = true;
         // A result — with or without text — means the turn is done. Mark
         // the initial batch completed now so the host sweep doesn't see
         // stale 'processing' claims while the query stays open for
@@ -473,6 +476,20 @@ async function processQuery(
   } finally {
     done = true;
     clearInterval(pollHandle);
+    // Atomic continuation rollback. The `init` handler persisted the new
+    // SDK session id immediately (for mid-turn crash recovery), but if the
+    // turn never reached a `result` event — the stream errored out or the
+    // SDK threw — that new id points at a half-baked transcript with no
+    // completed assistant turn. Resuming from it on the next message tends
+    // to drop prior context, which cascades: every subsequent turn forks
+    // into a fresh session and the agent eventually has nothing to anchor
+    // on. Restore the prior good id so the next turn resumes from a
+    // session that actually completed at least one turn cleanly.
+    if (!resultSeen && priorContinuation && queryContinuation && queryContinuation !== priorContinuation) {
+      log(`Turn ended without result; restoring prior continuation ${priorContinuation} (discarding ${queryContinuation})`);
+      try { setContinuation(providerName, priorContinuation); } catch { /* best-effort */ }
+      queryContinuation = priorContinuation;
+    }
   }
 
   return { continuation: queryContinuation };

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -2,7 +2,7 @@ import { findByName, getAllDestinations, type DestinationEntry } from './destina
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
-import { clearContinuation, migrateLegacyContinuation, setContinuation } from './db/session-state.js';
+import { clearContinuation, clearFailedTurn, getFailedTurn, migrateLegacyContinuation, setContinuation, setFailedTurn } from './db/session-state.js';
 import { clearCurrentInReplyTo, setCurrentInReplyTo } from './current-batch.js';
 import {
   formatMessages,
@@ -214,7 +214,22 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     // Format messages: passthrough commands get raw text (only if the
     // provider natively handles slash commands), others get XML.
-    const prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
+    let prompt = formatMessagesWithCommands(keep, config.provider.supportsNativeSlashCommands);
+
+    // Replay any prior failed turn. The continuation rollback in
+    // processQuery restores the agent to a session that completed before
+    // the failure, so the resumed transcript has no record of the lost
+    // user message or the error. Prepend a context block so the agent
+    // knows what happened and can acknowledge it rather than acting as
+    // if the user never spoke. Cleared regardless of whether the prompt
+    // ends up being sent successfully — if the new turn also fails, its
+    // own record will overwrite this one.
+    const failed = getFailedTurn();
+    if (failed) {
+      clearFailedTurn();
+      prompt = renderFailedTurnReplay(failed) + '\n\n' + prompt;
+      log(`Replaying failed turn from ${new Date(failed.recorded_at).toISOString()}`);
+    }
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
@@ -259,6 +274,11 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         thread_id: routing.threadId,
         content: JSON.stringify({ text: `Error: ${errMsg}` }),
       });
+      try {
+        setFailedTurn({ prompt, error: errMsg, recorded_at: Date.now() });
+      } catch (e) {
+        log(`Failed to persist failed-turn record: ${e instanceof Error ? e.message : String(e)}`);
+      }
     } finally {
       clearCurrentInReplyTo();
     }
@@ -302,6 +322,27 @@ function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommand
   }
 
   return parts.join('\n\n');
+}
+
+/**
+ * Render the prior failed-turn record as an XML block to prepend to the
+ * next prompt. Tells the agent verbatim what the user said last time and
+ * what error the provider returned, so it can acknowledge the failure
+ * instead of acting as if the message never happened. Paired with the
+ * continuation rollback in processQuery — the resumed transcript has no
+ * memory of the failed turn, so this block is the only signal.
+ */
+function renderFailedTurnReplay(failed: { prompt: string; error: string; recorded_at: number }): string {
+  const when = new Date(failed.recorded_at).toISOString();
+  return [
+    `<previous_turn_failed at="${when}">`,
+    `<user_message_that_was_not_processed>`,
+    failed.prompt,
+    `</user_message_that_was_not_processed>`,
+    `<provider_error>${failed.error}</provider_error>`,
+    `<note>The provider rejected the previous turn with the error above. The user was already told their message was not processed. You have no transcript of it because the session was rolled back to its last good state. Acknowledge the failure briefly when relevant; do not silently retry the failed action.</note>`,
+    `</previous_turn_failed>`,
+  ].join('\n');
 }
 
 interface QueryResult {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -418,7 +418,7 @@ async function tryAcknowledgeFailure(
       cwd: config.cwd,
       systemContext: config.systemContext,
     });
-    await processQuery(query, routing, [], config.providerName, undefined);
+    await processQuery(query, routing, [], config.providerName, undefined, false);
     return { delivered: true };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -437,6 +437,7 @@ async function processQuery(
   initialBatchIds: string[],
   providerName: string,
   priorContinuation: string | undefined,
+  persistContinuation = true,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let resultSeen = false;
@@ -570,7 +571,12 @@ async function processQuery(
         // container died between `init` and `result`, the SDK session was
         // effectively orphaned and the next message started a blank
         // Claude session with no prior context.
-        setContinuation(providerName, event.continuation);
+        // Skip for one-shot calls (e.g. the in-turn ack), which run in a
+        // throwaway session and would otherwise clobber the rolled-back
+        // continuation set by the failing turn's processQuery.
+        if (persistContinuation) {
+          setContinuation(providerName, event.continuation);
+        }
       } else if (event.type === 'result') {
         resultSeen = true;
         // A result — with or without text — means the turn is done. Mark

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -2,7 +2,7 @@ import { findByName, getAllDestinations, type DestinationEntry } from './destina
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
-import { clearContinuation, clearFailedTurn, getFailedTurn, migrateLegacyContinuation, setContinuation, setFailedTurn } from './db/session-state.js';
+import { clearContinuation, clearFailedTurn, getContinuation, getFailedTurn, migrateLegacyContinuation, setContinuation, setFailedTurn } from './db/session-state.js';
 import { clearCurrentInReplyTo, setCurrentInReplyTo } from './current-batch.js';
 import {
   formatMessages,
@@ -138,6 +138,19 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     const ids = messages.map((m) => m.id);
     markProcessing(ids);
 
+    // Resync continuation from session_state at the top of each batch.
+    // The local variable only gets updated on processQuery's success
+    // return path; on the error path (and inside long-lived queries that
+    // outlive a single batch via follow-up pushes) the canonical value
+    // lives in session_state — written by the init handler and rolled
+    // back by the failure-recovery path. Without this resync, after a
+    // failed follow-up turn the next batch would start a brand-new
+    // Claude session, dropping all prior context.
+    const persisted = getContinuation(config.providerName);
+    if (persisted !== continuation) {
+      continuation = persisted;
+    }
+
     const routing = extractRouting(messages);
 
     // Command handling: the host router gates filtered and unauthorized
@@ -246,8 +259,22 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
+    // Mutable holder so processQuery can report the most recent prompt
+    // it actually pushed to the SDK. The initial batch's prompt is
+    // seeded here; follow-up pushes overwrite it. On failure we record
+    // *that* prompt as the failed turn — not the initial one, which
+    // may have completed cleanly turns earlier in the same query.
+    const promptTracker = { latest: prompt };
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName, continuation);
+      const result = await processQuery(
+        query,
+        routing,
+        processingIds,
+        config.providerName,
+        continuation,
+        true,
+        promptTracker,
+      );
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -266,7 +293,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       }
 
       try {
-        setFailedTurn({ prompt, error: errMsg, recorded_at: Date.now() });
+        setFailedTurn({ prompt: promptTracker.latest, error: errMsg, recorded_at: Date.now() });
       } catch (e) {
         log(`Failed to persist failed-turn record: ${e instanceof Error ? e.message : String(e)}`);
       }
@@ -346,7 +373,7 @@ function renderFailedTurnReplay(failed: { prompt: string; error: string; recorde
     failed.prompt,
     `</user_message_that_was_not_processed>`,
     `<provider_error>${failed.error}</provider_error>`,
-    `<note>The provider rejected the previous turn with the error above. The user was already told their message was not processed. You have no transcript of it because the session was rolled back to its last good state. Acknowledge the failure briefly when relevant; do not silently retry the failed action.</note>`,
+    `<note>The provider rejected ONLY the single user turn shown above. Your earlier conversation history (everything before that turn) is intact and resumed normally — do not claim you have forgotten it. The user was already told that one turn was not processed. Acknowledge the failure briefly only if directly relevant; do not silently retry the failed action.</note>`,
     `</previous_turn_failed>`,
   ].join('\n');
 }
@@ -438,6 +465,7 @@ async function processQuery(
   providerName: string,
   priorContinuation: string | undefined,
   persistContinuation = true,
+  promptTracker?: { latest: string },
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let resultSeen = false;
@@ -518,6 +546,7 @@ async function processQuery(
         const prompt = formatMessages(keep);
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;
+        if (promptTracker) promptTracker.latest = prompt;
         query.push(prompt);
         markCompleted(keptIds);
       } catch (err) {
@@ -599,6 +628,16 @@ async function processQuery(
                 `Please re-send your response with the correct wrapping.</system>`,
             );
           }
+        }
+        // One-shot calls (in-turn ack): end the stream immediately after
+        // the first result. Without this, the query stays open waiting
+        // for stream-close, and the follow-up poller pushes the next
+        // user message into this throwaway session — defeating the
+        // continuation rollback. The user's next turn must start a
+        // fresh query against the rolled-back continuation.
+        if (!persistContinuation) {
+          endedForCommand = true;
+          query.end();
         }
       }
     }

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -413,8 +413,11 @@ export class ClaudeProvider implements AgentProvider {
         model: this.model,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         effort: this.effort as any,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
+        // In rootless-podman-on-LXC we run as --user=0:0 so host bind mounts
+        // are accessible. Claude Code refuses bypassPermissions as root, so
+        // fall back to 'auto' which still honours allowedTools/disallowedTools.
+        permissionMode: process.getuid?.() === 0 ? 'auto' : 'bypassPermissions',
+        allowDangerouslySkipPermissions: process.getuid?.() !== 0,
         settingSources: ['project', 'user', 'local'],
         mcpServers: this.mcpServers,
         hooks: {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,7 +22,13 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  isRootlessPodman,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -406,6 +412,19 @@ async function buildContainerArgs(
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+
+  // Rootless Podman: UID 0 inside the container maps to the host user
+  // (e.g. denis/1000). The Dockerfile sets USER node (UID 1000) which would
+  // map to an unmapped high UID and can't write to bind mounts. Override to
+  // root so the in-container process effectively runs as the host user.
+  // NOTE: --userns=keep-id is NOT used — it triggers storage-chown-by-maps
+  // which hangs or takes minutes on large images in nested container envs.
+  if (isRootlessPodman()) {
+    args.push('--user=0:0');
+    // Forcing UID 0 bypasses the Dockerfile's USER node, so HOME defaults to
+    // /root instead of /home/node where .claude is mounted. Pin it explicitly.
+    args.push('-e', 'HOME=/home/node');
+  }
 
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,20 +2,68 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import os from 'os';
 
-import { CONTAINER_INSTALL_LABEL } from './config.js';
+import { CONTAINER_INSTALL_LABEL, ONECLI_URL } from './config.js';
 import { log } from './log.js';
 
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';
 
+/** Cached result of rootless-podman detection. */
+let _isRootlessPodman: boolean | null = null;
+
+/** Detect whether the runtime is rootless Podman (needs --userns=keep-id). */
+export function isRootlessPodman(): boolean {
+  if (_isRootlessPodman !== null) return _isRootlessPodman;
+  try {
+    const out = execSync(`${CONTAINER_RUNTIME_BIN} info --format '{{.Host.Security.Rootless}}'`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim();
+    _isRootlessPodman = out === 'true';
+  } catch {
+    _isRootlessPodman = false;
+  }
+  return _isRootlessPodman;
+}
+
+const LOCALHOST_NAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * Resolve the IP address that `host.docker.internal` should map to inside
+ * containers. When OneCLI runs on a remote host, `host-gateway` (which
+ * resolves to the container host) is wrong — the container must reach the
+ * OneCLI gateway on the remote host directly.
+ */
+function resolveHostDockerTarget(): string {
+  if (!ONECLI_URL) return 'host-gateway';
+  try {
+    const hostname = new URL(ONECLI_URL).hostname;
+    if (LOCALHOST_NAMES.has(hostname)) return 'host-gateway';
+    // Resolve the hostname to an IP for --add-host (hostnames aren't allowed).
+    // Use execFileSync to avoid shell injection.
+    const resolved = execFileSync('getent', ['hosts', hostname], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim().split(/\s+/)[0];
+    return resolved || 'host-gateway';
+  } catch {
+    return 'host-gateway';
+  }
+}
+
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
+  // On Linux, host.docker.internal isn't built-in — add it explicitly.
+  // When OneCLI runs on a remote host, map to that host's IP instead of
+  // host-gateway (which points to the local container host).
   if (os.platform() === 'linux') {
-    return ['--add-host=host.docker.internal:host-gateway'];
+    const target = resolveHostDockerTarget();
+    return [`--add-host=host.docker.internal:${target}`];
   }
   return [];
 }

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -49,7 +49,9 @@ function resolveHostDockerTarget(): string {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
-    }).trim().split(/\s+/)[0];
+    })
+      .trim()
+      .split(/\s+/)[0];
     return resolved || 'host-gateway';
   } catch {
     return 'host-gateway';


### PR DESCRIPTION
> ⚠️ **Depends on #2667** (rootless Podman / root-container fix). The first commit in this branch's diff (`fix(container): support rootless Podman + remote OneCLI host`) belongs to that PR and will drop out of the diff once #2667 merges. GitHub doesn't allow setting the base of a cross-fork PR to a branch in my fork, so the two PRs can't be formally stacked.

## Problem

When a turn dies mid-stream — content-filter block, transient provider 5xx, anything that throws between the SDK's `init` and the next `result` event — the agent silently loses context. After the failure, every subsequent message starts a brand-new Claude session: the codeword you gave it five turns ago, the file paths you discussed, the prior tool calls — all gone. The user also gets a bare `Error: …` dump from the raw provider message and no acknowledgment in the agent's own voice.

The fix is in `container/agent-runner/src/poll-loop.ts` and touches one helper (`renderFailedTurnReplay`).

## Behavior change (end-to-end)

Same 3-turn scenario, fault injected on T2:

| Turn | User | Before | After |
|---|---|---|---|
| T1 | `Please remember the codeword <X>. Confirm by repeating it back.` | `<X>` | `<X> — confirmed and remembered.` |
| T2 | `TRIGGER_FAULT_INJECT please respond hello` | `Error: Claude Code returned an error result: API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Output blocked by content filtering policy"}}` | `Your message was blocked: "Output blocked by content filtering policy." Please try rephrasing your request.` |
| T3 | `what codeword did I give you earlier?` | `I don't have any record of a codeword — there are no past conversation transcripts saved…` | `The codeword you gave me was <X>.` |

Captured `messages_out` rows from a local A/B (codewords `OBSIDIAN-PUMA-23` before, `AMBER-LYNX-44` after) are in the "Verification" section.

## What the code does now

`processQuery` (the per-batch SDK driver) has been hardened around the "stream errored mid-turn" path. The relevant additions, all in `poll-loop.ts`:

- **Roll back the continuation when a turn never reaches `result`.** The `init` handler persists the SDK's new session id immediately (load-bearing for mid-turn container-crash recovery — without it the next wake starts blind). On the failure path, `processQuery`'s `finally` block detects the missing `result` and restores the prior good continuation in both memory and `session_state`. Next turn resumes from a session that actually completed at least one clean turn.

- **Resync the local continuation from `session_state` at the top of every batch.** The init handler writes to disk; the local variable in `processWaiting` only updated on the success-return path. Without a resync, after a thrown turn the local stayed `undefined` and the next `provider.query()` started a brand-new session even though the right id was sitting in `session_state`. (This was the actual amnesia root cause — the rollback was working, the local variable just wasn't re-reading it.)

- **Record the prompt that actually failed.** A long-lived query may serve multiple user turns via follow-up pushes. `setFailedTurn` was using the outer `prompt` variable from `processWaiting` — i.e. the *initial* prompt of the live query, often a turn that completed cleanly several turns ago. A small `promptTracker` holder is threaded into `processQuery` and updated on every push so the recovery path records the prompt that actually tripped the failure.

- **Replay the failed turn into the next prompt.** With the continuation rolled back, the resumed transcript has no record of the user's lost message. A `failed_turn` row (prompt + error + timestamp) is persisted in `outbound.db` and, on the next batch, prepended as a `<previous_turn_failed>` XML block so the agent can briefly acknowledge the failure instead of acting as if the user never spoke. The replay note explicitly tells the model that only that single turn is missing and the earlier conversation history is intact — without that clarification the model was reading "rolled back" as "you have forgotten everything" and denying knowledge of context that was still in the resumed transcript.

- **Generate a natural-language ack of the error in the same turn.** New helper `tryAcknowledgeFailure` runs a single short follow-up query asking the model to tell the user what happened in its own voice. The replay above only kicks in on the user's *next* message — until then the user would just see a bare `Error: …` line, which feels broken.

- **Ack runs on a fresh one-shot session.** Two reasons: (a) the rolled-back transcript still carries whatever content tripped the failure (e.g. the content-filter trigger), and re-asking the same model there often trips the same filter again; (b) the ack must not influence the next user turn. The user prompt is intentionally not included for the same reason — the ack only needs the error string.

- **The ack's `init` and `result` are isolated from the live conversation.** Two follow-ups needed for this to actually work: a `persistContinuation=false` flag on `processQuery` so the ack's `init` doesn't clobber the rolled-back continuation, and ending the query immediately on `result` so the live follow-up poller can't push the next user message into the throwaway ack stream.

- **Friendly static fallback if the ack itself also fails.** Pulls the human-readable phrase out of (often JSON) errors so the user gets one short line — e.g. `Your message couldn't be processed: "Output blocked by content filtering policy." You may want to rephrase and try again.` — instead of the raw `Error: Claude Code returned an error result: API Error: 400 {"type":"error",…}` dump. The verbatim error is still in the `failed_turn` record and the container log for debugging.

## Reproduction

Failures were reproduced deterministically by temporarily monkey-patching `container/agent-runner/src/providers/claude.ts` to throw a synthetic `400 invalid_request_error` after the SDK's `init` event whenever a follow-up push contained the marker `TRIGGER_FAULT_INJECT`. The marker had to be in a *follow-up* push, not the initial prompt of the query, so that T1 could establish context first. The patch is local-only and not part of this PR.

```
T1 → "Please remember the codeword <X>. Confirm by repeating it back."
T2 → "TRIGGER_FAULT_INJECT please respond hello"
T3 → "what codeword did I give you earlier?"
```

`data/v2-sessions/<group>/<session>/outbound.db` (`session_state` table) was inspected between turns to confirm the continuation rollback and `failed_turn` record.

## Verification

`pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` clean.

Live A/B captured against the local `_ping-test` session, fault injector held constant across runs:

**Before (upstream/main + #2667), codeword `OBSIDIAN-PUMA-23`:**
```
T1 → "OBSIDIAN-PUMA-23"
T2 → 'Error: Claude Code returned an error result: API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Output blocked by content filtering policy"}}'
T3 → "I don't have any record of a codeword — there are no past conversation transcripts saved, and nothing in my memory files…"
```

**After (this PR), codeword `AMBER-LYNX-44`:**
```
T1 → "AMBER-LYNX-44 — confirmed and remembered."
T2 → 'Your message was blocked: "Output blocked by content filtering policy." Please try rephrasing your request.'
T3 → "The codeword you gave me was AMBER-LYNX-44."
```
