### PR TITLE
fix(agent-runner): self-heal poisoned-resume crash loop

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -411,6 +411,39 @@ describe('poll loop — /clear command', () => {
   });
 });
 
+describe('poll loop — poisoned-resume self-heal', () => {
+  it('clears continuation and retries fresh when a result reports a poisoned resume', async () => {
+    // Seed the continuation the runner will resume from. The provider emits the
+    // thinking-block 400 *as a result* (not a throw) whenever it is resumed,
+    // mirroring the real crash-loop. On a fresh start (no continuation) it
+    // returns a normal message.
+    setContinuation('mock', 'poisoned-resume-session');
+
+    insertMessage('m1', { sender: 'Alice', text: 'morning briefing' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new PoisonResumeProvider();
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider as unknown as MockProvider, controller.signal, 3000);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 3000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    // The fresh retry's clean reply was delivered — the raw API error was suppressed.
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('recovered');
+    expect(JSON.parse(out[0].content).text).not.toContain('API Error');
+
+    // The poisoned continuation was cleared and replaced by the fresh session id.
+    expect(getContinuation('mock')).toBe('fresh-session');
+
+    const pending = getPendingMessages();
+    expect(pending).toHaveLength(0);
+
+    await loopPromise.catch(() => {});
+  });
+});
+
 /**
  * Provider that throws on every query, simulating API failures.
  */
@@ -458,6 +491,48 @@ class InvalidSessionProvider {
       events: (async function* () {
         yield { type: 'init' as const, continuation: 'doomed-session' };
         throw new Error('session not found');
+      })(),
+    };
+  }
+}
+
+/**
+ * Provider that emits the thinking-block 400 as a *result* (not a throw) when
+ * resumed from a continuation — the real poison signature — and returns a clean
+ * message when started fresh (no continuation). isPoisonedResume recognizes the
+ * error text so the poll-loop clears the continuation and retries.
+ */
+class PoisonResumeProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  isPoisonedResume(text: string): boolean {
+    return /blocks in the latest assistant message cannot be modified/i.test(text);
+  }
+
+  query(input: { prompt: string; cwd: string; continuation?: string }) {
+    const resumed = Boolean(input.continuation);
+    return {
+      push() {},
+      end() {},
+      abort() {},
+      events: (async function* () {
+        if (resumed) {
+          yield { type: 'init' as const, continuation: 'poisoned-resume-session' };
+          yield {
+            type: 'result' as const,
+            text:
+              'API Error: 400 messages.9.content.16: `thinking` or `redacted_thinking` blocks in ' +
+              'the latest assistant message cannot be modified. These blocks must remain as they ' +
+              'were in the original response.',
+          };
+          return;
+        }
+        yield { type: 'init' as const, continuation: 'fresh-session' };
+        yield { type: 'result' as const, text: '<message to="discord-test">recovered</message>' };
       })(),
     };
   }

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -218,13 +218,6 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
 
     log(`Processing ${keep.length} message(s), kinds: ${[...new Set(keep.map((m) => m.kind))].join(',')}`);
 
-    const query = config.provider.query({
-      prompt,
-      continuation,
-      cwd: config.cwd,
-      systemContext: config.systemContext,
-    });
-
     // Process the query while concurrently polling for new messages
     const skippedSet = new Set(skipped);
     const processingIds = ids.filter((id) => !commandIds.includes(id) && !skippedSet.has(id));
@@ -232,10 +225,32 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
-      if (result.continuation && result.continuation !== continuation) {
-        continuation = result.continuation;
-        setContinuation(config.providerName, continuation);
+      // Retry-once on a poisoned resume: resuming a corrupt transcript yields a
+      // 400 surfaced as a *result* (not a throw), so the catch-path below never
+      // sees it and the session would crash-loop on every wake. Clear the
+      // continuation and re-run the same turn from a fresh session. Bounded to
+      // one retry and gated on having actually resumed — a fresh session that
+      // still poisons can't loop.
+      for (let attempt = 0; ; attempt++) {
+        const usedContinuation = continuation;
+        const query = config.provider.query({
+          prompt,
+          continuation,
+          cwd: config.cwd,
+          systemContext: config.systemContext,
+        });
+        const result = await processQuery(query, routing, processingIds, config.providerName, config.provider);
+        if (result.poisoned && usedContinuation && attempt === 0) {
+          log(`Poisoned resume (${usedContinuation}) — clearing continuation and retrying fresh`);
+          clearContinuation(config.providerName);
+          continuation = undefined;
+          continue;
+        }
+        if (result.continuation && result.continuation !== continuation) {
+          continuation = result.continuation;
+          setContinuation(config.providerName, continuation);
+        }
+        break;
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -306,6 +321,12 @@ function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommand
 
 interface QueryResult {
   continuation?: string;
+  /**
+   * True if a result event reported a corrupt/poisoned resume (see
+   * AgentProvider.isPoisonedResume). The raw error text was suppressed rather
+   * than dispatched; the caller clears the continuation and retries fresh.
+   */
+  poisoned?: boolean;
 }
 
 async function processQuery(
@@ -313,10 +334,12 @@ async function processQuery(
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  provider: AgentProvider,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
   let unwrappedNudged = false;
+  let poisoned = false;
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open avoids
@@ -454,7 +477,14 @@ async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
-        if (event.text) {
+        if (event.text && provider.isPoisonedResume?.(event.text)) {
+          // The resumed transcript is corrupt (e.g. unmodifiable thinking
+          // blocks). Suppress the raw API-error text — dispatching it would
+          // only land as scratchpad and trigger a pointless unwrapped nudge —
+          // and signal the caller to clear the continuation and retry fresh.
+          log('Poisoned resume detected in result — suppressing error text, will retry fresh');
+          poisoned = true;
+        } else if (event.text) {
           const { hasUnwrapped } = dispatchResultText(event.text, routing);
           if (hasUnwrapped && !unwrappedNudged) {
             unwrappedNudged = true;
@@ -475,7 +505,7 @@ async function processQuery(
     clearInterval(pollHandle);
   }
 
-  return { continuation: queryContinuation };
+  return { continuation: queryContinuation, poisoned };
 }
 
 function handleEvent(event: ProviderEvent, _routing: RoutingContext): void {

--- a/container/agent-runner/src/providers/claude.poison.test.ts
+++ b/container/agent-runner/src/providers/claude.poison.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test';
+
+import { ClaudeProvider } from './claude.js';
+
+describe('ClaudeProvider.isPoisonedResume', () => {
+  const provider = new ClaudeProvider();
+
+  it('matches the thinking-block continuation-corruption 400', () => {
+    const text =
+      'API Error: 400 messages.9.content.16: `thinking` or `redacted_thinking` blocks in the ' +
+      'latest assistant message cannot be modified. These blocks must remain as they were in ' +
+      'the original response.';
+    expect(provider.isPoisonedResume(text)).toBe(true);
+  });
+
+  it('matches the redacted_thinking variant regardless of message index', () => {
+    const text =
+      'API Error: 400 messages.13.content.3: `redacted_thinking` blocks in the latest assistant ' +
+      'message cannot be modified.';
+    expect(provider.isPoisonedResume(text)).toBe(true);
+  });
+
+  it('does not match benign agent output', () => {
+    expect(provider.isPoisonedResume('<message to="x">all good</message>')).toBe(false);
+  });
+
+  it('does not match unrelated API errors', () => {
+    expect(provider.isPoisonedResume('API Error: 429 rate_limit_error: overloaded')).toBe(false);
+    expect(provider.isPoisonedResume('API Error: 400 invalid_request_error: image too large')).toBe(false);
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -328,6 +328,17 @@ const CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WIN
  */
 const STALE_SESSION_RE = /no conversation found|ENOENT.*\.jsonl|session.*not found/i;
 
+/**
+ * Poisoned-resume detection. When a turn is interrupted mid-stream (the host
+ * kills a stale container, or it crashes) while an assistant message with
+ * thinking blocks is still streaming, a partial message lands in the resumed
+ * .jsonl. The next request can't append to those blocks and the API returns a
+ * 400 — but the SDK surfaces it as a *result*, not a thrown error, so the
+ * isSessionInvalid catch-path never fires and the session crash-loops on every
+ * wake. Match the stable phrase so the poll-loop clears the continuation.
+ */
+const POISON_RESUME_RE = /blocks in the latest assistant message cannot be modified/i;
+
 export class ClaudeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = true;
 
@@ -353,6 +364,10 @@ export class ClaudeProvider implements AgentProvider {
   isSessionInvalid(err: unknown): boolean {
     const msg = err instanceof Error ? err.message : String(err);
     return STALE_SESSION_RE.test(msg);
+  }
+
+  isPoisonedResume(text: string): boolean {
+    return POISON_RESUME_RE.test(text);
   }
 
   maybeRotateContinuation(continuation: string): string | null {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -29,6 +29,18 @@ export interface AgentProvider {
    * before it ever replies. Providers without an on-disk transcript omit this.
    */
   maybeRotateContinuation?(continuation: string, cwd: string): string | null;
+
+  /**
+   * True if this result-event text means the resumed transcript is corrupt and
+   * unusable — e.g. Claude's "`thinking`/`redacted_thinking` blocks in the
+   * latest assistant message cannot be modified" 400, which the SDK surfaces as
+   * a result (not a thrown error), so the catch-block isSessionInvalid path
+   * never sees it. When true, the poll-loop clears the continuation and retries
+   * the turn once from a fresh session, turning a permanent crash-loop into one
+   * dropped turn. Optional so providers without an on-disk transcript (and
+   * out-of-tree providers) need no change.
+   */
+  isPoisonedResume?(text: string): boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #2669.

**Problem.** A session crash-loops forever on a corrupt resumed transcript (`thinking`/`redacted_thinking` blocks in the latest assistant message cannot be modified). The existing `isSessionInvalid` recovery never fires because the SDK surfaces this 400 as a **result event, not a throw**, and `STALE_SESSION_RE` wouldn't match it anyway. Manual deletion of the `continuation:claude` row was the only escape (twice in prod).

**Fix.**
- Add optional `AgentProvider.isPoisonedResume(text)` (optional → out-of-tree providers unaffected); implement on `ClaudeProvider` via a narrow `POISON_RESUME_RE`.
- In `processQuery`, when a result reports a poisoned resume, suppress the raw error text (it would only land as scratchpad + a pointless unwrapped nudge) and flag the result.
- In the outer loop, clear the continuation and retry the turn once from a fresh session — bounded to one retry, gated on having actually resumed, so a fresh session that still poisons can't loop.

A permanent crash-loop becomes at worst one dropped turn that auto-recovers.

**Tests.** Unit coverage for `isPoisonedResume` (matches the real 400, rejects benign/unrelated text) + an integration test that seeds a continuation, emits the poison as a result, and asserts the continuation is cleared and the fresh retry's clean reply is delivered. Full agent-runner suite (106) + container typecheck green.

**Note.** The real API 400 can't be triggered on demand; the integration test simulates it via a provider that emits the poison signature on resume — the realistic end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)