### PR TITLE
fix: NANOCLAW_* flags set in .env never reach process.env under launchd/systemd

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,16 @@
 import os from 'os';
 import path from 'path';
 
-import { readEnvFile } from './env.js';
+import { promoteEnvFlags, readEnvFile } from './env.js';
 import { getContainerImageBase, getDefaultContainerImage, getInstallSlug } from './install-slug.js';
 import { isValidTimezone } from './timezone.js';
+
+// Non-secret NANOCLAW_* flags from .env become process.env so any module can
+// read them directly (launchd/systemd services get no shell env). config.ts
+// is evaluated before every flag reader in the import graph, so top-level
+// `process.env.NANOCLAW_*` consts (e.g. egress-lockdown.ts) see the values.
+// Secrets stay out of process.env via readEnvFile below.
+promoteEnvFlags();
 
 // Read config values from .env (falls back to process.env).
 const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER', 'ONECLI_URL', 'ONECLI_API_KEY', 'TZ']);

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { promoteEnvFlags } from './env.js';
+
+describe('promoteEnvFlags', () => {
+  let dir: string;
+  let originalCwd: string;
+  let savedVitest: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-env-'));
+    originalCwd = process.cwd();
+    process.chdir(dir);
+    // The function no-ops under vitest so a developer's live .env can't steer
+    // test behavior; lift the guard only inside these tests, which use a
+    // fixture .env in a temp cwd.
+    savedVitest = process.env.VITEST;
+    delete process.env.VITEST;
+    delete process.env.NANOCLAW_TEST_FLAG;
+    delete process.env.NANOCLAW_TEST_PRESET;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (savedVitest !== undefined) process.env.VITEST = savedVitest;
+    delete process.env.NANOCLAW_TEST_FLAG;
+    delete process.env.NANOCLAW_TEST_PRESET;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('promotes prefixed flags from .env into process.env', () => {
+    fs.writeFileSync('.env', 'NANOCLAW_TEST_FLAG=true\nOTHER_KEY=secret\n# NANOCLAW_COMMENTED=x\n');
+    promoteEnvFlags();
+    expect(process.env.NANOCLAW_TEST_FLAG).toBe('true');
+    expect(process.env.OTHER_KEY).toBeUndefined();
+    expect(process.env.NANOCLAW_COMMENTED).toBeUndefined();
+  });
+
+  it('never overrides values already in process.env', () => {
+    process.env.NANOCLAW_TEST_PRESET = 'from-service-env';
+    fs.writeFileSync('.env', 'NANOCLAW_TEST_PRESET=from-dotenv\n');
+    promoteEnvFlags();
+    expect(process.env.NANOCLAW_TEST_PRESET).toBe('from-service-env');
+  });
+
+  it('strips surrounding quotes', () => {
+    fs.writeFileSync('.env', 'NANOCLAW_TEST_FLAG="quoted value"\n');
+    promoteEnvFlags();
+    expect(process.env.NANOCLAW_TEST_FLAG).toBe('quoted value');
+  });
+
+  it('is a no-op without a .env file', () => {
+    expect(() => promoteEnvFlags()).not.toThrow();
+    expect(process.env.NANOCLAW_TEST_FLAG).toBeUndefined();
+  });
+
+  it('is a no-op under vitest (hermetic tests)', () => {
+    process.env.VITEST = 'true';
+    fs.writeFileSync('.env', 'NANOCLAW_TEST_FLAG=true\n');
+    promoteEnvFlags();
+    expect(process.env.NANOCLAW_TEST_FLAG).toBeUndefined();
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,3 +40,42 @@ export function readEnvFile(keys: string[]): Record<string, string> {
 
   return result;
 }
+
+/**
+ * Promote non-secret operational flags from .env into process.env (existing
+ * process.env values win). Scoped to the NANOCLAW_ prefix by convention:
+ * those are feature flags and tuning knobs (e.g. NANOCLAW_EGRESS_LOCKDOWN),
+ * never credentials — secrets keep using readEnvFile so they stay out of
+ * the process environment (see the module doc above). Services started by
+ * launchd/systemd don't get a shell env, so without this a NANOCLAW_* flag
+ * added to .env silently never reaches modules that read process.env
+ * directly.
+ */
+export function promoteEnvFlags(prefixes = ['NANOCLAW_']): void {
+  // Tests must be hermetic: a developer's live-install .env flags must not
+  // steer test behavior.
+  if (process.env.VITEST) return;
+  const envFile = path.join(process.cwd(), '.env');
+  let content: string;
+  try {
+    content = fs.readFileSync(envFile, 'utf-8');
+  } catch {
+    return;
+  }
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    if (!prefixes.some((p) => key.startsWith(p)) || process.env[key] !== undefined) continue;
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) process.env[key] = value;
+  }
+}


### PR DESCRIPTION
## Bug

Several modules read operational flags straight from `process.env` — most notably `egress-lockdown.ts`, which gates on `process.env.NANOCLAW_EGRESS_LOCKDOWN` in a top-level const, and whose docs (`docs/SECURITY.md`) tell users to "set `NANOCLAW_EGRESS_LOCKDOWN=true`". But nothing loads `.env` into the process environment: `readEnvFile` deliberately returns values without exporting them (so secrets stay out of child-process envs), and services started by launchd/systemd get **no shell environment**.

The result: putting the flag in `.env` — the place every other setting lives — silently does nothing. The host spawns agents on the default bridge network while the operator believes lockdown is on. Fail-open, and invisible until you audit `docker inspect` output. Found this live: lockdown was "enabled" for days with zero effect.

Related symptom family: #1934, #2134 (flags behaving differently under the service manager vs `pnpm run dev` from a shell, where exported vars happen to exist).

## Fix

`promoteEnvFlags()` in `src/env.ts`: copies `NANOCLAW_`-prefixed entries from `.env` into `process.env`.

- **Scope:** `NANOCLAW_` prefix only — by convention those are feature flags and tuning knobs, never credentials. Secrets keep going through `readEnvFile` and stay out of child-process environments (the existing design, unchanged).
- **Precedence:** real environment values win; `.env` never overrides a var the service manager set explicitly.
- **Ordering:** called at the top of `src/config.ts`, which the import graph evaluates before any flag reader (verified: every importer of `egress-lockdown.ts` — `container-runner.ts`, `host-sweep.ts` — imports `config.js` first, as does `index.ts`).
- **Hermetic tests:** no-op under `VITEST`, so a developer's live-install `.env` can't steer test behavior.

## Testing

- New `src/env.test.ts`: 5 tests (promotion, comment/prefix filtering, no-override precedence, quote stripping, missing-file no-op, VITEST guard) — all pass
- `tsc` clean
- Full `vitest` suite: failure set byte-identical to stock `main` in the same environment (the pre-existing failures are unrelated to this change); the new test file passes
- Verified live under launchd: with this change, `NANOCLAW_EGRESS_LOCKDOWN=true` in `.env` takes effect on service start

🤖 Generated with [Claude Code](https://claude.com/claude-code)