### PR TITLE
fix(scheduling): surface permanently-failed scheduled tasks to the user

### DIFF
--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -200,10 +200,13 @@ async function sweepSession(session: Session): Promise<void> {
       resetStuckProcessingRows(inDb, outDb, session, 'container not running');
     }
 
-    // 5. Recurrence fanout for completed recurring tasks.
+    // 5. Recurrence fanout for completed recurring tasks + notices for tasks
+    // that exhausted their retries (so permanent failures aren't silent).
     // MODULE-HOOK:scheduling-recurrence:start
     const { handleRecurrence } = await import('./modules/scheduling/recurrence.js');
     await handleRecurrence(inDb, session);
+    const { notifyFailedTasks } = await import('./modules/scheduling/failure-notice.js');
+    notifyFailedTasks(inDb, session);
     // MODULE-HOOK:scheduling-recurrence:end
   } finally {
     inDb.close();

--- a/src/modules/scheduling/failure-notice.test.ts
+++ b/src/modules/scheduling/failure-notice.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for `notifyFailedTasks` — the sweep hook that surfaces permanently-
+ * failed scheduled tasks to the user instead of letting them die silently.
+ *
+ * Core invariants:
+ *  - a freshly failed task gets exactly one pending notice task, with the
+ *    same routing, instructing the agent to inform the user and offer a rerun
+ *  - the hook is idempotent across sweep ticks
+ *  - a failed notice never cascades into another notice
+ *  - stale failures (older than the 24h window) are not noticed
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ensureSchema, openInboundDb } from '../../db/session-db.js';
+import { insertTask } from './db.js';
+import { notifyFailedTasks } from './failure-notice.js';
+import type { Session } from '../../types.js';
+
+const TEST_DIR = '/tmp/nanoclaw-failure-notice-test';
+const DB_PATH = path.join(TEST_DIR, 'inbound.db');
+
+function freshDb() {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  ensureSchema(DB_PATH, 'inbound');
+  return openInboundDb(DB_PATH);
+}
+
+function fakeSession(): Session {
+  return {
+    id: 'sess-test',
+    agent_group_id: 'ag-test',
+    messaging_group_id: 'mg-test',
+    thread_id: null,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    last_active: new Date().toISOString(),
+    container_status: 'stopped',
+  } as Session;
+}
+
+function insertFailedTask(
+  db: ReturnType<typeof openInboundDb>,
+  id: string,
+  opts: { processAfter?: string; recurrence?: string | null; threadId?: string | null } = {},
+) {
+  insertTask(db, {
+    id,
+    processAfter: opts.processAfter ?? new Date().toISOString(),
+    recurrence: opts.recurrence ?? null,
+    platformId: 'user-123',
+    channelType: 'telegram',
+    threadId: opts.threadId ?? 'telegram:123',
+    content: JSON.stringify({ prompt: 'run the daily digest' }),
+  });
+  db.prepare("UPDATE messages_in SET status = 'failed', tries = 5 WHERE id = ?").run(id);
+}
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('notifyFailedTasks', () => {
+  it('inserts a pending notice task with the same routing when a task permanently fails', () => {
+    const db = freshDb();
+    insertFailedTask(db, 'task-1');
+
+    notifyFailedTasks(db, fakeSession());
+
+    const notice = db.prepare("SELECT * FROM messages_in WHERE id = 'task-failnotice-task-1'").get() as Record<
+      string,
+      unknown
+    >;
+    expect(notice).toBeDefined();
+    expect(notice.status).toBe('pending');
+    expect(notice.kind).toBe('task');
+    expect(notice.recurrence).toBeNull();
+    expect(notice.platform_id).toBe('user-123');
+    expect(notice.channel_type).toBe('telegram');
+    expect(notice.thread_id).toBe('telegram:123');
+
+    const prompt = (JSON.parse(notice.content as string) as { prompt: string }).prompt;
+    expect(prompt).toContain('task-1');
+    expect(prompt).toContain('failed permanently after 5 attempts');
+    expect(prompt).toContain('run the daily digest');
+    db.close();
+  });
+
+  it('is idempotent — repeated sweeps produce a single notice', () => {
+    const db = freshDb();
+    insertFailedTask(db, 'task-1');
+
+    notifyFailedTasks(db, fakeSession());
+    notifyFailedTasks(db, fakeSession());
+    notifyFailedTasks(db, fakeSession());
+
+    const count = (
+      db.prepare("SELECT COUNT(*) AS c FROM messages_in WHERE id LIKE 'task-failnotice-%'").get() as { c: number }
+    ).c;
+    expect(count).toBe(1);
+    db.close();
+  });
+
+  it('does not cascade — a failed notice task never generates another notice', () => {
+    const db = freshDb();
+    insertFailedTask(db, 'task-1');
+    notifyFailedTasks(db, fakeSession());
+
+    // The notice itself exhausts its retries too.
+    db.prepare("UPDATE messages_in SET status = 'failed', tries = 5 WHERE id = 'task-failnotice-task-1'").run();
+    notifyFailedTasks(db, fakeSession());
+
+    const count = (
+      db.prepare("SELECT COUNT(*) AS c FROM messages_in WHERE id LIKE 'task-failnotice-%'").get() as { c: number }
+    ).c;
+    expect(count).toBe(1);
+    db.close();
+  });
+
+  it('ignores failures older than the 24h notice window', () => {
+    const db = freshDb();
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    insertFailedTask(db, 'task-old', { processAfter: threeDaysAgo });
+
+    notifyFailedTasks(db, fakeSession());
+
+    const count = (
+      db.prepare("SELECT COUNT(*) AS c FROM messages_in WHERE id LIKE 'task-failnotice-%'").get() as { c: number }
+    ).c;
+    expect(count).toBe(0);
+    db.close();
+  });
+
+  it('ignores tasks that completed or are still pending', () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-done',
+      processAfter: new Date().toISOString(),
+      recurrence: null,
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'noop' }),
+    });
+    db.prepare("UPDATE messages_in SET status = 'completed' WHERE id = 'task-done'").run();
+    insertTask(db, {
+      id: 'task-waiting',
+      processAfter: new Date().toISOString(),
+      recurrence: null,
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'noop' }),
+    });
+
+    notifyFailedTasks(db, fakeSession());
+
+    const count = (
+      db.prepare("SELECT COUNT(*) AS c FROM messages_in WHERE id LIKE 'task-failnotice-%'").get() as { c: number }
+    ).c;
+    expect(count).toBe(0);
+    db.close();
+  });
+});

--- a/src/modules/scheduling/failure-notice.ts
+++ b/src/modules/scheduling/failure-notice.ts
@@ -1,0 +1,105 @@
+/**
+ * Sweep hook for permanently-failed scheduled tasks.
+ *
+ * When a task row exhausts its retries, host-sweep marks it 'failed' and
+ * writes a log line — nothing else. The user gets zero signal: the scheduled
+ * run simply never produces output, and the agent doesn't know either. The
+ * failure is only discoverable by querying inbound.db by hand.
+ *
+ * This hook closes that gap with the existing message flow: for each freshly
+ * failed task row, insert a one-shot notice task (same routing) instructing
+ * the agent to tell the user the run failed and offer to execute it now. The
+ * notice rides the normal due-message wake — no new delivery path.
+ *
+ * Loop/spam guards:
+ *  - Notice ids are deterministic (`task-failnotice-<failed id>`), and a
+ *    NOT EXISTS clause skips rows that already have one → idempotent across
+ *    sweep ticks.
+ *  - Notice rows themselves are excluded from the scan → a failed notice
+ *    never cascades into another notice.
+ *  - Only failures from the last 24h are noticed → deploying this on an
+ *    install with old failed rows doesn't flood the user.
+ *
+ * Called from `src/host-sweep.ts` inside `MODULE-HOOK:scheduling-recurrence`.
+ */
+import type Database from 'better-sqlite3';
+
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+import { insertTask } from './db.js';
+
+const NOTICE_ID_PREFIX = 'task-failnotice-';
+
+interface FailedTaskRow {
+  id: string;
+  tries: number;
+  process_after: string | null;
+  recurrence: string | null;
+  platform_id: string | null;
+  channel_type: string | null;
+  thread_id: string | null;
+  content: string;
+}
+
+export function notifyFailedTasks(inDb: Database.Database, session: Session): void {
+  const failed = inDb
+    .prepare(
+      `SELECT id, tries, process_after, recurrence, platform_id, channel_type, thread_id, content
+       FROM messages_in
+       WHERE status = 'failed'
+         AND kind = 'task'
+         AND id NOT LIKE '${NOTICE_ID_PREFIX}%'
+         AND datetime(COALESCE(process_after, timestamp)) > datetime('now', '-1 day')
+         AND NOT EXISTS (
+           SELECT 1 FROM messages_in n WHERE n.id = '${NOTICE_ID_PREFIX}' || messages_in.id
+         )`,
+    )
+    .all() as FailedTaskRow[];
+
+  for (const msg of failed) {
+    try {
+      insertTask(inDb, {
+        id: `${NOTICE_ID_PREFIX}${msg.id}`,
+        processAfter: new Date().toISOString(),
+        recurrence: null,
+        platformId: msg.platform_id,
+        channelType: msg.channel_type,
+        threadId: msg.thread_id,
+        content: JSON.stringify({ prompt: buildNoticePrompt(msg) }),
+      });
+
+      log.warn('Inserted failure notice for permanently-failed task', {
+        failedTaskId: msg.id,
+        tries: msg.tries,
+        sessionId: session.id,
+      });
+    } catch (err) {
+      log.error('Failed to insert task failure notice', { messageId: msg.id, err });
+    }
+  }
+}
+
+function buildNoticePrompt(msg: FailedTaskRow): string {
+  let originalPrompt = '';
+  try {
+    originalPrompt = (JSON.parse(msg.content) as { prompt?: string }).prompt ?? '';
+  } catch {
+    // Malformed content — the notice still tells the user the run failed.
+  }
+
+  return [
+    `A scheduled task of yours failed permanently after ${msg.tries} attempts and did not run.`,
+    `Task id: ${msg.id}`,
+    `Scheduled for: ${msg.process_after ?? 'immediate execution'}`,
+    msg.recurrence
+      ? `Recurrence: ${msg.recurrence} (check list_tasks to confirm the series is still scheduled)`
+      : 'Recurrence: none (one-shot task)',
+    '',
+    'Original task instructions:',
+    '---',
+    originalPrompt,
+    '---',
+    '',
+    'Tell the user this scheduled run failed and produced no results. Ask whether they want you to run it now — if they confirm, follow the original task instructions above.',
+  ].join('\n');
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** A new scheduling-module sweep hook, `notifyFailedTasks`, that turns a permanently-failed scheduled task into a notice the agent delivers to the user — instead of a log line nobody reads.

**Why:** When a scheduled task exhausts its retries, host-sweep marks it `failed` and logs a warning. That's the only signal. The user never learns the run didn't happen, and the agent doesn't either — when asked "where are today's results?", it has no idea anything failed. The failure is only discoverable by querying `inbound.db` by hand.

**How it works:** Each sweep tick, the hook scans for freshly-failed task rows (last 24h) and inserts a one-shot notice task with the same routing, instructing the agent to tell the user the run failed and offer to execute it now. The notice rides the existing due-message wake — no new delivery path, everything stays a message.

Guards:
- deterministic notice ids (`task-failnotice-<id>`) + `NOT EXISTS` → idempotent across sweep ticks
- notice rows are excluded from the scan → a failed notice never cascades into another notice
- 24h window → deploying this on an install with old failed rows doesn't flood the user

**How it was tested:** 5 new tests covering routing copy, idempotence, cascade guard, the 24h window, and status filtering. `pnpm exec vitest run src/modules/scheduling/ src/host-sweep.test.ts` — 37/37 pass. `pnpm run build` clean.

## Related

- #2492 proposes a full health-monitor agent for this class of problem; this PR is a minimal in-flow fix for the scheduled-task case specifically. Complementary, not competing.
- Pairs with #2678 (failed recurring run no longer kills its series) — together: the series survives, and the user hears about the miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)