### PR TITLE
fix(scheduling): retry pre-task script once on failure with diagnostics

### DIFF
--- a/container/agent-runner/src/scheduling/task-script.ts
+++ b/container/agent-runner/src/scheduling/task-script.ts
@@ -6,17 +6,24 @@ import { touchHeartbeat } from '../db/connection.js';
 
 const SCRIPT_TIMEOUT_MS = 30_000;
 const SCRIPT_MAX_BUFFER = 1024 * 1024;
+const SCRIPT_RETRY_DELAY_MS = 3_000;
 
 export interface ScriptResult {
   wakeAgent: boolean;
   data?: unknown;
 }
 
+export interface ScriptFailure {
+  reason: string; // Human-readable: error.message, 'no output', etc.
+  exitCode?: number; // Bash exit code (e.g. curl 6=DNS, 28=timeout)
+  nodeError?: string; // Node error code ('ENOENT', 'ETIMEDOUT')
+}
+
 function log(msg: string): void {
   console.error(`[task-script] ${msg}`);
 }
 
-export async function runScript(script: string, taskId: string): Promise<ScriptResult | null> {
+export async function runScript(script: string, taskId: string): Promise<ScriptResult | ScriptFailure> {
   const scriptPath = path.join('/tmp', `task-script-${taskId}.sh`);
   fs.writeFileSync(scriptPath, script, { mode: 0o755 });
 
@@ -38,26 +45,30 @@ export async function runScript(script: string, taskId: string): Promise<ScriptR
 
         if (error) {
           log(`[${taskId}] error: ${error.message}`);
-          return resolve(null);
+          return resolve({
+            reason: error.message,
+            exitCode: 'status' in error ? (error as { status?: number }).status : undefined,
+            nodeError: 'code' in error ? (error as { code?: string }).code : undefined,
+          });
         }
 
         const lines = stdout.trim().split('\n');
         const lastLine = lines[lines.length - 1];
         if (!lastLine) {
           log(`[${taskId}] no output`);
-          return resolve(null);
+          return resolve({ reason: 'no output' });
         }
 
         try {
           const result = JSON.parse(lastLine);
           if (typeof result.wakeAgent !== 'boolean') {
             log(`[${taskId}] output missing wakeAgent boolean: ${lastLine.slice(0, 200)}`);
-            return resolve(null);
+            return resolve({ reason: 'output missing wakeAgent boolean' });
           }
           resolve(result as ScriptResult);
         } catch {
           log(`[${taskId}] output is not valid JSON: ${lastLine.slice(0, 200)}`);
-          resolve(null);
+          resolve({ reason: 'invalid JSON' });
         }
       },
     );
@@ -102,12 +113,29 @@ export async function applyPreTaskScripts(messages: MessageInRow[]): Promise<Tas
 
     log(`running script for task ${msg.id}`);
     touchHeartbeat();
-    const result = await runScript(script, msg.id);
+    let result = await runScript(script, msg.id);
     touchHeartbeat();
 
-    if (!result || !result.wakeAgent) {
-      const reason = result ? 'wakeAgent=false' : 'script error/no output';
-      log(`task ${msg.id} skipped: ${reason}`);
+    // Retry once on failure. We retry all failures (not just "transient")
+    // because perfect classification is impossible — network failures like
+    // curl exit 6/7/28 look identical to bash syntax errors from execFile's
+    // perspective — and the cost of a false retry is low (max 30s).
+    if ('reason' in result) {
+      log(`task ${msg.id} script failed (${result.reason}), retrying in ${SCRIPT_RETRY_DELAY_MS / 1000}s`);
+      touchHeartbeat();
+      await new Promise((r) => setTimeout(r, SCRIPT_RETRY_DELAY_MS));
+      result = await runScript(script, msg.id);
+      touchHeartbeat();
+    }
+
+    if ('reason' in result) {
+      log(`task ${msg.id} skipped: script error (${result.reason})`);
+      skipped.push(msg.id);
+      continue;
+    }
+
+    if (!result.wakeAgent) {
+      log(`task ${msg.id} skipped: wakeAgent=false`);
       skipped.push(msg.id);
       continue;
     }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Pre-task scripts can fail transiently (DNS, network timeout) and permanently skip the task for that scheduling occurrence — `markCompleted` is terminal and host-sweep only retries `processing`-status rows. `runScript` also returns `null` for all failure modes with no diagnostic info.

Retries once after 3s delay. Replaces `null` with `ScriptFailure { reason, exitCode?, nodeError? }`. Heartbeat touched before sleep to guard against `CLAIM_STUCK_MS` ceiling. Retries all failures (not just transient) since perfect classification is impossible and false retry cost is low (max 30s).

## Related upstream issues

The closest upstream issues are tangential:
- **#1718** — v1 `outputChain` hang (doesn't exist in v2 architecture)
- **#2032** — follow-up poll bypasses script gating (different bug)
- **#2492** — silent-fail detection/alerting (our retry partially mitigates the transient subset, but the issue is about detection, not retry)

No `Closes` or `Related` tags to add for this PR.

## Tested

`pnpm run build` ✅
`bun run typecheck` ✅
`pnpm test` 332/332 ✅
`bun test` 101/101 ✅