### PR TITLE
feat(host): single-instance lock to prevent duplicate messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, st
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
+import { acquireSingleInstanceLock } from './single-instance.js';
 
 // Response + shutdown registries live in response-registry.ts to break the
 // circular import cycle: src/index.ts imports src/modules/index.js for side
@@ -66,7 +67,13 @@ import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from 
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
 
-  // 0. Circuit breaker — backoff on rapid restarts
+  // 0a. Single-instance guard — refuse to start if another host is already running.
+  //     Two concurrent hosts each run the sweep and double-spawn containers for the same
+  //     due message → duplicate messages. Nothing else stops a second host (sockets are
+  //     unlink-and-rebind; the webhook port is dormant on a polling install).
+  acquireSingleInstanceLock(DATA_DIR);
+
+  // 0b. Circuit breaker — backoff on rapid restarts
   await enforceStartupBackoff();
 
   // 1. Init central DB

--- a/src/single-instance.test.ts
+++ b/src/single-instance.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { tryAcquireLock } from './single-instance.js';
+
+describe('tryAcquireLock', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-lock-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('claims a clean directory and records our pid', () => {
+    const res = tryAcquireLock(dir);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(fs.readFileSync(res.lockPath, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('refuses when a LIVE process already holds the lock', () => {
+    // pid 1 (launchd/init) is always alive and is not us.
+    fs.writeFileSync(path.join(dir, 'nanoclaw.lock'), '1');
+    const res = tryAcquireLock(dir);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.holderPid).toBe(1);
+    expect(res.holderInfo).toBeTruthy();
+  });
+
+  it('reclaims a STALE lock left by a dead process', () => {
+    // A very high pid that is essentially guaranteed not to exist.
+    fs.writeFileSync(path.join(dir, 'nanoclaw.lock'), '2147483646');
+    const res = tryAcquireLock(dir);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(fs.readFileSync(res.lockPath, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a garbage / empty lock file', () => {
+    fs.writeFileSync(path.join(dir, 'nanoclaw.lock'), 'not-a-pid');
+    const res = tryAcquireLock(dir);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/single-instance.ts
+++ b/src/single-instance.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { log } from './log.js';
+
+/**
+ * Single-instance guard for the host process.
+ *
+ * Two concurrent host processes each run the 60s sweep and independently spawn a
+ * container for the same due message — the only spawn-idempotency check
+ * (`activeContainers` in container-runner) is per-process in-memory, so each host has
+ * its own empty map and both spawn. The agent then generates and delivers the same
+ * scheduled nudge twice (the duplicate-message bug). Nothing else stops a second
+ * `node dist/index.js` / `pnpm run dev`: the unix sockets are unlink-and-rebind
+ * (stolen, not contended) and the only EADDRINUSE-fatal bind (the webhook port) is
+ * dormant on a Telegram-polling install. This lock makes a second host refuse to start.
+ *
+ * Mechanism: an O_EXCL pidfile at <dataDir>/nanoclaw.lock. A stale lock (holder process
+ * gone) is reclaimed; a live holder is fatal. The pidfile is removed on clean exit; a
+ * SIGKILL leaves it behind, but the next start's liveness check reclaims the dead pid.
+ */
+
+const LOCK_FILE = 'nanoclaw.lock';
+
+function processAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM = the process exists but is owned by another user → still alive.
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function describeProcess(pid: number): string {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'pid=,ppid=,lstart=,command='], {
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return `pid ${pid} (ps lookup failed)`;
+  }
+}
+
+export type LockResult =
+  | { ok: true; lockPath: string }
+  | { ok: false; holderPid: number; holderInfo: string; lockPath: string };
+
+/**
+ * Pure, testable core: try to claim the lock. Never touches the process lifecycle.
+ * Returns ok:true having written our pid, or ok:false with the live holder's details.
+ */
+export function tryAcquireLock(dataDir: string): LockResult {
+  const lockPath = path.join(dataDir, LOCK_FILE);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx'); // O_CREAT|O_EXCL|O_WRONLY — throws EEXIST if present
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      return { ok: true, lockPath };
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e;
+      let holderPid = 0;
+      try {
+        holderPid = parseInt(fs.readFileSync(lockPath, 'utf8').trim(), 10) || 0;
+      } catch {
+        holderPid = 0;
+      }
+      if (holderPid !== process.pid && processAlive(holderPid)) {
+        return { ok: false, holderPid, holderInfo: describeProcess(holderPid), lockPath };
+      }
+      // Stale lock (holder gone, or it is our own pid) → remove and retry once.
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {
+        /* raced with another reclaimer — retry will resolve */
+      }
+    }
+  }
+  // Lost a reclaim race twice — treat as held rather than risk two hosts.
+  return { ok: false, holderPid: 0, holderInfo: 'unknown (lock contention)', lockPath };
+}
+
+/**
+ * Acquire the single-instance lock or exit(1). On success, registers an exit hook to
+ * remove the pidfile. Call this at the very top of main(), before any sweep/poll/socket
+ * starts.
+ */
+export function acquireSingleInstanceLock(dataDir: string): void {
+  const res = tryAcquireLock(dataDir);
+  if (!res.ok) {
+    log.fatal(
+      `Another NanoClaw host is already running (pid ${res.holderPid}) — refusing to start a ` +
+        `second host. Two hosts double-spawn containers and produce duplicate messages. Stop the ` +
+        `other instance first, then retry. Holder: ${res.holderInfo}`,
+    );
+    process.exit(1);
+  }
+  const cleanup = (): void => {
+    try {
+      if (fs.readFileSync(res.lockPath, 'utf8').trim() === String(process.pid)) {
+        fs.unlinkSync(res.lockPath);
+      }
+    } catch {
+      /* already gone / not ours — nothing to do */
+    }
+  };
+  process.once('exit', cleanup);
+  log.info('Single-instance lock acquired', { lockPath: res.lockPath, pid: process.pid });
+}


### PR DESCRIPTION
## Problem

If two host processes run at once — e.g. a hand-started `pnpm run dev` / `node dist/index.js` alongside the installed service — **the agent delivers duplicate messages**. Each host runs its own 60s host-sweep and independently spawns a container for the same due message; the only spawn-idempotency guard (`activeContainers` in `container-runner`) is **per-process in-memory**, so each host has its own empty map and both spawn. The result is two independent generations of the same scheduled message, delivered as two near-identical (paraphrased) replies.

Nothing currently stops a second host from running:

- the unix sockets (`data/ncl.sock`, `data/cli.sock`) are unlink-and-rebind (stolen, not contended), so a second host silently takes them over instead of failing;
- the only `EADDRINUSE`-fatal bind (the webhook HTTP server) is dormant on a Telegram-polling install — Telegram runs `mode: 'polling'` and never registers a webhook, and the gateway path binds an ephemeral port.

So two hosts coexist silently and produce duplicates with no error trace.

## Fix

Add a single-instance guard acquired at the very top of `main()`, before any sweep/poll/socket starts:

- an `O_EXCL` pidfile lock at `<DATA_DIR>/nanoclaw.lock`;
- a **live** holder → `log.fatal` (including the holder's pid + parent + command, looked up via `ps`) then `process.exit(1)`;
- a **stale** lock (holder process gone, verified with `process.kill(pid, 0)`) → reclaimed and taken over;
- the pidfile is removed on clean exit; a `SIGKILL` leaves it behind, but the next start's liveness check reclaims the dead pid.

The pure `tryAcquireLock()` core is unit-tested (clean directory, live holder refused, stale takeover, garbage/empty file).

## Notes

- No new dependencies. ~110 lines in a new `src/single-instance.ts` plus a one-line call in `src/index.ts`.
- Logging the offending pid/command means an operator can immediately see *what* started the second host, instead of chasing invisible duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
