### PR TITLE
fix(whatsapp): stop translating group participants to phone JIDs (fixes ack 421 on LID groups)

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -362,6 +362,16 @@ registerChannelAdapter('whatsapp', {
       return jid;
     }
 
+    // Group metadata for Baileys' OUTBOUND send path (cachedGroupMetadata).
+    //
+    // Return the RAW metadata with NATIVE participant addressing. Do NOT translate
+    // participant LIDs → phone JIDs here: Baileys uses this list to build the
+    // group sender-key envelope, and for a LID-addressed group it must address
+    // every participant by LID. Translating some participants to phone produced a
+    // mixed phone/LID envelope that WhatsApp rejects with ack error 421 (messages
+    // silently never delivered). Inbound LID→phone translation for the router is
+    // done per-message via translateJid (remoteJidAlt / participantAlt), so the
+    // agent still sees phone JIDs — that path is unaffected.
     async function getNormalizedGroupMetadata(jid: string): Promise<GroupMetadata | undefined> {
       if (!jid.endsWith('@g.us')) return undefined;
 
@@ -369,18 +379,11 @@ registerChannelAdapter('whatsapp', {
       if (cached && cached.expiresAt > Date.now()) return cached.metadata;
 
       const metadata = await sock.groupMetadata(jid);
-      const participants = await Promise.all(
-        metadata.participants.map(async (p) => ({
-          ...p,
-          id: await translateJid(p.id),
-        })),
-      );
-      const normalized = { ...metadata, participants };
       groupMetadataCache.set(jid, {
-        metadata: normalized,
+        metadata,
         expiresAt: Date.now() + GROUP_METADATA_CACHE_TTL_MS,
       });
-      return normalized;
+      return metadata;
     }
 
     async function syncGroupMetadata(force = false): Promise<void> {


### PR DESCRIPTION
## Problem

WhatsApp has been migrating groups to LID (LinkedID) participant addressing. On a LID-addressed group, the bot's replies silently never arrive — Baileys reports **ack error 421** on every outbound send, with no user-visible error.

## Root cause

`getNormalizedGroupMetadata` is passed to Baileys as `cachedGroupMetadata`, which Baileys uses to build the group **sender-key envelope** on the outbound send path. It was translating every participant's LID → phone JID:

```ts
const participants = await Promise.all(
  metadata.participants.map(async (p) => ({ ...p, id: await translateJid(p.id) })),
);
```

For a LID-addressed group this yields a **mixed phone/LID envelope**, which WhatsApp rejects with **421**.

## Fix

Hand Baileys the **raw** group metadata so it addresses all participants by LID consistently. The inbound LID→phone translation the router relies on is unaffected — that's done per-message via `translateJid(remoteJidAlt / participantAlt)`, so the agent still sees phone JIDs.

## Testing

- **Before:** a LID-migrated group dropped 100% of outbound messages (ack 421 in Baileys debug logs); non-LID groups worked.
- **After:** messages deliver to the LID group; the sender-key envelope is all-LID; 421 gone. Non-LID groups and the inbound router path unchanged.
