### PR TITLE
fix(container): support rootless Podman + root container user

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -413,8 +413,11 @@ export class ClaudeProvider implements AgentProvider {
         model: this.model,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         effort: this.effort as any,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
+        // In rootless-podman-on-LXC we run as --user=0:0 so host bind mounts
+        // are accessible. Claude Code refuses bypassPermissions as root, so
+        // fall back to 'auto' which still honours allowedTools/disallowedTools.
+        permissionMode: process.getuid?.() === 0 ? 'auto' : 'bypassPermissions',
+        allowDangerouslySkipPermissions: process.getuid?.() !== 0,
         settingSources: ['project', 'user', 'local'],
         mcpServers: this.mcpServers,
         hooks: {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,7 +22,13 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  hostGatewayArgs,
+  isRootlessPodman,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -406,6 +412,19 @@ async function buildContainerArgs(
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+
+  // Rootless Podman: UID 0 inside the container maps to the host user
+  // (e.g. denis/1000). The Dockerfile sets USER node (UID 1000) which would
+  // map to an unmapped high UID and can't write to bind mounts. Override to
+  // root so the in-container process effectively runs as the host user.
+  // NOTE: --userns=keep-id is NOT used — it triggers storage-chown-by-maps
+  // which hangs or takes minutes on large images in nested container envs.
+  if (isRootlessPodman()) {
+    args.push('--user=0:0');
+    // Forcing UID 0 bypasses the Dockerfile's USER node, so HOME defaults to
+    // /root instead of /home/node where .claude is mounted. Pin it explicitly.
+    args.push('-e', 'HOME=/home/node');
+  }
 
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,20 +2,68 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import os from 'os';
 
-import { CONTAINER_INSTALL_LABEL } from './config.js';
+import { CONTAINER_INSTALL_LABEL, ONECLI_URL } from './config.js';
 import { log } from './log.js';
 
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';
 
+/** Cached result of rootless-podman detection. */
+let _isRootlessPodman: boolean | null = null;
+
+/** Detect whether the runtime is rootless Podman (needs --userns=keep-id). */
+export function isRootlessPodman(): boolean {
+  if (_isRootlessPodman !== null) return _isRootlessPodman;
+  try {
+    const out = execSync(`${CONTAINER_RUNTIME_BIN} info --format '{{.Host.Security.Rootless}}'`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim();
+    _isRootlessPodman = out === 'true';
+  } catch {
+    _isRootlessPodman = false;
+  }
+  return _isRootlessPodman;
+}
+
+const LOCALHOST_NAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * Resolve the IP address that `host.docker.internal` should map to inside
+ * containers. When OneCLI runs on a remote host, `host-gateway` (which
+ * resolves to the container host) is wrong — the container must reach the
+ * OneCLI gateway on the remote host directly.
+ */
+function resolveHostDockerTarget(): string {
+  if (!ONECLI_URL) return 'host-gateway';
+  try {
+    const hostname = new URL(ONECLI_URL).hostname;
+    if (LOCALHOST_NAMES.has(hostname)) return 'host-gateway';
+    // Resolve the hostname to an IP for --add-host (hostnames aren't allowed).
+    // Use execFileSync to avoid shell injection.
+    const resolved = execFileSync('getent', ['hosts', hostname], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim().split(/\s+/)[0];
+    return resolved || 'host-gateway';
+  } catch {
+    return 'host-gateway';
+  }
+}
+
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
+  // On Linux, host.docker.internal isn't built-in — add it explicitly.
+  // When OneCLI runs on a remote host, map to that host's IP instead of
+  // host-gateway (which points to the local container host).
   if (os.platform() === 'linux') {
-    return ['--add-host=host.docker.internal:host-gateway'];
+    const target = resolveHostDockerTarget();
+    return [`--add-host=host.docker.internal:${target}`];
   }
   return [];
 }


### PR DESCRIPTION
## Problem

When the agent container runs as root (rootless Podman on LXC requires `--user=0:0` for host bind-mount access, and the default Docker setup also runs root), Claude Code v2.1.128 refuses to start:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

The host log only surfaces the wrapper error — `Claude Code process exited with code 1` — so the root cause is invisible without hooking the SDK's stderr callback.

Additionally, rootless Podman needs `HOME=/home/node` pinned and `host.docker.internal` routed to the host's OneCLI endpoint for the credential proxy to work.

## Fix

Cherry-pick of `771af22` from the `dtreskunov/prod` branch:

- `container/agent-runner/src/providers/claude.ts`: when running as uid 0, downgrade `permissionMode` from `bypassPermissions` to `auto` and drop `allowDangerouslySkipPermissions`. Non-root callers (Apple Container, Docker with user remap) are unaffected. `allowedTools` / `disallowedTools` still enforce the tool allowlist.
- `src/container-runner.ts`: map container UID to host user for rootless Podman volume permissions.
- `src/container-runtime.ts`: resolve `host.docker.internal` for remote OneCLI host; pin `HOME=/home/node` under rootless Podman.

## Verification

Without this patch on `upstream/main`, `pnpm run chat -- "say hi"` to any agent group returns `"Your message couldn't be processed due to a provider error."` and the container log shows `Claude Code process exited with code 1`. With the patch, the agent responds normally.

## Notes

This is the base PR for #2666 (Provider failure recovery), which will be rebased on top once this merges.