### PR TITLE
fix(telegram): use CSPRNG for pairing codes and lock down store permissions

### DIFF
--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -70,6 +70,17 @@ describe('createPairing', () => {
     expect(r.status).toBe('pending');
   });
 
+  it.skipIf(process.platform === 'win32')('writes the store with owner-only permissions', async () => {
+    await createPairing('main');
+    const storeFile = path.join(tmpDir, 'pairings.json');
+    expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+
+    // A stale tmp file with loose perms must not survive into the store.
+    fs.writeFileSync(`${storeFile}.tmp`, 'stale', { mode: 0o644 });
+    await createPairing('main');
+    expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+  });
+
   it('does not collide with active codes', async () => {
     const codes = new Set<string>();
     for (let i = 0; i < 20; i++) {

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -14,6 +14,7 @@
  * Storage is a JSON file at data/telegram-pairings.json — single-process,
  * read-modify-write under an in-process mutex.
  */
+import { randomInt } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -91,9 +92,12 @@ function readStore(): Store {
 
 function writeStore(store: Store): void {
   const p = storePath();
-  fs.mkdirSync(path.dirname(p), { recursive: true });
+  // Codes are auth material: dir 0700, file 0600. Modes only apply at
+  // creation, so drop any stale tmp that would carry old perms through rename.
+  fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o700 });
   const tmp = `${p}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(store, null, 2));
+  fs.rmSync(tmp, { force: true });
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
   fs.renameSync(tmp, p);
 }
 
@@ -106,10 +110,10 @@ function sweep(store: Store): boolean {
 
 function generateCode(active: Set<string>): string {
   // 4-digit numeric, zero-padded. 10k space, fine for one-at-a-time intents.
+  // randomInt, not Math.random: the first pairer can be promoted to owner,
+  // and Math.random is predictable from its prior outputs.
   for (let i = 0; i < 50; i++) {
-    const code = Math.floor(Math.random() * 10000)
-      .toString()
-      .padStart(4, '0');
+    const code = randomInt(0, 10000).toString().padStart(4, '0');
     if (!active.has(code)) return code;
   }
   throw new Error('Could not allocate a free pairing code (too many active).');
@@ -317,7 +321,7 @@ export async function waitForPairing(code: string, opts: WaitForPairingOptions =
 
     try {
       const dir = path.dirname(storePath());
-      fs.mkdirSync(dir, { recursive: true });
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
       watcher = fs.watch(dir, (_event, fname) => {
         if (!fname || fname.toString().startsWith(path.basename(storePath()))) check();
       });


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Pairing codes gate chat registration, and the first pairer can be promoted to owner — but `generateCode` drew them from `Math.random`, which is predictable from observed outputs. Switched to `crypto.randomInt`.

Also locks down the pairing store, which holds pending codes in plaintext: directory `0700`, file `0600`. `writeFileSync`'s `mode` only applies when the file is created, so a stale `.tmp` left by a crash could carry old permissions through the rename; it's now removed before writing.

Tested: new regression test asserts the store file lands at `0600` (skipped on Windows); `telegram-pairing.test.ts` passes 27/27. These files also typecheck and pass the full suite when copied into a trunk install. Note for reviewers: `tsc` on the `channels` branch tip fails for pre-existing, unrelated reasons (`telegram.ts` references `resolveChannelName`, absent from this branch's `ChannelAdapter`), same as noted in #2552.