### PR TITLE
fix: mount inbound attachments dir into agent containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -299,6 +299,13 @@ function buildMounts(
     mounts.push({ hostPath: globalDir, containerPath: '/workspace/global', readonly: true });
   }
 
+  // Inbound attachments — channel adapters drop media here on the host; the
+  // formatter references /workspace/attachments/<name>, so the mount target
+  // must exist. RO: outbound files flow via message.files, not by writing here.
+  const attachmentsDir = path.join(DATA_DIR, 'attachments');
+  fs.mkdirSync(attachmentsDir, { recursive: true });
+  mounts.push({ hostPath: attachmentsDir, containerPath: '/workspace/attachments', readonly: true });
+
   // Shared CLAUDE.md — read-only, imported by the composed entry point via
   // the `.claude-shared.md` symlink inside the group dir.
   const sharedClaudeMd = path.join(process.cwd(), 'container', 'CLAUDE.md');


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** Adds a read-only bind mount of `<DATA_DIR>/attachments/` at `/workspace/attachments/` so the mount target the formatter references actually exists in agent containers.

**Why:** Channel adapters (e.g. `whatsapp.ts:downloadInboundMedia`) download inbound media to `<DATA_DIR>/attachments/` on the host, and the formatter (`container/agent-runner/src/formatter.ts:248-251`) tells the agent the file is at `/workspace/attachments/<name>`. But that path was never mounted, so agents see the reference in their formatted message but can't actually open the file — easy to misdiagnose as a download failure or "platform bug" by the agent itself.

**How:** One mount block alongside the existing `/workspace/*` mounts. `fs.mkdirSync` runs first so Docker doesn't create a root-owned empty dir on the host as a side effect. RO is correct because outbound files flow via `message.files` in-memory through the adapter, not by writing back to this dir.

**Tested:** Reproduced the bug end-to-end in a real install — agent saw the path reference in its formatted message but `/workspace/attachments/` didn't exist inside the container. Applied the patch, restarted host, sent a CSV via WhatsApp. Mount now appears as `/dev/root on /workspace/attachments type ext4 (ro,...)`, files are readable, and all historical attachments become retroactively visible. `pnpm run build` clean, `pnpm test` 332/332 passing on upstream/main baseline (same count with patch applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)