### PR TITLE
feat(container-config): DB-backed env + blocked_hosts for ContainerConfig

### DIFF
--- a/src/backfill-container-configs.ts
+++ b/src/backfill-container-configs.ts
@@ -24,6 +24,8 @@ interface LegacyContainerJson {
   provider?: string;
   assistantName?: string;
   maxMessagesPerPrompt?: number;
+  env?: Record<string, string>;
+  blockedHosts?: string[];
 }
 
 export function backfillContainerConfigs(): void {
@@ -64,6 +66,8 @@ export function backfillContainerConfigs(): void {
       packages_apt: JSON.stringify(legacy.packages?.apt ?? []),
       packages_npm: JSON.stringify(legacy.packages?.npm ?? []),
       additional_mounts: JSON.stringify(legacy.additionalMounts ?? []),
+      env: JSON.stringify(legacy.env ?? {}),
+      blocked_hosts: JSON.stringify(legacy.blockedHosts ?? []),
       cli_scope: 'group',
       updated_at: new Date().toISOString(),
     };

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -27,6 +27,8 @@ function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
     packages_apt: JSON.parse(row.packages_apt),
     packages_npm: JSON.parse(row.packages_npm),
     additional_mounts: JSON.parse(row.additional_mounts),
+    env: JSON.parse(row.env),
+    blocked_hosts: JSON.parse(row.blocked_hosts),
     cli_scope: row.cli_scope,
     updated_at: row.updated_at,
   };
@@ -251,6 +253,72 @@ registerResource({
 
         const updated = getContainerConfig(id)!;
         return presentConfig(updated);
+      },
+    },
+    'config set-env': {
+      access: 'approval',
+      description:
+        'Set the container env vars for a group (replaces the whole map). Requires `ncl groups restart` to take effect. ' +
+        'Use --id <group-id> --env <json-object>, e.g. --env \'{"ANTHROPIC_BASE_URL":"http://host.docker.internal:11434"}\'. Pass --env \'{}\' to clear.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('--id is required');
+        if (args.env === undefined) throw new Error('--env <json-object> is required');
+
+        const row = getContainerConfig(id);
+        if (!row) throw new Error(`No container config for group: ${id}`);
+
+        let env: Record<string, string>;
+        try {
+          env = JSON.parse(args.env as string) as Record<string, string>;
+        } catch {
+          throw new Error('--env must be a valid JSON object');
+        }
+        if (typeof env !== 'object' || env === null || Array.isArray(env)) {
+          throw new Error('--env must be a JSON object of string values');
+        }
+        updateContainerConfigJson(id, 'env', env);
+
+        return presentConfig(getContainerConfig(id)!);
+      },
+    },
+    'config block-host': {
+      access: 'approval',
+      description:
+        'Block a host inside the container (mapped to 0.0.0.0). Requires `ncl groups restart` to take effect. Use --id <group-id> --host <hostname>.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('--id is required');
+        const host = args.host as string;
+        if (!host) throw new Error('--host is required');
+
+        const row = getContainerConfig(id);
+        if (!row) throw new Error(`No container config for group: ${id}`);
+
+        const hosts = JSON.parse(row.blocked_hosts) as string[];
+        if (!hosts.includes(host)) hosts.push(host);
+        updateContainerConfigJson(id, 'blocked_hosts', hosts);
+
+        return { blocked: host, blocked_hosts: hosts };
+      },
+    },
+    'config unblock-host': {
+      access: 'approval',
+      description:
+        'Remove a blocked host from a group. Requires `ncl groups restart` to take effect. Use --id <group-id> --host <hostname>.',
+      handler: async (args) => {
+        const id = args.id as string;
+        if (!id) throw new Error('--id is required');
+        const host = args.host as string;
+        if (!host) throw new Error('--host is required');
+
+        const row = getContainerConfig(id);
+        if (!row) throw new Error(`No container config for group: ${id}`);
+
+        const hosts = (JSON.parse(row.blocked_hosts) as string[]).filter((h) => h !== host);
+        updateContainerConfigJson(id, 'blocked_hosts', hosts);
+
+        return { unblocked: host, blocked_hosts: hosts };
       },
     },
     'config add-mcp-server': {

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -43,6 +43,19 @@ export interface ContainerConfig {
   maxMessagesPerPrompt?: number;
   model?: string;
   effort?: string;
+  /**
+   * Extra env vars injected into the container at spawn as `-e KEY=VALUE`.
+   * Used e.g. to redirect the agent to a local OpenAI/Anthropic-compatible
+   * endpoint (ANTHROPIC_BASE_URL, NO_PROXY). DB-backed (`container_configs.env`).
+   */
+  env: Record<string, string>;
+  /**
+   * Hosts made unreachable inside the container (mapped to 0.0.0.0 via
+   * `--add-host`). Pairs with `env` to harden a local-model redirect: block
+   * `api.anthropic.com` so the agent fails fast instead of silently falling
+   * back to the cloud API. DB-backed (`container_configs.blocked_hosts`).
+   */
+  blockedHosts: string[];
 }
 
 /** Build a `ContainerConfig` from a DB row + agent group identity. */
@@ -63,6 +76,8 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
     maxMessagesPerPrompt: row.max_messages_per_prompt ?? undefined,
     model: row.model ?? undefined,
     effort: row.effort ?? undefined,
+    env: JSON.parse(row.env) as Record<string, string>,
+    blockedHosts: JSON.parse(row.blocked_hosts) as string[],
   };
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -432,6 +432,19 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // Config-supplied env vars. Applied after the OneCLI gateway so they win over
+  // its injected vars (e.g. redirecting ANTHROPIC_BASE_URL to a local model).
+  for (const [key, value] of Object.entries(containerConfig.env)) {
+    args.push('-e', `${key}=${value}`);
+  }
+
+  // Blocked hosts → mapped to 0.0.0.0 so they're unreachable from the container
+  // (e.g. block api.anthropic.com so a local-model agent fails fast instead of
+  // silently reaching the cloud API if the redirect is misconfigured).
+  for (const host of containerConfig.blockedHosts) {
+    args.push('--add-host', `${host}:0.0.0.0`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 

--- a/src/db/container-configs.test.ts
+++ b/src/db/container-configs.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { configFromDb } from '../container-config.js';
+import type { AgentGroup, ContainerConfigRow } from '../types.js';
+import {
+  initTestDb,
+  closeDb,
+  runMigrations,
+  createAgentGroup,
+  getAgentGroup,
+  ensureContainerConfig,
+  getContainerConfig,
+  createContainerConfig,
+  updateContainerConfigJson,
+} from './index.js';
+
+function now() {
+  return new Date().toISOString();
+}
+
+const GROUP = {
+  id: 'ag-1',
+  name: 'Test Agent',
+  folder: 'test-agent',
+  agent_provider: null,
+  created_at: now(),
+};
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  createAgentGroup(GROUP);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('container_configs env / blocked_hosts', () => {
+  it('defaults to empty object / array for new rows', () => {
+    ensureContainerConfig('ag-1');
+    const row = getContainerConfig('ag-1')!;
+    expect(row.env).toBe('{}');
+    expect(row.blocked_hosts).toBe('[]');
+  });
+
+  it('round-trips env + blocked_hosts and configFromDb parses them', () => {
+    ensureContainerConfig('ag-1');
+    updateContainerConfigJson('ag-1', 'env', {
+      ANTHROPIC_BASE_URL: 'http://host.docker.internal:11434',
+      NO_PROXY: 'host.docker.internal',
+    });
+    updateContainerConfigJson('ag-1', 'blocked_hosts', ['api.anthropic.com']);
+
+    const row = getContainerConfig('ag-1')!;
+    const group = getAgentGroup('ag-1') as AgentGroup;
+    const config = configFromDb(row, group);
+
+    expect(config.env).toEqual({
+      ANTHROPIC_BASE_URL: 'http://host.docker.internal:11434',
+      NO_PROXY: 'host.docker.internal',
+    });
+    expect(config.blockedHosts).toEqual(['api.anthropic.com']);
+  });
+
+  it('createContainerConfig persists supplied env + blocked_hosts', () => {
+    const row: ContainerConfigRow = {
+      agent_group_id: 'ag-1',
+      provider: null,
+      model: null,
+      effort: null,
+      image_tag: null,
+      assistant_name: null,
+      max_messages_per_prompt: null,
+      skills: '"all"',
+      mcp_servers: '{}',
+      packages_apt: '[]',
+      packages_npm: '[]',
+      additional_mounts: '[]',
+      env: JSON.stringify({ FOO: 'bar' }),
+      blocked_hosts: JSON.stringify(['blocked.example']),
+      cli_scope: 'group',
+      updated_at: now(),
+    };
+    createContainerConfig(row);
+
+    const stored = getContainerConfig('ag-1')!;
+    expect(JSON.parse(stored.env)).toEqual({ FOO: 'bar' });
+    expect(JSON.parse(stored.blocked_hosts)).toEqual(['blocked.example']);
+  });
+});

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -10,7 +10,15 @@ const SCALAR_COLUMNS = new Set([
   'max_messages_per_prompt',
   'cli_scope',
 ]);
-const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
+const JSON_COLUMNS = new Set([
+  'skills',
+  'mcp_servers',
+  'packages_apt',
+  'packages_npm',
+  'additional_mounts',
+  'env',
+  'blocked_hosts',
+]);
 
 export function getContainerConfig(agentGroupId: string): ContainerConfigRow | undefined {
   return getDb().prepare('SELECT * FROM container_configs WHERE agent_group_id = ?').get(agentGroupId) as
@@ -29,11 +37,11 @@ export function createContainerConfig(config: ContainerConfigRow): void {
       `INSERT INTO container_configs (
         agent_group_id, provider, model, effort, image_tag, assistant_name,
         max_messages_per_prompt, skills, mcp_servers, packages_apt, packages_npm,
-        additional_mounts, updated_at
+        additional_mounts, env, blocked_hosts, updated_at
       ) VALUES (
         @agent_group_id, @provider, @model, @effort, @image_tag, @assistant_name,
         @max_messages_per_prompt, @skills, @mcp_servers, @packages_apt, @packages_npm,
-        @additional_mounts, @updated_at
+        @additional_mounts, @env, @blocked_hosts, @updated_at
       )`,
     )
     .run(config);
@@ -82,7 +90,7 @@ export function updateContainerConfigScalars(
 /** Overwrite a JSON column wholesale. Used for skills, mcp_servers, packages_*, additional_mounts. */
 export function updateContainerConfigJson(
   agentGroupId: string,
-  column: 'skills' | 'mcp_servers' | 'packages_apt' | 'packages_npm' | 'additional_mounts',
+  column: 'skills' | 'mcp_servers' | 'packages_apt' | 'packages_npm' | 'additional_mounts' | 'env' | 'blocked_hosts',
   value: unknown,
 ): void {
   if (!JSON_COLUMNS.has(column)) throw new Error(`Invalid JSON column: ${column}`);

--- a/src/db/migrations/016-container-env-blocked-hosts.ts
+++ b/src/db/migrations/016-container-env-blocked-hosts.ts
@@ -1,0 +1,11 @@
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration016: Migration = {
+  version: 16,
+  name: 'container-env-blocked-hosts',
+  up(db: Database.Database) {
+    db.prepare("ALTER TABLE container_configs ADD COLUMN env TEXT NOT NULL DEFAULT '{}'").run();
+    db.prepare("ALTER TABLE container_configs ADD COLUMN blocked_hosts TEXT NOT NULL DEFAULT '[]'").run();
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-container-configs.js';
 import { migration015 } from './015-cli-scope.js';
+import { migration016 } from './016-container-env-blocked-hosts.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -35,6 +36,7 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migration016,
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface ContainerConfigRow {
   packages_apt: string; // JSON: string[]
   packages_npm: string; // JSON: string[]
   additional_mounts: string; // JSON: AdditionalMountConfig[]
+  env: string; // JSON: Record<string, string>
+  blocked_hosts: string; // JSON: string[]
   cli_scope: string; // 'disabled' | 'group' | 'global'
   updated_at: string;
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

Implements maintainer-filed #1867 (a source-level enhancement the maintainers requested).

## Description

**What.** Adds two DB-backed JSON columns to `container_configs` — `env` (`Record<string,string>`) and `blocked_hosts` (`string[]`) — materialised into `container.json` and applied at container spawn:
- `env` → injected as `-e KEY=VALUE`, after the OneCLI gateway so config vars win (e.g. overriding `ANTHROPIC_BASE_URL`).
- `blocked_hosts` → each mapped to `0.0.0.0` via `--add-host`.

**Why.** Lets an agent group be routed to a local OpenAI/Anthropic-compatible endpoint and hardened against silent cloud fallback without editing source — the infra #1859 (`/add-ollama-provider`) documented as a deferred prerequisite, so that skill's redirect survives the DB→`container.json` materialise instead of being wiped on each spawn. Closes #1867.

**How.** Stored as JSON columns alongside `skills` / `mcp_servers` / `additional_mounts` for consistency. Migration 016 adds the columns; `configFromDb` parses them; backfill carries any legacy `container.json` values in. Managed via `ncl groups config set-env` / `block-host` / `unblock-host`; `config get` shows both. (#1859's third prereq, the Dockerfile chmod, is an independent concern — out of scope.)

**Tested.** `tsc` clean; `pnpm test` 335 passing (3 new in `container-configs.test.ts`). Validated live: an agent group pointed at a local Ollama endpoint via `env.ANTHROPIC_BASE_URL` with `api.anthropic.com` blocked — `docker inspect` confirms the `-e` vars + `ExtraHosts: api.anthropic.com:0.0.0.0`, the agent replies via the local model, and the config survives respawns.
