### PR TITLE
feat(skills): add QMD container skill for hybrid markdown search

### DIFF
--- a/container/skills/qmd/SKILL.md
+++ b/container/skills/qmd/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: qmd
+description: Search markdown knowledge bases and documentation using QMD. Use when users ask to search notes, find documents, look up past research, or query indexed knowledge. Provides hybrid search (BM25 + vector + rerank) across all configured collections.
+compatibility: QMD v2.5.3 MCP server running on host at host.docker.internal:8181. Accessible from all NanoClaw containers.
+---
+
+# QMD — Quick Markdown Search
+
+Local hybrid search engine (BM25 + vector + deep rerank) for markdown content. Runs on the host as an MCP server, accessible to all containers.
+
+## Status
+
+QMD runs on the same host as NanoClaw. It's always available — no service trigger needed.
+
+```
+Host: http://host.docker.internal:8181/mcp
+```
+
+## Searching via HTTP API
+
+```bash
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "params": {
+      "name": "query",
+      "arguments": {
+        "searches": [
+          { "type": "lex", "query": "VPS pricing" },
+          { "type": "vec", "query": "what are the cheapest cloud providers for always-free instances" }
+        ],
+        "limit": 5
+      }
+    },
+    "id": 1
+  }'
+```
+
+## Query Types
+
+| Type | Method | Best for |
+|------|--------|----------|
+| `lex` | BM25 keyword | Exact terms, names, code identifiers |
+| `vec` | Vector semantic | Natural language questions |
+| `hyde` | Hypothetical document | Write what the answer looks like (50-100 words) |
+| `expand` | Auto-expand | Single-line query, LLM generates variations |
+
+### Writing good queries
+
+**lex:** 2-5 terms, no filler. Quoted phrases: `"connection pool"`. Exclude: `performance -sports`
+**vec:** Full question. Be specific: `"how does the rate limiter handle burst traffic"`
+**hyde:** 50-100 words of what the answer would look like
+
+First query gets 2x weight in fusion — put your best guess first.
+
+### Combining types
+
+| Goal | Approach |
+|------|----------|
+| Know exact terms | `lex` only |
+| Don't know vocabulary | `vec` or single-line (auto-expand) |
+| Best recall | `lex` + `vec` |
+| Complex topic | `lex` + `vec` + `hyde` |
+
+### Collection filtering
+
+Use the `status` tool to discover available collections. Then filter:
+
+```json
+{ "collections": ["collection_name"] }           // Single
+{ "collections": ["alpha", "beta"] }             // Multiple (OR)
+```
+
+Omit `collections` to search all.
+
+### Intent (disambiguation)
+
+```json
+{
+  "searches": [{ "type": "lex", "query": "performance" }],
+  "intent": "web page load times and Core Web Vitals"
+}
+```
+
+## Other tools
+
+| Tool | Purpose |
+|------|---------|
+| `get` | Retrieve doc by `file` param (path or `#docid`). Line numbers default ON. |
+| `multi_get` | Retrieve multiple by glob pattern |
+| `status` | Collections and index health |
+| `query` | Hybrid search (renamed from `structured_search` in v2.5.3) |
+
+### get example
+
+```bash
+# By docid
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123","full":true}},"id":1}'
+```
+
+### get with line range (v2.5.3)
+
+```bash
+# First 10 lines of a document
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123:1:10"}},"id":1}'
+```
+
+### multi_get example
+
+```bash
+# By glob pattern
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"multi_get","arguments":{"pattern":"docs/*.md"}},"id":1}'
+```
+
+## Collections
+
+Use the `status` tool to discover available collections and index health. Filter searches with `collections: ["name"]` to target specific ones. Index is rebuilt daily — searches work against the existing index with no manual updates needed.
+
+## How it works
+
+QMD uses three stages:
+1. **BM25** (lex) + **vector** (vec/hyde) retrieve candidates
+2. **Reciprocal Rank Fusion** merges results (first query weighted 2x)
+3. **Qwen3 1.7B reranker** re-scores top candidates for final ranking
+
+All models run on CPU (ARM, no GPU). First search after idle loads models (~3 GB).
+
+## Usage patterns
+
+### "Search my notes about X"
+
+Use a lex+vec combo for best recall. Return top results with snippets.
+
+### "What did I research about Y?"
+
+Use vec with a natural language question. Add intent if the query is ambiguous.
+
+### "Find the document about Z"
+
+Use lex with specific terms. Use get or multi_get to retrieve full content.

--- a/container/skills/qmd/references/mcp-setup.md
+++ b/container/skills/qmd/references/mcp-setup.md
@@ -1,0 +1,102 @@
+# QMD MCP Server Setup
+
+## Install
+
+```bash
+npm install -g @tobilu/qmd
+qmd collection add ~/path/to/markdown --name myknowledge
+qmd embed
+```
+
+## Configure MCP Client
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{
+  "mcpServers": {
+    "qmd": { "command": "qmd", "args": ["mcp"] }
+  }
+}
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "qmd": { "command": "qmd", "args": ["mcp"] }
+  }
+}
+```
+
+**OpenClaw** (`~/.openclaw/openclaw.json`):
+```json
+{
+  "mcp": {
+    "servers": {
+      "qmd": { "command": "qmd", "args": ["mcp"] }
+    }
+  }
+}
+```
+
+## HTTP Mode
+
+```bash
+qmd mcp --http              # Port 8181
+qmd mcp --http --daemon     # Background
+qmd mcp stop                # Stop daemon
+```
+
+## Tools
+
+### query
+
+Hybrid search (renamed from `structured_search` in v2.5.3).
+
+```json
+{
+  "searches": [
+    { "type": "lex", "query": "keyword phrases" },
+    { "type": "vec", "query": "natural language question" },
+    { "type": "hyde", "query": "hypothetical answer passage..." }
+  ],
+  "limit": 10,
+  "collection": "optional",
+  "minScore": 0.0
+}
+```
+
+| Type | Method | Input |
+|------|--------|-------|
+| `lex` | BM25 | Keywords (2-5 terms) |
+| `vec` | Vector | Question |
+| `hyde` | Vector | Answer passage (50-100 words) |
+
+### get
+
+Retrieve document by file path or `#docid`.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `file` | string | File path or `#docid` |
+| `full` | bool? | Return full content |
+| `lineNumbers` | bool? | Add line numbers |
+
+### multi_get
+
+Retrieve multiple documents.
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `pattern` | string | Glob or comma-separated list |
+| `maxBytes` | number? | Skip large files (default 10KB) |
+
+### status
+
+Index health and collections. No params.
+
+## Troubleshooting
+
+- **Not starting**: `which qmd`, `qmd mcp` manually
+- **No results**: `qmd collection list`, `qmd embed`
+- **Slow first search**: Normal, models loading (~3GB)


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [X] **Container skill** - agent runtime skill (SKILL.md + reference files, no source changes)

## What

Adds a container skill for [QMD](https://github.com/tobi/qmd) (Query Markdown Documents) — a local hybrid search engine (BM25 + vector + rerank) for markdown content. Teaches agents how to query indexed knowledge bases via HTTP MCP.

## Why

Agents need a way to search past conversations and documentation stored as markdown. QMD provides hybrid search with no cloud dependencies.

## How it works

QMD runs on the host as an HTTP MCP server. Containers connect via `host.docker.internal:8181`. MCP server registration is handled via `container_configs` DB — no source code changes needed. The skill teaches query types (`lex`, `vec`, `hyde`, `expand`), tool usage (`query`, `get`, `multi_get`, `status`), and usage patterns.

## Supersedes

Closes #1597 — that PR targeted v1 architecture with hardcoded agent-runner wiring. This PR is a clean rewrite targeting v2, with no source code changes (MCP servers are now configured via DB).

## What was tested

Tested on an existing install with QMD v2.5.3 against indexed markdown collections.

## Usage

No host-side setup required for the skill itself. QMD must be installed and running on the host (`qmd mcp --http`). Users configure the MCP server endpoint via `ncl groups config add-mcp-server` or the self-mod tool.