### PR TITLE
test(setup): add unit tests for cli-agent parseArgs

### DIFF
--- a/setup/cli-agent.test.ts
+++ b/setup/cli-agent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('./status.js', () => ({ emitStatus: vi.fn() }));
+
+import { parseArgs } from './cli-agent.js';
+
+describe('parseArgs', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+  });
+
+  it('parses --display-name', () => {
+    const result = parseArgs(['--display-name', 'Alice']);
+    expect(result.displayName).toBe('Alice');
+    expect(result.agentName).toBeUndefined();
+    expect(result.folder).toBeUndefined();
+  });
+
+  it('parses all three flags', () => {
+    const result = parseArgs([
+      '--display-name', 'Alice',
+      '--agent-name', 'Andy',
+      '--folder', 'cli-with-alice',
+    ]);
+    expect(result).toEqual({ displayName: 'Alice', agentName: 'Andy', folder: 'cli-with-alice' });
+  });
+
+  it('accepts flags in any order', () => {
+    const result = parseArgs([
+      '--folder', 'mydir',
+      '--agent-name', 'Andy',
+      '--display-name', 'Alice',
+    ]);
+    expect(result.displayName).toBe('Alice');
+    expect(result.agentName).toBe('Andy');
+    expect(result.folder).toBe('mydir');
+  });
+
+  it('calls process.exit(2) when --display-name is missing', () => {
+    parseArgs(['--agent-name', 'Andy']);
+    expect(process.exit).toHaveBeenCalledWith(2);
+  });
+
+  it('calls process.exit(2) for empty args', () => {
+    parseArgs([]);
+    expect(process.exit).toHaveBeenCalledWith(2);
+  });
+});

--- a/setup/cli-agent.ts
+++ b/setup/cli-agent.ts
@@ -16,7 +16,7 @@ import path from 'path';
 import { log } from '../src/log.js';
 import { emitStatus } from './status.js';
 
-function parseArgs(args: string[]): {
+export function parseArgs(args: string[]): {
   displayName: string;
   agentName?: string;
   folder?: string;


### PR DESCRIPTION
Export parseArgs so it can be tested in isolation, then cover the happy path (all flags, any order) and the error path (missing --display-name).

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
