### PR TITLE
fix(signal): stage inbound image attachments as base64 so the container can read them

### DIFF
--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -368,7 +368,11 @@ describe('SignalAdapter', () => {
       await adapter.teardown();
     });
 
-    it('forwards image attachments as [Image: <path>] plus structured attachments array', async () => {
+    it('forwards image attachments as base64 data (for inbox staging into the container)', async () => {
+      const { mkdirSync, writeFileSync } = await import('node:fs');
+      mkdirSync('/tmp/signal-cli-test-data/attachments', { recursive: true });
+      writeFileSync('/tmp/signal-cli-test-data/attachments/att123abc', Buffer.from('fake-image-bytes'));
+
       const adapter = createAdapter();
       const cfg = createMockSetup();
       await adapter.setup(cfg);
@@ -388,8 +392,13 @@ describe('SignalAdapter', () => {
         null,
         expect.objectContaining({
           content: expect.objectContaining({
-            text: expect.stringMatching(/^\[Image: .+att123abc\]$/),
-            attachments: [expect.objectContaining({ contentType: 'image/jpeg' })],
+            attachments: [
+              expect.objectContaining({
+                contentType: 'image/jpeg',
+                type: 'image',
+                data: Buffer.from('fake-image-bytes').toString('base64'),
+              }),
+            ],
           }),
         }),
       );

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -670,16 +670,24 @@ export function createSignalAdapter(config: {
       }
     }
 
-    // Image attachments — emit `[Image: <path>]` lines so the agent's Read
-    // tool can pick them up, and surface the structured `attachments` array
-    // for consumers that prefer that shape. Without this, vision-capable
-    // models never see images sent over Signal.
-    const attachmentRefs: Array<{ path: string; contentType: string }> = [];
+    // Image attachments — read the bytes from signal-cli's store and pass them
+    // as base64 `data`. The host stages these into the session's mounted
+    // `inbox/` (session-manager.extractAttachmentFiles) and rewrites them to a
+    // container-readable `localPath`, which the agent-runner formatter surfaces
+    // as `[image: <name> — saved to /workspace/inbox/...]`. Emitting a host path
+    // here instead is unreadable from inside the agent container.
+    const attachmentRefs: Array<{ data: string; contentType: string; type: string }> = [];
     for (const img of imageAttachments) {
       const imagePath = join(config.signalDataDir, 'attachments', img.id!);
-      const imageLine = `[Image: ${imagePath}]`;
-      content = content ? `${content}\n${imageLine}` : imageLine;
-      attachmentRefs.push({ path: imagePath, contentType: img.contentType || 'image/jpeg' });
+      if (!existsSync(imagePath)) {
+        log.warn('Signal: image attachment file not found', { id: img.id, path: imagePath });
+        continue;
+      }
+      attachmentRefs.push({
+        data: readFileSync(imagePath).toString('base64'),
+        contentType: img.contentType || 'image/jpeg',
+        type: 'image',
+      });
     }
 
     const msg: InboundMessage = {


### PR DESCRIPTION
## Type of Change

- [x] **Fix** — bug fix to source code

## Description

The Signal adapter surfaces inbound images by emitting signal-cli's **host** attachment path (`<signalDataDir>/attachments/<id>`). The agent runs in a container that doesn't mount that path, so it can never read an image sent over Signal — the agent just gets an unreadable path.

**Fix:** read the attachment bytes and pass them as base64 `data`. The host's `session-manager.extractAttachmentFiles` already stages attachments carrying `data` into the session's mounted `inbox/` and rewrites them to a container-readable `localPath`, which the agent-runner formatter surfaces as `[image: <name> — saved to /workspace/inbox/...]`. This matches how inbound attachments reach the container on other channels. Also drops the now-misleading host-path `[Image: <path>]` text line.

**How it was tested:** updated the inbound-image unit test to assert base64 `data` is forwarded (full Signal suite passes, 37/37). Verified end-to-end on a live install — an image sent over Signal now stages into the inbox and the agent reads and describes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
