### PR TITLE
fix(telegram): create the wiring row when pairing with a wire-to intent

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -7,7 +7,14 @@ import { createTelegramAdapter } from '@chat-adapter/telegram';
 
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
-import { createMessagingGroup, getMessagingGroupByPlatform, updateMessagingGroup } from '../db/messaging-groups.js';
+import { getAgentGroupByFolder } from '../db/agent-groups.js';
+import {
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  getMessagingGroupAgentByPair,
+  getMessagingGroupByPlatform,
+  updateMessagingGroup,
+} from '../db/messaging-groups.js';
 import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js';
 import { upsertUser } from '../modules/permissions/db/users.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
@@ -179,10 +186,47 @@ function createPairingInterceptor(
         promotedToOwner = true;
       }
 
+      // Act on the pairing intent. Without this, `--intent wire-to:<folder>`
+      // only registers the chat: pairing reports success, but no wiring row
+      // exists, so messages from the chat route nowhere until one is created
+      // by hand. Defaults mirror setup/register.ts — groups engage on
+      // mention, DMs on every message, shared session. `new-agent` intents
+      // still need the full init flow; only wire-to is machine-consumable.
+      const intent = consumed.intent;
+      let wired = false;
+      if (typeof intent === 'object' && intent.kind === 'wire-to' && intent.folder) {
+        const agentGroup = getAgentGroupByFolder(intent.folder);
+        const mg = getMessagingGroupByPlatform('telegram', platformId);
+        if (agentGroup && mg) {
+          if (!getMessagingGroupAgentByPair(mg.id, agentGroup.id)) {
+            const isGroup = mg.is_group === 1;
+            createMessagingGroupAgent({
+              id: `mga-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              messaging_group_id: mg.id,
+              agent_group_id: agentGroup.id,
+              engage_mode: isGroup ? 'mention' : 'pattern',
+              engage_pattern: isGroup ? null : '.',
+              sender_scope: 'all',
+              ignored_message_policy: 'drop',
+              session_mode: 'shared',
+              priority: 0,
+              created_at: new Date().toISOString(),
+            });
+          }
+          wired = true;
+        } else {
+          log.warn('Telegram pairing: wire-to intent could not be applied', {
+            folder: intent.folder,
+            agentGroupFound: !!agentGroup,
+          });
+        }
+      }
+
       log.info('Telegram pairing accepted — chat registered', {
         platformId,
         pairedUser: pairedUserId,
         promotedToOwner,
+        wired,
         intent: consumed.intent,
       });
 


### PR DESCRIPTION
## Bug

Pairing with `--intent wire-to:<folder>` registers the messaging group, upserts the paired user, logs the intent, and reports `PAIR_TELEGRAM STATUS=success` — but never creates the `messaging_group_agents` row. The interceptor only carries the intent into a log line:

```ts
log.info('Telegram pairing accepted — chat registered', { ..., intent: consumed.intent });
```

So the operator is told pairing succeeded, yet messages from the newly paired chat route nowhere until someone hand-creates the wiring (via `/manage-channels` or SQL). Hit this live twice before tracing it to the unconsumed intent.

## Fix

Consume `wire-to` in the pairing interceptor: resolve the agent group by folder and wire it to the just-registered messaging group. Defaults mirror `setup/register.ts` (groups engage on `mention`, DMs on `pattern` `'.'`, shared session, priority 0).

- Idempotent: `getMessagingGroupAgentByPair` guard, same as register.ts
- A missing/unknown folder logs a warning instead of failing the pairing (the chat registration itself is still useful)
- `new-agent` intents are deliberately untouched — they need the full init flow; only wire-to is machine-consumable here
- `createMessagingGroupAgent` auto-creates the companion `agent_destinations` row; per the projection note in `src/db/messaging-groups.ts`, an already-running container for that agent group won't see the new destination until respawn — inbound routing (the broken half) works immediately since the router reads the central DB

## Testing

- `vitest run` on `telegram-registration`, `telegram-pairing`, `telegram-markdown-sanitize`: 42/42 pass
- `tsc`: no new errors (the three pre-existing errors on stock `channels` — deltachat module, `resolveChannelName` on the bridge type — are unchanged; the branch typechecks against `main`'s `ChannelAdapter`)
- Verified the same fix live on a running install: pairing a chat with `wire-to:<folder>` now produces a working wiring with no manual step

🤖 Generated with [Claude Code](https://claude.com/claude-code)