### PR TITLE
fix(service): skip linger on per-home-encrypted systems (#2680)

### DIFF
--- a/setup/linger.ts
+++ b/setup/linger.ts
@@ -6,6 +6,8 @@
  * evaluates on macOS (which dispatches to setupLaunchd) or on Linux/WSL
  * installs that fall back to nohup.
  *
+ * callers must gate on Linux; safe-but-wasteful elsewhere
+ *
  * See issue #2680: enabling linger on per-home-encrypted systems
  * (ecryptfs / fscrypt / gocryptfs) causes the user systemd manager to
  * come up at boot before PAM has decrypted ~/.config/systemd/user/, so it

--- a/setup/linger.ts
+++ b/setup/linger.ts
@@ -1,0 +1,198 @@
+/**
+ * Linger management for Linux user-systemd installs.
+ *
+ * This module is Linux-only and intentionally not imported from the top of
+ * service.ts. setupSystemd loads it via dynamic import so its body never
+ * evaluates on macOS (which dispatches to setupLaunchd) or on Linux/WSL
+ * installs that fall back to nohup.
+ *
+ * See issue #2680: enabling linger on per-home-encrypted systems
+ * (ecryptfs / fscrypt / gocryptfs) causes the user systemd manager to
+ * come up at boot before PAM has decrypted ~/.config/systemd/user/, so it
+ * starts with an empty unit table and nanoclaw never launches.
+ */
+import { execFileSync, execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { log } from '../src/log.js';
+import { commandExists } from './platform.js';
+
+export type EncryptedHomeType = 'ecryptfs' | 'fscrypt' | 'gocryptfs';
+
+export interface EncryptedHomeDetection {
+  detected: boolean;
+  type?: EncryptedHomeType;
+  /** Human-readable signal that triggered detection (used in warnings/logs). */
+  signal?: string;
+}
+
+export interface LingerResult {
+  lingerEnabled: boolean;
+  encryptedHome?: EncryptedHomeDetection;
+}
+
+/**
+ * Detect whether $HOME is on per-user-encrypted storage that only gets
+ * decrypted at PAM login (ecryptfs, fscrypt, gocryptfs).
+ *
+ * Block-device encryption (LUKS / dm-crypt) is intentionally NOT a trigger:
+ * those volumes are decrypted before userspace and don't break user systemd
+ * at boot. See issue #2680 for the failure mode this detection guards.
+ *
+ * fscrypt is per-directory with no mount entry and no universal marker file,
+ * so we rely on the `fscrypt` CLI when present. If it isn't installed, we
+ * skip fscrypt detection; there is no safe lightweight probe without it.
+ */
+export function detectEncryptedHome(
+  homeDir: string = os.homedir(),
+): EncryptedHomeDetection {
+  // findmnt: catches ecryptfs and fuse.gocryptfs cleanly via the mount table.
+  // execFileSync (no shell) so a hostile homeDir cannot inject — JSON.stringify
+  // does not escape `$` or backticks, and inside shell double-quotes `\"`
+  // still terminates the string, so the previous execSync form was a
+  // (low-likelihood) injection surface.
+  try {
+    const fstype = execFileSync(
+      'findmnt',
+      ['-n', '-T', homeDir, '-o', 'FSTYPE'],
+      { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' },
+    ).trim();
+    if (fstype === 'ecryptfs') {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `findmnt reports FSTYPE=ecryptfs for ${homeDir}`,
+      };
+    }
+    if (fstype === 'fuse.gocryptfs') {
+      return {
+        detected: true,
+        type: 'gocryptfs',
+        signal: `findmnt reports FSTYPE=fuse.gocryptfs for ${homeDir}`,
+      };
+    }
+  } catch {
+    // findmnt missing or no mount row; fall through to other probes.
+  }
+
+  // ecryptfs marker directories: present on the classic Ubuntu encrypted-home
+  // setup even when findmnt is unavailable.
+  //
+  // NOTE: `~/.Private` can persist after a user migrates *off* an
+  // ecryptfs-encrypted home (the ecryptfs-migrate-home script does not always
+  // remove it), so this check can produce a false positive on a system that
+  // is no longer encrypted. Worst case is linger gets skipped unnecessarily
+  // and the user has to run the recovery command once per boot; harmless but
+  // worth a future flag to override.
+  try {
+    if (fs.existsSync(path.join(homeDir, '.ecryptfs'))) {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `${homeDir}/.ecryptfs exists`,
+      };
+    }
+    if (fs.existsSync(path.join(homeDir, '.Private'))) {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `${homeDir}/.Private exists`,
+      };
+    }
+  } catch {
+    // fs probe failed; ignore.
+  }
+
+  // fscrypt: only reliable detection is the fscrypt CLI. The issue body
+  // specifically warns against marker-file heuristics, and rolling a raw
+  // FS_IOC_GET_ENCRYPTION_POLICY ioctl from Node isn't trivial.
+  if (commandExists('fscrypt')) {
+    try {
+      const out = execFileSync('fscrypt', ['status', homeDir], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+      // `fscrypt status DIR` exits 0 on encrypted dirs and prints lines like
+      // "Policy: ..." / "Unlocked: Yes". Match a couple of fscrypt-specific
+      // tokens rather than the generic word "encrypted" to avoid false
+      // positives on help text.
+      //
+      // Token match (`Policy:` / `Unlocked:`) verified against fscrypt v0.3.4
+      // (google/fscrypt, latest at time of writing). If upstream renames
+      // these fields, this probe goes silent (false-negative — linger gets
+      // enabled and the original #2680 failure mode is back). Re-check the
+      // output format when bumping the supported fscrypt version.
+      if (/policy\s*:/i.test(out) || /unlocked\s*:/i.test(out)) {
+        return {
+          detected: true,
+          type: 'fscrypt',
+          signal: `fscrypt status reports an encryption policy on ${homeDir}`,
+        };
+      }
+    } catch {
+      // Non-zero exit means no fscrypt policy on this dir; ignore.
+    }
+  }
+
+  return { detected: false };
+}
+
+/**
+ * Manage user-systemd lingering.
+ *
+ * Skipped silently on per-home-encrypted systems (ecryptfs / fscrypt /
+ * gocryptfs). On those, linger causes the user manager to come up at boot
+ * before PAM has decrypted ~/.config/systemd/user/, so it starts with an
+ * empty unit table and nanoclaw never launches. See issue #2680.
+ *
+ * `unitName` is the real per-install systemd unit name returned by
+ * getSystemdUnit(projectRoot) (e.g. `nanoclaw-v2-abc123`); it gets
+ * interpolated into the recovery command in the warning so a user who
+ * copy-pastes does not hit `Unit nanoclaw.service not found.`.
+ *
+ * TODO(#2680): item 4 of the suggested fix (a PAM / login-hook self-heal
+ * that runs `systemctl --user start <unitName>` on first login) is not
+ * implemented here. Tracked in the issue.
+ *
+ * Exported (along with `detect` / `exec` overrides) so service.test.ts can
+ * exercise the skip path without shelling out.
+ */
+export function manageUserLinger(
+  unitName: string,
+  detect: () => EncryptedHomeDetection = detectEncryptedHome,
+  exec: (cmd: string) => void = (cmd: string) =>
+    void execSync(cmd, { stdio: 'ignore' }),
+): LingerResult {
+  const detection = detect();
+  if (detection.detected) {
+    log.warn(
+      [
+        `Per-home encryption detected (${detection.type}); skipping`,
+        '`loginctl enable-linger`. With linger enabled on a per-home-encrypted',
+        'system, the user systemd manager starts at boot before PAM has',
+        'decrypted ~/.config/systemd/user/, so it comes up with an empty unit',
+        `table and ${unitName} never launches. Without linger, ${unitName}`,
+        'will start when you log in after each reboot. If the service is not',
+        `running after login, run: systemctl --user daemon-reload &&`,
+        `systemctl --user start ${unitName}. See`,
+        'https://github.com/nanocoai/nanoclaw/issues/2680.',
+      ].join(' '),
+      { type: detection.type, signal: detection.signal, unitName },
+    );
+    return { lingerEnabled: false, encryptedHome: detection };
+  }
+
+  try {
+    exec('loginctl enable-linger');
+    log.info('Enabled loginctl linger for current user');
+    return { lingerEnabled: true };
+  } catch (err) {
+    log.warn(
+      'loginctl enable-linger failed; service may stop on SSH logout',
+      { err },
+    );
+    return { lingerEnabled: false };
+  }
+}

--- a/setup/platform.ts
+++ b/setup/platform.ts
@@ -4,18 +4,9 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
 
 export type Platform = 'macos' | 'linux' | 'unknown';
 export type ServiceManager = 'launchd' | 'systemd' | 'none';
-export type EncryptedHomeType = 'ecryptfs' | 'fscrypt' | 'gocryptfs';
-
-export interface EncryptedHomeDetection {
-  detected: boolean;
-  type?: EncryptedHomeType;
-  /** Human-readable signal that triggered detection (used in warnings/logs). */
-  signal?: string;
-}
 
 export function getPlatform(): Platform {
   const platform = os.platform();
@@ -138,94 +129,4 @@ export function getNodeMajorVersion(): number | null {
   if (!version) return null;
   const major = parseInt(version.split('.')[0], 10);
   return isNaN(major) ? null : major;
-}
-
-/**
- * Detect whether $HOME is on per-user-encrypted storage that only gets
- * decrypted at PAM login (ecryptfs, fscrypt, gocryptfs).
- *
- * Block-device encryption (LUKS / dm-crypt) is intentionally NOT a trigger:
- * those volumes are decrypted before userspace and don't break user systemd
- * at boot. See issue #2680 for the failure mode this detection guards.
- *
- * fscrypt is per-directory with no mount entry and no universal marker file,
- * so we rely on the `fscrypt` CLI when present. If it isn't installed, we
- * skip fscrypt detection; there is no safe lightweight probe without it.
- */
-export function detectEncryptedHome(
-  homeDir: string = os.homedir(),
-): EncryptedHomeDetection {
-  if (getPlatform() !== 'linux') return { detected: false };
-
-  // findmnt: catches ecryptfs and fuse.gocryptfs cleanly via the mount table.
-  try {
-    const fstype = execSync(
-      `findmnt -n -T ${JSON.stringify(homeDir)} -o FSTYPE`,
-      { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' },
-    ).trim();
-    if (fstype === 'ecryptfs') {
-      return {
-        detected: true,
-        type: 'ecryptfs',
-        signal: `findmnt reports FSTYPE=ecryptfs for ${homeDir}`,
-      };
-    }
-    if (fstype === 'fuse.gocryptfs') {
-      return {
-        detected: true,
-        type: 'gocryptfs',
-        signal: `findmnt reports FSTYPE=fuse.gocryptfs for ${homeDir}`,
-      };
-    }
-  } catch {
-    // findmnt missing or no mount row; fall through to other probes.
-  }
-
-  // ecryptfs marker directories: present on the classic Ubuntu encrypted-home
-  // setup even when findmnt is unavailable.
-  try {
-    if (fs.existsSync(path.join(homeDir, '.ecryptfs'))) {
-      return {
-        detected: true,
-        type: 'ecryptfs',
-        signal: `${homeDir}/.ecryptfs exists`,
-      };
-    }
-    if (fs.existsSync(path.join(homeDir, '.Private'))) {
-      return {
-        detected: true,
-        type: 'ecryptfs',
-        signal: `${homeDir}/.Private exists`,
-      };
-    }
-  } catch {
-    // fs probe failed; ignore.
-  }
-
-  // fscrypt: only reliable detection is the fscrypt CLI. The issue body
-  // specifically warns against marker-file heuristics, and rolling a raw
-  // FS_IOC_GET_ENCRYPTION_POLICY ioctl from Node isn't trivial.
-  if (commandExists('fscrypt')) {
-    try {
-      const out = execSync(`fscrypt status ${JSON.stringify(homeDir)}`, {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        encoding: 'utf-8',
-      });
-      // `fscrypt status DIR` exits 0 on encrypted dirs and prints lines like
-      // "Policy: ..." / "Unlocked: Yes". Match a couple of fscrypt-specific
-      // tokens rather than the generic word "encrypted" to avoid false
-      // positives on help text.
-      if (/policy\s*:/i.test(out) || /unlocked\s*:/i.test(out)) {
-        return {
-          detected: true,
-          type: 'fscrypt',
-          signal: `fscrypt status reports an encryption policy on ${homeDir}`,
-        };
-      }
-    } catch {
-      // Non-zero exit means no fscrypt policy on this dir; ignore.
-    }
-  }
-
-  return { detected: false };
 }

--- a/setup/platform.ts
+++ b/setup/platform.ts
@@ -4,9 +4,18 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 
 export type Platform = 'macos' | 'linux' | 'unknown';
 export type ServiceManager = 'launchd' | 'systemd' | 'none';
+export type EncryptedHomeType = 'ecryptfs' | 'fscrypt' | 'gocryptfs';
+
+export interface EncryptedHomeDetection {
+  detected: boolean;
+  type?: EncryptedHomeType;
+  /** Human-readable signal that triggered detection (used in warnings/logs). */
+  signal?: string;
+}
 
 export function getPlatform(): Platform {
   const platform = os.platform();
@@ -129,4 +138,94 @@ export function getNodeMajorVersion(): number | null {
   if (!version) return null;
   const major = parseInt(version.split('.')[0], 10);
   return isNaN(major) ? null : major;
+}
+
+/**
+ * Detect whether $HOME is on per-user-encrypted storage that only gets
+ * decrypted at PAM login (ecryptfs, fscrypt, gocryptfs).
+ *
+ * Block-device encryption (LUKS / dm-crypt) is intentionally NOT a trigger:
+ * those volumes are decrypted before userspace and don't break user systemd
+ * at boot. See issue #2680 for the failure mode this detection guards.
+ *
+ * fscrypt is per-directory with no mount entry and no universal marker file,
+ * so we rely on the `fscrypt` CLI when present. If it isn't installed, we
+ * skip fscrypt detection; there is no safe lightweight probe without it.
+ */
+export function detectEncryptedHome(
+  homeDir: string = os.homedir(),
+): EncryptedHomeDetection {
+  if (getPlatform() !== 'linux') return { detected: false };
+
+  // findmnt: catches ecryptfs and fuse.gocryptfs cleanly via the mount table.
+  try {
+    const fstype = execSync(
+      `findmnt -n -T ${JSON.stringify(homeDir)} -o FSTYPE`,
+      { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' },
+    ).trim();
+    if (fstype === 'ecryptfs') {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `findmnt reports FSTYPE=ecryptfs for ${homeDir}`,
+      };
+    }
+    if (fstype === 'fuse.gocryptfs') {
+      return {
+        detected: true,
+        type: 'gocryptfs',
+        signal: `findmnt reports FSTYPE=fuse.gocryptfs for ${homeDir}`,
+      };
+    }
+  } catch {
+    // findmnt missing or no mount row; fall through to other probes.
+  }
+
+  // ecryptfs marker directories: present on the classic Ubuntu encrypted-home
+  // setup even when findmnt is unavailable.
+  try {
+    if (fs.existsSync(path.join(homeDir, '.ecryptfs'))) {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `${homeDir}/.ecryptfs exists`,
+      };
+    }
+    if (fs.existsSync(path.join(homeDir, '.Private'))) {
+      return {
+        detected: true,
+        type: 'ecryptfs',
+        signal: `${homeDir}/.Private exists`,
+      };
+    }
+  } catch {
+    // fs probe failed; ignore.
+  }
+
+  // fscrypt: only reliable detection is the fscrypt CLI. The issue body
+  // specifically warns against marker-file heuristics, and rolling a raw
+  // FS_IOC_GET_ENCRYPTION_POLICY ioctl from Node isn't trivial.
+  if (commandExists('fscrypt')) {
+    try {
+      const out = execSync(`fscrypt status ${JSON.stringify(homeDir)}`, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+      // `fscrypt status DIR` exits 0 on encrypted dirs and prints lines like
+      // "Policy: ..." / "Unlocked: Yes". Match a couple of fscrypt-specific
+      // tokens rather than the generic word "encrypted" to avoid false
+      // positives on help text.
+      if (/policy\s*:/i.test(out) || /unlocked\s*:/i.test(out)) {
+        return {
+          detected: true,
+          type: 'fscrypt',
+          signal: `fscrypt status reports an encryption policy on ${homeDir}`,
+        };
+      }
+    } catch {
+      // Non-zero exit means no fscrypt policy on this dir; ignore.
+    }
+  }
+
+  return { detected: false };
 }

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 
+import { log } from '../src/log.js';
 import { getLaunchdLabel } from '../src/install-slug.js';
+import { manageUserLinger } from './service.js';
+import type { EncryptedHomeDetection } from './platform.js';
 
 /**
  * Tests for service configuration generation.
@@ -164,6 +167,84 @@ describe('systemd unit generation', () => {
     expect(unit).toContain(
       'ExecStart=/usr/bin/node /srv/nanoclaw/dist/index.js',
     );
+  });
+});
+
+describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    infoSpy = vi.spyOn(log, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it('skips loginctl enable-linger when an encrypted home is detected', () => {
+    const detected: EncryptedHomeDetection = {
+      detected: true,
+      type: 'ecryptfs',
+      signal: 'findmnt reports FSTYPE=ecryptfs for /home/user',
+    };
+    const exec = vi.fn();
+
+    const result = manageUserLinger(() => detected, exec);
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(result.lingerEnabled).toBe(false);
+    expect(result.encryptedHome).toEqual(detected);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [warnMessage, warnData] = warnSpy.mock.calls[0];
+    expect(warnMessage).toContain('Per-home encryption detected (ecryptfs)');
+    expect(warnMessage).toContain('skipping');
+    expect(warnMessage).toContain('loginctl enable-linger');
+    expect(warnMessage).toContain('systemctl --user daemon-reload');
+    expect(warnMessage).toContain('systemctl --user start nanoclaw');
+    expect(warnMessage).toContain('issues/2680');
+    expect(warnData).toMatchObject({ type: 'ecryptfs' });
+  });
+
+  it('also skips for fscrypt and gocryptfs detections', () => {
+    for (const type of ['fscrypt', 'gocryptfs'] as const) {
+      const exec = vi.fn();
+      const result = manageUserLinger(
+        () => ({ detected: true, type, signal: `probe:${type}` }),
+        exec,
+      );
+      expect(exec).not.toHaveBeenCalled();
+      expect(result.lingerEnabled).toBe(false);
+      expect(result.encryptedHome?.type).toBe(type);
+    }
+  });
+
+  it('runs loginctl enable-linger when no encrypted home is detected', () => {
+    const exec = vi.fn();
+
+    const result = manageUserLinger(() => ({ detected: false }), exec);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith('loginctl enable-linger');
+    expect(result.lingerEnabled).toBe(true);
+    expect(result.encryptedHome).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports lingerEnabled=false and warns when loginctl fails', () => {
+    const exec = vi.fn(() => {
+      throw new Error('loginctl not available');
+    });
+
+    const result = manageUserLinger(() => ({ detected: false }), exec);
+
+    expect(result.lingerEnabled).toBe(false);
+    expect(result.encryptedHome).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('loginctl enable-linger failed');
   });
 });
 

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -3,8 +3,8 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel } from '../src/install-slug.js';
-import { manageUserLinger } from './service.js';
-import type { EncryptedHomeDetection } from './platform.js';
+import { manageUserLinger } from './linger.js';
+import type { EncryptedHomeDetection } from './linger.js';
 
 /**
  * Tests for service configuration generation.
@@ -184,6 +184,13 @@ describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
     infoSpy.mockRestore();
   });
 
+  // Realistic per-install unit name (matches getSystemdUnit(projectRoot)
+  // format `nanoclaw-v2-<8-hex-slug>`). The warning must interpolate this
+  // rather than the static word "nanoclaw" — copy-pasting the recovery
+  // command with the wrong unit name leaves users stuck on
+  // `Unit nanoclaw.service not found.` See issue #2680.
+  const testUnitName = 'nanoclaw-v2-abc123';
+
   it('skips loginctl enable-linger when an encrypted home is detected', () => {
     const detected: EncryptedHomeDetection = {
       detected: true,
@@ -192,7 +199,7 @@ describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
     };
     const exec = vi.fn();
 
-    const result = manageUserLinger(() => detected, exec);
+    const result = manageUserLinger(testUnitName, () => detected, exec);
 
     expect(exec).not.toHaveBeenCalled();
     expect(result.lingerEnabled).toBe(false);
@@ -204,15 +211,24 @@ describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
     expect(warnMessage).toContain('skipping');
     expect(warnMessage).toContain('loginctl enable-linger');
     expect(warnMessage).toContain('systemctl --user daemon-reload');
-    expect(warnMessage).toContain('systemctl --user start nanoclaw');
+    expect(warnMessage).toContain(
+      `systemctl --user start ${testUnitName}`,
+    );
+    // Regression guard: must NOT recommend the static `nanoclaw` unit name.
+    expect(warnMessage).not.toContain('systemctl --user start nanoclaw ');
+    expect(warnMessage).not.toMatch(/systemctl --user start nanoclaw\.$/);
     expect(warnMessage).toContain('issues/2680');
-    expect(warnData).toMatchObject({ type: 'ecryptfs' });
+    expect(warnData).toMatchObject({
+      type: 'ecryptfs',
+      unitName: testUnitName,
+    });
   });
 
   it('also skips for fscrypt and gocryptfs detections', () => {
     for (const type of ['fscrypt', 'gocryptfs'] as const) {
       const exec = vi.fn();
       const result = manageUserLinger(
+        testUnitName,
         () => ({ detected: true, type, signal: `probe:${type}` }),
         exec,
       );
@@ -225,7 +241,11 @@ describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
   it('runs loginctl enable-linger when no encrypted home is detected', () => {
     const exec = vi.fn();
 
-    const result = manageUserLinger(() => ({ detected: false }), exec);
+    const result = manageUserLinger(
+      testUnitName,
+      () => ({ detected: false }),
+      exec,
+    );
 
     expect(exec).toHaveBeenCalledTimes(1);
     expect(exec).toHaveBeenCalledWith('loginctl enable-linger');
@@ -239,7 +259,11 @@ describe('manageUserLinger (encrypted-home guard, issue #2680)', () => {
       throw new Error('loginctl not available');
     });
 
-    const result = manageUserLinger(() => ({ detected: false }), exec);
+    const result = manageUserLinger(
+      testUnitName,
+      () => ({ detected: false }),
+      exec,
+    );
 
     expect(result.lingerEnabled).toBe(false);
     expect(result.encryptedHome).toBeUndefined();

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -11,11 +11,10 @@ import path from 'path';
 
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import type { LingerResult } from './linger.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
-  detectEncryptedHome,
-  EncryptedHomeDetection,
   getPlatform,
   getNodePath,
   getServiceManager,
@@ -72,7 +71,7 @@ export async function run(_args: string[]): Promise<void> {
   if (platform === 'macos') {
     setupLaunchd(projectRoot, nodePath, homeDir);
   } else if (platform === 'linux') {
-    setupLinux(projectRoot, nodePath, homeDir);
+    await setupLinux(projectRoot, nodePath, homeDir);
   } else {
     emitStatus('SETUP_SERVICE', {
       SERVICE_TYPE: 'unknown',
@@ -218,15 +217,15 @@ function setupLaunchd(
   });
 }
 
-function setupLinux(
+async function setupLinux(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+): Promise<void> {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
-    setupSystemd(projectRoot, nodePath, homeDir);
+    await setupSystemd(projectRoot, nodePath, homeDir);
   } else {
     // WSL without systemd or other Linux without systemd
     setupNohupFallback(projectRoot, nodePath, homeDir);
@@ -275,11 +274,11 @@ function checkDockerGroupStale(): boolean {
   }
 }
 
-function setupSystemd(
+async function setupSystemd(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
-): void {
+): Promise<void> {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
   const unitFileName = `${unitName}.service`;
@@ -366,9 +365,12 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
+  // linger.ts is dynamic-imported so its body (and the encrypted-home detection
+  // helpers it pulls in) never evaluates on macOS or on the nohup fallback path.
   let lingerResult: LingerResult = { lingerEnabled: false };
   if (!runningAsRoot) {
-    lingerResult = manageUserLinger();
+    const { manageUserLinger } = await import('./linger.js');
+    lingerResult = manageUserLinger(unitName);
   }
 
   // Enable and start
@@ -419,63 +421,6 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
-}
-
-export interface LingerResult {
-  lingerEnabled: boolean;
-  encryptedHome?: EncryptedHomeDetection;
-}
-
-/**
- * Manage user-systemd lingering.
- *
- * Skipped silently on per-home-encrypted systems (ecryptfs / fscrypt /
- * gocryptfs). On those, linger causes the user manager to come up at boot
- * before PAM has decrypted ~/.config/systemd/user/, so it starts with an
- * empty unit table and nanoclaw never launches. See issue #2680.
- *
- * TODO(#2680): item 4 of the suggested fix (a PAM / login-hook self-heal
- * that runs `systemctl --user start nanoclaw` on first login) is not
- * implemented here. Tracked in the issue.
- *
- * Exported (along with `detect` / `exec` overrides) so service.test.ts can
- * exercise the skip path without shelling out.
- */
-export function manageUserLinger(
-  detect: () => EncryptedHomeDetection = detectEncryptedHome,
-  exec: (cmd: string) => void = (cmd: string) =>
-    void execSync(cmd, { stdio: 'ignore' }),
-): LingerResult {
-  const detection = detect();
-  if (detection.detected) {
-    log.warn(
-      [
-        `Per-home encryption detected (${detection.type}); skipping`,
-        '`loginctl enable-linger`. With linger enabled on a per-home-encrypted',
-        'system, the user systemd manager starts at boot before PAM has',
-        'decrypted ~/.config/systemd/user/, so it comes up with an empty unit',
-        'table and nanoclaw never launches. Without linger, nanoclaw will',
-        'start when you log in after each reboot. If the service is not',
-        'running after login, run: systemctl --user daemon-reload &&',
-        'systemctl --user start nanoclaw. See',
-        'https://github.com/nanocoai/nanoclaw/issues/2680.',
-      ].join(' '),
-      { type: detection.type, signal: detection.signal },
-    );
-    return { lingerEnabled: false, encryptedHome: detection };
-  }
-
-  try {
-    exec('loginctl enable-linger');
-    log.info('Enabled loginctl linger for current user');
-    return { lingerEnabled: true };
-  } catch (err) {
-    log.warn(
-      'loginctl enable-linger failed — service may stop on SSH logout',
-      { err },
-    );
-    return { lingerEnabled: false };
-  }
 }
 
 function setupNohupFallback(

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -14,6 +14,8 @@ import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
+  detectEncryptedHome,
+  EncryptedHomeDetection,
   getPlatform,
   getNodePath,
   getServiceManager,
@@ -364,16 +366,9 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
+  let lingerResult: LingerResult = { lingerEnabled: false };
   if (!runningAsRoot) {
-    try {
-      execSync('loginctl enable-linger', { stdio: 'ignore' });
-      log.info('Enabled loginctl linger for current user');
-    } catch (err) {
-      log.warn(
-        'loginctl enable-linger failed — service may stop on SSH logout',
-        { err },
-      );
-    }
+    lingerResult = manageUserLinger();
   }
 
   // Enable and start
@@ -417,10 +412,70 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     UNIT_PATH: unitPath,
     SERVICE_LOADED: serviceLoaded,
     ...(dockerGroupStale ? { DOCKER_GROUP_STALE: true } : {}),
-    LINGER_ENABLED: !runningAsRoot,
+    LINGER_ENABLED: lingerResult.lingerEnabled,
+    ...(lingerResult.encryptedHome
+      ? { ENCRYPTED_HOME: lingerResult.encryptedHome.type }
+      : {}),
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
+}
+
+export interface LingerResult {
+  lingerEnabled: boolean;
+  encryptedHome?: EncryptedHomeDetection;
+}
+
+/**
+ * Manage user-systemd lingering.
+ *
+ * Skipped silently on per-home-encrypted systems (ecryptfs / fscrypt /
+ * gocryptfs). On those, linger causes the user manager to come up at boot
+ * before PAM has decrypted ~/.config/systemd/user/, so it starts with an
+ * empty unit table and nanoclaw never launches. See issue #2680.
+ *
+ * TODO(#2680): item 4 of the suggested fix (a PAM / login-hook self-heal
+ * that runs `systemctl --user start nanoclaw` on first login) is not
+ * implemented here. Tracked in the issue.
+ *
+ * Exported (along with `detect` / `exec` overrides) so service.test.ts can
+ * exercise the skip path without shelling out.
+ */
+export function manageUserLinger(
+  detect: () => EncryptedHomeDetection = detectEncryptedHome,
+  exec: (cmd: string) => void = (cmd: string) =>
+    void execSync(cmd, { stdio: 'ignore' }),
+): LingerResult {
+  const detection = detect();
+  if (detection.detected) {
+    log.warn(
+      [
+        `Per-home encryption detected (${detection.type}); skipping`,
+        '`loginctl enable-linger`. With linger enabled on a per-home-encrypted',
+        'system, the user systemd manager starts at boot before PAM has',
+        'decrypted ~/.config/systemd/user/, so it comes up with an empty unit',
+        'table and nanoclaw never launches. Without linger, nanoclaw will',
+        'start when you log in after each reboot. If the service is not',
+        'running after login, run: systemctl --user daemon-reload &&',
+        'systemctl --user start nanoclaw. See',
+        'https://github.com/nanocoai/nanoclaw/issues/2680.',
+      ].join(' '),
+      { type: detection.type, signal: detection.signal },
+    );
+    return { lingerEnabled: false, encryptedHome: detection };
+  }
+
+  try {
+    exec('loginctl enable-linger');
+    log.info('Enabled loginctl linger for current user');
+    return { lingerEnabled: true };
+  } catch (err) {
+    log.warn(
+      'loginctl enable-linger failed — service may stop on SSH logout',
+      { err },
+    );
+    return { lingerEnabled: false };
+  }
 }
 
 function setupNohupFallback(


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Fixes #2680.

On systems where `$HOME` lives on per-user-encrypted storage (ecryptfs, fscrypt, gocryptfs), `loginctl enable-linger` causes the user systemd manager to come up at boot before PAM has decrypted the home. `~/.config/systemd/user/` is unreadable at that point, so the unit table is empty and nanoclaw never launches at boot. The service only starts after a manual `systemctl --user daemon-reload && systemctl --user start nanoclaw` following login. LUKS / dm-crypt block-device encryption is decrypted before userspace and is unaffected.

### What changed

- **`setup/platform.ts`**: new `detectEncryptedHome()` helper that probes for the three per-home encryption types:
  - `ecryptfs` via `findmnt -T "$HOME" -o FSTYPE` and the `~/.ecryptfs` / `~/.Private` marker directories.
  - `fuse.gocryptfs` via `findmnt`.
  - `fscrypt` via the `fscrypt` CLI when installed (no marker-file heuristic; the issue body explicitly warns against rolling our own `FS_IOC_GET_ENCRYPTION_POLICY` ioctl). When the `fscrypt` CLI is absent we skip fscrypt detection silently; ecryptfs and gocryptfs still get caught via findmnt.
  - LUKS and dm-crypt are intentionally not triggers.
- **`setup/service.ts`**: linger management lifted into a new exported `manageUserLinger(detect, exec)` so the skip path is testable. When detection is positive we skip `loginctl enable-linger` and log a `log.warn` that (a) names the detected encryption type, (b) explains why linger was skipped, and (c) prints the manual recovery sequence (`systemctl --user daemon-reload && systemctl --user start nanoclaw`). The warning links back to this issue. `LINGER_ENABLED` in the emitted status block now reflects the actual outcome, and a new `ENCRYPTED_HOME` field surfaces the detected type for the setup wizard to read.

### Out of scope (follow-up)

Item 4 of the issue's suggested fix (a PAM / `pam_exec` / `~/.bash_profile` login hook that runs `systemctl --user start nanoclaw` on first login so the service self-heals after each reboot) is **not** in this PR. A `TODO(#2680)` comment in `manageUserLinger` points back to this issue.

### Test plan

`setup/service.test.ts` gains a `manageUserLinger` block covering:

- ecryptfs detection skips `loginctl enable-linger` and emits a warning containing the encryption type, the recovery command sequence, and an `issues/2680` link.
- fscrypt and gocryptfs detections also skip linger.
- A negative detection runs `loginctl enable-linger` and returns `lingerEnabled: true`.
- A `loginctl` failure path logs the existing warning and returns `lingerEnabled: false`.

`pnpm typecheck` and `pnpm test` both pass locally (336 tests).
