### PR TITLE
fix(scheduling): re-arm recurrence when a run fails permanently

### DIFF
--- a/src/modules/scheduling/db.test.ts
+++ b/src/modules/scheduling/db.test.ts
@@ -16,7 +16,7 @@ import {
   pauseTask,
   resumeTask,
   updateTask,
-  getCompletedRecurring,
+  getFinishedRecurring,
   type RecurringMessage,
 } from './db.js';
 
@@ -99,12 +99,12 @@ describe('cancelTask / pauseTask / resumeTask series matching', () => {
     db.close();
   });
 
-  it('cancelled task is not picked up by getCompletedRecurring', () => {
+  it('cancelled task is not picked up by getFinishedRecurring', () => {
     const db = freshDb();
     insertBasicTask(db, 'task-1', '0 9 * * *');
     cancelTask(db, 'task-1');
 
-    const recurring = getCompletedRecurring(db);
+    const recurring = getFinishedRecurring(db);
     expect(recurring).toHaveLength(0);
     db.close();
   });

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -119,9 +119,16 @@ export interface RecurringMessage {
   series_id: string;
 }
 
-export function getCompletedRecurring(db: Database.Database): RecurringMessage[] {
+/**
+ * Recurring rows whose run has finished — successfully ('completed') or after
+ * exhausting retries ('failed') — and that still carry a recurrence expression.
+ * Failed rows must be included: nothing else ever re-schedules a series, so
+ * skipping them would let a single bad run (container crash, max-retry
+ * exhaustion) silently kill the recurring task forever.
+ */
+export function getFinishedRecurring(db: Database.Database): RecurringMessage[] {
   return db
-    .prepare("SELECT * FROM messages_in WHERE status = 'completed' AND recurrence IS NOT NULL")
+    .prepare("SELECT * FROM messages_in WHERE status IN ('completed', 'failed') AND recurrence IS NOT NULL")
     .all() as RecurringMessage[];
 }
 

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -77,6 +77,42 @@ describe('handleRecurrence', () => {
     expect(new Date(follow.process_after).getTime()).toBeGreaterThan(Date.now());
   });
 
+  it('clones a failed recurring task so a permanently-failed run does not kill the series', async () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-1',
+      processAfter: '2020-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'daily digest' }),
+    });
+    // As host-sweep's markMessageFailed would leave it after max retries.
+    db.prepare(`UPDATE messages_in SET status='failed', tries=5 WHERE id='task-1'`).run();
+
+    await handleRecurrence(db, fakeSession());
+
+    const rows = db
+      .prepare(`SELECT id, status, process_after, recurrence, series_id FROM messages_in ORDER BY seq`)
+      .all() as Array<{
+      id: string;
+      status: string;
+      process_after: string;
+      recurrence: string | null;
+      series_id: string;
+    }>;
+    expect(rows).toHaveLength(2);
+    const original = rows.find((r) => r.id === 'task-1')!;
+    const follow = rows.find((r) => r.id !== 'task-1')!;
+    // Recurrence cleared on the failed row so it isn't re-cloned next tick.
+    expect(original.recurrence).toBeNull();
+    expect(follow.status).toBe('pending');
+    expect(follow.recurrence).toBe('0 9 * * *');
+    expect(follow.series_id).toBe('task-1');
+    expect(new Date(follow.process_after).getTime()).toBeGreaterThan(Date.now());
+  });
+
   it('does not clone rows whose recurrence is already cleared', async () => {
     const db = freshDb();
     insertTask(db, {

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -1,10 +1,12 @@
 /**
  * Sweep hook for recurring tasks.
  *
- * Every sweep tick, find `messages_in` rows that are `completed` AND still
- * have a `recurrence` cron expression. For each, compute the next run via
- * cron-parser, insert a fresh pending row (copying series_id forward), then
- * clear the recurrence on the original so it isn't re-cloned next tick.
+ * Every sweep tick, find `messages_in` rows that finished (`completed` or
+ * `failed`) AND still have a `recurrence` cron expression. For each, compute
+ * the next run via cron-parser, insert a fresh pending row (copying series_id
+ * forward), then clear the recurrence on the original so it isn't re-cloned
+ * next tick. Failed rows fan out too — a run that exhausted its retries must
+ * not kill the series; it just misses that one occurrence.
  *
  * Called from `src/host-sweep.ts` inside `MODULE-HOOK:scheduling-recurrence`.
  * When scheduling ships inline (current state through PR #7), the hook is a
@@ -16,10 +18,10 @@ import type Database from 'better-sqlite3';
 import { TIMEZONE } from '../../config.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
-import { clearRecurrence, getCompletedRecurring, insertRecurrence } from './db.js';
+import { clearRecurrence, getFinishedRecurring, insertRecurrence } from './db.js';
 
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
-  const recurring = getCompletedRecurring(inDb);
+  const recurring = getFinishedRecurring(inDb);
 
   for (const msg of recurring) {
     try {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** `handleRecurrence` now fans out the next occurrence from `failed` recurring rows, not just `completed` ones. (`getCompletedRecurring` → `getFinishedRecurring`.)

**Why:** When a recurring task row exhausts its retries, host-sweep marks it `failed` — but the recurrence fanout only looked at `completed` rows, and nothing else ever re-schedules a series. One bad run (container crash loop, max-retry exhaustion) permanently and silently kills the recurring task. The user only finds out when the expected output stops arriving, and the only fix is asking the agent to re-create the schedule from scratch.

Observed in the wild: a daily `0 9 * * *` brand-monitoring task hit a container crash loop on one run, failed after 5 retries, and the series never fired again.

**How it works:** A failed run now costs the series exactly one missed occurrence instead of its life. Cancelled tasks are unaffected — `cancelTask` clears `recurrence`, so they remain excluded regardless of status.

**How it was tested:** New regression test (failed recurring row → next occurrence inserted, series_id preserved, recurrence cleared on the failed row). `pnpm exec vitest run src/modules/scheduling/` — 14/14 pass. `pnpm run build` clean.

## Related

- #2492 (silent task failures — this fixes the "series dies" half of that problem at the source)
- #2398 (catch-up policy — orthogonal, but both are about missed-run semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)