### PR TITLE
feat(add-dashboard): make the skill conformant (drift fix + shipped test)

### DIFF
--- a/.claude/skills/add-dashboard/SKILL.md
+++ b/.claude/skills/add-dashboard/SKILL.md
@@ -28,61 +28,34 @@ NanoClaw (pusher)              Dashboard (npm package)
 pnpm install @nanoco/nanoclaw-dashboard
 ```
 
-### 2. Copy the pusher module
+### 2. Copy the pusher module and its tests
 
-Copy the resource file into src:
+Copy all three resource files into `src/`. The tests ship with the skill and run against the composed project — they're how you confirm the skill works and is wired in correctly.
 
 ```
-.claude/skills/add-dashboard/resources/dashboard-pusher.ts → src/dashboard-pusher.ts
+.claude/skills/add-dashboard/resources/dashboard-pusher.ts       → src/dashboard-pusher.ts
+.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts  → src/dashboard-pusher.test.ts
+.claude/skills/add-dashboard/resources/dashboard-wiring.test.ts  → src/dashboard-wiring.test.ts
 ```
 
-### 3. Add exports to src/db/index.ts
+- `dashboard-pusher.test.ts` — behavior: starts the pusher, posts a real snapshot to a fake dashboard.
+- `dashboard-wiring.test.ts` — the code edit in step 3: asserts (via the TS AST) that `index.ts` dynamically imports `./dashboard-pusher.js` and `await`s `startDashboard()` as colocated statements of `main()`, after DB init and before the boot-complete log. Delete or misplace the edit and this goes red.
 
-Add these two export blocks if not already present:
+### 3. Wire into src/index.ts
+
+This is the skill's one integration point, and it's deliberately minimal and self-contained: all the startup logic lives in `dashboard-pusher.ts`, and the import is **colocated** with the call so the whole edit is a single block in one place — there's no separate top-of-file import to add (or to remember to remove).
+
+Add this block inside `main()`, just before the `log.info('NanoClaw running')` line:
 
 ```typescript
-// After the messaging-groups exports, add:
-export {
-  getMessagingGroupsByAgentGroup,
-} from './messaging-groups.js';
-
-// Before the credentials exports, add:
-export {
-  createDestination,
-  getDestinations,
-  getDestinationByName,
-  getDestinationByTarget,
-  hasDestination,
-  deleteDestination,
-} from './agent-destinations.js';
+  // Dashboard (optional; no-ops without DASHBOARD_SECRET)
+  const { startDashboard } = await import('./dashboard-pusher.js');
+  await startDashboard();
 ```
 
-### 4. Wire into src/index.ts
+`startDashboard()` reads `DASHBOARD_SECRET`/`DASHBOARD_PORT` itself and no-ops if the secret is unset, so nothing else in core needs to change.
 
-Add the `readEnvFile` import at the top if not already present:
-
-```typescript
-import { readEnvFile } from './env.js';
-```
-
-Add after step 7 (OneCLI approval handler), before the `log.info('NanoClaw running')` line:
-
-```typescript
-  // 8. Dashboard (optional)
-  const dashboardEnv = readEnvFile(['DASHBOARD_SECRET', 'DASHBOARD_PORT']);
-  const dashboardSecret = process.env.DASHBOARD_SECRET || dashboardEnv.DASHBOARD_SECRET;
-  const dashboardPort = parseInt(process.env.DASHBOARD_PORT || dashboardEnv.DASHBOARD_PORT || '3100', 10);
-  if (dashboardSecret) {
-    const { startDashboard } = await import('@nanoco/nanoclaw-dashboard');
-    const { startDashboardPusher } = await import('./dashboard-pusher.js');
-    startDashboard({ port: dashboardPort, secret: dashboardSecret });
-    startDashboardPusher({ port: dashboardPort, secret: dashboardSecret, intervalMs: 60000 });
-  } else {
-    log.info('Dashboard disabled (no DASHBOARD_SECRET)');
-  }
-```
-
-### 5. Add environment variables to .env
+### 4. Add environment variables to .env
 
 ```
 DASHBOARD_SECRET=<generate-a-random-secret>
@@ -91,18 +64,21 @@ DASHBOARD_PORT=3100
 
 Generate the secret: `node -e "console.log('nc-' + require('crypto').randomBytes(16).toString('hex'))"`
 
-### 6. Build and restart
+### 5. Build, test, and restart
 
 Run from your NanoClaw project root:
 
 ```bash
 pnpm run build
+pnpm exec vitest run src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts   # behavior + wiring
 source setup/lib/install-slug.sh
 systemctl --user restart $(systemd_unit)              # Linux
 # or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
 ```
 
-### 7. Verify
+### 6. Verify (runtime smoke check)
+
+Once the service is restarted, confirm the dashboard is live:
 
 ```bash
 curl -s http://localhost:3100/api/status
@@ -132,10 +108,15 @@ Open `http://localhost:3100/dashboard` in a browser.
 
 ## Removal
 
+Reverse the apply steps. Safe to re-run even if some pieces are already gone.
+
 ```bash
-pnpm uninstall @nanoco/nanoclaw-dashboard
-rm src/dashboard-pusher.ts
-# Remove the dashboard block from src/index.ts
-# Remove DASHBOARD_SECRET and DASHBOARD_PORT from .env
+rm -f src/dashboard-pusher.ts src/dashboard-pusher.test.ts src/dashboard-wiring.test.ts
+pnpm uninstall @nanoco/nanoclaw-dashboard 2>/dev/null || true
+```
+
+Then, by hand, remove the single dashboard block the skill added to `main()` in `src/index.ts` (the `// Dashboard (optional…)` comment, the `await import('./dashboard-pusher.js')` line, and the `await startDashboard();` call), and remove `DASHBOARD_SECRET` and `DASHBOARD_PORT` from `.env`.
+
+```bash
 pnpm run build
 ```

--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test for the add-dashboard skill's integration point —
+ * `startDashboard()`, the single call wired into src/index.ts.
+ *
+ * Archetype: in-process seam. It drives the *real* entry point against a
+ * *real* (in-memory) central DB and a *fake* dashboard HTTP endpoint. The
+ * only things stubbed are the external dashboard package (not needed to prove
+ * the wiring) and env-file reads (so the test doesn't depend on the real
+ * .env). This proves the skill works once applied: with a secret set it
+ * collects a DB snapshot and posts it; with no secret it does nothing.
+ *
+ * Ships with the add-dashboard skill; apply copies it to src/ alongside the
+ * pusher so it runs against the composed project.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-dashboard', ASSISTANT_NAME: 'TestBot' };
+});
+// The dashboard server package isn't needed to prove the integration point.
+vi.mock('@nanoco/nanoclaw-dashboard', () => ({ startDashboard: vi.fn() }));
+// Don't read the real .env — the test controls config via process.env only.
+vi.mock('./env.js', () => ({ readEnvFile: () => ({}) }));
+
+const TEST_DIR = '/tmp/nanoclaw-test-dashboard';
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { startDashboard, stopDashboardPusher } from './dashboard-pusher.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+interface CapturedPost {
+  path: string;
+  auth: string | undefined;
+  body: Record<string, unknown>;
+}
+
+/** A fake dashboard server that captures the bodies the pusher POSTs. */
+function startFakeDashboard(): Promise<{ port: number; posts: CapturedPost[]; close: () => Promise<void> }> {
+  const posts: CapturedPost[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (c) => { raw += c; });
+    req.on('end', () => {
+      let body: Record<string, unknown> = {};
+      try { body = JSON.parse(raw); } catch { /* leave empty */ }
+      posts.push({ path: req.url || '', auth: req.headers.authorization, body });
+      res.writeHead(200);
+      res.end('ok');
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ port, posts, close: () => new Promise<void>((r) => server.close(() => r())) });
+    });
+  });
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for condition');
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+describe('add-dashboard integration point (startDashboard)', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    const db = initTestDb();
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    stopDashboardPusher();
+    closeDb();
+    delete process.env.DASHBOARD_SECRET;
+    delete process.env.DASHBOARD_PORT;
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('posts a snapshot of the seeded state when DASHBOARD_SECRET is set', async () => {
+    createAgentGroup({ id: 'ag-1', name: 'Test Agent', folder: 'test-agent', agent_provider: null, created_at: now() });
+
+    const dash = await startFakeDashboard();
+    process.env.DASHBOARD_SECRET = 'test-secret';
+    process.env.DASHBOARD_PORT = String(dash.port);
+
+    await startDashboard();
+
+    await waitFor(() => dash.posts.some((p) => p.path === '/api/ingest'));
+
+    const ingest = dash.posts.find((p) => p.path === '/api/ingest')!;
+    expect(ingest.auth).toBe('Bearer test-secret');
+    expect(ingest.body.assistant_name).toBe('TestBot');
+
+    const groups = ingest.body.agent_groups as Array<{ id: string }>;
+    expect(groups.map((g) => g.id)).toContain('ag-1');
+
+    for (const key of ['timestamp', 'sessions', 'channels', 'users', 'tokens', 'context_windows', 'activity', 'messages']) {
+      expect(ingest.body).toHaveProperty(key);
+    }
+
+    await dash.close();
+  });
+
+  it('does nothing when DASHBOARD_SECRET is not set', async () => {
+    const dash = await startFakeDashboard();
+    // no DASHBOARD_SECRET in env, and readEnvFile is stubbed to {}
+
+    await startDashboard();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(dash.posts).toHaveLength(0);
+    await dash.close();
+  });
+});

--- a/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-pusher.ts
@@ -10,15 +10,17 @@ import Database from 'better-sqlite3';
 import { getAllAgentGroups, getAgentGroup } from './db/agent-groups.js';
 import { getSessionsByAgentGroup } from './db/sessions.js';
 import { getAllMessagingGroups, getMessagingGroupAgents } from './db/messaging-groups.js';
-import { getDestinations } from './db/agent-destinations.js';
-import { getMembers } from './db/agent-group-members.js';
-import { getAllUsers, getUser } from './db/users.js';
-import { getUserRoles, getAdminsOfAgentGroup } from './db/user-roles.js';
-import { getUserDmsForUser } from './db/user-dms.js';
+import { getDestinations } from './modules/agent-to-agent/db/agent-destinations.js';
+import { getMembers } from './modules/permissions/db/agent-group-members.js';
+import { getAllUsers, getUser } from './modules/permissions/db/users.js';
+import { getUserRoles, getAdminsOfAgentGroup } from './modules/permissions/db/user-roles.js';
+import { getUserDmsForUser } from './modules/permissions/db/user-dms.js';
 import { getActiveAdapters, getRegisteredChannelNames } from './channels/channel-registry.js';
 import { DATA_DIR, ASSISTANT_NAME } from './config.js';
 import { getDb } from './db/connection.js';
+import { getContainerConfig } from './db/container-configs.js';
 import { log } from './log.js';
+import { readEnvFile } from './env.js';
 
 interface PusherConfig {
   port: number;
@@ -54,6 +56,26 @@ export function stopDashboardPusher(): void {
     clearInterval(logTimer);
     logTimer = null;
   }
+}
+
+/**
+ * Skill entry point — the single call wired into the host boot sequence.
+ *
+ * All of the dashboard's startup logic lives here, in the skill's own file,
+ * so the integration point in src/index.ts is just `await startDashboard()`.
+ * No-ops (and says so) when DASHBOARD_SECRET is unset.
+ */
+export async function startDashboard(): Promise<void> {
+  const env = readEnvFile(['DASHBOARD_SECRET', 'DASHBOARD_PORT']);
+  const secret = process.env.DASHBOARD_SECRET || env.DASHBOARD_SECRET;
+  const port = parseInt(process.env.DASHBOARD_PORT || env.DASHBOARD_PORT || '3100', 10);
+  if (!secret) {
+    log.info('Dashboard disabled (no DASHBOARD_SECRET)');
+    return;
+  }
+  const { startDashboard: startServer } = await import('@nanoco/nanoclaw-dashboard');
+  startServer({ port, secret });
+  startDashboardPusher({ port, secret, intervalMs: 60000 });
 }
 
 /** Fire-and-forget POST to the dashboard. */
@@ -157,7 +179,7 @@ function collectAgentGroups() {
       name: g.name,
       folder: g.folder,
       agent_provider: g.agent_provider,
-      container_config: g.container_config ? JSON.parse(g.container_config) : null,
+      container_config: getContainerConfig(g.id) ?? null,
       sessionCount: sessions.length,
       runningSessions: running.length,
       wirings,

--- a/.claude/skills/add-dashboard/resources/dashboard-wiring.test.ts
+++ b/.claude/skills/add-dashboard/resources/dashboard-wiring.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Wiring test for the add-dashboard skill's code-edit integration point.
+ *
+ * The skill inserts one colocated block into src/index.ts (a dynamic
+ * `import('./dashboard-pusher.js')` + `await startDashboard()` in main()). A
+ * behavioral test of the pusher can't see whether that edit is actually
+ * present and correctly placed — booting the real host is too heavy — so this
+ * asserts the edit *structurally*, via the TypeScript AST. It verifies not
+ * just that the call exists, but that:
+ *   - the pusher module is dynamically imported by its correct path,
+ *   - startDashboard() is awaited,
+ *   - both are DIRECT statements of main()'s body (right scope/level, not
+ *     nested or stranded in another function),
+ *   - the import precedes the call, and the whole block sits after DB init
+ *     and before the boot-complete log (right place).
+ *
+ * Delete or misplace the edit and this goes red. Combined with the unit test
+ * (behavior of startDashboard) and the build (the call still type-checks),
+ * the three together cover deletion, misplacement, drift, and behavior — for
+ * a true code edit, with no registry required.
+ *
+ * Ships with the skill; apply copies it to src/.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+const indexPath = path.resolve(process.cwd(), 'src/index.ts');
+const source = fs.readFileSync(indexPath, 'utf8');
+const sf = ts.createSourceFile('index.ts', source, ts.ScriptTarget.Latest, true);
+
+function mainBody(): ts.NodeArray<ts.Statement> {
+  let body: ts.NodeArray<ts.Statement> | undefined;
+  sf.forEachChild((n) => {
+    if (ts.isFunctionDeclaration(n) && n.name?.text === 'main' && n.body) {
+      body = n.body.statements;
+    }
+  });
+  if (!body) throw new Error('main() not found in src/index.ts');
+  return body;
+}
+
+function isAwaitedStartDashboard(s: ts.Statement): boolean {
+  return (
+    ts.isExpressionStatement(s) &&
+    ts.isAwaitExpression(s.expression) &&
+    ts.isCallExpression(s.expression.expression) &&
+    ts.isIdentifier(s.expression.expression.expression) &&
+    s.expression.expression.expression.text === 'startDashboard'
+  );
+}
+
+/** `const { ... } = await import('./dashboard-pusher.js')` as a statement. */
+function isDynamicImportOfPusher(s: ts.Statement): boolean {
+  if (!ts.isVariableStatement(s)) return false;
+  const init = s.declarationList.declarations[0]?.initializer;
+  if (!init || !ts.isAwaitExpression(init) || !ts.isCallExpression(init.expression)) return false;
+  const call = init.expression;
+  if (call.expression.kind !== ts.SyntaxKind.ImportKeyword) return false;
+  const arg = call.arguments[0];
+  return !!arg && ts.isStringLiteral(arg) && arg.text === './dashboard-pusher.js';
+}
+
+describe('add-dashboard wiring in src/index.ts', () => {
+  it('dynamically imports the pusher and awaits startDashboard(), colocated in main(), after DB init and before the boot-complete log', () => {
+    const stmts = mainBody();
+    const importIdx = stmts.findIndex(isDynamicImportOfPusher);
+    const callIdx = stmts.findIndex(isAwaitedStartDashboard);
+    const migrateIdx = stmts.findIndex((s) => s.getText(sf).includes('runMigrations('));
+    const runningIdx = stmts.findIndex((s) => s.getText(sf).includes("log.info('NanoClaw running')"));
+
+    expect(importIdx, "dynamic import('./dashboard-pusher.js') must be a statement of main()").toBeGreaterThanOrEqual(0);
+    expect(callIdx, 'await startDashboard() must be a statement of main()').toBeGreaterThanOrEqual(0);
+    expect(migrateIdx, 'runMigrations() anchor not found').toBeGreaterThanOrEqual(0);
+    expect(runningIdx, 'boot-complete log anchor not found').toBeGreaterThanOrEqual(0);
+    expect(importIdx, 'the dynamic import must come after DB init').toBeGreaterThan(migrateIdx);
+    expect(callIdx, 'the call must come after its import (colocated)').toBeGreaterThan(importIdx);
+    expect(callIdx, 'startDashboard() must run before the boot-complete log').toBeLessThan(runningIdx);
+  });
+});


### PR DESCRIPTION
First exemplar of the skills upgradeability model. Giving the skill a real test surfaced silent drift: the pusher imported five DB modules that moved into src/modules/ when core was reorganized — it would fail to build for anyone adopting it today. Fixed the imports, added an in-process-seam integration test that ships with the skill and runs against the composed project, and tightened apply/remove.

- dashboard-pusher.ts: repoint imports to src/modules/{agent-to-agent,permissions}/db/*
- dashboard-pusher.test.ts (new): real in-memory DB + real pusher + fake dashboard HTTP endpoint; asserts the /api/ingest snapshot
- SKILL.md: apply copies the test too; dropped the vestigial src/db/index.ts export step; build step runs the test; idempotent removal

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
