### PR TITLE
fix(slack): switch adapter to Socket Mode

### DIFF
--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1,5 +1,5 @@
 /**
- * Slack channel adapter (v2) — uses Chat SDK bridge.
+ * Slack channel adapter (v2) — uses Chat SDK bridge in Socket Mode.
  * Self-registers on import.
  */
 import { createSlackAdapter } from '@chat-adapter/slack';
@@ -10,11 +10,12 @@ import { registerChannelAdapter } from './channel-registry.js';
 
 registerChannelAdapter('slack', {
   factory: () => {
-    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET']);
-    if (!env.SLACK_BOT_TOKEN) return null;
+    const env = readEnvFile(['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN']);
+    if (!env.SLACK_BOT_TOKEN || !env.SLACK_APP_TOKEN) return null;
     const slackAdapter = createSlackAdapter({
+      mode: 'socket',
       botToken: env.SLACK_BOT_TOKEN,
-      signingSecret: env.SLACK_SIGNING_SECRET,
+      appToken: env.SLACK_APP_TOKEN,
     });
     const bridge = createChatSdkBridge({ adapter: slackAdapter, concurrency: 'concurrent', supportsThreads: true });
     bridge.resolveChannelName = async (platformId: string) => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

`src/channels/slack.ts` wires `createSlackAdapter` for HTTP webhook mode (`botToken` + `signingSecret`), which requires a publicly reachable URL. But the rest of the codebase already expects Socket Mode:

- `setup/verify.ts` checks `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN`
- `setup/migrate-v2/shared.ts` preserves `SLACK_APP_TOKEN` from v1
- The `/add-slack` skill on `main` walks users through obtaining an App-Level Token (`xapp-...`) — see companion PR #2700

Result: a configured install has the right env vars (`xoxb-...` + `xapp-...`) but the adapter ignores `SLACK_APP_TOKEN` and falls back to webhook mode, which fails because no signing secret is set.

### Fix

Read `SLACK_APP_TOKEN`, fail-fast if either token is missing, and pass `mode: 'socket'` + `appToken` to `createSlackAdapter`. The underlying `@chat-adapter/slack` package then opens a WebSocket to Slack instead of expecting inbound HTTP.

### Heads-up for the reviewer

This change needs `@chat-adapter/slack >= 4.27.0` (where the `mode` and `appToken` fields were added). The lockfile on this branch pins `4.26.0`, so the code doesn't compile as-is.

I tried bumping `@chat-adapter/slack` to `^4.27.0` alone — it pulls in `chat@4.27.0` transitively, which doesn't match the project's pinned `chat@4.26.0`. Fixing that by bumping `chat` to `^4.27.0` then surfaced a separate type issue: `createChatSdkBridge`'s return type no longer exposes `resolveChannelName`, breaking the existing pattern used here and in `telegram.ts`.

So the version bump is bigger than a single-adapter fix — it's a coordinated `@chat-adapter/*` + `chat` SDK upgrade across all the channels. I left it out of this PR to keep the diff focused on the Socket Mode switch. Happy to bundle the SDK upgrade in if you'd prefer one PR.

### Testing

- Manually verified in a local install (with the SDK upgrade applied locally): host log shows `Slack auth completed`, `Slack socket mode connected`, and `Channel adapter started channel="slack"` on startup. No public URL, no webhook server. DMs deliver end-to-end.
- Companion PR #2700 documents this setup on the user-facing side.