### PR TITLE
fix(add-slack): patch Slack 3000-char section-block limit (invalid_blocks drops long messages)

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -18,6 +18,7 @@ Skip to **Credentials** if all of these are already in place:
 - `src/channels/slack.ts` exists
 - `src/channels/index.ts` contains `import './slack.js';`
 - `@chat-adapter/slack` is listed in `package.json` dependencies
+- `patches/@chat-adapter__slack@4.27.0.patch` exists and is registered under `patchedDependencies` in `pnpm-workspace.yaml`
 
 Otherwise continue. Every step below is safe to re-run.
 
@@ -41,11 +42,39 @@ Append to `src/channels/index.ts` (skip if the line is already present):
 import './slack.js';
 ```
 
-### 4. Install the adapter package (pinned)
+### 4. Install the adapter package (pinned, with the Slack 3000-char fix)
+
+Vercel's Chat SDK (`@chat-adapter/slack`) builds Slack `section` blocks with no
+length cap. Slack rejects the **entire** message if any section's text exceeds
+3000 chars (`invalid_blocks`), so long agent replies are silently dropped. The
+bug is unfixed upstream through at least 4.30.0, so we carry a pnpm patch that
+splits oversized `section`/`context` blocks at newline/word boundaries, caps
+`header` text at 150 chars, and guards Slack's 50-block-per-message limit.
+
+Copy the patch in:
 
 ```bash
-pnpm install @chat-adapter/slack@4.26.0
+mkdir -p patches
+git show origin/channels:patches/@chat-adapter__slack@4.27.0.patch > 'patches/@chat-adapter__slack@4.27.0.patch'
 ```
+
+Register it under `patchedDependencies` in `pnpm-workspace.yaml` (create the key if it doesn't exist):
+
+```yaml
+patchedDependencies:
+  '@chat-adapter/slack@4.27.0': patches/@chat-adapter__slack@4.27.0.patch
+```
+
+Then install — pnpm applies the patch during install:
+
+```bash
+pnpm install @chat-adapter/slack@4.27.0
+```
+
+> **Maintenance:** the patch is version-locked to `4.27.0`. If you bump the
+> package, regenerate it (`pnpm patch @chat-adapter/slack@<new>`, re-add the
+> `splitOversizedSectionBlocks` post-processor in `cardToBlockKit`) or drop it
+> once the fix lands upstream in [vercel/chat](https://github.com/vercel/chat).
 
 ### 5. Build
 

--- a/patches/@chat-adapter__slack@4.27.0.patch
+++ b/patches/@chat-adapter__slack@4.27.0.patch
@@ -1,0 +1,76 @@
+diff --git a/dist/index.js b/dist/index.js
+index e1d9675be93dfbd8a1e128edb9c2db0448b18109..6f8802199ed80d0ca659c3d598f162dc68ab34fe 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -32,6 +32,62 @@ import {
+ } from "@chat-adapter/shared";
+ import { cardChildToFallbackText, tableElementToAscii } from "chat";
+ var convertEmoji = createEmojiConverter("slack");
++var SLACK_SECTION_TEXT_LIMIT = 3000;
++var SLACK_SECTION_SAFE_LIMIT = 2900;
++var SLACK_HEADER_TEXT_LIMIT = 150;
++var SLACK_MAX_BLOCKS = 50;
++function chunkMrkdwnText(text, max) {
++  const chunks = [];
++  let remaining = String(text);
++  while (remaining.length > max) {
++    let cut = remaining.lastIndexOf("\n", max);
++    if (cut < max * 0.5) {
++      const space = remaining.lastIndexOf(" ", max);
++      cut = space > max * 0.5 ? space : max;
++    }
++    chunks.push(remaining.slice(0, cut));
++    remaining = remaining.slice(cut).replace(/^[\n ]+/, "");
++  }
++  if (remaining.length > 0) chunks.push(remaining);
++  return chunks;
++}
++function splitOversizedSectionBlocks(blocks) {
++  const out = [];
++  for (const block of blocks) {
++    if (block && block.type === "section" && block.text && typeof block.text.text === "string" && block.text.text.length > SLACK_SECTION_TEXT_LIMIT) {
++      for (const part of chunkMrkdwnText(block.text.text, SLACK_SECTION_SAFE_LIMIT)) {
++        out.push({ ...block, text: { ...block.text, text: part } });
++      }
++      continue;
++    }
++    if (block && block.type === "context" && Array.isArray(block.elements) && block.elements.some((el) => el && typeof el.text === "string" && el.text.length > SLACK_SECTION_TEXT_LIMIT)) {
++      for (const el of block.elements) {
++        if (el && typeof el.text === "string" && el.text.length > SLACK_SECTION_TEXT_LIMIT) {
++          for (const part of chunkMrkdwnText(el.text, SLACK_SECTION_SAFE_LIMIT)) {
++            out.push({ type: "context", elements: [{ ...el, text: part }] });
++          }
++        } else {
++          out.push({ type: "context", elements: [el] });
++        }
++      }
++      continue;
++    }
++    if (block && block.type === "header" && block.text && typeof block.text.text === "string" && block.text.text.length > SLACK_HEADER_TEXT_LIMIT) {
++      out.push({ ...block, text: { ...block.text, text: block.text.text.slice(0, SLACK_HEADER_TEXT_LIMIT) } });
++      continue;
++    }
++    out.push(block);
++  }
++  // Slack rejects messages with more than 50 blocks; splitting could newly
++  // exceed this on very long messages. Truncate rather than have Slack reject
++  // the whole message (the original failure mode).
++  if (out.length > SLACK_MAX_BLOCKS) {
++    const kept = out.slice(0, SLACK_MAX_BLOCKS - 1);
++    kept.push({ type: "context", elements: [{ type: "mrkdwn", text: "_…message truncated (too long for a single Slack post)_" }] });
++    return kept;
++  }
++  return out;
++}
+ function cardToBlockKit(card) {
+   const blocks = [];
+   if (card.title) {
+@@ -67,7 +123,7 @@ function cardToBlockKit(card) {
+     const childBlocks = convertChildToBlocks(child, state);
+     blocks.push(...childBlocks);
+   }
+-  return blocks;
++  return splitOversizedSectionBlocks(blocks);
+ }
+ function convertChildToBlocks(child, state) {
+   switch (child.type) {


### PR DESCRIPTION
## Problem

Vercel's Chat SDK (`@chat-adapter/slack`, which `/add-slack` installs) builds Slack `section` blocks with **no length cap**. Slack enforces a hard 3000-char limit per `section` block's `text.text`; if any section exceeds it, `chat.postMessage` rejects the **entire** message with `invalid_blocks`:

```
must be less than 3001 characters [json-pointer:/blocks/N/text/text]
failed to match all allowed schemas [json-pointer:/blocks/N/text]
```

Long agent replies are silently dropped — the message fails permanently after retries and the user receives nothing. Reproduced with a ~9.5k-char structured reply (headers + `---` dividers + long paragraphs). The bug is in the dependency and is **unfixed upstream through `@chat-adapter/slack@4.30.0`**, so bumping the package doesn't help.

## Fix

`/add-slack` now ships a pnpm patch on `@chat-adapter/slack@4.27.0` that post-processes `cardToBlockKit` output (the single block-assembly point feeding all send paths) via a `splitOversizedSectionBlocks` pass:

- splits oversized `section`/`context` mrkdwn at newline/word boundaries into ~2900-char chunks
- truncates `header` `plain_text` to Slack's 150-char limit
- caps total blocks at 50 (Slack's per-message ceiling), to avoid trading one `invalid_blocks` cause for another

Verified end-to-end against the real patched module: two 6,069-char sections → 6 compliant blocks (max 2,887 chars), none over the limit; short text untouched; no-whitespace blobs hard-cut without data loss.

The skill gains: a copy step for the patch, a `patchedDependencies` registration step, and a pre-flight idempotency check. Pinned version bumped `4.26.0` → `4.27.0` to match the validated patch.

## Maintenance

The patch is version-locked. It must be regenerated on any `@chat-adapter/slack` bump, and dropped once the fix lands upstream in [vercel/chat](https://github.com/vercel/chat) — noted inline in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)