### PR TITLE
Harden host + agent-runner from health audit findings

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -87,6 +87,20 @@ export function writeMessageOut(msg: WriteMessageOut): number {
  * Instead, look up the platform_message_id from the delivered table (host writes this
  * after successful delivery).
  */
+/**
+ * True if `seq` refers to one of the agent's own outbound messages (fromMe),
+ * false if it's an inbound message from someone else. Mirrors the inbound-first
+ * precedence of getMessageIdBySeq. Used so edit/reaction targeting can set the
+ * correct WhatsApp message key `fromMe` flag.
+ */
+export function isOwnMessageBySeq(seq: number): boolean {
+  const inbound = getInboundDb();
+  const inRow = inbound.prepare('SELECT 1 FROM messages_in WHERE seq = ?').get(seq);
+  if (inRow) return false;
+  const outRow = getOutboundDb().prepare('SELECT 1 FROM messages_out WHERE seq = ?').get(seq);
+  return !!outRow;
+}
+
 export function getMessageIdBySeq(seq: number): string | null {
   const inbound = getInboundDb();
 
@@ -135,9 +149,11 @@ export function getRoutingBySeq(
 export function getUndeliveredMessages(): MessageOutRow[] {
   return getOutboundDb()
     .prepare(
+      // seq is strictly monotonic — tiebreak on it so same-second multi-part
+      // replies stay in order rather than arbitrary rowid order.
       `SELECT * FROM messages_out
        WHERE (deliver_after IS NULL OR deliver_after <= datetime('now'))
-       ORDER BY timestamp ASC`,
+       ORDER BY timestamp ASC, seq ASC`,
     )
     .all() as MessageOutRow[];
 }

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -11,7 +11,7 @@ import path from 'path';
 
 import { getCurrentInReplyTo } from '../current-batch.js';
 import { findByName, getAllDestinations } from '../destinations.js';
-import { getMessageIdBySeq, getRoutingBySeq, writeMessageOut } from '../db/messages-out.js';
+import { getMessageIdBySeq, getRoutingBySeq, isOwnMessageBySeq, writeMessageOut } from '../db/messages-out.js';
 import { getSessionRouting } from '../db/session-routing.js';
 import { registerTools } from './server.js';
 import type { McpToolDefinition } from './types.js';
@@ -211,7 +211,7 @@ export const editMessage: McpToolDefinition = {
       platform_id: routing.platform_id,
       channel_type: routing.channel_type,
       thread_id: routing.thread_id,
-      content: JSON.stringify({ operation: 'edit', messageId: platformId, text }),
+      content: JSON.stringify({ operation: 'edit', messageId: platformId, text, fromMe: isOwnMessageBySeq(seq) }),
     });
 
     log(`edit_message: #${seq} → ${platformId}`);
@@ -252,7 +252,7 @@ export const addReaction: McpToolDefinition = {
       platform_id: routing.platform_id,
       channel_type: routing.channel_type,
       thread_id: routing.thread_id,
-      content: JSON.stringify({ operation: 'reaction', messageId: platformId, emoji }),
+      content: JSON.stringify({ operation: 'reaction', messageId: platformId, emoji, fromMe: isOwnMessageBySeq(seq) }),
     });
 
     log(`add_reaction: #${seq} → ${emoji} on ${platformId}`);

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -388,13 +388,19 @@ async function processQuery(
         const newMessages = pending.filter((m) => m.kind !== 'system');
         if (newMessages.length === 0) return;
 
-        const newIds = newMessages.map((m) => m.id);
-        markProcessing(newIds);
+        // Accumulate gate (mirrors the outer loop at the top of runPollLoop):
+        // if the follow-ups are all trigger=0 context-only rows, don't engage
+        // the agent. Leave them pending and unclaimed so they ride along the
+        // next real trigger=1 message. Without this, accumulate-only messages
+        // were pushed straight into the active query, defeating the
+        // "store as context, don't engage" contract the outer loop enforces.
+        if (!newMessages.some((m) => m.trigger === 1)) return;
 
         // Run pre-task scripts on follow-ups too — without this, a task that
         // arrives during an active query (e.g. a */10 monitoring cron) bypasses
         // its script gate and always wakes the agent, defeating the gate.
-        // Mirrors the initial-batch hook above.
+        // Mirrors the initial-batch hook above. Run BEFORE claiming so skipped
+        // rows don't need a separate release.
         let keep = newMessages;
         let skipped: string[] = [];
         // MODULE-HOOK:scheduling-pre-task-followup:start
@@ -410,11 +416,16 @@ async function processQuery(
 
         if (keep.length === 0) return;
         // Re-check done — the outer query may have finished while the script
-        // was awaited. Pushing into a closed stream is wasted work; the
-        // claimed messages get released by the host's processing-claim sweep.
+        // was awaited. Claim ONLY the messages we are about to push, and only
+        // after this check, so a query that ends mid-poll never leaves rows
+        // orphaned in 'processing'. getPendingMessages filters out any id in
+        // processing_ack, so an abandoned claim would be invisible to the outer
+        // loop until the container is killed. The re-entrancy guard
+        // (pollInFlight) means no other poll can grab these before we claim.
         if (done) return;
 
         const keptIds = keep.map((m) => m.id);
+        markProcessing(keptIds);
         const prompt = formatMessages(keep);
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -2,7 +2,16 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { resolveProviderName } from './container-runner.js';
+import {
+  CRASH_BACKOFF_BASE_MS,
+  CRASH_BACKOFF_MAX_MS,
+  CRASH_FAST_FAIL_MS,
+  CRASH_GIVEUP_COOLDOWN_MS,
+  MAX_CRASH_RESPAWNS,
+  decideCrashExit,
+  resolveProviderName,
+  type CrashBreakerState,
+} from './container-runner.js';
 
 describe('resolveProviderName', () => {
   it('prefers session over container config', () => {
@@ -44,5 +53,55 @@ describe('buildContainerArgs ordering invariant (structural)', () => {
     expect(mountsLoop).toBeGreaterThan(-1);
     expect(gatewayApply).toBeGreaterThan(-1);
     expect(gatewayApply).toBeGreaterThan(mountsLoop);
+  });
+});
+
+describe('decideCrashExit', () => {
+  const NOW = 1_000_000;
+
+  it('resets on a healthy exit (code 0)', () => {
+    expect(decideCrashExit({ fails: 3, notBefore: 0 }, 0, 100, NOW)).toEqual({ kind: 'reset' });
+  });
+
+  it('resets on a signalled exit (code null, e.g. host SIGKILL)', () => {
+    expect(decideCrashExit({ fails: 2, notBefore: 0 }, null, 100, NOW)).toEqual({ kind: 'reset' });
+  });
+
+  it('resets on a long-running crash (alive past fast-fail window)', () => {
+    // crashed nonzero but ran long enough to do real work — not a spawn loop
+    expect(decideCrashExit({ fails: 1, notBefore: 0 }, 1, CRASH_FAST_FAIL_MS + 1, NOW)).toEqual({
+      kind: 'reset',
+    });
+  });
+
+  it('backs off with exponential delay on the first fast-fails', () => {
+    const d1 = decideCrashExit(undefined, 127, 500, NOW);
+    expect(d1).toMatchObject({ kind: 'backoff', backoffMs: CRASH_BACKOFF_BASE_MS });
+    expect((d1 as { state: CrashBreakerState }).state).toEqual({
+      fails: 1,
+      notBefore: NOW + CRASH_BACKOFF_BASE_MS,
+    });
+
+    const d2 = decideCrashExit({ fails: 1, notBefore: 0 }, 127, 500, NOW);
+    expect(d2).toMatchObject({ kind: 'backoff', backoffMs: CRASH_BACKOFF_BASE_MS * 2 });
+  });
+
+  it('caps the backoff at CRASH_BACKOFF_MAX_MS', () => {
+    // fails high enough that 2^(fails-1)*base would exceed the cap, but still
+    // below the give-up threshold
+    const prev = { fails: MAX_CRASH_RESPAWNS - 2, notBefore: 0 };
+    const d = decideCrashExit(prev, 1, 500, NOW);
+    expect(d.kind).toBe('backoff');
+    expect((d as { backoffMs: number }).backoffMs).toBeLessThanOrEqual(CRASH_BACKOFF_MAX_MS);
+  });
+
+  it('opens the breaker after MAX_CRASH_RESPAWNS consecutive fast-fails', () => {
+    const prev = { fails: MAX_CRASH_RESPAWNS - 1, notBefore: 0 };
+    const d = decideCrashExit(prev, 127, 500, NOW);
+    expect(d).toMatchObject({ kind: 'open', consecutiveFails: MAX_CRASH_RESPAWNS });
+    expect((d as { state: CrashBreakerState }).state).toEqual({
+      fails: 0,
+      notBefore: NOW + CRASH_GIVEUP_COOLDOWN_MS,
+    });
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,7 @@ import {
   CONTAINER_INSTALL_LABEL,
   DATA_DIR,
   GROUPS_DIR,
+  MAX_CONCURRENT_CONTAINERS,
   ONECLI_API_KEY,
   ONECLI_URL,
   TIMEZONE,
@@ -22,7 +23,13 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  forceKillContainer,
+  hostGatewayArgs,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from './egress-lockdown.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -53,6 +60,60 @@ const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 /** Active containers tracked by session ID. */
 const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
+
+// Crash-on-spawn circuit breaker.
+//
+// A container that exits fast with a nonzero code never claimed a message
+// (no processing_ack rows are written before the agent-runner is up), so the
+// message-level retry/backoff in host-sweep — which keys entirely off
+// processing claims — never fires. countDueMessages stays > 0 and the sweep
+// (and the router) keep re-waking the same broken container every tick. This
+// is exactly how a broken per-group image / OneCLI race / OOM-at-startup turns
+// into a silent infinite respawn loop (observed: a stale Docker bind-mount
+// staging path crash-looping a session for hours with exit 127).
+//
+// We track consecutive fast-fail exits per session, back off exponentially,
+// and after MAX_CRASH_RESPAWNS open the breaker for a cooldown — respawns are
+// skipped during the window and a single ERROR is logged so the failure is
+// visible in nanoclaw.error.log instead of thrashing forever. Messages are
+// left pending (not failed) so they are processed once the breaker closes or
+// the host is restarted. A healthy or long-running exit resets the counter.
+export const CRASH_FAST_FAIL_MS = 15_000; // exited this fast => never did real work
+export const CRASH_BACKOFF_BASE_MS = 5_000;
+export const CRASH_BACKOFF_MAX_MS = 60_000;
+export const MAX_CRASH_RESPAWNS = 5;
+export const CRASH_GIVEUP_COOLDOWN_MS = 30 * 60_000;
+
+export type CrashBreakerState = { fails: number; notBefore: number };
+export type CrashExitDecision =
+  | { kind: 'reset' }
+  | { kind: 'backoff'; state: CrashBreakerState; backoffMs: number }
+  | { kind: 'open'; state: CrashBreakerState; consecutiveFails: number };
+
+/**
+ * Pure decision for the crash-on-spawn breaker (side effects — the crashState
+ * map + logging — live in recordContainerExit, mirroring decideStuckAction in
+ * host-sweep). A "fast fail" is a nonzero exit within CRASH_FAST_FAIL_MS of
+ * spawn; signalled exits (code === null) and healthy/long-running exits reset.
+ */
+export function decideCrashExit(
+  prev: CrashBreakerState | undefined,
+  code: number | null,
+  aliveMs: number,
+  now: number,
+): CrashExitDecision {
+  const fastFail = code !== null && code !== 0 && aliveMs < CRASH_FAST_FAIL_MS;
+  if (!fastFail) return { kind: 'reset' };
+
+  const fails = (prev?.fails ?? 0) + 1;
+  if (fails >= MAX_CRASH_RESPAWNS) {
+    return { kind: 'open', state: { fails: 0, notBefore: now + CRASH_GIVEUP_COOLDOWN_MS }, consecutiveFails: fails };
+  }
+  const backoffMs = Math.min(CRASH_BACKOFF_BASE_MS * 2 ** (fails - 1), CRASH_BACKOFF_MAX_MS);
+  return { kind: 'backoff', state: { fails, notBefore: now + backoffMs }, backoffMs };
+}
+
+const crashState = new Map<string, CrashBreakerState>();
 
 /**
  * In-flight wake promises, keyed by session id. Deduplicates concurrent
@@ -93,6 +154,33 @@ export function wakeContainer(session: Session): Promise<boolean> {
   if (existing) {
     log.debug('Container wake already in-flight — joining existing promise', { sessionId: session.id });
     return existing;
+  }
+  // Crash-loop circuit breaker: if recent spawns fast-failed, skip the wake
+  // until the backoff/cooldown window elapses. Leaves the inbound row pending
+  // so the next eligible tick retries.
+  const breaker = crashState.get(session.id);
+  if (breaker && breaker.notBefore > Date.now()) {
+    log.debug('Container in crash-loop backoff — skipping wake', {
+      sessionId: session.id,
+      retryInMs: breaker.notBefore - Date.now(),
+      fails: breaker.fails,
+    });
+    return Promise.resolve(false);
+  }
+  // Concurrency cap: never run more than MAX_CONCURRENT_CONTAINERS at once.
+  // host-sweep wakes one container per due session per tick, so without this a
+  // recurrence fanout or restart-all could spawn many containers simultaneously
+  // and exhaust the Docker host. Leave the inbound row pending — the next sweep
+  // tick retries once a slot frees up. (in-flight wakes are counted via
+  // wakePromises so a burst within one tick can't overshoot the cap.)
+  if (getActiveContainerCount() + wakePromises.size >= MAX_CONCURRENT_CONTAINERS) {
+    log.debug('At max concurrent containers — deferring wake', {
+      sessionId: session.id,
+      active: getActiveContainerCount(),
+      pending: wakePromises.size,
+      max: MAX_CONCURRENT_CONTAINERS,
+    });
+    return Promise.resolve(false);
   }
   const promise = spawnContainer(session)
     .then(() => true)
@@ -163,6 +251,7 @@ async function spawnContainer(session: Session): Promise<void> {
   // immediate kill before the new container touches the file itself.
   fs.rmSync(heartbeatPath(agentGroup.id, session.id), { force: true });
 
+  const spawnedAt = Date.now();
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
   activeContainers.set(session.id, { process: container, containerName });
@@ -187,7 +276,9 @@ async function spawnContainer(session: Session): Promise<void> {
     activeContainers.delete(session.id);
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
-    log.info('Container exited', { sessionId: session.id, code, containerName });
+    const aliveMs = Date.now() - spawnedAt;
+    log.info('Container exited', { sessionId: session.id, code, containerName, aliveMs });
+    recordContainerExit(session, agentGroup, code, aliveMs);
   });
 
   container.on('error', (err) => {
@@ -195,6 +286,46 @@ async function spawnContainer(session: Session): Promise<void> {
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     log.error('Container spawn error', { sessionId: session.id, err });
+  });
+}
+
+/**
+ * Update the crash-on-spawn circuit breaker on container exit. See the
+ * crashState declaration for the rationale. A "fast fail" is a nonzero exit
+ * within CRASH_FAST_FAIL_MS of spawn — the container never did real work.
+ * Signalled exits (code === null, e.g. host-initiated SIGKILL) and healthy /
+ * long-running exits reset the breaker.
+ */
+function recordContainerExit(session: Session, agentGroup: AgentGroup, code: number | null, aliveMs: number): void {
+  const decision = decideCrashExit(crashState.get(session.id), code, aliveMs, Date.now());
+
+  if (decision.kind === 'reset') {
+    crashState.delete(session.id);
+    return;
+  }
+
+  crashState.set(session.id, decision.state);
+
+  if (decision.kind === 'open') {
+    // Pause respawns for the cooldown and surface a single ERROR. The counter
+    // is reset (in decision.state) so a fresh round is attempted after cooldown.
+    log.error('Container crash-looping on spawn — pausing respawns (circuit breaker open)', {
+      sessionId: session.id,
+      agentGroup: agentGroup.name,
+      code,
+      consecutiveFails: decision.consecutiveFails,
+      cooldownMs: CRASH_GIVEUP_COOLDOWN_MS,
+    });
+    return;
+  }
+
+  log.warn('Container fast-fail on spawn — backing off before respawn', {
+    sessionId: session.id,
+    agentGroup: agentGroup.name,
+    code,
+    aliveMs,
+    consecutiveFails: decision.state.fails,
+    backoffMs: decision.backoffMs,
   });
 }
 
@@ -210,8 +341,27 @@ export function killContainer(sessionId: string, reason: string, onExit?: () => 
   log.info('Killing container', { sessionId, reason, containerName: entry.containerName });
   try {
     stopContainer(entry.containerName);
-  } catch {
-    entry.process.kill('SIGKILL');
+  } catch (stopErr) {
+    // `docker stop` failed (daemon transiently unreachable / timed out).
+    // Killing the local CLI client (entry.process) does NOT stop the
+    // container — the daemon owns its lifecycle — so try a daemon-level kill
+    // first to avoid leaving an orphan that still holds the session dir
+    // (double-writer hazard). Fall back to the CLI client only if that fails.
+    log.warn('docker stop failed — trying daemon-level kill', {
+      sessionId,
+      containerName: entry.containerName,
+      err: stopErr,
+    });
+    try {
+      forceKillContainer(entry.containerName);
+    } catch (killErr) {
+      log.warn('docker kill also failed — killing CLI client as last resort (container may orphan)', {
+        sessionId,
+        containerName: entry.containerName,
+        err: killErr,
+      });
+      entry.process.kill('SIGKILL');
+    }
   }
 }
 
@@ -281,6 +431,14 @@ export function buildMounts(
   // Session folder at /workspace (contains inbound.db, outbound.db, outbox/, .claude/)
   mounts.push({ hostPath: sessDir, containerPath: '/workspace', readonly: false });
 
+  // Inbound attachments — read-only mount so the agent can Read images/PDFs
+  // that channel adapters downloaded. Path matches what `formatAttachments`
+  // emits to the prompt (`/workspace/attachments/<name>`).
+  const attachmentsDir = path.resolve(DATA_DIR, 'attachments');
+  if (fs.existsSync(attachmentsDir)) {
+    mounts.push({ hostPath: attachmentsDir, containerPath: '/workspace/attachments', readonly: true });
+  }
+
   // Agent group folder at /workspace/agent (RW for working files + CLAUDE.local.md)
   mounts.push({ hostPath: groupDir, containerPath: '/workspace/agent', readonly: false });
 
@@ -348,6 +506,20 @@ export function buildMounts(
   }
 
   return mounts;
+}
+
+/**
+ * Resolve a mount's host path through realpath so symlinked roots (groups/,
+ * data/) point at their real ext4 location before being handed to Docker.
+ * Falls back to the original path if it can't be resolved (e.g. not yet
+ * created) so behaviour is unchanged for non-symlinked paths.
+ */
+function resolveMountHostPath(hostPath: string): string {
+  try {
+    return fs.realpathSync(hostPath);
+  } catch {
+    return hostPath;
+  }
 }
 
 /**
@@ -451,12 +623,19 @@ async function buildContainerArgs(
     args.push('-e', 'HOME=/home/node');
   }
 
-  // Volume mounts
+  // Volume mounts. Resolve each host path through realpath so symlinks
+  // (groups/ and data/ are symlinked onto ext4 to avoid drvfs issues) are
+  // followed on the host side. Passing the unresolved /mnt/c (drvfs) path to
+  // Docker Desktop makes it cache a path-keyed bind-mount staging entry that
+  // goes dangling when the source file is rewritten (e.g. composed CLAUDE.md),
+  // causing every spawn to fail with exit 127. Resolving keeps drvfs out of
+  // the mount path entirely.
   for (const mount of mounts) {
+    const hostPath = resolveMountHostPath(mount.hostPath);
     if (mount.readonly) {
-      args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
+      args.push(...readonlyMountArgs(hostPath, mount.containerPath));
     } else {
-      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+      args.push('-v', `${hostPath}:${mount.containerPath}`);
     }
   }
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -33,6 +33,19 @@ export function stopContainer(name: string): void {
   execSync(`${CONTAINER_RUNTIME_BIN} stop -t 1 ${name}`, { stdio: 'pipe' });
 }
 
+/**
+ * Force-kill a container at the daemon level (`docker kill`). Unlike killing
+ * the local `docker run` CLI client process, this reliably stops the container
+ * the daemon owns — use it when `stopContainer` fails so a container can't be
+ * left orphaned (still holding its mounts + OneCLI gateway).
+ */
+export function forceKillContainer(name: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name)) {
+    throw new Error(`Invalid container name: ${name}`);
+  }
+  execSync(`${CONTAINER_RUNTIME_BIN} kill ${name}`, { stdio: 'pipe' });
+}
+
 /** Ensure the container runtime is running, starting it if needed. */
 export function ensureContainerRuntimeRunning(): void {
   try {

--- a/src/db/agent-groups.ts
+++ b/src/db/agent-groups.ts
@@ -1,5 +1,21 @@
 import type { AgentGroup } from '../types.js';
-import { getDb } from './connection.js';
+import { getDb, hasTable } from './connection.js';
+
+// Child tables referencing agent_groups(id) WITHOUT ON DELETE CASCADE. With
+// foreign_keys=ON a bare DELETE of an agent group that has any dependent row
+// fails ("FOREIGN KEY constraint failed"), so we clear dependents first inside
+// a transaction. (container_configs cascades on its own.) Guarded by hasTable
+// because some are optional-module tables.
+const AGENT_GROUP_CHILD_TABLES = [
+  'messaging_group_agents',
+  'user_roles',
+  'agent_group_members',
+  'sessions',
+  'pending_approvals',
+  'agent_destinations',
+  'pending_sender_approvals',
+  'pending_channel_approvals',
+];
 
 export function createAgentGroup(group: AgentGroup): void {
   getDb()
@@ -40,5 +56,13 @@ export function updateAgentGroup(id: string, updates: Partial<Pick<AgentGroup, '
 }
 
 export function deleteAgentGroup(id: string): void {
-  getDb().prepare('DELETE FROM agent_groups WHERE id = ?').run(id);
+  const db = getDb();
+  db.transaction(() => {
+    for (const table of AGENT_GROUP_CHILD_TABLES) {
+      if (hasTable(db, table)) {
+        db.prepare(`DELETE FROM ${table} WHERE agent_group_id = ?`).run(id);
+      }
+    }
+    db.prepare('DELETE FROM agent_groups WHERE id = ?').run(id);
+  })();
 }

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -134,8 +134,26 @@ export function updateMessagingGroup(
     .run(values);
 }
 
+// Child tables referencing messaging_groups(id) WITHOUT ON DELETE CASCADE —
+// cleared first so a bare DELETE doesn't fail under foreign_keys=ON.
+const MESSAGING_GROUP_CHILD_TABLES = [
+  'messaging_group_agents',
+  'user_dms',
+  'sessions',
+  'pending_sender_approvals',
+  'pending_channel_approvals',
+];
+
 export function deleteMessagingGroup(id: string): void {
-  getDb().prepare('DELETE FROM messaging_groups WHERE id = ?').run(id);
+  const db = getDb();
+  db.transaction(() => {
+    for (const table of MESSAGING_GROUP_CHILD_TABLES) {
+      if (hasTable(db, table)) {
+        db.prepare(`DELETE FROM ${table} WHERE messaging_group_id = ?`).run(id);
+      }
+    }
+    db.prepare('DELETE FROM messaging_groups WHERE id = ?').run(id);
+  })();
 }
 
 /**

--- a/src/db/migrations/013-approval-render-metadata.ts
+++ b/src/db/migrations/013-approval-render-metadata.ts
@@ -15,13 +15,27 @@
 import type Database from 'better-sqlite3';
 import type { Migration } from './index.js';
 
+/** Add a column only if it doesn't already exist (idempotent re-run safety). */
+function addColumnIfMissing(db: Database.Database, table: string, column: string, ddl: string): void {
+  const cols = new Set(
+    (db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  if (!cols.has(column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${ddl}`);
+  }
+}
+
 export const migration013: Migration = {
   version: 13,
   name: 'approval-render-metadata',
   up(db: Database.Database) {
-    db.exec(`ALTER TABLE pending_channel_approvals ADD COLUMN title TEXT NOT NULL DEFAULT ''`);
-    db.exec(`ALTER TABLE pending_channel_approvals ADD COLUMN options_json TEXT NOT NULL DEFAULT '[]'`);
-    db.exec(`ALTER TABLE pending_sender_approvals ADD COLUMN title TEXT NOT NULL DEFAULT ''`);
-    db.exec(`ALTER TABLE pending_sender_approvals ADD COLUMN options_json TEXT NOT NULL DEFAULT '[]'`);
+    // Guarded ALTERs: bare ADD COLUMN throws "duplicate column" if a target
+    // column ever pre-exists (restored/merged DB, module touching these tables),
+    // which would abort startup since migrations run in a transaction. Mirror
+    // the moduleApprovalsTitleOptions guard pattern.
+    addColumnIfMissing(db, 'pending_channel_approvals', 'title', `title TEXT NOT NULL DEFAULT ''`);
+    addColumnIfMissing(db, 'pending_channel_approvals', 'options_json', `options_json TEXT NOT NULL DEFAULT '[]'`);
+    addColumnIfMissing(db, 'pending_sender_approvals', 'title', `title TEXT NOT NULL DEFAULT ''`);
+    addColumnIfMissing(db, 'pending_sender_approvals', 'options_json', `options_json TEXT NOT NULL DEFAULT '[]'`);
   },
 };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,7 +1,12 @@
 /**
- * Reference copy of the current v2 schema.
- * Read this to understand the DB structure.
- * Actual creation is done by migrations — do not use this at runtime.
+ * Reference sketch of the v2 schema for orientation only.
+ *
+ * NOT authoritative and NOT used at runtime — the migrations in ./migrations
+ * are the source of truth and add columns/tables this file omits (e.g.
+ * container_configs + cli_scope, pending_channel_approvals + title/options_json,
+ * messaging_groups.denied_at, agent_destinations, unregistered_senders, …).
+ * Verify against the migrations (or a live `sqlite_master` dump) before relying
+ * on any detail here.
  */
 
 export const SCHEMA = `
@@ -187,6 +192,8 @@ CREATE TABLE IF NOT EXISTS messages_in (
                -- Dying containers (past first poll) skip these rows.
 );
 CREATE INDEX IF NOT EXISTS idx_messages_in_series ON messages_in(series_id);
+-- Supports the host's hot countDueMessages poll (status/trigger/process_after).
+CREATE INDEX IF NOT EXISTS idx_messages_in_due ON messages_in(status, trigger, process_after);
 
 -- Host tracks delivery outcomes for messages_out IDs.
 -- Avoids writing to outbound.db (container-owned).

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -258,9 +258,12 @@ export interface OutboundMessage {
 export function getDueOutboundMessages(db: Database.Database): OutboundMessage[] {
   return db
     .prepare(
+      // seq is strictly monotonic (and disjoint per writer) — use it as the
+      // tiebreaker so a multi-part reply emitted within the same one-second
+      // timestamp is delivered in order rather than arbitrary rowid order.
       `SELECT * FROM messages_out
        WHERE (deliver_after IS NULL OR deliver_after <= datetime('now'))
-       ORDER BY timestamp ASC`,
+       ORDER BY timestamp ASC, seq ASC`,
     )
     .all() as OutboundMessage[];
 }
@@ -329,6 +332,11 @@ export function migrateMessagesInTable(db: Database.Database): void {
     // All existing rows are normal messages, so default 0.
     db.prepare('ALTER TABLE messages_in ADD COLUMN on_wake INTEGER NOT NULL DEFAULT 0').run();
   }
+  // Supports the host's hot countDueMessages poll (status/trigger/process_after);
+  // without it that query is a full table scan every tick. Created last so the
+  // `trigger` column (added above on legacy DBs) exists. IF NOT EXISTS makes it
+  // safe to run unconditionally on every existing session DB.
+  db.prepare('CREATE INDEX IF NOT EXISTS idx_messages_in_due ON messages_in(status, trigger, process_after)').run();
 }
 
 /**

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -67,6 +67,11 @@ export function getActiveSessions(): Session[] {
   return getDb().prepare("SELECT * FROM sessions WHERE status = 'active'").all() as Session[];
 }
 
+/** All known session ids (any status) — for on-disk folder reconciliation. */
+export function getAllSessionIds(): Set<string> {
+  return new Set((getDb().prepare('SELECT id FROM sessions').all() as Array<{ id: string }>).map((r) => r.id));
+}
+
 export function getRunningSessions(): Session[] {
   return getDb().prepare("SELECT * FROM sessions WHERE container_status IN ('running', 'idle')").all() as Session[];
 }

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -31,7 +31,14 @@ const ACTIVE_POLL_MS = 1000;
 const SWEEP_POLL_MS = 60_000;
 const MAX_DELIVERY_ATTEMPTS = 3;
 
-/** Track delivery attempt counts. Resets on process restart (gives failed messages a fresh chance). */
+/**
+ * Track in-flight delivery attempt counts (resets on process restart). NOTE:
+ * this does NOT give permanently-failed messages a fresh chance — after
+ * MAX_DELIVERY_ATTEMPTS a message is recorded in the host-owned `delivered`
+ * table with status='failed', and getDeliveredIds() returns all delivered rows
+ * regardless of status, so a failed message is filtered out of `undelivered`
+ * forever (restart or not). This map only bounds retries within a single run.
+ */
 const deliveryAttempts = new Map<string, number>();
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { runMigrations } from './db/migrations/index.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { reconcileSessionFolders } from './session-manager.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
 import { enforceUpgradeTripwire } from './upgrade-state.js';
@@ -94,6 +95,7 @@ async function main(): Promise<void> {
   // 2. Container runtime
   ensureContainerRuntimeRunning();
   cleanupOrphans();
+  reconcileSessionFolders();
 
   // 3. Channel adapters
   await initChannelAdapters((adapter: ChannelAdapter): ChannelSetup => {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,17 +1,24 @@
 const LEVELS = { debug: 20, info: 30, warn: 40, error: 50, fatal: 60 } as const;
 type Level = keyof typeof LEVELS;
 
+// Only emit ANSI color when writing to an interactive terminal. Under the
+// systemd service stdout/stderr are redirected to the log file, and embedded
+// color codes there break ops greps (e.g. `code=127` becomes `code\x1b[39m=127`)
+// and any exit-code alerting. A non-TTY sink gets plain, greppable text.
+const COLOR = process.stdout.isTTY === true;
+const paint = (code: string): string => (COLOR ? code : '');
+
 const COLORS: Record<Level, string> = {
-  debug: '\x1b[34m',
-  info: '\x1b[32m',
-  warn: '\x1b[33m',
-  error: '\x1b[31m',
-  fatal: '\x1b[41m\x1b[37m',
+  debug: paint('\x1b[34m'),
+  info: paint('\x1b[32m'),
+  warn: paint('\x1b[33m'),
+  error: paint('\x1b[31m'),
+  fatal: paint('\x1b[41m\x1b[37m'),
 };
-const KEY_COLOR = '\x1b[35m';
-const MSG_COLOR = '\x1b[36m';
-const RESET = '\x1b[39m';
-const FULL_RESET = '\x1b[0m';
+const KEY_COLOR = paint('\x1b[35m');
+const MSG_COLOR = paint('\x1b[36m');
+const RESET = paint('\x1b[39m');
+const FULL_RESET = paint('\x1b[0m');
 
 const threshold = LEVELS[(process.env.LOG_LEVEL as Level) || 'info'] ?? LEVELS.info;
 

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -117,11 +117,20 @@ export interface RecurringMessage {
   channel_type: string | null;
   thread_id: string | null;
   series_id: string;
+  // Populated by getCompletedRecurring (SELECT *); optional because callers that
+  // only build a row to pass to insertRecurrence don't need it.
+  status?: string;
 }
 
+// Include 'failed' as well as 'completed': the host-sweep MAX_TRIES path marks
+// a crashed-container occurrence status='failed' WITHOUT clearing recurrence.
+// If we only fanned out 'completed' rows, a single transient failure (wedged
+// pre-task script, provider outage) would silently and permanently kill the
+// whole recurring series. Fanning out from 'failed' too keeps the chain alive;
+// clearRecurrence() on the original prevents re-cloning, so there's no loop.
 export function getCompletedRecurring(db: Database.Database): RecurringMessage[] {
   return db
-    .prepare("SELECT * FROM messages_in WHERE status = 'completed' AND recurrence IS NOT NULL")
+    .prepare("SELECT * FROM messages_in WHERE status IN ('completed', 'failed') AND recurrence IS NOT NULL")
     .all() as RecurringMessage[];
 }
 

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -18,6 +18,13 @@ import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { clearRecurrence, getCompletedRecurring, insertRecurrence } from './db.js';
 
+/** Parse a SQLite UTC timestamp (no tz marker) as UTC, not host-local. */
+function sqliteToDate(s: string | null): Date | undefined {
+  if (!s) return undefined;
+  const ms = Date.parse(/[zZ]|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + 'Z');
+  return Number.isNaN(ms) ? undefined : new Date(ms);
+}
+
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
   const recurring = getCompletedRecurring(inDb);
 
@@ -28,13 +35,40 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
       // (src/v1/task-scheduler.ts:20-49); without it, a task written "0 9 * * *"
       // by an agent running in a user's local TZ fires at 09:00 UTC instead of
       // 09:00 user-local.
-      const interval = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE });
-      const nextRun = interval.next().toISOString();
+      //
+      // Anchor the next occurrence on the slot that just fired (process_after)
+      // rather than wall-clock now, so processing latency doesn't drift the
+      // whole series forward / skip slots. If anchoring lands in the past (the
+      // series fell behind, or this occurrence ran long / failed), recompute
+      // from now so we jump to the next future slot instead of replaying every
+      // missed one.
+      const anchor = sqliteToDate(msg.process_after);
+      const interval = CronExpressionParser.parse(
+        msg.recurrence,
+        anchor ? { tz: TIMEZONE, currentDate: anchor } : { tz: TIMEZONE },
+      );
+      let next = interval.next();
+      if (next.toDate().getTime() <= Date.now()) {
+        next = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE }).next();
+      }
+      const nextRun = next.toISOString();
       const prefix = msg.kind === 'task' ? 'task' : 'msg';
       const newId = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
       insertRecurrence(inDb, msg, newId, nextRun);
       clearRecurrence(inDb, msg.id);
+
+      // A 'failed' occurrence still keeps the series alive (see
+      // getCompletedRecurring) — surface it so a wedged recurring task is
+      // observable rather than silently limping along.
+      if (msg.status === 'failed') {
+        log.warn('Recurring occurrence failed but series continues — next run scheduled', {
+          originalId: msg.id,
+          seriesId: msg.series_id,
+          nextRun,
+          sessionId: session.id,
+        });
+      }
 
       log.info('Inserted next recurrence', {
         originalId: msg.id,

--- a/src/router.ts
+++ b/src/router.ts
@@ -372,6 +372,35 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  *                      a thread has engaged us once, follow-ups arrive
  *                      with no mention and should still fire.
  */
+// engage_pattern is admin-authored but run against fully attacker-controlled
+// message text on every inbound. Cap the input length and cache the compiled
+// RegExp to bound worst-case backtracking on the single-threaded event loop
+// and avoid recompiling per message. A bad pattern fails CLOSED (don't engage)
+// — an admin typo shouldn't turn a wiring into respond-to-everything.
+const MAX_PATTERN_TEXT_LEN = 4096;
+const compiledPatternCache = new Map<string, RegExp | null>(); // null = known-invalid
+const warnedBadPatterns = new Set<string>();
+
+function matchEngagePattern(pattern: string, text: string): boolean {
+  let re = compiledPatternCache.get(pattern);
+  if (re === undefined) {
+    try {
+      re = new RegExp(pattern);
+    } catch {
+      re = null;
+    }
+    compiledPatternCache.set(pattern, re);
+  }
+  if (re === null) {
+    if (!warnedBadPatterns.has(pattern)) {
+      warnedBadPatterns.add(pattern);
+      log.warn('Invalid engage_pattern — failing closed (agent will not engage until fixed)', { pattern });
+    }
+    return false;
+  }
+  return re.test(text.length > MAX_PATTERN_TEXT_LEN ? text.slice(0, MAX_PATTERN_TEXT_LEN) : text);
+}
+
 function evaluateEngage(
   agent: MessagingGroupAgent,
   text: string,
@@ -383,12 +412,7 @@ function evaluateEngage(
     case 'pattern': {
       const pat = agent.engage_pattern ?? '.';
       if (pat === '.') return true;
-      try {
-        return new RegExp(pat).test(text);
-      } catch {
-        // Bad regex: fail open so admin sees the agent responding + can fix.
-        return true;
-      }
+      return matchEngagePattern(pat, text);
     }
     case 'mention':
       return isMention;
@@ -438,7 +462,13 @@ async function deliverToAgent(
   // Command gate: classify slash commands before they reach the container.
   // Filtered commands are dropped silently. Denied admin commands get a
   // permission-denied response written directly to messages_out.
-  if (event.message.kind === 'chat' || event.message.kind === 'chat-sdk') {
+  //
+  // Only gate when actually engaging (wake). For an accumulate delivery
+  // (wake=false) the message is merely being stored as silent context, so a
+  // denied admin command must NOT produce a "Permission denied" reply, and a
+  // filtered command should still be stored — running the gate here would
+  // break the "silent context stays silent" contract.
+  if (wake && (event.message.kind === 'chat' || event.message.kind === 'chat-sdk')) {
     const gate = gateCommand(event.message.content, userId, agent.agent_group_id);
     if (gate.action === 'filter') {
       log.debug('Filtered command dropped by gate', { agentGroupId: agent.agent_group_id });

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -23,6 +23,7 @@ import {
   createSession,
   findSessionByAgentGroup,
   findSessionForAgent,
+  getAllSessionIds,
   getSession,
   updateSession,
 } from './db/sessions.js';
@@ -51,6 +52,37 @@ export function sessionsBaseDir(): string {
 /** Directory for a specific session: sessions/{agent_group_id}/{session_id}/ */
 export function sessionDir(agentGroupId: string, sessionId: string): string {
   return path.join(sessionsBaseDir(), agentGroupId, sessionId);
+}
+
+/**
+ * Non-destructive startup reconciliation: log on-disk session folders that have
+ * no corresponding central `sessions` row. Surfaces the lifecycle-drift /
+ * unbounded-growth problem (sessions are never closed or pruned) WITHOUT
+ * deleting anything — automated retention is intentionally a separate, opt-in
+ * decision so we never silently destroy conversation history.
+ */
+export function reconcileSessionFolders(): void {
+  const base = sessionsBaseDir();
+  if (!fs.existsSync(base)) return;
+  const known = getAllSessionIds();
+  const orphans: string[] = [];
+  for (const agentDir of fs.readdirSync(base)) {
+    const agentPath = path.join(base, agentDir);
+    try {
+      if (!fs.statSync(agentPath).isDirectory()) continue;
+      for (const sid of fs.readdirSync(agentPath)) {
+        if (sid.startsWith('sess-') && !known.has(sid)) orphans.push(sid);
+      }
+    } catch {
+      continue;
+    }
+  }
+  if (orphans.length > 0) {
+    log.warn('Orphan session folders on disk (no central sessions row) — not deleted', {
+      count: orphans.length,
+      sample: orphans.slice(0, 10),
+    });
+  }
 }
 
 /** Path to the host-owned inbound DB (messages_in + delivered). */


### PR DESCRIPTION
Fixes from a multi-agent health audit (adversarially verified). Scoped to upstream core; WhatsApp adapter fixes (skill-managed in core) and approval-click authorization (already implemented upstream) are intentionally excluded. Rebased onto latest main — 1 commit, 19 files, typecheck + tests green.

**Container lifecycle**
- realpath-resolve bind-mount sources so the groups/data ext4 symlinks are followed and drvfs never enters the mount path (fixes Docker Desktop stale-staging crash-loops, exit 127)
- crash-on-spawn circuit breaker (`decideCrashExit`) — a broken image backs off and pauses instead of respawning every 60s forever
- enforce `MAX_CONCURRENT_CONTAINERS` in `wakeContainer`
- `killContainer` falls back to daemon-level `docker kill` before the CLI client

**Agent-runner**
- follow-up poller claims only the messages it will push (no orphaned 'processing' rows)
- apply the accumulate (trigger=1) gate to follow-ups
- thread message origin (`fromMe`) through edit/reaction content

**Delivery + DB**
- order outbound by `(timestamp, seq)` so same-second multi-part replies stay ordered (host + container)
- add `idx_messages_in_due` for the hot `countDueMessages` poll
- guard migration013 ALTERs (idempotent)
- transactional FK-safe cascade deletes for agent/messaging groups
- correct misleading delivery-retry comment

**Router**
- cache compiled `engage_pattern` + cap input length (ReDoS guard)
- invalid pattern fails closed with a one-shot warn (was fail-open)
- run the command gate only when engaging (accumulate context stays silent)

**Scheduling**
- recurring series survives a failed occurrence instead of dying silently
- anchor next run on scheduled fire time to prevent drift

**Ops**
- only colorize logs on a TTY so the service log file is greppable
- non-destructive startup reconciliation of orphan session folders
- correct stale `schema.ts` header to point at migrations

Adds unit tests for the crash breaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)