### PR TITLE
fix(use-native-credential-proxy): actually bypass the OneCLI gateway

### DIFF
--- a/.claude/skills/use-native-credential-proxy/REMOVE.md
+++ b/.claude/skills/use-native-credential-proxy/REMOVE.md
@@ -10,18 +10,48 @@ rm -f src/native-credential-proxy.ts \
       src/native-credential-proxy-wiring.test.ts
 ```
 
-## 2. Revert the reach-in in `src/container-runner.ts`
+## 2. Revert the edits in `src/container-runner.ts`
 
 - Remove the import line:
 
   ```ts
-  import { nativeCredentialEnvArgs } from './native-credential-proxy.js';
+  import { nativeCredentialEnvArgs, nativeCredentialsEnabled } from './native-credential-proxy.js';
   ```
 
 - Remove the call that follows the `TZ` env line, leaving the `TZ` line intact:
 
   ```ts
   args.push(...nativeCredentialEnvArgs());
+  ```
+
+- Unwrap the OneCLI gateway guard so the gateway always applies again. Replace:
+
+  ```ts
+  if (!nativeCredentialsEnabled()) {
+    if (agentIdentifier) {
+      await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+    }
+    const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+    if (!onecliApplied) {
+      throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
+    }
+    log.info('OneCLI gateway applied', { containerName });
+  } else {
+    log.info('OneCLI gateway skipped — native credentials enabled', { containerName });
+  }
+  ```
+
+  with the original unguarded block:
+
+  ```ts
+  if (agentIdentifier) {
+    await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+  }
+  const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+  if (!onecliApplied) {
+    throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
+  }
+  log.info('OneCLI gateway applied', { containerName });
   ```
 
 ## 3. Remove the env keys
@@ -61,6 +91,7 @@ Confirm the reach-in is gone and the proxy file is removed:
 ```bash
 test -f src/native-credential-proxy.ts && echo "still present" || echo removed
 grep -c 'nativeCredentialEnvArgs' src/container-runner.ts
+grep -c 'nativeCredentialsEnabled' src/container-runner.ts
 ```
 
-Expected: `removed`, and a count of `0`.
+Expected: `removed`, and a count of `0` for both greps.

--- a/.claude/skills/use-native-credential-proxy/SKILL.md
+++ b/.claude/skills/use-native-credential-proxy/SKILL.md
@@ -9,23 +9,27 @@ This skill adds a **native, `.env`-based credential path** for the container age
 
 > **Credential-home inversion — read this first.** NanoClaw's default is that credentials live in the OneCLI agent vault and are injected per request, never threaded into the container via `-e`. This skill deliberately inverts that: the credential lives in `.env` on the host and is passed into the container's environment. That inversion is the *entire point* of this skill (simple `.env` credentials without OneCLI). Use it only if you accept that tradeoff; everywhere else in NanoClaw, env-threaded credentials are an anti-pattern.
 
-The skill is **additive**: it ships its proxy logic and tests in this folder, copies them into `src/`, and makes a single one-line reach-in at the container-spawn seam (gated by an env flag). It does not remove or rewrite the OneCLI gateway — when the flag is unset, the gateway path is exactly as it was, and the native proxy is a no-op.
+The skill is **additive**: it ships its proxy logic and tests in this folder, copies them into `src/`, and makes two small edits at the container-spawn seam (both gated by an env flag) — one to thread the `.env` credential into the container, one to skip the OneCLI gateway. When the flag is unset both are no-ops and the gateway path is exactly as it was; when it is set, the gateway is bypassed and the credential comes straight from `.env`.
 
 ## How it works
 
 - `src/native-credential-proxy.ts` exports `nativeCredentialEnvArgs()`. It reads `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` (and optional `ANTHROPIC_BASE_URL`) from `.env` via core's `readEnvFile`, and returns the Docker `-e VAR=value` arguments.
-- All gating lives inside that function: it returns an empty array unless `NANOCLAW_NATIVE_CREDENTIALS=true`. So the reach-in in core is a single unconditional `args.push(...nativeCredentialEnvArgs())`.
-- The seam is `buildContainerArgs` in `src/container-runner.ts`, right after the `TZ` env line — the same place container env vars are assembled, just before the OneCLI gateway is applied. With the flag on, the direct credential env vars take precedence in the container; with it off, nothing changes.
+- Most gating lives inside `nativeCredentialEnvArgs()`: it returns an empty array unless `NANOCLAW_NATIVE_CREDENTIALS=true`, so the reach-in in core is a single unconditional `args.push(...nativeCredentialEnvArgs())`. The companion `nativeCredentialsEnabled()` predicate gates the gateway skip.
+- The seam is `buildContainerArgs` in `src/container-runner.ts`. The credential reach-in goes right after the `TZ` env line; the gateway skip wraps the OneCLI gateway block further down. With the flag on, the gateway is bypassed and the `.env` credential is the sole auth path; with it off, nothing changes.
+- **Both edits are required.** Threading the credential without skipping the gateway leaves the gateway's HTTPS_PROXY in place, which MITMs `api.anthropic.com` and overrides the `.env` credential — the agent then fails every turn with "Invalid API key".
 
 ## Phase 1: Pre-flight
 
 ### Check if already applied
 
 ```bash
-test -f src/native-credential-proxy.ts && grep -q 'nativeCredentialEnvArgs' src/container-runner.ts && echo applied || echo not-applied
+test -f src/native-credential-proxy.ts \
+  && grep -q 'nativeCredentialEnvArgs' src/container-runner.ts \
+  && grep -q 'nativeCredentialsEnabled' src/container-runner.ts \
+  && echo applied || echo not-applied
 ```
 
-If it prints `applied`, the native proxy is already wired — skip to Phase 3 (Configure).
+If it prints `applied`, both the credential reach-in and the gateway skip are wired — skip to Phase 3 (Configure). If `src/native-credential-proxy.ts` exists and `nativeCredentialEnvArgs` is present but `nativeCredentialsEnabled` is not, an older version of this skill was installed *without* the gateway skip — re-apply Phase 2 to add it (this is the fix for an agent that gets "Invalid API key" with native credentials set).
 
 ### Confirm the seam exists
 
@@ -53,7 +57,7 @@ cp $S/native-credential-proxy-wiring.test.ts  src/native-credential-proxy-wiring
 Add this import alongside the other local imports (e.g. right after the `./container-config.js` import):
 
 ```ts
-import { nativeCredentialEnvArgs } from './native-credential-proxy.js';
+import { nativeCredentialEnvArgs, nativeCredentialsEnabled } from './native-credential-proxy.js';
 ```
 
 ### Make the one-line reach-in
@@ -65,7 +69,43 @@ In `buildContainerArgs`, find the `TZ` env line and add the call right after it:
   args.push(...nativeCredentialEnvArgs());
 ```
 
-That is the only edit to core. `native-credential-proxy-wiring.test.ts` asserts this `args.push(...nativeCredentialEnvArgs())` call exists inside `buildContainerArgs` — delete the reach-in and it goes red.
+`native-credential-proxy-wiring.test.ts` asserts this `args.push(...nativeCredentialEnvArgs())` call exists inside `buildContainerArgs` — delete the reach-in and it goes red.
+
+### Skip the OneCLI gateway when native credentials are on
+
+Threading the credential is necessary but **not sufficient**. The OneCLI gateway block (a little further down in `buildContainerArgs`) injects an `HTTPS_PROXY` + CA cert that routes every container request through the vault. With native credentials on, that proxy MITMs `api.anthropic.com` and overrides the `.env` credential with the vault's — the agent then fails every turn with **"Invalid API key"**. So the gateway must be skipped when the opt-out flag is set.
+
+Find the OneCLI gateway block — it looks like this:
+
+```ts
+  if (agentIdentifier) {
+    await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+  }
+  const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+  if (!onecliApplied) {
+    throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
+  }
+  log.info('OneCLI gateway applied', { containerName });
+```
+
+Wrap the whole block in a `nativeCredentialsEnabled()` guard so it is skipped entirely when the opt-out is on:
+
+```ts
+  if (!nativeCredentialsEnabled()) {
+    if (agentIdentifier) {
+      await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+    }
+    const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+    if (!onecliApplied) {
+      throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
+    }
+    log.info('OneCLI gateway applied', { containerName });
+  } else {
+    log.info('OneCLI gateway skipped — native credentials enabled', { containerName });
+  }
+```
+
+These two edits (the reach-in and this guard) are the only changes to core. `native-credential-proxy-wiring.test.ts` asserts the guard wraps the `applyContainerConfig` call — remove it and the test goes red.
 
 ### Add the env flag stub to `.env.example`
 
@@ -148,7 +188,9 @@ Send a test message in a registered chat and confirm the agent responds. If the 
 
 **401 errors from the API:** The credential in `.env` is invalid or expired. For a subscription token, re-run `claude setup-token` and update `CLAUDE_CODE_OAUTH_TOKEN`. For an API key, check it at console.anthropic.com.
 
-**Agent still goes through OneCLI:** Confirm `NANOCLAW_NATIVE_CREDENTIALS=true` is in `.env` and the service was restarted. With the flag unset, `nativeCredentialEnvArgs()` is a no-op and the OneCLI gateway remains the credential source.
+**"Invalid API key" on every turn (credential is valid):** The credential reaches the container but is being overridden by the OneCLI gateway's HTTPS_PROXY. This means the gateway skip is missing — confirm `grep nativeCredentialsEnabled src/container-runner.ts` returns the guard around the `applyContainerConfig` block, rebuild, and restart. The host log should print `OneCLI gateway skipped — native credentials enabled` on the next spawn. (To confirm the credential itself is good, call the API directly, bypassing the proxy: `curl https://api.anthropic.com/v1/messages -H "authorization: Bearer $CLAUDE_CODE_OAUTH_TOKEN" -H "anthropic-version: 2023-06-01" -H "anthropic-beta: oauth-2025-04-20" -H "content-type: application/json" -d '{"model":"claude-haiku-4-5-20251001","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}'` — a `200` means the token is fine and the proxy is the culprit.)
+
+**Agent still goes through OneCLI:** Confirm `NANOCLAW_NATIVE_CREDENTIALS=true` is in `.env` and the service was restarted. The flag is read from both `process.env` and `.env`; with it unset, `nativeCredentialEnvArgs()` is a no-op, `nativeCredentialsEnabled()` is false, and the OneCLI gateway remains the credential source.
 
 ## Removal
 

--- a/.claude/skills/use-native-credential-proxy/native-credential-proxy-wiring.test.ts
+++ b/.claude/skills/use-native-credential-proxy/native-credential-proxy-wiring.test.ts
@@ -6,9 +6,15 @@
  * isolation, but that does not prove buildContainerArgs actually uses it — a
  * direct unit test stays green even if the reach-in is deleted.
  * buildContainerArgs is entangled with the OneCLI gateway and not cheaply
- * invocable, so the integration is asserted structurally: inside
- * buildContainerArgs there is an `args.push(...nativeCredentialEnvArgs())`
- * call. Delete the reach-in and this goes red.
+ * invocable, so the integration is asserted structurally:
+ *   1. inside buildContainerArgs there is an
+ *      `args.push(...nativeCredentialEnvArgs())` call (the credential reach-in);
+ *   2. the OneCLI gateway block (`onecli.applyContainerConfig(...)`) is wrapped
+ *      in a `nativeCredentialsEnabled()` guard so it is skipped under the
+ *      opt-out (the gateway skip).
+ * Delete either and the corresponding assertion goes red. The second guards the
+ * "Invalid API key" failure: threading the credential without skipping the
+ * gateway leaves an HTTPS_PROXY that MITMs the API and overrides the credential.
  */
 import fs from 'fs';
 import path from 'path';
@@ -52,6 +58,34 @@ function isSpreadPushOfCredentialArgs(node: ts.Node): boolean {
   );
 }
 
+/** Does this subtree contain a call to the named identifier (e.g. a method like `applyContainerConfig`)? */
+function containsCallTo(node: ts.Node, name: string): boolean {
+  let found = false;
+  const visit = (n: ts.Node) => {
+    if (ts.isCallExpression(n)) {
+      const callee = n.expression;
+      if (ts.isIdentifier(callee) && callee.text === name) found = true;
+      if (ts.isPropertyAccessExpression(callee) && callee.name.text === name) found = true;
+    }
+    if (!found) ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * Is this an `if` whose condition calls `nativeCredentialsEnabled()` and whose
+ * branches contain the OneCLI gateway apply? Matches both `if (!enabled()) {
+ * apply }` and `if (enabled()) {} else { apply }` shapes.
+ */
+function isGatewaySkipGuard(node: ts.Node): boolean {
+  if (!ts.isIfStatement(node)) return false;
+  if (!containsCallTo(node.expression, 'nativeCredentialsEnabled')) return false;
+  const inThen = containsCallTo(node.thenStatement, 'applyContainerConfig');
+  const inElse = node.elseStatement ? containsCallTo(node.elseStatement, 'applyContainerConfig') : false;
+  return inThen || inElse;
+}
+
 describe('container-runner.ts wires in nativeCredentialEnvArgs', () => {
   const sf = sourceFile();
   const fn = findFunction(sf, 'buildContainerArgs');
@@ -68,5 +102,15 @@ describe('container-runner.ts wires in nativeCredentialEnvArgs', () => {
     };
     if (fn?.body) visit(fn.body);
     expect(wired).toBe(true);
+  });
+
+  it('guards the OneCLI gateway apply with nativeCredentialsEnabled()', () => {
+    let guarded = false;
+    const visit = (node: ts.Node) => {
+      if (isGatewaySkipGuard(node)) guarded = true;
+      if (!guarded) ts.forEachChild(node, visit);
+    };
+    if (fn?.body) visit(fn.body);
+    expect(guarded).toBe(true);
   });
 });

--- a/.claude/skills/use-native-credential-proxy/native-credential-proxy.ts
+++ b/.claude/skills/use-native-credential-proxy/native-credential-proxy.ts
@@ -16,11 +16,18 @@
  * skill — simple `.env`-based credentials without OneCLI — so the env-var
  * threading is intentional here, not an accident.
  *
- * Lives in its own file so the reach-in in `container-runner.ts` is a single
- * call (`args.push(...nativeCredentialEnvArgs())`) and this logic is
- * behavior-testable in isolation, without invoking the OneCLI-entangled
- * `buildContainerArgs`. All gating lives here too: when the opt-out flag is
- * not set, the function returns no args and the gateway path is untouched.
+ * Lives in its own file so the reach-in in `container-runner.ts` is small —
+ * an `args.push(...nativeCredentialEnvArgs())` to thread the credential plus a
+ * `nativeCredentialsEnabled()` guard that skips the OneCLI gateway — and this
+ * logic is behavior-testable in isolation, without invoking the OneCLI-entangled
+ * `buildContainerArgs`. All gating lives here too: when the opt-out flag is not
+ * set, `nativeCredentialEnvArgs()` returns no args and the guard is false, so
+ * the OneCLI gateway path is exactly as it was.
+ *
+ * The gateway MUST be skipped when this opt-out is on: it injects an HTTPS_PROXY
+ * that MITMs api.anthropic.com and overrides the `.env` credential with the
+ * vault's (yielding "Invalid API key"). Threading the credential without
+ * skipping the gateway is a no-op at best and a breakage at worst.
  */
 import { readEnvFile } from './env.js';
 
@@ -39,9 +46,17 @@ export const NATIVE_CREDENTIAL_VARS = [
   'ANTHROPIC_BASE_URL',
 ] as const;
 
-/** Is the native `.env` credential opt-out enabled? */
+/**
+ * Is the native `.env` credential opt-out enabled?
+ *
+ * Honors both `process.env` and `.env` (matching the `process.env.X ||
+ * envConfig.X` convention in `config.ts`). The host is launched by launchd /
+ * systemd without `.env` loaded into its environment, so checking only
+ * `process.env` would leave the flag perpetually off even when set in `.env`.
+ */
 export function nativeCredentialsEnabled(): boolean {
-  return process.env[NATIVE_CREDENTIALS_FLAG] === 'true';
+  if (process.env[NATIVE_CREDENTIALS_FLAG] === 'true') return true;
+  return readEnvFile([NATIVE_CREDENTIALS_FLAG])[NATIVE_CREDENTIALS_FLAG] === 'true';
 }
 
 /**


### PR DESCRIPTION
**What** — Makes the `use-native-credential-proxy` skill actually opt out of the OneCLI gateway, instead of silently falling back to it.

**Why** — As shipped, the skill failed on a real (launchd/systemd) install in two compounding ways:

1. `nativeCredentialsEnabled()` only read `process.env`. The host runs under launchd/systemd with no `.env` loaded, so the flag was always `false` and the opt-out never engaged.
2. Even with the credential threaded in, the gateway stayed applied. Its `HTTPS_PROXY` MITMs `api.anthropic.com` and overrides the `.env` credential — so the agent fails every turn with **"Invalid API key."**

**How it works** — `nativeCredentialsEnabled()` now also reads `.env` via `readEnvFile` (matching the `process.env.X || envConfig.X` convention used elsewhere); `SKILL.md` wraps the OneCLI gateway block in a `nativeCredentialsEnabled()` guard so it is skipped under the opt-out; the wiring test asserts the guard; `REMOVE.md` unwinds it. Both fixes are required — the gateway skip is dead code without the `.env` read, since the guard never trips under launchd.

**How it was tested** — `pnpm exec vitest run native-credential-proxy{,-wiring}.test.ts` (7 passing, including the new guard assertion), and end-to-end on a launchd install: host logs `OneCLI gateway skipped — native credentials enabled` and the agent authenticates with a Claude Max OAuth token served from `.env`.

Scope: 4 files, all under `.claude/skills/use-native-credential-proxy/`.

---
Type: **Fix**

🤖 Generated with [Claude Code](https://claude.com/claude-code)