### PR TITLE
feat(skill): add /add-google-contacts-tool

### DIFF
--- a/.claude/skills/add-google-contacts-tool/SKILL.md
+++ b/.claude/skills/add-google-contacts-tool/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: add-google-contacts-tool
+description: Add Google Contacts (People API) as an MCP tool — list, search, get, create, update, and delete contacts plus "other contacts" — using OneCLI-managed OAuth. Ships a small bundled stdio MCP server (no maintained, Linux-friendly People-API server exists on npm); the OneCLI gateway injects the real bearer for people.googleapis.com, so no raw credentials ever reach the container. Mirrors /add-gmail-tool and /add-gcal-tool's credential model and /add-atomic-chat-tool's bundled-server pattern.
+---
+
+# Add Google Contacts Tool (OneCLI-native)
+
+This skill wires a small **bundled** stdio MCP server (`google-contacts-mcp-stdio.ts`, shipped in this folder) into the agent-runner. The server calls the [Google People API](https://developers.google.com/people) (`people.googleapis.com`); the OneCLI gateway intercepts those calls and swaps the placeholder bearer for the real OAuth token from its vault. Same credential model as `/add-gmail-tool` and `/add-gcal-tool` — **no raw credentials reach the container.**
+
+**Why a bundled server (not an npm package):** unlike Calendar (`@cocal/google-calendar-mcp`), there is no well-maintained, Linux-friendly People-API MCP server that runs against stub credentials. The "Google Workspace" kitchen-sink servers expose 90+ unrelated tools (Gmail/Drive/Sheets/…) that would 401, since the gateway only injects for `people.googleapis.com`. So this skill ships its own minimal server — the same approach as `/add-atomic-chat-tool`.
+
+Tools exposed (surfaced as `mcp__google_contacts__<name>`):
+- `list_contacts` — list saved contacts (connections)
+- `search_contacts` — search saved contacts by name/email/phone
+- `search_other_contacts` — search auto-saved "other contacts" (emailed but not added)
+- `get_contact` — full details for one contact by `resourceName`
+- `create_contact`, `update_contact`, `delete_contact`
+
+## Phase 1: Pre-flight
+
+### Verify OneCLI has Google Contacts connected
+
+```bash
+onecli apps get --provider google-contacts
+```
+
+Expected: `"connection": { "status": "connected" }` with People-API scopes (`contacts.readonly`, and `contacts` if you want write). If not connected, tell the user:
+
+> Open the OneCLI web UI at http://127.0.0.1:10254, go to Apps → Google Contacts, and click Connect. Sign in with the Google account the agent should act as. `contacts` (read/write) + `contacts.other.readonly` are the most useful scopes.
+
+### Check if already applied
+
+```bash
+test -f container/agent-runner/src/google-contacts-mcp-stdio.ts && echo "ALREADY APPLIED — skip to Phase 3"
+```
+
+## Phase 2: Apply code changes
+
+### Copy the MCP server source into the agent-runner tree
+
+```bash
+cp .claude/skills/add-google-contacts-tool/google-contacts-mcp-stdio.ts \
+   container/agent-runner/src/google-contacts-mcp-stdio.ts
+```
+
+It imports `@modelcontextprotocol/sdk` and `zod`, both already in `container/agent-runner/package.json`.
+
+### Register the MCP server in the agent-runner
+
+Edit `container/agent-runner/src/index.ts`. Find the `mcpServers` object:
+
+```ts
+  const mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {
+    nanoclaw: {
+      command: 'bun',
+      args: ['run', mcpServerPath],
+      env: {},
+    },
+  };
+```
+
+Add a `google_contacts` entry alongside `nanoclaw`:
+
+```ts
+  const mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }> = {
+    nanoclaw: {
+      command: 'bun',
+      args: ['run', mcpServerPath],
+      env: {},
+    },
+    google_contacts: {
+      command: 'bun',
+      args: ['run', path.join(__dirname, 'google-contacts-mcp-stdio.ts')],
+      env: {},
+    },
+  };
+```
+
+`env: {}` is correct — the server needs no host env. The OneCLI gateway injects `HTTPS_PROXY` + CA trust + the real bearer at the container level (`src/container-runner.ts`, `applyContainerConfig`), so the server's `fetch()` to `people.googleapis.com` is intercepted and authenticated automatically.
+
+**No `TOOL_ALLOWLIST` / `claude.ts` edit needed.** The Claude provider derives MCP allow-patterns dynamically from the registered servers — `container/agent-runner/src/providers/claude.ts` does `...Object.keys(this.mcpServers).map(mcpAllowPattern)` — so registering `google_contacts` above automatically allows `mcp__google_contacts__*`. (Older skills edited a static allowlist; that's redundant now.)
+
+### Validate code changes
+
+```bash
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
+```
+
+All three must be clean before proceeding.
+
+## Phase 3: Configure
+
+### Confirm the agent's secret mode covers Google Contacts
+
+```bash
+onecli agents list
+```
+
+`secretMode: all` is sufficient — the gateway injects the matching `google-contacts` credential per request. If an agent is `selective`, assign the secret explicitly:
+
+```bash
+onecli agents set-secret-mode --id <agent-id> --mode all
+# or stay selective and: onecli agents set-secrets --id <agent-id> --secret-ids <google-contacts-secret-id>
+```
+
+### Restart so the new image is used
+
+Run from your NanoClaw project root:
+
+```bash
+source setup/lib/install-slug.sh
+systemctl --user restart "$(systemd_unit)"            # Linux
+# launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+docker ps -q --filter 'name=nanoclaw-v2-' | xargs -r docker kill   # respawn agents on new image
+```
+
+## Phase 4: Verify
+
+> Send a message like: **"list my contacts"**, **"search my contacts for Alice"**, or **"add a contact: Bob Lee, bob@example.com"**.
+>
+> The first call takes a couple seconds while the MCP server starts and OneCLI does the token exchange.
+
+If it isn't working:
+
+```bash
+tail -100 logs/nanoclaw.log | grep -iE 'GCONTACTS|mcp|google_contacts'
+```
+
+- `401`/`403` from `people.googleapis.com` → OneCLI isn't injecting: verify the `google-contacts` provider is connected and the agent's secret mode includes it.
+- Agent says "I don't have contact tools" → image not rebuilt (`./container/build.sh`) or the `google_contacts` entry wasn't added to `index.ts`.
+- Empty `search_contacts` on the very first call → the People API search cache is warming; retry once (the server already issues a warmup request).
+
+## Removal
+
+1. Remove the `google_contacts` entry from the `mcpServers` object in `container/agent-runner/src/index.ts`.
+2. `rm container/agent-runner/src/google-contacts-mcp-stdio.ts`
+3. `pnpm run build && ./container/build.sh && systemctl --user restart "$(. setup/lib/install-slug.sh && systemd_unit)"`
+4. Optional: `onecli apps disconnect --provider google-contacts`.
+
+## Credits & references
+
+- **MCP server:** bundled in this folder (`google-contacts-mcp-stdio.ts`) — a minimal stdio server over the Google People API v1, built with `@modelcontextprotocol/sdk`.
+- **Bundled-server pattern:** sibling of [`/add-atomic-chat-tool`](../add-atomic-chat-tool/SKILL.md).
+- **OneCLI credential model:** same stub-bearer + gateway-injection pattern as [`/add-gmail-tool`](../add-gmail-tool/SKILL.md) and [`/add-gcal-tool`](../add-gcal-tool/SKILL.md).
+- **Why not a Workspace MCP server:** those bundle 90+ tools across Gmail/Drive/Calendar; only the contacts subset would work here (the gateway injects for `people.googleapis.com` only), so a focused server is the right fit.

--- a/.claude/skills/add-google-contacts-tool/google-contacts-mcp-stdio.ts
+++ b/.claude/skills/add-google-contacts-tool/google-contacts-mcp-stdio.ts
@@ -1,0 +1,407 @@
+/**
+ * Google Contacts MCP Server for NanoClaw
+ *
+ * Exposes the Google People API (https://people.googleapis.com) as tools for the
+ * container agent: list / search / get / create / update / delete contacts, plus
+ * "other contacts" (auto-saved people you've emailed but not added).
+ *
+ * Auth is handled by the OneCLI gateway, NOT by this server. The gateway intercepts
+ * outbound calls to people.googleapis.com and replaces the Authorization header with
+ * the real OAuth bearer from its vault (see container/skills/onecli-gateway). This
+ * server therefore sends only a placeholder bearer and relies on the container's
+ * injected HTTPS_PROXY + CA trust — exactly the same pattern the gmail/gcal tools use.
+ * No raw credentials ever reach the container.
+ *
+ * Requires the `google-contacts` provider to be connected in OneCLI.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const PEOPLE_API_BASE =
+  process.env.GOOGLE_CONTACTS_API_BASE || 'https://people.googleapis.com/v1';
+
+// The OneCLI gateway overwrites this header with the real vault token. It is only a
+// placeholder so the request is well-formed before it reaches the proxy.
+const STUB_BEARER = process.env.GOOGLE_CONTACTS_BEARER || 'onecli-managed';
+
+// Fields requested when reading a full contact.
+const DEFAULT_PERSON_FIELDS =
+  'names,emailAddresses,phoneNumbers,organizations,addresses,biographies,memberships,metadata';
+// Lighter mask for list/search result rows.
+const DEFAULT_READ_MASK = 'names,emailAddresses,phoneNumbers,organizations';
+
+function log(msg: string): void {
+  console.error(`[GCONTACTS] ${msg}`);
+}
+
+interface Person {
+  resourceName?: string;
+  etag?: string;
+  names?: Array<{ displayName?: string; givenName?: string; familyName?: string }>;
+  emailAddresses?: Array<{ value?: string; type?: string }>;
+  phoneNumbers?: Array<{ value?: string; type?: string }>;
+  organizations?: Array<{ name?: string; title?: string }>;
+  addresses?: Array<{ formattedValue?: string; type?: string }>;
+  biographies?: Array<{ value?: string }>;
+}
+
+async function peopleFetch(
+  apiPath: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const url = apiPath.startsWith('http')
+    ? apiPath
+    : `${PEOPLE_API_BASE}${apiPath}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${STUB_BEARER}`,
+    Accept: 'application/json',
+    ...((options.headers as Record<string, string>) || {}),
+  };
+  return fetch(url, { ...options, headers });
+}
+
+/** Turn a non-2xx People API response into a helpful agent-facing error string. */
+async function apiError(res: Response): Promise<string> {
+  let detail = '';
+  try {
+    const body = (await res.json()) as { error?: { message?: string } };
+    detail = body?.error?.message ? ` — ${body.error.message}` : '';
+  } catch {
+    /* non-JSON body */
+  }
+  if (res.status === 401 || res.status === 403) {
+    return (
+      `Google People API returned ${res.status}${detail}. ` +
+      `The OneCLI gateway could not inject a valid token. Check that the ` +
+      `\`google-contacts\` provider is connected in OneCLI (http://127.0.0.1:10254 → ` +
+      `Apps → Google Contacts) and that this agent's secret mode includes it.`
+    );
+  }
+  return `Google People API error ${res.status}${detail}`;
+}
+
+function fmtPerson(p: Person): string {
+  const name = p.names?.[0]?.displayName || '(no name)';
+  const emails = (p.emailAddresses || [])
+    .map((e) => e.value)
+    .filter(Boolean)
+    .join(', ');
+  const phones = (p.phoneNumbers || [])
+    .map((ph) => ph.value)
+    .filter(Boolean)
+    .join(', ');
+  const org = p.organizations?.[0];
+  const orgStr = org ? [org.title, org.name].filter(Boolean).join(' @ ') : '';
+  const lines = [`• ${name}`];
+  if (emails) lines.push(`    email: ${emails}`);
+  if (phones) lines.push(`    phone: ${phones}`);
+  if (orgStr) lines.push(`    org:   ${orgStr}`);
+  if (p.resourceName) lines.push(`    id:    ${p.resourceName}`);
+  return lines.join('\n');
+}
+
+function textResult(text: string, isError = false) {
+  return { content: [{ type: 'text' as const, text }], isError };
+}
+
+const server = new McpServer({ name: 'google_contacts', version: '1.0.0' });
+
+server.tool(
+  'list_contacts',
+  "List the user's saved Google Contacts (their 'connections'). Returns name, email, phone, org, and the resourceName id needed for get/update/delete.",
+  {
+    page_size: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe('Max contacts to return (default 50, max 1000).'),
+  },
+  async (args) => {
+    const pageSize = args.page_size ?? 50;
+    log(`list_contacts pageSize=${pageSize}`);
+    try {
+      const qs = new URLSearchParams({
+        personFields: DEFAULT_READ_MASK,
+        pageSize: String(pageSize),
+        sortOrder: 'LAST_MODIFIED_DESCENDING',
+      });
+      const res = await peopleFetch(`/people/me/connections?${qs}`);
+      if (!res.ok) return textResult(await apiError(res), true);
+      const data = (await res.json()) as {
+        connections?: Person[];
+        totalpeople?: number;
+      };
+      const people = data.connections || [];
+      if (people.length === 0) return textResult('No contacts found.');
+      return textResult(
+        `${people.length} contact(s):\n\n${people.map(fmtPerson).join('\n')}`,
+      );
+    } catch (err) {
+      return textResult(`Failed to list contacts: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+server.tool(
+  'search_contacts',
+  "Search the user's saved contacts by name, email, or phone. Returns matching contacts with their resourceName ids.",
+  {
+    query: z.string().min(1).describe('Search text (name, email, or phone).'),
+    page_size: z.number().int().min(1).max(30).optional(),
+  },
+  async (args) => {
+    const pageSize = args.page_size ?? 15;
+    log(`search_contacts query=${JSON.stringify(args.query)}`);
+    try {
+      // People API recommends a warmup request (empty query) before searching so the
+      // server-side cache is primed; results can be empty otherwise on the first call.
+      await peopleFetch(
+        `/people:searchContacts?${new URLSearchParams({ query: '', readMask: DEFAULT_READ_MASK })}`,
+      ).catch(() => undefined);
+
+      const qs = new URLSearchParams({
+        query: args.query,
+        readMask: DEFAULT_READ_MASK,
+        pageSize: String(pageSize),
+      });
+      const res = await peopleFetch(`/people:searchContacts?${qs}`);
+      if (!res.ok) return textResult(await apiError(res), true);
+      const data = (await res.json()) as { results?: Array<{ person?: Person }> };
+      const people = (data.results || [])
+        .map((r) => r.person)
+        .filter((p): p is Person => Boolean(p));
+      if (people.length === 0)
+        return textResult(`No contacts matched "${args.query}".`);
+      return textResult(
+        `${people.length} match(es) for "${args.query}":\n\n${people.map(fmtPerson).join('\n')}`,
+      );
+    } catch (err) {
+      return textResult(`Failed to search contacts: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+server.tool(
+  'search_other_contacts',
+  "Search 'other contacts' — people the user has interacted with (e.g. emailed) but not explicitly saved. Useful when someone isn't in the main contact list.",
+  {
+    query: z.string().min(1).describe('Search text (name or email).'),
+    page_size: z.number().int().min(1).max(30).optional(),
+  },
+  async (args) => {
+    const pageSize = args.page_size ?? 15;
+    log(`search_other_contacts query=${JSON.stringify(args.query)}`);
+    try {
+      const readMask = 'names,emailAddresses,phoneNumbers';
+      await peopleFetch(
+        `/otherContacts:search?${new URLSearchParams({ query: '', readMask })}`,
+      ).catch(() => undefined);
+      const qs = new URLSearchParams({
+        query: args.query,
+        readMask,
+        pageSize: String(pageSize),
+      });
+      const res = await peopleFetch(`/otherContacts:search?${qs}`);
+      if (!res.ok) return textResult(await apiError(res), true);
+      const data = (await res.json()) as { results?: Array<{ person?: Person }> };
+      const people = (data.results || [])
+        .map((r) => r.person)
+        .filter((p): p is Person => Boolean(p));
+      if (people.length === 0)
+        return textResult(`No other contacts matched "${args.query}".`);
+      return textResult(
+        `${people.length} other-contact match(es):\n\n${people.map(fmtPerson).join('\n')}`,
+      );
+    } catch (err) {
+      return textResult(`Failed to search other contacts: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+server.tool(
+  'get_contact',
+  'Get full details for a single contact by its resourceName (e.g. "people/c12345"). Use list_contacts or search_contacts first to find the id.',
+  {
+    resource_name: z
+      .string()
+      .min(1)
+      .describe('The contact resourceName, e.g. "people/c1234567890".'),
+  },
+  async (args) => {
+    log(`get_contact ${args.resource_name}`);
+    try {
+      const qs = new URLSearchParams({ personFields: DEFAULT_PERSON_FIELDS });
+      const res = await peopleFetch(
+        `/${encodeURI(args.resource_name)}?${qs}`,
+      );
+      if (!res.ok) return textResult(await apiError(res), true);
+      const p = (await res.json()) as Person;
+      const bio = p.biographies?.[0]?.value;
+      const addr = (p.addresses || [])
+        .map((a) => a.formattedValue)
+        .filter(Boolean)
+        .join(' | ');
+      let out = fmtPerson(p);
+      if (addr) out += `\n    address: ${addr}`;
+      if (bio) out += `\n    notes: ${bio}`;
+      if (p.etag) out += `\n    etag:  ${p.etag}`;
+      return textResult(out);
+    } catch (err) {
+      return textResult(`Failed to get contact: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+const ContactFields = {
+  given_name: z.string().optional().describe('First name.'),
+  family_name: z.string().optional().describe('Last name.'),
+  emails: z
+    .array(z.string())
+    .optional()
+    .describe('Email addresses.'),
+  phones: z
+    .array(z.string())
+    .optional()
+    .describe('Phone numbers.'),
+  organization: z.string().optional().describe('Company / organization name.'),
+  job_title: z.string().optional().describe('Job title.'),
+  notes: z.string().optional().describe('Freeform notes / biography.'),
+};
+
+type ContactArgs = {
+  given_name?: string;
+  family_name?: string;
+  emails?: string[];
+  phones?: string[];
+  organization?: string;
+  job_title?: string;
+  notes?: string;
+};
+
+/** Build a People API person body from the flat tool args; returns the set field paths too. */
+function buildPersonBody(args: ContactArgs): {
+  body: Record<string, unknown>;
+  fields: string[];
+} {
+  const body: Record<string, unknown> = {};
+  const fields: string[] = [];
+  if (args.given_name !== undefined || args.family_name !== undefined) {
+    body.names = [
+      { givenName: args.given_name, familyName: args.family_name },
+    ];
+    fields.push('names');
+  }
+  if (args.emails) {
+    body.emailAddresses = args.emails.map((value) => ({ value }));
+    fields.push('emailAddresses');
+  }
+  if (args.phones) {
+    body.phoneNumbers = args.phones.map((value) => ({ value }));
+    fields.push('phoneNumbers');
+  }
+  if (args.organization !== undefined || args.job_title !== undefined) {
+    body.organizations = [
+      { name: args.organization, title: args.job_title },
+    ];
+    fields.push('organizations');
+  }
+  if (args.notes !== undefined) {
+    body.biographies = [{ value: args.notes, contentType: 'TEXT_PLAIN' }];
+    fields.push('biographies');
+  }
+  return { body, fields };
+}
+
+server.tool(
+  'create_contact',
+  'Create a new contact in the user\'s Google Contacts. Provide at least a name or an email.',
+  ContactFields,
+  async (args) => {
+    log(`create_contact ${args.given_name ?? ''} ${args.family_name ?? ''}`);
+    const { body, fields } = buildPersonBody(args);
+    if (fields.length === 0)
+      return textResult(
+        'Nothing to create — provide at least a name, email, or phone.',
+        true,
+      );
+    try {
+      const res = await peopleFetch('/people:createContact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) return textResult(await apiError(res), true);
+      const p = (await res.json()) as Person;
+      return textResult(`Created contact:\n${fmtPerson(p)}`);
+    } catch (err) {
+      return textResult(`Failed to create contact: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+server.tool(
+  'update_contact',
+  'Update fields on an existing contact (by resourceName). Only the fields you pass are changed. Fetches the current etag automatically.',
+  { resource_name: z.string().min(1), ...ContactFields },
+  async (args) => {
+    const { resource_name, ...rest } = args;
+    log(`update_contact ${resource_name}`);
+    const { body, fields } = buildPersonBody(rest);
+    if (fields.length === 0)
+      return textResult('Nothing to update — provide at least one field.', true);
+    try {
+      // Fetch current etag (required by updateContact to avoid lost updates).
+      const cur = await peopleFetch(
+        `/${encodeURI(resource_name)}?personFields=metadata`,
+      );
+      if (!cur.ok) return textResult(await apiError(cur), true);
+      const { etag } = (await cur.json()) as Person;
+
+      const qs = new URLSearchParams({ updatePersonFields: fields.join(',') });
+      const res = await peopleFetch(
+        `/${encodeURI(resource_name)}:updateContact?${qs}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ etag, ...body }),
+        },
+      );
+      if (!res.ok) return textResult(await apiError(res), true);
+      const p = (await res.json()) as Person;
+      return textResult(`Updated contact:\n${fmtPerson(p)}`);
+    } catch (err) {
+      return textResult(`Failed to update contact: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+server.tool(
+  'delete_contact',
+  'Delete a contact by its resourceName (e.g. "people/c12345"). This is permanent.',
+  { resource_name: z.string().min(1) },
+  async (args) => {
+    log(`delete_contact ${args.resource_name}`);
+    try {
+      const res = await peopleFetch(
+        `/${encodeURI(args.resource_name)}:deleteContact`,
+        { method: 'DELETE' },
+      );
+      if (!res.ok) return textResult(await apiError(res), true);
+      return textResult(`Deleted contact ${args.resource_name}.`);
+    } catch (err) {
+      return textResult(`Failed to delete contact: ${errMsg(err)}`, true);
+    }
+  },
+);
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+log('Google Contacts MCP server started');


### PR DESCRIPTION
## Type of Change

- [x] **Utility skill** — adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes in this PR)

## Description

Adds `/add-google-contacts-tool`, the OneCLI-native sibling to `/add-gmail-tool` and `/add-gcal-tool`. It wires a small **bundled** stdio MCP server (`google-contacts-mcp-stdio.ts`) that exposes the Google **People API** as `mcp__google_contacts__*` tools: `list_contacts`, `search_contacts`, `search_other_contacts`, `get_contact`, `create_contact`, `update_contact`, `delete_contact`.

**Why** — rounds out the OneCLI-native Google tools (Gmail, Calendar) with Contacts.

**How it works** — the server is built on `@modelcontextprotocol/sdk` (already an agent-runner dep) and sends only a placeholder bearer; the OneCLI gateway intercepts `people.googleapis.com` and swaps in the real OAuth token, so **no raw credentials reach the container**. The skill copies the server into `container/agent-runner/src/` and registers it in `index.ts`'s `mcpServers` map. No `TOOL_ALLOWLIST`/`claude.ts` edit is needed — the Claude provider auto-allows registered servers via `Object.keys(this.mcpServers).map(mcpAllowPattern)`. No mounts, no stub-cred files.

**Why a bundled server (not an npm package)** — unlike Calendar (`@cocal/google-calendar-mcp`), there's no maintained, Linux-friendly People-API MCP server that runs against stub credentials; the "Google Workspace" kitchen-sink servers ship 90+ tools that would 401 here (the gateway injects for `people.googleapis.com` only). So this ships a focused server — same approach as `/add-atomic-chat-tool`.

**How it was tested** — installed and exercised end-to-end on a self-hosted nanoclaw + OneCLI deployment: `list_contacts`, `search_contacts`, and create/update/delete all round-trip through the gateway against the live People API (with the `https://www.googleapis.com/auth/contacts` scope granted in OneCLI).

**Usage** — run `/add-google-contacts-tool`, then message the agent "list my contacts", "search my contacts for …", or "add a contact: …".

**Relation to #146** — #146 proposes a broad `/add-google` Workspace skill via `gogcli` (self-managed GCP OAuth, all of Workspace). This skill is narrower and OneCLI-native, consistent with the existing `/add-gmail-tool` and `/add-gcal-tool`. Complementary, not a replacement.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill end-to-end (see "How it was tested")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
