### PR TITLE
fix(setup): reap orphaned agent containers on service stop

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -10,7 +10,7 @@ import os from 'os';
 import path from 'path';
 
 import { log } from '../src/log.js';
-import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { getInstallSlug, getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
 import {
   commandExists,
@@ -280,6 +280,7 @@ function setupSystemd(
 ): void {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
+  const installSlug = getInstallSlug(projectRoot);
   const unitFileName = `${unitName}.service`;
 
   // Root uses system-level service, non-root uses user-level
@@ -318,6 +319,10 @@ WorkingDirectory=${projectRoot}
 Restart=always
 RestartSec=5
 KillMode=process
+# Reap this install's agent containers when the host stops, so KillMode=process
+# (which spares them from systemd) doesn't leave orphans across restarts. Scoped
+# by label so peer installs are untouched; matches the host's docker stop -t 1.
+ExecStopPost=/bin/sh -c 'docker ps -q --filter label=nanoclaw-install=${installSlug} | xargs -r docker stop -t 1'
 Environment=HOME=${homeDir}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
 StandardOutput=append:${projectRoot}/logs/nanoclaw.log


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — The generated Linux systemd unit now reaps this install's agent containers when the host service stops, via an `ExecStopPost` hook in `setup/service.ts`.

**Why** — The unit runs with `KillMode=process`, which deliberately spares the agent containers from systemd's cgroup kill so in-flight work can survive a host restart. The side effect is that on `stop`/`restart` those containers are orphaned until the *next* startup's `cleanupOrphans()` reaps them. In the meantime systemd logs a `Found left-over process <pid> (docker) in control group while starting unit ... unclean termination` warning on every restart, and a container lingers during the gap.

**How it works** — `ExecStopPost` runs `docker stop -t 1` against containers carrying this install's `nanoclaw-install=<slug>` label (slug interpolated via `getInstallSlug`). This reuses the exact label scoping and stop command the host already uses in `cleanupOrphans()`/`stopContainer`, so:
- peer installs sharing the Docker daemon are never touched,
- `KillMode=process` is kept, so the host still gets a clean SIGTERM shutdown,
- startup `cleanupOrphans()` stays in place as a fallback for crash (non-graceful) exits.

Only the systemd path is affected; macOS/launchd and the nohup fallback are unchanged.

**How it was tested** —
- Planted a container labeled `nanoclaw-install=<slug>`, ran `systemctl --user stop`, and confirmed `ExecStopPost` ran (`code=exited status=0`) and reaped it — container list empty afterward.
- Confirmed a container labeled for a *different* install on the same daemon was left running (label scoping holds).
- Restarted the service and verified a clean start with no `left-over process` / `unclean termination` warning in the journal.
- `pnpm run build` (`tsc`) passes.