### PR TITLE
Add web-search-plus skill (multi-provider web search + extraction, no MCP)

### DIFF
--- a/.claude/skills/add-web-search-plus/REMOVE.md
+++ b/.claude/skills/add-web-search-plus/REMOVE.md
@@ -1,0 +1,68 @@
+# Remove Web Search Plus
+
+Idempotent — safe to run even if some steps were never applied. Reverses the
+copied container skill, the integration test, and the Dockerfile edit.
+
+## 1. Delete the copied skill files and test
+
+```bash
+rm -rf container/skills/web-search-plus
+rm -f src/wsp-skill.test.ts
+```
+
+## 2. Revert the Dockerfile edit
+
+In `container/Dockerfile`, delete the `python3 \` line this skill added to the
+system-deps `apt-get install` block (between `git \` and `tini \`). Skip if
+already gone. Leave every other package line untouched.
+
+## 3. Dependencies
+
+The engine is pure-stdlib Python and `wsp` is a shell script — there is no npm
+or bun package to uninstall. Step 2 removes the only dependency surface
+(the apt `python3` install).
+
+## 4. Per-group key files and cache
+
+Remove the key file and cache from each group that configured a provider key,
+unless another integration uses them:
+
+```bash
+rm -f groups/<folder>/.wsp.env
+rm -rf groups/<folder>/.wsp-cache
+```
+
+If a provider key was stored in the OneCLI vault solely for wsp, delete that
+secret in the OneCLI dashboard.
+
+For any group with an explicit skills list in container config (not `"all"`),
+remove `"web-search-plus"` from that list.
+
+## 5. Rebuild and restart
+
+Run from your NanoClaw project root:
+
+```bash
+pnpm run build && ./container/build.sh
+source setup/lib/install-slug.sh
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+
+# Linux
+systemctl --user restart $(systemd_unit)
+```
+
+## Verification
+
+After removal, the skill's guards no longer apply (their files are gone).
+Confirm it is fully unwired:
+
+```bash
+ls container/skills/web-search-plus 2>/dev/null        # no such directory
+grep -n "python3" container/Dockerfile                 # no output
+ls src/wsp-skill.test.ts 2>/dev/null                   # no such file
+```
+
+New containers spawned after the restart no longer show `web-search-plus`
+under `/app/skills/`.

--- a/.claude/skills/add-web-search-plus/SKILL.md
+++ b/.claude/skills/add-web-search-plus/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: add-web-search-plus
+description: Add Web Search Plus (wsp) to agent containers — multi-provider web search and URL extraction on self-managed provider keys instead of the metered WebSearch tool. 13 providers (Serper, Brave, Tavily, Exa, Linkup, Firecrawl, Perplexity, SearXNG, ...) with auto-routing, fallback chains, and caching. Pure-stdlib Python engine; adds python3 to the agent image.
+---
+
+# Web Search Plus (wsp)
+
+Gives every agent container a `wsp` CLI for web search and page extraction
+through the Web Search Plus engine: provider auto-routing, fallback chains,
+parallel extraction, response caching. Calls go out on self-managed provider
+keys — not the metered `WebSearch` tool — at a fraction of the cost.
+
+This is a utility skill: it ships its code in this folder and copies it into
+the project. The engine is pure-stdlib Python (12 `.py` files, no pip, no
+venv); the only runtime requirement is a `python3` interpreter, which this
+skill adds to the agent image.
+
+## Install
+
+### Pre-flight
+
+If all of the following are already present, skip to **Configure a provider key**:
+
+- `container/skills/web-search-plus/SKILL.md`
+- `container/skills/web-search-plus/bin/wsp` (executable)
+- `container/skills/web-search-plus/engine/search.py` (plus the other engine files)
+- `src/wsp-skill.test.ts`
+- a `python3 \` line in the system-deps `apt-get install` block of `container/Dockerfile`
+
+Missing pieces — continue below. All steps are idempotent; re-running is safe.
+
+### 1. Copy the container skill files
+
+Wholesale copies (owned entirely by this skill — user edits to these files
+won't survive a re-run, as designed):
+
+```bash
+mkdir -p container/skills/web-search-plus
+cp -R .claude/skills/add-web-search-plus/resources/web-search-plus/. container/skills/web-search-plus/
+chmod +x container/skills/web-search-plus/bin/wsp
+```
+
+This lands the agent-facing `SKILL.md`, the `bin/wsp` wrapper, and the
+`engine/` directory (12 `.py` files + `LICENSE`). `container/skills/` is
+mounted read-only into every agent container at `/app/skills/`, so agents see
+the tool at `/app/skills/web-search-plus/bin/wsp`.
+
+### 2. Add python3 to the container Dockerfile
+
+The base image is Node-only; the engine needs a Python interpreter. In
+`container/Dockerfile`, add one line to the system-deps `apt-get install
+-y --no-install-recommends` block, between `git \` and `tini \`:
+
+```dockerfile
+        python3 \
+```
+
+Idempotent: if the line is already in the block, skip this step.
+
+`python3` is deliberately **not** version-pinned. The `ARG <X>_VERSION` pin
+pattern in this Dockerfile is for pnpm-installed CLIs; the apt system-deps
+block installs unpinned distro packages by house style (chromium, git, curl —
+all unpinned), because Debian's archive drops superseded point releases and a
+pinned `python3=3.x.y-z` breaks rebuilds at random. Reproducibility for apt
+packages comes from the base image, and the engine targets the stdlib of any
+python3 ≥ 3.9, so the distro's stable version is the correct dependency.
+
+### 3. Copy the integration-point test
+
+```bash
+cp .claude/skills/add-web-search-plus/resources/wsp-skill.test.ts src/wsp-skill.test.ts
+```
+
+`wsp-skill.test.ts` is the guard for this skill's one functional integration
+point, the Dockerfile python3 dependency: a CLI binary installed via apt is
+not importable, so neither a behavior test nor the build leg can see it, and a
+structural test of the Dockerfile line is the correct guard. The test scopes
+its assertion to the apt-get install block (a `python3` mention elsewhere
+can't keep it green) and also asserts the copied wrapper, engine entry, and
+container SKILL.md are present and executable — red on a half-applied or
+half-removed skill.
+
+The skill reaches into no host or container TypeScript (no barrel edit, no
+`main()` call), so there is no code-wiring test to ship; the engine files are
+pure adds.
+
+### 4. Build and validate
+
+```bash
+pnpm run build                              # host typecheck (unaffected, must stay green)
+pnpm exec vitest run src/wsp-skill.test.ts  # Dockerfile + skill-file guards
+./container/build.sh                        # agent image — bakes python3 in
+```
+
+All must be clean before proceeding. To confirm the interpreter actually
+landed in the image:
+
+```bash
+docker run --rm --entrypoint python3 nanoclaw-agent:latest --version
+```
+
+Then restart the service so new sessions use the new image:
+
+```bash
+source setup/lib/install-slug.sh
+systemctl --user restart $(systemd_unit)              # Linux
+# or: launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+```
+
+### 5. Enable for groups
+
+Groups with the default skill selection (`skills: "all"` in container config)
+pick up `web-search-plus` automatically at the next container spawn. For a
+group with an explicit skills list, add `"web-search-plus"` to that list —
+`ncl groups config get` shows the current selection; until an `ncl` verb for
+skill selection lands, the in-tree query wrapper (`pnpm exec tsx scripts/q.ts`)
+is the sanctioned way to update the `skills` JSON column.
+
+## Configure a provider key
+
+This skill never handles credential values: apply copies no keys, sets no env
+vars, and threads nothing into the container. The engine routes to a provider
+when that provider's key variable is set in the per-group key file
+`/workspace/agent/.wsp.env` (inside the container; `groups/<folder>/.wsp.env`
+on the host, covered by the `groups/*` git-ignore).
+
+**Preferred: the OneCLI gateway holds the real key.** The engine's HTTP layer
+is stdlib `urllib`, which honors the `HTTPS_PROXY` / `SSL_CERT_FILE`
+environment the gateway sets in every agent container, so provider calls route
+through the gateway like all other outbound HTTPS. Store the key in the OneCLI
+vault as a custom secret scoped to the provider's API host (e.g.
+`api.search.brave.com` with header `X-Subscription-Token` for Brave), and set
+the placeholder in the key file so the engine routes to that provider:
+
+```bash
+# inside the agent container / group workspace
+cat > /workspace/agent/.wsp.env <<'EOF'
+BRAVE_API_KEY=onecli-managed
+EOF
+chmod 600 /workspace/agent/.wsp.env
+```
+
+The gateway injects the real credential per request; no key material enters
+the container or the repo.
+
+**Fallback: real key in the key file.** On installs without a vault entry for
+the provider, put the real key in `.wsp.env` instead of the placeholder. Same
+file, same permissions. One working provider is enough; more keys add fallback
+resilience. The full provider/key-variable table is in the agent-facing
+[SKILL.md](resources/web-search-plus/SKILL.md) this skill installs.
+
+## Next steps
+
+In a wired agent, run `wsp doctor` (offline provider/key report), then a live
+`wsp search "test query"` — the JSON response's `routing.provider` shows which
+provider served it. If every provider reports `missing_api_key`, the key file
+is absent or unreadable; if `python3: command not found`, the running
+container predates the image rebuild in step 4.
+
+## Recipe entry
+
+Independent — no dependency on other skills and no ordering constraint. Needs
+the agent-image rebuild (step 4) after apply; when composing several
+image-touching skills in one recipe run, one rebuild at the end covers them
+all.
+
+To back this skill out, follow [REMOVE.md](REMOVE.md).

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/SKILL.md
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: web-search-plus
+description: Multi-provider web search and URL extraction via your own provider keys. Use INSTEAD of the built-in WebSearch tool for every web search, and instead of WebFetch when a page needs real content extraction — WebSearch is metered against the SDK credit pool; wsp runs on self-managed keys at a fraction of the cost. Supports 13 providers (Serper, Brave, Tavily, Exa, Linkup, Firecrawl, Perplexity, SearXNG, ...) with smart auto-routing and fallback.
+allowed-tools: Bash(/app/skills/web-search-plus/bin/wsp:*)
+---
+
+# Web Search Plus (wsp)
+
+Search the web and extract page content through the Web Search Plus engine —
+provider auto-routing, fallback chains, parallel extraction, response caching.
+All calls go out on your own provider keys, **not** the metered WebSearch tool.
+
+The wrapper lives at `/app/skills/web-search-plus/bin/wsp` (called `wsp` below).
+
+## Quick start
+
+```bash
+wsp search "anthropic claude opus 4.8 release notes"   # auto-routed search, JSON out
+wsp search "graz hifi events" --max-results 5          # any engine flag passes through
+wsp search "breaking news openai" --type news --time-range day
+wsp extract https://example.com/article                # clean markdown from URL(s)
+wsp explain "some query"                               # dry-run: show routing decision
+wsp doctor                                             # offline provider/key/cooldown status
+```
+
+`wsp search` accepts the full engine flag surface after the query — e.g.
+`--provider brave` (pin one provider), `--type news|images|videos|places|shopping`,
+`--time-range hour|day|week|month|year`, `--include-domains`, `--exclude-domains`,
+`--mode research` (multi-provider research with extraction). For the full flag
+surface run `python3 /app/skills/web-search-plus/engine/search.py --help`.
+
+## Output handling
+
+- Output is **JSON on stdout — parse it, don't regex it.** Results are in
+  `results[]` (`title`, `url`, `snippet`/`content`); extraction output carries
+  per-URL `content` in markdown.
+- The `routing` object tells you what happened: `routing.provider` (who served
+  it), `routing.chain_tried` (fallback path), `routing.reason`.
+- On failure you get `"error": "All providers failed"` plus per-provider
+  `provider_errors` (e.g. `missing_api_key`, rate limits, cooldowns) — read
+  them before retrying; a missing key won't fix itself.
+- **Don't extract every search hit.** Snippets are usually enough; run
+  `wsp extract` only on the 1–3 URLs you actually need full content from.
+- Results are cached (default TTL applies). `--no-cache` forces a live call.
+
+## Provider keys
+
+The engine routes to a provider when that provider's key variable is **set**.
+Keys live in the per-group key file `/workspace/agent/.wsp.env` (mode 0600) —
+**never** in this skill directory and never in git.
+
+**Preferred: OneCLI gateway holds the real key.** The engine's HTTP layer is
+stdlib `urllib`, which honors the `HTTPS_PROXY` and `SSL_CERT_FILE` environment
+the gateway sets in every agent container — provider calls route through the
+gateway like any other outbound HTTPS. Store the provider key in the OneCLI
+vault as a custom secret scoped to the provider's API host (e.g.
+`api.search.brave.com`, header `X-Subscription-Token`), and put the placeholder
+in the key file so the engine routes to that provider:
+
+```bash
+cat > /workspace/agent/.wsp.env <<'EOF'
+BRAVE_API_KEY=onecli-managed
+EOF
+chmod 600 /workspace/agent/.wsp.env
+```
+
+The gateway replaces the credential at request time; no real key enters the
+container.
+
+**Fallback: real key in the key file.** On installs without a vault entry for
+the provider, put the real key in `/workspace/agent/.wsp.env` instead of the
+placeholder. Same file, same permissions; the workspace is git-ignored.
+
+One working provider beats ten configured ones. Two routing gotchas when
+picking which key to configure:
+
+- **Brave is excluded from auto-routing by the engine's default `auto_allow`
+  config.** With only `BRAVE_API_KEY` set, a plain `wsp search` reports
+  `no_available_providers` — pin it with `--provider brave`, or configure at
+  least one auto-allowed provider (Serper, Tavily, Linkup, Exa, Firecrawl,
+  You, SearXNG).
+- **`wsp extract` needs an extract-capable provider** (Tavily, Exa, Linkup,
+  Firecrawl, Parallel, You). Brave and Serper are search-only.
+
+Supported key variables (one per provider, no key pools):
+
+| Variable | Provider |
+|----------|----------|
+| `SERPER_API_KEY` | Serper (Google-style search/news/shopping/places) |
+| `SERPBASE_API_KEY` | Serpbase |
+| `BRAVE_API_KEY` | Brave Search |
+| `TAVILY_API_KEY` | Tavily |
+| `QUERIT_API_KEY` | Querit |
+| `LINKUP_API_KEY` | Linkup (cheap clean extraction) |
+| `EXA_API_KEY` | Exa (neural/keyword search) |
+| `FIRECRAWL_API_KEY` | Firecrawl (search + scrape) |
+| `PARALLEL_API_KEY` | Parallel |
+| `PERPLEXITY_API_KEY` | Perplexity (answer-style search) |
+| `KILOCODE_API_KEY` | Kilo (Perplexity via Kilo) |
+| `YOU_API_KEY` | You.com |
+| `SEARXNG_INSTANCE_URL` | SearXNG (keyless, self-hosted, $0/search) |
+
+Override the key-file location with `WSP_ENV_FILE`. Cache and provider-health
+state live in `/workspace/agent/.wsp-cache/` (override with `WSP_CACHE_DIR`).
+
+## Troubleshooting
+
+Run `wsp doctor` first — it reports, offline, every provider's key presence,
+cooldown state, and the cache status.
+
+- `missing_api_key` for every provider → no key file, or wrong path: check
+  `ls -la /workspace/agent/.wsp.env`.
+- One provider keeps failing with 401/422 → key invalid (or the gateway has no
+  secret for that host while the key file holds a placeholder); the engine puts
+  it in cooldown and falls through the chain. Fix the key or the vault entry.
+- `python3: command not found` → the container image predates this skill;
+  the host needs an image rebuild (`./container/build.sh`).
+
+## Engine
+
+The engine under `engine/` is vendored from
+[`hermes-web-search-plus`](https://github.com/robbyczgw-cla/hermes-web-search-plus)
+(v2.4.0 @ `373024c`). Pure stdlib, zero Python dependencies. Engine bugs are
+fixed upstream and pulled in via sync commits to this skill, never patched here.

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/SKILL.md
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/SKILL.md
@@ -120,5 +120,5 @@ cooldown state, and the cache status.
 
 The engine under `engine/` is vendored from
 [`hermes-web-search-plus`](https://github.com/robbyczgw-cla/hermes-web-search-plus)
-(v2.4.0 @ `373024c`). Pure stdlib, zero Python dependencies. Engine bugs are
+(v2.8.1 @ `373024c`). Pure stdlib, zero Python dependencies. Engine bugs are
 fixed upstream and pulled in via sync commits to this skill, never patched here.

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/bin/wsp
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/bin/wsp
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# wsp — thin pass-through to the Web Search Plus engine CLI (engine/search.py).
+#
+# The engine is pure-stdlib Python (no pip, no venv); the only runtime
+# requirement is a python3 interpreter, installed via container/Dockerfile.
+#
+# Env handling:
+#   - Sources the per-group key file (default /workspace/agent/.wsp.env,
+#     override with WSP_ENV_FILE) so provider keys never live in the shared
+#     read-only skill mount. The engine additionally auto-loads a .env next
+#     to engine/ if one exists (host-side / standalone use).
+#   - Sets WSP_CACHE_DIR explicitly: without it the engine writes .cache/
+#     next to engine/, which is a read-only mount inside the container.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ENV_FILE="${WSP_ENV_FILE:-/workspace/agent/.wsp.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+if [ -z "${WSP_CACHE_DIR:-}" ]; then
+  if [ -d /workspace/agent ] && [ -w /workspace/agent ]; then
+    WSP_CACHE_DIR=/workspace/agent/.wsp-cache   # persists across container restarts
+  else
+    WSP_CACHE_DIR="${HOME}/.wsp-cache"          # host-side / standalone fallback
+  fi
+fi
+export WSP_CACHE_DIR
+
+cd "$SKILL_DIR/engine"
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  search)  exec python3 search.py -q "$@" ;;
+  explain) exec python3 search.py --explain-routing -q "$@" ;;
+  extract) exec python3 search.py --extract-urls "$@" ;;
+  doctor)  exec python3 search.py doctor "$@" ;;
+  *)
+    echo "usage: wsp search <query> [flags] | wsp explain <query> | wsp extract <url>... | wsp doctor" >&2
+    exit 2
+    ;;
+esac

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/LICENSE
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Robby
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/__init__.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/__init__.py
@@ -1,0 +1,1771 @@
+"""
+web-search-plus — Hermes Plugin v2.8.1
+Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
+Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
+"""
+from __future__ import annotations
+
+__version__ = "2.8.1"
+
+import argparse
+import getpass
+import importlib.util
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import sys
+import threading
+import time
+import webbrowser
+from concurrent.futures import TimeoutError as FuturesTimeout
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+# Hermes standalone plugin discovery can execute this flat plugin from outside
+# the plugin directory. Keep sibling-module fallback imports cwd-independent
+# without shadowing host/other-plugin modules ahead of normal sys.path entries.
+_PLUGIN_DIR = Path(__file__).resolve().parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.append(str(_PLUGIN_DIR))
+
+try:  # Package load path used by Hermes plugin discovery.
+    from .provider_registry import (
+        DEFAULT_AUTO_ALLOW,
+        DEFAULT_PROVIDER_PRIORITY,
+        EXTRACT_PROVIDER_ENV_KEYS,
+        KEYLESS_EXTRACT_PROVIDER_IDS,
+        KEYLESS_PROVIDER_IDS,
+        PROVIDER_ENV_KEYS,
+        PROVIDER_SPECS,
+        keyless_public_env_var,
+        plugin_catalog,
+    )
+    from .env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, is_truthy, load_env_files
+    from .cache import MAX_STORED_TEXT_CHARS, store_web_text
+    from .config import load_config
+except ImportError:  # Direct script/test imports from the plugin directory.
+    from provider_registry import (
+        DEFAULT_AUTO_ALLOW,
+        DEFAULT_PROVIDER_PRIORITY,
+        EXTRACT_PROVIDER_ENV_KEYS,
+        KEYLESS_EXTRACT_PROVIDER_IDS,
+        KEYLESS_PROVIDER_IDS,
+        PROVIDER_ENV_KEYS,
+        PROVIDER_SPECS,
+        keyless_public_env_var,
+        plugin_catalog,
+    )
+    from env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, is_truthy, load_env_files
+    from cache import MAX_STORED_TEXT_CHARS, store_web_text
+    from config import load_config
+
+try:
+    from .daemon_tasks import DaemonTask
+except ImportError:
+    from daemon_tasks import DaemonTask
+
+_SEARCH_SCRIPT = Path(__file__).parent / "search.py"
+_TOOLSET_NAME = "web-search-plus"
+_PROVIDER_ENV_KEYS = list(PROVIDER_ENV_KEYS)
+_EXTRACT_PROVIDER_ENV_KEYS = list(EXTRACT_PROVIDER_ENV_KEYS)
+_KEYLESS_EXTRACT_PROVIDER_IDS = list(KEYLESS_EXTRACT_PROVIDER_IDS)
+_KEYLESS_PROVIDER_IDS = list(KEYLESS_PROVIDER_IDS)
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_env_value(value: str) -> Optional[str]:
+    """Return a real env value, or None for empty/template placeholders."""
+    return _shared_clean_env_value(value)
+
+
+_PROVIDER_CATALOG = plugin_catalog()
+
+
+def _load_plugin_env() -> None:
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
+
+# Load plugin .env on import
+_load_plugin_env()
+
+
+def _get_provider_catalog() -> List[Dict[str, Any]]:
+    """Return provider onboarding metadata without exposing secrets."""
+    return [dict(item) for item in _PROVIDER_CATALOG]
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    """Read simple KEY=VALUE entries from an env file without exposing secrets."""
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        value = _clean_env_value(value)
+        if key.strip() and value:
+            values[key.strip()] = value
+    return values
+
+
+def _provider_config_status(env: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
+    """Describe configured providers by capability tier.
+
+    No single provider key is globally required. Search and extraction are
+    capability-based: one search provider enables web_search_plus; one
+    extraction-capable provider enables web_extract_plus.
+    """
+    env = env if env is not None else os.environ
+    providers: Dict[str, Dict[str, Any]] = {}
+    configured_count = 0
+    configured_search_count = 0
+    configured_extract_count = 0
+    for item in _PROVIDER_CATALOG:
+        key = item["env"]
+        configured = _clean_env_value(env.get(key) or "") is not None
+        configured_count += int(configured)
+        capabilities = item.get("capabilities", [])
+        if configured and "search" in capabilities:
+            configured_search_count += 1
+        if configured and "extract" in capabilities:
+            configured_extract_count += 1
+        providers[item["provider"]] = {
+            "env": key,
+            "display_name": item["display_name"],
+            "configured": configured,
+            "recommended": item.get("recommended", False),
+            "capabilities": capabilities,
+        }
+    return {
+        "configured": configured_count > 0,
+        "search_configured": configured_search_count > 0,
+        "extract_configured": configured_extract_count > 0,
+        "configured_count": configured_count,
+        "configured_search_count": configured_search_count,
+        "configured_extract_count": configured_extract_count,
+        "total": len(_PROVIDER_CATALOG),
+        "providers": providers,
+    }
+
+
+def _get_hermes_env_path() -> Path:
+    """Return Hermes' profile-aware .env path when available."""
+    return get_hermes_env_path()
+
+
+
+
+_SETUP_PROVIDER_NAMES = set(PROVIDER_SPECS)
+_DEFAULT_PROVIDER_PRIORITY = list(DEFAULT_PROVIDER_PRIORITY)
+_DEFAULT_AUTO_ALLOW = dict(DEFAULT_AUTO_ALLOW)
+_ROUTING_PROVIDER_NAMES = set(PROVIDER_SPECS)
+
+
+def _get_plugin_config_path() -> Path:
+    """Return the behavior config path shared with search.py."""
+    override = os.environ.get("WEB_SEARCH_PLUS_CONFIG")
+    if override:
+        return Path(override)
+    return Path(__file__).parent.parent / "config.json"
+
+
+def _get_hermes_config_path() -> Path:
+    """Return the default Hermes config path inspected by the fast-path doctor."""
+    return Path(os.environ.get("HERMES_CONFIG", Path.home() / ".hermes" / "config.yaml"))
+
+
+def _yamlish_has_list_item(text: str, key: str, item: str) -> bool:
+    """Tiny dependency-free YAML-ish list checker for Hermes config hints.
+
+    This intentionally avoids PyYAML because the setup helper is stdlib-only. It
+    handles the two forms users normally write in config.yaml:
+
+    - key: [a, b]
+    - key:
+      - a
+      - b
+    """
+    escaped_key = re.escape(key)
+    escaped_item = re.escape(item)
+    inline = re.search(rf"(?m)^\s*{escaped_key}\s*:\s*\[[^\]]*\b{escaped_item}\b", text)
+    if inline:
+        return True
+
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        match = re.match(rf"^(\s*){escaped_key}\s*:\s*$", line)
+        if not match:
+            continue
+        base_indent = len(match.group(1))
+        for child in lines[idx + 1:]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                continue
+            indent = len(child) - len(child.lstrip())
+            is_list_item = child.lstrip().startswith("-")
+            if indent < base_indent or (indent == base_indent and not is_list_item):
+                break
+            if re.match(rf"^\s*-\s*{escaped_item}\s*(?:#.*)?$", child):
+                return True
+    return False
+
+
+def _yamlish_nested_list_item(text: str, parent: str, key: str, item: str) -> bool:
+    """Best-effort check for parent.key containing item in simple YAML config."""
+    escaped_parent = re.escape(parent)
+    escaped_key = re.escape(key)
+    escaped_item = re.escape(item)
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        match = re.match(rf"^(\s*){escaped_parent}\s*:\s*$", line)
+        if not match:
+            continue
+        parent_indent = len(match.group(1))
+        block: List[str] = []
+        for child in lines[idx + 1:]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                block.append(child)
+                continue
+            indent = len(child) - len(child.lstrip())
+            if indent <= parent_indent:
+                break
+            block.append(child[parent_indent + 1:] if len(child) > parent_indent else child)
+        block_text = "\n".join(block)
+        if _yamlish_has_list_item(block_text, key, item):
+            return True
+        if re.search(rf"(?m)^\s*{escaped_key}\s*:\s*\[[^\]]*\b{escaped_item}\b", block_text):
+            return True
+    return False
+
+
+def _build_fastpath_report(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Inspect local plugin/Hermes hints that affect perceived WSP latency."""
+    config_path = config_path or _get_hermes_config_path()
+    plugin_yaml = Path(__file__).resolve().parent / "plugin.yaml"
+    setup_script = Path(__file__).resolve().parent / "setup.py"
+    checks: List[Dict[str, Any]] = []
+
+    plugin_text = ""
+    try:
+        plugin_text = plugin_yaml.read_text()
+    except OSError:
+        pass
+    checks.append({
+        "id": "plugin_tools_declared",
+        "ok": all(name in plugin_text for name in ["provides_tools", "web_search_plus", "web_extract_plus"]),
+        "detail": "plugin.yaml declares both WSP tools for direct Hermes registration",
+    })
+    checks.append({
+        "id": "standalone_setup_available",
+        "ok": setup_script.exists(),
+        "detail": "setup.py works without unreleased Hermes core plugin-CLI support",
+    })
+
+    config_text = ""
+    config_exists = config_path.exists()
+    if config_exists:
+        try:
+            config_text = config_path.read_text()
+        except OSError:
+            config_text = ""
+    legacy_web_disabled = _yamlish_nested_list_item(config_text, "agent", "disabled_toolsets", "web")
+
+    checks.extend([
+        {
+            "id": "hermes_config_found",
+            "ok": config_exists,
+            "detail": f"Hermes config inspected at {config_path}",
+        },
+        {
+            "id": "legacy_web_toolset_disabled",
+            "ok": legacy_web_disabled,
+            "detail": "agent.disabled_toolsets includes web, reducing legacy web-tool ambiguity on current Hermes builds",
+            "recommendation": "On current public Hermes builds, set agent.disabled_toolsets: [web] when you want Web Search Plus to be the preferred web path.",
+        },
+    ])
+    ok = all(check["ok"] for check in checks if check["id"] in {"plugin_tools_declared", "standalone_setup_available"})
+    preferred = ok and legacy_web_disabled
+    return {
+        "ok": ok,
+        "preferred_web_path_configured": preferred,
+        "hermes_config": str(config_path),
+        "checks": checks,
+        "recommended_hermes_config": {
+            "agent.disabled_toolsets": ["web"],
+        },
+        "notes": [
+            "Current public Hermes builds can register plugin tools directly, but may still route large tool catalogs through Tool Search when enabled.",
+            "Provider latency still depends on keys, cache, provider health, and whether the agent chooses normal search or research/extract mode.",
+            "No local Hermes core patches are required; this doctor only recommends config that exists in current Hermes.",
+        ],
+    }
+
+
+def _render_fastpath_report(report: Mapping[str, Any]) -> str:
+    lines = [
+        "Web Search Plus Fast-Path Doctor",
+        f"Status: {'preferred web path configured' if report.get('preferred_web_path_configured') else 'plugin ok; Hermes config can improve routing'}",
+        f"Hermes config: {report.get('hermes_config')}",
+        "",
+        "Checks:",
+    ]
+    for check in report.get("checks", []):
+        marker = "✓" if check.get("ok") else "•"
+        lines.append(f"  {marker} {check.get('id')}: {check.get('detail')}")
+        if not check.get("ok") and check.get("recommendation"):
+            lines.append(f"    Tip: {check.get('recommendation')}")
+    lines.extend([
+        "",
+        "Recommended Hermes config for current public Hermes builds:",
+        "  agent:",
+        "    disabled_toolsets: [web]",
+        "",
+        "Note: this plugin does not require local Hermes core patches. If your Hermes build",
+        "supports additional tool-pinning options, those may further reduce routing latency,",
+        "but they are not required for this doctor or the plugin to work.",
+    ])
+    return "\n".join(lines)
+
+
+def _keyless_public_opted_in(provider: str, config_path: Optional[Path] = None) -> bool:
+    """Registration-path mirror of config.keyless_public_allowed (env var or config.json, default off)."""
+    if is_truthy(os.environ.get(keyless_public_env_var(provider))):
+        return True
+    try:
+        config_path = config_path or _get_plugin_config_path()
+        if config_path.exists():
+            with open(config_path) as f:
+                section = json.load(f).get(PROVIDER_SPECS[provider].config_section, {})
+            return isinstance(section, dict) and is_truthy(section.get("allow_public"))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        pass
+    return False
+
+
+def _default_behavior_config() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "default_provider": None,
+        "auto_routing": {
+            "enabled": True,
+            "fallback_provider": "serper",
+            "provider_priority": list(_DEFAULT_PROVIDER_PRIORITY),
+            "disabled_providers": [],
+            "auto_allow": dict(_DEFAULT_AUTO_ALLOW),
+            "confidence_threshold": 0.3,
+        },
+    }
+
+
+def _normalize_provider_name(provider: str) -> str:
+    """Normalize a setup-provider name from the onboarding catalog."""
+    normalized = (provider or "").strip().lower()
+    if normalized not in _SETUP_PROVIDER_NAMES:
+        valid = ", ".join(sorted(_SETUP_PROVIDER_NAMES))
+        print(f"Unknown provider: {provider}. Valid providers: {valid}", file=sys.stderr)
+        raise SystemExit(2)
+    return normalized
+
+
+def _normalize_routing_provider(provider: str) -> str:
+    """Normalize a provider that search.py can actually route to."""
+    normalized = (provider or "").strip().lower()
+    if normalized == "kilo_perplexity":
+        normalized = "kilo-perplexity"
+    if normalized not in _ROUTING_PROVIDER_NAMES:
+        valid = ", ".join(sorted(_ROUTING_PROVIDER_NAMES))
+        print(f"Unknown routing provider: {provider}. Valid routing providers: {valid}", file=sys.stderr)
+        raise SystemExit(2)
+    return normalized
+
+
+def _normalize_provider_csv(value: str, *, routing: bool = True) -> List[str]:
+    providers: List[str] = []
+    seen = set()
+    for raw in (value or "").split(","):
+        if not raw.strip():
+            continue
+        provider = _normalize_routing_provider(raw) if routing else _normalize_provider_name(raw)
+        if provider in seen:
+            print(f"warning: duplicate provider ignored: {provider}", file=sys.stderr)
+            continue
+        seen.add(provider)
+        providers.append(provider)
+    if not providers:
+        raise SystemExit("At least one provider is required.")
+    return providers
+
+
+def _append_missing_default_providers(providers: List[str]) -> List[str]:
+    seen = set(providers)
+    merged = list(providers)
+    for provider in _DEFAULT_PROVIDER_PRIORITY:
+        if provider not in seen:
+            seen.add(provider)
+            merged.append(provider)
+    return merged
+
+
+def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
+    config = _default_behavior_config()
+    if not isinstance(user_config, Mapping):
+        return config
+    config["version"] = int(user_config.get("version", 1) or 1)
+    default_provider = user_config.get("default_provider")
+    if default_provider:
+        config["default_provider"] = _normalize_routing_provider(str(default_provider))
+    auto_user = user_config.get("auto_routing", {}) if isinstance(user_config.get("auto_routing", {}), Mapping) else {}
+    auto = dict(config["auto_routing"])
+    if "enabled" in auto_user:
+        auto["enabled"] = bool(auto_user.get("enabled"))
+    if auto_user.get("fallback_provider"):
+        auto["fallback_provider"] = _normalize_routing_provider(str(auto_user["fallback_provider"]))
+    if auto_user.get("provider_priority"):
+        if isinstance(auto_user["provider_priority"], str):
+            priority = _normalize_provider_csv(auto_user["provider_priority"], routing=True)
+        else:
+            priority = _normalize_provider_csv(",".join(str(p) for p in auto_user["provider_priority"]), routing=True)
+        auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
+    if "disabled_providers" in auto_user:
+        disabled = auto_user.get("disabled_providers") or []
+        if isinstance(disabled, str):
+            auto["disabled_providers"] = _normalize_provider_csv(disabled, routing=True) if disabled.strip() else []
+        else:
+            auto["disabled_providers"] = _normalize_provider_csv(",".join(str(p) for p in disabled), routing=True) if disabled else []
+    if "auto_allow" in auto_user:
+        raw_allow = auto_user.get("auto_allow") or {}
+        if not isinstance(raw_allow, Mapping):
+            raise SystemExit("auto_allow must be an object mapping provider names to booleans")
+        normalized_allow = dict(_DEFAULT_AUTO_ALLOW)
+        for raw_provider, allowed in raw_allow.items():
+            normalized_allow[_normalize_routing_provider(str(raw_provider))] = bool(allowed)
+        auto["auto_allow"] = normalized_allow
+    if "confidence_threshold" in auto_user:
+        threshold = float(auto_user["confidence_threshold"])
+        if threshold < 0.0 or threshold > 1.0:
+            raise SystemExit("confidence_threshold must be between 0.0 and 1.0")
+        auto["confidence_threshold"] = threshold
+    config["auto_routing"] = auto
+    if config["default_provider"] and config["default_provider"] in set(auto.get("disabled_providers", [])):
+        raise SystemExit("default_provider cannot be disabled")
+    return config
+
+
+def _unique_timestamped_path(path: Path, marker: str) -> Path:
+    base = path.with_name(path.name + f".{marker}-{int(time.time())}")
+    candidate = base
+    suffix = 2
+    while candidate.exists():
+        candidate = base.with_name(base.name + f"-{suffix}")
+        suffix += 1
+    return candidate
+
+
+def _quarantine_behavior_config(path: Path, reason: str) -> None:
+    broken = _unique_timestamped_path(path, "broken")
+    try:
+        path.rename(broken)
+        print(f"warning: invalid config moved to {broken}: {reason}", file=sys.stderr)
+    except OSError as exc:
+        print(f"warning: invalid config could not be moved: {exc}; reason: {reason}", file=sys.stderr)
+
+
+def _load_behavior_config(path: Optional[Path] = None) -> Dict[str, Any]:
+    path = path or _get_plugin_config_path()
+    if not path.exists():
+        return _default_behavior_config()
+    try:
+        raw = json.loads(path.read_text() or "{}")
+        return _merge_behavior_config(raw)
+    except json.JSONDecodeError as exc:
+        _quarantine_behavior_config(path, str(exc))
+        return _default_behavior_config()
+    except (SystemExit, ValueError, TypeError) as exc:
+        _quarantine_behavior_config(path, str(exc))
+        return _default_behavior_config()
+
+
+def _atomic_write_json(path: Path, data: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _write_behavior_config(path: Path, data: Mapping[str, Any], *, dry_run: bool = False, backup: bool = False) -> None:
+    merged: Dict[str, Any] = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text() or "{}")
+            if isinstance(existing, Mapping):
+                merged = dict(existing)
+        except (json.JSONDecodeError, OSError):
+            merged = {}
+    for key, value in data.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = {**merged[key], **value}
+        else:
+            merged[key] = value
+    rendered = json.dumps(merged, indent=2, sort_keys=True) + "\n"
+    if dry_run:
+        print(rendered, end="")
+        return
+    if backup and path.exists():
+        backup_path = _unique_timestamped_path(path, "bak")
+        shutil.copy2(path, backup_path)
+        print(f"Backup written: {backup_path}")
+    _atomic_write_json(path, merged)
+
+
+def _routing_summary(config: Mapping[str, Any]) -> str:
+    auto = config.get("auto_routing", {}) if isinstance(config.get("auto_routing"), Mapping) else {}
+    lines = [
+        "Routing:",
+        f"  auto-routing: {'on' if auto.get('enabled', True) else 'off'}",
+        f"  default provider: {config.get('default_provider') or 'none'}",
+        f"  fallback provider: {auto.get('fallback_provider', 'serper')}",
+        "  priority: " + ", ".join(auto.get("provider_priority", _DEFAULT_PROVIDER_PRIORITY)),
+        "  disabled: " + (", ".join(auto.get("disabled_providers", [])) or "none"),
+        "  auto-allow false: " + (
+            ", ".join(p for p, allowed in sorted((auto.get("auto_allow") or {}).items()) if allowed is False) or "none"
+        ),
+        f"  confidence threshold: {auto.get('confidence_threshold', 0.3)}",
+    ]
+    return "\n".join(lines)
+
+
+def _status_payload(env: Optional[Mapping[str, str]] = None, config: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    return {"providers": _provider_config_status(env), "routing": dict(config or _default_behavior_config())}
+
+def _setup_state_path() -> Path:
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state" / "web-search-plus-onboarding.json"
+
+
+def _supports_color() -> bool:
+    """Return whether ANSI color should be used for the standalone CLI."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return bool(getattr(sys.stdout, "isatty", lambda: False)())
+
+
+def _style(text: str, code: str, *, color: Optional[bool] = None) -> str:
+    if color is None:
+        color = _supports_color()
+    return f"\033[{code}m{text}\033[0m" if color else text
+
+
+def _capability_badge(enabled: bool, label: str, *, color: Optional[bool] = None) -> str:
+    mark = "✓" if enabled else "•"
+    rendered = f"{mark} {label}"
+    return _style(rendered, "32;1" if enabled else "2", color=color)
+
+
+def _render_setup_guidance(env: Optional[Mapping[str, str]] = None, *, fancy: bool = False) -> str:
+    """Return concise user-facing onboarding guidance."""
+    status = _provider_config_status(env)
+    if fancy:
+        return _render_status_dashboard(status)
+
+    if status["configured"]:
+        configured = [
+            meta["display_name"]
+            for meta in status["providers"].values()
+            if meta["configured"]
+        ]
+        lines = ["web-search-plus is configured. Providers: " + ", ".join(configured)]
+        lines.append(
+            "Capabilities: "
+            f"search={'yes' if status['search_configured'] else 'no'}, "
+            f"extraction={'yes' if status['extract_configured'] else 'no'}"
+        )
+        if status["search_configured"] and not status["extract_configured"]:
+            lines.append(
+                "Tip: add LINKUP_API_KEY or another extraction key for web_extract_plus."
+            )
+        return "\n".join(lines)
+
+    lines = [
+        "web-search-plus is installed but no provider keys are configured.",
+        "No single key is mandatory, but at least one search-capable provider is needed for web_search_plus.",
+        "Add LINKUP_API_KEY or another extraction-capable provider for web_extract_plus.",
+        "Run `python ~/.hermes/plugins/web-search-plus/setup.py setup` to walk through every supported provider, or add `--preset starter` for the short path.",
+        "",
+        "Recommended starter providers:",
+    ]
+    for item in _PROVIDER_CATALOG:
+        if item.get("recommended"):
+            lines.append(
+                f"- {item['display_name']} ({item['env']}): {item['description']} "
+                f"Free tier: {item['free_tier']}. Signup: {item['signup_url']}"
+            )
+    return "\n".join(lines)
+
+
+def _render_status_dashboard(status: Optional[Dict[str, Any]] = None, *, color: Optional[bool] = None) -> str:
+    """Render a compact, premium-feeling status dashboard for humans."""
+    status = status or _provider_config_status()
+    if color is None:
+        color = _supports_color()
+    configured = [
+        meta["display_name"]
+        for meta in status["providers"].values()
+        if meta["configured"]
+    ]
+    title = _style("web-search-plus", "36;1", color=color)
+    subtitle = "provider setup"
+    lines = [
+        f"╭─ {title} {subtitle} " + "─" * 28,
+        "│ " + "  ".join([
+            _capability_badge(status["search_configured"], "search", color=color),
+            _capability_badge(status["extract_configured"], "extraction", color=color),
+        ]),
+        f"│ Providers: {status['configured_count']}/{status['total']} configured",
+    ]
+    if configured:
+        lines.append("│ Active: " + ", ".join(configured))
+    else:
+        lines.append("│ Active: none yet — add one search provider to unlock the tools")
+    if status["search_configured"] and not status["extract_configured"]:
+        lines.append("│ Tip: add Linkup for clean web_extract_plus markdown.")
+    elif not status["search_configured"]:
+        lines.append("│ Starter: You + Serper + Linkup is the best first setup.")
+    lines.extend([
+        "╰─ Next commands",
+        "   python ~/.hermes/plugins/web-search-plus/setup.py setup",
+        "   python ~/.hermes/plugins/web-search-plus/setup.py list",
+        "   python ~/.hermes/plugins/web-search-plus/search.py --query \"Hermes Agent latest release\" --quality-report",
+    ])
+    return "\n".join(lines)
+
+
+def _render_provider_catalog(*, json_output: bool = False, color: Optional[bool] = None) -> str:
+    """Render provider metadata for either scripts or humans."""
+    catalog = _get_provider_catalog()
+    if json_output:
+        return json.dumps(catalog, indent=2)
+    if color is None:
+        color = _supports_color()
+    lines = [_style("Providers", "36;1", color=color)]
+    for item in catalog:
+        star = _style("★", "33;1", color=color) if item.get("recommended") else " "
+        caps = ", ".join(item.get("capabilities", []))
+        lines.append(f"{star} {item['provider']:<10} {item['display_name']}")
+        lines.append(f"    env: {item['env']}  caps: {caps}")
+        lines.append(f"    {item['description']}")
+        lines.append(f"    free: {item['free_tier']}  signup: {item['signup_url']}")
+    lines.append("\n★ recommended starter providers")
+    return "\n".join(lines)
+
+
+def _providers_for_preset(preset: str) -> List[Dict[str, Any]]:
+    """Return provider catalog entries for a named setup preset."""
+    preset = preset.lower().strip()
+    if preset == "starter":
+        names = {"you", "serper", "linkup"}
+    elif preset == "lean":
+        names = {"you", "linkup"}
+    elif preset == "search":
+        names = {"you", "serper", "exa", "firecrawl", "tavily", "linkup"}
+    elif preset == "extract":
+        names = {"linkup", "firecrawl", "tavily"}
+    elif preset == "all":
+        names = {item["provider"] for item in _PROVIDER_CATALOG}
+    else:
+        raise SystemExit(f"Unknown preset: {preset}. Choose starter, lean, search, extract, or all.")
+    return [item for item in _PROVIDER_CATALOG if item["provider"] in names]
+
+
+def _upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Dict[str, List[str]]:
+    """Insert/update env values in a .env file. Caller owns secret prompting."""
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    keys = set(values)
+    seen = set()
+    added: List[str] = []
+    updated: List[str] = []
+    output: List[str] = []
+
+    for line in existing_lines:
+        if "=" not in line or line.lstrip().startswith("#"):
+            output.append(line)
+            continue
+        key, _, _old = line.partition("=")
+        clean_key = key.strip()
+        if clean_key in keys:
+            output.append(f"{clean_key}={values[clean_key]}")
+            updated.append(clean_key)
+            seen.add(clean_key)
+        else:
+            output.append(line)
+
+    for key, value in values.items():
+        if key not in seen:
+            output.append(f"{key}={value}")
+            added.append(key)
+
+    # The .env holds plaintext API keys: create it 0600 and re-tighten an
+    # existing file before writing so other local users cannot read secrets.
+    env_path.touch(mode=0o600, exist_ok=True)
+    try:
+        os.chmod(env_path, 0o600)
+    except OSError:
+        pass
+    env_path.write_text("\n".join(output).rstrip() + "\n", encoding="utf-8")
+    return {"updated": updated, "added": added}
+
+
+def _unconfigured_session_hint(
+    env: Optional[Mapping[str, str]] = None,
+    state_path: Optional[Path] = None,
+) -> Optional[Dict[str, str]]:
+    """Return a one-shot unconfigured hint payload, recording acknowledgement in state."""
+    if _provider_config_status(env)["configured"]:
+        return None
+    state_path = state_path or _setup_state_path()
+    try:
+        if state_path.exists():
+            data = json.loads(state_path.read_text() or "{}")
+            if data.get("unconfigured_hint_shown"):
+                return None
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({"unconfigured_hint_shown": True}, indent=2) + "\n")
+    except Exception as exc:
+        logger.debug("web-search-plus onboarding state write failed: %s", exc)
+    return {
+        "action": "hint",
+        "message": "web-search-plus loaded but no provider keys are configured. Run `python ~/.hermes/plugins/web-search-plus/setup.py setup`.",
+    }
+
+
+def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
+    parser.description = "Configure web-search-plus provider keys with a tiny, secret-safe wizard."
+    parser.epilog = (
+        "Default setup prompts every provider. Presets: starter=You+Serper+Linkup, lean=You+Linkup, "
+        "search=You+Serper+Exa+Firecrawl+Tavily+Linkup, extract=Linkup+Firecrawl+Tavily."
+    )
+    subs = parser.add_subparsers(dest="web_search_plus_command")
+    status = subs.add_parser("status", help="Show a setup dashboard without printing secrets")
+    status.add_argument("--plain", action="store_true", help="Print compact legacy text instead of the dashboard")
+    status.add_argument("--json", action="store_true", help="Print status as JSON")
+    status.add_argument("--env-path", help="Override Hermes .env path for status checks")
+    status.add_argument("--config-path", help="Override web-search-plus config.json path")
+
+    setup = subs.add_parser("setup", help="Run the provider-key setup wizard")
+    setup.add_argument("providers", nargs="*", help="Provider names to configure (overrides --preset)")
+    setup.add_argument("--preset", default="all", help="starter, lean, search, extract, or all (default: all)")
+    setup.add_argument("--open", action="store_true", help="Open signup URLs in a browser before prompting")
+    setup.add_argument("--env-path", help="Override Hermes .env path")
+    setup.add_argument("--config-path", help="Override web-search-plus config.json path")
+    setup.add_argument("--show-values", action="store_true", help="Use visible input instead of hidden secret prompts")
+    setup.add_argument("--keyless-public", action="store_true", help="Opt into the keyless public tier (no API key) for any keyless provider, skipping its confirmation prompt")
+    setup.add_argument("--dry-run", action="store_true", help="Show the setup/routing plan without writing files")
+    setup.add_argument("--routing", choices=["auto", "fixed"], help="Persist routing mode after key setup")
+    setup.add_argument("--default-provider", help="Provider to use when routing is fixed/off")
+    setup.add_argument("--provider-priority", help="Comma-separated auto-routing priority")
+    setup.add_argument("--disable-providers", help="Comma-separated providers to exclude from auto-routing")
+    setup.add_argument("--auto-allow", help="Comma-separated providers allowed in auto-routing")
+    setup.add_argument("--auto-deny", help="Comma-separated providers blocked from auto-routing but still usable explicitly")
+    setup.add_argument("--fallback-provider", help="Fallback provider when no route is available")
+    setup.add_argument("--confidence-threshold", type=float, help="Auto-routing confidence threshold 0.0-1.0")
+
+    list_cmd = subs.add_parser("list", help="List supported providers, capabilities, and signup URLs")
+    list_cmd.add_argument("--json", action="store_true", help="Print provider catalog as JSON")
+
+    fastpath = subs.add_parser("fastpath", help="Inspect WSP setup and Hermes config hints for low-latency tool routing")
+    fastpath.add_argument("--json", action="store_true", help="Print fast-path report as JSON")
+    fastpath.add_argument("--config-path", help="Hermes config.yaml path to inspect")
+
+    bench_cmd = subs.add_parser(
+        "bench",
+        help="Benchmark configured search providers with a fixed live query suite and recommend an auto-routing priority (spends real provider quota)",
+    )
+    bench_cmd.add_argument("--json", action="store_true", help="Print the bench report as JSON")
+
+    config_cmd = subs.add_parser("config", help="Inspect or change routing preferences")
+    config_subs = config_cmd.add_subparsers(dest="config_command")
+    show = config_subs.add_parser("show", help="Show routing config")
+    show.add_argument("--json", action="store_true")
+    show.add_argument("--config-path")
+    set_routing = config_subs.add_parser("set-routing", help="Turn auto-routing on or off")
+    set_routing.add_argument("mode", choices=["on", "off"])
+    set_routing.add_argument("--config-path")
+    set_routing.add_argument("--dry-run", action="store_true")
+    set_default = config_subs.add_parser("set-default", help="Use one fixed provider when auto-routing is off")
+    set_default.add_argument("provider")
+    set_default.add_argument("--config-path")
+    set_default.add_argument("--dry-run", action="store_true")
+    set_fallback = config_subs.add_parser("set-fallback", help="Set fallback provider")
+    set_fallback.add_argument("provider")
+    set_fallback.add_argument("--config-path")
+    set_fallback.add_argument("--dry-run", action="store_true")
+    set_priority = config_subs.add_parser("set-priority", help="Set comma-separated auto-routing priority")
+    set_priority.add_argument("providers")
+    set_priority.add_argument("--config-path")
+    set_priority.add_argument("--dry-run", action="store_true")
+    disable = config_subs.add_parser("disable", help="Disable a provider for auto-routing")
+    disable.add_argument("provider")
+    disable.add_argument("--config-path")
+    disable.add_argument("--dry-run", action="store_true")
+    enable = config_subs.add_parser("enable", help="Re-enable a provider for auto-routing")
+    enable.add_argument("provider")
+    enable.add_argument("--config-path")
+    enable.add_argument("--dry-run", action="store_true")
+    allow_auto = config_subs.add_parser("set-auto-allow", help="Allow or block a provider from automatic routing/fallback")
+    allow_auto.add_argument("provider")
+    allow_auto.add_argument("mode", choices=["on", "off", "true", "false", "yes", "no"])
+    allow_auto.add_argument("--config-path")
+    allow_auto.add_argument("--dry-run", action="store_true")
+    threshold = config_subs.add_parser("set-threshold", help="Set routing confidence threshold")
+    threshold.add_argument("value", type=float)
+    threshold.add_argument("--config-path")
+    threshold.add_argument("--dry-run", action="store_true")
+    reset = config_subs.add_parser("reset", help="Reset routing config to defaults and back up existing config")
+    reset.add_argument("--config-path")
+    reset.add_argument("--dry-run", action="store_true")
+    reset.add_argument("--yes", action="store_true")
+    parser.set_defaults(func=_web_search_plus_cli_command)
+
+
+def _apply_setup_routing_args(config: Dict[str, Any], args: Any) -> Dict[str, Any]:
+    updated = _merge_behavior_config(config)
+    auto = dict(updated["auto_routing"])
+    if getattr(args, "routing", None):
+        auto["enabled"] = getattr(args, "routing") == "auto"
+    if getattr(args, "default_provider", None):
+        updated["default_provider"] = _normalize_routing_provider(getattr(args, "default_provider"))
+        auto["enabled"] = False
+    if getattr(args, "provider_priority", None):
+        auto["provider_priority"] = _normalize_provider_csv(getattr(args, "provider_priority"), routing=True)
+    if getattr(args, "disable_providers", None):
+        auto["disabled_providers"] = _normalize_provider_csv(getattr(args, "disable_providers"), routing=True)
+    auto_allow = dict(auto.get("auto_allow") or _DEFAULT_AUTO_ALLOW)
+    if getattr(args, "auto_allow", None):
+        for provider in _normalize_provider_csv(getattr(args, "auto_allow"), routing=True):
+            auto_allow[provider] = True
+    if getattr(args, "auto_deny", None):
+        for provider in _normalize_provider_csv(getattr(args, "auto_deny"), routing=True):
+            auto_allow[provider] = False
+    auto["auto_allow"] = auto_allow
+    if getattr(args, "fallback_provider", None):
+        auto["fallback_provider"] = _normalize_routing_provider(getattr(args, "fallback_provider"))
+    if getattr(args, "confidence_threshold", None) is not None:
+        value = float(getattr(args, "confidence_threshold"))
+        if value < 0.0 or value > 1.0:
+            raise SystemExit("confidence threshold must be between 0.0 and 1.0")
+        auto["confidence_threshold"] = value
+    updated["auto_routing"] = auto
+    return _merge_behavior_config(updated)
+
+
+def _handle_config_command(args: Any) -> None:
+    subcommand = getattr(args, "config_command", None) or "show"
+    path = Path(getattr(args, "config_path", None) or _get_plugin_config_path())
+    config = _load_behavior_config(path)
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    if subcommand == "show":
+        if getattr(args, "json", False):
+            print(json.dumps(config, indent=2, sort_keys=True))
+        else:
+            print(_routing_summary(config))
+        return
+
+    if subcommand == "set-routing":
+        config["auto_routing"]["enabled"] = getattr(args, "mode") == "on"
+    elif subcommand == "set-default":
+        provider = _normalize_routing_provider(getattr(args, "provider"))
+        config["default_provider"] = provider
+        config["auto_routing"]["enabled"] = False
+    elif subcommand == "set-fallback":
+        config["auto_routing"]["fallback_provider"] = _normalize_routing_provider(getattr(args, "provider"))
+    elif subcommand == "set-priority":
+        config["auto_routing"]["provider_priority"] = _normalize_provider_csv(getattr(args, "providers"), routing=True)
+    elif subcommand == "disable":
+        provider = _normalize_routing_provider(getattr(args, "provider"))
+        disabled = list(config["auto_routing"].get("disabled_providers", []))
+        if provider == config.get("default_provider"):
+            raise SystemExit("default_provider cannot be disabled")
+        if provider not in disabled:
+            disabled.append(provider)
+        config["auto_routing"]["disabled_providers"] = disabled
+    elif subcommand == "enable":
+        provider = _normalize_routing_provider(getattr(args, "provider"))
+        config["auto_routing"]["disabled_providers"] = [p for p in config["auto_routing"].get("disabled_providers", []) if p != provider]
+    elif subcommand == "set-auto-allow":
+        provider = _normalize_routing_provider(getattr(args, "provider"))
+        mode = str(getattr(args, "mode")).lower()
+        auto_allow = dict(config["auto_routing"].get("auto_allow") or _DEFAULT_AUTO_ALLOW)
+        auto_allow[provider] = mode in {"on", "true", "yes"}
+        config["auto_routing"]["auto_allow"] = auto_allow
+    elif subcommand == "set-threshold":
+        value = float(getattr(args, "value"))
+        if value < 0.0 or value > 1.0:
+            raise SystemExit("confidence threshold must be between 0.0 and 1.0")
+        config["auto_routing"]["confidence_threshold"] = value
+    elif subcommand == "reset":
+        if not getattr(args, "yes", False) and not dry_run:
+            raise SystemExit("Refusing to reset without --yes. Use --dry-run to preview.")
+        config = _default_behavior_config()
+        _write_behavior_config(path, config, dry_run=dry_run, backup=True)
+        if not dry_run:
+            print(f"✓ Reset routing config: {path}")
+        return
+    else:
+        raise SystemExit(f"Unknown config command: {subcommand}")
+
+    config = _merge_behavior_config(config)
+    _write_behavior_config(path, config, dry_run=dry_run)
+    if not dry_run:
+        print(f"✓ Updated routing config: {path}")
+        print(_routing_summary(config))
+
+
+def _web_search_plus_cli_command(args: Any) -> None:
+    command = getattr(args, "web_search_plus_command", None) or "status"
+    if command == "list":
+        print(_render_provider_catalog(json_output=getattr(args, "json", False)))
+        return
+
+    if command == "fastpath":
+        config_arg = getattr(args, "config_path", None)
+        report = _build_fastpath_report(Path(config_arg) if config_arg else None)
+        if getattr(args, "json", False):
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(_render_fastpath_report(report))
+        return
+
+    if command == "bench":
+        search = _load_search_module()
+        if search is None:
+            raise SystemExit(
+                "web-search-plus: in-process search engine unavailable; "
+                "run `python3 search.py --bench` from the plugin directory instead."
+            )
+        report = search.run_provider_bench(search.load_config())
+        if getattr(args, "json", False):
+            print(json.dumps(report, indent=2, ensure_ascii=False))
+        else:
+            print(search.format_bench_text(report))
+        return
+
+    if command == "config":
+        _handle_config_command(args)
+        return
+
+    if command == "status":
+        env_path = getattr(args, "env_path", None)
+        config_path = getattr(args, "config_path", None)
+        if env_path:
+            env = _read_env_file(Path(env_path))
+        else:
+            env = dict(os.environ)
+            for key, value in _read_env_file(_get_hermes_env_path()).items():
+                env.setdefault(key, value)
+        config = _load_behavior_config(Path(config_path)) if config_path else _load_behavior_config()
+        if getattr(args, "json", False):
+            print(json.dumps(_status_payload(env, config), indent=2, sort_keys=True))
+        else:
+            print(_render_setup_guidance(env=env, fancy=not getattr(args, "plain", False)))
+            print("\n" + _routing_summary(config))
+        return
+
+    if command == "setup":
+        selected = set(getattr(args, "providers", None) or [])
+        selected = {_normalize_provider_name(p) for p in selected} if selected else set()
+        catalog = [item for item in _PROVIDER_CATALOG if item["provider"] in selected] if selected else _providers_for_preset(getattr(args, "preset", "all"))
+        if not catalog:
+            raise SystemExit("No matching providers. Run `python ~/.hermes/plugins/web-search-plus/setup.py list`.")
+
+        env_path = Path(getattr(args, "env_path", None) or _get_hermes_env_path())
+        config_path = Path(getattr(args, "config_path", None) or _get_plugin_config_path())
+        config = _apply_setup_routing_args(_load_behavior_config(config_path), args)
+        print(_render_status_dashboard(_provider_config_status(_read_env_file(env_path))))
+        print("\nSetup plan:")
+        for item in catalog:
+            rec = " recommended" if item.get("recommended") else ""
+            caps = ", ".join(item.get("capabilities", []))
+            keyless = " — keyless public tier available (no key needed)" if item["provider"] in _KEYLESS_PROVIDER_IDS else ""
+            print(f"  • {item['display_name']} ({item['provider']}) — {item['env']} — {caps}{rec}{keyless}")
+            print(f"    {item['signup_url']}")
+        print(f"\nTarget env file: {env_path}")
+        print(f"Target config file: {config_path}")
+        print(_routing_summary(config))
+        if getattr(args, "dry_run", False):
+            print("Dry run only; no keys or routing config written.")
+            return
+
+        force_keyless = getattr(args, "keyless_public", False)
+        values: Dict[str, str] = {}
+        keyless_enable: List[str] = []
+        for item in catalog:
+            if getattr(args, "open", False):
+                webbrowser.open(item["signup_url"])
+            prompt = f"{item['display_name']} key ({item['env']}, Enter to skip): "
+            try:
+                if getattr(args, "show_values", False):
+                    value = input(prompt).strip()
+                else:
+                    value = getpass.getpass(prompt).strip()
+            except EOFError:
+                value = ""
+            if value:
+                values[item["env"]] = value
+                continue
+            if item["provider"] not in _KEYLESS_PROVIDER_IDS or _keyless_public_opted_in(item["provider"], config_path):
+                continue
+            if force_keyless:
+                answer = "y"
+            else:
+                try:
+                    answer = input(f"  Use {item['display_name']} keyless public search (no API key)? [y/N, Enter to skip]: ").strip().lower()
+                except (EOFError, OSError):
+                    answer = ""
+            if answer in ("y", "yes"):
+                keyless_enable.append(item["provider"])
+        for provider in keyless_enable:
+            config.setdefault(PROVIDER_SPECS[provider].config_section, {})["allow_public"] = True
+        routing_args_present = any(
+            getattr(args, name, None) is not None
+            for name in ["routing", "default_provider", "provider_priority", "disable_providers", "fallback_provider", "confidence_threshold"]
+        )
+        wrote_any = False
+        if values:
+            result = _upsert_env_values(env_path, values)
+            changed = sorted(result["updated"] + result["added"])
+            print(f"\n✓ Configured {len(changed)} provider key(s) in {env_path}: " + ", ".join(changed))
+            print("✓ Secrets were not printed.")
+            wrote_any = True
+        if routing_args_present or keyless_enable:
+            _write_behavior_config(config_path, config)
+            if routing_args_present:
+                print(f"✓ Saved routing preferences in {config_path}")
+            if keyless_enable:
+                names = ", ".join(PROVIDER_SPECS[p].display_name for p in keyless_enable)
+                print(f"✓ Enabled keyless public search for {names} in {config_path}")
+            wrote_any = True
+        if not wrote_any:
+            print("No keys entered; nothing changed.")
+            return
+        print("Next: restart Hermes or run /reset so tools re-register with the new credentials/preferences.")
+        return
+
+    raise SystemExit(f"Unknown web-search-plus command: {command}")
+
+def _web_search_plus_slash_setup(raw_args: str = "") -> str:
+    """In-session lightweight status/help command."""
+    return _render_setup_guidance()
+
+
+def _on_session_start(**kwargs: Any) -> Optional[Dict[str, str]]:
+    hint = _unconfigured_session_hint()
+    if hint:
+        logger.info(hint["message"])
+    return hint
+
+
+_search_module: Any = None
+_search_import_failed = False
+_search_import_lock = threading.Lock()
+
+
+def _load_search_module() -> Any:
+    """Load the in-process search engine from this plugin's ``search.py``.
+
+    ``search.py`` still uses flat absolute imports for sibling modules, so the
+    plugin directory must be on ``sys.path`` while it loads. The search module
+    itself is loaded from its exact file path under a private module name instead
+    of ``import search`` so an unrelated global ``search`` module cannot shadow the
+    plugin engine.
+    """
+    global _search_module, _search_import_failed
+    if _search_module is not None:
+        return _search_module
+    if _search_import_failed:
+        return None
+    with _search_import_lock:
+        if _search_module is not None:
+            return _search_module
+        if _search_import_failed:
+            return None
+        plugin_dir = str(Path(__file__).parent)
+        inserted = False
+        if plugin_dir not in sys.path:
+            sys.path.insert(0, plugin_dir)
+            inserted = True
+        # Stash any top-level modules whose names collide with this plugin's
+        # flat sibling imports (providers, extract, routing, research, etc.).
+        # If hermes-agent's `providers` package is already in sys.modules,
+        # `from providers import extract_exa` inside extract.py resolves
+        # to the wrong module. Pop them for the duration of the load,
+        # restore afterward.
+        _COLLIDING_MODULES = (
+            "providers",
+            "bench",
+            "extract",
+            "routing",
+            "research",
+            "search",
+            "config",
+            "cache",
+            "quality",
+            "http_client",
+            "env_loader",
+            "provider_health",
+            "provider_registry",
+        )
+        stashed: dict[str, Any] = {}
+        for _name in _COLLIDING_MODULES:
+            if _name in sys.modules:
+                stashed[_name] = sys.modules.pop(_name)
+        try:
+            spec = importlib.util.spec_from_file_location("_wsp_search_engine", _SEARCH_SCRIPT)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"cannot load search engine from {_SEARCH_SCRIPT}")
+            _search = importlib.util.module_from_spec(spec)
+            sys.modules["_wsp_search_engine"] = _search
+            spec.loader.exec_module(_search)
+        except Exception:  # pragma: no cover - defensive: fall back to subprocess
+            sys.modules.pop("_wsp_search_engine", None)
+            logger.exception("web-search-plus: in-process search import failed; using subprocess fallback")
+            _search_import_failed = True
+            return None
+        finally:
+            # Restore the original top-level modules so unrelated code that
+            # imported `providers` etc. still sees what it expects.
+            for _name in _COLLIDING_MODULES:
+                sys.modules.pop(_name, None)
+            for _name, _mod in stashed.items():
+                sys.modules[_name] = _mod
+            if inserted:
+                try:
+                    sys.path.remove(plugin_dir)
+                except ValueError:  # pragma: no cover - defensive cleanup
+                    pass
+        _search_module = _search
+        return _search_module
+
+
+def _force_subprocess() -> bool:
+    """Allow operators to opt back into the legacy subprocess path via env."""
+    return _clean_env_value(os.environ.get("WSP_FORCE_SUBPROCESS", "")) is not None
+
+
+def _search_timeout(mode: str, research_time_budget: float, base: int = 75) -> int:
+    """Wall-clock budget for a search call, widened for research mode."""
+    if mode == "research":
+        return max(base, int(research_time_budget) + 15)
+    return base
+
+
+def _call_with_timeout(fn: Callable[[], dict], timeout: int) -> dict:
+    """Run ``fn`` on a daemon thread bounded by a wall-clock timeout.
+
+    Mirrors the hard timeout the subprocess used to give us. On timeout we stop
+    waiting (the orphaned worker is bounded by per-provider HTTP timeouts) and
+    raise ``FuturesTimeout`` for the caller to translate into a structured error.
+    A daemon thread — unlike a ThreadPoolExecutor worker — is not joined at
+    interpreter exit, so an overdue call cannot stall process shutdown either.
+    """
+    return DaemonTask(fn).result(timeout=timeout)
+
+
+def _run_search(
+    query: str,
+    provider: str = "auto",
+    count: int = 5,
+    exa_depth: str = "normal",
+    time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
+    research_time_budget: float = 55.0,
+    language: Optional[str] = None,
+    country: Optional[str] = None,
+    subprocess_timeout: int = 75,
+) -> dict:
+    """Run a search in-process (fast path), falling back to the subprocess engine.
+
+    The in-process path avoids per-call interpreter startup, module re-import, and
+    a JSON round-trip. A thread watchdog preserves the wall-clock timeout the
+    subprocess previously enforced.
+    """
+    timeout = _search_timeout(mode, research_time_budget, subprocess_timeout)
+    search = None if _force_subprocess() else _load_search_module()
+    if search is None:
+        return _run_search_subprocess(
+            query=query, provider=provider, count=count, exa_depth=exa_depth,
+            time_range=time_range, freshness=freshness, include_domains=include_domains,
+            exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
+            research_time_budget=research_time_budget, language=language, country=country,
+            subprocess_timeout=timeout,
+        )
+
+    def call() -> dict:
+        return search.run_search_request(
+            query=query, provider=provider, count=count, exa_depth=exa_depth,
+            time_range=time_range, freshness=freshness, include_domains=include_domains,
+            exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
+            research_time_budget=research_time_budget, language=language, country=country,
+        )
+
+    try:
+        return _call_with_timeout(call, timeout)
+    except FuturesTimeout:
+        return {"error": f"Search timed out after {timeout}s", "provider": provider, "query": query, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "query": query, "results": []}
+
+
+def _run_search_subprocess(
+    query: str,
+    provider: str = "auto",
+    count: int = 5,
+    exa_depth: str = "normal",
+    time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
+    research_time_budget: float = 55.0,
+    language: Optional[str] = None,
+    country: Optional[str] = None,
+    subprocess_timeout: int = 75,
+) -> dict:
+    """Legacy fallback: call search.py as a subprocess and return parsed JSON."""
+    cmd = [
+        sys.executable,
+        str(_SEARCH_SCRIPT),
+        "--query", query,
+        "--provider", provider,
+        "--max-results", str(count),
+        "--compact",
+    ]
+    if exa_depth != "normal":
+        cmd += ["--exa-depth", exa_depth]
+    if time_range and time_range != "none":
+        cmd += ["--time-range", time_range]
+    if freshness:
+        cmd += ["--freshness", str(freshness)]
+    if include_domains:
+        cmd += ["--include-domains"] + include_domains
+    if exclude_domains:
+        cmd += ["--exclude-domains"] + exclude_domains
+    if mode != "normal":
+        cmd += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
+        if mode == "research":
+            subprocess_timeout = max(subprocess_timeout, int(research_time_budget) + 15)
+    if quality_report:
+        cmd.append("--quality-report")
+    if language and language != "auto":
+        cmd += ["--language", language]
+    if country and country != "auto":
+        cmd += ["--country", country]
+
+    env = os.environ.copy()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=subprocess_timeout,
+            env=env,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            try:
+                return json.loads(stderr)
+            except json.JSONDecodeError:
+                return {"error": stderr or "Search failed", "provider": provider, "query": query, "results": []}
+
+        return json.loads(result.stdout)
+
+    except subprocess.TimeoutExpired:
+        return {"error": f"Search timed out after {subprocess_timeout}s", "provider": provider, "query": query, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "query": query, "results": []}
+
+
+def _run_extract(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    subprocess_timeout: int = 90,
+) -> dict:
+    """Run URL extraction in-process (fast path), falling back to the subprocess."""
+    search = None if _force_subprocess() else _load_search_module()
+    if search is None:
+        return _run_extract_subprocess(
+            urls, provider=provider, output_format=output_format,
+            include_images=include_images, include_raw_html=include_raw_html,
+            render_js=render_js, subprocess_timeout=subprocess_timeout,
+        )
+
+    def call() -> dict:
+        return search.run_extract_request(
+            urls, provider=provider, output_format=output_format,
+            include_images=include_images, include_raw_html=include_raw_html,
+            render_js=render_js,
+        )
+
+    try:
+        return _call_with_timeout(call, subprocess_timeout)
+    except FuturesTimeout:
+        return {"error": f"Extract timed out after {subprocess_timeout}s", "provider": provider, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "results": []}
+
+
+def _run_extract_subprocess(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    subprocess_timeout: int = 90,
+) -> dict:
+    """Legacy fallback: call search.py extract mode and return parsed JSON result."""
+    cmd = [
+        sys.executable,
+        str(_SEARCH_SCRIPT),
+        "--extract-urls",
+        *urls,
+        "--provider",
+        provider,
+        "--format",
+        output_format,
+        "--compact",
+    ]
+    if include_images:
+        cmd.append("--extract-images")
+    if include_raw_html:
+        cmd.append("--include-raw-html")
+    if render_js:
+        cmd.append("--render-js")
+
+    env = os.environ.copy()
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=subprocess_timeout, env=env)
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            try:
+                return json.loads(stderr)
+            except json.JSONDecodeError:
+                return {"error": stderr or "Extract failed", "provider": provider, "results": []}
+        return json.loads(result.stdout)
+    except subprocess.TimeoutExpired:
+        return {"error": f"Extract timed out after {subprocess_timeout}s", "provider": provider, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "results": []}
+
+
+def _format_results(data: dict) -> str:
+    """Format search results for LLM consumption."""
+    if "error" in data and not data.get("results"):
+        return f"Search error: {data['error']}"
+
+    results = data.get("results", [])
+    provider = data.get("provider", "unknown")
+    routing = data.get("routing", {})
+    answer = data.get("answer", "")
+    cached = data.get("cached", False)
+
+    lines = []
+
+    if routing.get("auto_routed"):
+        confidence = routing.get("confidence_level", "")
+        reason = routing.get("reason", "")
+        lines.append(f"[Provider: {provider} | auto-routed | {confidence} confidence | {reason}]")
+    else:
+        lines.append(f"[Provider: {provider}{' | cached' if cached else ''}]")
+
+    freshness_meta = (data.get("metadata") or {}).get("freshness")
+    if isinstance(freshness_meta, dict) and freshness_meta.get("requested"):
+        per_provider = freshness_meta.get("providers")
+        if isinstance(per_provider, list):
+            applied = [m.get("provider") for m in per_provider if m.get("applied")]
+            skipped = [m.get("provider") for m in per_provider if not m.get("applied")]
+            detail = "applied by: " + (", ".join(str(p) for p in applied) or "none")
+            if skipped:
+                detail += " | not supported: " + ", ".join(str(p) for p in skipped)
+        elif freshness_meta.get("applied"):
+            detail = "applied"
+        else:
+            detail = f"not applied — {freshness_meta.get('reason', 'unsupported provider')}"
+        lines.append(f"[Freshness: {freshness_meta['requested']} | {detail}]")
+
+    if answer:
+        lines.append(f"\nAnswer: {answer}\n")
+
+    quality_report = data.get("quality_report") or {}
+    if quality_report:
+        lines.append(
+            "Quality: "
+            f"{quality_report.get('confidence', 'unknown')} confidence | "
+            f"{quality_report.get('domain_count', 0)} domains | "
+            f"{quality_report.get('duplicate_count', 0)} duplicates | "
+            f"extract recommended: {quality_report.get('extract_recommended', False)}"
+        )
+        if quality_report.get("extract_reasons"):
+            lines.append("Quality reasons: " + ", ".join(quality_report["extract_reasons"]))
+        lines.append("")
+
+    source_summaries = data.get("source_summaries") or []
+    if source_summaries:
+        lines.append("Extracted source summaries:")
+        for i, src in enumerate(source_summaries, 1):
+            url = src.get("url", "")
+            content = (src.get("content") or src.get("raw_content") or "").strip()
+            lines.append(f"{i}. {url}")
+            if content:
+                lines.append(f"   {content[:500]}")
+        lines.append("")
+
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "No title")
+        url = r.get("url", "")
+        snippet = r.get("snippet", "")
+        lines.append(f"{i}. {title}")
+        if url:
+            lines.append(f"   {url}")
+        if snippet:
+            lines.append(f"   {snippet}")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+
+
+_BASE64_MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(\s*data:image/[^)]+\)", re.IGNORECASE)
+_BASE64_HTML_IMAGE_RE = re.compile(r"<img\b(?=[^>]*\bsrc=[\"']data:image/)[^>]*(?:\balt=[\"']([^\"']*)[\"'])?[^>]*>", re.IGNORECASE)
+_DEFAULT_EXTRACT_CHAR_LIMIT = 15000
+
+
+def _sanitize_extract_content(content: str) -> str:
+    """Remove inline base64 image bombs while preserving normal http(s) images."""
+    def markdown_repl(match: re.Match[str]) -> str:
+        alt = (match.group(1) or "image").strip() or "image"
+        return f"[IMAGE: {alt}]"
+
+    def html_repl(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        alt_match = re.search(r"\balt=[\"']([^\"']*)[\"']", tag, re.IGNORECASE)
+        alt = (alt_match.group(1) if alt_match else "image").strip() or "image"
+        return f"[IMAGE: {alt}]"
+
+    content = _BASE64_MARKDOWN_IMAGE_RE.sub(markdown_repl, content)
+    content = _BASE64_HTML_IMAGE_RE.sub(html_repl, content)
+    return content
+
+
+def _extract_char_limit() -> int:
+    """Read web.extract_char_limit with a safe default for old configs."""
+    try:
+        config = load_config()
+        limit = int(((config.get("web") or {}).get("extract_char_limit")) or _DEFAULT_EXTRACT_CHAR_LIMIT)
+    except Exception:
+        return _DEFAULT_EXTRACT_CHAR_LIMIT
+    return max(1000, limit)
+
+
+def _split_extract_content(content: str, limit: int) -> tuple[str, str, int, int]:
+    """Return head, tail, omitted-start line, and omitted char count."""
+    head_chars = min(max(1, int(limit * 2 / 3)), max(1, limit - 1))
+    tail_chars = min(max(1, int(limit * 0.2)), max(1, limit - head_chars))
+    if head_chars + tail_chars >= len(content):
+        return content, "", content.count("\n") + 1, 0
+    head = content[:head_chars].rstrip()
+    tail = content[-tail_chars:].lstrip()
+    omitted_start_line = head.count("\n") + 1
+    omitted_chars = max(0, len(content) - len(head) - len(tail))
+    return head, tail, omitted_start_line, omitted_chars
+
+
+def _format_truncated_extract_content(content: str, url: str, limit: int) -> str:
+    """Return inline-safe extract content, storing full text when truncated."""
+    cleaned = _sanitize_extract_content(content)
+    if len(cleaned) <= limit:
+        return cleaned
+
+    store_meta = store_web_text(url or "unknown-url", cleaned, max_chars=MAX_STORED_TEXT_CHARS)
+    head, tail, omitted_start_line, omitted_chars = _split_extract_content(cleaned, limit)
+    footer = [
+        "",
+        "---",
+        f"[Content truncated: original {len(cleaned)} chars; omitted middle {omitted_chars} chars; showing head and tail.]",
+    ]
+    if store_meta.get("stored"):
+        footer.append(f"Full cleaned text stored at: {store_meta['path']}")
+        footer.append(
+            "Page omitted middle with Hermes file tool: "
+            f"read_file(path=\"{store_meta['path']}\", offset={omitted_start_line}, limit=500)"
+        )
+        footer.append("For more of the omitted middle, repeat read_file with the next offset; the stored path contains the cleaned text for page-on-demand.")
+        if store_meta.get("capped"):
+            footer.append(
+                f"Stored file capped at {MAX_STORED_TEXT_CHARS} characters; cleaned text was {store_meta.get('original_chars')} chars."
+            )
+    else:
+        footer.append(f"Full-text store failed for path: {store_meta.get('path')} ({store_meta.get('error', 'unknown error')})")
+    return f"{head}\n\n[... omitted middle; see footer for page-on-demand ...]\n\n{tail}" + "\n" + "\n".join(footer)
+
+
+def _format_extract_results(data: dict) -> str:
+    """Format extracted URL content for LLM consumption."""
+    if "error" in data and not data.get("results"):
+        return f"Extract error: {data['error']}"
+    provider = data.get("provider", "unknown")
+    lines = [f"[Provider: {provider}]"]
+    limit = _extract_char_limit()
+    for i, r in enumerate(data.get("results", []), 1):
+        title = r.get("title") or "No title"
+        url = r.get("url", "")
+        content = r.get("content") or r.get("raw_content") or ""
+        lines.append(f"\n{i}. {title}")
+        if url:
+            lines.append(url)
+        if r.get("error"):
+            lines.append(f"Error: {r['error']}")
+        elif content:
+            lines.append(_format_truncated_extract_content(content, url, limit))
+    return "\n".join(lines).strip()
+
+
+def register(ctx: Any) -> None:
+    """Register web-search-plus tools with Hermes plugin system."""
+
+    schema = {
+        "name": "web_search_plus",
+        "description": (
+            "Multi-provider web search with intelligent auto-routing. "
+            "Automatically selects the best provider based on query intent: "
+            "Serper for shopping/news/facts, Tavily for research/analysis, "
+            "Exa for semantic discovery, "
+            "Brave for general web search, "
+            "Linkup for source-backed grounding/citations, "
+            "Firecrawl for web search plus optional scrape-ready results, "
+            "Perplexity for direct answers, You.com for real-time snippets, "
+            "SearXNG for privacy-focused/self-hosted search, and SerpBase/Querit only when explicitly enabled or forced. "
+            "Set depth='deep' for Exa multi-source synthesis, 'deep-reasoning' for complex cross-document analysis. "
+            "Override with provider param if needed."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query",
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": ["auto", "serper", "serpbase", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "parallel", "perplexity", "kilo-perplexity", "you", "searxng", "keenable"],
+                    "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
+                    "default": "auto",
+                },
+                "depth": {
+                    "type": "string",
+                    "enum": ["normal", "deep", "deep-reasoning"],
+                    "description": "Exa search depth: 'deep' synthesizes across sources (4-12s), 'deep-reasoning' for complex cross-document analysis (12-50s). Only applies when routed to Exa.",
+                    "default": "normal",
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of results to return (default: 5)",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+                "time_range": {
+                    "type": "string",
+                    "enum": ["day", "week", "month", "year"],
+                    "description": "Filter results by recency. Optional.",
+                },
+                "freshness": {
+                    "type": "string",
+                    "enum": ["day", "week", "month", "year"],
+                    "description": (
+                        "Unified recency filter (case-insensitive). Applied natively by serper, brave, "
+                        "querit, firecrawl, keenable, you, perplexity, kilo-perplexity, and searxng; "
+                        "providers without recency support (tavily, exa, linkup, parallel, serpbase) still "
+                        "run the search and report freshness.applied=false in result metadata. Optional."
+                    ),
+                },
+                "include_domains": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Whitelist specific domains (e.g. ['arxiv.org', 'github.com']). Optional.",
+                },
+                "exclude_domains": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Blacklist specific domains (e.g. ['reddit.com']). Optional.",
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["normal", "research"],
+                    "description": "normal = fast routed search; research = multi-provider search plus top-source extraction.",
+                    "default": "normal",
+                },
+                "quality_report": {
+                    "type": "boolean",
+                    "description": "Attach routing/result quality diagnostics such as selected provider, skips, dedup count, domain diversity, and extraction recommendation.",
+                    "default": False,
+                },
+                "research_time_budget": {
+                    "type": "number",
+                    "description": "Best-effort wall-clock budget in seconds for research mode. Checked between provider calls and before extraction.",
+                    "default": 55.0,
+                    "minimum": 1,
+                    "maximum": 75,
+                },
+            },
+            "required": ["query"],
+        },
+    }
+
+    def handler(args_or_query, provider: str = "auto", count: int = 5, depth: str = "normal",
+                time_range: Optional[str] = None, freshness: Optional[str] = None,
+                include_domains: Optional[List[str]] = None,
+                exclude_domains: Optional[List[str]] = None, mode: str = "normal",
+                quality_report: bool = False, research_time_budget: float = 55.0, **kwargs) -> str:
+        # Hermes registry passes the entire input dict as first positional arg
+        if isinstance(args_or_query, dict):
+            query = args_or_query.get("query", "")
+            provider = args_or_query.get("provider", provider)
+            count = args_or_query.get("count", count)
+            depth = args_or_query.get("depth", depth)
+            time_range = args_or_query.get("time_range", time_range)
+            freshness = args_or_query.get("freshness", freshness)
+            include_domains = args_or_query.get("include_domains", include_domains)
+            exclude_domains = args_or_query.get("exclude_domains", exclude_domains)
+            mode = args_or_query.get("mode", mode)
+            quality_report = args_or_query.get("quality_report", quality_report)
+            research_time_budget = args_or_query.get("research_time_budget", research_time_budget)
+        else:
+            query = args_or_query
+        data = _run_search(
+            query=query,
+            provider=provider,
+            count=count,
+            exa_depth=depth,
+            time_range=time_range,
+            freshness=freshness,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            mode=mode,
+            quality_report=quality_report,
+            research_time_budget=research_time_budget,
+        )
+        return _format_results(data)
+
+    def check_fn() -> bool:
+        return any(os.environ.get(k) for k in _PROVIDER_ENV_KEYS) or any(
+            _keyless_public_opted_in(p) for p in _KEYLESS_PROVIDER_IDS)
+
+    def extract_check_fn() -> bool:
+        return any(os.environ.get(k) for k in _EXTRACT_PROVIDER_ENV_KEYS) or any(
+            _keyless_public_opted_in(p) for p in _KEYLESS_EXTRACT_PROVIDER_IDS)
+
+    ctx.register_tool(
+        name="web_search_plus",
+        toolset=_TOOLSET_NAME,
+        schema=schema,
+        handler=handler,
+        check_fn=check_fn,
+        requires_env=[],
+        description="Multi-provider web search with intelligent auto-routing",
+        emoji="🔍",
+    )
+
+    extract_schema = {
+        "name": "web_extract_plus",
+        "description": (
+            "Multi-provider URL content extraction. Auto tries Tavily, Exa, Linkup, "
+            "Firecrawl, You.com (plus keyless Keenable when its public endpoint is opted in); "
+            "force a provider for robust scraping, clean markdown, or explicit fallback tests."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to extract"},
+                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "parallel", "tavily", "exa", "you", "keenable"], "default": "auto"},
+                "format": {"type": "string", "enum": ["markdown", "html"], "default": "markdown"},
+                "include_images": {"type": "boolean", "default": False},
+                "include_raw_html": {"type": "boolean", "default": False},
+                "render_js": {"type": "boolean", "default": False},
+            },
+            "required": ["urls"],
+        },
+    }
+
+    def extract_handler(args_or_urls, provider: str = "auto", format: str = "markdown",
+                        include_images: bool = False, include_raw_html: bool = False,
+                        render_js: bool = False, **kwargs) -> str:
+        if isinstance(args_or_urls, dict):
+            urls = args_or_urls.get("urls", [])
+            provider = args_or_urls.get("provider", provider)
+            format = args_or_urls.get("format", format)
+            include_images = args_or_urls.get("include_images", include_images)
+            include_raw_html = args_or_urls.get("include_raw_html", include_raw_html)
+            render_js = args_or_urls.get("render_js", render_js)
+        else:
+            urls = args_or_urls
+        if isinstance(urls, str):
+            urls = [urls]
+        data = _run_extract(
+            urls=urls,
+            provider=provider,
+            output_format=format,
+            include_images=include_images,
+            include_raw_html=include_raw_html,
+            render_js=render_js,
+        )
+        return _format_extract_results(data)
+
+    ctx.register_tool(
+        name="web_extract_plus",
+        toolset=_TOOLSET_NAME,
+        schema=extract_schema,
+        handler=extract_handler,
+        check_fn=extract_check_fn,
+        requires_env=[],
+        description="Multi-provider URL extraction",
+        emoji="📄",
+    )
+
+    if hasattr(ctx, "register_command"):
+        ctx.register_command(
+            name="web-search-plus-setup",
+            handler=_web_search_plus_slash_setup,
+            description="Show Web Search Plus provider setup status and starter-key guidance.",
+            args_hint="",
+        )
+
+    if hasattr(ctx, "register_hook"):
+        ctx.register_hook("on_session_start", _on_session_start)

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/bench.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/bench.py
@@ -1,0 +1,398 @@
+"""In-process provider bakeoff ("bench") for Web Search Plus.
+
+Runs a small fixed query suite against every configured search-capable
+provider and reports success rate, median latency, result volume, and simple
+quality signals (duplicate-free URLs, snippet coverage), then recommends an
+``auto_routing.provider_priority`` order ranked by a weighted score.
+
+Two deliberate properties:
+
+- Provider failures never abort a bench run; they are captured per query and
+  simply rank the provider lower.
+- Bench traffic must not poison operational state: provider search functions
+  are called directly, bypassing ``execute_provider_with_retry`` /
+  ``mark_provider_failure`` (provider_health cooldowns) and
+  ``record_provider_outcome`` (provider_stats adaptive-routing memory).
+
+The bench never writes configuration. Applying the recommended priority is an
+explicit operator step (``setup.py config set-priority ...``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import statistics
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from config import (
+    _validate_searxng_url,
+    keyless_public_allowed,
+    provider_configured,
+    validate_api_key,
+)
+from provider_registry import DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS, SEARCH_PROVIDER_IDS
+from provider_stats import LATENCY_CEILING_SECONDS
+from quality import _snippet_text, normalize_result_url
+
+
+# Fixed, representative query suite drawn from the scripts/golden_eval.py
+# categories (docs, vendor release, community, non-English). Kept small on
+# purpose: every bench query spends real provider quota.
+BENCH_QUERIES: List[Dict[str, str]] = [
+    {
+        "id": "docs-mcp-spec",
+        "category": "docs",
+        "query": "model context protocol specification documentation",
+    },
+    {
+        "id": "vendor-release-tailscale",
+        "category": "news_vendor_release",
+        "query": "latest Tailscale release notes subnet router",
+    },
+    {
+        "id": "community-local-llm",
+        "category": "community",
+        "query": "site:reddit.com/r/LocalLLaMA best local LLM inference server 2026",
+    },
+    {
+        "id": "german-ki-regulierung",
+        "category": "non_english",
+        "query": "aktuelle KI Regulierung Österreich Unternehmen 2026",
+    },
+]
+
+# Results requested per bench query: enough for duplicate/snippet signals
+# without burning provider quota.
+DEFAULT_BENCH_MAX_RESULTS = 5
+# Best-effort wall-clock budget for one whole bench run, checked between
+# providers. A provider that would start after the budget is skipped and
+# reported, never silently dropped.
+DEFAULT_BENCH_TIMEOUT_BUDGET_SECONDS = 120.0
+
+# Ranking weights. Reliability dominates: a provider that errors is useless no
+# matter how fast it is. Latency beats fine-grained quality signals because a
+# slow provider stalls every fallback chain it leads.
+SCORE_WEIGHT_SUCCESS_RATE = 0.5
+SCORE_WEIGHT_LATENCY = 0.3
+SCORE_WEIGHT_QUALITY = 0.2
+# Quality signal mix: duplicate-free URLs vs. results carrying a usable snippet.
+QUALITY_WEIGHT_UNIQUE_URLS = 0.5
+QUALITY_WEIGHT_SNIPPET_COVERAGE = 0.5
+# Snippets shorter than this count as thin (mirrors quality.build_quality_report).
+MIN_SNIPPET_CHARS = 40
+# Bench output is often pasted into issues; keep captured error strings short.
+ERROR_MESSAGE_MAX_CHARS = 200
+
+RECOMMENDATION_CONFIG_KEY = "auto_routing.provider_priority"
+RECOMMENDATION_NOTE = (
+    "Recommendation only — no configuration was written. Review the scores, "
+    "then apply the priority yourself if it matches your needs."
+)
+
+
+def _resolve_search_module(search_module: Optional[Any] = None) -> Any:
+    """Return the module exposing the ``search_<provider>`` seams.
+
+    ``search.py`` passes itself so bench honours the same monkeypatch seams as
+    the rest of the pipeline (tests patch ``search.search_you`` etc.). When
+    called without one (e.g. ``bench.run_bench(config)`` from a REPL), the flat
+    sibling ``search`` module is imported lazily to avoid an import cycle.
+    """
+    if search_module is not None:
+        return search_module
+    return importlib.import_module("search")
+
+
+def bench_eligible_providers(config: Dict[str, Any]) -> List[str]:
+    """Configured, search-capable, not-disabled providers, in registry order."""
+    auto_config = config.get("auto_routing")
+    if not isinstance(auto_config, dict):
+        auto_config = {}
+    disabled = set(auto_config.get("disabled_providers", []) or [])
+    return [
+        provider
+        for provider in SEARCH_PROVIDER_IDS
+        if provider not in disabled and provider_configured(provider, config)
+    ]
+
+
+def _call_provider_search(
+    search: Any,
+    provider: str,
+    query: str,
+    max_results: int,
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Call one provider's search function directly.
+
+    Deliberately bypasses ``execute_provider_with_retry`` so a bench run never
+    marks provider health failures, triggers cooldowns, or records adaptive
+    routing stats.
+    """
+    key = validate_api_key(provider, config)
+    if provider == "searxng":
+        return search.search_searxng(
+            query=query,
+            instance_url=_validate_searxng_url(key),
+            max_results=max_results,
+        )
+    if provider == "keenable":
+        return search.search_keenable(
+            query=query,
+            api_key=key,
+            max_results=max_results,
+            public=keyless_public_allowed(provider, config),
+        )
+    if provider in ("perplexity", "kilo-perplexity"):
+        return search.search_perplexity(
+            query=query,
+            api_key=key,
+            max_results=max_results,
+            provider_name=provider,
+        )
+    search_fn = getattr(search, "search_" + provider, None)
+    if search_fn is None:
+        raise ValueError("Unknown search provider: {}".format(provider))
+    return search_fn(query=query, api_key=key, max_results=max_results)
+
+
+def compute_provider_score(
+    success_rate: float,
+    median_latency_seconds: Optional[float],
+    unique_url_ratio: float,
+    snippet_coverage: float,
+) -> Tuple[float, Dict[str, float]]:
+    """Weighted 0..1 score from success rate, speed, and quality signals."""
+    if median_latency_seconds is None:
+        latency_component = 0.0
+    else:
+        latency_component = max(
+            0.0, 1.0 - float(median_latency_seconds) / LATENCY_CEILING_SECONDS
+        )
+    quality_component = (
+        QUALITY_WEIGHT_UNIQUE_URLS * unique_url_ratio
+        + QUALITY_WEIGHT_SNIPPET_COVERAGE * snippet_coverage
+    )
+    score = (
+        SCORE_WEIGHT_SUCCESS_RATE * success_rate
+        + SCORE_WEIGHT_LATENCY * latency_component
+        + SCORE_WEIGHT_QUALITY * quality_component
+    )
+    components = {
+        "success_rate": round(success_rate, 3),
+        "latency": round(latency_component, 3),
+        "quality": round(quality_component, 3),
+    }
+    return round(score, 3), components
+
+
+def _bench_one_provider(
+    search: Any,
+    provider: str,
+    queries: List[Dict[str, str]],
+    max_results: int,
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Run the query suite against one provider; errors are captured, not raised."""
+    runs: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+    latencies: List[float] = []
+    total_results = 0
+    unique_results = 0
+    snippet_results = 0
+
+    for case in queries:
+        run: Dict[str, Any] = {
+            "id": case.get("id"),
+            "category": case.get("category"),
+            "query": case.get("query"),
+        }
+        started = time.monotonic()
+        try:
+            payload = _call_provider_search(search, provider, case.get("query", ""), max_results, config)
+        except Exception as exc:  # noqa: BLE001 - one provider must never abort the bench
+            run["ok"] = False
+            run["latency_seconds"] = round(time.monotonic() - started, 3)
+            run["error"] = str(exc)[:ERROR_MESSAGE_MAX_CHARS]
+            errors.append({"id": run["id"], "error": run["error"]})
+            runs.append(run)
+            continue
+
+        latency = time.monotonic() - started
+        results = payload.get("results") if isinstance(payload, dict) else None
+        results = [item for item in (results or []) if isinstance(item, dict)]
+        seen_urls = set()
+        unique_count = 0
+        for item in results:
+            normalized = normalize_result_url(item.get("url", ""))
+            if normalized and normalized in seen_urls:
+                continue
+            if normalized:
+                seen_urls.add(normalized)
+            unique_count += 1
+        snippet_count = sum(1 for item in results if len(_snippet_text(item)) >= MIN_SNIPPET_CHARS)
+
+        run.update({
+            "ok": True,
+            "latency_seconds": round(latency, 3),
+            "result_count": len(results),
+            "unique_result_count": unique_count,
+            "snippet_result_count": snippet_count,
+        })
+        runs.append(run)
+        latencies.append(latency)
+        total_results += len(results)
+        unique_results += unique_count
+        snippet_results += snippet_count
+
+    success_count = sum(1 for run in runs if run.get("ok"))
+    query_count = len(runs)
+    success_rate = round(success_count / query_count, 3) if query_count else 0.0
+    median_latency = round(statistics.median(latencies), 3) if latencies else None
+    unique_url_ratio = round(unique_results / total_results, 3) if total_results else 0.0
+    snippet_coverage = round(snippet_results / total_results, 3) if total_results else 0.0
+    avg_result_count = round(total_results / success_count, 1) if success_count else 0.0
+    score, components = compute_provider_score(
+        success_rate, median_latency, unique_url_ratio, snippet_coverage
+    )
+
+    return {
+        "provider": provider,
+        "score": score,
+        "score_components": components,
+        "query_count": query_count,
+        "success_count": success_count,
+        "success_rate": success_rate,
+        "median_latency_seconds": median_latency,
+        "avg_result_count": avg_result_count,
+        "unique_url_ratio": unique_url_ratio,
+        "snippet_coverage": snippet_coverage,
+        "errors": errors,
+        "queries": runs,
+    }
+
+
+def _build_recommendation(ranked: List[str], current_priority: List[str]) -> Dict[str, Any]:
+    if ranked:
+        apply_hint = "python setup.py config set-priority " + ",".join(ranked)
+    else:
+        apply_hint = "configure at least one search provider first: python setup.py setup"
+    return {
+        "config_key": RECOMMENDATION_CONFIG_KEY,
+        "provider_priority": list(ranked),
+        "current_provider_priority": list(current_priority),
+        "apply_hint": apply_hint,
+        "note": RECOMMENDATION_NOTE,
+    }
+
+
+def run_bench(
+    config: Dict[str, Any],
+    queries: Optional[List[Dict[str, str]]] = None,
+    providers: Optional[List[str]] = None,
+    max_results: int = DEFAULT_BENCH_MAX_RESULTS,
+    timeout_budget: float = DEFAULT_BENCH_TIMEOUT_BUDGET_SECONDS,
+    search_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Bench configured search providers in-process and rank them.
+
+    Returns a structured report with per-provider metrics (best score first)
+    plus an ``auto_routing.provider_priority`` recommendation. Provider errors
+    are captured per query; a failing provider ranks last but never aborts the
+    run. Health cooldowns and adaptive routing stats are untouched.
+    """
+    search = _resolve_search_module(search_module)
+    config = config if isinstance(config, dict) else {}
+    suite = [dict(case) for case in (queries if queries is not None else BENCH_QUERIES)]
+
+    skipped: List[Dict[str, str]] = []
+    selected: List[str] = []
+    for provider in (providers if providers is not None else bench_eligible_providers(config)):
+        spec = PROVIDER_SPECS.get(provider)
+        if spec is None or not spec.supports_search:
+            skipped.append({"provider": provider, "reason": "unknown_or_not_search_capable"})
+        else:
+            selected.append(provider)
+
+    started = time.monotonic()
+    rows: List[Dict[str, Any]] = []
+    for provider in selected:
+        if time.monotonic() - started >= float(timeout_budget):
+            skipped.append({"provider": provider, "reason": "time_budget_exhausted"})
+            continue
+        rows.append(_bench_one_provider(search, provider, suite, max_results, config))
+
+    auto_config = config.get("auto_routing") if isinstance(config.get("auto_routing"), dict) else {}
+    current_priority = list(auto_config.get("provider_priority") or DEFAULT_PROVIDER_PRIORITY)
+    priority_index = {provider: idx for idx, provider in enumerate(current_priority)}
+    rows.sort(
+        key=lambda row: (
+            -row["score"],
+            priority_index.get(row["provider"], len(priority_index)),
+            row["provider"],
+        )
+    )
+    ranked = [row["provider"] for row in rows]
+
+    return {
+        "ok": any(row["success_count"] for row in rows),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "query_count": len(suite),
+        "max_results": int(max_results),
+        "timeout_budget_seconds": float(timeout_budget),
+        "weights": {
+            "success_rate": SCORE_WEIGHT_SUCCESS_RATE,
+            "latency": SCORE_WEIGHT_LATENCY,
+            "quality": SCORE_WEIGHT_QUALITY,
+        },
+        "providers": rows,
+        "skipped_providers": skipped,
+        "recommendation": _build_recommendation(ranked, current_priority),
+    }
+
+
+def format_bench_text(report: Dict[str, Any]) -> str:
+    """Human-readable bench table, styled after the doctor's plain-text output."""
+    lines = [
+        "Web Search Plus Bench",
+        "OK: {}".format(report["ok"]),
+        "Queries per provider: {} (max_results={})".format(
+            report["query_count"], report["max_results"]
+        ),
+        "",
+        "Providers (best first):",
+        "  {:<16} {:>5} {:>8} {:>8} {:>8} {:>7} {:>9}".format(
+            "provider", "score", "success", "median", "results", "unique", "snippets"
+        ),
+    ]
+    for row in report["providers"]:
+        median = row["median_latency_seconds"]
+        median_text = "{:.2f}s".format(median) if median is not None else "-"
+        lines.append(
+            "  {:<16} {:>5.2f} {:>8} {:>8} {:>8} {:>6.0f}% {:>8.0f}%".format(
+                row["provider"],
+                row["score"],
+                "{}/{}".format(row["success_count"], row["query_count"]),
+                median_text,
+                row["avg_result_count"],
+                row["unique_url_ratio"] * 100,
+                row["snippet_coverage"] * 100,
+            )
+        )
+        for error in row.get("errors", []):
+            lines.append("    ! {}: {}".format(error.get("id"), error.get("error")))
+    for item in report.get("skipped_providers", []):
+        lines.append("  - {}: skipped ({})".format(item.get("provider"), item.get("reason")))
+
+    recommendation = report["recommendation"]
+    lines.extend([
+        "",
+        "Recommended {}:".format(recommendation["config_key"]),
+        "  {}".format(", ".join(recommendation["provider_priority"]) or "(none — no provider produced results)"),
+        "Apply with:",
+        "  {}".format(recommendation["apply_hint"]),
+        recommendation["note"],
+    ])
+    return "\n".join(lines)

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/cache.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/cache.py
@@ -15,6 +15,99 @@ DEFAULT_CACHE_TTL = 3600  # 1 hour in seconds
 PROVIDER_HEALTH_FILENAME = "provider_health.json"
 
 
+WEB_TEXT_CACHE_DIRNAME = "web"
+MAX_STORED_TEXT_CHARS = 2_000_000
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write text through a temp file and atomic replace to avoid torn cache reads."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _get_web_text_cache_path(url: str) -> Path:
+    """Return the stable full-text cache path for an extracted URL."""
+    key = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return CACHE_DIR / WEB_TEXT_CACHE_DIRNAME / f"{key}.md"
+
+
+def _iter_web_text_cache_files():
+    """Yield stored web full-text files, tolerating a missing web cache dir."""
+    web_dir = CACHE_DIR / WEB_TEXT_CACHE_DIRNAME
+    if not web_dir.exists():
+        return iter(())
+    return web_dir.glob("*.md")
+
+
+def _iter_web_text_temp_files():
+    """Yield orphaned atomic-write temp files from the web full-text store."""
+    web_dir = CACHE_DIR / WEB_TEXT_CACHE_DIRNAME
+    if not web_dir.exists():
+        return iter(())
+    return web_dir.glob("*.tmp")
+
+
+def _web_text_cache_stats() -> Dict[str, Any]:
+    """Return count and size stats for page-on-demand full-text files."""
+    entries = []
+    total_size = 0
+    for web_file in _iter_web_text_cache_files():
+        try:
+            total_size += web_file.stat().st_size
+            entries.append(web_file)
+        except IOError:
+            pass
+    return {
+        "web_text_entries": len(entries),
+        "web_text_size_bytes": total_size,
+        "web_text_size_kb": round(total_size / 1024, 2),
+        "web_text_cache_dir": str(CACHE_DIR / WEB_TEXT_CACHE_DIRNAME),
+    }
+
+
+def store_web_text(url: str, text: str, max_chars: int = MAX_STORED_TEXT_CHARS) -> Dict[str, Any]:
+    """Store cleaned extracted text under cache/web and return storage metadata.
+
+    The write is intentionally separate from the search-result JSON cache so
+    cache_clear() does not collide with page-on-demand full-text files.
+    """
+    path = _get_web_text_cache_path(url)
+    original_chars = len(text)
+    capped = original_chars > max_chars
+    stored_text = text[:max_chars] if capped else text
+    if capped:
+        stored_text = stored_text.rstrip() + f"\n\n[TRUNCATED: stored text capped at {max_chars} characters]\n"
+    try:
+        _atomic_write_text(path, stored_text)
+    except IOError as e:
+        print(json.dumps({"web_text_cache_write_error": str(e)}), file=sys.stderr)
+        return {
+            "stored": False,
+            "path": str(path),
+            "capped": capped,
+            "original_chars": original_chars,
+            "stored_chars": len(stored_text),
+            "error": str(e),
+        }
+    return {
+        "stored": True,
+        "path": str(path),
+        "capped": capped,
+        "original_chars": original_chars,
+        "stored_chars": len(stored_text),
+    }
+
+
 def _build_cache_payload(query: str, provider: str, max_results: int, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Build normalized payload used for cache key hashing."""
     payload = {
@@ -41,7 +134,9 @@ def _get_cache_path(cache_key: str) -> Path:
 
 def _ensure_cache_dir() -> None:
     """Create cache directory if it doesn't exist."""
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    # 0700: cached files carry search queries/results that other local users
+    # have no business listing or reading.
+    CACHE_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
 
 
 def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:
@@ -130,16 +225,34 @@ def cache_put(query: str, provider: str, max_results: int, result: Dict[str, Any
 
 def cache_clear() -> Dict[str, Any]:
     """
-    Clear all cached results.
+    Clear cached search results and page-on-demand full-text files.
+
+    Provider health is intentionally preserved.
 
     Returns:
         Stats about what was cleared
     """
     if not CACHE_DIR.exists():
-        return {"cleared": 0, "message": "Cache directory does not exist"}
+        return {
+            "cleared": 0,
+            "web_text_cleared": 0,
+            "web_text_tmp_cleared": 0,
+            "web_text_errors": 0,
+            "size_freed_bytes": 0,
+            "size_freed_kb": 0,
+            "json_size_freed_bytes": 0,
+            "web_text_size_freed_bytes": 0,
+            "web_text_tmp_size_freed_bytes": 0,
+            "message": "Cache directory does not exist",
+        }
 
     count = 0
     size_freed = 0
+    web_text_count = 0
+    web_text_errors = 0
+    web_text_size_freed = 0
+    web_text_tmp_count = 0
+    web_text_tmp_size_freed = 0
 
     for cache_file in CACHE_DIR.glob("*.json"):
         if cache_file.name == PROVIDER_HEALTH_FILENAME:
@@ -151,11 +264,36 @@ def cache_clear() -> Dict[str, Any]:
         except IOError:
             pass
 
+    for web_file in _iter_web_text_cache_files():
+        try:
+            file_size = web_file.stat().st_size
+            web_file.unlink()
+            web_text_size_freed += file_size
+            web_text_count += 1
+        except IOError:
+            web_text_errors += 1
+
+    for tmp_file in _iter_web_text_temp_files():
+        try:
+            file_size = tmp_file.stat().st_size
+            tmp_file.unlink()
+            web_text_tmp_size_freed += file_size
+            web_text_tmp_count += 1
+        except IOError:
+            web_text_errors += 1
+
+    total_size_freed = size_freed + web_text_size_freed + web_text_tmp_size_freed
     return {
         "cleared": count,
-        "size_freed_bytes": size_freed,
-        "size_freed_kb": round(size_freed / 1024, 2),
-        "message": f"Cleared {count} cached entries"
+        "web_text_cleared": web_text_count,
+        "web_text_tmp_cleared": web_text_tmp_count,
+        "web_text_errors": web_text_errors,
+        "size_freed_bytes": total_size_freed,
+        "size_freed_kb": round(total_size_freed / 1024, 2),
+        "json_size_freed_bytes": size_freed,
+        "web_text_size_freed_bytes": web_text_size_freed,
+        "web_text_tmp_size_freed_bytes": web_text_tmp_size_freed,
+        "message": f"Cleared {count} cached entries and {web_text_count} web text files",
     }
 
 
@@ -171,10 +309,16 @@ def cache_stats() -> Dict[str, Any]:
             "total_entries": 0,
             "total_size_bytes": 0,
             "total_size_kb": 0,
+            "total_size_bytes_including_web": 0,
+            "total_size_kb_including_web": 0,
+            "web_text_entries": 0,
+            "web_text_size_bytes": 0,
+            "web_text_size_kb": 0,
+            "web_text_cache_dir": str(CACHE_DIR / WEB_TEXT_CACHE_DIRNAME),
             "oldest": None,
             "newest": None,
             "cache_dir": str(CACHE_DIR),
-            "exists": False
+            "exists": False,
         }
 
     entries = [p for p in CACHE_DIR.glob("*.json") if p.name != PROVIDER_HEALTH_FILENAME]
@@ -208,10 +352,15 @@ def cache_stats() -> Dict[str, Any]:
         except (json.JSONDecodeError, IOError):
             pass
 
+    web_stats = _web_text_cache_stats()
+    total_with_web = total_size + web_stats["web_text_size_bytes"]
     return {
         "total_entries": len(entries),
         "total_size_bytes": total_size,
         "total_size_kb": round(total_size / 1024, 2),
+        "total_size_bytes_including_web": total_with_web,
+        "total_size_kb_including_web": round(total_with_web / 1024, 2),
+        **web_stats,
         "providers": provider_counts,
         "oldest": {
             "timestamp": oldest_time,
@@ -224,5 +373,5 @@ def cache_stats() -> Dict[str, Any]:
             "query": newest_query
         } if newest_time else None,
         "cache_dir": str(CACHE_DIR),
-        "exists": True
+        "exists": True,
     }

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/cache.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/cache.py
@@ -1,0 +1,228 @@
+"""Filesystem cache helpers for Web Search Plus."""
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+CACHE_DIR = Path(os.environ.get("WSP_CACHE_DIR", os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".cache")))
+DEFAULT_CACHE_TTL = 3600  # 1 hour in seconds
+PROVIDER_HEALTH_FILENAME = "provider_health.json"
+
+
+def _build_cache_payload(query: str, provider: str, max_results: int, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Build normalized payload used for cache key hashing."""
+    payload = {
+        "query": query,
+        "provider": provider,
+        "max_results": max_results,
+    }
+    if params:
+        payload.update(params)
+    return payload
+
+
+def _get_cache_key(query: str, provider: str, max_results: int, params: Optional[Dict[str, Any]] = None) -> str:
+    """Generate a unique cache key from all relevant query parameters."""
+    payload = _build_cache_payload(query, provider, max_results, params)
+    key_string = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(key_string.encode("utf-8")).hexdigest()[:32]
+
+
+def _get_cache_path(cache_key: str) -> Path:
+    """Get the file path for a cache entry."""
+    return CACHE_DIR / f"{cache_key}.json"
+
+
+def _ensure_cache_dir() -> None:
+    """Create cache directory if it doesn't exist."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:
+    """Write JSON through a temp file and atomic replace to avoid torn cache reads."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def cache_get(query: str, provider: str, max_results: int, ttl: int = DEFAULT_CACHE_TTL, params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    """
+    Retrieve cached search results if they exist and are not expired.
+
+    Args:
+        query: The search query
+        provider: The search provider
+        max_results: Maximum results requested
+        ttl: Time-to-live in seconds (default: 1 hour)
+
+    Returns:
+        Cached result dict or None if not found/expired
+    """
+    cache_key = _get_cache_key(query, provider, max_results, params)
+    cache_path = _get_cache_path(cache_key)
+
+    if not cache_path.exists():
+        return None
+
+    try:
+        with open(cache_path, "r", encoding="utf-8") as f:
+            cached = json.load(f)
+
+        cached_time = cached.get("_cache_timestamp", 0)
+        if time.time() - cached_time > ttl:
+            # Cache expired, remove it
+            cache_path.unlink(missing_ok=True)
+            return None
+
+        return cached
+    except (json.JSONDecodeError, IOError, KeyError):
+        # Corrupted cache file, remove it
+        cache_path.unlink(missing_ok=True)
+        return None
+
+
+def cache_put(query: str, provider: str, max_results: int, result: Dict[str, Any], params: Optional[Dict[str, Any]] = None) -> None:
+    """
+    Store search results in cache.
+
+    Args:
+        query: The search query
+        provider: The search provider
+        max_results: Maximum results requested
+        result: The search result to cache
+    """
+    _ensure_cache_dir()
+
+    cache_key = _get_cache_key(query, provider, max_results, params)
+    cache_path = _get_cache_path(cache_key)
+
+    # Add cache metadata
+    cached_result = result.copy()
+    cached_result["_cache_timestamp"] = time.time()
+    cached_result["_cache_key"] = cache_key
+    cached_result["_cache_query"] = query
+    cached_result["_cache_provider"] = provider
+    cached_result["_cache_max_results"] = max_results
+    cached_result["_cache_params"] = params or {}
+
+    try:
+        _atomic_write_json(cache_path, cached_result)
+    except IOError as e:
+        # Non-fatal: log to stderr but don't fail
+        print(json.dumps({"cache_write_error": str(e)}), file=sys.stderr)
+
+
+def cache_clear() -> Dict[str, Any]:
+    """
+    Clear all cached results.
+
+    Returns:
+        Stats about what was cleared
+    """
+    if not CACHE_DIR.exists():
+        return {"cleared": 0, "message": "Cache directory does not exist"}
+
+    count = 0
+    size_freed = 0
+
+    for cache_file in CACHE_DIR.glob("*.json"):
+        if cache_file.name == PROVIDER_HEALTH_FILENAME:
+            continue
+        try:
+            size_freed += cache_file.stat().st_size
+            cache_file.unlink()
+            count += 1
+        except IOError:
+            pass
+
+    return {
+        "cleared": count,
+        "size_freed_bytes": size_freed,
+        "size_freed_kb": round(size_freed / 1024, 2),
+        "message": f"Cleared {count} cached entries"
+    }
+
+
+def cache_stats() -> Dict[str, Any]:
+    """
+    Get statistics about the cache.
+
+    Returns:
+        Dict with cache statistics
+    """
+    if not CACHE_DIR.exists():
+        return {
+            "total_entries": 0,
+            "total_size_bytes": 0,
+            "total_size_kb": 0,
+            "oldest": None,
+            "newest": None,
+            "cache_dir": str(CACHE_DIR),
+            "exists": False
+        }
+
+    entries = [p for p in CACHE_DIR.glob("*.json") if p.name != PROVIDER_HEALTH_FILENAME]
+    total_size = 0
+    oldest_time = None
+    newest_time = None
+    oldest_query = None
+    newest_query = None
+    provider_counts = {}
+
+    for cache_file in entries:
+        try:
+            stat = cache_file.stat()
+            total_size += stat.st_size
+
+            with open(cache_file, "r", encoding="utf-8") as f:
+                cached = json.load(f)
+
+            ts = cached.get("_cache_timestamp", 0)
+            query = cached.get("_cache_query", "unknown")
+            provider = cached.get("_cache_provider", "unknown")
+
+            provider_counts[provider] = provider_counts.get(provider, 0) + 1
+
+            if oldest_time is None or ts < oldest_time:
+                oldest_time = ts
+                oldest_query = query
+            if newest_time is None or ts > newest_time:
+                newest_time = ts
+                newest_query = query
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    return {
+        "total_entries": len(entries),
+        "total_size_bytes": total_size,
+        "total_size_kb": round(total_size / 1024, 2),
+        "providers": provider_counts,
+        "oldest": {
+            "timestamp": oldest_time,
+            "age_seconds": int(time.time() - oldest_time) if oldest_time else None,
+            "query": oldest_query
+        } if oldest_time else None,
+        "newest": {
+            "timestamp": newest_time,
+            "age_seconds": int(time.time() - newest_time) if newest_time else None,
+            "query": newest_query
+        } if newest_time else None,
+        "cache_dir": str(CACHE_DIR),
+        "exists": True
+    }

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/config.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/config.py
@@ -1,0 +1,423 @@
+"""Configuration and credential helpers for Web Search Plus."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from env_loader import clean_env_value as _shared_clean_env_value, load_env_files
+from provider_registry import DEFAULT_AUTO_ALLOW, DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is missing or has an invalid API key/config."""
+    pass
+
+
+def _is_placeholder_env_value(value: str) -> bool:
+    """Return True for template placeholders that should not count as credentials."""
+    return _shared_clean_env_value(value) is None
+
+
+def _clean_env_value(value: str) -> Optional[str]:
+    return _shared_clean_env_value(value)
+
+
+def _load_env_file():
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
+
+DEFAULT_CONFIG = {
+    "version": 1,
+    "default_provider": None,
+    "defaults": {
+        "provider": "serper",
+        "max_results": 5
+    },
+    "auto_routing": {
+        "enabled": True,
+        "fallback_provider": "serper",
+        # Low-trust / experimental providers can stay configured for explicit use
+        # without being selected automatically.
+        "provider_priority": list(DEFAULT_PROVIDER_PRIORITY),
+        "disabled_providers": [],
+        "auto_allow": dict(DEFAULT_AUTO_ALLOW),
+        "confidence_threshold": 0.3,  # Below this, note low confidence
+    },
+    "serper": {
+        "country": "us",
+        "language": "en",
+        "type": "search"
+    },
+    "brave": {
+        "country": "US",
+        "search_lang": "en",
+        "safesearch": "moderate",
+    },
+    "tavily": {
+        "depth": "basic",
+        "topic": "general"
+    },
+    "querit": {
+        "base_url": "https://api.querit.ai",
+        "base_path": "/v1/search",
+        "timeout": 10
+    },
+    "linkup": {
+        "api_url": "https://api.linkup.so/v1/search",
+        "depth": "standard",
+        "output_type": "searchResults",
+        "timeout": 30
+    },
+    "exa": {
+        "type": "neural",
+        "depth": "normal",
+        "verbosity": "standard"
+    },
+    "perplexity": {
+        "api_url": "https://api.perplexity.ai/chat/completions",
+        "model": "sonar-pro"
+    },
+    "parallel": {
+        "api_url": "https://api.parallel.ai/v1/search",
+        "extract_url": "https://api.parallel.ai/v1/extract",
+        "timeout": 45,
+        "extract_timeout": 60,
+        "client_model": None,
+        "max_chars_total": 12000,
+        "max_chars_per_result": 6000
+    },
+    "kilo-perplexity": {
+        "api_url": "https://api.kilo.ai/api/gateway/chat/completions",
+        "model": "perplexity/sonar-pro"
+    },
+    "firecrawl": {
+        "api_url": "https://api.firecrawl.dev/v2/search",
+        "country": "US",
+        "timeout": 30000,
+        "sources": ["web"],
+        "ignore_invalid_urls": False
+    },
+    "you": {
+        "country": "us",
+        "safesearch": "moderate"
+    },
+    "serpbase": {
+        "api_url": "https://api.serpbase.dev/google/search",
+        "country": "us",
+        "language": "en",
+        "page": 1,
+        "timeout": 30,
+    },
+    "searxng": {
+        "instance_url": None,  # Required - user must set their own instance
+        "safesearch": 0,  # 0=off, 1=moderate, 2=strict
+        "engines": None,  # Optional list of engines to use
+        "language": "en"
+    }
+}
+
+
+def _deepcopy_default_config() -> Dict[str, Any]:
+    return json.loads(json.dumps(DEFAULT_CONFIG))
+
+
+_ROUTING_PROVIDER_NAMES = set(PROVIDER_SPECS)
+
+
+def _normalize_routing_provider_config(provider: str) -> str:
+    normalized = (provider or "").strip().lower()
+    if normalized == "kilo_perplexity":
+        normalized = "kilo-perplexity"
+    if normalized not in _ROUTING_PROVIDER_NAMES:
+        raise ValueError(f"unknown routing provider: {provider}")
+    return normalized
+
+
+def _normalize_routing_provider_list_config(value: Any) -> List[str]:
+    if isinstance(value, str):
+        raw_values = [item.strip() for item in value.split(",")]
+    elif isinstance(value, list):
+        raw_values = [str(item).strip() for item in value]
+    else:
+        raise ValueError("provider list must be a string or list")
+    providers = []
+    seen = set()
+    for raw in raw_values:
+        if not raw:
+            continue
+        provider = _normalize_routing_provider_config(raw)
+        if provider in seen:
+            continue
+        seen.add(provider)
+        providers.append(provider)
+    if not providers:
+        raise ValueError("provider list cannot be empty")
+    return providers
+
+
+def _append_missing_default_providers(providers: List[str]) -> List[str]:
+    """Preserve user ordering while adding newly introduced default providers.
+
+    Existing config.json files often pin provider_priority from an older plugin
+    version. Without this migration, newly added explicit/guarded providers can
+    be valid but invisible to fallback/auto-allow configuration until users
+    manually reset config.
+    """
+    seen = set(providers)
+    merged = list(providers)
+    for provider in DEFAULT_CONFIG["auto_routing"].get("provider_priority", []):
+        if provider not in seen:
+            seen.add(provider)
+            merged.append(provider)
+    return merged
+
+
+def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    auto = config.get("auto_routing", {})
+    if not isinstance(auto, dict):
+        raise ValueError("auto_routing must be an object")
+    if config.get("default_provider"):
+        config["default_provider"] = _normalize_routing_provider_config(str(config["default_provider"]))
+    if auto.get("fallback_provider"):
+        auto["fallback_provider"] = _normalize_routing_provider_config(str(auto["fallback_provider"]))
+    if auto.get("provider_priority"):
+        priority = _normalize_routing_provider_list_config(auto["provider_priority"])
+        auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
+    if "disabled_providers" in auto:
+        disabled = auto.get("disabled_providers") or []
+        if disabled:
+            auto["disabled_providers"] = _normalize_routing_provider_list_config(disabled)
+        else:
+            auto["disabled_providers"] = []
+    if "auto_allow" in auto:
+        raw_allow = auto.get("auto_allow") or {}
+        if not isinstance(raw_allow, dict):
+            raise ValueError("auto_allow must be an object mapping provider names to booleans")
+        normalized_allow = dict(DEFAULT_CONFIG["auto_routing"].get("auto_allow", {}))
+        for raw_provider, allowed in raw_allow.items():
+            provider = _normalize_routing_provider_config(str(raw_provider))
+            normalized_allow[provider] = bool(allowed)
+        auto["auto_allow"] = normalized_allow
+    else:
+        auto["auto_allow"] = dict(DEFAULT_CONFIG["auto_routing"].get("auto_allow", {}))
+    if "confidence_threshold" in auto:
+        threshold = float(auto["confidence_threshold"])
+        if threshold < 0.0 or threshold > 1.0:
+            raise ValueError("confidence_threshold must be between 0.0 and 1.0")
+        auto["confidence_threshold"] = threshold
+    if config.get("default_provider") and config["default_provider"] in set(auto.get("disabled_providers", [])):
+        raise ValueError("default_provider cannot be disabled")
+    config["auto_routing"] = auto
+    return config
+
+
+def _unique_timestamped_path(path: Path, marker: str) -> Path:
+    base = path.with_name(path.name + f".{marker}-{int(time.time())}")
+    candidate = base
+    suffix = 2
+    while candidate.exists():
+        candidate = base.with_name(base.name + f"-{suffix}")
+        suffix += 1
+    return candidate
+
+
+def _quarantine_runtime_config(config_path: Path, reason: str) -> None:
+    broken = _unique_timestamped_path(config_path, "broken")
+    try:
+        config_path.rename(broken)
+        print(json.dumps({
+            "warning": f"Invalid config moved to {broken}: {reason}",
+            "using": "default configuration",
+        }), file=sys.stderr)
+    except OSError as exc:
+        print(json.dumps({
+            "warning": f"Invalid config could not be moved: {exc}; reason: {reason}",
+            "using": "default configuration",
+        }), file=sys.stderr)
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from config.json if it exists, with defaults."""
+    config = _deepcopy_default_config()
+    config_path = Path(os.environ.get("WEB_SEARCH_PLUS_CONFIG") or (Path(__file__).parent.parent / "config.json"))
+
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                user_config = json.load(f)
+                for key, value in user_config.items():
+                    if isinstance(value, dict) and key in config:
+                        config[key] = {**config.get(key, {}), **value}
+                    else:
+                        config[key] = value
+            config = _validate_runtime_config(config)
+        except (json.JSONDecodeError, IOError, ValueError, TypeError) as e:
+            _quarantine_runtime_config(config_path, str(e))
+            config = _deepcopy_default_config()
+
+    return config
+
+
+def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
+    """Get API key for provider from config.json or environment.
+
+    Priority: config.json > .env > environment variable
+
+    Note: SearXNG doesn't require an API key, but returns instance_url if configured.
+    """
+    # Special case: SearXNG uses instance_url instead of API key
+    if provider == "searxng":
+        return get_searxng_instance_url(config)
+
+    # Check config.json first
+    if config:
+        provider_config = config.get(provider, {})
+        if isinstance(provider_config, dict):
+            key = provider_config.get("api_key") or provider_config.get("apiKey")
+            key = _clean_env_value(str(key)) if key is not None else None
+            if key:
+                return key
+
+    # Then check environment
+    spec = PROVIDER_SPECS.get(provider)
+    return _clean_env_value(os.environ.get(spec.env_var if spec else "", ""))
+
+
+def _validate_searxng_url(url: str) -> str:
+    """Validate and sanitize SearXNG instance URL to prevent SSRF.
+
+    Enforces http/https scheme and blocks requests to private/internal networks
+    including cloud metadata endpoints, loopback, link-local, and RFC1918 ranges.
+    """
+    import ipaddress
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"SearXNG URL must use http or https scheme, got: {parsed.scheme}")
+    if not parsed.hostname:
+        raise ValueError("SearXNG URL must include a hostname")
+
+    hostname = parsed.hostname
+
+    # Block cloud metadata endpoints by hostname
+    BLOCKED_HOSTS = {
+        "169.254.169.254",        # AWS/GCP/Azure metadata
+        "metadata.google.internal",
+        "metadata.internal",
+    }
+    if hostname in BLOCKED_HOSTS:
+        raise ValueError(f"SearXNG URL blocked: {hostname} is a cloud metadata endpoint")
+
+    # Resolve hostname and check for private/internal IPs
+    # Operators who intentionally self-host on private networks can opt out
+    allow_private = os.environ.get("SEARXNG_ALLOW_PRIVATE", "").strip() == "1"
+    if not allow_private:
+        try:
+            resolved_ips = socket.getaddrinfo(hostname, parsed.port or 80, proto=socket.IPPROTO_TCP)
+            for family, _type, _proto, _canonname, sockaddr in resolved_ips:
+                ip = ipaddress.ip_address(sockaddr[0])
+                if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved:
+                    raise ValueError(
+                        f"SearXNG URL blocked: {hostname} resolves to private/internal IP {ip}. "
+                        f"If this is intentional, set SEARXNG_ALLOW_PRIVATE=1 in your environment."
+                    )
+        except socket.gaierror:
+            raise ValueError(f"SearXNG URL blocked: cannot resolve hostname {hostname}")
+
+    return url
+
+
+def get_searxng_instance_url(config: Dict[str, Any] = None) -> Optional[str]:
+    """Get SearXNG instance URL from config or environment.
+
+    SearXNG is self-hosted, so no API key needed - just the instance URL.
+    Priority: config.json > SEARXNG_INSTANCE_URL environment variable
+
+    Security: URL is validated to prevent SSRF via scheme enforcement.
+    Both config sources (config.json, env var) are operator-controlled,
+    not agent-controlled, so private IPs like localhost are permitted.
+    """
+    # Check config.json first
+    if config:
+        searxng_config = config.get("searxng", {})
+        if isinstance(searxng_config, dict):
+            url = searxng_config.get("instance_url")
+            if url:
+                return _validate_searxng_url(url)
+
+    # Then check environment
+    env_url = _clean_env_value(os.environ.get("SEARXNG_INSTANCE_URL", ""))
+    if env_url:
+        return _validate_searxng_url(env_url)
+    return None
+
+
+# Backward compatibility alias
+def get_env_key(provider: str) -> Optional[str]:
+    """Get API key for provider from environment (legacy function)."""
+    return get_api_key(provider)
+
+
+def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
+    """Validate and return API key (or instance URL for SearXNG), with helpful error messages."""
+    key = get_api_key(provider, config)
+
+    # Special handling for SearXNG - it needs instance URL, not API key
+    if provider == "searxng":
+        if not key:
+            error_msg = {
+                "error": "Missing SearXNG instance URL",
+                "env_var": "SEARXNG_INSTANCE_URL",
+                "how_to_fix": [
+                    "1. Set up your own SearXNG instance: https://docs.searxng.org/admin/installation.html",
+                    "2. Add to config.json: \"searxng\": {\"instance_url\": \"https://your-instance.example.com\"}",
+                    "3. Or set environment variable: export SEARXNG_INSTANCE_URL=\"https://your-instance.example.com\"",
+                    "Note: SearXNG requires a self-hosted instance with JSON format enabled.",
+                ],
+                "provider": provider
+            }
+            raise ProviderConfigError(json.dumps(error_msg))
+
+        # Validate URL format
+        if not key.startswith(("http://", "https://")):
+            raise ProviderConfigError(json.dumps({
+                "error": "SearXNG instance URL must start with http:// or https://",
+                "provided": key,
+                "provider": provider
+            }))
+
+        return key
+
+    if not key:
+        spec = PROVIDER_SPECS[provider]
+        env_var = spec.env_var
+
+        error_msg = {
+            "error": f"Missing API key for {provider}",
+            "env_var": env_var,
+            "how_to_fix": [
+                f"1. Get your API key from {spec.signup_url}",
+                f"2. Add to config.json: \"{provider}\": {{\"api_key\": \"your-key\"}}",
+                f"3. Or set environment variable: export {env_var}=\"your-key\"",
+            ],
+            "provider": provider
+        }
+        raise ProviderConfigError(json.dumps(error_msg))
+
+    if len(key) < 10:
+        raise ProviderConfigError(json.dumps({
+            "error": f"API key for {provider} appears invalid (too short)",
+            "provider": provider
+        }))
+
+    return key
+
+
+_load_env_file()

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/config.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/config.py
@@ -9,8 +9,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from env_loader import clean_env_value as _shared_clean_env_value, load_env_files
-from provider_registry import DEFAULT_AUTO_ALLOW, DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS
+from env_loader import clean_env_value as _shared_clean_env_value, is_truthy, load_env_files
+from provider_registry import DEFAULT_AUTO_ALLOW, DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS, keyless_public_env_var
 
 
 class ProviderConfigError(Exception):
@@ -47,6 +47,16 @@ DEFAULT_CONFIG = {
         "disabled_providers": [],
         "auto_allow": dict(DEFAULT_AUTO_ALLOW),
         "confidence_threshold": 0.3,  # Below this, note low confidence
+    },
+    "web": {
+        # Maximum cleaned characters returned inline per extracted result before
+        # truncate-and-store keeps the full text on disk for page-on-demand.
+        "extract_char_limit": 15000,
+    },
+    "extract": {
+        # Target URLs supplied to extract_plus are blocked when they resolve to
+        # private/internal networks. Operators can opt in for trusted intranet use.
+        "allow_private_urls": False,
     },
     "serper": {
         "country": "us",
@@ -118,6 +128,12 @@ DEFAULT_CONFIG = {
         "safesearch": 0,  # 0=off, 1=moderate, 2=strict
         "engines": None,  # Optional list of engines to use
         "language": "en"
+    },
+    "keenable": {
+        "search_url": "https://api.keenable.ai/v1/search",
+        "fetch_url": "https://api.keenable.ai/v1/fetch",
+        "timeout": 30,
+        "allow_public": False
     }
 }
 
@@ -248,7 +264,7 @@ def load_config() -> Dict[str, Any]:
 
     if config_path.exists():
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 user_config = json.load(f)
                 for key, value in user_config.items():
                     if isinstance(value, dict) and key in config:
@@ -286,6 +302,32 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
     # Then check environment
     spec = PROVIDER_SPECS.get(provider)
     return _clean_env_value(os.environ.get(spec.env_var if spec else "", ""))
+
+
+def keyless_public_allowed(provider: str, config: Dict[str, Any] = None) -> bool:
+    """Whether a keyless provider may use its unauthenticated public endpoint.
+
+    Off by default; opt in via config.json (``<provider>.allow_public``) or the
+    ``<PROVIDER>_ALLOW_PUBLIC`` env var.
+    """
+    spec = PROVIDER_SPECS.get(provider)
+    if not (spec and spec.keyless):
+        return False
+    section = (config or {}).get(spec.config_section, {})
+    if isinstance(section, dict) and is_truthy(section.get("allow_public")):
+        return True
+    return is_truthy(os.environ.get(keyless_public_env_var(provider)))
+
+
+def provider_configured(provider: str, config: Dict[str, Any] = None) -> bool:
+    """Whether a provider can run: it has a key, or its keyless public endpoint is opted in.
+
+    Distinct from ``get_api_key`` truthiness so key-status logic never treats a
+    keyless provider as keyed.
+    """
+    if get_api_key(provider, config):
+        return True
+    return keyless_public_allowed(provider, config)
 
 
 def _validate_searxng_url(url: str) -> str:
@@ -365,8 +407,11 @@ def get_env_key(provider: str) -> Optional[str]:
     return get_api_key(provider)
 
 
-def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
-    """Validate and return API key (or instance URL for SearXNG), with helpful error messages."""
+def validate_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
+    """Validate and return the API key (or SearXNG instance URL), with helpful error messages.
+
+    Returns None for a keyless provider whose public endpoint is opted in.
+    """
     key = get_api_key(provider, config)
 
     # Special handling for SearXNG - it needs instance URL, not API key
@@ -394,6 +439,9 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             }))
 
         return key
+
+    if not key and keyless_public_allowed(provider, config):
+        return None
 
     if not key:
         spec = PROVIDER_SPECS[provider]

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/daemon_tasks.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/daemon_tasks.py
@@ -1,0 +1,56 @@
+"""Future-like tasks on daemon threads that never block interpreter exit.
+
+``concurrent.futures`` registers an atexit hook that joins every worker
+thread, so even after ``ThreadPoolExecutor.shutdown(wait=False)`` a hung
+provider call keeps the *process* alive until the worker finishes. The
+budget-bounded caller returns on time, but a CLI/subprocess invocation then
+stalls at exit — exactly the path web-search-plus uses for its subprocess
+fallback. Daemon threads are abandoned at interpreter shutdown instead, so
+the time budget bounds both the function return and the process lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any, Callable, Optional
+
+
+class DaemonTask:
+    """Run a callable on a daemon thread with a Future-like ``result(timeout)``."""
+
+    def __init__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any):
+        self._done = threading.Event()
+        self._result: Any = None
+        self._exc: Optional[BaseException] = None
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(fn, args, kwargs),
+            daemon=True,
+            name="wsp-daemon-task",
+        )
+        self._thread.start()
+
+    def _run(self, fn: Callable[..., Any], args: tuple, kwargs: dict) -> None:
+        try:
+            self._result = fn(*args, **kwargs)
+        except BaseException as exc:  # re-raised to result() callers
+            self._exc = exc
+        finally:
+            self._done.set()
+
+    def done(self) -> bool:
+        return self._done.is_set()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        """Return the callable's result, raising FuturesTimeoutError on timeout.
+
+        A timeout abandons the task: the daemon thread keeps running in the
+        background (bounded by per-request HTTP timeouts) but neither blocks
+        the caller nor interpreter shutdown.
+        """
+        if not self._done.wait(timeout):
+            raise FuturesTimeoutError("daemon task did not finish in time")
+        if self._exc is not None:
+            raise self._exc
+        return self._result

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/env_loader.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/env_loader.py
@@ -1,0 +1,80 @@
+"""Shared environment loading helpers for Web Search Plus.
+
+The plugin supports three credential locations, in precedence order:
+1. plugin-local ``.env`` for standalone/plugin development
+2. legacy parent ``.env`` used by earlier installs
+3. Hermes profile ``.env`` (``$HERMES_HOME/.env`` or hermes_constants)
+
+Values already present in ``os.environ`` are never overwritten.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, MutableMapping, Optional, Set, Union
+
+
+def is_placeholder_env_value(value: str) -> bool:
+    """Return True for empty/template placeholders that are not credentials."""
+    stripped = (value or "").strip().strip('"').strip("'")
+    return not stripped or set(stripped) == {"*"}
+
+
+def clean_env_value(value: str) -> Optional[str]:
+    """Return a real env value, or None for empty/template placeholders."""
+    stripped = (value or "").strip().strip('"').strip("'")
+    return None if is_placeholder_env_value(stripped) else stripped
+
+
+def get_hermes_env_path() -> Path:
+    """Return Hermes' profile-aware .env path when available."""
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()) / ".env"
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / ".env"
+
+
+def candidate_env_paths(anchor_file: Union[str, Path]) -> List[Path]:
+    """Return .env files checked for a module anchored in the plugin dir."""
+    plugin_dir = Path(anchor_file).resolve().parent
+    paths = [
+        plugin_dir / ".env",
+        plugin_dir.parent / ".env",
+        get_hermes_env_path(),
+    ]
+    deduped: List[Path] = []
+    seen: Set[str] = set()
+    for path in paths:
+        key = str(path.expanduser())
+        if key not in seen:
+            deduped.append(path)
+            seen.add(key)
+    return deduped
+
+
+def load_env_files(anchor_file: Union[str, Path], environ: Optional[MutableMapping[str, str]] = None) -> List[Path]:
+    """Load supported .env files without overriding existing env vars.
+
+    Returns the files that existed and were inspected. Template placeholders such
+    as ``***`` are ignored so they do not mask later real credentials.
+    """
+    target_env = environ if environ is not None else os.environ
+    loaded: List[Path] = []
+    for env_path in candidate_env_paths(anchor_file):
+        if not env_path.exists():
+            continue
+        loaded.append(env_path)
+        for raw_line in env_path.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[7:]
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = clean_env_value(value)
+            if key and value and key not in target_env:
+                target_env[key] = value
+    return loaded

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/env_loader.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/env_loader.py
@@ -26,6 +26,18 @@ def clean_env_value(value: str) -> Optional[str]:
     return None if is_placeholder_env_value(stripped) else stripped
 
 
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_truthy(value: object) -> bool:
+    """Strict opt-in parse: only 1/true/yes/on are truthy, so a present-but-false value never enables an egress flag."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().strip('"').strip("'").lower() in _TRUTHY_VALUES
+
+
 def get_hermes_env_path() -> Path:
     """Return Hermes' profile-aware .env path when available."""
     try:
@@ -66,7 +78,7 @@ def load_env_files(anchor_file: Union[str, Path], environ: Optional[MutableMappi
         if not env_path.exists():
             continue
         loaded.append(env_path)
-        for raw_line in env_path.read_text().splitlines():
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
             line = raw_line.strip()
             if not line or line.startswith("#") or "=" not in line:
                 continue

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/extract.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/extract.py
@@ -1,0 +1,113 @@
+"""Extraction orchestrator for Web Search Plus."""
+
+from typing import Any, Dict, List, Optional
+
+from config import get_api_key, load_config
+from provider_health import (
+    execute_provider_with_retry,
+    mark_provider_failure,
+    provider_in_cooldown,
+    reset_provider_health,
+)
+from providers import (
+    extract_exa,
+    extract_firecrawl,
+    extract_linkup,
+    extract_parallel,
+    extract_tavily,
+    extract_you,
+)
+from provider_registry import EXTRACT_PROVIDER_IDS
+
+
+EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
+
+
+def extract_plus(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    config: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Extract URL content with provider fallback."""
+    config = config or load_config()
+    selected = provider or "auto"
+    if not urls:
+        return {"provider": selected, "results": [], "error": "No URLs provided", "requested_provider": selected}
+    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
+    if invalid:
+        return {
+            "provider": selected,
+            "results": [],
+            "error": f"Invalid URL(s) — must start with http:// or https://: {invalid}",
+            "requested_provider": selected,
+        }
+    providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    errors = []
+    cooldown_skips = []
+    for prov in providers:
+        if prov not in EXTRACT_PROVIDER_PRIORITY:
+            errors.append({"provider": prov, "error": f"Provider {prov} does not support extraction"})
+            continue
+        key = get_api_key(prov, config)
+        if not key:
+            errors.append({"provider": prov, "error": "missing_api_key"})
+            continue
+        in_cooldown, remaining = provider_in_cooldown(prov)
+        if in_cooldown and not (selected != "auto" and prov == selected):
+            cooldown_skips.append({"provider": prov, "cooldown_remaining_seconds": remaining})
+            continue
+        try:
+            def execute_extract() -> Dict[str, Any]:
+                if prov == "firecrawl":
+                    fc = config.get("firecrawl", {})
+                    return extract_firecrawl(urls, key, output_format, include_images, include_raw_html, render_js, api_url=fc.get("scrape_url", "https://api.firecrawl.dev/v2/scrape"), timeout=int(fc.get("extract_timeout", 60)))
+                if prov == "linkup":
+                    lu = config.get("linkup", {})
+                    return extract_linkup(urls, key, output_format, include_images, include_raw_html, render_js, api_url=lu.get("fetch_url", "https://api.linkup.so/v1/fetch"), timeout=int(lu.get("timeout", 30)))
+                if prov == "tavily":
+                    tv = config.get("tavily", {})
+                    return extract_tavily(urls, key, output_format, include_images, include_raw_html, render_js, api_url=tv.get("extract_url", "https://api.tavily.com/extract"), timeout=int(tv.get("timeout", 30)))
+                if prov == "exa":
+                    exa = config.get("exa", {})
+                    return extract_exa(urls, key, output_format, include_images, include_raw_html, render_js, api_url=exa.get("contents_url", "https://api.exa.ai/contents"), timeout=int(exa.get("timeout", 30)))
+                if prov == "parallel":
+                    parallel = config.get("parallel", {})
+                    return extract_parallel(
+                        urls, key, output_format, include_images, include_raw_html, render_js,
+                        api_url=parallel.get("extract_url", "https://api.parallel.ai/v1/extract"),
+                        timeout=int(parallel.get("extract_timeout", parallel.get("timeout", 60))),
+                        client_model=parallel.get("client_model"),
+                        max_chars_total=int(parallel.get("max_chars_total", 12000)),
+                        max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
+                    )
+                you = config.get("you", {})
+                return extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
+
+            result = execute_provider_with_retry(prov, execute_extract)
+            res_list = result.get("results") or []
+            all_failed = bool(res_list) and all(r.get("error") for r in res_list)
+            if all_failed:
+                errors.append({
+                    "provider": prov,
+                    "error": "all_urls_failed",
+                    "details": [r.get("error") for r in res_list],
+                })
+                continue
+            reset_provider_health(prov)
+            result["routing"] = {"provider": prov, "requested_provider": selected, "fallback_used": bool(errors) or bool(cooldown_skips), "fallback_errors": errors}
+            if cooldown_skips:
+                result["routing"]["cooldown_skips"] = cooldown_skips
+            return result
+        except Exception as e:
+            error_msg = str(e)
+            cooldown_info = mark_provider_failure(prov, error_msg)
+            errors.append({"provider": prov, "error": error_msg, "cooldown_seconds": cooldown_info.get("cooldown_seconds")})
+            continue
+    error_result = {"provider": selected, "results": [], "error": "All extraction providers failed", "fallback_errors": errors}
+    if cooldown_skips:
+        error_result["cooldown_skips"] = cooldown_skips
+    return error_result

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/extract.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/extract.py
@@ -1,8 +1,11 @@
 """Extraction orchestrator for Web Search Plus."""
 
+import ipaddress
+import socket
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
-from config import get_api_key, load_config
+from config import get_api_key, keyless_public_allowed, load_config
 from provider_health import (
     execute_provider_with_retry,
     mark_provider_failure,
@@ -12,6 +15,7 @@ from provider_health import (
 from providers import (
     extract_exa,
     extract_firecrawl,
+    extract_keenable,
     extract_linkup,
     extract_parallel,
     extract_tavily,
@@ -21,6 +25,73 @@ from provider_registry import EXTRACT_PROVIDER_IDS
 
 
 EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
+
+
+class ExtractUrlSecurityError(ValueError):
+    """Raised when an extraction target URL points at an internal resource."""
+
+
+_BLOCKED_EXTRACT_HOSTS = {
+    "localhost",
+    "metadata.google.internal",
+    "metadata.internal",
+}
+
+
+def _extract_allows_private_urls(config: Dict[str, Any]) -> bool:
+    extract_config = config.get("extract", {}) if isinstance(config, dict) else {}
+    if not isinstance(extract_config, dict):
+        return False
+    return extract_config.get("allow_private_urls") is True
+
+
+def _is_private_or_internal_ip(value: str) -> bool:
+    ip = ipaddress.ip_address(value)
+    return (not ip.is_global) or ip.is_multicast
+
+
+def _validate_extract_urls(urls: List[str], config: Optional[Dict[str, Any]] = None) -> List[str]:
+    """Validate extraction target URLs before handing them to remote/local fetchers.
+
+    Provider endpoint URLs are operator-controlled config and are intentionally
+    not checked here. This guard only covers user/agent-controlled target URLs.
+    """
+    config = config or {}
+    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
+    if invalid:
+        raise ValueError(f"Invalid URL(s) — must start with http:// or https://: {invalid}")
+    if _extract_allows_private_urls(config):
+        return urls
+
+    for url in urls:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+        if not hostname:
+            raise ValueError(f"Invalid URL — hostname is required: {url}")
+        if hostname in _BLOCKED_EXTRACT_HOSTS:
+            raise ExtractUrlSecurityError(f"Extraction URL blocked: {hostname} is private/internal")
+
+        try:
+            ipaddress.ip_address(hostname)
+        except ValueError:
+            pass
+        else:
+            if _is_private_or_internal_ip(hostname):
+                raise ExtractUrlSecurityError(f"Extraction URL blocked: {hostname} is private/internal")
+            continue
+
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        try:
+            resolved_ips = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as exc:
+            raise ExtractUrlSecurityError(f"Extraction URL blocked: cannot resolve hostname {hostname}") from exc
+        for _family, _type, _proto, _canonname, sockaddr in resolved_ips:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if _is_private_or_internal_ip(str(ip)):
+                raise ExtractUrlSecurityError(
+                    f"Extraction URL blocked: {hostname} resolves to private/internal IP {ip}"
+                )
+    return urls
 
 
 def extract_plus(
@@ -37,15 +108,19 @@ def extract_plus(
     selected = provider or "auto"
     if not urls:
         return {"provider": selected, "results": [], "error": "No URLs provided", "requested_provider": selected}
-    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
-    if invalid:
+    try:
+        urls = _validate_extract_urls(urls, config)
+    except (ValueError, ExtractUrlSecurityError) as exc:
         return {
             "provider": selected,
             "results": [],
-            "error": f"Invalid URL(s) — must start with http:// or https://: {invalid}",
+            "error": str(exc),
             "requested_provider": selected,
         }
-    providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    auto_config = config.get("auto_routing", {})
+    disabled_providers = set(auto_config.get("disabled_providers", []))
+    base_providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    providers = [p for p in base_providers if p == selected or p not in disabled_providers]
     errors = []
     cooldown_skips = []
     for prov in providers:
@@ -53,7 +128,8 @@ def extract_plus(
             errors.append({"provider": prov, "error": f"Provider {prov} does not support extraction"})
             continue
         key = get_api_key(prov, config)
-        if not key:
+        keyless_allowed = keyless_public_allowed(prov, config)
+        if not key and not keyless_allowed:
             errors.append({"provider": prov, "error": "missing_api_key"})
             continue
         in_cooldown, remaining = provider_in_cooldown(prov)
@@ -84,6 +160,9 @@ def extract_plus(
                         max_chars_total=int(parallel.get("max_chars_total", 12000)),
                         max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
                     )
+                if prov == "keenable":
+                    kn = config.get("keenable", {})
+                    return extract_keenable(urls, key, output_format, include_images, include_raw_html, render_js, public=keyless_allowed, api_url=kn.get("fetch_url", "https://api.keenable.ai/v1/fetch"), timeout=int(kn.get("timeout", 30)))
                 you = config.get("you", {})
                 return extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
 
@@ -104,7 +183,7 @@ def extract_plus(
             return result
         except Exception as e:
             error_msg = str(e)
-            cooldown_info = mark_provider_failure(prov, error_msg)
+            cooldown_info = mark_provider_failure(prov, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({"provider": prov, "error": error_msg, "cooldown_seconds": cooldown_info.get("cooldown_seconds")})
             continue
     error_result = {"provider": selected, "results": [], "error": "All extraction providers failed", "fallback_errors": errors}

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/http_client.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/http_client.py
@@ -1,0 +1,151 @@
+"""Shared HTTP client helpers for Web Search Plus providers."""
+
+from __future__ import annotations
+
+from http.client import IncompleteRead
+import gzip
+import json
+import zlib
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+TRANSIENT_HTTP_CODES = {429, 503}
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.4.0"
+
+
+class ProviderRequestError(Exception):
+    """Structured provider error with retry/cooldown metadata."""
+
+    def __init__(self, message: str, status_code: int | None = None, transient: bool = False):
+        super().__init__(message)
+        self.status_code = status_code
+        self.transient = transient
+
+
+def _response_header(response, name: str) -> str:
+    """Return an HTTP response header from urllib response/error objects."""
+    if hasattr(response, "getheader"):
+        value = response.getheader(name)
+        if value is not None:
+            return str(value)
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        try:
+            value = headers.get(name)
+        except AttributeError:
+            value = None
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def _read_response_body(response) -> bytes:
+    """Read an urllib response body and decode supported Content-Encoding values."""
+    raw = response.read()
+    encoding = _response_header(response, "Content-Encoding").strip().lower()
+
+    if encoding in {"gzip", "x-gzip"} or raw.startswith(b"\x1f\x8b"):
+        return gzip.decompress(raw)
+    if encoding == "deflate":
+        try:
+            return zlib.decompress(raw)
+        except zlib.error:
+            # Some servers send raw deflate without the zlib wrapper.
+            return zlib.decompress(raw, -zlib.MAX_WBITS)
+    if encoding == "br":
+        raise ProviderRequestError(
+            "Brotli-compressed response received, but web-search-plus does not bundle brotli support. "
+            "Disable brotli for this provider or install a brotli-capable transport.",
+            transient=False,
+        )
+    return raw
+
+
+def _read_json_response(response) -> dict:
+    """Read an urllib response as UTF-8 JSON with Content-Encoding handling."""
+    return json.loads(_read_response_body(response).decode("utf-8"))
+
+
+def _friendly_http_error(code: int, error_detail: str) -> str:
+    error_messages = {
+        401: "Invalid or expired API key. Please check your credentials.",
+        403: "Access forbidden. Your API key may not have permission for this operation.",
+        429: "Rate limit exceeded. Please wait a moment and try again.",
+        500: "Server error. The search provider is experiencing issues.",
+        503: "Service unavailable. The search provider may be down.",
+    }
+    return error_messages.get(code, f"API error: {error_detail}")
+
+
+def _extract_http_error_detail(error: HTTPError) -> str:
+    error_body = _read_response_body(error).decode("utf-8") if error.fp else str(error)
+    try:
+        error_json = json.loads(error_body)
+        return error_json.get("error") or error_json.get("message") or error_body
+    except json.JSONDecodeError:
+        return error_body[:500]
+
+
+def _raise_provider_http_error(error: HTTPError) -> None:
+    error_detail = _extract_http_error_detail(error)
+    friendly_msg = _friendly_http_error(error.code, error_detail)
+    raise ProviderRequestError(
+        f"{friendly_msg} (HTTP {error.code})",
+        status_code=error.code,
+        transient=error.code in TRANSIENT_HTTP_CODES,
+    )
+
+
+def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict:
+    """Make HTTP POST request and return JSON response."""
+    # Ensure User-Agent is set (required by some APIs like Exa/Cloudflare)
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = DEFAULT_USER_AGENT
+    data = json.dumps(body).encode("utf-8")
+    req = Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            return _read_json_response(response)
+    except HTTPError as e:
+        _raise_provider_http_error(e)
+        raise
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except IncompleteRead as e:
+        partial_len = len(getattr(e, "partial", b"") or b"")
+        raise ProviderRequestError(
+            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
+            transient=True,
+        )
+    except TimeoutError:
+        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
+
+
+def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
+    """Make HTTP GET request and return JSON response."""
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = DEFAULT_USER_AGENT
+    req = Request(url, headers=headers, method="GET")
+
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            return _read_json_response(response)
+    except HTTPError as e:
+        _raise_provider_http_error(e)
+        raise
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except IncompleteRead as e:
+        partial_len = len(getattr(e, "partial", b"") or b"")
+        raise ProviderRequestError(
+            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
+            transient=True,
+        )
+    except TimeoutError:
+        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/http_client.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/http_client.py
@@ -2,25 +2,36 @@
 
 from __future__ import annotations
 
+from email.utils import parsedate_to_datetime
 from http.client import IncompleteRead
 import gzip
 import json
+import socket
+import time
 import zlib
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.4.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.8.1"
 
 
 class ProviderRequestError(Exception):
     """Structured provider error with retry/cooldown metadata."""
 
-    def __init__(self, message: str, status_code: int | None = None, transient: bool = False):
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        transient: bool = False,
+        retry_after: float | None = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.transient = transient
+        # Provider-requested wait (seconds) from a Retry-After header, if any.
+        self.retry_after = retry_after
 
 
 def _response_header(response, name: str) -> str:
@@ -46,13 +57,25 @@ def _read_response_body(response) -> bytes:
     encoding = _response_header(response, "Content-Encoding").strip().lower()
 
     if encoding in {"gzip", "x-gzip"} or raw.startswith(b"\x1f\x8b"):
-        return gzip.decompress(raw)
+        try:
+            return gzip.decompress(raw)
+        except (OSError, EOFError, zlib.error):
+            raise ProviderRequestError(
+                "Provider sent a corrupted gzip response body. Please retry.",
+                transient=True,
+            )
     if encoding == "deflate":
         try:
             return zlib.decompress(raw)
         except zlib.error:
             # Some servers send raw deflate without the zlib wrapper.
-            return zlib.decompress(raw, -zlib.MAX_WBITS)
+            try:
+                return zlib.decompress(raw, -zlib.MAX_WBITS)
+            except zlib.error:
+                raise ProviderRequestError(
+                    "Provider sent a corrupted deflate response body. Please retry.",
+                    transient=True,
+                )
     if encoding == "br":
         raise ProviderRequestError(
             "Brotli-compressed response received, but web-search-plus does not bundle brotli support. "
@@ -64,7 +87,21 @@ def _read_response_body(response) -> bytes:
 
 def _read_json_response(response) -> dict:
     """Read an urllib response as UTF-8 JSON with Content-Encoding handling."""
-    return json.loads(_read_response_body(response).decode("utf-8"))
+    body = _read_response_body(response)
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ProviderRequestError(
+            "Provider sent a non-UTF-8 response body. Please retry.",
+            transient=True,
+        )
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        raise ProviderRequestError(
+            "Provider sent an invalid JSON response. Please retry.",
+            transient=True,
+        )
 
 
 def _friendly_http_error(code: int, error_detail: str) -> str:
@@ -79,12 +116,34 @@ def _friendly_http_error(code: int, error_detail: str) -> str:
 
 
 def _extract_http_error_detail(error: HTTPError) -> str:
-    error_body = _read_response_body(error).decode("utf-8") if error.fp else str(error)
+    try:
+        error_body = _read_response_body(error).decode("utf-8", errors="replace") if error.fp else str(error)
+    except (ProviderRequestError, OSError):
+        # A corrupted error body must not mask the HTTP status we are reporting.
+        return str(error)
     try:
         error_json = json.loads(error_body)
         return error_json.get("error") or error_json.get("message") or error_body
     except json.JSONDecodeError:
         return error_body[:500]
+
+
+def _parse_retry_after(error: HTTPError) -> float | None:
+    """Parse a Retry-After header (delta-seconds or HTTP-date) into seconds."""
+    value = _response_header(error, "Retry-After").strip()
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at is None:
+        return None
+    return max(0.0, retry_at.timestamp() - time.time())
 
 
 def _raise_provider_http_error(error: HTTPError) -> None:
@@ -94,6 +153,7 @@ def _raise_provider_http_error(error: HTTPError) -> None:
         f"{friendly_msg} (HTTP {error.code})",
         status_code=error.code,
         transient=error.code in TRANSIENT_HTTP_CODES,
+        retry_after=_parse_retry_after(error) if error.code == 429 else None,
     )
 
 
@@ -113,7 +173,7 @@ def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict
         raise
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
     except IncompleteRead as e:
         partial_len = len(getattr(e, "partial", b"") or b"")
@@ -121,7 +181,9 @@ def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict
             f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
             transient=True,
         )
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
+        # socket.timeout only becomes a TimeoutError alias in Python 3.10;
+        # catching both keeps read timeouts transient on 3.8/3.9.
         raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
 
 
@@ -139,7 +201,7 @@ def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
         raise
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
     except IncompleteRead as e:
         partial_len = len(getattr(e, "partial", b"") or b"")
@@ -147,5 +209,7 @@ def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
             f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
             transient=True,
         )
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
+        # socket.timeout only becomes a TimeoutError alias in Python 3.10;
+        # catching both keeps read timeouts transient on 3.8/3.9.
         raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_health.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_health.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from cache import CACHE_DIR
 from http_client import ProviderRequestError
@@ -19,6 +19,16 @@ RETRY_BACKOFF_SECONDS = [1, 3, 9]
 # Add up to this fraction of the base delay as random jitter so concurrent or
 # repeated retries against a recovering provider do not synchronize into bursts.
 RETRY_JITTER_FRACTION = 0.5
+# Failures older than this no longer escalate the cooldown ladder: a provider
+# that fails once every few hours should restart at the shortest cooldown step
+# instead of compounding toward the 1h cap.
+FAILURE_DECAY_SECONDS = 1800
+# Rate-limit (429) responses get at most one retry per request; burning the full
+# retry budget against an exhausted quota only wastes time and provider credits.
+RATE_LIMIT_MAX_ATTEMPTS = 2
+# Longest Retry-After wait we will honor inline. Anything above this is left to
+# the cooldown ladder instead of blocking the current request.
+MAX_RETRY_AFTER_WAIT_SECONDS = 30.0
 
 # Serializes read-modify-write of the shared health file when search/extract run
 # providers concurrently in-process (e.g. parallel research mode). Atomic writes
@@ -75,13 +85,21 @@ def provider_in_cooldown(provider: str) -> Tuple[bool, int]:
     return (remaining > 0, max(0, remaining))
 
 
-def mark_provider_failure(provider: str, error_message: str) -> Dict[str, Any]:
+def mark_provider_failure(provider: str, error_message: str, retry_after: Optional[float] = None) -> Dict[str, Any]:
     with _HEALTH_LOCK:
         state = _load_provider_health()
         now = int(time.time())
         pstate = state.get(provider, {})
-        fail_count = int(pstate.get("failure_count", 0)) + 1
+        prev_count = int(pstate.get("failure_count", 0))
+        last_failure_at = int(pstate.get("last_failure_at", 0) or 0)
+        if last_failure_at and now - last_failure_at > FAILURE_DECAY_SECONDS:
+            # Stale failure history: restart the escalation ladder.
+            prev_count = 0
+        fail_count = prev_count + 1
         cooldown_seconds = COOLDOWN_STEPS_SECONDS[min(fail_count - 1, len(COOLDOWN_STEPS_SECONDS) - 1)]
+        if retry_after is not None and retry_after > 0:
+            # Respect the provider's explicit wait request, capped at the ladder max.
+            cooldown_seconds = min(max(cooldown_seconds, int(retry_after)), COOLDOWN_STEPS_SECONDS[-1])
         state[provider] = {
             "failure_count": fail_count,
             "cooldown_until": now + cooldown_seconds,
@@ -113,10 +131,20 @@ def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3)
                 break
             if not e.transient:
                 break
-            if attempt < max_attempts - 1:
+            is_rate_limited = e.status_code == 429
+            attempt_cap = min(max_attempts, RATE_LIMIT_MAX_ATTEMPTS) if is_rate_limited else max_attempts
+            if attempt >= attempt_cap - 1:
+                break
+            retry_after = getattr(e, "retry_after", None)
+            if is_rate_limited and retry_after is not None:
+                if retry_after > MAX_RETRY_AFTER_WAIT_SECONDS:
+                    # Provider asked for a longer pause than we will block inline;
+                    # let the cooldown ladder handle it instead.
+                    break
+                time.sleep(retry_after)
+            else:
                 time.sleep(_retry_delay(attempt))
-                continue
-            break
+            continue
         except Exception as e:
             last_error = e
             break

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_health.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_health.py
@@ -1,0 +1,123 @@
+"""Provider cooldown and retry helpers for Web Search Plus."""
+
+import json
+import os
+import random
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from cache import CACHE_DIR
+from http_client import ProviderRequestError
+
+
+PROVIDER_HEALTH_FILE = CACHE_DIR / "provider_health.json"
+COOLDOWN_STEPS_SECONDS = [60, 300, 1500, 3600]  # 1m -> 5m -> 25m -> 1h cap
+RETRY_BACKOFF_SECONDS = [1, 3, 9]
+# Add up to this fraction of the base delay as random jitter so concurrent or
+# repeated retries against a recovering provider do not synchronize into bursts.
+RETRY_JITTER_FRACTION = 0.5
+
+# Serializes read-modify-write of the shared health file when search/extract run
+# providers concurrently in-process (e.g. parallel research mode). Atomic writes
+# already prevent torn reads; this prevents lost updates between threads.
+_HEALTH_LOCK = threading.Lock()
+
+
+def _retry_delay(attempt: int) -> float:
+    """Return the backoff delay (seconds) for a retry attempt, with jitter."""
+    base = RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)]
+    return base + random.uniform(0.0, base * RETRY_JITTER_FRACTION)
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _load_provider_health() -> Dict[str, Any]:
+    if not PROVIDER_HEALTH_FILE.exists():
+        return {}
+    try:
+        with open(PROVIDER_HEALTH_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def _save_provider_health(state: Dict[str, Any]) -> None:
+    _ensure_parent(PROVIDER_HEALTH_FILE)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=PROVIDER_HEALTH_FILE.name + ".",
+        suffix=".tmp",
+        dir=str(PROVIDER_HEALTH_FILE.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, PROVIDER_HEALTH_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def provider_in_cooldown(provider: str) -> Tuple[bool, int]:
+    state = _load_provider_health()
+    pstate = state.get(provider, {})
+    cooldown_until = int(pstate.get("cooldown_until", 0) or 0)
+    remaining = cooldown_until - int(time.time())
+    return (remaining > 0, max(0, remaining))
+
+
+def mark_provider_failure(provider: str, error_message: str) -> Dict[str, Any]:
+    with _HEALTH_LOCK:
+        state = _load_provider_health()
+        now = int(time.time())
+        pstate = state.get(provider, {})
+        fail_count = int(pstate.get("failure_count", 0)) + 1
+        cooldown_seconds = COOLDOWN_STEPS_SECONDS[min(fail_count - 1, len(COOLDOWN_STEPS_SECONDS) - 1)]
+        state[provider] = {
+            "failure_count": fail_count,
+            "cooldown_until": now + cooldown_seconds,
+            "cooldown_seconds": cooldown_seconds,
+            "last_error": error_message,
+            "last_failure_at": now,
+        }
+        _save_provider_health(state)
+        return state[provider]
+
+
+def reset_provider_health(provider: str) -> None:
+    with _HEALTH_LOCK:
+        state = _load_provider_health()
+        if provider in state:
+            state.pop(provider, None)
+            _save_provider_health(state)
+
+
+def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3) -> Dict[str, Any]:
+    """Execute a provider operation with shared transient-error retry semantics."""
+    last_error = None
+    for attempt in range(0, max_attempts):
+        try:
+            return operation()
+        except ProviderRequestError as e:
+            last_error = e
+            if e.status_code in {401, 403}:
+                break
+            if not e.transient:
+                break
+            if attempt < max_attempts - 1:
+                time.sleep(_retry_delay(attempt))
+                continue
+            break
+        except Exception as e:
+            last_error = e
+            break
+    raise last_error if last_error else Exception(f"Unknown {provider} provider execution error")

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_registry.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_registry.py
@@ -28,6 +28,7 @@ class ProviderSpec:
     free_tier: str = "API key required"
     signup_url: str = ""
     upstream_capabilities: Tuple[str, ...] = ()
+    keyless: bool = False
 
 
 _PROVIDER_SPECS = (
@@ -94,7 +95,7 @@ _PROVIDER_SPECS = (
         capability_labels=("search", "multilingual"),
         auto_allowed_by_default=False,
         free_tier="1,000 free searches/month",
-        signup_url="https://querit.com",
+        signup_url="https://www.querit.ai",
     ),
     ProviderSpec(
         provider="linkup",
@@ -195,11 +196,24 @@ _PROVIDER_SPECS = (
         free_tier="Free if self-hosted",
         signup_url="https://docs.searxng.org/admin/installation.html",
     ),
+    ProviderSpec(
+        provider="keenable",
+        env_var="KEENABLE_API_KEY",
+        display_name="Keenable",
+        description="Independent web index for search and extraction; works keyless, optional key raises rate limits.",
+        config_section="keenable",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract"),
+        free_tier="Keyless public tier; optional key for higher limits",
+        signup_url="https://keenable.ai",
+        keyless=True,
+    ),
 )
 
 PROVIDER_SPECS: Dict[str, ProviderSpec] = {spec.provider: spec for spec in _PROVIDER_SPECS}
 SEARCH_PROVIDER_IDS = tuple(spec.provider for spec in _PROVIDER_SPECS if spec.supports_search)
-EXTRACT_PROVIDER_IDS = ("tavily", "exa", "linkup", "parallel", "firecrawl", "you")
+EXTRACT_PROVIDER_IDS = ("tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable")
 DEFAULT_PROVIDER_PRIORITY = (
     "you",
     "serper",
@@ -214,6 +228,7 @@ DEFAULT_PROVIDER_PRIORITY = (
     "kilo-perplexity",
     "perplexity",
     "searxng",
+    "keenable",
 )
 DEFAULT_AUTO_ALLOW = {
     spec.provider: False
@@ -222,6 +237,14 @@ DEFAULT_AUTO_ALLOW = {
 }
 PROVIDER_ENV_KEYS = tuple(spec.env_var for spec in _PROVIDER_SPECS)
 EXTRACT_PROVIDER_ENV_KEYS = tuple(spec.env_var for spec in _PROVIDER_SPECS if spec.supports_extract)
+KEYLESS_PROVIDER_IDS = tuple(spec.provider for spec in _PROVIDER_SPECS if spec.keyless)
+KEYLESS_EXTRACT_PROVIDER_IDS = tuple(
+    spec.provider for spec in _PROVIDER_SPECS if spec.keyless and spec.supports_extract
+)
+
+
+def keyless_public_env_var(provider: str) -> str:
+    return f"{PROVIDER_SPECS[provider].config_section.upper()}_ALLOW_PUBLIC"
 
 
 def doctor_catalog() -> Dict[str, Dict[str, object]]:

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_registry.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_registry.py
@@ -1,0 +1,256 @@
+"""Central provider metadata registry for Web Search Plus.
+
+This module is deliberately data-only: search, extraction, doctor diagnostics,
+setup/onboarding, and config validation import it so provider metadata has one
+source of truth instead of one copy per surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Public, non-secret metadata for one provider."""
+
+    provider: str
+    env_var: str
+    display_name: str
+    description: str
+    config_section: str
+    supports_search: bool
+    supports_extract: bool
+    capability_labels: Tuple[str, ...]
+    auto_allowed_by_default: bool = True
+    recommended: bool = False
+    free_tier: str = "API key required"
+    signup_url: str = ""
+    upstream_capabilities: Tuple[str, ...] = ()
+
+
+_PROVIDER_SPECS = (
+    ProviderSpec(
+        provider="serper",
+        env_var="SERPER_API_KEY",
+        display_name="Serper",
+        description="Google-like SERP results for facts, shopping, local and news queries.",
+        config_section="serper",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "news", "shopping", "local"),
+        free_tier="2,500 one-time credits",
+        signup_url="https://serper.dev/api-key",
+    ),
+    ProviderSpec(
+        provider="serpbase",
+        env_var="SERPBASE_API_KEY",
+        display_name="SerpBase",
+        description="Cheap Google-like SERP fallback; WSP exposes search only, explicit/fallback-only by default.",
+        config_section="serpbase",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search",),
+        auto_allowed_by_default=False,
+        free_tier="100 free searches, paid packs available",
+        signup_url="https://www.serpbase.dev",
+        upstream_capabilities=("images", "news", "videos", "maps_search", "maps_detail"),
+    ),
+    ProviderSpec(
+        provider="brave",
+        env_var="BRAVE_API_KEY",
+        display_name="Brave Search",
+        description="Independent general web index; explicit/guarded by default after Routing v2 reliability testing.",
+        config_section="brave",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "news", "local"),
+        auto_allowed_by_default=False,
+        free_tier="$5 free monthly credits",
+        signup_url="https://api.search.brave.com/app/keys",
+    ),
+    ProviderSpec(
+        provider="tavily",
+        env_var="TAVILY_API_KEY",
+        display_name="Tavily",
+        description="Research/tutorial provider in the Routing v2 default pool.",
+        config_section="tavily",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract", "research"),
+        recommended=True,
+        free_tier="1,000 free searches/month",
+        signup_url="https://tavily.com",
+    ),
+    ProviderSpec(
+        provider="querit",
+        env_var="QUERIT_API_KEY",
+        display_name="Querit",
+        description="Multilingual and real-time search candidate.",
+        config_section="querit",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "multilingual"),
+        auto_allowed_by_default=False,
+        free_tier="1,000 free searches/month",
+        signup_url="https://querit.com",
+    ),
+    ProviderSpec(
+        provider="linkup",
+        env_var="LINKUP_API_KEY",
+        display_name="Linkup",
+        description="Best starter for cheap clean extraction and citation-grounded retrieval.",
+        config_section="linkup",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract", "citations"),
+        recommended=True,
+        free_tier="€5 free monthly credits (~5,000 standard extracts)",
+        signup_url="https://www.linkup.so",
+    ),
+    ProviderSpec(
+        provider="exa",
+        env_var="EXA_API_KEY",
+        display_name="Exa",
+        description="Semantic discovery, alternatives, docs, academic and long-form discovery.",
+        config_section="exa",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract", "semantic"),
+        free_tier="1,000 free searches/month",
+        signup_url="https://dashboard.exa.ai/api-keys",
+    ),
+    ProviderSpec(
+        provider="firecrawl",
+        env_var="FIRECRAWL_API_KEY",
+        display_name="Firecrawl",
+        description="Robust scraping/extraction fallback, especially for JS-heavy pages.",
+        config_section="firecrawl",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract", "js"),
+        free_tier="500 one-time credits",
+        signup_url="https://www.firecrawl.dev/app/api-keys",
+    ),
+    ProviderSpec(
+        provider="parallel",
+        env_var="PARALLEL_API_KEY",
+        display_name="Parallel",
+        description="LLM-ready web search and fast URL extraction with long source excerpts.",
+        config_section="parallel",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract", "citations"),
+        auto_allowed_by_default=False,
+        signup_url="https://platform.parallel.ai",
+    ),
+    ProviderSpec(
+        provider="perplexity",
+        env_var="PERPLEXITY_API_KEY",
+        display_name="Perplexity",
+        description="Direct answer-style search when configured directly.",
+        config_section="perplexity",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "answer"),
+        auto_allowed_by_default=False,
+        signup_url="https://www.perplexity.ai/settings/api",
+    ),
+    ProviderSpec(
+        provider="kilo-perplexity",
+        env_var="KILOCODE_API_KEY",
+        display_name="Kilo Code Perplexity bridge",
+        description="Perplexity-compatible access through Kilo Code when configured.",
+        config_section="kilo-perplexity",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "answer"),
+        auto_allowed_by_default=False,
+        free_tier="Depends on Kilo account",
+        signup_url="https://kilo.ai",
+    ),
+    ProviderSpec(
+        provider="you",
+        env_var="YOU_API_KEY",
+        display_name="You.com",
+        description="Fast Routing v2 core provider for current, multilingual, and LLM-ready search.",
+        config_section="you",
+        supports_search=True,
+        supports_extract=True,
+        capability_labels=("search", "extract"),
+        recommended=True,
+        free_tier="Limited/API key required",
+        signup_url="https://api.you.com",
+    ),
+    ProviderSpec(
+        provider="searxng",
+        env_var="SEARXNG_INSTANCE_URL",
+        display_name="SearXNG",
+        description="Self-hosted/privacy-preserving metasearch instance URL.",
+        config_section="searxng",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search", "self-hosted"),
+        free_tier="Free if self-hosted",
+        signup_url="https://docs.searxng.org/admin/installation.html",
+    ),
+)
+
+PROVIDER_SPECS: Dict[str, ProviderSpec] = {spec.provider: spec for spec in _PROVIDER_SPECS}
+SEARCH_PROVIDER_IDS = tuple(spec.provider for spec in _PROVIDER_SPECS if spec.supports_search)
+EXTRACT_PROVIDER_IDS = ("tavily", "exa", "linkup", "parallel", "firecrawl", "you")
+DEFAULT_PROVIDER_PRIORITY = (
+    "you",
+    "serper",
+    "exa",
+    "firecrawl",
+    "tavily",
+    "linkup",
+    "parallel",
+    "brave",
+    "serpbase",
+    "querit",
+    "kilo-perplexity",
+    "perplexity",
+    "searxng",
+)
+DEFAULT_AUTO_ALLOW = {
+    spec.provider: False
+    for spec in _PROVIDER_SPECS
+    if spec.supports_search and not spec.auto_allowed_by_default
+}
+PROVIDER_ENV_KEYS = tuple(spec.env_var for spec in _PROVIDER_SPECS)
+EXTRACT_PROVIDER_ENV_KEYS = tuple(spec.env_var for spec in _PROVIDER_SPECS if spec.supports_extract)
+
+
+def doctor_catalog() -> Dict[str, Dict[str, object]]:
+    """Return the legacy doctor JSON metadata shape from the registry."""
+    return {
+        provider: {
+            "env_var": spec.env_var,
+            "search_capable": spec.supports_search,
+            "extract_capable": spec.supports_extract,
+        }
+        for provider, spec in PROVIDER_SPECS.items()
+    }
+
+
+def plugin_catalog() -> list[Dict[str, object]]:
+    """Return setup/onboarding provider metadata from the registry."""
+    catalog = []
+    for spec in _PROVIDER_SPECS:
+        item: Dict[str, object] = {
+            "provider": spec.provider,
+            "env": spec.env_var,
+            "display_name": spec.display_name,
+            "description": spec.description,
+            "free_tier": spec.free_tier,
+            "signup_url": spec.signup_url,
+            "capabilities": list(spec.capability_labels),
+            "recommended": spec.recommended,
+        }
+        if spec.upstream_capabilities:
+            item["upstream_capabilities"] = list(spec.upstream_capabilities)
+        catalog.append(item)
+    return catalog

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_stats.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/provider_stats.py
@@ -1,0 +1,161 @@
+"""Rolling provider performance memory for adaptive routing.
+
+Routing v2 scores are benchmarked but static: a provider that has been slow
+or returning empty results for days keeps its full score. This module records
+the real outcome of every provider call (latency, result count, errors) in a
+small rolling window and turns it into a bounded score adjustment, so routing
+gently prefers providers that are currently fast and productive — without
+ever overriding strong query-class signals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import tempfile
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from cache import CACHE_DIR
+
+
+PROVIDER_STATS_FILE = CACHE_DIR / "provider_stats.json"
+# Rolling window: keep this many most-recent samples per provider.
+MAX_SAMPLES_PER_PROVIDER = 50
+# Ignore samples older than this; stale history should not steer routing.
+SAMPLE_MAX_AGE_SECONDS = 7 * 24 * 3600
+# Providers need this many fresh samples before stats influence routing.
+MIN_SAMPLES_FOR_ADJUSTMENT = 5
+# Hard bound on routing-score influence. Query-class signals weigh 1.0-4.0
+# per match, so performance can break ties and nudge close calls but never
+# overrule a clear content-based winner.
+MAX_SCORE_ADJUSTMENT = 1.0
+# Median latency at or above this counts as fully slow (speed factor 0).
+LATENCY_CEILING_SECONDS = 8.0
+# Neutral point: providers performing at this combined level get adjustment 0.
+PERFORMANCE_BASELINE = 0.75
+
+_STATS_LOCK = threading.Lock()
+
+
+def _load_stats() -> Dict[str, Any]:
+    if not PROVIDER_STATS_FILE.exists():
+        return {}
+    try:
+        with open(PROVIDER_STATS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def _save_stats(state: Dict[str, Any]) -> None:
+    PROVIDER_STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=PROVIDER_STATS_FILE.name + ".",
+        suffix=".tmp",
+        dir=str(PROVIDER_STATS_FILE.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp_name, PROVIDER_STATS_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def record_provider_outcome(
+    provider: str,
+    latency_seconds: float,
+    result_count: int,
+    error: bool,
+    now: Optional[float] = None,
+) -> None:
+    """Append one provider-call outcome to the rolling window.
+
+    Best-effort: stats must never break a search, so persistence errors are
+    swallowed.
+    """
+    sample = {
+        "t": int(now if now is not None else time.time()),
+        "lat": round(max(0.0, float(latency_seconds)), 3),
+        "n": int(max(0, result_count)),
+        "err": bool(error),
+    }
+    try:
+        with _STATS_LOCK:
+            state = _load_stats()
+            samples = state.get(provider)
+            if not isinstance(samples, list):
+                samples = []
+            samples.append(sample)
+            state[provider] = samples[-MAX_SAMPLES_PER_PROVIDER:]
+            _save_stats(state)
+    except Exception:
+        pass
+
+
+def _fresh_samples(samples: Any, now: float) -> List[Dict[str, Any]]:
+    if not isinstance(samples, list):
+        return []
+    cutoff = now - SAMPLE_MAX_AGE_SECONDS
+    return [
+        sample for sample in samples
+        if isinstance(sample, dict) and int(sample.get("t", 0) or 0) >= cutoff
+    ]
+
+
+def get_provider_performance(provider: str, now: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    """Return summarized fresh performance for one provider, or None."""
+    now_ts = now if now is not None else time.time()
+    samples = _fresh_samples(_load_stats().get(provider), now_ts)
+    if not samples:
+        return None
+    successes = [s for s in samples if not s.get("err")]
+    empty = [s for s in successes if int(s.get("n", 0) or 0) == 0]
+    latencies = [float(s.get("lat", 0.0) or 0.0) for s in successes]
+    return {
+        "samples": len(samples),
+        "success_rate": round(len(successes) / len(samples), 3),
+        "empty_rate": round(len(empty) / len(successes), 3) if successes else 0.0,
+        "median_latency_seconds": round(statistics.median(latencies), 3) if latencies else None,
+    }
+
+
+def performance_adjustment(provider: str, now: Optional[float] = None) -> float:
+    """Bounded routing-score adjustment from recent real-world performance.
+
+    Combines reliability (success rate, discounted by empty-result rate) and
+    speed (median latency vs. LATENCY_CEILING_SECONDS) into
+    [-MAX_SCORE_ADJUSTMENT, +MAX_SCORE_ADJUSTMENT]. Returns 0.0 until
+    MIN_SAMPLES_FOR_ADJUSTMENT fresh samples exist.
+    """
+    perf = get_provider_performance(provider, now=now)
+    if not perf or perf["samples"] < MIN_SAMPLES_FOR_ADJUSTMENT:
+        return 0.0
+    reliability = perf["success_rate"] * (1.0 - 0.5 * perf["empty_rate"])
+    median_latency = perf["median_latency_seconds"]
+    if median_latency is None:
+        speed = 0.0
+    else:
+        speed = max(0.0, min(1.0, 1.0 - median_latency / LATENCY_CEILING_SECONDS))
+    combined = 0.6 * reliability + 0.4 * speed
+    adjustment = (combined - PERFORMANCE_BASELINE) * 2 * MAX_SCORE_ADJUSTMENT
+    return round(max(-MAX_SCORE_ADJUSTMENT, min(MAX_SCORE_ADJUSTMENT, adjustment)), 3)
+
+
+def performance_adjustments(providers: List[str], now: Optional[float] = None) -> Dict[str, float]:
+    """Adjustments for several providers; providers without impact are omitted."""
+    adjustments = {}
+    for provider in providers:
+        value = performance_adjustment(provider, now=now)
+        if value != 0.0:
+            adjustments[provider] = value
+    return adjustments

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/providers.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/providers.py
@@ -1,13 +1,18 @@
 """Provider implementations for Web Search Plus search and extraction backends."""
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 import json
 import re
+import socket
+import sys
+import threading
+import time
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
+from daemon_tasks import DaemonTask
 from http_client import (
     DEFAULT_USER_AGENT,
     ProviderRequestError,
@@ -18,6 +23,85 @@ from http_client import (
     make_request,
 )
 from quality import _title_from_url
+
+
+# Extra scheduling headroom added on top of the per-request HTTP timeout when
+# bounding a concurrent extraction batch.
+_BATCH_TIMEOUT_GRACE_SECONDS = 5
+
+
+# =============================================================================
+# Unified freshness filter
+# =============================================================================
+
+FRESHNESS_VALUES = ("day", "week", "month", "year")
+
+# Native recency formats per provider, derived from the request bodies the
+# provider functions in this module already send. Providers absent from this
+# table (tavily, exa, linkup, parallel, serpbase) have no relative-recency
+# parameter in their current API calls, so no native value is invented for them.
+PROVIDER_FRESHNESS_FORMATS: Dict[str, Dict[str, str]] = {
+    # search_serper: body["tbs"]
+    "serper": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+    # search_brave: params["freshness"]
+    "brave": {"day": "pd", "week": "pw", "month": "pm", "year": "py"},
+    # search_querit: filters["timeRange"]["date"]
+    "querit": {"day": "d1", "week": "w1", "month": "m1", "year": "y1"},
+    # search_firecrawl: body["tbs"]
+    "firecrawl": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+    # search_keenable: body["published_after"]
+    "keenable": {"day": "1d", "week": "7d", "month": "1mo", "year": "1y"},
+    # search_you: params["freshness"] (native values match the unified ones)
+    "you": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    # search_perplexity: body["search_recency_filter"]
+    "perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    "kilo-perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    # search_searxng: params["time_range"]
+    "searxng": {"day": "day", "week": "week", "month": "month", "year": "year"},
+}
+
+
+def normalize_freshness(value: Optional[str]) -> Optional[str]:
+    """Return the canonical lowercase freshness value, or None when unset.
+
+    Raises ValueError for values outside day|week|month|year so callers can
+    surface the standard error dict instead of silently dropping the filter.
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized not in FRESHNESS_VALUES:
+        raise ValueError(
+            "Invalid freshness value: {!r}. Valid values: {}".format(value, ", ".join(FRESHNESS_VALUES))
+        )
+    return normalized
+
+
+def provider_supports_freshness(provider: str) -> bool:
+    """Return whether a provider's current API call can apply a freshness filter."""
+    return provider in PROVIDER_FRESHNESS_FORMATS
+
+
+def map_freshness_for_provider(provider: str, freshness: Optional[str]) -> Optional[str]:
+    """Translate the unified freshness value into the provider's native format."""
+    if not freshness:
+        return None
+    return PROVIDER_FRESHNESS_FORMATS.get(provider, {}).get(freshness)
+
+
+def freshness_metadata(provider: str, requested: str) -> Dict[str, Any]:
+    """Describe whether a provider applied the requested freshness filter."""
+    native = map_freshness_for_provider(provider, requested)
+    if native is not None:
+        return {"requested": requested, "applied": True, "provider": provider, "native_value": native}
+    return {
+        "requested": requested,
+        "applied": False,
+        "provider": provider,
+        "reason": "provider {} does not support freshness".format(provider),
+    }
 
 
 def search_serper(
@@ -705,12 +789,30 @@ def extract_linkup(
     if len(urls) <= 1:
         return {"provider": "linkup", "results": [fetch_one(url) for url in urls]}
 
-    indexed_results: Dict[int, Dict[str, Any]] = {}
-    with ThreadPoolExecutor(max_workers=min(len(urls), 5)) as executor:
-        futures = {executor.submit(fetch_one, url): idx for idx, url in enumerate(urls)}
-        for future in as_completed(futures):
-            indexed_results[futures[future]] = future.result()
-    results = [indexed_results[idx] for idx in range(len(urls)) if idx in indexed_results]
+    workers = min(len(urls), 5)
+    # Bound the total wait so one hung fetch cannot stall the whole batch beyond
+    # the per-request HTTP timeout window (plus a small scheduling grace).
+    # Daemon tasks (instead of a ThreadPoolExecutor) keep overdue fetches from
+    # blocking interpreter exit in the CLI/subprocess path.
+    overall_timeout = timeout * ((len(urls) + workers - 1) // workers) + _BATCH_TIMEOUT_GRACE_SECONDS
+    gate = threading.Semaphore(workers)
+
+    def fetch_gated(url: str) -> Dict[str, Any]:
+        with gate:
+            return fetch_one(url)
+
+    tasks = [DaemonTask(fetch_gated, url) for url in urls]
+    deadline = time.monotonic() + overall_timeout
+    results = []
+    for url, task in zip(urls, tasks):
+        try:
+            results.append(task.result(timeout=max(0.0, deadline - time.monotonic())))
+        except FuturesTimeoutError:
+            # Keep partial results; the overdue fetch finishes in the background
+            # bounded by the HTTP timeout without blocking caller or process exit.
+            results.append(_normalize_extract_result(
+                "linkup", url, error=f"Extraction timed out after {overall_timeout}s",
+            ))
     return {"provider": "linkup", "results": results}
 
 def extract_tavily(
@@ -1302,9 +1404,9 @@ def search_you(
         raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
         raise ProviderRequestError("You.com request timed out after 30s.", transient=True)
 
     # Parse results
@@ -1461,9 +1563,9 @@ def search_searxng(
         raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Cannot reach SearXNG instance at {instance_url}. Error: {reason}", transient=is_timeout)
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
         raise ProviderRequestError("SearXNG request timed out after 30s. Check instance health.", transient=True)
 
     # Parse results
@@ -1510,3 +1612,122 @@ def search_searxng(
             "instance_url": instance_url,
         }
     }
+
+
+_KEENABLE_TIME_RANGE = {"hour": "1h", "day": "1d", "week": "7d", "month": "1mo", "year": "1y"}
+
+
+_KEENABLE_PUBLIC_WARNED = False
+
+
+def _warn_keenable_public_once() -> None:
+    global _KEENABLE_PUBLIC_WARNED
+    if _KEENABLE_PUBLIC_WARNED:
+        return
+    _KEENABLE_PUBLIC_WARNED = True
+    print(json.dumps({
+        "warning": (
+            "Keenable keyless public endpoint in use: queries and fetched URLs are sent "
+            "to an unauthenticated shared service (https://keenable.ai) with no SLA. "
+            "Set KEENABLE_API_KEY for the authenticated endpoint."
+        )
+    }), file=sys.stderr)
+
+
+def _keenable_endpoint(api_url: str, api_key: Optional[str], public: bool) -> tuple:
+    """Return (endpoint, headers). A present key always uses the authenticated route;
+    with no key, the keyless /public route is used when public is enabled."""
+    headers = {"X-Keenable-Title": "hermes-web-search-plus"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+        return api_url, headers
+    if public:
+        _warn_keenable_public_once()
+        return f"{api_url}/public", headers
+    raise ValueError("Keenable requires an API key or an enabled public endpoint")
+
+
+def search_keenable(
+    query: str,
+    api_key: Optional[str] = None,
+    max_results: int = 5,
+    time_range: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    public: bool = False,
+    api_url: str = "https://api.keenable.ai/v1/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using Keenable's independent web index.
+
+    Uses the authenticated endpoint when api_key is set; with no key, public=True
+    selects the keyless /public endpoint.
+    """
+    body: Dict[str, Any] = {"query": query}
+    if time_range and time_range in _KEENABLE_TIME_RANGE:
+        body["published_after"] = _KEENABLE_TIME_RANGE[time_range]
+    if include_domains:
+        body["site"] = include_domains[0]
+
+    url, headers = _keenable_endpoint(api_url, api_key, public)
+    headers["Content-Type"] = "application/json"
+
+    data = make_request(url, headers, body, timeout=timeout)
+    results = []
+    for i, item in enumerate(data.get("results", [])[:max_results]):
+        item_url = item.get("url", "")
+        results.append({
+            "title": item.get("title") or _title_from_url(item_url),
+            "url": item_url,
+            "snippet": item.get("snippet") or item.get("description", ""),
+            "score": round(1.0 - i * 0.05, 3),
+            "date": item.get("published_at"),
+            "acquired_at": item.get("acquired_at"),
+        })
+
+    answer = results[0]["snippet"] if results else ""
+    return {
+        "provider": "keenable",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {"number_of_results": data.get("number_of_results")},
+    }
+
+
+def extract_keenable(
+    urls: List[str],
+    api_key: Optional[str] = None,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    public: bool = False,
+    api_url: str = "https://api.keenable.ai/v1/fetch",
+    timeout: int = 30,
+) -> dict:
+    """Extract page content via Keenable's fetch endpoint (clean markdown).
+
+    Uses the authenticated endpoint when api_key is set; with no key, public=True
+    selects the keyless /public endpoint.
+    """
+    base_url, headers = _keenable_endpoint(api_url, api_key, public)
+
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        try:
+            endpoint = f"{base_url}?url={quote(url, safe='')}"
+            data = make_get_request(endpoint, headers, timeout=timeout)
+            content = data.get("content") or ""
+            results.append(_normalize_extract_result(
+                "keenable",
+                data.get("url") or url,
+                title=data.get("title", ""),
+                content=content,
+                raw_content=content,
+                author=data.get("author"),
+                description=data.get("description"),
+            ))
+        except Exception as e:
+            results.append(_normalize_extract_result("keenable", url, error=str(e)))
+    return {"provider": "keenable", "results": results}

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/providers.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/providers.py
@@ -1,0 +1,1512 @@
+"""Provider implementations for Web Search Plus search and extraction backends."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
+import re
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+from http_client import (
+    DEFAULT_USER_AGENT,
+    ProviderRequestError,
+    TRANSIENT_HTTP_CODES,
+    _read_json_response,
+    _read_response_body,
+    make_get_request,
+    make_request,
+)
+from quality import _title_from_url
+
+
+def search_serper(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "us",
+    language: str = "en",
+    search_type: str = "search",
+    time_range: Optional[str] = None,
+    include_images: bool = False,
+) -> dict:
+    """Search using Serper (Google Search API)."""
+    endpoint = f"https://google.serper.dev/{search_type}"
+
+    body = {
+        "q": query,
+        "gl": country,
+        "hl": language,
+        "num": max_results,
+        "autocorrect": True,
+    }
+
+    if time_range and time_range != "none":
+        tbs_map = {
+            "hour": "qdr:h",
+            "day": "qdr:d",
+            "week": "qdr:w",
+            "month": "qdr:m",
+            "year": "qdr:y",
+        }
+        if time_range in tbs_map:
+            body["tbs"] = tbs_map[time_range]
+
+    headers = {
+        "X-API-KEY": api_key,
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(endpoint, headers, body)
+
+    results = []
+    for i, item in enumerate(data.get("organic", [])[:max_results]):
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("link", ""),
+            "snippet": item.get("snippet", ""),
+            "score": round(1.0 - i * 0.1, 2),
+            "date": item.get("date"),
+        })
+
+    answer = ""
+    if data.get("answerBox", {}).get("answer"):
+        answer = data["answerBox"]["answer"]
+    elif data.get("answerBox", {}).get("snippet"):
+        answer = data["answerBox"]["snippet"]
+    elif data.get("knowledgeGraph", {}).get("description"):
+        answer = data["knowledgeGraph"]["description"]
+    elif results:
+        answer = results[0]["snippet"]
+
+    images = []
+    if include_images:
+        try:
+            img_data = make_request(
+                "https://google.serper.dev/images",
+                headers,
+                {"q": query, "gl": country, "hl": language, "num": 5},
+            )
+            images = [img.get("imageUrl", "") for img in img_data.get("images", [])[:5] if img.get("imageUrl")]
+        except Exception:
+            pass
+
+    return {
+        "provider": "serper",
+        "query": query,
+        "results": results,
+        "images": images,
+        "answer": answer,
+        "metadata": {},
+        "knowledge_graph": data.get("knowledgeGraph"),
+        "related_searches": [r.get("query") for r in data.get("relatedSearches", [])]
+    }
+
+def _strip_tracking_params(url: str) -> str:
+    """Remove common SERP tracking params while preserving the canonical target URL."""
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    tracking_prefixes = ("utm_",)
+    tracking_names = {"srsltid", "gclid", "fbclid", "mc_cid", "mc_eid"}
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in tracking_names and not key.lower().startswith(tracking_prefixes)
+    ]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+def _serpbase_related_search_query(item: Any) -> Optional[str]:
+    if isinstance(item, dict):
+        return item.get("query") or item.get("title")
+    if isinstance(item, str):
+        return item
+    return None
+
+def search_serpbase(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "us",
+    language: str = "en",
+    page: int = 1,
+    api_url: str = "https://api.serpbase.dev/google/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using SerpBase's Google Search endpoint.
+
+    SerpBase returns HTTP 200 for some business failures, so `status == 0` is
+    required before parsing results.
+    """
+    body = {
+        "q": query,
+        "hl": language,
+        "gl": country,
+        "page": page,
+    }
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    status = data.get("status", 0)
+    if status != 0:
+        message = data.get("message") or data.get("error") or data.get("msg") or "business status failure"
+        transient = status in {1029, 1502, 1503, 1504}
+        raise ProviderRequestError(f"SerpBase error {status}: {message}", transient=transient)
+
+    results = []
+    for i, item in enumerate(data.get("organic", [])[:max_results]):
+        results.append({
+            "title": item.get("title", ""),
+            "url": _strip_tracking_params(item.get("link", "") or item.get("url", "")),
+            "snippet": item.get("snippet", ""),
+            "score": round(1.0 - i * 0.1, 2),
+            "rank": item.get("rank") or item.get("position") or i + 1,
+            "display_link": item.get("display_link") or item.get("displayed_link"),
+        })
+
+    related_searches = [
+        value for value in (_serpbase_related_search_query(item) for item in data.get("related_searches", [])) if value
+    ]
+    answer = ""
+    if data.get("answer_box"):
+        answer_box = data.get("answer_box") or {}
+        answer = answer_box.get("answer") or answer_box.get("snippet") or ""
+    elif data.get("knowledge_graph"):
+        kg = data.get("knowledge_graph") or {}
+        answer = kg.get("description") or kg.get("subtitle") or ""
+    elif results:
+        answer = results[0]["snippet"]
+
+    return {
+        "provider": "serpbase",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "session_id": data.get("session_id"),
+        },
+        "knowledge_graph": data.get("knowledge_graph"),
+        "related_searches": related_searches,
+        "session_id": data.get("session_id"),
+    }
+
+def search_brave(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "US",
+    language: str = "en",
+    time_range: Optional[str] = None,
+    safesearch: str = "moderate",
+) -> dict:
+    """Search using Brave Search API."""
+    freshness_map = {
+        "hour": "pd",
+        "day": "pd",
+        "week": "pw",
+        "month": "pm",
+        "year": "py",
+    }
+    params = {
+        "q": query,
+        "count": max_results,
+        "country": country.upper(),
+        "search_lang": language,
+        "safesearch": safesearch,
+        "spellcheck": 1,
+    }
+    if time_range and time_range in freshness_map:
+        params["freshness"] = freshness_map[time_range]
+
+    url = f"https://api.search.brave.com/res/v1/web/search?{urlencode(params)}"
+    headers = {
+        "X-Subscription-Token": api_key,
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+    }
+
+    data = make_get_request(url, headers)
+
+    web_results = (data.get("web") or {}).get("results", [])[:max_results]
+    results = []
+    for i, item in enumerate(web_results):
+        snippet_parts = []
+        description = item.get("description") or item.get("snippet") or ""
+        if description:
+            snippet_parts.append(description)
+        extra_snippets = item.get("extra_snippets") or []
+        if extra_snippets:
+            snippet_parts.extend(extra_snippets[:2])
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": " ... ".join(part for part in snippet_parts if part),
+            "score": round(1.0 - i * 0.1, 2),
+            "age": item.get("age"),
+        })
+
+    answer = ""
+    if data.get("summary"):
+        answer = data.get("summary", "")
+    elif data.get("infobox", {}).get("description"):
+        answer = data["infobox"]["description"]
+    elif results:
+        answer = results[0]["snippet"]
+
+    return {
+        "provider": "brave",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {},
+        "mixed": data.get("mixed"),
+    }
+
+def search_tavily(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    depth: str = "basic",
+    topic: str = "general",
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    include_images: bool = False,
+    include_raw_content: bool = False,
+) -> dict:
+    """Search using Tavily (AI Research Search)."""
+    endpoint = "https://api.tavily.com/search"
+
+    body = {
+        "api_key": api_key,
+        "query": query,
+        "max_results": max_results,
+        "search_depth": depth,
+        "topic": topic,
+        "include_images": include_images,
+        "include_answer": True,
+        "include_raw_content": include_raw_content,
+    }
+
+    if include_domains:
+        body["include_domains"] = include_domains
+    if exclude_domains:
+        body["exclude_domains"] = exclude_domains
+
+    headers = {"Content-Type": "application/json"}
+
+    data = make_request(endpoint, headers, body)
+
+    results = []
+    for item in data.get("results", [])[:max_results]:
+        result = {
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": item.get("content", ""),
+            "score": round(item.get("score", 0.0), 3),
+        }
+        if include_raw_content and item.get("raw_content"):
+            result["raw_content"] = item["raw_content"]
+        results.append(result)
+
+    return {
+        "provider": "tavily",
+        "query": query,
+        "results": results,
+        "images": data.get("images", []),
+        "answer": data.get("answer", ""),
+        "metadata": {},
+    }
+
+def _map_querit_time_range(time_range: Optional[str]) -> Optional[str]:
+    """Map generic time ranges to Querit's compact date filter format."""
+    if not time_range:
+        return None
+    return {
+        "day": "d1",
+        "week": "w1",
+        "month": "m1",
+        "year": "y1",
+    }.get(time_range, time_range)
+
+def search_querit(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    language: str = "en",
+    country: str = "us",
+    time_range: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    base_url: str = "https://api.querit.ai",
+    base_path: str = "/v1/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using Querit.
+
+    Mirrors the Querit Python SDK payload shape:
+      - query
+      - count
+      - optional filters: languages, geo, sites, timeRange
+    """
+    endpoint = base_url.rstrip("/") + base_path
+
+    filters: Dict[str, Any] = {}
+    if language:
+        filters["languages"] = {"include": [language.lower()]}
+    if country:
+        filters["geo"] = {"countries": {"include": [country.upper()]}}
+    if include_domains or exclude_domains:
+        sites: Dict[str, List[str]] = {}
+        if include_domains:
+            sites["include"] = include_domains
+        if exclude_domains:
+            sites["exclude"] = exclude_domains
+        filters["sites"] = sites
+
+    querit_time_range = _map_querit_time_range(time_range)
+    if querit_time_range:
+        filters["timeRange"] = {"date": querit_time_range}
+
+    body: Dict[str, Any] = {
+        "query": query,
+        "count": max_results,
+    }
+    if filters:
+        body["filters"] = filters
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(endpoint, headers, body, timeout=timeout)
+
+    error_code = data.get("error_code")
+    error_msg = data.get("error_msg")
+    if error_msg or (error_code not in (None, 0, 200)):
+        message = error_msg or f"Querit request failed with error_code={error_code}"
+        raise ProviderRequestError(message)
+
+    raw_results = ((data.get("results") or {}).get("result")) or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        snippet = item.get("snippet") or item.get("page_age") or ""
+        result = {
+            "title": item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+        }
+        if item.get("page_time") is not None:
+            result["page_time"] = item["page_time"]
+        if item.get("page_age"):
+            result["date"] = item["page_age"]
+        if item.get("language") is not None:
+            result["language"] = item["language"]
+        results.append(result)
+
+    answer = results[0]["snippet"] if results else ""
+
+    return {
+        "provider": "querit",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "search_id": data.get("search_id"),
+            "time_range": querit_time_range,
+        }
+    }
+
+def search_linkup(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    depth: str = "standard",
+    output_type: str = "searchResults",
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    api_url: str = "https://api.linkup.so/v1/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using Linkup's source-grounded web search API."""
+    body: Dict[str, Any] = {
+        "q": query,
+        "depth": depth,
+        "outputType": output_type,
+    }
+    if include_domains:
+        body["includeDomains"] = include_domains[:50]
+    if exclude_domains:
+        body["excludeDomains"] = exclude_domains[:50]
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    if data.get("error"):
+        raise ProviderRequestError(str(data.get("error")))
+
+    raw_results = data.get("results") or data.get("sources") or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        snippet = item.get("content") or item.get("snippet") or item.get("description") or ""
+        result = {
+            "title": item.get("name") or item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+        }
+        if item.get("type") is not None:
+            result["type"] = item["type"]
+        if item.get("favicon") is not None:
+            result["favicon"] = item["favicon"]
+        results.append(result)
+
+    return {
+        "provider": "linkup",
+        "query": query,
+        "results": results,
+        "images": data.get("images", []),
+        "answer": data.get("answer", ""),
+        "metadata": {
+            "depth": depth,
+            "output_type": output_type,
+        },
+    }
+
+def _map_firecrawl_time_range(time_range: Optional[str]) -> Optional[str]:
+    """Map generic time ranges to Firecrawl/Google tbs values."""
+    if not time_range:
+        return None
+    return {
+        "hour": "qdr:h",
+        "day": "qdr:d",
+        "week": "qdr:w",
+        "month": "qdr:m",
+        "year": "qdr:y",
+    }.get(time_range, time_range)
+
+def search_firecrawl(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "US",
+    time_range: Optional[str] = None,
+    sources: Optional[List[str]] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    scrape_markdown: bool = False,
+    ignore_invalid_urls: bool = False,
+    api_url: str = "https://api.firecrawl.dev/v2/search",
+    timeout_ms: int = 30000,
+) -> dict:
+    """Search using Firecrawl's v2 search endpoint."""
+    selected_sources = sources or ["web"]
+    body: Dict[str, Any] = {
+        "query": query,
+        "limit": max_results,
+        "sources": selected_sources,
+        "timeout": timeout_ms,
+        "ignoreInvalidURLs": ignore_invalid_urls,
+    }
+
+    if country:
+        body["country"] = country.upper()
+
+    tbs = _map_firecrawl_time_range(time_range)
+    if tbs:
+        body["tbs"] = tbs
+
+    if include_domains:
+        body["query"] += " " + " ".join(f"site:{domain}" for domain in include_domains)
+    if exclude_domains:
+        body["query"] += " " + " ".join(f"-site:{domain}" for domain in exclude_domains)
+
+    if scrape_markdown:
+        body["scrapeOptions"] = {"formats": ["markdown"]}
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=max(1, int(timeout_ms / 1000)))
+    if data.get("success") is False:
+        raise ProviderRequestError(data.get("error") or data.get("warning") or "Firecrawl request failed")
+
+    response_data = data.get("data") or {}
+    raw_web = response_data.get("web") or []
+    results = []
+    for i, item in enumerate(raw_web[:max_results]):
+        snippet = item.get("description") or item.get("snippet") or ""
+        result = {
+            "title": item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+        }
+        if item.get("position") is not None:
+            result["position"] = item.get("position")
+        if item.get("category") is not None:
+            result["category"] = item.get("category")
+        if item.get("markdown"):
+            result["raw_content"] = item["markdown"]
+            if not result["snippet"]:
+                result["snippet"] = item["markdown"][:500]
+        metadata = item.get("metadata") or {}
+        if metadata.get("statusCode") is not None:
+            result["status_code"] = metadata.get("statusCode")
+        if metadata.get("error"):
+            result["error"] = metadata.get("error")
+        results.append(result)
+
+    images = []
+    for image in response_data.get("images") or []:
+        image_url = image.get("imageUrl")
+        if image_url:
+            images.append(image_url)
+
+    answer = results[0]["snippet"] if results else ""
+    return {
+        "provider": "firecrawl",
+        "query": query,
+        "results": results,
+        "images": images,
+        "answer": answer,
+        "warning": data.get("warning"),
+        "credits_used": data.get("creditsUsed"),
+        "metadata": {
+            "id": data.get("id"),
+            "sources": selected_sources,
+            "tbs": tbs,
+        },
+    }
+
+def _normalize_extract_result(
+    provider: str,
+    url: str,
+    title: str = "",
+    content: str = "",
+    raw_content: Optional[str] = None,
+    **extra: Any,
+) -> Dict[str, Any]:
+    result = {
+        "url": url,
+        "title": title or _title_from_url(url),
+        "content": content or "",
+        "raw_content": raw_content if raw_content is not None else (content or ""),
+        "provider": provider,
+    }
+    for key, value in extra.items():
+        if value is not None:
+            result[key] = value
+    return result
+
+def extract_firecrawl(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.firecrawl.dev/v2/scrape",
+    timeout: int = 60,
+) -> dict:
+    """Extract URL content using Firecrawl scrape."""
+    formats = ["markdown"] if output_format != "html" else ["html"]
+    if include_raw_html and "html" not in formats:
+        formats.append("html")
+
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        body: Dict[str, Any] = {"url": url, "formats": formats}
+        if render_js:
+            body["waitFor"] = 1000
+        data = make_request(api_url, headers, body, timeout=timeout)
+        if data.get("success") is False:
+            results.append(_normalize_extract_result("firecrawl", url, error=data.get("error") or data.get("warning") or "Firecrawl scrape failed"))
+            continue
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        metadata = payload.get("metadata") or {}
+        final_url = metadata.get("sourceURL") or metadata.get("url") or url
+        title = metadata.get("title") or ""
+        markdown = payload.get("markdown") or ""
+        html = payload.get("html") or payload.get("rawHtml") or ""
+        content = html if output_format == "html" else markdown or html
+        images = None
+        if include_images:
+            md_images = []
+            seen_image_urls = set()
+            for alt, image_url in re.findall(r"!\[([^\]]*)\]\(([^)]+)\)", markdown):
+                if image_url not in seen_image_urls:
+                    md_images.append({"alt": alt, "url": image_url})
+                    seen_image_urls.add(image_url)
+            og_image = metadata.get("ogImage") or metadata.get("og:image")
+            if og_image and og_image not in seen_image_urls:
+                md_images.insert(0, {"alt": "og:image", "url": og_image})
+            images = md_images or None
+        results.append(_normalize_extract_result(
+            "firecrawl",
+            final_url,
+            title=title,
+            content=content,
+            raw_content=content,
+            raw_html=html if html else None,
+            images=images,
+            metadata=metadata,
+        ))
+    return {"provider": "firecrawl", "results": results}
+
+def extract_linkup(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.linkup.so/v1/fetch",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Linkup fetch."""
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def fetch_one(url: str) -> Dict[str, Any]:
+        body = {
+            "url": url,
+            "extractImages": include_images,
+            "includeRawHtml": include_raw_html or output_format == "html",
+            "renderJs": render_js,
+        }
+        data = make_request(api_url, headers, body, timeout=timeout)
+        if data.get("error"):
+            return _normalize_extract_result("linkup", url, error=str(data.get("error")))
+        markdown = data.get("markdown") or ""
+        raw_html = data.get("rawHtml") or data.get("raw_html") or ""
+        content = raw_html if output_format == "html" else markdown or raw_html
+        return _normalize_extract_result(
+            "linkup",
+            url,
+            content=content,
+            raw_content=content,
+            raw_html=raw_html if raw_html else None,
+            images=data.get("images") if include_images else None,
+        )
+
+    if len(urls) <= 1:
+        return {"provider": "linkup", "results": [fetch_one(url) for url in urls]}
+
+    indexed_results: Dict[int, Dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=min(len(urls), 5)) as executor:
+        futures = {executor.submit(fetch_one, url): idx for idx, url in enumerate(urls)}
+        for future in as_completed(futures):
+            indexed_results[futures[future]] = future.result()
+    results = [indexed_results[idx] for idx in range(len(urls)) if idx in indexed_results]
+    return {"provider": "linkup", "results": results}
+
+def extract_tavily(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.tavily.com/extract",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Tavily extract."""
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    body = {"urls": urls, "include_images": include_images}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []):
+        url = item.get("url", "")
+        content = item.get("raw_content") or item.get("content") or ""
+        results.append(_normalize_extract_result(
+            "tavily",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            images=item.get("images") if include_images else None,
+        ))
+    for failed in data.get("failed_results", []) or []:
+        failed_url = failed.get("url", "")
+        results.append(_normalize_extract_result("tavily", failed_url, error=failed.get("error") or "Tavily extract failed"))
+    return {"provider": "tavily", "results": results}
+
+def extract_exa(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.exa.ai/contents",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Exa Contents API."""
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    body: Dict[str, Any] = {"urls": urls, "text": True}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []):
+        url = item.get("url") or item.get("id") or ""
+        content = item.get("text") or item.get("summary") or ""
+        results.append(_normalize_extract_result(
+            "exa",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            summary=item.get("summary"),
+            highlights=item.get("highlights"),
+            published_date=item.get("publishedDate"),
+            author=item.get("author"),
+            image=item.get("image") if include_images else None,
+            favicon=item.get("favicon"),
+        ))
+    return {
+        "provider": "exa",
+        "results": results,
+        "request_id": data.get("requestId"),
+        "cost_dollars": data.get("costDollars"),
+        "statuses": data.get("statuses"),
+    }
+
+def extract_you(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://ydc-index.io/v1/contents",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using You.com Contents API."""
+    formats = ["html" if output_format == "html" else "markdown"]
+    if include_raw_html and "html" not in formats:
+        formats.append("html")
+    if "metadata" not in formats:
+        formats.append("metadata")
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+    body = {"urls": urls, "formats": formats, "crawl_timeout": max(1, min(timeout, 60))}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    raw_items = data if isinstance(data, list) else data.get("results", []) or data.get("data", [])
+    results: List[Dict[str, Any]] = []
+    for item in raw_items:
+        url = item.get("url", "")
+        markdown = item.get("markdown") or ""
+        html = item.get("html") or ""
+        content = html if output_format == "html" else markdown or html
+        results.append(_normalize_extract_result(
+            "you",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            raw_html=html if html else None,
+            metadata=item.get("metadata"),
+        ))
+    return {"provider": "you", "results": results}
+
+def extract_parallel(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.parallel.ai/v1/extract",
+    timeout: int = 60,
+    client_model: Optional[str] = None,
+    max_chars_total: int = 12000,
+    max_chars_per_result: int = 6000,
+) -> dict:
+    """Extract URL content using Parallel Extract.
+
+    Parallel returns excerpts by default; request full_content explicitly and
+    normalize it into the common markdown/content shape. HTML/raw-image options
+    are accepted for tool compatibility but ignored when unsupported upstream.
+    """
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    body: Dict[str, Any] = {
+        "urls": urls,
+        "max_chars_total": max_chars_total,
+        "advanced_settings": {
+            "full_content": {"max_chars_per_result": max_chars_per_result}
+        },
+    }
+    if client_model:
+        body["client_model"] = client_model
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []) or []:
+        url = item.get("url") or ""
+        excerpts = item.get("excerpts") or []
+        excerpt_text = "\n\n".join(
+            (ex.get("text") or ex.get("content") or "") if isinstance(ex, dict) else str(ex)
+            for ex in excerpts
+        ).strip()
+        content = item.get("full_content") or item.get("markdown") or item.get("content") or excerpt_text
+        results.append(_normalize_extract_result(
+            "parallel",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            excerpts=excerpts or None,
+            metadata={k: v for k, v in item.items() if k not in {"url", "title", "full_content", "markdown", "content", "excerpts"}},
+        ))
+    for failed in data.get("errors", []) or []:
+        failed_url = failed.get("url", "") if isinstance(failed, dict) else ""
+        results.append(_normalize_extract_result("parallel", failed_url, error=str(failed)))
+    return {
+        "provider": "parallel",
+        "results": results,
+        "metadata": {
+            "search_id": data.get("search_id"),
+            "session_id": data.get("session_id"),
+        },
+    }
+
+def search_exa(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    search_type: str = "neural",
+    exa_depth: str = "normal",
+    category: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    similar_url: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    text_verbosity: str = "standard",
+) -> dict:
+    """Search using Exa (Neural/Semantic/Deep Search).
+
+    exa_depth controls synthesis level:
+      - "normal": standard search (neural/fast/auto/keyword/instant)
+      - "deep": multi-source synthesis with grounding (4-12s, $12/1k)
+      - "deep-reasoning": cross-reference reasoning with grounding (12-50s, $15/1k)
+    """
+    is_deep = exa_depth in ("deep", "deep-reasoning")
+
+    if similar_url:
+        # findSimilar does not support deep search types
+        endpoint = "https://api.exa.ai/findSimilar"
+        body: Dict[str, Any] = {
+            "url": similar_url,
+            "numResults": max_results,
+            "contents": {
+                "text": {"maxCharacters": 2000, "verbosity": text_verbosity},
+                "highlights": {"numSentences": 3, "highlightsPerUrl": 2},
+            },
+        }
+    elif is_deep:
+        endpoint = "https://api.exa.ai/search"
+        body = {
+            "query": query,
+            "numResults": max_results,
+            "type": exa_depth,
+            "contents": {
+                "text": {"maxCharacters": 5000, "verbosity": "full"},
+            },
+        }
+    else:
+        endpoint = "https://api.exa.ai/search"
+        body = {
+            "query": query,
+            "numResults": max_results,
+            "type": search_type,
+            "contents": {
+                "text": {"maxCharacters": 2000, "verbosity": text_verbosity},
+                "highlights": {"numSentences": 3, "highlightsPerUrl": 2},
+            },
+        }
+
+    if category:
+        body["category"] = category
+    if start_date:
+        body["startPublishedDate"] = start_date
+    if end_date:
+        body["endPublishedDate"] = end_date
+    if include_domains:
+        body["includeDomains"] = include_domains
+    if exclude_domains:
+        body["excludeDomains"] = exclude_domains
+
+    headers = {
+        "x-api-key": api_key,
+        "Content-Type": "application/json",
+    }
+
+    timeout = 55 if is_deep else 30
+    data = make_request(endpoint, headers, body, timeout=timeout)
+
+    results = []
+
+    # Deep search: primary content in output field with grounding citations
+    if is_deep:
+        deep_output = data.get("output", {})
+        synthesized_text = ""
+        grounding_citations: List[Dict[str, Any]] = []
+
+        if isinstance(deep_output.get("content"), str):
+            synthesized_text = deep_output["content"]
+        elif isinstance(deep_output.get("content"), dict):
+            synthesized_text = json.dumps(deep_output["content"], ensure_ascii=False)
+
+        for field_citation in deep_output.get("grounding", []):
+            for cite in field_citation.get("citations", []):
+                grounding_citations.append({
+                    "url": cite.get("url", ""),
+                    "title": cite.get("title", ""),
+                    "confidence": field_citation.get("confidence", ""),
+                    "field": field_citation.get("field", ""),
+                })
+
+        # Primary synthesized result
+        if synthesized_text:
+            results.append({
+                "title": f"Exa {exa_depth.replace('-', ' ').title()} Synthesis",
+                "url": "",
+                "snippet": synthesized_text,
+                "full_synthesis": synthesized_text,
+                "score": 1.0,
+                "grounding": grounding_citations[:10],
+                "type": "synthesis",
+            })
+
+        # Supporting source documents
+        for item in data.get("results", [])[:max_results]:
+            text_content = item.get("text", "") or ""
+            highlights = item.get("highlights", [])
+            snippet = text_content[:800] if text_content else (highlights[0] if highlights else "")
+            results.append({
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "snippet": snippet,
+                "score": round(item.get("score", 0.0), 3),
+                "published_date": item.get("publishedDate"),
+                "author": item.get("author"),
+                "type": "source",
+            })
+
+        answer = synthesized_text if synthesized_text else (results[1]["snippet"] if len(results) > 1 else "")
+
+        return {
+            "provider": "exa",
+            "query": query,
+            "exa_depth": exa_depth,
+            "results": results,
+            "images": [],
+            "answer": answer,
+            "grounding": grounding_citations,
+            "metadata": {
+                "synthesis_length": len(synthesized_text),
+                "source_count": len(data.get("results", [])),
+            },
+        }
+
+    # Standard search result parsing
+    for item in data.get("results", [])[:max_results]:
+        text_content = item.get("text", "") or ""
+        highlights = item.get("highlights", [])
+        if text_content:
+            snippet = text_content[:800]
+        elif highlights:
+            snippet = " ... ".join(highlights[:2])
+        else:
+            snippet = ""
+
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(item.get("score", 0.0), 3),
+            "published_date": item.get("publishedDate"),
+            "author": item.get("author"),
+        })
+
+    answer = results[0]["snippet"] if results else ""
+
+    return {
+        "provider": "exa",
+        "query": query if not similar_url else f"Similar to: {similar_url}",
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {},
+    }
+
+def search_parallel(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    api_url: str = "https://api.parallel.ai/v1/search",
+    timeout: int = 45,
+    client_model: Optional[str] = None,
+) -> dict:
+    """Search using Parallel's web search API.
+
+    Parallel returns source URLs plus long LLM-ready excerpts. Its API does not
+    currently accept a generic max_results parameter, so results are trimmed
+    locally to the requested count.
+    """
+    search_query = query
+    if include_domains:
+        search_query += " " + " ".join(f"site:{domain}" for domain in include_domains)
+    if exclude_domains:
+        search_query += " " + " ".join(f"-site:{domain}" for domain in exclude_domains)
+
+    body: Dict[str, Any] = {
+        "objective": query,
+        "search_queries": [search_query],
+    }
+    if client_model:
+        body["client_model"] = client_model
+
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    data = make_request(api_url, headers, body, timeout=timeout)
+
+    raw_results = data.get("results") or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        excerpts = item.get("excerpts") or []
+        snippet_parts = []
+        for excerpt in excerpts:
+            if isinstance(excerpt, dict):
+                snippet_parts.append(excerpt.get("text") or excerpt.get("content") or "")
+            elif isinstance(excerpt, str):
+                snippet_parts.append(excerpt)
+        snippet = "\n\n".join(part for part in snippet_parts if part).strip()
+        results.append({
+            "title": item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+            "publish_date": item.get("publish_date"),
+            "excerpts": excerpts,
+        })
+
+    answer = " ".join(r.get("snippet", "") for r in results[:3])[:1200]
+    return {
+        "provider": "parallel",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "search_id": data.get("search_id"),
+            "session_id": data.get("session_id"),
+            "result_count_raw": len(raw_results),
+        },
+    }
+
+def search_perplexity(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    model: str = "sonar-pro",
+    api_url: str = "https://api.perplexity.ai/chat/completions",
+    freshness: Optional[str] = None,
+    provider_name: str = "perplexity",
+) -> dict:
+    """Search/answer using the native Perplexity API or a compatible gateway.
+
+    Args:
+        query: Search query
+        api_key: Provider API key
+        max_results: Maximum results to return
+        model: Perplexity-compatible model to use
+        api_url: Chat completions endpoint
+        freshness: Filter by recency — 'day', 'week', 'month', 'year' (maps to
+                   Perplexity's search_recency_filter parameter)
+        provider_name: Result provider label (perplexity or kilo-perplexity)
+    """
+    # Map generic freshness values to Perplexity's search_recency_filter
+    recency_map = {"day": "day", "pd": "day", "week": "week", "pw": "week", "month": "month", "pm": "month", "year": "year", "py": "year"}
+    recency_filter = recency_map.get(freshness or "", None)
+
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "Answer with concise factual summary and include source URLs."},
+            {"role": "user", "content": query},
+        ],
+        "temperature": 0.2,
+    }
+    if recency_filter:
+        body["search_recency_filter"] = recency_filter
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body)
+    choices = data.get("choices", [])
+    message = choices[0].get("message", {}) if choices else {}
+    answer = (message.get("content") or "").strip()
+
+    # Prefer the structured citations array from Perplexity API response
+    api_citations = data.get("citations", [])
+
+    # Fallback: extract URLs from answer text if API doesn't provide citations
+    if not api_citations:
+        api_citations = []
+        seen = set()
+        for u in re.findall(r"https?://[^\s)\]}>\"']+", answer):
+            if u not in seen:
+                seen.add(u)
+                api_citations.append(u)
+
+    results = []
+
+    # Primary result: the synthesized answer itself
+    if answer:
+        # Clean citation markers [1][2] for the snippet
+        clean_answer = re.sub(r'\[\d+\]', '', answer).strip()
+        results.append({
+            "title": f"Perplexity Answer: {query[:80]}",
+            "url": "https://www.perplexity.ai",
+            "snippet": clean_answer[:500],
+            "score": 1.0,
+        })
+
+    # Source results from citations
+    for i, citation in enumerate(api_citations[:max_results - 1]):
+        # citations can be plain URL strings or dicts with url/title
+        if isinstance(citation, str):
+            url = citation
+            title = _title_from_url(url)
+        else:
+            url = citation.get("url", "")
+            title = citation.get("title") or _title_from_url(url)
+        results.append({
+            "title": title,
+            "url": url,
+            "snippet": f"Source cited in Perplexity answer [citation {i+1}]",
+            "score": round(0.9 - i * 0.1, 3),
+        })
+
+    return {
+        "provider": provider_name,
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "model": model,
+            "usage": data.get("usage", {}),
+        }
+    }
+
+def search_you(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "US",
+    language: str = "en",
+    freshness: Optional[str] = None,
+    safesearch: str = "moderate",
+    include_news: bool = True,
+    livecrawl: Optional[str] = None,
+) -> dict:
+    """Search using You.com (LLM-Ready Web & News Search).
+
+    You.com excels at:
+    - RAG applications with pre-extracted snippets
+    - Combined web + news results in one call
+    - Real-time information with automatic news classification
+    - Clean, structured JSON optimized for AI consumption
+
+    Args:
+        query: Search query
+        api_key: You.com API key
+        max_results: Maximum results to return (default 5, max 100)
+        country: ISO 3166-2 country code (e.g., US, GB, DE)
+        language: BCP 47 language code (e.g., en, de, fr)
+        freshness: Filter by recency: day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD
+        safesearch: Content filter: off, moderate (default), strict
+        include_news: Include news results when relevant (default True)
+        livecrawl: Fetch full page content: "web", "news", or "all"
+    """
+    endpoint = "https://ydc-index.io/v1/search"
+
+    # Build query parameters
+    params = {
+        "query": query,
+        "count": max_results,
+        "safesearch": safesearch,
+    }
+
+    if country:
+        params["country"] = country.upper()
+    if language:
+        params["language"] = language.upper()
+    if freshness:
+        params["freshness"] = freshness
+    if livecrawl:
+        params["livecrawl"] = livecrawl
+        params["livecrawl_formats"] = "markdown"
+
+    # Build URL with query params (URL-encode values)
+    query_string = "&".join(f"{k}={quote(str(v))}" for k, v in params.items())
+    url = f"{endpoint}?{query_string}"
+
+    headers = {
+        "X-API-KEY": api_key,
+        "Accept": "application/json",
+        "User-Agent": DEFAULT_USER_AGENT,
+    }
+
+    # Make GET request (You.com uses GET, not POST)
+    from urllib.request import Request, urlopen
+    req = Request(url, headers=headers, method="GET")
+
+    try:
+        with urlopen(req, timeout=30) as response:
+            data = _read_json_response(response)
+    except HTTPError as e:
+        error_body = _read_response_body(e).decode("utf-8") if e.fp else str(e)
+        try:
+            error_json = json.loads(error_body)
+            error_detail = error_json.get("error") or error_json.get("message") or error_body
+        except json.JSONDecodeError:
+            error_detail = error_body[:500]
+
+        error_messages = {
+            401: "Invalid or expired API key. Get one at https://api.you.com",
+            403: "Access forbidden. Check your API key permissions.",
+            429: "Rate limit exceeded. Please wait and try again.",
+            500: "You.com server error. Try again later.",
+            503: "You.com service unavailable."
+        }
+        friendly_msg = error_messages.get(e.code, f"API error: {error_detail}")
+        raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except TimeoutError:
+        raise ProviderRequestError("You.com request timed out after 30s.", transient=True)
+
+    # Parse results
+    results_data = data.get("results", {})
+    web_results = results_data.get("web", [])
+    news_results = results_data.get("news", []) if include_news else []
+    metadata = data.get("metadata", {})
+
+    # Normalize web results
+    results = []
+    for i, item in enumerate(web_results[:max_results]):
+        snippets = item.get("snippets", [])
+        snippet = snippets[0] if snippets else item.get("description", "")
+
+        result = {
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),  # Assign descending score
+            "date": item.get("page_age"),
+            "source": "web",
+        }
+
+        # Include additional snippets if available (great for RAG)
+        if len(snippets) > 1:
+            result["additional_snippets"] = snippets[1:3]
+
+        # Include thumbnail and favicon for UI display
+        if item.get("thumbnail_url"):
+            result["thumbnail"] = item["thumbnail_url"]
+        if item.get("favicon_url"):
+            result["favicon"] = item["favicon_url"]
+
+        # Include live-crawled content if available
+        if item.get("contents"):
+            result["raw_content"] = item["contents"].get("markdown") or item["contents"].get("html", "")
+
+        results.append(result)
+
+    # Add news results (if any)
+    news = []
+    for item in news_results[:5]:
+        news.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": item.get("description", ""),
+            "date": item.get("page_age"),
+            "thumbnail": item.get("thumbnail_url"),
+            "source": "news",
+        })
+
+    # Build answer from best snippets
+    answer = ""
+    if results:
+        # Combine top snippets for LLM context
+        top_snippets = []
+        for r in results[:3]:
+            if r.get("snippet"):
+                top_snippets.append(r["snippet"])
+        answer = " ".join(top_snippets)[:1000]
+
+    return {
+        "provider": "you",
+        "query": query,
+        "results": results,
+        "news": news,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "search_uuid": metadata.get("search_uuid"),
+            "latency": metadata.get("latency"),
+        }
+    }
+
+def search_searxng(
+    query: str,
+    instance_url: str,
+    max_results: int = 5,
+    categories: Optional[List[str]] = None,
+    engines: Optional[List[str]] = None,
+    language: str = "en",
+    time_range: Optional[str] = None,
+    safesearch: int = 0,
+) -> dict:
+    """Search using SearXNG (self-hosted privacy-first meta-search).
+
+    SearXNG excels at:
+    - Privacy-preserving search (no tracking, no profiling)
+    - Multi-source aggregation (70+ upstream engines)
+    - $0 API cost (self-hosted)
+    - Diverse perspectives from multiple search engines
+
+    Args:
+        query: Search query
+        instance_url: URL of your SearXNG instance (required)
+        max_results: Maximum results to return (default 5)
+        categories: Search categories (general, images, news, videos, etc.)
+        engines: Specific engines to use (google, bing, duckduckgo, etc.)
+        language: Language code (e.g., en, de, fr)
+        time_range: Filter by recency: day, week, month, year
+        safesearch: Content filter: 0=off, 1=moderate, 2=strict
+
+    Note:
+        Requires a self-hosted SearXNG instance with JSON format enabled.
+        See: https://docs.searxng.org/admin/installation.html
+    """
+    # Build URL with query parameters
+    params = {
+        "q": query,
+        "format": "json",
+        "language": language,
+        "safesearch": str(safesearch),
+    }
+
+    if categories:
+        params["categories"] = ",".join(categories)
+    if engines:
+        params["engines"] = ",".join(engines)
+    if time_range:
+        params["time_range"] = time_range
+
+    # Build URL — instance_url comes from operator-controlled config/env only
+    # (validated by _validate_searxng_url), not from agent/LLM input
+    base_url = instance_url.rstrip("/")
+    query_string = "&".join(f"{k}={quote(str(v))}" for k, v in params.items())
+    url = f"{base_url}/search?{query_string}"
+
+    headers = {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Accept": "application/json",
+    }
+
+    # Make GET request
+    req = Request(url, headers=headers, method="GET")
+
+    try:
+        with urlopen(req, timeout=30) as response:
+            data = _read_json_response(response)
+    except HTTPError as e:
+        error_body = _read_response_body(e).decode("utf-8") if e.fp else str(e)
+        try:
+            error_json = json.loads(error_body)
+            error_detail = error_json.get("error") or error_json.get("message") or error_body
+        except json.JSONDecodeError:
+            error_detail = error_body[:500]
+
+        error_messages = {
+            403: "JSON API disabled on this SearXNG instance. Enable 'json' in search.formats in settings.yml",
+            404: "SearXNG instance not found. Check your instance URL.",
+            500: "SearXNG server error. Check instance health.",
+            503: "SearXNG service unavailable."
+        }
+        friendly_msg = error_messages.get(e.code, f"SearXNG error: {error_detail}")
+        raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Cannot reach SearXNG instance at {instance_url}. Error: {reason}", transient=is_timeout)
+    except TimeoutError:
+        raise ProviderRequestError("SearXNG request timed out after 30s. Check instance health.", transient=True)
+
+    # Parse results
+    raw_results = data.get("results", [])
+
+    # Normalize results to unified format
+    results = []
+    engines_used = set()
+    for i, item in enumerate(raw_results[:max_results]):
+        engine = item.get("engine", "unknown")
+        engines_used.add(engine)
+
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": item.get("content", ""),
+            "score": round(item.get("score", 1.0 - i * 0.05), 3),
+            "engine": engine,
+            "category": item.get("category", "general"),
+            "date": item.get("publishedDate"),
+        })
+
+    # Build answer from answers, infoboxes, or first result
+    answer = ""
+    if data.get("answers"):
+        answer = data["answers"][0] if isinstance(data["answers"][0], str) else str(data["answers"][0])
+    elif data.get("infoboxes"):
+        infobox = data["infoboxes"][0]
+        answer = infobox.get("content", "") or infobox.get("infobox", "")
+    elif results:
+        answer = results[0]["snippet"]
+
+    return {
+        "provider": "searxng",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "suggestions": data.get("suggestions", []),
+        "corrections": data.get("corrections", []),
+        "metadata": {
+            "number_of_results": data.get("number_of_results"),
+            "engines_used": list(engines_used),
+            "instance_url": instance_url,
+        }
+    }

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/quality.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/quality.py
@@ -1,0 +1,293 @@
+"""Result normalization, deduplication, reranking, and quality-report helpers."""
+
+import hashlib
+import re
+from typing import Any, Dict, List, Tuple
+from urllib.parse import urlparse
+
+
+ROUTING_POLICY = "routing-v2"
+
+
+def _title_from_url(url: str) -> str:
+    """Derive a readable title from a URL when none is provided."""
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.replace("www.", "")
+        # Use last meaningful path segment as context
+        segments = [s for s in parsed.path.strip("/").split("/") if s]
+        if segments:
+            last = segments[-1].replace("-", " ").replace("_", " ")
+            # Strip file extensions
+            last = re.sub(r'\.\w{2,4}$', '', last)
+            if last:
+                return f"{domain} — {last[:80]}"
+        return domain
+    except Exception:
+        return url[:60]
+
+
+def normalize_result_url(url: str) -> str:
+    if not url:
+        return ""
+    parsed = urlparse(url.strip())
+    netloc = (parsed.netloc or "").lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    path = parsed.path.rstrip("/")
+    return f"{netloc}{path}"
+
+
+def deduplicate_results_across_providers(results_by_provider: List[Tuple[str, Dict[str, Any]]], max_results: int) -> Tuple[List[Dict[str, Any]], int]:
+    deduped = []
+    seen = set()
+    dedup_count = 0
+    for provider_name, data in results_by_provider:
+        for item in data.get("results", []):
+            norm = normalize_result_url(item.get("url", ""))
+            if norm and norm in seen:
+                dedup_count += 1
+                continue
+            if norm:
+                seen.add(norm)
+            item = item.copy()
+            item.setdefault("provider", provider_name)
+            deduped.append(item)
+            if len(deduped) >= max_results:
+                return deduped, dedup_count
+    return deduped, dedup_count
+
+def _choose_tie_winner(query: str, winners: List[str], priority: List[str]) -> str:
+    """Break score ties deterministically per query.
+
+    Uses a stable hash of the query to distribute ties across providers while
+    keeping the same query reproducible across runs.
+    """
+    ordered_winners = [p for p in priority if p in winners]
+    if not ordered_winners:
+        ordered_winners = sorted(winners)
+    if len(ordered_winners) == 1:
+        return ordered_winners[0]
+    digest = hashlib.sha256(f"{query}|{'|'.join(ordered_winners)}".encode("utf-8")).hexdigest()
+    idx = int(digest[:8], 16) % len(ordered_winners)
+    return ordered_winners[idx]
+
+
+def _result_domain(url: str) -> str:
+    try:
+        netloc = urlparse(url or "").netloc.lower()
+        return netloc[4:] if netloc.startswith("www.") else netloc
+    except Exception:
+        return ""
+
+
+CANONICAL_DOMAIN_RULES: Dict[str, Dict[str, List[str]]] = {
+    "official_vendor_release": {
+        "boost": [
+            "mistral.ai", "anthropic.com", "openai.com", "googleblog.com",
+            "blog.google", "ai.google.dev", "meta.com", "ai.meta.com",
+            "nvidia.com", "developer.nvidia.com", "apple.com", "microsoft.com",
+        ],
+        "demote": ["youtube.com", "youtu.be", "medium.com", "aizolo.com", "reddit.com"],
+    },
+    "official_docs": {
+        "boost": ["docs.", "developer.", "github.com", "readthedocs.io", "modelcontextprotocol.io"],
+        "demote": ["medium.com", "dev.to", "reddit.com", "stackoverflow.com", "youtube.com"],
+    },
+    "policy_pdf": {
+        "boost": ["europa.eu", "ec.europa.eu", "nist.gov", "nvlpubs.nist.gov", "oecd.org", "who.int", "gov.uk", "federalregister.gov"],
+        "demote": ["scribd.com", "researchgate.net", "universityofcalifornia.edu", "slideshare.net"],
+    },
+    "finance_earnings_official": {
+        "boost": ["investor.", "ir.", "nvidia.com", "sec.gov", "nasdaq.com"],
+        "demote": ["reddit.com", "fool.com", "seekingalpha.com", "youtube.com"],
+    },
+    "security_advisory": {
+        "boost": ["nvd.nist.gov", "cve.org", "github.com", "github.com/advisories", "security.", "cert.europa.eu", "kb.cert.org"],
+        "demote": ["youtube.com", "medium.com", "reddit.com"],
+    },
+}
+
+
+def _domain_matches_rule(domain: str, rule: str) -> bool:
+    return domain == rule or domain.endswith(f".{rule}") or domain.startswith(rule)
+
+
+def _url_matches_rule(url: str, rule: str) -> bool:
+    domain = _result_domain(url)
+    if "/" not in rule:
+        return _domain_matches_rule(domain, rule)
+    normalized = normalize_result_url(url)
+    normalized_rule = rule.lower().strip().rstrip("/")
+    return normalized == normalized_rule or normalized.startswith(f"{normalized_rule}/")
+
+
+def rerank_results_for_intent(
+    query: str,
+    routing_class: str,
+    results: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Small authority reranker for classes where source authority beats snippet luck."""
+    rules = CANONICAL_DOMAIN_RULES.get(routing_class, {})
+    if not results or not rules:
+        return results, {"reranked": False, "routing_class": routing_class}
+
+    q = query.lower()
+    scored: List[Tuple[float, int, Dict[str, Any]]] = []
+    for idx, item in enumerate(results):
+        url = item.get("url", "")
+        domain = _result_domain(url)
+        title = (item.get("title") or "").lower()
+        snippet = (item.get("snippet") or item.get("description") or "").lower()
+        score = float(len(results) - idx) * 0.01
+        if any(_url_matches_rule(url, rule) for rule in rules.get("boost", [])):
+            score += 10.0
+        if any(_url_matches_rule(url, rule) for rule in rules.get("demote", [])):
+            score -= 6.0
+        if routing_class == "official_vendor_release" and any(term in domain for term in ("mistral", "anthropic", "openai", "nvidia", "google", "meta")):
+            score += 3.0
+        if routing_class == "policy_pdf" and (item.get("url", "").lower().endswith(".pdf") or "pdf" in title):
+            score += 2.0
+        if "official" in q and ("official" in title or "official" in snippet):
+            score += 1.0
+        scored.append((score, idx, item))
+
+    reranked = [item.copy() for _, _, item in sorted(scored, key=lambda row: (-row[0], row[1]))]
+    before_urls = [item.get("url", "") for item in results]
+    after_urls = [item.get("url", "") for item in reranked]
+    changed = before_urls != after_urls
+    return reranked, {
+        "reranked": changed,
+        "routing_class": routing_class,
+        "top_domain_before": _result_domain(results[0].get("url", "")) if results else None,
+        "top_domain_after": _result_domain(reranked[0].get("url", "")) if reranked else None,
+    }
+
+
+def build_authority_signals(routing_class: str, results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize primary-source authority signals for quality reports."""
+    rules = CANONICAL_DOMAIN_RULES.get(routing_class, {})
+    urls = [item.get("url", "") for item in results if item.get("url")]
+    domains = [_result_domain(url) for url in urls]
+    boosted_domains = []
+    demoted_domains = []
+    boosted_flags = []
+    for url, domain in zip(urls, domains):
+        boosted = any(_url_matches_rule(url, rule) for rule in rules.get("boost", []))
+        demoted = any(_url_matches_rule(url, rule) for rule in rules.get("demote", []))
+        boosted_flags.append(boosted)
+        if boosted:
+            boosted_domains.append(domain)
+        if demoted:
+            demoted_domains.append(domain)
+
+    return {
+        "routing_class": routing_class,
+        "rules_applied": bool(rules),
+        "top_domain": domains[0] if domains else None,
+        "canonical_domain_hits": sorted(set(boosted_domains)),
+        "demoted_domain_hits": sorted(set(demoted_domains)),
+        "canonical_top_result": bool(boosted_flags and boosted_flags[0]),
+    }
+
+
+def _snippet_text(item: Dict[str, Any]) -> str:
+    return " ".join(
+        str(item.get(k) or "")
+        for k in ("description", "snippet", "content", "raw_content", "summary")
+    ).strip()
+
+
+def build_quality_report(
+    query: str,
+    result: Dict[str, Any],
+    routing_info: Dict[str, Any],
+    providers_considered: List[str],
+    eligible_providers: List[str],
+    cooldown_skips: List[Dict[str, Any]],
+    errors: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build transparent search-quality diagnostics without changing results."""
+    results = result.get("results", []) or []
+    domains = [_result_domain(r.get("url", "")) for r in results]
+    domains = [d for d in domains if d]
+    unique_domains = sorted(set(domains))
+    duplicate_count = int(result.get("metadata", {}).get("dedup_count", 0) or 0)
+
+    short_snippets = 0
+    for item in results:
+        if len(_snippet_text(item)) < 40:
+            short_snippets += 1
+
+    extract_reasons: List[str] = []
+    confidence_level = routing_info.get("confidence_level") or "unknown"
+    confidence_score = routing_info.get("confidence")
+    if confidence_level == "low" or (confidence_score is not None and float(confidence_score or 0) < 0.4):
+        extract_reasons.append("low routing confidence")
+    if len(results) < 3:
+        extract_reasons.append("few search results")
+    if results and len(unique_domains) <= 1:
+        extract_reasons.append("low domain diversity")
+    if duplicate_count:
+        extract_reasons.append("duplicate results detected")
+    if results and short_snippets / max(len(results), 1) >= 0.5:
+        extract_reasons.append("thin snippets")
+
+    skipped = []
+    for item in cooldown_skips:
+        skipped.append({
+            "provider": item.get("provider"),
+            "reason": "cooldown",
+            "cooldown_remaining_seconds": item.get("cooldown_remaining_seconds"),
+        })
+    for err in errors:
+        skipped.append({
+            "provider": err.get("provider"),
+            "reason": "error",
+            "error": err.get("error"),
+        })
+
+    routing_class = routing_info.get("analysis_summary", {}).get("routing_class")
+    authority_signals = build_authority_signals(routing_class, results) if routing_class else None
+
+    return {
+        "query": query,
+        "selected_provider": routing_info.get("provider") or result.get("provider"),
+        "routing_reason": routing_info.get("reason"),
+        "routing_policy": routing_info.get("routing_policy", ROUTING_POLICY),
+        "routing_class": routing_class,
+        "language_hint": routing_info.get("analysis_summary", {}).get("language_hint"),
+
+        "confidence": confidence_level,
+        "confidence_score": routing_info.get("confidence"),
+        "providers_considered": providers_considered,
+        "eligible_providers": eligible_providers,
+        "skipped_providers": skipped,
+        "result_count": len(results),
+        "domain_count": len(unique_domains),
+        "domains": unique_domains,
+        "domain_diversity": (len(unique_domains) / len(results)) if results else 0.0,
+        "duplicate_count": duplicate_count,
+        "thin_snippet_count": short_snippets,
+        "extract_recommended": bool(extract_reasons),
+        "extract_reasons": extract_reasons,
+        "scores": routing_info.get("scores", {}),
+        "authority_signals": authority_signals,
+    }
+
+
+def select_research_providers(
+    primary_provider: str,
+    provider_priority: List[str],
+    available_providers: set,
+    max_providers: int = 3,
+) -> List[str]:
+    """Pick a compact provider set for research mode."""
+    preferred = [primary_provider, "linkup", "tavily", "exa", "firecrawl", "brave", "serper", "you", "querit"]
+    ordered: List[str] = []
+    for provider in preferred + provider_priority:
+        if provider and provider in available_providers and provider not in ordered:
+            ordered.append(provider)
+        if len(ordered) >= max_providers:
+            break
+    return ordered

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/quality.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/quality.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 
@@ -110,7 +110,127 @@ CANONICAL_DOMAIN_RULES: Dict[str, Dict[str, List[str]]] = {
 
 
 def _domain_matches_rule(domain: str, rule: str) -> bool:
-    return domain == rule or domain.endswith(f".{rule}") or domain.startswith(rule)
+    if rule.endswith("."):
+        # Label-prefix rules such as "docs." / "investor." / "ir." match a
+        # leading host label (docs.python.org), never a bare domain (notdocs.com).
+        return domain.startswith(rule)
+    # Exact domain or true subdomain only. A bare startswith would let
+    # look-alike registrations such as openai.com.evil.example inherit
+    # authority boosts (same reasoning as _blocked_domain_matches below).
+    return domain == rule or domain.endswith(f".{rule}")
+
+
+# Known content mirrors and SEO scraper sites that republish Stack Overflow,
+# GitHub, and documentation content. These add no information over the
+# canonical source and frequently outrank it; they are removed from results
+# rather than merely demoted. Operators can extend via config
+# quality.blocked_domains or rescue a domain via quality.allowed_domains.
+SPAM_MIRROR_DOMAINS: List[str] = [
+    # Stack Overflow / Q&A scrapers
+    "newbedev.com",
+    "stackoom.com",
+    "stackovergo.com",
+    "syntaxfix.com",
+    "copyprogramming.com",
+    "devcodef1.com",
+    "exceptionshub.com",
+    "code-examples.net",
+    "i-harness.com",
+    "fixmycodeerror.com",
+    "stacklesson.com",
+    # GitHub issue/readme mirrors
+    "githubmemory.com",
+    "gitmemory.com",
+    "issueexplorer.com",
+    "bleepcoder.com",
+    "gitanswer.com",
+    # Documentation mirrors
+    "w3cub.com",
+    # Generic AI/SEO content farms already demoted by the intent reranker
+    "aizolo.com",
+]
+
+
+def _blocked_domain_matches(domain: str, rule: str) -> bool:
+    """Strict matcher for domain block/allow lists.
+
+    Only the exact domain or true subdomains match (``newbedev.com``,
+    ``de.newbedev.com``). Unlike ``_domain_matches_rule`` there is no
+    ``startswith`` clause, so look-alike registrations such as
+    ``newbedev.com.evil.example`` do NOT match.
+    """
+    return domain == rule or domain.endswith(f".{rule}")
+
+
+_SITE_OPERATOR_RE = re.compile(r"\bsite:([a-z0-9][a-z0-9.-]*)", re.IGNORECASE)
+
+
+def extract_domain_constraints(query: str, include_domains: Optional[List[str]] = None) -> List[str]:
+    """Domains the user explicitly constrained the search to.
+
+    Collects ``site:`` operators from the query plus ``include_domains``.
+    Explicit constraints express intent: constrained domains are exempt from
+    spam filtering, and domain-diversity reranking is skipped entirely.
+    """
+    domains = [d.lower().rstrip(".") for d in _SITE_OPERATOR_RE.findall(query or "")]
+    for entry in include_domains or []:
+        if entry and entry.strip():
+            domains.append(entry.lower().strip())
+    return sorted(set(domains))
+
+
+def filter_spam_results(
+    results: List[Dict[str, Any]],
+    extra_blocked: Optional[List[str]] = None,
+    allowed: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Drop results from known mirror/SEO-spam domains.
+
+    Returns the kept results and the sorted unique domains that were removed.
+    ``allowed`` rescues a domain from both the builtin and extra blocklists.
+    """
+    blocked_rules = SPAM_MIRROR_DOMAINS + [d.lower().strip() for d in (extra_blocked or []) if d and d.strip()]
+    allowed_rules = [d.lower().strip() for d in (allowed or []) if d and d.strip()]
+    kept: List[Dict[str, Any]] = []
+    removed_domains: List[str] = []
+    for item in results:
+        domain = _result_domain(item.get("url", ""))
+        if (
+            domain
+            and not any(_blocked_domain_matches(domain, rule) for rule in allowed_rules)
+            and any(_blocked_domain_matches(domain, rule) for rule in blocked_rules)
+        ):
+            removed_domains.append(domain)
+            continue
+        kept.append(item)
+    return kept, sorted(set(removed_domains))
+
+
+def rerank_domain_diversity(
+    results: List[Dict[str, Any]],
+    max_per_domain: int = 2,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Stable rerank that stops one domain from crowding out the result list.
+
+    The first ``max_per_domain`` results per domain keep their original order;
+    overflow results are moved behind the diverse head (also in original
+    order) instead of being dropped. Returns the reranked list and how many
+    results were demoted.
+    """
+    if max_per_domain < 1 or len(results) < 3:
+        return results, 0
+    head: List[Dict[str, Any]] = []
+    overflow: List[Dict[str, Any]] = []
+    per_domain: Dict[str, int] = {}
+    for item in results:
+        domain = _result_domain(item.get("url", ""))
+        count = per_domain.get(domain, 0)
+        if domain and count >= max_per_domain:
+            overflow.append(item)
+            continue
+        per_domain[domain] = count + 1
+        head.append(item)
+    return head + overflow, len(overflow)
 
 
 def _url_matches_rule(url: str, rule: str) -> bool:
@@ -272,6 +392,7 @@ def build_quality_report(
         "extract_recommended": bool(extract_reasons),
         "extract_reasons": extract_reasons,
         "scores": routing_info.get("scores", {}),
+        "adaptive_adjustments": routing_info.get("adaptive_adjustments", {}),
         "authority_signals": authority_signals,
     }
 

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/research.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/research.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Tuple
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any, Dict, List, Optional, Tuple
 
+from daemon_tasks import DaemonTask
 from quality import deduplicate_results_across_providers
+
+
+# Small real-time grace given to already-submitted provider calls once the
+# (possibly fake-clock) budget reads as exhausted, so completed futures can
+# still be harvested without blocking on slow ones.
+_RESULT_GRACE_SECONDS = 0.25
 
 
 def run_research_mode(
@@ -27,8 +35,10 @@ def run_research_mode(
     whole response. Provider searches run concurrently to keep the wall-clock cost
     close to the slowest single provider rather than the sum of all of them. The
     optional time budget gates which providers are launched (checked before each
-    submission, so a tight budget still skips later providers deterministically) and
-    whether extraction runs at all.
+    submission, so a tight budget still skips later providers deterministically),
+    bounds how long already-launched providers may run, and gates whether
+    extraction runs at all — so the budget caps total wall-clock time instead of
+    only limiting how many providers start.
 
     Result ordering is preserved by provider submission order regardless of which
     provider finishes first, so deduplication stays deterministic.
@@ -37,31 +47,47 @@ def run_research_mode(
     now = now_fn or time.monotonic
     start = now()
 
-    def budget_exhausted() -> bool:
-        return time_budget_seconds is not None and (now() - start) >= time_budget_seconds
+    def remaining_budget() -> Optional[float]:
+        if time_budget_seconds is None:
+            return None
+        return time_budget_seconds - (now() - start)
 
     # Submit providers (budget gate is sequential/deterministic); the actual
-    # provider HTTP calls run concurrently in the thread pool.
+    # provider HTTP calls run concurrently on daemon threads. Daemon threads —
+    # unlike ThreadPoolExecutor workers — are not joined at interpreter exit,
+    # so an overdue provider cannot stall CLI/subprocess shutdown either.
     pending: List[Tuple[int, str]] = []
-    futures: Dict[int, Any] = {}
+    tasks: Dict[int, DaemonTask] = {}
     workers = max_workers or max(1, len(research_providers))
-    executor = ThreadPoolExecutor(max_workers=workers)
-    try:
-        for index, provider in enumerate(research_providers):
-            if budget_exhausted():
-                provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
-                continue
-            futures[index] = executor.submit(execute_search, provider)
-            pending.append((index, provider))
+    gate = threading.Semaphore(workers)
 
-        results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
-        for index, provider in pending:
-            try:
-                results_by_index[index] = (provider, futures[index].result())
-            except Exception as e:
-                provider_errors.append({"provider": provider, "error": str(e)})
-    finally:
-        executor.shutdown(wait=True)
+    def run_gated(provider_name: str) -> Dict[str, Any]:
+        with gate:
+            return execute_search(provider_name)
+
+    for index, provider in enumerate(research_providers):
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
+            provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
+            continue
+        tasks[index] = DaemonTask(run_gated, provider)
+        pending.append((index, provider))
+
+    results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
+    for index, provider in pending:
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
+            # Budget gone: give already-submitted calls a short real-time grace
+            # so finished tasks are still harvested without blocking on slow ones.
+            timeout = _RESULT_GRACE_SECONDS
+        else:
+            timeout = remaining
+        try:
+            results_by_index[index] = (provider, tasks[index].result(timeout=timeout))
+        except FuturesTimeoutError:
+            provider_errors.append({"provider": provider, "error": "timed out: research time budget exhausted"})
+        except Exception as e:
+            provider_errors.append({"provider": provider, "error": str(e)})
 
     provider_results: List[Tuple[str, Dict[str, Any]]] = [
         results_by_index[index] for index in sorted(results_by_index)
@@ -72,11 +98,22 @@ def run_research_mode(
     extracted = {"provider": None, "results": []}
     extraction_error = None
     if urls:
-        if budget_exhausted():
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
             extraction_error = "skipped: research time budget exhausted"
-        else:
+        elif remaining is None:
             try:
                 extracted = extract_urls(urls) or {"provider": None, "results": []}
+            except Exception as e:
+                extraction_error = str(e)
+                extracted = {"provider": None, "results": []}
+        else:
+            # Run extraction on a daemon thread so the remaining budget bounds it too.
+            try:
+                extracted = DaemonTask(extract_urls, urls).result(timeout=remaining) or {"provider": None, "results": []}
+            except FuturesTimeoutError:
+                extraction_error = "timed out: research time budget exhausted"
+                extracted = {"provider": None, "results": []}
             except Exception as e:
                 extraction_error = str(e)
                 extracted = {"provider": None, "results": []}

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/research.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/research.py
@@ -1,0 +1,106 @@
+"""Research mode orchestration helpers."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Tuple
+
+from quality import deduplicate_results_across_providers
+
+
+def run_research_mode(
+    query: str,
+    research_providers: List[str],
+    execute_search,
+    extract_urls,
+    max_results: int,
+    max_extract_urls: int = 3,
+    time_budget_seconds: float | None = None,
+    now_fn=None,
+    max_workers: int | None = None,
+) -> Dict[str, Any]:
+    """Run broad search, deduplicate, then extract top sources for grounding.
+
+    Research mode is intentionally best-effort: provider/extraction failures should
+    produce diagnostics and partial search results instead of throwing away the
+    whole response. Provider searches run concurrently to keep the wall-clock cost
+    close to the slowest single provider rather than the sum of all of them. The
+    optional time budget gates which providers are launched (checked before each
+    submission, so a tight budget still skips later providers deterministically) and
+    whether extraction runs at all.
+
+    Result ordering is preserved by provider submission order regardless of which
+    provider finishes first, so deduplication stays deterministic.
+    """
+    provider_errors: List[Dict[str, Any]] = []
+    now = now_fn or time.monotonic
+    start = now()
+
+    def budget_exhausted() -> bool:
+        return time_budget_seconds is not None and (now() - start) >= time_budget_seconds
+
+    # Submit providers (budget gate is sequential/deterministic); the actual
+    # provider HTTP calls run concurrently in the thread pool.
+    pending: List[Tuple[int, str]] = []
+    futures: Dict[int, Any] = {}
+    workers = max_workers or max(1, len(research_providers))
+    executor = ThreadPoolExecutor(max_workers=workers)
+    try:
+        for index, provider in enumerate(research_providers):
+            if budget_exhausted():
+                provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
+                continue
+            futures[index] = executor.submit(execute_search, provider)
+            pending.append((index, provider))
+
+        results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
+        for index, provider in pending:
+            try:
+                results_by_index[index] = (provider, futures[index].result())
+            except Exception as e:
+                provider_errors.append({"provider": provider, "error": str(e)})
+    finally:
+        executor.shutdown(wait=True)
+
+    provider_results: List[Tuple[str, Dict[str, Any]]] = [
+        results_by_index[index] for index in sorted(results_by_index)
+    ]
+
+    deduped, dedup_count = deduplicate_results_across_providers(provider_results, max_results)
+    urls = [r.get("url") for r in deduped if r.get("url")][:max(0, max_extract_urls)]
+    extracted = {"provider": None, "results": []}
+    extraction_error = None
+    if urls:
+        if budget_exhausted():
+            extraction_error = "skipped: research time budget exhausted"
+        else:
+            try:
+                extracted = extract_urls(urls) or {"provider": None, "results": []}
+            except Exception as e:
+                extraction_error = str(e)
+                extracted = {"provider": None, "results": []}
+
+    routing = {
+        "providers_queried": [p for p, _ in provider_results],
+        "provider_errors": provider_errors,
+        "extraction_provider": extracted.get("provider"),
+    }
+    if extraction_error:
+        routing["extraction_error"] = extraction_error
+
+    source_summaries = extracted.get("results", []) or []
+
+    return {
+        "mode": "research",
+        "provider": "research",
+        "query": query,
+        "results": deduped,
+        "source_summaries": source_summaries,
+        "routing": routing,
+        "metadata": {
+            "dedup_count": dedup_count,
+            "providers_merged": [p for p, _ in provider_results],
+            "extracted_url_count": len(source_summaries),
+        },
+    }

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/routing.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/routing.py
@@ -5,10 +5,128 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from config import DEFAULT_CONFIG, get_api_key
 from provider_registry import DEFAULT_PROVIDER_PRIORITY
+from provider_stats import performance_adjustments
 from quality import _choose_tie_winner
 
 
 ROUTING_POLICY = "routing-v2"
+
+
+# Ordered routing-class rules from the qualitative 25-query benchmark.
+# Each entry maps a class name to one or more regex pattern groups; a class
+# matches when every group matches the lowercased query. Entries are evaluated
+# top to bottom and the first match wins, so order is part of the behavior.
+# Synthesis/briefing queries should prefer broad real-time/search providers,
+# but Web Search Plus no longer exposes a separate answer tool.
+ROUTING_CLASS_RULES: List[Tuple[str, Tuple[str, ...]]] = [
+    ("briefing_synthesis", (
+        r'\b(difference|differences|unterschiede|vergleich|compare|comparison|brief(?:ing)?|summari[sz]e|zusammenfass(?:en|ung)|was sind|what are)\b',
+    )),
+    ("security_advisory", (
+        r'\b(advisory|security advisory|cve|mitigation|openssl|openssh|vulnerability|zero[-\s]?day)\b',
+    )),
+    ("patents", (
+        r'\b(patent|patents|patentscope|espacenet|uspto|google patents)\b',
+    )),
+    ("policy_pdf", (
+        r'\b(pdf|whitepaper|code of practice)\b',
+        r'\b(nist|eu ai act|regulation|regulatory|policy|commission|government|official|rmf)\b',
+    )),
+    ("official_regulatory", (
+        r'\b(eu ai act|european commission|regulation|regulatory|obligations?)\b',
+    )),
+    ("finance_earnings_official", (
+        r'\b(nvidia|earnings|gross margin|investor relations|guidance|10-[qk]|eps|revenue|quarterly results?)\b',
+    )),
+    ("finance_investor_monthly", (
+        r'\b(investor monthly|monthly factsheet|monthly report|aum|fund flows?)\b',
+    )),
+    ("reddit_community", (
+        r'\bsite:\s*reddit\.com\b|\br/\w+|\breddit\s+(thread|post|community|users?|discussion|comments?)\b',
+    )),
+    ("shopping_reviews_local", (
+        r'\b(geizhals|preis|prices?|buy|kaufen|österreich|austria|shop|händler|deal|angebot)\b',
+        r'\b(sony|denon|iphone|samsung|bose|kef|marantz|yamaha|lg|asus|laptop|tv|headphones?|speaker|receiver|avc|wh-|[a-z]{1,5}[-\s]?\d{3,}[a-z0-9-]*)\b',
+        r'\b(review(s)?|test|tests?|vergleich|best|beste|under|unter|erfahrungen)\b',
+    )),
+    ("shopping_specs", (
+        r'\b(geizhals|preis|prices?|buy|kaufen|österreich|austria|shop|händler|deal|angebot)\b',
+        r'\b(sony|denon|iphone|samsung|bose|kef|marantz|yamaha|lg|asus|laptop|tv|headphones?|speaker|receiver|avc|wh-|[a-z]{1,5}[-\s]?\d{3,}[a-z0-9-]*)\b',
+    )),
+    ("community_forum", (
+        r'\b(forum|forums|community|discussion|comments?|erfahrungen|review(s)?|measurements?|head-fi|audiosciencereview|hifi-forum)\b',
+    )),
+    ("academic_arxiv", (
+        r'\barxiv\b|\bpaper(s)?\b|\bscaling laws\b|\brandomi[sz]ed trial\b|\bprimary sources?\b',
+    )),
+    ("github_docs", (
+        r'\b(github\b|repo(sitory)?\b|plugin docs\b)',
+    )),
+    ("official_docs", (
+        r'\b(official docs?|official documentation|api reference|developer docs?|official manual)\b',
+    )),
+    ("official_vendor_release", (
+        r'\b(official|release|announcement|launch|changelog|release notes?)\b',
+        r'\b(mistral|anthropic|openai|google|meta|nvidia|apple|microsoft|claude|gemini|llama)\b',
+    )),
+    ("docs_api", (
+        r'\b(python|pydantic|node\.js|api docs?|documentation|docs|changelog|release notes?|taskgroup|basemodel)\b',
+    )),
+    ("official_regulatory", (
+        r'\b(official|regulatory filing|public authority)\b',
+    )),
+    ("local_at", (
+        r'\b(graz|öffnungszeiten|adresse|restaurants?|vegan|hifi team)\b',
+    )),
+    ("sports_current", (
+        r'\b(bundesliga|standings?|fixtures?|tabelle|punkte|spieltag|matchday|lineups?|scores?|sturm|salzburg|lask)\b|\b(league|liga|standings?|points?)\s+table\b',
+    )),
+    ("weather_local", (
+        r'\b(wetter|weather|forecast|regen|rain)\b',
+    )),
+    ("oss_discovery", (
+        r'\b(alternatives? to|open source|self hosted|competitors?|similar to)\b',
+    )),
+]
+
+# Fallback classes assigned when no rule above matches.
+MULTILINGUAL_ROUTING_CLASS = "multilingual_current"
+DEFAULT_ROUTING_CLASS = "general"
+
+# Script/language-aware boosts for current queries in non-en/de languages:
+# You performed best as the safe fast default, with Exa/Firecrawl/Linkup
+# useful by script. Kept modest so strong class rules win.
+LANGUAGE_HINT_PROVIDER_BOOSTS: Dict[str, List[Tuple[str, float]]] = {
+    "zh": [("exa", 7.0), ("you", 6.0), ("firecrawl", 4.0), ("linkup", 3.0), ("serper", 2.5)],
+    "ar": [("you", 8.0), ("linkup", 5.0), ("serper", 4.0), ("firecrawl", 2.0)],
+    "default": [("you", 8.0), ("exa", 5.0), ("firecrawl", 4.0), ("linkup", 3.0), ("tavily", 2.0)],
+}
+
+# Conservative class-aware provider boosts (positive) and penalties (negative)
+# from the qualitative routing benchmark, applied on top of the signal scores.
+ROUTING_CLASS_PROVIDER_BOOSTS: Dict[str, List[Tuple[str, float]]] = {
+    "shopping_at": [("serper", 8.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)],
+    "local_at": [("firecrawl", 8.0), ("serper", 6.0), ("linkup", 4.0), ("you", 2.0)],
+    "official_vendor_release": [("you", 14.0), ("linkup", 10.0), ("exa", 7.0), ("serper", 4.0), ("firecrawl", 3.0)],
+    "official_docs": [("exa", 12.0), ("you", 7.0), ("firecrawl", 5.0), ("serper", 3.0), ("tavily", 2.0)],
+    "policy_pdf": [("linkup", 10.0), ("exa", 8.0), ("serper", 7.0), ("firecrawl", 6.0), ("you", 4.0)],
+    "official_regulatory": [("exa", 8.0), ("firecrawl", 6.0), ("serper", 5.0), ("you", 3.0)],
+    "sports_current": [("you", 8.0), ("serper", 6.0), ("linkup", 5.0), ("tavily", 2.0)],
+    "github_docs": [("exa", 10.0), ("you", 6.0), ("firecrawl", 5.0), ("serper", 4.0)],
+    "docs_api": [("serper", 6.0), ("exa", 5.0), ("you", 4.0), ("firecrawl", 3.0), ("tavily", 3.0)],
+    "academic_arxiv": [("exa", 12.0), ("serper", 3.0), ("linkup", 2.0), ("you", 1.5)],
+    "oss_discovery": [("exa", 8.0), ("firecrawl", 5.0), ("tavily", 4.0), ("you", 3.0)],
+    "reddit_community": [("serper", 10.0), ("firecrawl", 8.0), ("tavily", 6.0), ("exa", -20.0)],
+    "security_advisory": [("serper", 10.0), ("exa", 8.0), ("linkup", 5.0), ("you", 2.0), ("firecrawl", -20.0)],
+    "finance_earnings_official": [("linkup", 14.0), ("you", 9.0), ("exa", 7.0), ("serper", 6.0), ("firecrawl", 4.0)],
+    "finance_investor_monthly": [("linkup", 12.0), ("serper", 7.0), ("you", 5.0), ("exa", 4.0)],
+    "community_forum": [("firecrawl", 10.0), ("serper", 8.0), ("tavily", 5.0), ("you", 4.0), ("exa", -18.0)],
+    "shopping_specs": [("serper", 9.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)],
+    "shopping_reviews_local": [("serper", 9.0), ("firecrawl", 7.0), ("you", 4.0), ("tavily", 3.0), ("exa", -4.0)],
+    "patents": [("exa", 10.0), ("serper", 7.0), ("linkup", 4.0), ("you", 3.0)],
+    "weather_local": [("serper", 8.0), ("firecrawl", 6.0), ("you", 2.0)],
+    "briefing_synthesis": [("you", 16.0), ("tavily", 4.0), ("linkup", 3.0), ("exa", 2.0)],
+}
 
 
 class QueryAnalyzer:
@@ -640,56 +758,12 @@ class QueryAnalyzer:
     def _detect_routing_class(self, query: str, language_hint: str) -> str:
         """Coarse class labels from the qualitative 25-query benchmark."""
         q = query.lower()
-        # Synthesis/briefing queries should prefer broad real-time/search providers,
-        # but Web Search Plus no longer exposes a separate answer tool.
-        if re.search(r'\b(difference|differences|unterschiede|vergleich|compare|comparison|brief(?:ing)?|summari[sz]e|zusammenfass(?:en|ung)|was sind|what are)\b', q):
-            return "briefing_synthesis"
-        if re.search(r'\b(advisory|security advisory|cve|mitigation|openssl|openssh|vulnerability|zero[-\s]?day)\b', q):
-            return "security_advisory"
-        if re.search(r'\b(patent|patents|patentscope|espacenet|uspto|google patents)\b', q):
-            return "patents"
-        if re.search(r'\b(pdf|whitepaper|code of practice)\b', q) and re.search(r'\b(nist|eu ai act|regulation|regulatory|policy|commission|government|official|rmf)\b', q):
-            return "policy_pdf"
-        if re.search(r'\b(eu ai act|european commission|regulation|regulatory|obligations?)\b', q):
-            return "official_regulatory"
-        if re.search(r'\b(nvidia|earnings|gross margin|investor relations|guidance|10-[qk]|eps|revenue|quarterly results?)\b', q):
-            return "finance_earnings_official"
-        if re.search(r'\b(investor monthly|monthly factsheet|monthly report|aum|fund flows?)\b', q):
-            return "finance_investor_monthly"
-        if re.search(r'\bsite:\s*reddit\.com\b|\br/\w+|\breddit\s+(thread|post|community|users?|discussion|comments?)\b', q):
-            return "reddit_community"
-        if (
-            re.search(r'\b(geizhals|preis|prices?|buy|kaufen|österreich|austria|shop|händler|deal|angebot)\b', q)
-            and re.search(r'\b(sony|denon|iphone|samsung|bose|kef|marantz|yamaha|lg|asus|laptop|tv|headphones?|speaker|receiver|avc|wh-|[a-z]{1,5}[-\s]?\d{3,}[a-z0-9-]*)\b', q)
-        ):
-            if re.search(r'\b(review(s)?|test|tests?|vergleich|best|beste|under|unter|erfahrungen)\b', q):
-                return "shopping_reviews_local"
-            return "shopping_specs"
-        if re.search(r'\b(forum|forums|community|discussion|comments?|erfahrungen|review(s)?|measurements?|head-fi|audiosciencereview|hifi-forum)\b', q):
-            return "community_forum"
-        if re.search(r'\barxiv\b|\bpaper(s)?\b|\bscaling laws\b|\brandomi[sz]ed trial\b|\bprimary sources?\b', q):
-            return "academic_arxiv"
-        if re.search(r'\b(github\b|repo(sitory)?\b|plugin docs\b)', q):
-            return "github_docs"
-        if re.search(r'\b(official docs?|official documentation|api reference|developer docs?|official manual)\b', q):
-            return "official_docs"
-        if re.search(r'\b(official|release|announcement|launch|changelog|release notes?)\b', q) and re.search(r'\b(mistral|anthropic|openai|google|meta|nvidia|apple|microsoft|claude|gemini|llama)\b', q):
-            return "official_vendor_release"
-        if re.search(r'\b(python|pydantic|node\.js|api docs?|documentation|docs|changelog|release notes?|taskgroup|basemodel)\b', q):
-            return "docs_api"
-        if re.search(r'\b(official|regulatory filing|public authority)\b', q):
-            return "official_regulatory"
-        if re.search(r'\b(graz|öffnungszeiten|adresse|restaurants?|vegan|hifi team)\b', q):
-            return "local_at"
-        if re.search(r'\b(bundesliga|standings?|fixtures?|tabelle|punkte|spieltag|matchday|lineups?|scores?|sturm|salzburg|lask)\b|\b(league|liga|standings?|points?)\s+table\b', q):
-            return "sports_current"
-        if re.search(r'\b(wetter|weather|forecast|regen|rain)\b', q):
-            return "weather_local"
-        if re.search(r'\b(alternatives? to|open source|self hosted|competitors?|similar to)\b', q):
-            return "oss_discovery"
+        for routing_class, patterns in ROUTING_CLASS_RULES:
+            if all(re.search(pattern, q) for pattern in patterns):
+                return routing_class
         if language_hint not in {"en", "de"}:
-            return "multilingual_current"
-        return "general"
+            return MULTILINGUAL_ROUTING_CLASS
+        return DEFAULT_ROUTING_CLASS
 
     def _apply_vnext_routing_boosts(
         self,
@@ -713,56 +787,14 @@ class QueryAnalyzer:
         # Script/language-aware current queries: You performed best as the safe fast default,
         # with Exa/Firecrawl/Linkup useful by script. Keep this modest so strong class rules win.
         if language_hint not in {"en", "de"}:
-            if language_hint == "zh":
-                boost_many([("exa", 7.0), ("you", 6.0), ("firecrawl", 4.0), ("linkup", 3.0), ("serper", 2.5)])
-            elif language_hint == "ar":
-                boost_many([("you", 8.0), ("linkup", 5.0), ("serper", 4.0), ("firecrawl", 2.0)])
-            else:
-                boost_many([("you", 8.0), ("exa", 5.0), ("firecrawl", 4.0), ("linkup", 3.0), ("tavily", 2.0)])
+            boost_many(LANGUAGE_HINT_PROVIDER_BOOSTS.get(
+                language_hint, LANGUAGE_HINT_PROVIDER_BOOSTS["default"]
+            ))
             boost("you", min(recency_score, 3.0))
 
-        if routing_class == "shopping_at":
-            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)])
-        elif routing_class == "local_at":
-            boost_many([("firecrawl", 8.0), ("serper", 6.0), ("linkup", 4.0), ("you", 2.0)])
-        elif routing_class == "official_vendor_release":
-            boost_many([("you", 14.0), ("linkup", 10.0), ("exa", 7.0), ("serper", 4.0), ("firecrawl", 3.0)])
-        elif routing_class == "official_docs":
-            boost_many([("exa", 12.0), ("you", 7.0), ("firecrawl", 5.0), ("serper", 3.0), ("tavily", 2.0)])
-        elif routing_class == "policy_pdf":
-            boost_many([("linkup", 10.0), ("exa", 8.0), ("serper", 7.0), ("firecrawl", 6.0), ("you", 4.0)])
-        elif routing_class == "official_regulatory":
-            boost_many([("exa", 8.0), ("firecrawl", 6.0), ("serper", 5.0), ("you", 3.0)])
-        elif routing_class == "sports_current":
-            boost_many([("you", 8.0), ("serper", 6.0), ("linkup", 5.0), ("tavily", 2.0)])
-        elif routing_class == "github_docs":
-            boost_many([("exa", 10.0), ("you", 6.0), ("firecrawl", 5.0), ("serper", 4.0)])
-        elif routing_class == "docs_api":
-            boost_many([("serper", 6.0), ("exa", 5.0), ("you", 4.0), ("firecrawl", 3.0), ("tavily", 3.0)])
-        elif routing_class == "academic_arxiv":
-            boost_many([("exa", 12.0), ("serper", 3.0), ("linkup", 2.0), ("you", 1.5)])
-        elif routing_class == "oss_discovery":
-            boost_many([("exa", 8.0), ("firecrawl", 5.0), ("tavily", 4.0), ("you", 3.0)])
-        elif routing_class == "reddit_community":
-            boost_many([("serper", 10.0), ("firecrawl", 8.0), ("tavily", 6.0), ("exa", -20.0)])
-        elif routing_class == "security_advisory":
-            boost_many([("serper", 10.0), ("exa", 8.0), ("linkup", 5.0), ("you", 2.0), ("firecrawl", -20.0)])
-        elif routing_class == "finance_earnings_official":
-            boost_many([("linkup", 14.0), ("you", 9.0), ("exa", 7.0), ("serper", 6.0), ("firecrawl", 4.0)])
-        elif routing_class == "finance_investor_monthly":
-            boost_many([("linkup", 12.0), ("serper", 7.0), ("you", 5.0), ("exa", 4.0)])
-        elif routing_class == "community_forum":
-            boost_many([("firecrawl", 10.0), ("serper", 8.0), ("tavily", 5.0), ("you", 4.0), ("exa", -18.0)])
-        elif routing_class == "shopping_specs":
-            boost_many([("serper", 9.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)])
-        elif routing_class == "shopping_reviews_local":
-            boost_many([("serper", 9.0), ("firecrawl", 7.0), ("you", 4.0), ("tavily", 3.0), ("exa", -4.0)])
-        elif routing_class == "patents":
-            boost_many([("exa", 10.0), ("serper", 7.0), ("linkup", 4.0), ("you", 3.0)])
-        elif routing_class == "weather_local":
-            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("you", 2.0)])
-        elif routing_class == "briefing_synthesis":
-            boost_many([("you", 16.0), ("tavily", 4.0), ("linkup", 3.0), ("exa", 2.0)])
+        class_boosts = ROUTING_CLASS_PROVIDER_BOOSTS.get(routing_class)
+        if class_boosts:
+            boost_many(class_boosts)
 
     def analyze(self, query: str) -> Dict[str, Any]:
         """
@@ -925,6 +957,19 @@ class QueryAnalyzer:
                 "auto_allow_excluded": auto_excluded,
             }
 
+        # Adaptive routing: blend in bounded, learned performance adjustments
+        # (latency / success / empty-result history of real calls). Only when
+        # query-class signals matched at all — performance memory breaks close
+        # calls but never invents a winner out of silence.
+        adaptive_adjustments: Dict[str, float] = {}
+        if max(available.values()) > 0 and self.auto_config.get("adaptive_routing", True):
+            adaptive_adjustments = performance_adjustments(list(available))
+            if adaptive_adjustments:
+                available = {
+                    p: max(0.0, s + adaptive_adjustments.get(p, 0.0))
+                    for p, s in available.items()
+                }
+
         # Find the winner
         max_score = max(available.values())
 
@@ -994,6 +1039,7 @@ class QueryAnalyzer:
             "routing_policy": ROUTING_POLICY,
             "exa_depth": exa_depth,
             "scores": {p: round(s, 2) for p, s in available.items()},
+            "adaptive_adjustments": adaptive_adjustments,
             "winning_score": round(max_score, 2),
             "top_signals": [
                 {"matched": s["matched"], "weight": s["weight"]}

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/routing.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/routing.py
@@ -1,0 +1,1111 @@
+"""Routing v2 query analysis for Web Search Plus."""
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from config import DEFAULT_CONFIG, get_api_key
+from provider_registry import DEFAULT_PROVIDER_PRIORITY
+from quality import _choose_tie_winner
+
+
+ROUTING_POLICY = "routing-v2"
+
+
+class QueryAnalyzer:
+    """
+    Intelligent query analysis for smart provider routing.
+
+    Uses multi-signal analysis:
+    - Intent classification (shopping, research, discovery, local, news)
+    - Linguistic patterns (question structure, phrase patterns)
+    - Entity detection (products, brands, URLs, dates)
+    - Complexity assessment
+    """
+
+    # Intent signal patterns with weights
+    # Higher weight = stronger signal for that provider
+
+    SHOPPING_SIGNALS = {
+        # Price patterns (very strong)
+        r'\bhow much\b': 4.0,
+        r'\bprice of\b': 4.0,
+        r'\bcost of\b': 4.0,
+        r'\bprices?\b': 3.0,
+        r'\$\d+|\d+\s*dollars?': 3.0,
+        r'€\d+|\d+\s*euros?': 3.0,
+        r'£\d+|\d+\s*pounds?': 3.0,
+
+        # German price patterns (sehr stark)
+        r'\bpreis(e)?\b': 3.5,
+        r'\bkosten\b': 3.0,
+        r'\bwieviel\b': 3.5,
+        r'\bwie viel\b': 3.5,
+        r'\bwas kostet\b': 4.0,
+
+        # Purchase intent (strong)
+        r'\bbuy\b': 3.5,
+        r'\bpurchase\b': 3.5,
+        r'\border\b(?!\s+by)': 3.0,  # "order" but not "order by"
+        r'\bshopping\b': 3.5,
+        r'\bshop for\b': 3.5,
+        r'\bwhere to (buy|get|purchase)\b': 4.0,
+
+        # German purchase intent (stark)
+        r'\bkaufen\b': 3.5,
+        r'\bbestellen\b': 3.5,
+        r'\bwo kaufen\b': 4.0,
+        r'\bhändler\b': 3.0,
+        r'\bshop\b': 2.5,
+
+        # Deal/discount signals
+        r'\bdeal(s)?\b': 3.0,
+        r'\bdiscount(s)?\b': 3.0,
+        r'\bsale\b': 2.5,
+        r'\bcheap(er|est)?\b': 3.0,
+        r'\baffordable\b': 2.5,
+        r'\bbudget\b': 2.5,
+        r'\bbest price\b': 3.5,
+        r'\bcompare prices\b': 3.5,
+        r'\bcoupon\b': 3.0,
+
+        # German deal/discount signals
+        r'\bgünstig(er|ste)?\b': 3.0,
+        r'\bbillig(er|ste)?\b': 3.0,
+        r'\bangebot(e)?\b': 3.0,
+        r'\brabatt\b': 3.0,
+        r'\baktion\b': 2.5,
+        r'\bschnäppchen\b': 3.0,
+
+        # Product comparison
+        r'\bvs\.?\b': 2.0,
+        r'\bversus\b': 2.0,
+        r'\bor\b.*\bwhich\b': 2.0,
+        r'\bspecs?\b': 2.5,
+        r'\bspecifications?\b': 2.5,
+        r'\breview(s)?\b': 2.0,
+        r'\brating(s)?\b': 2.0,
+        r'\bunboxing\b': 2.5,
+
+        # German product comparison
+        r'\btest\b': 2.5,
+        r'\bbewertung(en)?\b': 2.5,
+        r'\btechnische daten\b': 3.0,
+        r'\bspezifikationen\b': 2.5,
+    }
+
+    RESEARCH_SIGNALS = {
+        # Explanation patterns (very strong)
+        r'\bhow does\b': 4.0,
+        r'\bhow do\b': 3.5,
+        r'\bwhy does\b': 4.0,
+        r'\bwhy do\b': 3.5,
+        r'\bwhy is\b': 3.5,
+        r'\bexplain\b': 4.0,
+        r'\bexplanation\b': 4.0,
+        r'\bwhat is\b': 3.0,
+        r'\bwhat are\b': 3.0,
+        r'\bdefine\b': 3.5,
+        r'\bdefinition of\b': 3.5,
+        r'\bmeaning of\b': 3.0,
+
+        # Analysis patterns (strong)
+        r'\banalyze\b': 3.5,
+        r'\banalysis\b': 3.5,
+        r'\bcompare\b(?!\s*prices?)': 3.0,  # compare but not "compare prices"
+        r'\bcomparison\b': 3.0,
+        r'\bstatus of\b': 3.5,
+        r'\bstatus\b': 2.5,
+        r'\bwhat happened with\b': 4.0,
+        r'\bpros and cons\b': 4.0,
+        r'\badvantages?\b': 3.0,
+        r'\bdisadvantages?\b': 3.0,
+        r'\bbenefits?\b': 2.5,
+        r'\bdrawbacks?\b': 3.0,
+        r'\bdifference between\b': 3.5,
+
+        # Learning patterns
+        r'\bunderstand\b': 3.0,
+        r'\blearn(ing)?\b': 2.5,
+        r'\btutorial\b': 3.0,
+        r'\bguide\b': 2.5,
+        r'\bhow to\b': 2.0,  # Lower weight - could be shopping too
+        r'\bstep by step\b': 3.0,
+
+        # Depth signals
+        r'\bin[- ]depth\b': 3.0,
+        r'\bdetailed\b': 2.5,
+        r'\bcomprehensive\b': 3.0,
+        r'\bthorough\b': 2.5,
+        r'\bdeep dive\b': 3.5,
+        r'\boverall\b': 2.0,
+        r'\bsummary\b': 2.0,
+
+        # Academic patterns
+        r'\bstudy\b': 2.5,
+        r'\bresearch shows\b': 3.5,
+        r'\baccording to\b': 2.5,
+        r'\bevidence\b': 3.0,
+        r'\bscientific\b': 3.0,
+        r'\bhistory of\b': 3.0,
+        r'\bbackground\b': 2.5,
+        r'\bcontext\b': 2.5,
+        r'\bimplications?\b': 3.0,
+
+        # German explanation patterns (sehr stark)
+        r'\bwie funktioniert\b': 4.0,
+        r'\bwarum\b': 3.5,
+        r'\berklär(en|ung)?\b': 4.0,
+        r'\bwas ist\b': 3.0,
+        r'\bwas sind\b': 3.0,
+        r'\bbedeutung\b': 3.0,
+
+        # German analysis patterns
+        r'\banalyse\b': 3.5,
+        r'\bvergleich(en)?\b': 3.0,
+        r'\bvor- und nachteile\b': 4.0,
+        r'\bvorteile\b': 3.0,
+        r'\bnachteile\b': 3.0,
+        r'\bunterschied(e)?\b': 3.5,
+
+        # German learning patterns
+        r'\bverstehen\b': 3.0,
+        r'\blernen\b': 2.5,
+        r'\banleitung\b': 3.0,
+        r'\bübersicht\b': 2.5,
+        r'\bhintergrund\b': 2.5,
+        r'\bzusammenfassung\b': 2.5,
+    }
+
+    DISCOVERY_SIGNALS = {
+        # Similarity patterns (very strong)
+        r'\bsimilar to\b': 5.0,
+        r'\blike\s+\w+\.com': 4.5,  # "like notion.com"
+        r'\balternatives? to\b': 5.0,
+        r'\bcompetitors? (of|to)\b': 4.5,
+        r'\bcompeting with\b': 4.0,
+        r'\brivals? (of|to)\b': 4.0,
+        r'\binstead of\b': 3.0,
+        r'\breplacement for\b': 3.5,
+
+        # Company/startup patterns (strong)
+        r'\bcompanies (like|that|doing|building)\b': 4.5,
+        r'\bstartups? (like|that|doing|building)\b': 4.5,
+        r'\bwho else\b': 4.0,
+        r'\bother (companies|startups|tools|apps)\b': 3.5,
+        r'\bfind (companies|startups|tools|examples?)\b': 4.5,
+        r'\bevents? in\b': 4.0,
+        r'\bthings to do in\b': 4.5,
+
+        # Funding/business patterns
+        r'\bseries [a-d]\b': 4.0,
+        r'\byc\b|y combinator': 4.0,
+        r'\bfund(ed|ing|raise)\b': 3.5,
+        r'\bventure\b': 3.0,
+        r'\bvaluation\b': 3.0,
+
+        # Category patterns
+        r'\bresearch papers? (on|about)\b': 4.0,
+        r'\barxiv\b': 4.5,
+        r'\bgithub (projects?|repos?)\b': 4.5,
+        r'\bopen source\b.*\bprojects?\b': 4.0,
+        r'\btweets? (about|on)\b': 3.5,
+        r'\bblogs? (about|on|like)\b': 3.0,
+
+        # URL detection (very strong signal for Exa similar)
+        r'https?://[^\s]+': 5.0,
+        r'\b\w+\.(com|org|io|ai|co|dev)\b': 3.5,
+    }
+
+    LOCAL_NEWS_SIGNALS = {
+        # Local patterns → Serper
+        r'\bnear me\b': 4.0,
+        r'\bnearby\b': 3.5,
+        r'\blocal\b': 3.0,
+        r'\bin (my )?(city|area|town|neighborhood)\b': 3.5,
+        r'\brestaurants?\b': 2.5,
+        r'\bhotels?\b': 2.5,
+        r'\bcafes?\b': 2.5,
+        r'\bstores?\b': 2.0,
+        r'\bdirections? to\b': 3.5,
+        r'\bmap of\b': 3.0,
+        r'\bphone number\b': 3.0,
+        r'\baddress of\b': 3.0,
+        r'\bopen(ing)? hours\b': 3.0,
+
+        # Weather/time
+        r'\bweather\b': 4.0,
+        r'\bforecast\b': 3.5,
+        r'\btemperature\b': 3.0,
+        r'\btime in\b': 3.0,
+
+        # News/recency patterns → Serper (or Tavily for news depth)
+        r'\blatest\b': 2.5,
+        r'\brecent\b': 2.5,
+        r'\btoday\b': 2.5,
+        r'\bbreaking\b': 3.5,
+        r'\bnews\b': 2.5,
+        r'\bheadlines?\b': 3.0,
+        r'\b202[4-9]\b': 2.0,  # Current year mentions
+        r'\blast (week|month|year)\b': 2.0,
+
+        # German local patterns
+        r'\bin der nähe\b': 4.0,
+        r'\bin meiner nähe\b': 4.0,
+        r'\böffnungszeiten\b': 3.0,
+        r'\badresse von\b': 3.0,
+        r'\bweg(beschreibung)? nach\b': 3.5,
+
+        # German news/recency patterns
+        r'\bheute\b': 2.5,
+        r'\bmorgen\b': 2.0,
+        r'\baktuell\b': 2.5,
+        r'\bnachrichten\b': 3.0,
+    }
+
+    # Source-grounded/RAG retrieval signals → Linkup
+    # Linkup is strongest when the user wants source-backed evidence for LLM grounding.
+    LINKUP_SOURCE_SIGNALS = {
+        r'\bcitations?\b': 5.0,
+        r'\bsources?\b': 4.5,
+        r'\bsource.?backed\b': 5.0,
+        r'\bwith sources\b': 5.0,
+        r'\bwith references\b': 5.0,
+        r'\breferences?\b': 4.5,
+        r'\bevidence\b': 4.5,
+        r'\bcredible sources?\b': 5.5,
+        r'\bprimary sources?\b': 5.0,
+        r'\bsupporting links?\b': 4.5,
+        r'\bverify (this|the)?\b': 4.5,
+        r'\bfact.?check\b': 5.0,
+        r'\bground(ed|ing)?\b': 4.5,
+        r'\bground this\b': 5.0,
+        r'\bclaim\b': 2.5,
+        r'\bfind (credible )?sources?\b': 5.5,
+        r'\bfind pages? that support\b': 5.0,
+        r'\bwhere did this come from\b': 5.0,
+        r'\bsource material\b': 4.0,
+    }
+
+    # RAG/AI signals → You.com
+    # You.com excels at providing LLM-ready snippets and combined web+news
+    RAG_SIGNALS = {
+        # RAG/context patterns (strong signal for You.com)
+        r'\brag\b': 4.5,
+        r'\bcontext for\b': 4.0,
+        r'\bsummarize\b': 3.5,
+        r'\bbrief(ly)?\b': 3.0,
+        r'\bquick overview\b': 3.5,
+        r'\btl;?dr\b': 4.0,
+        r'\bkey (points|facts|info)\b': 3.5,
+        r'\bmain (points|takeaways)\b': 3.5,
+
+        # Combined web + news queries
+        r'\b(web|online)\s+and\s+news\b': 4.0,
+        r'\ball sources\b': 3.5,
+        r'\bcomprehensive (search|overview)\b': 3.5,
+        r'\blatest\s+(news|updates)\b': 3.0,
+        r'\bcurrent (events|situation|status)\b': 3.5,
+
+        # Real-time information needs
+        r'\bright now\b': 3.0,
+        r'\bas of today\b': 3.5,
+        r'\bup.to.date\b': 3.5,
+        r'\breal.time\b': 4.0,
+        r'\blive\b': 2.5,
+
+        # Information synthesis
+        r'\bwhat\'?s happening with\b': 3.5,
+        r'\bwhat\'?s the latest\b': 4.0,
+        r'\bupdates?\s+on\b': 3.5,
+        r'\bstatus of\b': 3.0,
+        r'\bsituation (in|with|around)\b': 3.5,
+    }
+
+    # Direct answer / synthesis signals → Perplexity via Kilo Gateway
+    DIRECT_ANSWER_SIGNALS = {
+        r'\bwhat is\b': 3.0,
+        r'\bwhat are\b': 2.5,
+        r'\bcurrent status\b': 4.0,
+        r'\bstatus of\b': 3.5,
+        r'\bstatus\b': 2.5,
+        r'\bwhat happened with\b': 4.0,
+        r"\bwhat'?s happening with\b": 4.0,
+        r'\bas of (today|now)\b': 4.0,
+        r'\bthis weekend\b': 3.5,
+        r'\bevents? in\b': 3.5,
+        r'\bthings to do in\b': 4.0,
+        r'\bnear me\b': 3.0,
+        r'\bcan you (tell me|summarize|explain)\b': 3.5,
+        # German
+        r'\bwann\b': 3.0,
+        r'\bwer\b': 3.0,
+        r'\bwo\b': 2.5,
+        r'\bwie viele\b': 3.0,
+    }
+
+    # Privacy/Multi-source signals → SearXNG (self-hosted meta-search)
+    # SearXNG is ideal for privacy-focused queries and aggregating multiple sources
+    PRIVACY_SIGNALS = {
+        # Privacy signals (very strong)
+        r'\bprivate(ly)?\b': 4.0,
+        r'\banonymous(ly)?\b': 4.0,
+        r'\bwithout tracking\b': 4.5,
+        r'\bno track(ing)?\b': 4.5,
+        r'\bprivacy\b': 3.5,
+        r'\bprivacy.?focused\b': 4.5,
+        r'\bprivacy.?first\b': 4.5,
+        r'\bduckduckgo alternative\b': 4.5,
+        r'\bprivate search\b': 5.0,
+
+        # German privacy signals
+        r'\bprivat\b': 4.0,
+        r'\banonym\b': 4.0,
+        r'\bohne tracking\b': 4.5,
+        r'\bdatenschutz\b': 4.0,
+
+        # Multi-source aggregation signals
+        r'\baggregate results?\b': 4.0,
+        r'\bmultiple sources?\b': 4.0,
+        r'\bdiverse (results|perspectives|sources)\b': 4.0,
+        r'\bfrom (all|multiple|different) (engines?|sources?)\b': 4.5,
+        r'\bmeta.?search\b': 5.0,
+        r'\ball engines?\b': 4.0,
+
+        # German multi-source signals
+        r'\bverschiedene quellen\b': 4.0,
+        r'\baus mehreren quellen\b': 4.0,
+        r'\balle suchmaschinen\b': 4.5,
+
+        # Budget/free signals (SearXNG is self-hosted = $0 API cost)
+        r'\bfree search\b': 3.5,
+        r'\bno api cost\b': 4.0,
+        r'\bself.?hosted search\b': 5.0,
+        r'\bzero cost\b': 3.5,
+        r'\bbudget\b(?!\s*(laptop|phone|option))\b': 2.5,  # "budget" alone, not "budget laptop"
+
+        # German budget signals
+        r'\bkostenlos(e)?\s+suche\b': 3.5,
+        r'\bkeine api.?kosten\b': 4.0,
+    }
+
+    # Exa Deep Search signals → deep multi-source synthesis
+    EXA_DEEP_SIGNALS = {
+        r'\bsynthesi[sz]e\b': 5.0,
+        r'\bdeep research\b': 5.0,
+        r'\bcomprehensive (analysis|report|overview|survey)\b': 4.5,
+        r'\bacross (multiple|many|several) (sources|documents|papers)\b': 4.5,
+        r'\baggregat(e|ing) (information|data|results)\b': 4.0,
+        r'\bcross.?referenc': 4.5,
+        r'\bsec filings?\b': 4.5,
+        r'\bannual reports?\b': 4.0,
+        r'\bearnings (call|report|transcript)\b': 4.5,
+        r'\bfinancial analysis\b': 4.0,
+        r'\bliterature (review|survey)\b': 5.0,
+        r'\bacademic literature\b': 4.5,
+        r'\bstate of the (art|field|industry)\b': 4.0,
+        r'\bcompile (a |the )?(report|findings|results)\b': 4.5,
+        r'\bsummariz(e|ing) (research|papers|studies)\b': 4.0,
+        r'\bmultiple documents?\b': 4.0,
+        r'\bdossier\b': 4.5,
+        r'\bdue diligence\b': 4.5,
+        r'\bstructured (output|data|report)\b': 4.0,
+        r'\bmarket research\b': 4.0,
+        r'\bindustry (report|analysis|overview)\b': 4.0,
+        r'\bresearch (on|about|into)\b': 4.0,
+        r'\bwhitepaper\b': 4.5,
+        r'\btechnical report\b': 4.0,
+        r'\bsurvey of\b': 4.5,
+        r'\bmeta.?analysis\b': 5.0,
+        r'\bsystematic review\b': 5.0,
+        r'\bcase study\b': 3.5,
+        r'\bbenchmark(s|ing)?\b': 3.5,
+        # German
+        r'\btiefenrecherche\b': 5.0,
+        r'\bumfassende (analyse|übersicht|recherche)\b': 4.5,
+        r'\baus mehreren quellen zusammenfassen\b': 4.5,
+        r'\bmarktforschung\b': 4.0,
+    }
+
+    # Exa Deep Reasoning signals → complex cross-reference analysis
+    EXA_DEEP_REASONING_SIGNALS = {
+        r'\bdeep.?reasoning\b': 6.0,
+        r'\bcomplex (analysis|reasoning|research)\b': 4.5,
+        r'\bcontradictions?\b': 4.5,
+        r'\breconcil(e|ing)\b': 5.0,
+        r'\bcritical(ly)? analyz': 4.5,
+        r'\bweigh(ing)? (the )?evidence\b': 4.5,
+        r'\bcompeting (claims|theories|perspectives)\b': 4.5,
+        r'\bcomplex financial\b': 4.5,
+        r'\bregulatory (analysis|compliance|landscape)\b': 4.5,
+        r'\blegal analysis\b': 4.5,
+        r'\bcomprehensive (due diligence|investigation)\b': 5.0,
+        r'\bpatent (landscape|analysis|search)\b': 4.5,
+        r'\bmarket intelligence\b': 4.5,
+        r'\bcompetitive (intelligence|landscape)\b': 4.5,
+        r'\btrade.?offs?\b': 4.0,
+        r'\bpros and cons of\b': 4.0,
+        r'\bshould I (use|choose|pick)\b': 3.5,
+        r'\bwhich is better\b': 4.0,
+        # German
+        r'\bkomplexe analyse\b': 4.5,
+        r'\bwidersprüche\b': 4.5,
+        r'\bquellen abwägen\b': 4.5,
+        r'\brechtliche analyse\b': 4.5,
+        r'\bvergleich(e|en)?\b': 3.5,
+    }
+
+
+    # Brand/product patterns for shopping detection
+    BRAND_PATTERNS = [
+        # Tech brands
+        r'\b(apple|iphone|ipad|macbook|airpods?)\b',
+        r'\b(samsung|galaxy)\b',
+        r'\b(google|pixel)\b',
+        r'\b(microsoft|surface|xbox)\b',
+        r'\b(sony|playstation)\b',
+        r'\b(nvidia|geforce|rtx)\b',
+        r'\b(amd|ryzen|radeon)\b',
+        r'\b(intel|core i[3579])\b',
+        r'\b(dell|hp|lenovo|asus|acer)\b',
+        r'\b(lg|tcl|hisense)\b',
+
+        # Product categories
+        r'\b(laptop|phone|tablet|tv|monitor|headphones?|earbuds?)\b',
+        r'\b(camera|lens|drone)\b',
+        r'\b(watch|smartwatch|fitbit|garmin)\b',
+        r'\b(router|modem|wifi)\b',
+        r'\b(keyboard|mouse|gaming)\b',
+    ]
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self.auto_config = config.get("auto_routing", DEFAULT_CONFIG["auto_routing"])
+
+    def _calculate_signal_score(
+        self,
+        query: str,
+        signals: Dict[str, float]
+    ) -> Tuple[float, List[Dict[str, Any]]]:
+        """
+        Calculate score for a signal category.
+        Returns (total_score, list of matched signals with details).
+        """
+        query_lower = query.lower()
+        matches = []
+        total_score = 0.0
+
+        for pattern, weight in signals.items():
+            regex = re.compile(pattern, re.IGNORECASE)
+            found = regex.findall(query_lower)
+            if found:
+                # Normalize found matches
+                match_text = found[0] if isinstance(found[0], str) else found[0][0] if found[0] else pattern
+                matches.append({
+                    "pattern": pattern,
+                    "matched": match_text,
+                    "weight": weight
+                })
+                total_score += weight
+
+        return total_score, matches
+
+    def _detect_product_brand_combo(self, query: str) -> float:
+        """
+        Detect product + brand combinations which strongly indicate shopping intent.
+        Returns a bonus score.
+        """
+        query_lower = query.lower()
+        brand_found = False
+        product_found = False
+
+        for pattern in self.BRAND_PATTERNS:
+            if re.search(pattern, query_lower, re.IGNORECASE):
+                brand_found = True
+                break
+
+        # Check for product indicators
+        product_indicators = [
+            r'\b(buy|price|specs?|review|vs|compare)\b',
+            r'\b(pro|max|plus|mini|ultra|lite)\b',  # Product tier names
+            r'\b\d+\s*(gb|tb|inch|mm|hz)\b',  # Specifications
+        ]
+        for pattern in product_indicators:
+            if re.search(pattern, query_lower, re.IGNORECASE):
+                product_found = True
+                break
+
+        if brand_found and product_found:
+            return 3.0  # Strong shopping signal
+        elif brand_found:
+            return 1.5  # Moderate shopping signal
+        return 0.0
+
+    def _detect_url(self, query: str) -> Optional[str]:
+        """Detect URLs in query - strong signal for Exa similar search."""
+        url_pattern = r'https?://[^\s]+'
+        match = re.search(url_pattern, query)
+        if match:
+            return match.group()
+
+        # Also check for domain-like patterns
+        domain_pattern = r'\b(\w+\.(com|org|io|ai|co|dev|net|app))\b'
+        match = re.search(domain_pattern, query, re.IGNORECASE)
+        if match:
+            return match.group()
+
+        return None
+
+    def _assess_query_complexity(self, query: str) -> Dict[str, Any]:
+        """
+        Assess query complexity - complex queries favor Tavily.
+        """
+        words = query.split()
+        word_count = len(words)
+
+        # Count question words
+        question_words = len(re.findall(
+            r'\b(what|why|how|when|where|which|who|whose|whom)\b',
+            query, re.IGNORECASE
+        ))
+
+        # Check for multiple clauses
+        clause_markers = len(re.findall(
+            r'\b(and|but|or|because|since|while|although|if|when)\b',
+            query, re.IGNORECASE
+        ))
+
+        complexity_score = 0.0
+        if word_count > 10:
+            complexity_score += 1.5
+        if word_count > 20:
+            complexity_score += 1.0
+        if question_words > 1:
+            complexity_score += 1.0
+        if clause_markers > 0:
+            complexity_score += 0.5 * clause_markers
+
+        return {
+            "word_count": word_count,
+            "question_words": question_words,
+            "clause_markers": clause_markers,
+            "complexity_score": complexity_score,
+            "is_complex": complexity_score > 2.0
+        }
+
+    def _detect_recency_intent(self, query: str) -> Tuple[bool, float]:
+        """
+        Detect if query wants recent/timely information.
+        Returns (is_recency_focused, score).
+        """
+        recency_patterns = [
+            (r'\b(latest|newest|recent|current)\b', 2.5),
+            (r'\b(today|yesterday|this week|this month)\b', 3.0),
+            (r'\b(202[4-9]|2030)\b', 2.0),
+            (r'\b(breaking|live|just|now)\b', 3.0),
+            (r'\blast (hour|day|week|month)\b', 2.5),
+            # Common non-English freshness markers from the 25-query routing benchmark.
+            (r'\b(hoy|aujourd|heute|aktuell)\b', 2.5),
+            (r'[今日最新]', 2.5),
+            (r'(сегодня|новости)', 2.5),
+            (r'(اليوم|أخبار)', 2.5),
+            (r'(最新|今天)', 2.5),
+        ]
+
+        total = 0.0
+        for pattern, weight in recency_patterns:
+            if re.search(pattern, query, re.IGNORECASE):
+                total += weight
+
+        return total > 2.0, total
+
+    def _detect_language_hint(self, query: str) -> str:
+        """Best-effort language/script hint for routing; not user-facing translation."""
+        q = query.lower()
+        if re.search(r'[\u0600-\u06ff]', query):
+            return "ar"
+        if re.search(r'[\u0400-\u04ff]', query):
+            return "ru"
+        if re.search(r'[\u3040-\u30ff]', query) or re.search(r'(東京|ニュース|今日|企業|発表)', query):
+            return "ja"
+        if re.search(r'[\u4e00-\u9fff]', query):
+            return "zh"
+        if re.search(r'\b(noticias|españa|hoy|regulación|inteligencia artificial)\b', q):
+            return "es"
+        if re.search(r'\b(actualités|france|aujourd|ouverts?|dimanche|récents?|avis)\b', q):
+            return "fr"
+        if re.search(r'\b(der|die|das|und|oder|nicht|ist|sind|aktuelle?n?|preis|kaufen|öffnungszeiten|österreich)\b', q):
+            return "de"
+        return "en"
+
+    def _detect_routing_class(self, query: str, language_hint: str) -> str:
+        """Coarse class labels from the qualitative 25-query benchmark."""
+        q = query.lower()
+        # Synthesis/briefing queries should prefer broad real-time/search providers,
+        # but Web Search Plus no longer exposes a separate answer tool.
+        if re.search(r'\b(difference|differences|unterschiede|vergleich|compare|comparison|brief(?:ing)?|summari[sz]e|zusammenfass(?:en|ung)|was sind|what are)\b', q):
+            return "briefing_synthesis"
+        if re.search(r'\b(advisory|security advisory|cve|mitigation|openssl|openssh|vulnerability|zero[-\s]?day)\b', q):
+            return "security_advisory"
+        if re.search(r'\b(patent|patents|patentscope|espacenet|uspto|google patents)\b', q):
+            return "patents"
+        if re.search(r'\b(pdf|whitepaper|code of practice)\b', q) and re.search(r'\b(nist|eu ai act|regulation|regulatory|policy|commission|government|official|rmf)\b', q):
+            return "policy_pdf"
+        if re.search(r'\b(eu ai act|european commission|regulation|regulatory|obligations?)\b', q):
+            return "official_regulatory"
+        if re.search(r'\b(nvidia|earnings|gross margin|investor relations|guidance|10-[qk]|eps|revenue|quarterly results?)\b', q):
+            return "finance_earnings_official"
+        if re.search(r'\b(investor monthly|monthly factsheet|monthly report|aum|fund flows?)\b', q):
+            return "finance_investor_monthly"
+        if re.search(r'\bsite:\s*reddit\.com\b|\br/\w+|\breddit\s+(thread|post|community|users?|discussion|comments?)\b', q):
+            return "reddit_community"
+        if (
+            re.search(r'\b(geizhals|preis|prices?|buy|kaufen|österreich|austria|shop|händler|deal|angebot)\b', q)
+            and re.search(r'\b(sony|denon|iphone|samsung|bose|kef|marantz|yamaha|lg|asus|laptop|tv|headphones?|speaker|receiver|avc|wh-|[a-z]{1,5}[-\s]?\d{3,}[a-z0-9-]*)\b', q)
+        ):
+            if re.search(r'\b(review(s)?|test|tests?|vergleich|best|beste|under|unter|erfahrungen)\b', q):
+                return "shopping_reviews_local"
+            return "shopping_specs"
+        if re.search(r'\b(forum|forums|community|discussion|comments?|erfahrungen|review(s)?|measurements?|head-fi|audiosciencereview|hifi-forum)\b', q):
+            return "community_forum"
+        if re.search(r'\barxiv\b|\bpaper(s)?\b|\bscaling laws\b|\brandomi[sz]ed trial\b|\bprimary sources?\b', q):
+            return "academic_arxiv"
+        if re.search(r'\b(github\b|repo(sitory)?\b|plugin docs\b)', q):
+            return "github_docs"
+        if re.search(r'\b(official docs?|official documentation|api reference|developer docs?|official manual)\b', q):
+            return "official_docs"
+        if re.search(r'\b(official|release|announcement|launch|changelog|release notes?)\b', q) and re.search(r'\b(mistral|anthropic|openai|google|meta|nvidia|apple|microsoft|claude|gemini|llama)\b', q):
+            return "official_vendor_release"
+        if re.search(r'\b(python|pydantic|node\.js|api docs?|documentation|docs|changelog|release notes?|taskgroup|basemodel)\b', q):
+            return "docs_api"
+        if re.search(r'\b(official|regulatory filing|public authority)\b', q):
+            return "official_regulatory"
+        if re.search(r'\b(graz|öffnungszeiten|adresse|restaurants?|vegan|hifi team)\b', q):
+            return "local_at"
+        if re.search(r'\b(bundesliga|standings?|fixtures?|tabelle|punkte|spieltag|matchday|lineups?|scores?|sturm|salzburg|lask)\b|\b(league|liga|standings?|points?)\s+table\b', q):
+            return "sports_current"
+        if re.search(r'\b(wetter|weather|forecast|regen|rain)\b', q):
+            return "weather_local"
+        if re.search(r'\b(alternatives? to|open source|self hosted|competitors?|similar to)\b', q):
+            return "oss_discovery"
+        if language_hint not in {"en", "de"}:
+            return "multilingual_current"
+        return "general"
+
+    def _apply_vnext_routing_boosts(
+        self,
+        query: str,
+        provider_scores: Dict[str, float],
+        language_hint: str,
+        routing_class: str,
+        recency_score: float,
+    ) -> None:
+        """Apply conservative class-aware boosts from the qualitative routing benchmark.
+
+        Search auto-routing still avoids slow answer-only providers unless explicitly selected.
+        """
+        def boost(provider: str, value: float) -> None:
+            provider_scores[provider] = provider_scores.get(provider, 0.0) + value
+
+        def boost_many(items: List[Tuple[str, float]]) -> None:
+            for provider, value in items:
+                boost(provider, value)
+
+        # Script/language-aware current queries: You performed best as the safe fast default,
+        # with Exa/Firecrawl/Linkup useful by script. Keep this modest so strong class rules win.
+        if language_hint not in {"en", "de"}:
+            if language_hint == "zh":
+                boost_many([("exa", 7.0), ("you", 6.0), ("firecrawl", 4.0), ("linkup", 3.0), ("serper", 2.5)])
+            elif language_hint == "ar":
+                boost_many([("you", 8.0), ("linkup", 5.0), ("serper", 4.0), ("firecrawl", 2.0)])
+            else:
+                boost_many([("you", 8.0), ("exa", 5.0), ("firecrawl", 4.0), ("linkup", 3.0), ("tavily", 2.0)])
+            boost("you", min(recency_score, 3.0))
+
+        if routing_class == "shopping_at":
+            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)])
+        elif routing_class == "local_at":
+            boost_many([("firecrawl", 8.0), ("serper", 6.0), ("linkup", 4.0), ("you", 2.0)])
+        elif routing_class == "official_vendor_release":
+            boost_many([("you", 14.0), ("linkup", 10.0), ("exa", 7.0), ("serper", 4.0), ("firecrawl", 3.0)])
+        elif routing_class == "official_docs":
+            boost_many([("exa", 12.0), ("you", 7.0), ("firecrawl", 5.0), ("serper", 3.0), ("tavily", 2.0)])
+        elif routing_class == "policy_pdf":
+            boost_many([("linkup", 10.0), ("exa", 8.0), ("serper", 7.0), ("firecrawl", 6.0), ("you", 4.0)])
+        elif routing_class == "official_regulatory":
+            boost_many([("exa", 8.0), ("firecrawl", 6.0), ("serper", 5.0), ("you", 3.0)])
+        elif routing_class == "sports_current":
+            boost_many([("you", 8.0), ("serper", 6.0), ("linkup", 5.0), ("tavily", 2.0)])
+        elif routing_class == "github_docs":
+            boost_many([("exa", 10.0), ("you", 6.0), ("firecrawl", 5.0), ("serper", 4.0)])
+        elif routing_class == "docs_api":
+            boost_many([("serper", 6.0), ("exa", 5.0), ("you", 4.0), ("firecrawl", 3.0), ("tavily", 3.0)])
+        elif routing_class == "academic_arxiv":
+            boost_many([("exa", 12.0), ("serper", 3.0), ("linkup", 2.0), ("you", 1.5)])
+        elif routing_class == "oss_discovery":
+            boost_many([("exa", 8.0), ("firecrawl", 5.0), ("tavily", 4.0), ("you", 3.0)])
+        elif routing_class == "reddit_community":
+            boost_many([("serper", 10.0), ("firecrawl", 8.0), ("tavily", 6.0), ("exa", -20.0)])
+        elif routing_class == "security_advisory":
+            boost_many([("serper", 10.0), ("exa", 8.0), ("linkup", 5.0), ("you", 2.0), ("firecrawl", -20.0)])
+        elif routing_class == "finance_earnings_official":
+            boost_many([("linkup", 14.0), ("you", 9.0), ("exa", 7.0), ("serper", 6.0), ("firecrawl", 4.0)])
+        elif routing_class == "finance_investor_monthly":
+            boost_many([("linkup", 12.0), ("serper", 7.0), ("you", 5.0), ("exa", 4.0)])
+        elif routing_class == "community_forum":
+            boost_many([("firecrawl", 10.0), ("serper", 8.0), ("tavily", 5.0), ("you", 4.0), ("exa", -18.0)])
+        elif routing_class == "shopping_specs":
+            boost_many([("serper", 9.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)])
+        elif routing_class == "shopping_reviews_local":
+            boost_many([("serper", 9.0), ("firecrawl", 7.0), ("you", 4.0), ("tavily", 3.0), ("exa", -4.0)])
+        elif routing_class == "patents":
+            boost_many([("exa", 10.0), ("serper", 7.0), ("linkup", 4.0), ("you", 3.0)])
+        elif routing_class == "weather_local":
+            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("you", 2.0)])
+        elif routing_class == "briefing_synthesis":
+            boost_many([("you", 16.0), ("tavily", 4.0), ("linkup", 3.0), ("exa", 2.0)])
+
+    def analyze(self, query: str) -> Dict[str, Any]:
+        """
+        Perform comprehensive query analysis.
+        Returns detailed analysis with scores for each provider.
+        """
+        # Calculate scores for each intent category
+        shopping_score, shopping_matches = self._calculate_signal_score(
+            query, self.SHOPPING_SIGNALS
+        )
+        research_score, research_matches = self._calculate_signal_score(
+            query, self.RESEARCH_SIGNALS
+        )
+        discovery_score, discovery_matches = self._calculate_signal_score(
+            query, self.DISCOVERY_SIGNALS
+        )
+        local_news_score, local_news_matches = self._calculate_signal_score(
+            query, self.LOCAL_NEWS_SIGNALS
+        )
+        rag_score, rag_matches = self._calculate_signal_score(
+            query, self.RAG_SIGNALS
+        )
+        privacy_score, privacy_matches = self._calculate_signal_score(
+            query, self.PRIVACY_SIGNALS
+        )
+        linkup_source_score, linkup_source_matches = self._calculate_signal_score(
+            query, self.LINKUP_SOURCE_SIGNALS
+        )
+        direct_answer_score, direct_answer_matches = self._calculate_signal_score(
+            query, self.DIRECT_ANSWER_SIGNALS
+        )
+        exa_deep_score, exa_deep_matches = self._calculate_signal_score(
+            query, self.EXA_DEEP_SIGNALS
+        )
+        exa_deep_reasoning_score, exa_deep_reasoning_matches = self._calculate_signal_score(
+            query, self.EXA_DEEP_REASONING_SIGNALS
+        )
+
+        # Apply product/brand bonus to shopping
+        brand_bonus = self._detect_product_brand_combo(query)
+        if brand_bonus > 0:
+            shopping_score += brand_bonus
+            shopping_matches.append({
+                "pattern": "product_brand_combo",
+                "matched": "brand + product detected",
+                "weight": brand_bonus
+            })
+
+        # Detect URL → strong Exa signal
+        detected_url = self._detect_url(query)
+        if detected_url:
+            discovery_score += 5.0
+            discovery_matches.append({
+                "pattern": "url_detected",
+                "matched": detected_url,
+                "weight": 5.0
+            })
+
+        # Assess complexity → favors Tavily
+        complexity = self._assess_query_complexity(query)
+        if complexity["is_complex"]:
+            research_score += complexity["complexity_score"]
+            research_matches.append({
+                "pattern": "query_complexity",
+                "matched": f"complex query ({complexity['word_count']} words)",
+                "weight": complexity["complexity_score"]
+            })
+
+        # Check recency intent and benchmark-derived language/class hints
+        is_recency, recency_score = self._detect_recency_intent(query)
+        language_hint = self._detect_language_hint(query)
+        routing_class = self._detect_routing_class(query, language_hint)
+
+        # Map intents to providers with final scores
+        provider_scores = {
+            "serper": shopping_score + local_news_score + (recency_score * 0.35),
+            "serpbase": (shopping_score * 0.8) + (local_news_score * 0.8) + (recency_score * 0.25),
+            "brave": shopping_score + local_news_score + (recency_score * 0.35),
+            "tavily": research_score + (complexity["complexity_score"] if not complexity["is_complex"] else 0) + (0.2 * recency_score),
+            "querit": (research_score * 0.65) + (rag_score * 0.35) + (recency_score * 0.45),
+            "linkup": linkup_source_score + (rag_score * 0.7) + (research_score * 0.45) + (recency_score * 0.35),
+            "exa": discovery_score + (1.0 if re.search(r"\b(similar|alternatives?|examples?)\b", query, re.IGNORECASE) else 0.0) + (exa_deep_score * 0.5) + (exa_deep_reasoning_score * 0.5),
+            "perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
+            "kilo-perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
+            "you": rag_score + (recency_score * 0.25),  # You.com good for real-time + RAG
+            "searxng": privacy_score,  # SearXNG for privacy/multi-source queries
+            "firecrawl": discovery_score + (research_score * 0.35) + (recency_score * 0.25),
+        }
+        self._apply_vnext_routing_boosts(
+            query,
+            provider_scores,
+            language_hint,
+            routing_class,
+            recency_score,
+        )
+
+        # Build match details per provider
+        provider_matches = {
+            "serper": shopping_matches + local_news_matches,
+            "serpbase": shopping_matches + local_news_matches,
+            "brave": shopping_matches + local_news_matches,
+            "tavily": research_matches,
+            "querit": research_matches,
+            "linkup": linkup_source_matches + rag_matches + research_matches,
+            "exa": discovery_matches + exa_deep_matches + exa_deep_reasoning_matches,
+            "perplexity": direct_answer_matches,
+            "kilo-perplexity": direct_answer_matches,
+            "you": rag_matches,
+            "searxng": privacy_matches,
+            "firecrawl": discovery_matches + research_matches,
+        }
+
+        return {
+            "query": query,
+            "provider_scores": provider_scores,
+            "provider_matches": provider_matches,
+            "detected_url": detected_url,
+            "complexity": complexity,
+            "recency_focused": is_recency,
+            "recency_score": recency_score,
+            "language_hint": language_hint,
+            "routing_class": routing_class,
+            "linkup_source_score": linkup_source_score,
+            "exa_deep_score": exa_deep_score,
+            "exa_deep_reasoning_score": exa_deep_reasoning_score,
+        }
+
+    def route(self, query: str) -> Dict[str, Any]:
+        """
+        Route query to optimal provider with confidence scoring.
+        """
+        analysis = self.analyze(query)
+        scores = analysis["provider_scores"]
+
+        # Filter to available providers
+        disabled = set(self.auto_config.get("disabled_providers", []))
+        # Filter to configured providers that are eligible for automatic routing.
+        # Providers with auto_allow=false remain available for explicit calls.
+        auto_excluded = [
+            p for p in scores
+            if get_api_key(p, self.config) and p not in disabled and not _provider_auto_allowed(p, self.auto_config)
+        ]
+        available = {
+            p: s for p, s in scores.items()
+            if p not in disabled and _provider_auto_allowed(p, self.auto_config) and get_api_key(p, self.config)
+        }
+
+        if not available:
+            # No providers available, use fallback
+            fallback = self.auto_config.get("fallback_provider", "serper")
+            return {
+                "provider": fallback,
+                "confidence": 0.0,
+                "confidence_level": "low",
+                "reason": "no_available_providers",
+                "routing_policy": ROUTING_POLICY,
+                "scores": scores,
+                "top_signals": [],
+                "analysis": analysis,
+                "auto_allow_excluded": auto_excluded,
+            }
+
+        # Find the winner
+        max_score = max(available.values())
+
+        # Handle ties using deterministic per-query distribution
+        priority = self.auto_config.get("provider_priority", list(DEFAULT_PROVIDER_PRIORITY))
+        winners = [p for p, s in available.items() if s == max_score]
+
+        if len(winners) > 1:
+            winner = _choose_tie_winner(query, winners, priority)
+        else:
+            winner = winners[0]
+
+        # Calculate confidence
+        # High confidence = clear winner with good margin
+        if max_score == 0:
+            confidence = 0.0
+            reason = "no_signals_matched"
+        else:
+            # Confidence based on:
+            # 1. Absolute score (is it strong enough?)
+            # 2. Relative margin (is there a clear winner?)
+            second_best = sorted(available.values(), reverse=True)[1] if len(available) > 1 else 0
+            margin = (max_score - second_best) / max_score if max_score > 0 else 0
+
+            # Normalize score to 0-1 range (assuming max reasonable score ~15)
+            normalized_score = min(max_score / 15.0, 1.0)
+
+            # Confidence is combination of absolute strength and relative margin
+            confidence = round((normalized_score * 0.6 + margin * 0.4), 3)
+
+            if confidence >= 0.7:
+                reason = "high_confidence_match"
+            elif confidence >= 0.4:
+                reason = "moderate_confidence_match"
+            else:
+                reason = "low_confidence_match"
+
+        # Get top signals for the winning provider
+        matches = analysis["provider_matches"].get(winner, [])
+        top_signals = sorted(matches, key=lambda x: x["weight"], reverse=True)[:5]
+
+        # Special case: URL detected and Exa available → strong recommendation
+        if analysis["detected_url"] and "exa" in available:
+            if winner != "exa":
+                # Override if URL is present but didn't win
+                # (user might want similar search)
+                pass  # Keep current winner but note it
+
+        # Determine Exa search depth when routed to Exa
+        exa_depth = "normal"
+        if winner == "exa":
+            deep_r_score = analysis.get("exa_deep_reasoning_score", 0)
+            deep_score = analysis.get("exa_deep_score", 0)
+            if deep_r_score >= 4.0:
+                exa_depth = "deep-reasoning"
+            elif deep_score >= 4.0:
+                exa_depth = "deep"
+
+        # Build detailed routing result
+        threshold = self.auto_config.get("confidence_threshold", 0.3)
+
+        return {
+            "provider": winner,
+            "confidence": confidence,
+            "confidence_level": "high" if confidence >= 0.7 else "medium" if confidence >= 0.4 else "low",
+            "reason": reason,
+            "routing_policy": ROUTING_POLICY,
+            "exa_depth": exa_depth,
+            "scores": {p: round(s, 2) for p, s in available.items()},
+            "winning_score": round(max_score, 2),
+            "top_signals": [
+                {"matched": s["matched"], "weight": s["weight"]}
+                for s in top_signals
+            ],
+            "below_threshold": confidence < threshold,
+            "auto_allow_excluded": auto_excluded,
+            "analysis_summary": {
+                "query_length": len(query.split()),
+                "is_complex": analysis["complexity"]["is_complex"],
+                "has_url": analysis["detected_url"] is not None,
+                "recency_focused": analysis["recency_focused"],
+                "language_hint": analysis.get("language_hint", "en"),
+                "routing_class": analysis.get("routing_class", "general"),
+            }
+        }
+
+def auto_route_provider(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Intelligently route query to the best provider.
+    Returns detailed routing decision with confidence.
+    """
+    auto_config = config.get("auto_routing", DEFAULT_CONFIG["auto_routing"])
+    if auto_config.get("enabled", True) is False:
+        default_provider = config.get("default_provider")
+        if default_provider:
+            return {
+                "provider": default_provider,
+                "confidence": 1.0,
+                "confidence_level": "high",
+                "reason": "auto_routing_disabled_default_provider",
+                "scores": {default_provider: 1.0},
+                "top_signals": [],
+                "auto_routed": False,
+            }
+        return {
+            "provider": None,
+            "confidence": 0.0,
+            "confidence_level": "low",
+            "reason": "auto_routing_disabled_no_default_provider",
+            "scores": {},
+            "top_signals": [],
+            "auto_routed": False,
+        }
+    analyzer = QueryAnalyzer(config)
+    return analyzer.route(query)
+
+def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Provide detailed explanation of routing decision for debugging.
+    """
+    analyzer = QueryAnalyzer(config)
+    analysis = analyzer.analyze(query)
+    routing = analyzer.route(query)
+
+    return {
+        "query": query,
+        "routing_decision": {
+            "provider": routing["provider"],
+            "confidence": routing["confidence"],
+            "confidence_level": routing["confidence_level"],
+            "reason": routing["reason"],
+            "routing_policy": routing.get("routing_policy", ROUTING_POLICY),
+            "exa_depth": routing.get("exa_depth", "normal"),
+            "auto_allow_excluded": routing.get("auto_allow_excluded", []),
+        },
+        "scores": routing["scores"],
+        "top_signals": routing["top_signals"],
+        "intent_breakdown": {
+            "shopping_signals": len(analysis["provider_matches"]["serper"]),
+            "serpbase_signals": len(analysis["provider_matches"].get("serpbase", [])),
+            "brave_signals": len(analysis["provider_matches"]["brave"]),
+            "research_signals": len(analysis["provider_matches"]["tavily"]),
+            "querit_signals": len(analysis["provider_matches"]["querit"]),
+            "linkup_signals": len(analysis["provider_matches"].get("linkup", [])),
+            "linkup_source_score": round(analysis.get("linkup_source_score", 0), 2),
+            "discovery_signals": len(analysis["provider_matches"]["exa"]),
+            "rag_signals": len(analysis["provider_matches"]["you"]),
+            "exa_deep_score": round(analysis.get("exa_deep_score", 0), 2),
+            "exa_deep_reasoning_score": round(analysis.get("exa_deep_reasoning_score", 0), 2),
+            "firecrawl_signals": len(analysis["provider_matches"].get("firecrawl", [])),
+        },
+        "query_analysis": {
+            "word_count": analysis["complexity"]["word_count"],
+            "is_complex": analysis["complexity"]["is_complex"],
+            "complexity_score": round(analysis["complexity"]["complexity_score"], 2),
+            "has_url": analysis["detected_url"],
+            "recency_focused": analysis["recency_focused"],
+            "language_hint": analysis.get("language_hint", "en"),
+            "routing_class": analysis.get("routing_class", "general"),
+        },
+        "all_matches": {
+            provider: [
+                {"matched": m["matched"], "weight": m["weight"]}
+                for m in matches
+            ]
+            for provider, matches in analysis["provider_matches"].items()
+            if matches
+        },
+        "available_providers": [
+            p for p in ["serper", "serpbase", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"]
+            if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", []) and _provider_auto_allowed(p, config.get("auto_routing", {}))
+        ]
+    }
+
+def _provider_auto_allowed(provider: str, auto_config: Dict[str, Any]) -> bool:
+    """Return whether a configured provider may be selected by auto-routing/fallback.
+
+    Explicit provider calls still work; this gate only prevents low-trust or
+    experimental providers from receiving user queries automatically.
+    """
+    auto_allow = auto_config.get("auto_allow", {}) if isinstance(auto_config, dict) else {}
+    if not isinstance(auto_allow, dict):
+        return True
+    return bool(auto_allow.get(provider, True))

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/search.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/search.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.4.0
+Version: 2.8.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
-Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
-Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.
+Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
+Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable.
 
 Smart Routing uses multi-signal analysis:
   - Routing v2 language/script and query-class detection
@@ -54,7 +54,9 @@ from config import (  # noqa: F401 - re-exported for backward-compatible tests/i
     _validate_runtime_config,
     _validate_searxng_url,
     get_api_key,
+    keyless_public_allowed,
     load_config,
+    provider_configured,
     validate_api_key,
 )
 from provider_health import (  # noqa: F401 - re-exported for backward-compatible tests/imports
@@ -66,21 +68,26 @@ from provider_health import (  # noqa: F401 - re-exported for backward-compatibl
     provider_in_cooldown,
     reset_provider_health,
 )
+from provider_stats import record_provider_outcome
 from quality import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     _choose_tie_winner,
     _domain_matches_rule,
     build_authority_signals,
     build_quality_report,
     deduplicate_results_across_providers,
+    extract_domain_constraints,
+    filter_spam_results,
+    rerank_domain_diversity,
     rerank_results_for_intent,
     select_research_providers,
 )
-from provider_registry import SEARCH_PROVIDER_IDS, doctor_catalog
+from provider_registry import PROVIDER_SPECS, SEARCH_PROVIDER_IDS, doctor_catalog
 from env_loader import load_env_files
 from research import run_research_mode
 import providers as _providers
 import routing as _routing
 import extract as _extract
+import bench as _bench
 
 # Backward-compatible cache helper aliases for older imports/tests.
 get_cached_result = cache_get
@@ -278,6 +285,27 @@ def _sync_provider_dependencies() -> None:
     _providers.execute_provider_with_retry = execute_provider_with_retry
 
 
+# Unified freshness helpers (re-exported for tests and callers).
+FRESHNESS_VALUES = _providers.FRESHNESS_VALUES
+PROVIDER_FRESHNESS_FORMATS = _providers.PROVIDER_FRESHNESS_FORMATS
+
+
+def normalize_freshness(*args, **kwargs):
+    return _providers.normalize_freshness(*args, **kwargs)
+
+
+def provider_supports_freshness(*args, **kwargs):
+    return _providers.provider_supports_freshness(*args, **kwargs)
+
+
+def map_freshness_for_provider(*args, **kwargs):
+    return _providers.map_freshness_for_provider(*args, **kwargs)
+
+
+def freshness_metadata(*args, **kwargs):
+    return _providers.freshness_metadata(*args, **kwargs)
+
+
 def search_serper(*args, **kwargs):
     _sync_provider_dependencies()
     return _providers.search_serper(*args, **kwargs)
@@ -388,6 +416,16 @@ def search_searxng(*args, **kwargs):
     return _providers.search_searxng(*args, **kwargs)
 
 
+def search_keenable(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_keenable(*args, **kwargs)
+
+
+def extract_keenable(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_keenable(*args, **kwargs)
+
+
 
 # =============================================================================
 # Exa (Neural/Semantic/Deep Search)
@@ -442,6 +480,7 @@ def _sync_extract_dependencies() -> None:
     _extract.extract_exa = extract_exa
     _extract.extract_you = extract_you
     _extract.extract_parallel = extract_parallel
+    _extract.extract_keenable = extract_keenable
 
 
 EXTRACT_PROVIDER_PRIORITY = _extract.EXTRACT_PROVIDER_PRIORITY
@@ -496,12 +535,18 @@ def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[
             key_present = False
             errors.append(_doctor_error("config", "invalid provider configuration"))
 
+        spec_obj = PROVIDER_SPECS.get(provider)
+        keyless = bool(spec_obj and spec_obj.keyless)
+        keyless_enabled = keyless and keyless_public_allowed(provider, config)
+
         provider_report = {
             "provider": provider,
             "env_var": spec["env_var"],
             "search_capable": spec["search_capable"],
             "extract_capable": spec["extract_capable"],
             "key_present": key_present,
+            "keyless": keyless,
+            "keyless_public_enabled": keyless_enabled,
             "auto_allowed": _provider_auto_allowed(provider, auto_config),
             "disabled": provider in disabled,
             "cooldown": cooldown,
@@ -510,7 +555,7 @@ def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[
             provider_report["error"] = errors[0] if len(errors) == 1 else errors
         providers.append(provider_report)
 
-    usable = [p for p in providers if p["key_present"] and not p["disabled"]]
+    usable = [p for p in providers if (p["key_present"] or p["keyless_public_enabled"]) and not p["disabled"]]
     config_errors = [p for p in providers if _doctor_provider_has_error_type(p, "config")]
     return {
         "ok": bool(usable) and not config_errors,
@@ -531,6 +576,19 @@ def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[
     }
 
 
+def run_provider_bench(config: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+    """Run the in-process provider bakeoff (see bench.py) and return its report.
+
+    Passes this module as the provider seam so bench honours the same
+    monkeypatch surface as the rest of the pipeline (``search.search_you``
+    etc.), and never records provider health cooldowns or provider stats.
+    """
+    return _bench.run_bench(config, search_module=sys.modules[__name__], **kwargs)
+
+
+format_bench_text = _bench.format_bench_text
+
+
 def _format_doctor_text(report: Dict[str, Any]) -> str:
     lines = ["Web Search Plus Doctor", f"Mode: {report['mode']}", f"OK: {report['ok']}", "", "Providers:"]
     for provider in report["providers"]:
@@ -541,9 +599,13 @@ def _format_doctor_text(report: Dict[str, Any]) -> str:
             capabilities.append("extract")
         cooldown = provider["cooldown"]
         cooldown_text = f"cooldown {cooldown['remaining_seconds']}s" if cooldown["active"] else "no cooldown"
+        keyless_text = ""
+        if provider.get("keyless"):
+            keyless_text = f"keyless={'on' if provider.get('keyless_public_enabled') else 'off'} "
         lines.append(
             f"- {provider['provider']}: env={provider['env_var']} "
             f"key={'yes' if provider['key_present'] else 'no'} "
+            f"{keyless_text}"
             f"capabilities={','.join(capabilities)} "
             f"auto_allowed={'yes' if provider['auto_allowed'] else 'no'} "
             f"disabled={'yes' if provider['disabled'] else 'no'} "
@@ -608,11 +670,16 @@ Full docs: See README.md and SKILL.md
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["doctor"],
-        help="Run a maintenance command such as 'doctor'",
+        choices=["doctor", "bench"],
+        help="Run a maintenance command such as 'doctor' or 'bench'",
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON for maintenance commands")
     parser.add_argument("--live", action="store_true", help="Allow doctor to run live provider smokes (reserved; offline by default)")
+    parser.add_argument(
+        "--bench",
+        action="store_true",
+        help="Benchmark configured search providers against a fixed live query suite and recommend an auto_routing.provider_priority (alias for the 'bench' command; spends real provider quota)",
+    )
 
     # Common arguments
     parser.add_argument(
@@ -679,8 +746,19 @@ Full docs: See README.md and SKILL.md
         choices=["search", "news", "images", "videos", "places", "shopping"]
     )
     parser.add_argument(
-        "--time-range", 
+        "--time-range",
         choices=["hour", "day", "week", "month", "year"]
+    )
+    parser.add_argument(
+        "--freshness",
+        type=str.lower,
+        choices=list(_providers.FRESHNESS_VALUES),
+        help=(
+            "Unified recency filter (day, week, month, year; case-insensitive). "
+            "Applied natively where the provider supports it (serper, brave, querit, firecrawl, "
+            "keenable, you, perplexity, kilo-perplexity, searxng); otherwise the search runs "
+            "unfiltered and result metadata reports freshness.applied=false"
+        )
     )
     
     # Tavily-specific
@@ -778,11 +856,6 @@ Full docs: See README.md and SKILL.md
         default=you_config.get("safesearch", "moderate"),
         choices=["off", "moderate", "strict"],
         help="You.com SafeSearch filter"
-    )
-    parser.add_argument(
-        "--freshness",
-        choices=["day", "week", "month", "year"],
-        help="Filter results by recency (You.com/Serper)"
     )
     parser.add_argument(
         "--livecrawl",
@@ -895,7 +968,16 @@ def main():
         else:
             print(_format_doctor_text(report))
         return
-    
+
+    if args.command == "bench" or args.bench:
+        report = run_provider_bench(config, max_results=args.max_results)
+        if args.json or args.compact:
+            indent = None if args.compact else 2
+            print(json.dumps(report, indent=indent, ensure_ascii=False))
+        else:
+            print(format_bench_text(report))
+        return
+
     # Handle cache management commands first (before query validation)
     if args.clear_cache:
         result = cache_clear()
@@ -942,6 +1024,54 @@ def main():
     else:
         print(json.dumps(payload, indent=2), file=sys.stderr)
         sys.exit(1)
+
+
+def _apply_result_quality_pipeline(
+    result: Dict[str, Any],
+    config: Dict[str, Any],
+    query: str = "",
+    include_domains: Optional[List[str]] = None,
+) -> None:
+    """Filter mirror/SEO-spam domains and cap per-domain dominance, in place.
+
+    Explicit domain constraints (``site:`` operators, ``include_domains``)
+    express user intent and win: constrained domains are exempt from the spam
+    filter, and the diversity rerank is skipped entirely — a deliberately
+    one-domain query must not have its order shuffled.
+
+    Both steps are truthful: removals and demotions are reported in
+    ``result["metadata"]`` so quality reports and callers can see what changed.
+    """
+    results = result.get("results")
+    if not isinstance(results, list) or not results:
+        return
+    quality_config = config.get("quality") if isinstance(config.get("quality"), dict) else {}
+    constrained_domains = extract_domain_constraints(query, include_domains)
+    if quality_config.get("filter_spam", True):
+        allowed = list(quality_config.get("allowed_domains") or []) + constrained_domains
+        kept, removed_domains = filter_spam_results(
+            results,
+            extra_blocked=quality_config.get("blocked_domains"),
+            allowed=allowed,
+        )
+        if removed_domains:
+            result["results"] = kept
+            result.setdefault("metadata", {})["spam_filtered"] = {
+                "removed_count": len(results) - len(kept),
+                "domains": removed_domains,
+            }
+            results = kept
+    if constrained_domains:
+        return
+    try:
+        max_per_domain = int(quality_config.get("max_results_per_domain", 2))
+    except (TypeError, ValueError):
+        max_per_domain = 2
+    if max_per_domain > 0:
+        reranked, demoted = rerank_domain_diversity(results, max_per_domain=max_per_domain)
+        if demoted:
+            result["results"] = reranked
+            result.setdefault("metadata", {})["domain_diversity_demoted"] = demoted
 
 
 def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
@@ -1005,7 +1135,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
     providers_to_try = [provider] if provider else []
     if not strict_provider_mode:
         for p in provider_priority:
-            if p not in providers_to_try and p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config):
+            if p not in providers_to_try and p not in disabled_providers and _provider_auto_allowed(p, auto_config) and provider_configured(p, config):
                 providers_to_try.append(p)
 
     # Skip providers currently in cooldown
@@ -1032,7 +1162,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
                 country=args.country,
                 language=args.language,
                 search_type=args.search_type,
-                time_range=args.time_range,
+                time_range=args.time_range or args.freshness,
                 include_images=args.images,
             )
         elif prov == "serpbase":
@@ -1181,14 +1311,40 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
                 categories=args.categories,
                 engines=args.engines,
                 language=args.language,
-                time_range=args.time_range,
+                time_range=args.time_range or args.freshness,
                 safesearch=args.searxng_safesearch,
+            )
+        elif prov == "keenable":
+            keenable_config = config.get("keenable", {})
+            return search_keenable(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                time_range=args.time_range or args.freshness,
+                include_domains=args.include_domains,
+                public=keyless_public_allowed(prov, config),
+                api_url=keenable_config.get("search_url", "https://api.keenable.ai/v1/search"),
+                timeout=int(keenable_config.get("timeout", 30)),
             )
         else:
             raise ValueError(f"Unknown provider: {prov}")
 
     def execute_with_retry(prov: str) -> Dict[str, Any]:
-        return execute_provider_with_retry(prov, lambda: execute_search(prov))
+        started = time.monotonic()
+        try:
+            provider_result = execute_provider_with_retry(prov, lambda: execute_search(prov))
+        except ProviderRequestError:
+            # Only real provider interactions count as performance signal;
+            # config/validation errors (e.g. missing keys) are not recorded.
+            record_provider_outcome(prov, latency_seconds=time.monotonic() - started, result_count=0, error=True)
+            raise
+        record_provider_outcome(
+            prov,
+            latency_seconds=time.monotonic() - started,
+            result_count=len(provider_result.get("results", []) or []),
+            error=False,
+        )
+        return provider_result
 
     cache_context = {
         "locale": f"{args.country}:{args.language}",
@@ -1214,14 +1370,14 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
     if args.mode == "research":
         available_research_providers = {
             p for p in providers_to_try
-            if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+            if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and provider_configured(p, config) and not provider_in_cooldown(p)[0]
         }
-        if provider and get_api_key(provider, config) and not provider_in_cooldown(provider)[0]:
+        if provider and provider_configured(provider, config) and not provider_in_cooldown(provider)[0]:
             available_research_providers.add(provider)
         if args.research_providers:
             research_providers = [
                 p for p in args.research_providers
-                if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+                if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and provider_configured(p, config) and not provider_in_cooldown(p)[0]
             ]
         else:
             research_providers = select_research_providers(
@@ -1258,6 +1414,14 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
         routing_info["mode"] = "research"
         routing_info["provider"] = "research"
         result["routing"].update(routing_info)
+        if args.freshness:
+            result.setdefault("metadata", {})["freshness"] = {
+                "requested": args.freshness,
+                "providers": [
+                    _providers.freshness_metadata(p, args.freshness) for p in research_providers
+                ],
+            }
+        _apply_result_quality_pipeline(result, config, query=args.query or "", include_domains=args.include_domains)
         result["quality_report"] = build_quality_report(
             query=args.query,
             result=result,
@@ -1308,9 +1472,18 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             # Only continue collecting from lower-priority providers when fallback was needed.
             if not errors:
                 break
+        except ProviderConfigError as e:
+            # Missing/invalid local credentials are configuration errors, not
+            # provider health failures. Do not poison shared cooldown state for
+            # a provider the runtime never actually contacted.
+            errors.append({
+                "provider": current_provider,
+                "error": str(e),
+            })
+            continue
         except Exception as e:
             error_msg = str(e)
-            cooldown_info = mark_provider_failure(current_provider, error_msg)
+            cooldown_info = mark_provider_failure(current_provider, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({
                 "provider": current_provider,
                 "error": error_msg,
@@ -1356,8 +1529,14 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             result["results"] = reranked
             if rerank_metadata.get("reranked"):
                 result.setdefault("metadata", {})["intent_rerank"] = rerank_metadata
+            _apply_result_quality_pipeline(result, config, query=args.query or "", include_domains=args.include_domains)
 
         result["routing"] = routing_info
+
+        if args.freshness:
+            result.setdefault("metadata", {})["freshness"] = _providers.freshness_metadata(
+                successful_provider or provider, args.freshness
+            )
 
         if not cache_hit and not args.no_cache and args.query:
             cache_put(
@@ -1405,6 +1584,7 @@ def run_search_request(
     count: int = 5,
     exa_depth: str = "normal",
     time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
     include_domains: Optional[List[str]] = None,
     exclude_domains: Optional[List[str]] = None,
     mode: str = "normal",
@@ -1422,6 +1602,10 @@ def run_search_request(
     """
     if not query and not (include_domains or exclude_domains):
         return {"error": "query is required", "provider": provider, "query": query, "results": []}
+    try:
+        freshness = _providers.normalize_freshness(freshness)
+    except ValueError as exc:
+        return {"error": str(exc), "provider": provider, "query": query, "results": []}
     config = config or load_config()
     argv: List[str] = [
         "--query", query or "",
@@ -1432,6 +1616,8 @@ def run_search_request(
         argv += ["--exa-depth", exa_depth]
     if time_range and time_range != "none":
         argv += ["--time-range", time_range]
+    if freshness:
+        argv += ["--freshness", freshness]
     if include_domains:
         argv += ["--include-domains", *include_domains]
     if exclude_domains:

--- a/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/search.py
+++ b/.claude/skills/add-web-search-plus/resources/web-search-plus/engine/search.py
@@ -1,0 +1,1478 @@
+#!/usr/bin/env python3
+"""
+Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
+Version: 2.4.0
+Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
+Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
+Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.
+
+Smart Routing uses multi-signal analysis:
+  - Routing v2 language/script and query-class detection
+  - Query intent classification (shopping, research, discovery)
+  - Linguistic pattern detection (how much vs how does)
+  - Product/brand recognition
+  - URL detection
+  - Confidence scoring
+
+Usage:
+    python3 search.py --query "..."                    # Auto-route based on query
+    python3 search.py --provider [you|serper|exa|firecrawl|tavily|linkup|brave|serpbase|querit|perplexity|kilo-perplexity|searxng|auto] --query "..." [options]
+
+Examples:
+    python3 search.py -q "東京 AI ニュース 今日"              # → You.com (multilingual current)
+    python3 search.py -q "arXiv 2024 LLM scaling laws"      # → Exa (academic discovery)
+    python3 search.py -q "latest OpenSSH CVE mitigation"    # → Serper (security/current)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import List, Dict, Any, Optional, Tuple
+from http_client import (  # noqa: F401 - re-exported for backward-compatible tests/imports
+    ProviderRequestError,
+    TRANSIENT_HTTP_CODES,
+    _read_json_response,
+    _read_response_body,
+    make_get_request,
+    make_request,
+)
+from cache import (
+    CACHE_DIR,
+    DEFAULT_CACHE_TTL,
+    cache_clear,
+    cache_get,
+    cache_put,
+    cache_stats,
+)
+from config import (  # noqa: F401 - re-exported for backward-compatible tests/imports
+    DEFAULT_CONFIG,
+    ProviderConfigError,
+    _clean_env_value,
+    _deepcopy_default_config,
+    _validate_runtime_config,
+    _validate_searxng_url,
+    get_api_key,
+    load_config,
+    validate_api_key,
+)
+from provider_health import (  # noqa: F401 - re-exported for backward-compatible tests/imports
+    RETRY_BACKOFF_SECONDS,
+    RETRY_JITTER_FRACTION,
+    COOLDOWN_STEPS_SECONDS,
+    execute_provider_with_retry,
+    mark_provider_failure,
+    provider_in_cooldown,
+    reset_provider_health,
+)
+from quality import (  # noqa: F401 - re-exported for backward-compatible tests/imports
+    _choose_tie_winner,
+    _domain_matches_rule,
+    build_authority_signals,
+    build_quality_report,
+    deduplicate_results_across_providers,
+    rerank_results_for_intent,
+    select_research_providers,
+)
+from provider_registry import SEARCH_PROVIDER_IDS, doctor_catalog
+from env_loader import load_env_files
+from research import run_research_mode
+import providers as _providers
+import routing as _routing
+import extract as _extract
+
+# Backward-compatible cache helper aliases for older imports/tests.
+get_cached_result = cache_get
+cache_search_result = cache_put
+clear_cache = cache_clear
+get_cache_stats = cache_stats
+
+
+def _load_env_file():
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
+
+
+ROUTING_POLICY = "routing-v2"
+
+COMPATIBILITY_SHIM_DEPRECATION = {
+    "public_surface": [
+        "QueryAnalyzer",
+        "auto_route_provider",
+        "search_provider",
+        "extract_plus",
+        "get_cached_result",
+        "cache_search_result",
+        "clear_cache",
+        "get_cache_stats",
+    ],
+    "internal_shims": [
+        "_sync_routing_dependencies",
+        "_sync_provider_dependencies",
+        "_sync_extract_dependencies",
+        "provider function wrappers",
+    ],
+    "removal_target": "after ProviderSpec registry stabilization and one documented minor release window",
+    "tracking_issue": "#34",
+    "policy": "Keep search.py imports working while tests/users migrate to module-level seams; do not remove wrappers in feature PRs.",
+}
+
+
+def get_compatibility_shim_policy() -> Dict[str, Any]:
+    """Return the documented compatibility-shim policy for tests and release notes."""
+    return {
+        key: value.copy() if isinstance(value, list) else value
+        for key, value in COMPATIBILITY_SHIM_DEPRECATION.items()
+    }
+
+
+def _sync_routing_dependencies() -> None:
+    """Keep moved routing implementation compatible with search.py monkeypatches.
+
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
+    """
+    _routing.get_api_key = get_api_key
+
+
+class QueryAnalyzer(_routing.QueryAnalyzer):
+    def __init__(self, *args, **kwargs):
+        _sync_routing_dependencies()
+        super().__init__(*args, **kwargs)
+
+
+def auto_route_provider(*args, **kwargs):
+    _sync_routing_dependencies()
+    return _routing.auto_route_provider(*args, **kwargs)
+
+
+def explain_routing(*args, **kwargs):
+    _sync_routing_dependencies()
+    return _routing.explain_routing(*args, **kwargs)
+
+
+def _provider_auto_allowed(*args, **kwargs):
+    return _routing._provider_auto_allowed(*args, **kwargs)
+
+
+
+
+
+
+# =============================================================================
+# Intelligent Auto-Routing Engine
+# =============================================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ProviderRequestError and TRANSIENT_HTTP_CODES live in http_client.py.
+# Provider cooldown/backoff constants live in provider_health.py.
+
+
+
+
+
+
+# =============================================================================
+# HTTP Client
+# =============================================================================
+
+
+
+# HTTP request helpers live in http_client.py and are imported above for backward-compatible monkeypatching.
+
+
+# =============================================================================
+# Serper (Google Search API)
+# =============================================================================
+
+
+
+# =============================================================================
+# SerpBase (Google SERP API)
+# =============================================================================
+
+
+
+
+
+
+
+# =============================================================================
+# Brave Search
+# =============================================================================
+
+
+
+# =============================================================================
+# Tavily (Research Search)
+# =============================================================================
+
+
+
+# =============================================================================
+# Querit (Multi-lingual search API for AI, with rich metadata and real-time information)
+# =============================================================================
+
+
+
+
+
+# =============================================================================
+# Linkup Search
+# =============================================================================
+
+
+
+# =============================================================================
+# Firecrawl Search
+# =============================================================================
+
+
+
+
+
+# =============================================================================
+# Extract Plus (URL Content Extraction)
+# =============================================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def _sync_provider_dependencies() -> None:
+    """Keep moved provider implementations compatible with search.py monkeypatches.
+
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
+    """
+    _providers.make_request = make_request
+    _providers.make_get_request = make_get_request
+    _providers.get_api_key = get_api_key
+    _providers.load_config = load_config
+    _providers.provider_in_cooldown = provider_in_cooldown
+    _providers.mark_provider_failure = mark_provider_failure
+    _providers.reset_provider_health = reset_provider_health
+    _providers.execute_provider_with_retry = execute_provider_with_retry
+
+
+def search_serper(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_serper(*args, **kwargs)
+
+
+def _strip_tracking_params(*args, **kwargs):
+    return _providers._strip_tracking_params(*args, **kwargs)
+
+
+def _serpbase_related_search_query(*args, **kwargs):
+    return _providers._serpbase_related_search_query(*args, **kwargs)
+
+
+def search_serpbase(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_serpbase(*args, **kwargs)
+
+
+def search_brave(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_brave(*args, **kwargs)
+
+
+def search_tavily(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_tavily(*args, **kwargs)
+
+
+def _map_querit_time_range(*args, **kwargs):
+    return _providers._map_querit_time_range(*args, **kwargs)
+
+
+def search_querit(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_querit(*args, **kwargs)
+
+
+def search_linkup(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_linkup(*args, **kwargs)
+
+
+def _map_firecrawl_time_range(*args, **kwargs):
+    return _providers._map_firecrawl_time_range(*args, **kwargs)
+
+
+def search_firecrawl(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_firecrawl(*args, **kwargs)
+
+
+def _normalize_extract_result(*args, **kwargs):
+    return _providers._normalize_extract_result(*args, **kwargs)
+
+
+def extract_firecrawl(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_firecrawl(*args, **kwargs)
+
+
+def extract_linkup(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_linkup(*args, **kwargs)
+
+
+def extract_tavily(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_tavily(*args, **kwargs)
+
+
+def extract_exa(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_exa(*args, **kwargs)
+
+
+def extract_you(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_you(*args, **kwargs)
+
+
+def extract_parallel(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.extract_parallel(*args, **kwargs)
+
+
+def search_exa(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_exa(*args, **kwargs)
+
+
+def search_parallel(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_parallel(*args, **kwargs)
+
+
+def search_perplexity(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_perplexity(*args, **kwargs)
+
+
+def search_you(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_you(*args, **kwargs)
+
+
+def search_searxng(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_searxng(*args, **kwargs)
+
+
+
+# =============================================================================
+# Exa (Neural/Semantic/Deep Search)
+# =============================================================================
+
+
+
+# =============================================================================
+# Parallel (LLM-ready web search)
+# =============================================================================
+
+
+
+# =============================================================================
+# Perplexity-compatible Direct Answers
+# =============================================================================
+
+
+
+
+# =============================================================================
+# You.com (LLM-Ready Web & News Search)
+# =============================================================================
+
+
+
+# =============================================================================
+# SearXNG (Privacy-First Meta-Search)
+# =============================================================================
+
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+
+def _sync_extract_dependencies() -> None:
+    """Keep moved extract orchestrator compatible with search.py monkeypatches.
+
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
+    """
+    _extract.get_api_key = get_api_key
+    _extract.load_config = load_config
+    _extract.provider_in_cooldown = provider_in_cooldown
+    _extract.mark_provider_failure = mark_provider_failure
+    _extract.reset_provider_health = reset_provider_health
+    _extract.execute_provider_with_retry = execute_provider_with_retry
+    _extract.extract_firecrawl = extract_firecrawl
+    _extract.extract_linkup = extract_linkup
+    _extract.extract_tavily = extract_tavily
+    _extract.extract_exa = extract_exa
+    _extract.extract_you = extract_you
+    _extract.extract_parallel = extract_parallel
+
+
+EXTRACT_PROVIDER_PRIORITY = _extract.EXTRACT_PROVIDER_PRIORITY
+
+
+PROVIDER_DOCTOR_CATALOG = doctor_catalog()
+
+
+def extract_plus(*args, **kwargs):
+    _sync_extract_dependencies()
+    return _extract.extract_plus(*args, **kwargs)
+
+
+def _doctor_error(error_type: str, message: str) -> Dict[str, str]:
+    """Return a deliberately sanitized doctor error.
+
+    Doctor output is often pasted into issues/support chats. Keep it useful without
+    echoing private URLs, filesystem paths, tokens, or corrupt raw cache values.
+    """
+    safe_messages = {
+        "config": "Provider configuration is invalid; inspect local config/env for this provider.",
+        "cooldown": "Provider health cache has an invalid cooldown entry; reset provider health cache if it persists.",
+    }
+    return {"type": error_type, "message": safe_messages.get(error_type, "Provider diagnostic failed.")}
+
+
+def _doctor_provider_has_error_type(provider_report: Dict[str, Any], error_type: str) -> bool:
+    error = provider_report.get("error")
+    if isinstance(error, dict):
+        return error.get("type") == error_type
+    if isinstance(error, list):
+        return any(isinstance(item, dict) and item.get("type") == error_type for item in error)
+    return False
+
+
+def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[str, Any]:
+    auto_config = config.get("auto_routing", {})
+    disabled = set(auto_config.get("disabled_providers", []) or [])
+    providers = []
+    for provider, spec in PROVIDER_DOCTOR_CATALOG.items():
+        errors = []
+        try:
+            in_cooldown, remaining = provider_in_cooldown(provider)
+            cooldown = {"active": bool(in_cooldown), "remaining_seconds": int(remaining)}
+        except (TypeError, ValueError):
+            cooldown = {"active": False, "remaining_seconds": 0}
+            errors.append(_doctor_error("cooldown", "invalid provider health cache value"))
+
+        try:
+            key_present = bool(get_api_key(provider, config))
+        except (ProviderConfigError, ValueError):
+            key_present = False
+            errors.append(_doctor_error("config", "invalid provider configuration"))
+
+        provider_report = {
+            "provider": provider,
+            "env_var": spec["env_var"],
+            "search_capable": spec["search_capable"],
+            "extract_capable": spec["extract_capable"],
+            "key_present": key_present,
+            "auto_allowed": _provider_auto_allowed(provider, auto_config),
+            "disabled": provider in disabled,
+            "cooldown": cooldown,
+        }
+        if errors:
+            provider_report["error"] = errors[0] if len(errors) == 1 else errors
+        providers.append(provider_report)
+
+    usable = [p for p in providers if p["key_present"] and not p["disabled"]]
+    config_errors = [p for p in providers if _doctor_provider_has_error_type(p, "config")]
+    return {
+        "ok": bool(usable) and not config_errors,
+        "mode": "live" if live else "offline",
+        "config": {
+            "auto_routing_enabled": auto_config.get("enabled", True),
+            "default_provider": config.get("default_provider"),
+            "fallback_provider": auto_config.get("fallback_provider"),
+            "disabled_providers": sorted(disabled),
+        },
+        "cache": {
+            "dir": str(CACHE_DIR),
+            "exists": CACHE_DIR.exists(),
+            "writable": os.access(CACHE_DIR if CACHE_DIR.exists() else CACHE_DIR.parent, os.W_OK),
+            "provider_health_file": str(CACHE_DIR / "provider_health.json"),
+        },
+        "providers": providers,
+    }
+
+
+def _format_doctor_text(report: Dict[str, Any]) -> str:
+    lines = ["Web Search Plus Doctor", f"Mode: {report['mode']}", f"OK: {report['ok']}", "", "Providers:"]
+    for provider in report["providers"]:
+        capabilities = []
+        if provider["search_capable"]:
+            capabilities.append("search")
+        if provider["extract_capable"]:
+            capabilities.append("extract")
+        cooldown = provider["cooldown"]
+        cooldown_text = f"cooldown {cooldown['remaining_seconds']}s" if cooldown["active"] else "no cooldown"
+        lines.append(
+            f"- {provider['provider']}: env={provider['env_var']} "
+            f"key={'yes' if provider['key_present'] else 'no'} "
+            f"capabilities={','.join(capabilities)} "
+            f"auto_allowed={'yes' if provider['auto_allowed'] else 'no'} "
+            f"disabled={'yes' if provider['disabled'] else 'no'} "
+            f"{cooldown_text}"
+        )
+    lines.extend(["", f"Cache: {report['cache']['dir']} (writable={report['cache']['writable']})"])
+    return "\n".join(lines)
+
+
+def build_parser_for_tests() -> argparse.ArgumentParser:
+    """Return a minimal parser exposing registry-backed provider choices for drift tests."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--provider",
+        "-p",
+        choices=[*SEARCH_PROVIDER_IDS, "auto"],
+        help="Search provider (auto=intelligent routing)",
+    )
+    return parser
+
+
+def build_parser(config: Dict[str, Any]) -> argparse.ArgumentParser:
+    """Build the search.py CLI argument parser.
+
+    Shared by the CLI ``main()`` entry and the in-process ``run_search_request``
+    helper so the Hermes plugin can route argv through the exact same parsing and
+    defaults without spawning a subprocess.
+    """
+    parser = argparse.ArgumentParser(
+        description="Web Search Plus — Intelligent multi-provider search with smart auto-routing",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Intelligent Auto-Routing:
+  The query is analyzed using multi-signal detection to find the optimal provider:
+  
+  Shopping Intent → Serper (Google)
+    "how much", "price of", "buy", product+brand combos, deals, specs
+  
+  Research Intent → Tavily  
+    "how does", "explain", "what is", analysis, pros/cons, tutorials
+
+  Multilingual + Real-Time AI Search → Querit
+    multilingual search, metadata-rich results, current information for AI workflows
+  
+  Discovery Intent → Exa (Neural)
+    "similar to", "companies like", "alternatives", URLs, startups, papers
+
+  Direct Answer Intent → Perplexity (via Kilo Gateway)
+    "what is", "current status", local events, synthesized up-to-date answers
+
+Examples:
+  python3 search.py -q "iPhone 16 Pro Max price"          # → Serper (shopping)
+  python3 search.py -q "how does HTTPS encryption work"   # → Tavily (research)
+  python3 search.py -q "startups similar to Notion"       # → Exa (discovery)
+  python3 search.py --explain-routing -q "your query"     # Debug routing
+
+Full docs: See README.md and SKILL.md
+        """,
+    )
+    
+    # Command arguments
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["doctor"],
+        help="Run a maintenance command such as 'doctor'",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON for maintenance commands")
+    parser.add_argument("--live", action="store_true", help="Allow doctor to run live provider smokes (reserved; offline by default)")
+
+    # Common arguments
+    parser.add_argument(
+        "--provider", "-p", 
+        choices=[*SEARCH_PROVIDER_IDS, "auto"],
+        help="Search provider (auto=intelligent routing)"
+    )
+    parser.add_argument(
+        "--query", "-q", 
+        help="Search query"
+    )
+    parser.add_argument(
+        "--extract-urls",
+        nargs="*",
+        help="Extract content from one or more URLs instead of running a search"
+    )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        default="markdown",
+        choices=["markdown", "html"],
+        help="Extraction output format"
+    )
+    parser.add_argument("--extract-images", action="store_true", help="Extract image metadata when supported")
+    parser.add_argument("--include-raw-html", action="store_true", help="Include raw HTML when supported")
+    parser.add_argument("--render-js", action="store_true", help="Render JavaScript before extraction when supported")
+    parser.add_argument(
+        "--max-results", "-n", 
+        type=int, 
+        default=config.get("defaults", {}).get("max_results", 5),
+        help="Maximum results (default: 5)"
+    )
+    parser.add_argument(
+        "--images", 
+        action="store_true",
+        help="Include images (Serper/Tavily)"
+    )
+    
+    # Auto-routing options
+    parser.add_argument(
+        "--auto", "-a",
+        action="store_true",
+        help="Use intelligent auto-routing (default when no provider specified)"
+    )
+    parser.add_argument(
+        "--allow-fallback",
+        action="store_true",
+        help="Allow explicit --provider calls to fall back to other configured providers on failure. Auto-routing already uses fallback."
+    )
+    parser.add_argument(
+        "--explain-routing",
+        action="store_true",
+        help="Show detailed routing analysis (debug mode)"
+    )
+    
+    # Serper-specific
+    serper_config = config.get("serper", {})
+    parser.add_argument("--country", default=serper_config.get("country", "us"))
+    parser.add_argument("--language", default=serper_config.get("language", "en"))
+    parser.add_argument(
+        "--type", 
+        dest="search_type", 
+        default=serper_config.get("type", "search"),
+        choices=["search", "news", "images", "videos", "places", "shopping"]
+    )
+    parser.add_argument(
+        "--time-range", 
+        choices=["hour", "day", "week", "month", "year"]
+    )
+    
+    # Tavily-specific
+    tavily_config = config.get("tavily", {})
+    parser.add_argument(
+        "--depth", 
+        default=tavily_config.get("depth", "basic"), 
+        choices=["basic", "advanced"]
+    )
+    parser.add_argument(
+        "--topic", 
+        default=tavily_config.get("topic", "general"), 
+        choices=["general", "news"]
+    )
+    parser.add_argument("--raw-content", action="store_true")
+    
+    # Querit-specific
+    querit_config = config.get("querit", {})
+    parser.add_argument(
+        "--querit-base-url",
+        default=querit_config.get("base_url", "https://api.querit.ai"),
+        help="Querit API base URL"
+    )
+    parser.add_argument(
+        "--querit-base-path",
+        default=querit_config.get("base_path", "/v1/search"),
+        help="Querit API path"
+    )
+
+    # Linkup-specific
+    linkup_config = config.get("linkup", {})
+    parser.add_argument(
+        "--linkup-depth",
+        default=linkup_config.get("depth", "standard"),
+        choices=["fast", "standard", "deep"],
+        help="Linkup search depth: fast, standard, or deep"
+    )
+    parser.add_argument(
+        "--linkup-output-type",
+        default=linkup_config.get("output_type", "searchResults"),
+        choices=["searchResults", "sourcedAnswer"],
+        help="Linkup output type"
+    )
+
+    # Exa-specific
+    exa_config = config.get("exa", {})
+    parser.add_argument(
+        "--exa-type",
+        default=exa_config.get("type", "neural"),
+        choices=["neural", "fast", "auto", "keyword", "instant"],
+        help="Exa search type (for standard search, ignored when --exa-depth is set)"
+    )
+    parser.add_argument(
+        "--exa-depth",
+        default=exa_config.get("depth", "normal"),
+        choices=["normal", "deep", "deep-reasoning"],
+        help="Exa search depth: deep (synthesized, 4-12s), deep-reasoning (cross-reference, 12-50s)"
+    )
+    parser.add_argument(
+        "--exa-verbosity",
+        default=exa_config.get("verbosity", "standard"),
+        choices=["compact", "standard", "full"],
+        help="Exa text verbosity for content extraction"
+    )
+    parser.add_argument(
+        "--category",
+        choices=[
+            "company", "research paper", "news", "pdf", "github", 
+            "tweet", "personal site", "linkedin profile"
+        ]
+    )
+    parser.add_argument("--start-date")
+    parser.add_argument("--end-date")
+    parser.add_argument("--similar-url")
+
+    # Firecrawl-specific
+    firecrawl_config = config.get("firecrawl", {})
+    parser.add_argument(
+        "--firecrawl-scrape",
+        action="store_true",
+        help="Firecrawl: scrape result pages and include markdown as raw_content"
+    )
+    parser.add_argument(
+        "--firecrawl-sources",
+        nargs="+",
+        default=firecrawl_config.get("sources", ["web"]),
+        choices=["web", "news", "images"],
+        help="Firecrawl result sources"
+    )
+    
+    # You.com-specific
+    you_config = config.get("you", {})
+    parser.add_argument(
+        "--you-safesearch",
+        default=you_config.get("safesearch", "moderate"),
+        choices=["off", "moderate", "strict"],
+        help="You.com SafeSearch filter"
+    )
+    parser.add_argument(
+        "--freshness",
+        choices=["day", "week", "month", "year"],
+        help="Filter results by recency (You.com/Serper)"
+    )
+    parser.add_argument(
+        "--livecrawl",
+        choices=["web", "news", "all"],
+        help="You.com: fetch full page content"
+    )
+    parser.add_argument(
+        "--no-news",
+        action="store_true",
+        help="You.com: exclude news results (included by default)"
+    )
+    
+    # SearXNG-specific
+    searxng_config = config.get("searxng", {})
+    parser.add_argument(
+        "--searxng-url",
+        default=searxng_config.get("instance_url"),
+        help="SearXNG instance URL (e.g., https://searx.example.com)"
+    )
+    parser.add_argument(
+        "--searxng-safesearch",
+        type=int,
+        default=searxng_config.get("safesearch", 0),
+        choices=[0, 1, 2],
+        help="SearXNG SafeSearch: 0=off, 1=moderate, 2=strict"
+    )
+    parser.add_argument(
+        "--engines",
+        nargs="+",
+        default=searxng_config.get("engines"),
+        help="SearXNG: specific engines to use (e.g., google bing duckduckgo)"
+    )
+    parser.add_argument(
+        "--categories",
+        nargs="+",
+        help="SearXNG: search categories (general, images, news, videos, etc.)"
+    )
+    
+    # Domain filters
+    parser.add_argument("--include-domains", nargs="+")
+    parser.add_argument("--exclude-domains", nargs="+")
+    
+    # Output
+    parser.add_argument("--compact", action="store_true")
+    parser.add_argument(
+        "--quality-report",
+        action="store_true",
+        help="Attach transparent routing/result diagnostics to the JSON output"
+    )
+    parser.add_argument(
+        "--mode",
+        default="normal",
+        choices=["normal", "research"],
+        help="Search mode: normal single-provider route or research multi-provider + extraction"
+    )
+    parser.add_argument(
+        "--research-providers",
+        nargs="+",
+        help="Explicit provider list for --mode research"
+    )
+    parser.add_argument(
+        "--research-extract-count",
+        type=int,
+        default=3,
+        help="Number of top research-mode URLs to extract for grounding"
+    )
+    parser.add_argument(
+        "--research-time-budget",
+        type=float,
+        default=55.0,
+        help="Best-effort wall-clock budget for research mode; skips remaining providers/extraction between calls when exhausted"
+    )
+    
+    # Caching options
+    parser.add_argument(
+        "--cache-ttl",
+        type=int,
+        default=DEFAULT_CACHE_TTL,
+        help=f"Cache TTL in seconds (default: {DEFAULT_CACHE_TTL} = 1 hour)"
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Bypass cache (always fetch fresh results)"
+    )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear all cached results and exit"
+    )
+    parser.add_argument(
+        "--cache-stats",
+        action="store_true",
+        help="Show cache statistics and exit"
+    )
+
+    return parser
+
+
+def main():
+    config = load_config()
+    parser = build_parser(config)
+    args = parser.parse_args()
+
+    if args.command == "doctor":
+        report = _build_doctor_report(config, live=args.live)
+        if args.json or args.compact:
+            indent = None if args.compact else 2
+            print(json.dumps(report, indent=indent, ensure_ascii=False))
+        else:
+            print(_format_doctor_text(report))
+        return
+    
+    # Handle cache management commands first (before query validation)
+    if args.clear_cache:
+        result = cache_clear()
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
+    
+    if args.cache_stats:
+        result = cache_stats()
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
+
+    if args.extract_urls is not None:
+        result = extract_plus(
+            urls=args.extract_urls,
+            provider=args.provider or "auto",
+            output_format=args.output_format,
+            include_images=args.extract_images,
+            include_raw_html=args.include_raw_html,
+            render_js=args.render_js,
+            config=config,
+        )
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
+    
+    if not args.query and not args.similar_url:
+        parser.error("--query is required (unless using --similar-url with Exa)")
+    
+    # Handle --explain-routing
+    if args.explain_routing:
+        if not args.query:
+            parser.error("--query is required for --explain-routing")
+        explanation = explain_routing(args.query, config)
+        indent = None if args.compact else 2
+        print(json.dumps(explanation, indent=indent, ensure_ascii=False))
+        return
+
+    payload, exit_code = execute_search_request(args, config)
+    if exit_code == 0:
+        indent = None if args.compact else 2
+        print(json.dumps(payload, indent=indent, ensure_ascii=False))
+    else:
+        print(json.dumps(payload, indent=2), file=sys.stderr)
+        sys.exit(1)
+
+
+def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    """Run the search/research pipeline for parsed args.
+
+    Returns ``(payload, exit_code)`` where exit_code 0 means a success payload bound
+    for stdout and 1 means an error payload bound for stderr. This function never
+    prints or calls ``sys.exit`` so the Hermes plugin can invoke it in-process
+    instead of spawning a subprocess.
+    """
+    # Determine provider
+    if args.provider == "auto" or (args.provider is None and not args.similar_url):
+        if args.query:
+            routing = auto_route_provider(args.query, config)
+            provider = routing["provider"]
+            routing_info = {
+                "auto_routed": True,
+                "provider": provider,
+                "confidence": routing["confidence"],
+                "confidence_level": routing["confidence_level"],
+                "reason": routing["reason"],
+                "routing_policy": routing.get("routing_policy", ROUTING_POLICY),
+                "top_signals": routing["top_signals"],
+                "scores": routing["scores"],
+                "auto_allow_excluded": routing.get("auto_allow_excluded", []),
+                "analysis_summary": routing.get("analysis_summary", {}),
+            }
+        else:
+            provider = "exa"
+            routing_info = {
+                "auto_routed": True,
+                "provider": "exa",
+                "confidence": 1.0,
+                "confidence_level": "high",
+                "reason": "similar_url_specified",
+                "routing_policy": ROUTING_POLICY,
+            }
+    else:
+        provider = args.provider or "serper"
+        routing_info = {"auto_routed": False, "provider": provider, "routing_policy": ROUTING_POLICY}
+    
+    # Build provider fallback list
+    auto_config = config.get("auto_routing", {})
+    provider_priority = auto_config.get("provider_priority", list(SEARCH_PROVIDER_IDS))
+    disabled_providers = auto_config.get("disabled_providers", [])
+
+    # Start with the selected provider, then try others in priority order.
+    # Explicit provider calls are strict by default: requested provider must be
+    # the actual provider. Use --allow-fallback to opt into legacy fallback.
+    # Fixed-provider mode is intentionally strict: if auto-routing is disabled
+    # and the saved default was selected via provider=auto, do not silently
+    # fall back to other providers. Users who want fallback should keep
+    # auto-routing enabled and tune priority/fallback instead.
+    explicit_provider_mode = args.provider not in (None, "auto")
+    fixed_provider_mode = (
+        auto_config.get("enabled", True) is False
+        and provider == config.get("default_provider")
+        and (args.provider == "auto" or (args.provider is None and not args.similar_url))
+    )
+    strict_provider_mode = fixed_provider_mode or (explicit_provider_mode and not args.allow_fallback)
+    providers_to_try = [provider] if provider else []
+    if not strict_provider_mode:
+        for p in provider_priority:
+            if p not in providers_to_try and p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config):
+                providers_to_try.append(p)
+
+    # Skip providers currently in cooldown
+    eligible_providers = []
+    cooldown_skips = []
+    for p in providers_to_try:
+        in_cd, remaining = provider_in_cooldown(p)
+        if in_cd:
+            cooldown_skips.append({"provider": p, "cooldown_remaining_seconds": remaining})
+        else:
+            eligible_providers.append(p)
+
+    if not eligible_providers:
+        eligible_providers = providers_to_try[:1]
+
+    # Helper function to execute search for a provider
+    def execute_search(prov: str) -> Dict[str, Any]:
+        key = validate_api_key(prov, config)
+        if prov == "serper":
+            return search_serper(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=args.country,
+                language=args.language,
+                search_type=args.search_type,
+                time_range=args.time_range,
+                include_images=args.images,
+            )
+        elif prov == "serpbase":
+            serpbase_config = config.get("serpbase", {})
+            return search_serpbase(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=serpbase_config.get("country", args.country),
+                language=serpbase_config.get("language", args.language),
+                page=int(serpbase_config.get("page", 1)),
+                api_url=serpbase_config.get("api_url", "https://api.serpbase.dev/google/search"),
+                timeout=int(serpbase_config.get("timeout", 30)),
+            )
+        elif prov == "brave":
+            brave_config = config.get("brave", {})
+            return search_brave(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=brave_config.get("country", args.country),
+                language=brave_config.get("search_lang", args.language),
+                time_range=args.time_range or args.freshness,
+                safesearch=brave_config.get("safesearch", "moderate"),
+            )
+        elif prov == "tavily":
+            return search_tavily(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                depth=args.depth,
+                topic=args.topic,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                include_images=args.images,
+                include_raw_content=args.raw_content,
+            )
+        elif prov == "linkup":
+            linkup_config = config.get("linkup", {})
+            return search_linkup(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                depth=args.linkup_depth,
+                output_type=args.linkup_output_type,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                api_url=linkup_config.get("api_url", "https://api.linkup.so/v1/search"),
+                timeout=int(linkup_config.get("timeout", 30)),
+            )
+        elif prov == "querit":
+            querit_config = config.get("querit", {})
+            return search_querit(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                language=args.language,
+                country=args.country,
+                time_range=args.time_range or args.freshness,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                base_url=args.querit_base_url,
+                base_path=args.querit_base_path,
+                timeout=int(querit_config.get("timeout", 30)),
+            )
+        elif prov == "exa":
+            # CLI --exa-depth overrides; fallback to auto-routing suggestion
+            exa_depth = args.exa_depth
+            if exa_depth == "normal" and routing_info.get("exa_depth") in ("deep", "deep-reasoning"):
+                exa_depth = routing_info["exa_depth"]
+            return search_exa(
+                query=args.query or "",
+                api_key=key,
+                max_results=args.max_results,
+                search_type=args.exa_type,
+                exa_depth=exa_depth,
+                category=args.category,
+                start_date=args.start_date,
+                end_date=args.end_date,
+                similar_url=args.similar_url,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                text_verbosity=args.exa_verbosity,
+            )
+        elif prov == "firecrawl":
+            firecrawl_config = config.get("firecrawl", {})
+            return search_firecrawl(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=firecrawl_config.get("country", args.country),
+                time_range=args.time_range or args.freshness,
+                sources=args.firecrawl_sources,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                scrape_markdown=args.firecrawl_scrape or args.raw_content,
+                ignore_invalid_urls=firecrawl_config.get("ignore_invalid_urls", False),
+                api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
+                timeout_ms=int(firecrawl_config.get("timeout", 30000)),
+            )
+        elif prov == "parallel":
+            parallel_config = config.get("parallel", {})
+            return search_parallel(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                api_url=parallel_config.get("api_url", "https://api.parallel.ai/v1/search"),
+                timeout=int(parallel_config.get("timeout", 45)),
+                client_model=parallel_config.get("client_model"),
+            )
+        elif prov in {"perplexity", "kilo-perplexity"}:
+            perplexity_config = config.get(prov, {})
+            defaults = DEFAULT_CONFIG.get(prov, {})
+            return search_perplexity(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                model=perplexity_config.get("model", defaults.get("model", "sonar-pro")),
+                api_url=perplexity_config.get("api_url", defaults.get("api_url", "https://api.perplexity.ai/chat/completions")),
+                freshness=getattr(args, "freshness", None),
+                provider_name=prov,
+            )
+        elif prov == "you":
+            return search_you(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=args.country,
+                language=args.language,
+                freshness=args.freshness,
+                safesearch=args.you_safesearch,
+                include_news=not args.no_news,
+                livecrawl=args.livecrawl,
+            )
+        elif prov == "searxng":
+            # For SearXNG, 'key' is actually the instance URL
+            instance_url = args.searxng_url or key
+            if instance_url:
+                instance_url = _validate_searxng_url(instance_url)
+            return search_searxng(
+                query=args.query,
+                instance_url=instance_url,
+                max_results=args.max_results,
+                categories=args.categories,
+                engines=args.engines,
+                language=args.language,
+                time_range=args.time_range,
+                safesearch=args.searxng_safesearch,
+            )
+        else:
+            raise ValueError(f"Unknown provider: {prov}")
+
+    def execute_with_retry(prov: str) -> Dict[str, Any]:
+        return execute_provider_with_retry(prov, lambda: execute_search(prov))
+
+    cache_context = {
+        "locale": f"{args.country}:{args.language}",
+        "freshness": args.freshness,
+        "time_range": args.time_range,
+        "include_domains": sorted(args.include_domains) if args.include_domains else None,
+        "exclude_domains": sorted(args.exclude_domains) if args.exclude_domains else None,
+        "topic": args.topic,
+        "search_engines": sorted(args.engines) if args.engines else None,
+        "include_news": not args.no_news,
+        "search_type": args.search_type,
+        "exa_type": args.exa_type,
+        "exa_depth": args.exa_depth,
+        "exa_verbosity": args.exa_verbosity,
+        "category": args.category,
+        "similar_url": args.similar_url,
+        "mode": args.mode,
+        "quality_report": args.quality_report,
+    }
+
+    providers_considered = providers_to_try.copy()
+
+    if args.mode == "research":
+        available_research_providers = {
+            p for p in providers_to_try
+            if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+        }
+        if provider and get_api_key(provider, config) and not provider_in_cooldown(provider)[0]:
+            available_research_providers.add(provider)
+        if args.research_providers:
+            research_providers = [
+                p for p in args.research_providers
+                if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+            ]
+        else:
+            research_providers = select_research_providers(
+                primary_provider=provider,
+                provider_priority=provider_priority,
+                available_providers=available_research_providers,
+                max_providers=3,
+            )
+
+        if not research_providers:
+            error_result = {
+                "error": "No configured providers available for research mode",
+                "provider": provider,
+                "query": args.query,
+                "routing": routing_info,
+                "cooldown_skips": cooldown_skips,
+            }
+            return error_result, 1
+
+        result = run_research_mode(
+            query=args.query,
+            research_providers=research_providers,
+            execute_search=execute_with_retry,
+            extract_urls=lambda urls: extract_plus(
+                urls=urls,
+                provider="auto",
+                output_format="markdown",
+                config=config,
+            ),
+            max_results=args.max_results,
+            max_extract_urls=args.research_extract_count,
+            time_budget_seconds=args.research_time_budget,
+        )
+        routing_info["mode"] = "research"
+        routing_info["provider"] = "research"
+        result["routing"].update(routing_info)
+        result["quality_report"] = build_quality_report(
+            query=args.query,
+            result=result,
+            routing_info=routing_info,
+            providers_considered=providers_considered,
+            eligible_providers=research_providers,
+            cooldown_skips=cooldown_skips,
+            errors=result.get("routing", {}).get("provider_errors", []),
+        )
+        return result, 0
+
+    # Check cache first (unless --no-cache is set)
+    cached_result = None
+    cache_hit = False
+    if not args.no_cache and args.query:
+        cached_result = cache_get(
+            query=args.query,
+            provider=provider,
+            max_results=args.max_results,
+            ttl=args.cache_ttl,
+            params=cache_context,
+        )
+        if cached_result:
+            cache_hit = True
+            result = {k: v for k, v in cached_result.items() if not k.startswith("_cache_")}
+            result["cached"] = True
+            result["cache_age_seconds"] = int(time.time() - cached_result.get("_cache_timestamp", 0))
+
+    errors = []
+    successful_provider = None
+    successful_results: List[Tuple[str, Dict[str, Any]]] = []
+    result = None if not cache_hit else result
+
+    for idx, current_provider in enumerate(eligible_providers):
+        if cache_hit:
+            successful_provider = provider
+            break
+        try:
+            provider_result = execute_with_retry(current_provider)
+            reset_provider_health(current_provider)
+            successful_results.append((current_provider, provider_result))
+            successful_provider = current_provider
+
+            # If we have enough results, stop.
+            if len(provider_result.get("results", [])) >= args.max_results:
+                break
+
+            # Only continue collecting from lower-priority providers when fallback was needed.
+            if not errors:
+                break
+        except Exception as e:
+            error_msg = str(e)
+            cooldown_info = mark_provider_failure(current_provider, error_msg)
+            errors.append({
+                "provider": current_provider,
+                "error": error_msg,
+                "cooldown_seconds": cooldown_info.get("cooldown_seconds"),
+            })
+            if len(eligible_providers) > 1:
+                remaining = eligible_providers[idx + 1:]
+                if remaining:
+                    print(json.dumps({
+                        "fallback": True,
+                        "failed_provider": current_provider,
+                        "error": error_msg,
+                        "trying_next": remaining[0],
+                    }), file=sys.stderr)
+            continue
+
+    if successful_results:
+        if len(successful_results) == 1:
+            result = successful_results[0][1]
+        else:
+            primary = successful_results[0][1].copy()
+            deduped_results, dedup_count = deduplicate_results_across_providers(successful_results, args.max_results)
+            primary["results"] = deduped_results
+            primary["deduplicated"] = dedup_count > 0
+            primary.setdefault("metadata", {})
+            primary["metadata"]["dedup_count"] = dedup_count
+            primary["metadata"]["providers_merged"] = [p for p, _ in successful_results]
+            result = primary
+
+    if result is not None:
+        if successful_provider != provider:
+            routing_info["fallback_used"] = True
+            routing_info["original_provider"] = provider
+            routing_info["provider"] = successful_provider
+            routing_info["fallback_errors"] = errors
+
+        if cooldown_skips:
+            routing_info["cooldown_skips"] = cooldown_skips
+
+        routing_class = routing_info.get("analysis_summary", {}).get("routing_class", "general")
+        if not cache_hit and isinstance(result.get("results"), list):
+            reranked, rerank_metadata = rerank_results_for_intent(args.query or "", routing_class, result.get("results", []))
+            result["results"] = reranked
+            if rerank_metadata.get("reranked"):
+                result.setdefault("metadata", {})["intent_rerank"] = rerank_metadata
+
+        result["routing"] = routing_info
+
+        if not cache_hit and not args.no_cache and args.query:
+            cache_put(
+                query=args.query,
+                provider=successful_provider or provider,
+                max_results=args.max_results,
+                result=result,
+                params=cache_context,
+            )
+
+        result["cached"] = bool(cache_hit)
+        if "deduplicated" not in result:
+            result["deduplicated"] = False
+            result.setdefault("metadata", {})
+            result["metadata"].setdefault("dedup_count", 0)
+
+        if args.quality_report:
+            result["quality_report"] = build_quality_report(
+                query=args.query,
+                result=result,
+                routing_info=routing_info,
+                providers_considered=providers_considered,
+                eligible_providers=eligible_providers,
+                cooldown_skips=cooldown_skips,
+                errors=errors,
+            )
+
+        return result, 0
+    else:
+        error_result = {
+            "error": "All providers failed",
+            "provider": provider,
+            "query": args.query,
+            "routing": routing_info,
+            "provider_errors": errors,
+            "cooldown_skips": cooldown_skips,
+        }
+        return error_result, 1
+
+
+def run_search_request(
+    *,
+    query: str,
+    provider: str = "auto",
+    count: int = 5,
+    exa_depth: str = "normal",
+    time_range: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
+    research_time_budget: float = 55.0,
+    language: Optional[str] = None,
+    country: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run a search in-process and return the result dict the CLI would emit.
+
+    Mirrors the argv the Hermes plugin used to pass to the subprocess, then routes
+    it through the same parser and pipeline so behaviour is identical without the
+    interpreter-startup and JSON round-trip cost of spawning ``search.py``.
+    """
+    if not query and not (include_domains or exclude_domains):
+        return {"error": "query is required", "provider": provider, "query": query, "results": []}
+    config = config or load_config()
+    argv: List[str] = [
+        "--query", query or "",
+        "--provider", provider or "auto",
+        "--max-results", str(count),
+    ]
+    if exa_depth and exa_depth != "normal":
+        argv += ["--exa-depth", exa_depth]
+    if time_range and time_range != "none":
+        argv += ["--time-range", time_range]
+    if include_domains:
+        argv += ["--include-domains", *include_domains]
+    if exclude_domains:
+        argv += ["--exclude-domains", *exclude_domains]
+    if mode and mode != "normal":
+        argv += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
+    if quality_report:
+        argv += ["--quality-report"]
+    if language and language != "auto":
+        argv += ["--language", language]
+    if country and country != "auto":
+        argv += ["--country", country]
+
+    parser = build_parser(config)
+    args = parser.parse_args(argv)
+    payload, _exit_code = execute_search_request(args, config)
+    return payload
+
+
+def run_extract_request(
+    urls: List[str],
+    *,
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run URL extraction in-process and return the result dict."""
+    config = config or load_config()
+    return extract_plus(
+        urls=urls,
+        provider=provider or "auto",
+        output_format=output_format,
+        include_images=include_images,
+        include_raw_html=include_raw_html,
+        render_js=render_js,
+        config=config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/add-web-search-plus/resources/wsp-skill.test.ts
+++ b/.claude/skills/add-web-search-plus/resources/wsp-skill.test.ts
@@ -1,0 +1,53 @@
+// Integration-point guards for the web-search-plus skill.
+//
+// The skill's one functional reach-in is the python3 system dependency in
+// container/Dockerfile: the wsp engine is pure-stdlib Python, and the base
+// image is Node-only, so the apt edit is what makes the skill runnable at all.
+// python3 is an apt binary, not an importable package, so neither a behavior
+// test nor the build leg can see it — this structural test is the guard
+// (skill-guidelines.md, "Dependencies are integration points", case 3).
+//
+// The copied skill files themselves are pure adds; the wrapper/engine
+// assertions below guard against a half-applied or half-removed skill
+// (wrapper present but engine missing leaves the agent with a broken tool).
+//
+// Runs under vitest from the project root:
+//   pnpm exec vitest run src/wsp-skill.test.ts
+
+import { readFileSync, statSync } from 'fs';
+import path from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+const ROOT = process.cwd();
+const DOCKERFILE = path.resolve(ROOT, 'container/Dockerfile');
+const SKILL_DIR = path.resolve(ROOT, 'container/skills/web-search-plus');
+
+describe('container/Dockerfile python3 system dependency', () => {
+  const dockerfile = readFileSync(DOCKERFILE, 'utf8');
+
+  it('installs python3 in the system-deps apt-get block', () => {
+    // Scope the assertion to the apt-get install command so a python3
+    // mention elsewhere (a comment, an env var) can't keep this green.
+    const aptBlock = dockerfile.match(/apt-get install -y --no-install-recommends[\s\S]*?(?:&&|\n\n)/);
+    expect(aptBlock, 'system-deps apt-get install block not found').not.toBeNull();
+    expect(aptBlock![0]).toMatch(/^\s+python3(\s|\\)/m);
+  });
+});
+
+describe('web-search-plus container skill files', () => {
+  it('ships the executable wsp wrapper', () => {
+    const st = statSync(path.join(SKILL_DIR, 'bin/wsp'));
+    expect(st.isFile()).toBe(true);
+    expect(st.mode & 0o111, 'bin/wsp must be executable').not.toBe(0);
+  });
+
+  it('ships the engine CLI entry the wrapper execs', () => {
+    expect(statSync(path.join(SKILL_DIR, 'engine/search.py')).isFile()).toBe(true);
+  });
+
+  it('ships the SKILL.md the agent loads at runtime', () => {
+    const skillMd = readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf8');
+    expect(skillMd).toMatch(/^name: web-search-plus$/m);
+  });
+});


### PR DESCRIPTION
## What

Adds **web-search-plus** — a self-contained utility skill giving the container agent multi-provider web search + URL extraction via a `wsp` CLI. Search + extract only, no LLM synthesis, **no MCP**.

Engine vendored byte-identical from [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) v2.4.0 — pure Python **stdlib** (no pip deps; HTTP via `urllib`). 13 providers with deterministic routing + fallback.

## Why

The built-in `WebSearch` runs as a server-side LLM tool billed against the Agent-SDK credit pool. web-search-plus calls providers directly, so it runs *outside* that pool (self-hosted SearXNG is $0), with provider control + higher-quality extraction. It coexists with `WebSearch` — it does not replace it.

## Conformance to the skills model

Built to `docs/skill-guidelines.md`:
- **Utility skill**, self-contained in `.claude/skills/add-web-search-plus/`; apply **copies files in** — no branch, no `git merge`.
- **One integration point** — `python3` added to the container Dockerfile — guarded by a structural test (`src/wsp-skill.test.ts`, vitest). Negative-probe verified: red on unapplied tree, green on applied.
- **REMOVE.md** reverses every change (copied files, Dockerfile edit, test).
- Apply is **idempotent** (re-run safe). Present-tense steps, no VERIFY.md.
- Apply copies no credential values into the container (no secret threading).

## Verification (full /add cycle, real keys)

- Apply → image build (python3 3.11.2) → REMOVE leaves `git status` clean → apply twice = idempotent. `pnpm test` **353/353**, `tsc` clean.
- **Credentials, both paths E2E-verified:**
  - *Per-group `.wsp.env` (real key):* real Serper key → `wsp search` in the built container → live results.
  - *OneCLI gateway injection:* a host-scoped vault secret (`api.search.brave.com`, header `X-Subscription-Token`) is injected by the gateway for an `all`-mode agent — verified with a real Brave search returning live results while the container sent no auth header.
- **Multi-provider + routing:** serper, tavily, exa each return live results; `--explain-routing` decides + explains; explicit provider selection works.
- **Small-model robustness:** the apply was performed by a small model from `SKILL.md` alone, with no ambiguity reported; all files landed correctly.
