### PR TITLE
fix(container-runner): add NO_PROXY to bypass OneCLI proxy for local services

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -432,6 +432,22 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // NO_PROXY — bypass gateway for local services.
+  // OneCLI container-config injects HTTPS_PROXY but NOT NO_PROXY, so all
+  // container HTTP routes through the gateway — including local MCP traffic
+  // to QMD (host.docker.internal:8181) which hangs.
+  // Merge with any provider-contributed NO_PROXY to avoid clobbering
+  // provider-specific bypass entries (e.g. OpenCode endpoints).
+  const LOCAL_NO_PROXY = 'host.docker.internal,localhost,127.0.0.1,::1';
+  const existingNoProxy = providerContribution.env?.NO_PROXY;
+  if (existingNoProxy) {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY},${existingNoProxy}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY},${existingNoProxy}`);
+  } else {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY}`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

OneCLI `applyContainerConfig` injects `HTTPS_PROXY` but not `NO_PROXY`. All container HTTP routes through the gateway — local MCP traffic to QMD (`host.docker.internal:8181`) hangs.

Adds `NO_PROXY`/`no_proxy` after the OneCLI apply block, includes `::1` for IPv6 loopback, and merges with provider-contributed `NO_PROXY`. Takes effect on next container spawn.

## Related upstream issues

Closes #1906 — Ollama MCP stdio server fails behind OneCLI gateway. Directly fixed by this PR. The issue reports that OneCLI's plain-HTTP forward-proxy path rejects all requests to local services, and confirms that NO_PROXY=host.docker.internal resolves it. Our fix sets NO_PROXY for all local services (host.docker.internal,localhost,127.0.0.1,::1).

## Tested

`pnpm run build` ✅
`pnpm test` 332/332 ✅