### PR TITLE
fix(codex): MCP union compatibility + HTTP-only transport behind proxies

### DIFF
--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -15,6 +15,8 @@ import path from 'path';
 import { spawn, type ChildProcess } from 'child_process';
 import { createInterface, type Interface as ReadlineInterface } from 'readline';
 
+import type { McpServerConfig } from './types.js';
+
 function log(msg: string): void {
   console.error(`[codex-app-server] ${msg}`);
 }
@@ -355,19 +357,21 @@ export async function startCodexTurn(server: AppServer, params: TurnParams): Pro
 // We rewrite it on every spawn from whatever mcpServers the agent-runner
 // passes in, so the container's config reflects the current host wiring.
 
-export interface CodexMcpServer {
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-}
-
-export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>): void {
+export function writeCodexMcpConfigToml(servers: Record<string, McpServerConfig>): void {
   const codexConfigDir = path.join(process.env.HOME || '/home/node', '.codex');
   fs.mkdirSync(codexConfigDir, { recursive: true });
   const configTomlPath = path.join(codexConfigDir, 'config.toml');
 
   const lines: string[] = [];
+  let written = 0;
   for (const [name, config] of Object.entries(servers)) {
+    // Codex's config.toml only models stdio MCP servers. The host's
+    // McpServerConfig union also carries http/sse variants (which have a `url`
+    // and no `command`); skip those rather than emit a broken stanza.
+    if (!('command' in config)) {
+      log(`Skipping non-stdio MCP server "${name}" — Codex config.toml supports stdio only`);
+      continue;
+    }
     lines.push(`[mcp_servers.${name}]`);
     lines.push('type = "stdio"');
     lines.push(`command = ${tomlBasicString(config.command)}`);
@@ -382,12 +386,74 @@ export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>)
       }
     }
     lines.push('');
+    written++;
   }
 
   fs.writeFileSync(configTomlPath, lines.join('\n'));
-  log(`Wrote MCP config.toml (${Object.keys(servers).length} server(s))`);
+  log(`Wrote MCP config.toml (${written} server(s))`);
 }
 
-export function createCodexConfigOverrides(): string[] {
-  return ['features.use_linux_sandbox_bwrap=false'];
+// ── HTTP-only transport (websocket workaround) ───────────────────────────────
+// Some deployments reach OpenAI/ChatGPT only through a forward proxy that
+// doesn't pass the WebSocket upgrade — so every Responses API call first fails
+// repeatedly with `405 Method Not Allowed` on wss://…/responses before Codex
+// falls back to HTTP. The clean fix is `supports_websockets=false`, but Codex
+// won't let it be set on the built-in `openai` provider (reserved id; see
+// openai/codex#13103). The documented workaround is to clone the backend as a
+// non-reserved provider with the flag off and point `model_provider` at it.
+
+export interface CodexHttpProvider {
+  id: string;
+  name: string;
+  baseUrl: string;
+  /** true → use the ChatGPT subscription OAuth (auth.json); false → API key. */
+  requiresOpenAiAuth: boolean;
+  /** env var holding the API key, for non-subscription auth. */
+  envKey?: string;
+}
+
+/**
+ * Pick an HTTP-only provider clone for the current auth mode, or null to leave
+ * Codex's defaults untouched (BYO endpoints manage their own transport).
+ */
+export function resolveHttpOnlyProvider(env: Record<string, string | undefined> = {}): CodexHttpProvider | null {
+  // A user-supplied OpenAI-compatible endpoint sets its own base URL and almost
+  // never attempts the Responses WS upgrade; don't second-guess it.
+  if (env.OPENAI_BASE_URL) return null;
+  // Raw API-key auth → the public API over HTTP.
+  if (env.OPENAI_API_KEY) {
+    return {
+      id: 'openai-http',
+      name: 'OpenAI (HTTP)',
+      baseUrl: 'https://api.openai.com/v1',
+      requiresOpenAiAuth: false,
+      envKey: 'OPENAI_API_KEY',
+    };
+  }
+  // Default: ChatGPT subscription (auth.json) → the Codex backend over HTTP.
+  return {
+    id: 'chatgpt-http',
+    name: 'ChatGPT (HTTP)',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    requiresOpenAiAuth: true,
+  };
+}
+
+export function createCodexConfigOverrides(httpProvider: CodexHttpProvider | null = null): string[] {
+  const overrides = ['features.use_linux_sandbox_bwrap=false'];
+  if (httpProvider) {
+    const { id } = httpProvider;
+    overrides.push(
+      `model_provider=${id}`,
+      `model_providers.${id}.name=${httpProvider.name}`,
+      `model_providers.${id}.base_url=${httpProvider.baseUrl}`,
+      `model_providers.${id}.wire_api=responses`,
+      `model_providers.${id}.requires_openai_auth=${httpProvider.requiresOpenAiAuth}`,
+      `model_providers.${id}.supports_websockets=false`,
+    );
+    if (httpProvider.envKey) {
+      overrides.push(`model_providers.${id}.env_key=${httpProvider.envKey}`);
+    }
+  }
+  return overrides;
 }

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -17,15 +17,24 @@ import fs from 'fs';
 import path from 'path';
 
 import { registerProvider } from './provider-registry.js';
-import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import type {
+  AgentProvider,
+  AgentQuery,
+  McpServerConfig,
+  ProviderEvent,
+  ProviderOptions,
+  QueryInput,
+} from './types.js';
 import {
   type AppServer,
+  type CodexHttpProvider,
   type JsonRpcNotification,
   STALE_THREAD_RE,
   attachCodexAutoApproval,
   createCodexConfigOverrides,
   initializeCodexAppServer,
   killCodexAppServer,
+  resolveHttpOnlyProvider,
   spawnCodexAppServer,
   startCodexTurn,
   startOrResumeCodexThread,
@@ -101,12 +110,14 @@ function composeBaseInstructions(promptAddendum: string | undefined): string | u
 export class CodexProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
-  private readonly mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  private readonly mcpServers: Record<string, McpServerConfig>;
   private readonly model: string;
+  private readonly httpProvider: CodexHttpProvider | null;
 
   constructor(options: ProviderOptions = {}) {
     this.mcpServers = options.mcpServers ?? {};
     this.model = (options.env?.CODEX_MODEL as string | undefined) ?? 'gpt-5.4-mini';
+    this.httpProvider = resolveHttpOnlyProvider(options.env ?? {});
   }
 
   isSessionInvalid(err: unknown): boolean {
@@ -132,7 +143,7 @@ export class CodexProvider implements AgentProvider {
       // query active per batch of pending messages and ends it on idle, so
       // spawn-per-query matches that cadence naturally.
       writeCodexMcpConfigToml(self.mcpServers);
-      const server = spawnCodexAppServer(createCodexConfigOverrides());
+      const server = spawnCodexAppServer(createCodexConfigOverrides(self.httpProvider));
       attachCodexAutoApproval(server);
 
       let threadId: string | undefined = input.continuation;


### PR DESCRIPTION
## What

Two related fixes to the Codex provider on the `providers` branch.

### 1. MCP config — `McpServerConfig` union compatibility

Trunk's `McpServerConfig` evolved into a `stdio | http | sse` union with optional `args`/`env`, but the Codex provider files still assumed the old stdio-only interface (`{ command; args; env }`, all required). So when `/add-codex` copies these files onto a current install, `container/agent-runner` no longer typechecks:

```
codex.ts: Type 'Record<string, McpServerConfig>' is not assignable to
  type 'Record<string, { command: string; args: string[]; env: ... }>'.
```

Fix: use `McpServerConfig` directly, and narrow `writeCodexMcpConfigToml()` to stdio servers (Codex's `config.toml` only models stdio). http/sse servers are skipped with a log rather than emitting a broken `[mcp_servers.*]` stanza.

### 2. HTTP-only transport behind a forward proxy

When the container reaches OpenAI/ChatGPT only through a forward proxy that doesn't pass the WebSocket upgrade, every Responses API call first fails repeatedly with `405 Method Not Allowed` on `wss://…/responses` before Codex falls back to HTTP — adding latency and log noise to every turn.

The clean fix, `supports_websockets = false`, can't be applied to the built-in `openai` provider (reserved id — see [openai/codex#13103](https://github.com/openai/codex/issues/13103)). The documented workaround is to clone the backend as a **non-reserved** provider with the flag off and point `model_provider` at it. `resolveHttpOnlyProvider()` does this per auth mode:

| Auth | Provider id | base_url | notes |
|------|-------------|----------|-------|
| ChatGPT subscription (`auth.json`) | `chatgpt-http` | `https://chatgpt.com/backend-api/codex` | `requires_openai_auth=true` |
| API key (`OPENAI_API_KEY`) | `openai-http` | `https://api.openai.com/v1` | `env_key=OPENAI_API_KEY` |
| BYO (`OPENAI_BASE_URL`) | — | — | left untouched |

## Testing

- `bun run typecheck` (agent-runner) — clean
- `bun test src/providers/codex.factory.test.ts src/providers/codex-app-server.test.ts` — 16/16 pass
- Verified end-to-end on a live install: a ChatGPT-subscription Codex turn completes with **0** websocket errors, and `config.toml` correctly skips an `http` MCP server.

## Note for maintainers

This branch trails `main` on `container/agent-runner/src/providers/types.ts` — it's missing the `McpServerConfig` union (fix #1 makes the provider forward-compatible either way), and also `ProviderOptions.model`/`effort` and `AgentProvider.maybeRotateContinuation`. A sync with main would additionally let the Codex provider honor per-group `model`/`effort` (it currently ignores both and only reads `CODEX_MODEL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
