### PR TITLE
fix(cli): generate letter-leading IDs in CRUD create

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -12,6 +12,12 @@ import { getDb } from '../db/connection.js';
 import { register } from './registry.js';
 import type { CallerContext } from './frame.js';
 
+function letterLeadingId(): string {
+  let id = randomUUID();
+  while (!/^[a-z]/.test(id)) id = randomUUID();
+  return id;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -133,7 +139,11 @@ function genericCreate(def: ResourceDef) {
     for (const col of def.columns) {
       if (col.generated) {
         if (col.name === def.idColumn) {
-          values[col.name] = randomUUID();
+          // Generated IDs are used as the OneCLI agent identifier
+          // (container-runner.ts), which must start with a letter. Raw
+          // randomUUID() starts with a hex digit ~60% of the time and is
+          // rejected by OneCLI with a 400, breaking container spawn.
+          values[col.name] = letterLeadingId();
         } else if (col.name.endsWith('_at')) {
           values[col.name] = new Date().toISOString();
         }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`ncl groups create` calls `crypto.randomUUID()` (`src/cli/crud.ts:136`). The resulting ID is passed straight to OneCLI as the agent identifier (`src/container-runner.ts:138`), which OneCLI rejects unless it starts with a letter:

> `Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens`

Raw `randomUUID()` starts with a hex digit (`0-9`) ~60% of the time, so the majority of groups created via `ncl groups create` fail container spawn with `OneCLI returned 400 Bad Request`. Groups created by `init-first-agent` aren't affected — they use the `ag-<ts>-<rand>` format which already starts with `a`.

### Fix

Wrap `randomUUID()` in a small helper that retries until the leading char is `[a-f]`. Average ~2.5 tries; bounded by entropy. ID shape stays UUID-like; existing rows are untouched. Applied at the generic CRUD layer so any future resource whose ID flows to OneCLI is covered defensively.

### Testing

- `pnpm run build` — clean
- `pnpm test --run` — 332/332 pass
- Verified locally: creating a new group via `ncl groups create` now produces a letter-leading ID that OneCLI accepts on first try, and the container spawns successfully.