### PR TITLE
fix(poll-loop): retry transient 5xx API-error results, notify on exhaustion

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
-import { getPendingMessages, markCompleted } from './db/messages-in.js';
+import { getPendingMessages, markCompleted, markProcessing } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { isCorruptionError } from './poll-loop.js';
+import { isCorruptionError, classifyApiError, computeBackoffMs, apiErrorNotice, processQuery } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
+import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -393,5 +394,209 @@ describe('isCorruptionError', () => {
     expect(isCorruptionError('database is locked')).toBe(false);
     expect(isCorruptionError('no such table: messages_in')).toBe(false);
     expect(isCorruptionError('')).toBe(false);
+  });
+});
+
+describe('classifyApiError', () => {
+  it('treats 5xx server errors as retryable', () => {
+    for (const status of [500, 502, 503, 522, 529, 599]) {
+      expect(classifyApiError(status)).toBe('retryable');
+    }
+  });
+
+  it('treats 4xx and status-less errors as fatal', () => {
+    for (const status of [400, 401, 404, 429, 499, undefined]) {
+      expect(classifyApiError(status)).toBe('fatal');
+    }
+  });
+});
+
+describe('computeBackoffMs', () => {
+  it('doubles per attempt and caps', () => {
+    const cfg = { baseMs: 2000, capMs: 30000 };
+    expect(computeBackoffMs(0, cfg)).toBe(2000);
+    expect(computeBackoffMs(1, cfg)).toBe(4000);
+    expect(computeBackoffMs(2, cfg)).toBe(8000);
+    expect(computeBackoffMs(3, cfg)).toBe(16000);
+    expect(computeBackoffMs(4, cfg)).toBe(30000); // 32000 capped
+    expect(computeBackoffMs(5, cfg)).toBe(30000);
+  });
+});
+
+describe('apiErrorNotice', () => {
+  it('names the status and hints to resend when we retried', () => {
+    const msg = apiErrorNotice(529, true);
+    expect(msg).toContain('529');
+    expect(msg.toLowerCase()).toContain('resend');
+  });
+
+  it('omits the resend hint for a non-retried (fatal) error', () => {
+    const msg = apiErrorNotice(400, false);
+    expect(msg).toContain('400');
+    expect(msg.toLowerCase()).not.toContain('resend');
+  });
+
+  it('never prints the literal "undefined" when status is missing', () => {
+    expect(apiErrorNotice(undefined, true)).not.toContain('undefined');
+  });
+});
+
+describe('processQuery — transient API-error handling', () => {
+  const fastRetry = { maxAttempts: 2, baseMs: 1, capMs: 1 };
+
+  function seedDestination(name: string, channelType: string, platformId: string): void {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO destinations (name, display_name, type, channel_type, platform_id, agent_group_id)
+         VALUES (?, ?, 'channel', ?, ?, NULL)`,
+      )
+      .run(name, name, channelType, platformId);
+  }
+
+  function insertChat(id: string, platformId: string): void {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, content)
+         VALUES (?, 'chat', datetime('now'), 'pending', ?, 'discord', ?)`,
+      )
+      .run(id, platformId, JSON.stringify({ sender: 'A', text: 'hi' }));
+  }
+
+  function ackStatus(id: string): string | undefined {
+    const row = getOutboundDb().prepare('SELECT status FROM processing_ack WHERE message_id = ?').get(id) as
+      | { status: string }
+      | undefined;
+    return row?.status;
+  }
+
+  type Turn = { kind: 'success'; text: string } | { kind: 'error'; status?: number };
+
+  // A provider query that emits one result per turn, parking between turns
+  // until a push() (a retry) arrives. Mirrors the real SDK: the first turn is
+  // delivered eagerly; each subsequent turn waits for the poll-loop to re-drive.
+  function scriptedQuery(turns: Turn[]): AgentQuery {
+    let pending = 0;
+    let resolveNext: (() => void) | null = null;
+    let aborted = false;
+    const wake = () => {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r();
+      } else {
+        pending += 1;
+      }
+    };
+    const events = (async function* (): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-test' };
+      let i = 0;
+      while (i < turns.length && !aborted) {
+        const t = turns[i++];
+        if (t.kind === 'success') {
+          yield { type: 'result', text: t.text };
+        } else {
+          yield {
+            type: 'result',
+            text: `API Error: ${t.status ?? '???'} Overloaded`,
+            isError: true,
+            apiErrorStatus: t.status,
+          };
+        }
+        if (i >= turns.length) break;
+        if (pending > 0) pending -= 1;
+        else await new Promise<void>((r) => (resolveNext = r));
+      }
+    })();
+    return {
+      push: () => wake(),
+      end: () => {
+        if (resolveNext) {
+          const r = resolveNext;
+          resolveNext = null;
+          r();
+        }
+      },
+      events,
+      abort: () => {
+        aborted = true;
+        if (resolveNext) {
+          const r = resolveNext;
+          resolveNext = null;
+          r();
+        }
+      },
+    };
+  }
+
+  it('retries a 5xx result, then dispatches the eventual success', async () => {
+    seedDestination('discord-main', 'discord', 'chan-1');
+    insertChat('m1', 'chan-1');
+    const routing = extractRouting(getPendingMessages());
+    markProcessing(['m1']);
+
+    const query = scriptedQuery([
+      { kind: 'error', status: 529 },
+      { kind: 'success', text: '<message to="discord-main">hello there</message>' },
+    ]);
+    await processQuery(query, routing, ['m1'], 'claude', 'PROMPT', fastRetry);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toContain('hello there');
+    expect(ackStatus('m1')).toBe('completed');
+  });
+
+  it('notifies the user after exhausting retries on a persistent 5xx', async () => {
+    insertChat('m2', 'chan-1');
+    const routing = extractRouting(getPendingMessages());
+    markProcessing(['m2']);
+
+    // maxAttempts=2 → retry after turn 0 and turn 1; turn 2 exhausts the budget.
+    const query = scriptedQuery([
+      { kind: 'error', status: 503 },
+      { kind: 'error', status: 503 },
+      { kind: 'error', status: 503 },
+    ]);
+    await processQuery(query, routing, ['m2'], 'claude', 'PROMPT', fastRetry);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    const text = JSON.parse(out[0].content).text;
+    expect(text).toContain('503');
+    expect(text.toLowerCase()).toContain('resend');
+    expect(ackStatus('m2')).toBe('completed');
+  });
+
+  it('notifies immediately on a fatal 4xx without retrying', async () => {
+    insertChat('m3', 'chan-1');
+    const routing = extractRouting(getPendingMessages());
+    markProcessing(['m3']);
+
+    // Only one turn available: if it retried, the generator would end with no
+    // notice. A notice containing "400" proves it short-circuited to notify.
+    const query = scriptedQuery([{ kind: 'error', status: 400 }]);
+    await processQuery(query, routing, ['m3'], 'claude', 'PROMPT', fastRetry);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    const text = JSON.parse(out[0].content).text;
+    expect(text).toContain('400');
+    expect(text.toLowerCase()).not.toContain('resend');
+    expect(ackStatus('m3')).toBe('completed');
+  });
+
+  it('dispatches a normal successful result unchanged (regression)', async () => {
+    seedDestination('discord-main', 'discord', 'chan-1');
+    insertChat('m4', 'chan-1');
+    const routing = extractRouting(getPendingMessages());
+    markProcessing(['m4']);
+
+    const query = scriptedQuery([{ kind: 'success', text: '<message to="discord-main">ok</message>' }]);
+    await processQuery(query, routing, ['m4'], 'claude', 'PROMPT', fastRetry);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toContain('ok');
+    expect(ackStatus('m4')).toBe('completed');
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -51,6 +51,45 @@ function generateId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+export interface ApiRetryConfig {
+  /** Maximum number of backoff retries before giving up and notifying the user. */
+  maxAttempts: number;
+  /** First backoff delay; doubles each attempt up to `capMs`. */
+  baseMs: number;
+  /** Upper bound on a single backoff delay. */
+  capMs: number;
+}
+
+/**
+ * Default API-error retry policy. Worst case ≈ 2+4+8+16+30 = 60s of sleep
+ * before notifying — comfortably under the host's 30-min absolute ceiling, and
+ * the kept-fresh heartbeat (see `sleepWithHeartbeat`) means the 60s
+ * "claimed then silent" sweep never fires while we wait.
+ */
+export const DEFAULT_API_RETRY: ApiRetryConfig = { maxAttempts: 5, baseMs: 2000, capMs: 30000 };
+
+/**
+ * A turn that ends in an `is_error` result is only worth retrying for transient
+ * server-side failures (HTTP 5xx). 4xx (bad request, auth) and status-less
+ * errors won't improve on retry, so they go straight to the user.
+ */
+export function classifyApiError(status: number | undefined): 'retryable' | 'fatal' {
+  return status !== undefined && status >= 500 && status <= 599 ? 'retryable' : 'fatal';
+}
+
+/** Exponential backoff with a hard cap: min(baseMs * 2^attempt, capMs). */
+export function computeBackoffMs(attempt: number, cfg: { baseMs: number; capMs: number }): number {
+  return Math.min(cfg.baseMs * 2 ** attempt, cfg.capMs);
+}
+
+/** User-facing notice when a turn could not complete because of an API error. */
+export function apiErrorNotice(status: number | undefined, retried: boolean): string {
+  const code = status ? ` (${status})` : '';
+  return retried
+    ? `I couldn't reach the model — the API kept returning a server error${code} and my retries didn't get through. Please resend in a few minutes.`
+    : `I couldn't reach the model — the API returned an error${code}. Please try again.`;
+}
+
 export interface PollLoopConfig {
   provider: AgentProvider;
   /**
@@ -63,6 +102,8 @@ export interface PollLoopConfig {
   systemContext?: {
     instructions?: string;
   };
+  /** API-error retry policy (exponential backoff). Defaults to DEFAULT_API_RETRY. */
+  apiRetry?: ApiRetryConfig;
 }
 
 /**
@@ -232,7 +273,14 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
     try {
-      const result = await processQuery(query, routing, processingIds, config.providerName);
+      const result = await processQuery(
+        query,
+        routing,
+        processingIds,
+        config.providerName,
+        prompt,
+        config.apiRetry ?? DEFAULT_API_RETRY,
+      );
       if (result.continuation && result.continuation !== continuation) {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
@@ -308,15 +356,34 @@ interface QueryResult {
   continuation?: string;
 }
 
-async function processQuery(
+/** Sleep in chunks, touching the heartbeat each chunk so a long backoff never
+ * trips the host's "claimed then silent" sweep (which only fires when no
+ * heartbeat has been written since the claim — see src/host-sweep.ts). */
+async function sleepWithHeartbeat(ms: number): Promise<void> {
+  const CHUNK_MS = 5000;
+  let remaining = ms;
+  while (remaining > 0) {
+    const slice = Math.min(remaining, CHUNK_MS);
+    await sleep(slice);
+    touchHeartbeat();
+    remaining -= slice;
+  }
+}
+
+export async function processQuery(
   query: AgentQuery,
   routing: RoutingContext,
   initialBatchIds: string[],
   providerName: string,
+  prompt: string,
+  retry: ApiRetryConfig = DEFAULT_API_RETRY,
 ): Promise<QueryResult> {
   let queryContinuation: string | undefined;
   let done = false;
   let unwrappedNudged = false;
+  // How many transient-error backoff retries we've spent on the current turn.
+  // Reset on every successful result so each turn gets a fresh budget.
+  let transientAttempt = 0;
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open avoids
@@ -447,12 +514,47 @@ async function processQuery(
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
       } else if (event.type === 'result') {
-        // A result — with or without text — means the turn is done. Mark
-        // the initial batch completed now so the host sweep doesn't see
-        // stale 'processing' claims while the query stays open for
-        // follow-up pushes. The agent may have responded via MCP
-        // (send_message) mid-turn, or the message may not need a response
-        // at all — either way the turn is finished.
+        // A failed turn (the SDK gave up and reported the error *as a result*,
+        // e.g. an exhausted-retry 529) must NOT be treated as a finished turn.
+        // Retry transient 5xx with backoff; on exhaustion or a fatal error,
+        // tell the user. Without this the batch would be marked completed and
+        // the error text discarded as scratchpad — a silent drop.
+        if (event.isError) {
+          const status = event.apiErrorStatus;
+          if (classifyApiError(status) === 'retryable' && transientAttempt < retry.maxAttempts) {
+            const delay = computeBackoffMs(transientAttempt, retry);
+            transientAttempt += 1;
+            log(
+              `API error${status ? ` ${status}` : ''} — backing off ${delay}ms, ` +
+                `retry ${transientAttempt}/${retry.maxAttempts}`,
+            );
+            await sleepWithHeartbeat(delay);
+            // The follow-up poll may have ended the stream for a slash command
+            // while we slept; don't push into a closed stream.
+            if (done || endedForCommand) continue;
+            query.push(prompt); // re-drive the same turn; claim stays 'processing'
+            continue;
+          }
+          // Out of retries, or a non-retryable error: notify, then finish.
+          markCompleted(initialBatchIds);
+          writeMessageOut({
+            id: generateId(),
+            kind: 'chat',
+            platform_id: routing.platformId,
+            channel_type: routing.channelType,
+            thread_id: routing.threadId,
+            content: JSON.stringify({ text: apiErrorNotice(status, transientAttempt > 0) }),
+          });
+          continue;
+        }
+
+        // A successful result — with or without text — means the turn is done.
+        // Mark the initial batch completed now so the host sweep doesn't see
+        // stale 'processing' claims while the query stays open for follow-up
+        // pushes. The agent may have responded via MCP (send_message) mid-turn,
+        // or the message may not need a response at all — either way the turn
+        // is finished.
+        transientAttempt = 0;
         markCompleted(initialBatchIds);
         if (event.text) {
           const { hasUnwrapped } = dispatchResultText(event.text, routing);

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -440,8 +440,18 @@ export class ClaudeProvider implements AgentProvider {
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
-          const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
-          yield { type: 'result', text };
+          // The SDK reports a turn it gave up on (e.g. exhausted API retries on
+          // a 529) as a result with `is_error: true` and the error string in
+          // `result`, plus `api_error_status` for HTTP-level failures. Carry
+          // both through so the poll-loop can retry transient 5xx and notify
+          // the user instead of silently completing the batch.
+          const m = message as { result?: string; is_error?: boolean; api_error_status?: number | null };
+          yield {
+            type: 'result',
+            text: m.result ?? null,
+            isError: m.is_error === true,
+            apiErrorStatus: m.api_error_status ?? undefined,
+          };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -96,7 +96,15 @@ export interface AgentQuery {
 
 export type ProviderEvent =
   | { type: 'init'; continuation: string }
-  | { type: 'result'; text: string | null }
+  /**
+   * A finished turn. `isError` is true when the underlying SDK gave up on the
+   * turn (e.g. after exhausting its own API retries) and surfaced the failure
+   * *as a result* rather than a thrown error — `text` then holds the error
+   * string and `apiErrorStatus` the HTTP status (5xx = transient/retryable).
+   * Optional so out-of-tree providers that never set them keep success
+   * semantics unchanged.
+   */
+  | { type: 'result'; text: string | null; isError?: boolean; apiErrorStatus?: number }
   | { type: 'error'; message: string; retryable: boolean; classification?: string }
   | { type: 'progress'; message: string }
   /**


### PR DESCRIPTION
## What

When the Claude Agent SDK exhausts its internal retries on a transient API error (e.g. `529 Overloaded`), it reports the failure **as a terminal `result` message** (`is_error: true`, the error string in `result`, HTTP status in `api_error_status`) rather than throwing. Today that result is treated as a finished turn: the provider drops `is_error`/`api_error_status`, the poll loop calls `markCompleted` and discards the unwrapped error text as scratchpad. The user's messages are silently swallowed — no reply, no notice, and an unwrapped-nudge push that just 529s again.

This makes a failed turn distinguishable from a successful one again:

- **`providers/claude.ts`** — carry `is_error` and `api_error_status` through on `result` events.
- **`poll-loop.ts`** — on an `is_error` result, classify by status. Retryable **5xx**: back off exponentially (capped) and re-drive the turn via `query.push`, touching the heartbeat during the sleep so the host's "claimed then silent" sweep doesn't reap the container mid-backoff. On exhaustion or a non-5xx error: write the user a clear notice and complete. Successful results behave exactly as before.

## Why

A single API blip currently turns into permanent silence on the affected session while the rest of the system keeps working — and the operator has no signal it happened. Long-running continuation sessions (large prompts) are the first to get shed under overload, so this hits the heaviest, most-used sessions hardest.

## How it works

- `classifyApiError(status)` → `retryable` for 5xx, `fatal` otherwise (4xx, status-less).
- `computeBackoffMs(attempt, cfg)` → `min(base * 2^attempt, cap)`.
- Defaults: 5 attempts, 2s base, 30s cap (~60s worst case, well under the 30-min ceiling). Configurable via `PollLoopConfig.apiRetry`.
- Backoff stays under the host's reaper because `kill-claim` only fires when no heartbeat has been written since the claim (`src/host-sweep.ts`); `sleepWithHeartbeat` touches it each chunk.
- The new `result` event fields are optional, so out-of-tree providers keep success semantics unchanged.

## How it was tested

`bun test` in `container/agent-runner` (111 pass) + `tsc` clean. New tests cover: `classifyApiError`, `computeBackoffMs`, `apiErrorNotice`, and `processQuery` end-to-end via a scripted provider — retry-then-succeed, exhaust-then-notify, fatal-4xx-notify-immediately, and a success regression. Written test-first (red → green).

## Related

Fills the current-architecture gap left by adjacent work, complementary rather than duplicative:
- #1741 — same friendly-notify intent, but against the pre-poll-loop `index.ts`/`GroupQueue` catch path; this handles the `is_error` *result-event* path with no new deps.
- #2184 — establishes the retry-then-notify-on-final-failure pattern in `poll-loop.ts` for the `isSessionInvalid` thrown-error trigger; this is the sibling 5xx result-event case.
- #2666 (draft) — broader provider-recovery effort touching the same files; this is the focused, independently-mergeable slice.

## PR type

- [x] **Fix**

🤖 Generated with [Claude Code](https://claude.com/claude-code)