### PR TITLE
feat(channels): native channel-instance dimension — multi-bot substrate

### DIFF
--- a/.claude/skills/add-github/SKILL.md
+++ b/.claude/skills/add-github/SKILL.md
@@ -111,8 +111,8 @@ Run `/manage-channels` to wire the GitHub channel to an agent group, or insert m
 
 ```sql
 -- Create messaging group (one per repo)
-INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-VALUES ('mg-github-myrepo', 'github', 'github:owner/repo', 'owner/repo', 1, '<policy>', datetime('now'));
+INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+VALUES ('mg-github-myrepo', 'github', 'github:owner/repo', 'github', 'owner/repo', 1, '<policy>', datetime('now'));
 
 -- Wire to agent group
 INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, trigger_rules, response_scope, session_mode, priority, created_at)

--- a/.claude/skills/add-linear/SKILL.md
+++ b/.claude/skills/add-linear/SKILL.md
@@ -119,8 +119,8 @@ Run `/manage-channels` to wire the Linear channel to an agent group, or insert m
 
 ```sql
 -- Create messaging group (one per team)
-INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-VALUES ('mg-linear-eng', 'linear', 'linear:ENG', 'Engineering', 1, 'public', datetime('now'));
+INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+VALUES ('mg-linear-eng', 'linear', 'linear:ENG', 'linear', 'Engineering', 1, 'public', datetime('now'));
 
 -- Wire to agent group
 INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, trigger_rules, response_scope, session_mode, priority, created_at)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ user_dms (user_id, channel_type, messaging_group_id) — cold-DM cache
 
 agent_groups (workspace, memory, CLAUDE.md, personality, container config)
     ↕ many-to-many via messaging_group_agents (session_mode, trigger_rules, priority)
-messaging_groups (one chat/channel on one platform; unknown_sender_policy)
+messaging_groups (one chat/channel on one platform; instance = adapter-instance name, defaults to channel_type; unknown_sender_policy)
 
 sessions (agent_group_id + messaging_group_id + thread_id → per-session container)
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -668,15 +668,19 @@ CREATE TABLE agent_groups (
 );
 
 -- Platform groups/channels (WhatsApp group, Slack channel, Discord channel, email thread, etc.)
+-- One row per chat PER ADAPTER INSTANCE. instance defaults to channel_type
+-- (the "default instance"), so single-instance installs never see it.
 CREATE TABLE messaging_groups (
   id                     TEXT PRIMARY KEY,
   channel_type           TEXT NOT NULL,     -- 'whatsapp', 'slack', 'discord', 'telegram', 'email'
   platform_id            TEXT NOT NULL,     -- platform-specific ID (JID, channel ID, etc.)
+  instance               TEXT NOT NULL,     -- adapter-instance name; default = channel_type
   name                   TEXT,
   is_group               INTEGER DEFAULT 0,
   unknown_sender_policy  TEXT NOT NULL DEFAULT 'strict',  -- 'strict' | 'request_approval' | 'public'
   created_at             TEXT NOT NULL,
-  UNIQUE(channel_type, platform_id)
+  denied_at              TEXT,
+  UNIQUE(channel_type, platform_id, instance)
 );
 
 -- Users (messaging platform identities, namespaced "<channel_type>:<handle>")

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -27,21 +27,24 @@ CREATE TABLE agent_groups (
 
 ### 1.2 `messaging_groups`
 
-One row per platform chat (one WhatsApp group, one Slack channel, one 1:1 DM, etc.).
+One row per platform chat (one WhatsApp group, one Slack channel, one 1:1 DM, etc.) per adapter instance.
 
 ```sql
 CREATE TABLE messaging_groups (
   id                    TEXT PRIMARY KEY,
   channel_type          TEXT NOT NULL,
   platform_id           TEXT NOT NULL,
+  instance              TEXT NOT NULL,
   name                  TEXT,
   is_group              INTEGER DEFAULT 0,
   unknown_sender_policy TEXT NOT NULL DEFAULT 'strict',
   created_at            TEXT NOT NULL,
-  UNIQUE(channel_type, platform_id)
+  denied_at             TEXT,
+  UNIQUE(channel_type, platform_id, instance)
 );
 ```
 
+- `instance`: adapter-instance name — N adapters of one platform (e.g. three Slack apps in one workspace) each own their rows. The default instance IS the channel type: migration 016 backfills `instance = channel_type` and `createMessagingGroup` stamps the same default, so single-instance installs never see the dimension. Inbound lookups are exact-on-instance (an unknown named instance auto-creates its own row); outbound lookups resolve default-instance-first.
 - `unknown_sender_policy`: `strict` (drop), `request_approval` (ask admin), `public` (allow).
 - **Readers:** `src/router.ts`, `src/delivery.ts`, `src/session-manager.ts`
 - **Writers:** `src/db/messaging-groups.ts`, channel setup flows
@@ -134,7 +137,7 @@ CREATE TABLE user_dms (
 );
 ```
 
-Populated lazily by `ensureUserDm()` in `src/user-dm.ts`.
+Populated lazily by `ensureUserDm()` in `src/user-dm.ts`. Cold DMs resolve via the channel's default adapter instance — `PRIMARY KEY (user_id, channel_type)` is per-platform, not per-instance.
 
 ### 1.8 `sessions`
 

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -44,6 +44,9 @@ export interface DeliveryAddress {
  */
 export interface InboundEvent {
   channelType: string;
+  /** Receiving adapter instance; stamped host-side (src/index.ts onInbound).
+   *  Absent (e.g. CLI onInboundEvent) means the default instance (= channelType). */
+  instance?: string;
   platformId: string;
   threadId: string | null;
   message: {
@@ -111,6 +114,15 @@ export interface ConversationInfo {
 export interface ChannelAdapter {
   name: string;
   channelType: string;
+
+  /**
+   * Adapter-instance name — distinguishes N adapters of one platform
+   * (e.g. three Slack apps in one workspace). Defaults to channelType.
+   * channelType stays the SEMANTIC platform key (user ids '<channelType>:<handle>',
+   * formatting, container config); instance is a host-side routing key only.
+   * Must be unique across active adapters and URL-safe (no '/', '?', ':').
+   */
+  instance?: string;
 
   /**
    * Whether this adapter models conversations as threads.

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -133,10 +133,9 @@ describe('channel registry — instance keying', () => {
   afterEach(async () => {
     const { teardownChannelAdapters } = await import('./channel-registry.js');
     await teardownChannelAdapters();
-    vi.useRealTimers();
     // Drop this test's registrations so later describe blocks (which import
     // the registry without resetting) start from an empty registry instead
-    // of inheriting same-channelType pairs (and their 10s stagger).
+    // of inheriting same-channelType pairs.
     vi.resetModules();
   });
 
@@ -154,11 +153,7 @@ describe('channel registry — instance keying', () => {
     reg.registerChannelAdapter('slack-worker', { factory: () => worker });
     reg.registerChannelAdapter('slack-tester', { factory: () => tester });
 
-    vi.useFakeTimers();
-    const init = reg.initChannelAdapters(mockSetup);
-    await vi.runAllTimersAsync();
-    await init;
-    vi.useRealTimers();
+    await reg.initChannelAdapters(mockSetup);
 
     expect(reg.getChannelAdapter('slack-worker')).toBe(worker);
     expect(reg.getChannelAdapter('slack-tester')).toBe(tester);
@@ -172,11 +167,7 @@ describe('channel registry — instance keying', () => {
     reg.registerChannelAdapter('slack-tester', { factory: () => named });
     reg.registerChannelAdapter('slack', { factory: () => unnamed });
 
-    vi.useFakeTimers();
-    const init = reg.initChannelAdapters(mockSetup);
-    await vi.runAllTimersAsync();
-    await init;
-    vi.useRealTimers();
+    await reg.initChannelAdapters(mockSetup);
 
     // Exact key (default instance keyed by channelType) beats the fallback
     // scan, even though the named sibling registered first.
@@ -191,44 +182,54 @@ describe('channel registry — instance keying', () => {
     const second = createMockAdapter('slack', 'slack-worker');
     reg2.registerChannelAdapter('slack-tester', { factory: () => first });
     reg2.registerChannelAdapter('slack-worker', { factory: () => second });
-    vi.useFakeTimers();
-    const init2 = reg2.initChannelAdapters(mockSetup);
-    await vi.runAllTimersAsync();
-    await init2;
-    vi.useRealTimers();
+    await reg2.initChannelAdapters(mockSetup);
     expect(reg2.getChannelAdapter('slack')).toBe(first);
   });
 
-  it('staggers the second same-channelType adapter setup by 10s; different platforms unstaggered', async () => {
-    vi.useFakeTimers();
+  it('does NOT reroute default-instance outbound through a named sibling when the default adapter is missing', async () => {
+    // The default Slack app is offline (token rotated, factory returned
+    // null, …) while a named sibling boots fine. Outbound for the default
+    // instance must get the offline-adapter handling (drop into the retry
+    // path) — NEVER a cross-identity send through the sibling bot.
     const reg = await import('./channel-registry.js');
-    const a = createMockAdapter('slack', 'slack-a');
-    const b = createMockAdapter('slack', 'slack-b');
-    const c = createMockAdapter('discord');
-    reg.registerChannelAdapter('slack-a', { factory: () => a });
-    reg.registerChannelAdapter('slack-b', { factory: () => b });
-    reg.registerChannelAdapter('discord', { factory: () => c });
+    const tester = createMockAdapter('slack', 'slack-tester');
+    reg.registerChannelAdapter('slack-tester', { factory: () => tester });
+    reg.registerChannelAdapter('slack', { factory: () => null });
 
-    const init = reg.initChannelAdapters(mockSetup);
+    await reg.initChannelAdapters(mockSetup);
 
-    // Flush microtasks without advancing the clock: a sets up, b is held.
-    await vi.advanceTimersByTimeAsync(0);
-    expect(a.setupTimes).toHaveLength(1);
-    expect(b.setupTimes).toHaveLength(0);
-    expect(c.setupTimes).toHaveLength(0);
+    // Exact lookup (delivery/typing path): the default key resolves nothing.
+    expect(reg.getChannelAdapterExact('slack')).toBeUndefined();
+    // Fallback-capable lookup (channelType-only callers) still resolves.
+    expect(reg.getChannelAdapter('slack')).toBe(tester);
 
-    // Not yet at the stagger window.
-    await vi.advanceTimersByTimeAsync(9_000);
-    expect(b.setupTimes).toHaveLength(0);
+    // The delivery bridge dispatches by exact key: a default-instance
+    // message (instance === channelType after backfill) is dropped, not
+    // delivered through the sibling's identity.
+    const bridge = reg.createChannelDeliveryAdapter();
+    const result = await bridge.deliver(
+      'slack',
+      'slack:C1',
+      null,
+      'chat',
+      JSON.stringify({ text: 'to the default bot' }),
+      undefined,
+      'slack',
+    );
+    expect(result).toBeUndefined();
+    expect(tester.delivered).toHaveLength(0);
 
-    // Crossing 10s releases b; discord (different platform) follows with
-    // no additional stagger of its own.
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(b.setupTimes).toHaveLength(1);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(c.setupTimes).toHaveLength(1);
-
-    await init;
+    // Sanity: the same bridge DOES deliver when the exact instance is live.
+    await bridge.deliver(
+      'slack',
+      'slack:C1',
+      null,
+      'chat',
+      JSON.stringify({ text: 'to the tester bot' }),
+      undefined,
+      'slack-tester',
+    );
+    expect(tester.delivered).toHaveLength(1);
   });
 });
 

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -30,19 +30,24 @@ function now() {
 /** Create a mock ChannelAdapter for testing. */
 function createMockAdapter(
   channelType: string,
-): ChannelAdapter & { delivered: OutboundMessage[]; inbound: InboundMessage[] } {
+  instance?: string,
+): ChannelAdapter & { delivered: OutboundMessage[]; inbound: InboundMessage[]; setupTimes: number[] } {
   const delivered: OutboundMessage[] = [];
   const inbound: InboundMessage[] = [];
+  const setupTimes: number[] = [];
   let setupConfig: ChannelSetup | null = null;
 
   return {
-    name: channelType,
+    name: instance ?? channelType,
     channelType,
+    instance,
     supportsThreads: false,
     delivered,
     inbound,
+    setupTimes,
 
     async setup(config: ChannelSetup) {
+      setupTimes.push(Date.now());
       setupConfig = config;
     },
 
@@ -114,6 +119,116 @@ describe('channel registry', () => {
     const active = getActiveAdapters();
     const noCreds = active.find((a) => a.name === 'no-creds');
     expect(noCreds).toBeUndefined();
+  });
+});
+
+describe('channel registry — instance keying', () => {
+  // Fresh module per test: the registry and activeAdapters maps are
+  // module-level, and these arms register conflicting same-channelType
+  // adapters that must not leak across tests.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const { teardownChannelAdapters } = await import('./channel-registry.js');
+    await teardownChannelAdapters();
+    vi.useRealTimers();
+    // Drop this test's registrations so later describe blocks (which import
+    // the registry without resetting) start from an empty registry instead
+    // of inheriting same-channelType pairs (and their 10s stagger).
+    vi.resetModules();
+  });
+
+  const mockSetup = () => ({
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  });
+
+  it('keys two same-channelType adapters by instance — both resolvable', async () => {
+    const reg = await import('./channel-registry.js');
+    const worker = createMockAdapter('slack', 'slack-worker');
+    const tester = createMockAdapter('slack', 'slack-tester');
+    reg.registerChannelAdapter('slack-worker', { factory: () => worker });
+    reg.registerChannelAdapter('slack-tester', { factory: () => tester });
+
+    vi.useFakeTimers();
+    const init = reg.initChannelAdapters(mockSetup);
+    await vi.runAllTimersAsync();
+    await init;
+    vi.useRealTimers();
+
+    expect(reg.getChannelAdapter('slack-worker')).toBe(worker);
+    expect(reg.getChannelAdapter('slack-tester')).toBe(tester);
+    expect(reg.getActiveAdapters()).toHaveLength(2);
+  });
+
+  it('resolves channelType to the default-instance adapter when one exists, else first-registered', async () => {
+    const reg = await import('./channel-registry.js');
+    const named = createMockAdapter('slack', 'slack-tester');
+    const unnamed = createMockAdapter('slack');
+    reg.registerChannelAdapter('slack-tester', { factory: () => named });
+    reg.registerChannelAdapter('slack', { factory: () => unnamed });
+
+    vi.useFakeTimers();
+    const init = reg.initChannelAdapters(mockSetup);
+    await vi.runAllTimersAsync();
+    await init;
+    vi.useRealTimers();
+
+    // Exact key (default instance keyed by channelType) beats the fallback
+    // scan, even though the named sibling registered first.
+    expect(reg.getChannelAdapter('slack')).toBe(unnamed);
+
+    // With ONLY named instances active, channelType still resolves —
+    // deterministic first-registered fallback.
+    await reg.teardownChannelAdapters();
+    vi.resetModules();
+    const reg2 = await import('./channel-registry.js');
+    const first = createMockAdapter('slack', 'slack-tester');
+    const second = createMockAdapter('slack', 'slack-worker');
+    reg2.registerChannelAdapter('slack-tester', { factory: () => first });
+    reg2.registerChannelAdapter('slack-worker', { factory: () => second });
+    vi.useFakeTimers();
+    const init2 = reg2.initChannelAdapters(mockSetup);
+    await vi.runAllTimersAsync();
+    await init2;
+    vi.useRealTimers();
+    expect(reg2.getChannelAdapter('slack')).toBe(first);
+  });
+
+  it('staggers the second same-channelType adapter setup by 10s; different platforms unstaggered', async () => {
+    vi.useFakeTimers();
+    const reg = await import('./channel-registry.js');
+    const a = createMockAdapter('slack', 'slack-a');
+    const b = createMockAdapter('slack', 'slack-b');
+    const c = createMockAdapter('discord');
+    reg.registerChannelAdapter('slack-a', { factory: () => a });
+    reg.registerChannelAdapter('slack-b', { factory: () => b });
+    reg.registerChannelAdapter('discord', { factory: () => c });
+
+    const init = reg.initChannelAdapters(mockSetup);
+
+    // Flush microtasks without advancing the clock: a sets up, b is held.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(a.setupTimes).toHaveLength(1);
+    expect(b.setupTimes).toHaveLength(0);
+    expect(c.setupTimes).toHaveLength(0);
+
+    // Not yet at the stagger window.
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(b.setupTimes).toHaveLength(0);
+
+    // Crossing 10s releases b; discord (different platform) follows with
+    // no additional stagger of its own.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(b.setupTimes).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(c.setupTimes).toHaveLength(1);
+
+    await init;
   });
 });
 

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -4,7 +4,8 @@
  * Channels self-register on import. The host calls initChannelAdapters() at startup
  * to instantiate and set up all registered adapters.
  */
-import type { ChannelAdapter, ChannelRegistration, ChannelSetup } from './adapter.js';
+import type { ChannelAdapter, ChannelRegistration, ChannelSetup, OutboundFile } from './adapter.js';
+import type { ChannelDeliveryAdapter } from '../delivery.js';
 import { log } from '../log.js';
 
 const SETUP_RETRY_DELAYS_MS = [2000, 5000, 10000];
@@ -18,14 +19,6 @@ function isNetworkError(err: unknown): err is Error {
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-/**
- * Two gateway instances of one platform (e.g. two Discord bots) identifying
- * simultaneously from one IP trip platform rate limits at boot. Stagger the
- * second (and later) same-platform adapter's setup. Inert for installs with
- * one adapter per platform — no two registrations share a channelType.
- */
-const SAME_CHANNEL_SETUP_STAGGER_MS = 10_000;
-
 const registry = new Map<string, ChannelRegistration>();
 const activeAdapters = new Map<string, ChannelAdapter>();
 
@@ -34,20 +27,79 @@ export function registerChannelAdapter(name: string, registration: ChannelRegist
   registry.set(name, registration);
 }
 
+/** Get a live adapter by its EXACT registry key (instance name; default
+ *  instances are keyed by channelType itself). No channelType fallback —
+ *  callers that address a specific instance (outbound delivery, typing)
+ *  must never be rerouted through a sibling instance: that would send
+ *  through the wrong bot identity with the wrong token. A missing key
+ *  means the owning adapter is offline; callers apply their normal
+ *  offline-adapter handling. */
+export function getChannelAdapterExact(key: string): ChannelAdapter | undefined {
+  return activeAdapters.get(key);
+}
+
 /** Get a live adapter by instance name, falling back to any adapter of the
- *  given channel type. channelType-only callers (user-id prefix resolution
- *  and cold DMs in user-dm.ts, approval delivery in channel-approval.ts)
- *  must still resolve when every instance of a platform is named — first
- *  registered wins (Map insertion order, deterministic). Default instances
- *  are keyed by channelType itself, so single-instance installs always hit
- *  the exact-key path. */
+ *  given channel type. The fallback exists ONLY for channelType-only callers
+ *  (user-id prefix resolution and cold DMs in user-dm.ts, approval delivery
+ *  in channel-approval.ts, the router's thread-policy probe when an event
+ *  carries no instance) — they must still resolve when every instance of a
+ *  platform is named. First registered wins (Map insertion order,
+ *  deterministic). Default instances are keyed by channelType itself, so
+ *  single-instance installs always hit the exact-key path. Instance-addressed
+ *  dispatch (delivery, typing) must use getChannelAdapterExact instead. */
 export function getChannelAdapter(key: string): ChannelAdapter | undefined {
   const exact = activeAdapters.get(key);
   if (exact) return exact;
-  for (const adapter of activeAdapters.values()) {
-    if (adapter.channelType === key) return adapter;
+  for (const [registryKey, adapter] of activeAdapters) {
+    if (adapter.channelType === key) {
+      log.warn('Channel adapter fallback: requested key resolved through a differently-keyed instance', {
+        requested: key,
+        resolvedKey: registryKey,
+      });
+      return adapter;
+    }
   }
   return undefined;
+}
+
+/**
+ * Build the host's outbound delivery bridge: dispatches delivery-poll and
+ * typing traffic into the adapter registry. Resolution is EXACT-key only —
+ * `instance ?? channelType`. For default-instance messaging_groups rows the
+ * stored instance IS the channelType, which matches default-registered
+ * adapters, so single-instance behavior is unchanged. A named instance whose
+ * adapter is offline gets the normal offline-adapter handling (warn + drop
+ * into the delivery retry path) — never a cross-identity send through a
+ * sibling bot of the same platform.
+ */
+export function createChannelDeliveryAdapter(): ChannelDeliveryAdapter {
+  return {
+    async deliver(
+      channelType: string,
+      platformId: string,
+      threadId: string | null,
+      kind: string,
+      content: string,
+      files?: OutboundFile[],
+      instance?: string,
+    ): Promise<string | undefined> {
+      const adapter = getChannelAdapterExact(instance ?? channelType);
+      if (!adapter) {
+        log.warn('No adapter for channel type', { channelType, instance });
+        return;
+      }
+      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
+    },
+    async setTyping(
+      channelType: string,
+      platformId: string,
+      threadId: string | null,
+      instance?: string,
+    ): Promise<void> {
+      const adapter = getChannelAdapterExact(instance ?? channelType);
+      await adapter?.setTyping?.(platformId, threadId);
+    },
+  };
 }
 
 /** Get all active adapters. */
@@ -70,24 +122,12 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
  * Skips adapters that return null (missing credentials).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
-  const activeChannelTypes = new Set<string>();
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
       if (!adapter) {
         log.warn('Channel credentials missing, skipping', { channel: name });
         continue;
-      }
-
-      // Same-platform stagger: a second instance of an already-active
-      // platform waits before identifying (gateway logins from one IP).
-      if (activeChannelTypes.has(adapter.channelType)) {
-        log.info('Staggering same-platform adapter setup', {
-          channel: name,
-          type: adapter.channelType,
-          delayMs: SAME_CHANNEL_SETUP_STAGGER_MS,
-        });
-        await sleep(SAME_CHANNEL_SETUP_STAGGER_MS);
       }
 
       const setup = setupFn(adapter);
@@ -125,7 +165,6 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
         log.warn('Duplicate adapter instance key — overwriting previous adapter', { key, channel: name });
       }
       activeAdapters.set(key, adapter);
-      activeChannelTypes.add(adapter.channelType);
       log.info('Channel adapter started', { channel: name, type: adapter.channelType, instance: key });
     } catch (err) {
       log.error('Failed to start channel adapter', { channel: name, err });

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -18,6 +18,14 @@ function isNetworkError(err: unknown): err is Error {
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Two gateway instances of one platform (e.g. two Discord bots) identifying
+ * simultaneously from one IP trip platform rate limits at boot. Stagger the
+ * second (and later) same-platform adapter's setup. Inert for installs with
+ * one adapter per platform — no two registrations share a channelType.
+ */
+const SAME_CHANNEL_SETUP_STAGGER_MS = 10_000;
+
 const registry = new Map<string, ChannelRegistration>();
 const activeAdapters = new Map<string, ChannelAdapter>();
 
@@ -26,9 +34,20 @@ export function registerChannelAdapter(name: string, registration: ChannelRegist
   registry.set(name, registration);
 }
 
-/** Get a live adapter by channel type. */
-export function getChannelAdapter(channelType: string): ChannelAdapter | undefined {
-  return activeAdapters.get(channelType);
+/** Get a live adapter by instance name, falling back to any adapter of the
+ *  given channel type. channelType-only callers (user-id prefix resolution
+ *  and cold DMs in user-dm.ts, approval delivery in channel-approval.ts)
+ *  must still resolve when every instance of a platform is named — first
+ *  registered wins (Map insertion order, deterministic). Default instances
+ *  are keyed by channelType itself, so single-instance installs always hit
+ *  the exact-key path. */
+export function getChannelAdapter(key: string): ChannelAdapter | undefined {
+  const exact = activeAdapters.get(key);
+  if (exact) return exact;
+  for (const adapter of activeAdapters.values()) {
+    if (adapter.channelType === key) return adapter;
+  }
+  return undefined;
 }
 
 /** Get all active adapters. */
@@ -51,12 +70,24 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
  * Skips adapters that return null (missing credentials).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
+  const activeChannelTypes = new Set<string>();
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
       if (!adapter) {
         log.warn('Channel credentials missing, skipping', { channel: name });
         continue;
+      }
+
+      // Same-platform stagger: a second instance of an already-active
+      // platform waits before identifying (gateway logins from one IP).
+      if (activeChannelTypes.has(adapter.channelType)) {
+        log.info('Staggering same-platform adapter setup', {
+          channel: name,
+          type: adapter.channelType,
+          delayMs: SAME_CHANNEL_SETUP_STAGGER_MS,
+        });
+        await sleep(SAME_CHANNEL_SETUP_STAGGER_MS);
       }
 
       const setup = setupFn(adapter);
@@ -85,8 +116,17 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
           throw err;
         }
       }
-      activeAdapters.set(adapter.channelType, adapter);
-      log.info('Channel adapter started', { channel: name, type: adapter.channelType });
+      // Adapters key by instance (default instance = channelType), so N
+      // instances of one platform coexist. Duplicate keys warn instead of
+      // throwing — boot stays resilient, matching the historical silent
+      // last-write-wins, but now visibly.
+      const key = adapter.instance ?? adapter.channelType;
+      if (activeAdapters.has(key)) {
+        log.warn('Duplicate adapter instance key — overwriting previous adapter', { key, channel: name });
+      }
+      activeAdapters.set(key, adapter);
+      activeChannelTypes.add(adapter.channelType);
+      log.info('Channel adapter started', { channel: name, type: adapter.channelType, instance: key });
     } catch (err) {
       log.error('Failed to start channel adapter', { channel: name, err });
     }

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
 import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+
+vi.mock('../webhook-server.js', () => ({
+  registerWebhookAdapter: vi.fn(),
+}));
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
@@ -90,6 +94,136 @@ describe('createChatSdkBridge', () => {
       supportsThreads: true,
     });
     expect(typeof bridge.subscribe).toBe('function');
+  });
+});
+
+describe('createChatSdkBridge — instance identity', () => {
+  it('default: name === channelType === adapter.name, instance undefined', () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'slack' }),
+      supportsThreads: true,
+    });
+    expect(bridge.name).toBe('slack');
+    expect(bridge.channelType).toBe('slack');
+    expect(bridge.instance).toBeUndefined();
+  });
+
+  it('named instance: name follows the instance, channelType stays the platform', () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({ name: 'slack' }),
+      instance: 'slack-tester',
+      supportsThreads: true,
+    });
+    expect(bridge.name).toBe('slack-tester');
+    expect(bridge.channelType).toBe('slack');
+    expect(bridge.instance).toBe('slack-tester');
+  });
+
+  it('rejects instance names that would break the webhook route or state delimiter', () => {
+    for (const bad of ['a/b', 'a:b', 'a?b', 'a b']) {
+      expect(() =>
+        createChatSdkBridge({ adapter: stubAdapter({ name: 'slack' }), instance: bad, supportsThreads: true }),
+      ).toThrow(/URL-safe/);
+    }
+  });
+});
+
+describe('createChatSdkBridge.setup — webhook route and state namespace', () => {
+  // Real setup() over a stub adapter: Chat.initialize() needs a working
+  // StateAdapter (chat_sdk_* tables) and an adapter.initialize — nothing
+  // platform-side. registerWebhookAdapter is mocked at module level so we
+  // can assert the (chat, adapterName, routingPath) triple.
+  function setupStubAdapter(): Adapter {
+    return stubAdapter({
+      name: 'slack',
+      initialize: async () => {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as Partial<Adapter>) as any;
+  }
+
+  beforeEach(async () => {
+    const { initTestDb } = await import('../db/connection.js');
+    const { runMigrations } = await import('../db/migrations/index.js');
+    runMigrations(initTestDb());
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    vi.mocked(registerWebhookAdapter).mockClear();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../db/connection.js');
+    closeDb();
+  });
+
+  const hostConfig = {
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  };
+
+  it('named instance registers the webhook with adapterName as handler key and instance as route', async () => {
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    const bridge = createChatSdkBridge({
+      adapter: setupStubAdapter(),
+      instance: 'slack-tester',
+      supportsThreads: true,
+    });
+    await bridge.setup(hostConfig);
+    expect(registerWebhookAdapter).toHaveBeenCalledTimes(1);
+    const [, adapterName, routingPath] = vi.mocked(registerWebhookAdapter).mock.calls[0];
+    expect(adapterName).toBe('slack');
+    expect(routingPath).toBe('slack-tester');
+    await bridge.teardown();
+  });
+
+  it('default instance registers the historical route', async () => {
+    const { registerWebhookAdapter } = await import('../webhook-server.js');
+    const bridge = createChatSdkBridge({ adapter: setupStubAdapter(), supportsThreads: true });
+    await bridge.setup(hostConfig);
+    const [, adapterName, routingPath] = vi.mocked(registerWebhookAdapter).mock.calls[0];
+    expect(adapterName).toBe('slack');
+    expect(routingPath ?? adapterName).toBe('slack');
+    await bridge.teardown();
+  });
+
+  it('named instance namespaces Chat SDK state; default stays unprefixed (live-install constraint)', async () => {
+    const { getDb } = await import('../db/connection.js');
+
+    const named = createChatSdkBridge({
+      adapter: setupStubAdapter(),
+      instance: 'slack-tester',
+      supportsThreads: true,
+    });
+    await named.setup(hostConfig);
+    await named.subscribe!('slack:C1', 'slack:T1');
+
+    const def = createChatSdkBridge({ adapter: setupStubAdapter(), supportsThreads: true });
+    await def.setup(hostConfig);
+    await def.subscribe!('slack:C1', 'slack:T1');
+
+    const rows = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions ORDER BY thread_id').all() as Array<{
+      thread_id: string;
+    }>;
+    expect(rows.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1', 'slack:T1']);
+
+    await named.teardown();
+    await def.teardown();
+  });
+
+  it('explicitly naming the primary instance after the platform stays on the unprefixed keyspace', async () => {
+    const { getDb } = await import('../db/connection.js');
+    const bridge = createChatSdkBridge({
+      adapter: setupStubAdapter(),
+      instance: 'slack', // explicit, but equal to adapter.name ⇒ default keyspace
+      supportsThreads: true,
+    });
+    await bridge.setup(hostConfig);
+    await bridge.subscribe!('slack:C1', 'slack:T9');
+    const rows = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+      thread_id: string;
+    }>;
+    expect(rows.map((r) => r.thread_id)).toEqual(['slack:T9']);
+    await bridge.teardown();
   });
 });
 

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -126,6 +126,18 @@ describe('createChatSdkBridge — instance identity', () => {
       ).toThrow(/URL-safe/);
     }
   });
+
+  it('rejects empty and whitespace-only instance names (config bug — fail loud)', () => {
+    // '' is falsy: a truthiness guard would skip it, dead-ending the
+    // webhook route ('/webhook/' + '') and collapsing the state namespace
+    // into the default instance's unprefixed keyspace — the exact
+    // cross-bot dedupe/lock collisions the namespace exists to prevent.
+    for (const bad of ['', ' ', '   ', '\t']) {
+      expect(() =>
+        createChatSdkBridge({ adapter: stubAdapter({ name: 'slack' }), instance: bad, supportsThreads: true }),
+      ).toThrow(/URL-safe/);
+    }
+  });
 });
 
 describe('createChatSdkBridge.setup — webhook route and state namespace', () => {
@@ -137,8 +149,7 @@ describe('createChatSdkBridge.setup — webhook route and state namespace', () =
     return stubAdapter({
       name: 'slack',
       initialize: async () => {},
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as unknown as Partial<Adapter>) as any;
+    } as unknown as Partial<Adapter>);
   }
 
   beforeEach(async () => {

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -47,6 +47,15 @@ export type ReplyContextExtractor = (raw: Record<string, any>) => ReplyContext |
 
 export interface ChatSdkBridgeConfig {
   adapter: Adapter;
+  /**
+   * Adapter-instance name for running multiple bridges of one platform
+   * (e.g. several Slack apps in one workspace). Defaults to the platform
+   * name. Drives the registry key, the webhook route (/webhook/<instance>),
+   * and the Chat SDK state namespace. channelType is NOT affected — user
+   * identity, formatting, and container config stay keyed on the platform.
+   * Must be URL-safe: no '/', '?', ':' or whitespace.
+   */
+  instance?: string;
   concurrency?: ConcurrencyStrategy;
   /** Bot token for authenticating forwarded Gateway events (required for interaction handling). */
   botToken?: string;
@@ -121,6 +130,14 @@ export function splitForLimit(text: string, limit: number): string[] {
 
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
+  // The instance name becomes a webhook route segment (the route regex is
+  // [^/?]+) and ':' is the state-namespace delimiter — reject anything that
+  // would break either, at construction time rather than at first webhook.
+  if (config.instance && /[/?:\s]/.test(config.instance)) {
+    throw new Error(
+      `chat-sdk bridge instance ${JSON.stringify(config.instance)} must be URL-safe: no '/', '?', ':' or whitespace`,
+    );
+  }
   const transformText = (t: string): string => (config.transformOutboundText ? config.transformOutboundText(t) : t);
   let chat: Chat;
   let state: SqliteStateAdapter;
@@ -193,14 +210,21 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
   }
 
   const bridge: ChannelAdapter = {
-    name: adapter.name,
-    channelType: adapter.name,
+    name: config.instance ?? adapter.name,
+    channelType: adapter.name, // unchanged — semantic platform key
+    instance: config.instance, // undefined ⇒ default instance
+
     supportsThreads: config.supportsThreads,
 
     async setup(hostConfig: ChannelSetup) {
       setupConfig = hostConfig;
 
-      state = new SqliteStateAdapter();
+      // State namespace: ONLY for a named non-default instance. A skill
+      // that explicitly names the primary instance after the platform
+      // (instance === adapter.name) still lands on the legacy UNPREFIXED
+      // keyspace — prefixing the default would orphan every live install's
+      // chat_sdk_subscriptions/kv/locks/lists rows.
+      state = new SqliteStateAdapter(config.instance && config.instance !== adapter.name ? config.instance : undefined);
 
       chat = new Chat({
         adapters: { [adapter.name]: adapter },
@@ -358,8 +382,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         startGateway();
         log.info('Gateway listener started', { adapter: adapter.name });
       } else {
-        // Non-gateway adapters (Slack, Teams, GitHub, etc.) — register on the shared webhook server
-        registerWebhookAdapter(chat, adapter.name);
+        // Non-gateway adapters (Slack, Teams, GitHub, etc.) — register on the
+        // shared webhook server. The handler key stays adapter.name (the
+        // Chat instance's webhooks map is keyed by it); the route segment is
+        // the instance, so each same-platform bridge gets its own URL (and
+        // its own signing secret — platforms sign per-app).
+        registerWebhookAdapter(chat, adapter.name, config.instance ?? adapter.name);
       }
 
       log.info('Chat SDK bridge initialized', { adapter: adapter.name });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -53,7 +53,7 @@ export interface ChatSdkBridgeConfig {
    * name. Drives the registry key, the webhook route (/webhook/<instance>),
    * and the Chat SDK state namespace. channelType is NOT affected — user
    * identity, formatting, and container config stay keyed on the platform.
-   * Must be URL-safe: no '/', '?', ':' or whitespace.
+   * Must be URL-safe: non-empty, only letters, digits, '.', '_' or '-'.
    */
   instance?: string;
   concurrency?: ConcurrencyStrategy;
@@ -133,9 +133,14 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
   // The instance name becomes a webhook route segment (the route regex is
   // [^/?]+) and ':' is the state-namespace delimiter — reject anything that
   // would break either, at construction time rather than at first webhook.
-  if (config.instance && /[/?:\s]/.test(config.instance)) {
+  // Positive allow-list (not a deny-list): also rejects '' and
+  // whitespace-only names, which are config bugs — '' is falsy, so it
+  // would skip a truthiness guard, dead-end the webhook route, and
+  // collapse the state namespace into the default instance's keyspace.
+  if (config.instance !== undefined && !/^[A-Za-z0-9._-]+$/.test(config.instance)) {
     throw new Error(
-      `chat-sdk bridge instance ${JSON.stringify(config.instance)} must be URL-safe: no '/', '?', ':' or whitespace`,
+      `chat-sdk bridge instance ${JSON.stringify(config.instance)} must be URL-safe: ` +
+        `non-empty, only letters, digits, '.', '_' or '-'`,
     );
   }
   const transformText = (t: string): string => (config.transformOutboundText ? config.transformOutboundText(t) : t);

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -90,8 +90,8 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
       now(),
     );
     db.prepare(
-      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-       VALUES (?, 'telegram', 'tg-1', 'chat', 1, 'strict', ?)`,
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+       VALUES (?, 'telegram', 'tg-1', 'telegram', 'chat', 1, 'strict', ?)`,
     ).run(MGID, now());
 
     db.prepare(

--- a/src/db/messaging-groups-instance.test.ts
+++ b/src/db/messaging-groups-instance.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Channel-instance dimension tests (migration 016 + messaging-groups queries).
+ *
+ * Covers the three load-bearing rules:
+ *   1. Backfill/default — instance = channel_type everywhere it isn't set,
+ *      so single-instance installs behave byte-identically.
+ *   2. UNIQUE(channel_type, platform_id, instance) — siblings coexist,
+ *      single-bot pair-uniqueness is preserved via the default value.
+ *   3. Lookup asymmetry — inbound (getMessagingGroupWithAgentCount) is
+ *      exact-on-instance with NO fallback (unknown named instance ⇒ null ⇒
+ *      router auto-creates instead of hijacking a sibling's row); outbound
+ *      (getMessagingGroupByPlatform) is default-instance-first.
+ *
+ * The wired-DB arm reproduces the failure mode that bit migration 011: a
+ * table recreate on a live DB with FK children. It must pass with
+ * disableForeignKeys: true and fail without it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { initTestDb, closeDb, getDb } from './connection.js';
+import { runMigrations, migrations } from './migrations/index.js';
+import {
+  createMessagingGroup,
+  getMessagingGroupByPlatform,
+  getMessagingGroupWithAgentCount,
+} from './messaging-groups.js';
+import type { MessagingGroup } from '../types.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function mg(overrides: Partial<MessagingGroup> & { id: string }): MessagingGroup {
+  return {
+    channel_type: 'slack',
+    platform_id: 'slack:C1',
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    created_at: now(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('migration 016 — fresh DB', () => {
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+  });
+
+  it('adds a NOT NULL instance column', () => {
+    const cols = getDb().prepare("PRAGMA table_info('messaging_groups')").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const instance = cols.find((c) => c.name === 'instance');
+    expect(instance).toBeDefined();
+    expect(instance!.notnull).toBe(1);
+  });
+
+  it('createMessagingGroup without instance stamps instance = channel_type', () => {
+    createMessagingGroup(mg({ id: 'mg-default' }));
+    const row = getDb().prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-default'").get() as {
+      instance: string;
+    };
+    expect(row.instance).toBe('slack');
+  });
+
+  it('allows sibling instances on the same (channel_type, platform_id)', () => {
+    createMessagingGroup(mg({ id: 'mg-default' }));
+    createMessagingGroup(mg({ id: 'mg-tester', instance: 'slack-tester' }));
+    const count = getDb().prepare('SELECT COUNT(*) AS c FROM messaging_groups').get() as { c: number };
+    expect(count.c).toBe(2);
+  });
+
+  it('rejects a duplicate (channel_type, platform_id, instance) triple', () => {
+    createMessagingGroup(mg({ id: 'mg-a', instance: 'slack-tester' }));
+    expect(() => createMessagingGroup(mg({ id: 'mg-b', instance: 'slack-tester' }))).toThrow();
+  });
+
+  it('rejects a duplicate default pair (single-bot uniqueness preserved)', () => {
+    createMessagingGroup(mg({ id: 'mg-a' }));
+    expect(() => createMessagingGroup(mg({ id: 'mg-b' }))).toThrow();
+  });
+});
+
+describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () => {
+  it('recreates messaging_groups under FK children without violations and backfills instance', () => {
+    const db = initTestDb();
+    // Bring the DB to the pre-016 schema.
+    runMigrations(
+      db,
+      migrations.filter((m) => m.name !== 'messaging-group-instance'),
+    );
+    const preCols = db.prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
+    expect(preCols.some((c) => c.name === 'instance')).toBe(false);
+
+    // Seed a wired install: messaging_groups with live FK children
+    // (messaging_group_agents + sessions reference messaging_groups.id).
+    // Raw SQL — the new createMessagingGroup expects the instance column.
+    db.prepare("INSERT INTO agent_groups (id, name, folder, created_at) VALUES ('ag-1', 'A', 'a', ?)").run(now());
+    db.prepare(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
+       VALUES ('mg-1', 'telegram', 'telegram:123', 'Chat', 0, 'public', ?)`,
+    ).run(now());
+    db.prepare(
+      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, engage_mode, sender_scope, ignored_message_policy, created_at)
+       VALUES ('mga-1', 'mg-1', 'ag-1', 'pattern', 'all', 'drop', ?)`,
+    ).run(now());
+    db.prepare(
+      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, created_at)
+       VALUES ('sess-1', 'ag-1', 'mg-1', ?)`,
+    ).run(now());
+
+    // Upgrade: only 016 is pending now. Without disableForeignKeys this
+    // throws 'FOREIGN KEY constraint failed' at DROP TABLE.
+    expect(() => runMigrations(db)).not.toThrow();
+
+    // Backfill: existing row got instance = channel_type.
+    const row = db.prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-1'").get() as { instance: string };
+    expect(row.instance).toBe('telegram');
+
+    // Children intact and pointing at the recreated parent.
+    expect(
+      db.prepare("SELECT COUNT(*) AS c FROM messaging_group_agents WHERE messaging_group_id = 'mg-1'").get(),
+    ).toEqual({ c: 1 });
+    expect(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE messaging_group_id = 'mg-1'").get()).toEqual({ c: 1 });
+
+    // Full-DB FK integrity (FK enforcement was restored by the runner).
+    expect(db.pragma('foreign_key_check')).toEqual([]);
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('is idempotent — re-running the full barrel is a no-op', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    createMessagingGroup(mg({ id: 'mg-keep', instance: 'slack-tester' }));
+    expect(() => runMigrations(db)).not.toThrow();
+    const row = db.prepare("SELECT instance FROM messaging_groups WHERE id = 'mg-keep'").get() as {
+      instance: string;
+    };
+    expect(row.instance).toBe('slack-tester');
+  });
+});
+
+describe('lookup asymmetry — inbound exact-only vs outbound default-first', () => {
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+    // The named instance ('alpha-tester') sorts lexically BEFORE the
+    // channel type ('slack') and is inserted first — so both rowid order
+    // and the triple-autoindex order put it ahead of the default row.
+    // A query missing the `(instance = channel_type) DESC` ORDER BY would
+    // return it; only the deterministic default-first ordering picks
+    // mg-default.
+    createMessagingGroup(mg({ id: 'mg-tester', instance: 'alpha-tester' }));
+    createMessagingGroup(mg({ id: 'mg-default' }));
+  });
+
+  it('getMessagingGroupWithAgentCount without instance resolves the default-instance row', () => {
+    const found = getMessagingGroupWithAgentCount('slack', 'slack:C1');
+    expect(found).not.toBeNull();
+    expect(found!.mg.id).toBe('mg-default');
+  });
+
+  it('getMessagingGroupWithAgentCount with a named instance resolves exactly that row', () => {
+    const found = getMessagingGroupWithAgentCount('slack', 'slack:C1', 'alpha-tester');
+    expect(found).not.toBeNull();
+    expect(found!.mg.id).toBe('mg-tester');
+  });
+
+  it('getMessagingGroupWithAgentCount with an unknown instance returns null (no-hijack rule)', () => {
+    expect(getMessagingGroupWithAgentCount('slack', 'slack:C1', 'slack-unknown')).toBeNull();
+  });
+
+  it('getMessagingGroupByPlatform without instance prefers the default-instance row', () => {
+    const found = getMessagingGroupByPlatform('slack', 'slack:C1');
+    expect(found).toBeDefined();
+    expect(found!.id).toBe('mg-default');
+  });
+
+  it('getMessagingGroupByPlatform with explicit instance is exact', () => {
+    expect(getMessagingGroupByPlatform('slack', 'slack:C1', 'alpha-tester')!.id).toBe('mg-tester');
+    expect(getMessagingGroupByPlatform('slack', 'slack:C1', 'slack-unknown')).toBeUndefined();
+  });
+
+  it('getMessagingGroupByPlatform falls back deterministically when only named instances exist', () => {
+    const db = getDb();
+    db.prepare("DELETE FROM messaging_groups WHERE id = 'mg-default'").run();
+    createMessagingGroup(mg({ id: 'mg-zeta', instance: 'zeta' }));
+    const found = getMessagingGroupByPlatform('slack', 'slack:C1');
+    // Lexically-first named instance: 'alpha-tester' < 'zeta'.
+    expect(found!.id).toBe('mg-tester');
+  });
+});

--- a/src/db/messaging-groups-instance.test.ts
+++ b/src/db/messaging-groups-instance.test.ts
@@ -18,7 +18,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { initTestDb, closeDb, getDb } from './connection.js';
-import { runMigrations, migrations } from './migrations/index.js';
+import { runMigrations, migrations, type Migration } from './migrations/index.js';
 import {
   createMessagingGroup,
   getMessagingGroupByPlatform,
@@ -133,6 +133,62 @@ describe('migration 016 — wired legacy DB upgrade (the FK recreate arm)', () =
     // Full-DB FK integrity (FK enforcement was restored by the runner).
     expect(db.pragma('foreign_key_check')).toEqual([]);
     expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('tolerates pre-existing FK orphans: the migration still applies (no boot crash-loop)', () => {
+    const db = initTestDb();
+    runMigrations(
+      db,
+      migrations.filter((m) => m.name !== 'messaging-group-instance'),
+    );
+
+    // Seed the orphan class that demonstrably exists on live installs
+    // (ensureUserDm tolerates it at runtime): a user_dms row whose
+    // messaging_group was deleted through a FK-OFF connection — the
+    // sqlite3 CLI ships with foreign_keys OFF, and operators are told to
+    // poke v2.db when troubleshooting.
+    db.prepare("INSERT INTO users (id, kind, created_at) VALUES ('slack:U1', 'slack', ?)").run(now());
+    db.pragma('foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+       VALUES ('slack:U1', 'slack', 'mg-deleted-via-cli', ?)`,
+    ).run(now());
+    db.pragma('foreign_keys = ON');
+    expect(db.pragma('foreign_key_check')).toHaveLength(1);
+
+    // 016 did not create this violation — it must still apply (the runner
+    // diffs post-up violations against a pre-up snapshot and only throws
+    // on NEW ones; pre-existing ones are warned about and carried through).
+    expect(() => runMigrations(db)).not.toThrow();
+    const cols = db.prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'instance')).toBe(true);
+
+    // The orphan is untouched: still present, still the only violation.
+    expect(db.pragma('foreign_key_check')).toHaveLength(1);
+  });
+
+  it('still rejects a migration that ITSELF introduces FK violations', () => {
+    const db = initTestDb();
+    runMigrations(db);
+
+    const rogue: Migration = {
+      version: 999,
+      name: 'test-rogue-fk-violation',
+      disableForeignKeys: true,
+      up: (d) => {
+        d.prepare("INSERT INTO users (id, kind, created_at) VALUES ('slack:U-rogue', 'slack', datetime('now'))").run();
+        d.prepare(
+          `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+           VALUES ('slack:U-rogue', 'slack', 'mg-never-existed', datetime('now'))`,
+        ).run();
+      },
+    };
+
+    expect(() => runMigrations(db, [...migrations, rogue])).toThrow(/left FK violations/);
+
+    // Rolled back atomically: not recorded as applied, nothing committed.
+    expect(db.prepare("SELECT 1 FROM schema_version WHERE name = 'test-rogue-fk-violation'").get()).toBeUndefined();
+    expect(db.pragma('foreign_key_check')).toEqual([]);
   });
 
   it('is idempotent — re-running the full barrel is a no-op', () => {

--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -21,19 +21,43 @@ import { getDb, hasTable } from './connection.js';
 export function createMessagingGroup(group: MessagingGroup): void {
   getDb()
     .prepare(
-      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
-       VALUES (@id, @channel_type, @platform_id, @name, @is_group, @unknown_sender_policy, @created_at)`,
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+       VALUES (@id, @channel_type, @platform_id, @instance, @name, @is_group, @unknown_sender_policy, @created_at)`,
     )
-    .run(group);
+    .run({ ...group, instance: group.instance ?? group.channel_type });
 }
 
 export function getMessagingGroup(id: string): MessagingGroup | undefined {
   return getDb().prepare('SELECT * FROM messaging_groups WHERE id = ?').get(id) as MessagingGroup | undefined;
 }
 
-export function getMessagingGroupByPlatform(channelType: string, platformId: string): MessagingGroup | undefined {
+/**
+ * Outbound / cold-DM / setup lookup by platform address.
+ *
+ * Instance semantics are deliberately ASYMMETRIC with the router's
+ * `getMessagingGroupWithAgentCount` (exact-only): outbound callers usually
+ * don't know (or care) which adapter instance owns a chat, so an unset
+ * `instance` resolves the default instance first (instance = channel_type),
+ * falling back deterministically to the lexically-first named instance.
+ * A set `instance` is exact-only — unknown instance returns undefined.
+ */
+export function getMessagingGroupByPlatform(
+  channelType: string,
+  platformId: string,
+  instance?: string,
+): MessagingGroup | undefined {
+  if (instance !== undefined) {
+    return getDb()
+      .prepare('SELECT * FROM messaging_groups WHERE channel_type = ? AND platform_id = ? AND instance = ?')
+      .get(channelType, platformId, instance) as MessagingGroup | undefined;
+  }
   return getDb()
-    .prepare('SELECT * FROM messaging_groups WHERE channel_type = ? AND platform_id = ?')
+    .prepare(
+      `SELECT * FROM messaging_groups
+        WHERE channel_type = ? AND platform_id = ?
+     ORDER BY (instance = channel_type) DESC, instance ASC
+        LIMIT 1`,
+    )
     .get(channelType, platformId) as MessagingGroup | undefined;
 }
 
@@ -46,23 +70,31 @@ export function getMessagingGroupByPlatform(channelType: string, platformId: str
  *
  * Returns `null` when no messaging_groups row exists for this channel.
  * Returns `{ mg, agentCount: 0 }` when the row exists but has no wired
- * agents. Uses the `UNIQUE(channel_type, platform_id)` index plus the
- * `UNIQUE(messaging_group_id, agent_group_id)` index for the JOIN — both
+ * agents. Uses the `UNIQUE(channel_type, platform_id, instance)` index plus
+ * the `UNIQUE(messaging_group_id, agent_group_id)` index for the JOIN — both
  * covered by existing SQLite auto-indexes from the UNIQUE constraints.
+ *
+ * `instance` is EXACT-ONLY, with no fallback — deliberately asymmetric with
+ * `getMessagingGroupByPlatform`'s default-instance-first resolution. An
+ * unknown named instance must return null so the router auto-creates a
+ * per-instance group instead of hijacking a sibling instance's row. The
+ * default param (= channelType) keeps instance-less callers resolving the
+ * default instance, identical to pre-instance behavior.
  */
 export function getMessagingGroupWithAgentCount(
   channelType: string,
   platformId: string,
+  instance: string = channelType,
 ): { mg: MessagingGroup; agentCount: number } | null {
   const row = getDb()
     .prepare(
       `SELECT mg.*, COUNT(mga.id) AS agent_count
          FROM messaging_groups mg
     LEFT JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
-        WHERE mg.channel_type = ? AND mg.platform_id = ?
+        WHERE mg.channel_type = ? AND mg.platform_id = ? AND mg.instance = ?
      GROUP BY mg.id`,
     )
-    .get(channelType, platformId) as (MessagingGroup & { agent_count: number }) | undefined;
+    .get(channelType, platformId, instance) as (MessagingGroup & { agent_count: number }) | undefined;
   if (!row) return null;
   const { agent_count, ...mg } = row;
   return { mg: mg as MessagingGroup, agentCount: agent_count };
@@ -72,6 +104,12 @@ export function getAllMessagingGroups(): MessagingGroup[] {
   return getDb().prepare('SELECT * FROM messaging_groups ORDER BY name').all() as MessagingGroup[];
 }
 
+/**
+ * All messaging groups on a platform, across every adapter instance.
+ * Semantics intentionally unchanged by the instance dimension — channel_type
+ * stays the semantic platform key. No live caller today; if a caller needs
+ * a single instance's rows, filter on `mg.instance`.
+ */
 export function getMessagingGroupsByChannel(channelType: string): MessagingGroup[] {
   return getDb().prepare('SELECT * FROM messaging_groups WHERE channel_type = ?').all(channelType) as MessagingGroup[];
 }

--- a/src/db/migrations/016-messaging-group-instance.ts
+++ b/src/db/migrations/016-messaging-group-instance.ts
@@ -1,0 +1,61 @@
+/**
+ * Channel-instance dimension on messaging_groups.
+ *
+ * `instance` names the adapter instance that owns a chat — N adapters of one
+ * platform (e.g. three Slack apps in one workspace) each get their own
+ * messaging_groups rows. The default instance IS the channel type: every
+ * existing row is backfilled with `instance = channel_type`, so all existing
+ * lookups keep resolving the same rows with zero operator action. NOT NULL
+ * (instead of nullable + partial unique index) keeps every lookup two-state:
+ * "default instance" is just the literal value `channel_type`.
+ *
+ * Uniqueness relaxes from UNIQUE(channel_type, platform_id) to
+ * UNIQUE(channel_type, platform_id, instance). SQLite cannot relax a
+ * table-level UNIQUE in place — this requires the documented 12-step
+ * recreate (new table → copy → DROP → RENAME, sqlite.org/lang_altertable.html).
+ * DROP TABLE fails `FOREIGN KEY constraint failed` on live DBs because five
+ * child tables REFERENCE messaging_groups(id) (messaging_group_agents,
+ * user_dms, sessions, pending_sender_approvals, pending_channel_approvals) —
+ * the exact failure that forced migration 011 to abandon its rebuild (see
+ * its header). Hence `disableForeignKeys: true`: the runner toggles
+ * foreign_keys=OFF around the transaction (the pragma is a no-op inside one)
+ * and runs PRAGMA foreign_key_check inside it so violations roll back.
+ *
+ * Column list mirrors the live tip schema exactly (001 columns + 012's
+ * denied_at) — verified against PRAGMA table_info on a freshly-migrated DB.
+ * A recreate with a stale column list silently drops data.
+ */
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const migration016: Migration = {
+  version: 16,
+  name: 'messaging-group-instance',
+  disableForeignKeys: true,
+  up: (db: Database.Database) => {
+    // Idempotency guard per the 012 pattern.
+    const cols = db.prepare("PRAGMA table_info('messaging_groups')").all() as Array<{ name: string }>;
+    if (cols.some((c) => c.name === 'instance')) return;
+
+    db.exec(`
+      CREATE TABLE messaging_groups_new (
+        id                    TEXT PRIMARY KEY,
+        channel_type          TEXT NOT NULL,
+        platform_id           TEXT NOT NULL,
+        instance              TEXT NOT NULL,
+        name                  TEXT,
+        is_group              INTEGER DEFAULT 0,
+        unknown_sender_policy TEXT NOT NULL DEFAULT 'strict',
+        created_at            TEXT NOT NULL,
+        denied_at             TEXT,
+        UNIQUE(channel_type, platform_id, instance)
+      );
+      INSERT INTO messaging_groups_new
+        (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at, denied_at)
+        SELECT id, channel_type, platform_id, channel_type, name, is_group, unknown_sender_policy, created_at, denied_at
+          FROM messaging_groups;
+      DROP TABLE messaging_groups;
+      ALTER TABLE messaging_groups_new RENAME TO messaging_groups;
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-container-configs.js';
 import { migration015 } from './015-cli-scope.js';
+import { migration016 } from './016-messaging-group-instance.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -19,9 +20,18 @@ export interface Migration {
   version: number;
   name: string;
   up: (db: Database.Database) => void;
+  /**
+   * Run with foreign_keys=OFF. Required for table recreates (SQLite can't
+   * drop a table-level UNIQUE without DROP+RENAME, and DROP fails FK
+   * integrity when child rows exist — see migration 011's header).
+   * PRAGMA foreign_keys is a no-op inside a transaction, so the runner
+   * toggles it around the transaction and runs PRAGMA foreign_key_check
+   * inside it, so violations roll the migration back.
+   */
+  disableForeignKeys?: boolean;
 }
 
-const migrations: Migration[] = [
+export const migrations: Migration[] = [
   migration001,
   migration002,
   moduleApprovalsPendingApprovals,
@@ -35,9 +45,10 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migration016,
 ];
 
-export function runMigrations(db: Database.Database): void {
+export function runMigrations(db: Database.Database, list: Migration[] = migrations): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY,
@@ -56,22 +67,38 @@ export function runMigrations(db: Database.Database): void {
   const applied = new Set<string>(
     (db.prepare('SELECT name FROM schema_version').all() as { name: string }[]).map((r) => r.name),
   );
-  const pending = migrations.filter((m) => !applied.has(m.name));
+  const pending = list.filter((m) => !applied.has(m.name));
   if (pending.length === 0) return;
 
   log.info('Running migrations', { count: pending.length });
 
   for (const m of pending) {
-    db.transaction(() => {
-      m.up(db);
-      const next = (db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as { v: number })
-        .v;
-      db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
-        next,
-        m.name,
-        new Date().toISOString(),
-      );
-    })();
+    // Table recreates need FK enforcement off for the DROP+RENAME window.
+    // The pragma must be toggled OUTSIDE the transaction (it's a silent
+    // no-op inside one); foreign_key_check runs INSIDE so a violating
+    // recreate rolls back atomically with nothing committed.
+    if (m.disableForeignKeys) db.pragma('foreign_keys = OFF');
+    try {
+      db.transaction(() => {
+        m.up(db);
+        if (m.disableForeignKeys) {
+          const violations = db.pragma('foreign_key_check') as unknown[];
+          if (violations.length > 0) {
+            throw new Error(`migration ${m.name} left FK violations: ${JSON.stringify(violations.slice(0, 5))}`);
+          }
+        }
+        const next = (
+          db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as { v: number }
+        ).v;
+        db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
+          next,
+          m.name,
+          new Date().toISOString(),
+        );
+      })();
+    } finally {
+      if (m.disableForeignKeys) db.pragma('foreign_keys = ON');
+    }
     log.info('Migration applied', { name: m.name });
   }
 }

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -48,6 +48,19 @@ export const migrations: Migration[] = [
   migration016,
 ];
 
+/** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a
+ *  parent-table recreate (child tables aren't touched), so this JSON identity
+ *  is a reliable before/after diff key. */
+interface FkViolation {
+  table: string;
+  rowid: number | null;
+  parent: string;
+  fkid: number;
+}
+
+const fkIdentity = (v: FkViolation): string =>
+  JSON.stringify({ table: v.table, rowid: v.rowid, parent: v.parent, fkid: v.fkid });
+
 export function runMigrations(db: Database.Database, list: Migration[] = migrations): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
@@ -80,11 +93,28 @@ export function runMigrations(db: Database.Database, list: Migration[] = migrati
     if (m.disableForeignKeys) db.pragma('foreign_keys = OFF');
     try {
       db.transaction(() => {
+        // Snapshot violations BEFORE up() runs: live DBs can carry latent
+        // FK orphans (e.g. parents deleted through a FK-OFF sqlite3 CLI
+        // session — ensureUserDm tolerates exactly this at runtime). The
+        // migration must only fail for violations it INTRODUCED; throwing
+        // on pre-existing ones would crash-loop the host at every boot
+        // (runMigrations runs on startup) until manual DB surgery.
+        const preexisting = m.disableForeignKeys
+          ? new Set((db.pragma('foreign_key_check') as FkViolation[]).map(fkIdentity))
+          : null;
         m.up(db);
-        if (m.disableForeignKeys) {
-          const violations = db.pragma('foreign_key_check') as unknown[];
-          if (violations.length > 0) {
-            throw new Error(`migration ${m.name} left FK violations: ${JSON.stringify(violations.slice(0, 5))}`);
+        if (m.disableForeignKeys && preexisting) {
+          const violations = db.pragma('foreign_key_check') as FkViolation[];
+          const introduced = violations.filter((v) => !preexisting.has(fkIdentity(v)));
+          const carried = violations.length - introduced.length;
+          if (carried > 0) {
+            log.warn('Pre-existing FK violations carried through migration (not introduced by it)', {
+              migration: m.name,
+              count: carried,
+            });
+          }
+          if (introduced.length > 0) {
+            throw new Error(`migration ${m.name} left FK violations: ${JSON.stringify(introduced.slice(0, 5))}`);
           }
         }
         const next = (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,16 +22,21 @@ CREATE TABLE agent_groups (
 -- only matters if something inserts without specifying the field, which no
 -- current callsite does. Router auto-create hardcodes "request_approval"
 -- (see src/router.ts:151); setup scripts pick per context.
+-- instance = adapter-instance name; the default instance IS the channel
+-- type (migration 016 backfill), so single-instance installs never see it.
+-- Inbound lookups are exact-on-instance; outbound lookups default-first.
 CREATE TABLE messaging_groups (
   id                    TEXT PRIMARY KEY,
   channel_type          TEXT NOT NULL,
   platform_id           TEXT NOT NULL,
+  instance              TEXT NOT NULL,
   name                  TEXT,
   is_group              INTEGER DEFAULT 0,
   unknown_sender_policy TEXT NOT NULL DEFAULT 'strict',
                         -- 'strict' | 'request_approval' | 'public'
   created_at            TEXT NOT NULL,
-  UNIQUE(channel_type, platform_id)
+  denied_at             TEXT,
+  UNIQUE(channel_type, platform_id, instance)
 );
 
 -- Which agent groups handle which messaging groups.

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -220,6 +220,76 @@ describe('deliverSessionMessages — retry and permanent failure', () => {
   });
 });
 
+describe('deliverSessionMessages — instance resolution', () => {
+  it('delivers via the origin session instance when sibling rows share (channel_type, platform_id)', async () => {
+    createAgentGroup({
+      id: 'ag-1',
+      name: 'Test Agent',
+      folder: 'test-agent',
+      agent_provider: null,
+      created_at: now(),
+    });
+    // Two instances own the same chat address. The named row sorts before
+    // 'slack', so a plain by-platform lookup (default-instance-first) would
+    // pick mg-default — only origin-session preference selects mg-tester.
+    createMessagingGroup({
+      id: 'mg-default',
+      channel_type: 'slack',
+      platform_id: 'slack:C1',
+      name: 'Default',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: 'mg-tester',
+      channel_type: 'slack',
+      platform_id: 'slack:C1',
+      instance: 'alpha-tester',
+      name: 'Tester',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    const { session } = resolveSession('ag-1', 'mg-tester', null, 'shared');
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES ('out-inst', datetime('now'), 'chat', 'slack:C1', 'slack', ?)`,
+    ).run(JSON.stringify({ text: 'hi' }));
+    db.close();
+
+    const instances: Array<string | undefined> = [];
+    setDeliveryAdapter({
+      async deliver(_ct, _pid, _tid, _kind, _content, _files, instance) {
+        instances.push(instance);
+        return 'plat-1';
+      },
+    });
+
+    await deliverSessionMessages(session);
+    expect(instances).toEqual(['alpha-tester']);
+  });
+
+  it('default session passes the backfilled default instance (= channel_type)', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+    insertOutbound('ag-1', session.id, 'out-default-inst');
+
+    const instances: Array<string | undefined> = [];
+    setDeliveryAdapter({
+      async deliver(_ct, _pid, _tid, _kind, _content, _files, instance) {
+        instances.push(instance);
+        return 'plat-2';
+      },
+    });
+
+    await deliverSessionMessages(session);
+    expect(instances).toEqual(['telegram']);
+  });
+});
+
 describe('deliverSessionMessages — permission check', () => {
   it('rejects delivery to an unauthorized channel destination', async () => {
     seedAgentAndChannel();

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -12,7 +12,7 @@ import type Database from 'better-sqlite3';
 import { getRunningSessions, getActiveSessions, createPendingQuestion } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
-import { getMessagingGroupByPlatform } from './db/messaging-groups.js';
+import { getMessagingGroup, getMessagingGroupByPlatform } from './db/messaging-groups.js';
 import {
   getDueOutboundMessages,
   getDeliveredIds,
@@ -57,8 +57,11 @@ export interface ChannelDeliveryAdapter {
     kind: string,
     content: string,
     files?: OutboundFile[],
+    /** Delivering adapter instance (defaults to channelType downstream).
+     *  Host-internal only — containers never see instance. */
+    instance?: string,
   ): Promise<string | undefined>;
-  setTyping?(channelType: string, platformId: string, threadId: string | null): Promise<void>;
+  setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
 }
 
 let deliveryAdapter: ChannelDeliveryAdapter | null = null;
@@ -286,8 +289,18 @@ async function deliverMessage(
   // path in deliverSessionMessages and eventually marks the message as failed
   // (instead of marking it delivered when nothing was actually delivered,
   // which was the pre-refactor bug).
+  let deliverInstance: string | undefined;
   if (msg.channel_type && msg.platform_id) {
-    const mg = getMessagingGroupByPlatform(msg.channel_type, msg.platform_id);
+    // Resolve the messaging group ORIGIN-SESSION-FIRST: when the message
+    // targets the session's own chat address, the origin row wins even if
+    // sibling instances share the same (channel_type, platform_id) — so the
+    // reply goes out through the instance the message came in on. Otherwise
+    // fall back to the by-platform lookup (default-instance-first).
+    const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+    const mg =
+      originMg && originMg.channel_type === msg.channel_type && originMg.platform_id === msg.platform_id
+        ? originMg
+        : getMessagingGroupByPlatform(msg.channel_type, msg.platform_id);
     if (!mg) {
       throw new Error(`unknown messaging group for ${msg.channel_type}/${msg.platform_id} (message ${msg.id})`);
     }
@@ -308,6 +321,7 @@ async function deliverMessage(
         );
       }
     }
+    deliverInstance = mg.instance;
   }
 
   // Track pending questions for ask_user_question flow.
@@ -360,6 +374,7 @@ async function deliverMessage(
     msg.kind,
     msg.content,
     files,
+    deliverInstance,
   );
   log.info('Message delivered', {
     id: msg.id,

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -597,6 +597,193 @@ describe('router', () => {
   });
 });
 
+describe('router — channel instances', () => {
+  beforeEach(() => {
+    createAgentGroup({
+      id: 'ag-1',
+      name: 'Default Bot',
+      folder: 'default-bot',
+      agent_provider: null,
+      created_at: now(),
+    });
+    createAgentGroup({
+      id: 'ag-2',
+      name: 'Tester Bot',
+      folder: 'tester-bot',
+      agent_provider: null,
+      created_at: now(),
+    });
+    // Two messaging groups on the SAME (channel_type, platform_id), owned
+    // by different adapter instances and wired to different agents.
+    createMessagingGroup({
+      id: 'mg-default',
+      channel_type: 'slack',
+      platform_id: 'slack:C1',
+      name: 'Default chat',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: 'mg-tester',
+      channel_type: 'slack',
+      platform_id: 'slack:C1',
+      instance: 'slack-tester',
+      name: 'Tester chat',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    for (const [mgaId, mgId, agId] of [
+      ['mga-default', 'mg-default', 'ag-1'],
+      ['mga-tester', 'mg-tester', 'ag-2'],
+    ] as const) {
+      createMessagingGroupAgent({
+        id: mgaId,
+        messaging_group_id: mgId,
+        agent_group_id: agId,
+        engage_mode: 'pattern',
+        engage_pattern: '.',
+        sender_scope: 'all',
+        ignored_message_policy: 'drop',
+        session_mode: 'shared',
+        priority: 0,
+        created_at: now(),
+      });
+    }
+  });
+
+  it('routes by receiving instance: named instance lands in its own mg/agent, default in the default', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { registerChannelAdapter, initChannelAdapters, teardownChannelAdapters } =
+      await import('./channels/channel-registry.js');
+    const { getSessionsByAgentGroup } = await import('./db/sessions.js');
+
+    // Default 'slack' adapter is THREADED; the named instance is NOT.
+    // The same arm therefore also pins the thread-policy lookup at the
+    // receiving instance: if the router resolved the adapter by
+    // channelType, the tester event's threadId would survive.
+    const makeAdapter = (instance: string | undefined, supportsThreads: boolean) => ({
+      name: instance ?? 'slack',
+      channelType: 'slack',
+      instance,
+      supportsThreads,
+      async setup() {},
+      async teardown() {},
+      isConnected: () => true,
+      async deliver() {
+        return undefined;
+      },
+    });
+    registerChannelAdapter('slack', { factory: () => makeAdapter(undefined, true) });
+    registerChannelAdapter('slack-tester', { factory: () => makeAdapter('slack-tester', false) });
+    vi.useFakeTimers();
+    const init = initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+    await vi.runAllTimersAsync();
+    await init;
+    vi.useRealTimers();
+
+    try {
+      // Inbound on the named instance, with a threadId the non-threaded
+      // adapter must collapse.
+      await routeInbound({
+        channelType: 'slack',
+        instance: 'slack-tester',
+        platformId: 'slack:C1',
+        threadId: 'thread-9',
+        message: {
+          id: 'msg-tester',
+          kind: 'chat',
+          content: JSON.stringify({ sender: 'U', text: 'to tester' }),
+          timestamp: now(),
+        },
+      });
+
+      const testerSessions = getSessionsByAgentGroup('ag-2');
+      expect(testerSessions).toHaveLength(1);
+      expect(testerSessions[0].messaging_group_id).toBe('mg-tester');
+      expect(getSessionsByAgentGroup('ag-1')).toHaveLength(0);
+
+      const tDb = new Database(inboundDbPath('ag-2', testerSessions[0].id));
+      const tRow = tDb.prepare('SELECT thread_id, content FROM messages_in').get() as {
+        thread_id: string | null;
+        content: string;
+      };
+      tDb.close();
+      expect(JSON.parse(tRow.content).text).toBe('to tester');
+      // Collapsed by the named instance's thread policy.
+      expect(tRow.thread_id).toBeNull();
+
+      // Same address, no instance ⇒ default instance ⇒ default mg/agent,
+      // and the default adapter is threaded so the threadId survives.
+      await routeInbound({
+        channelType: 'slack',
+        platformId: 'slack:C1',
+        threadId: 'thread-9',
+        message: {
+          id: 'msg-default',
+          kind: 'chat',
+          content: JSON.stringify({ sender: 'U', text: 'to default' }),
+          timestamp: now(),
+        },
+      });
+
+      const defaultSessions = getSessionsByAgentGroup('ag-1');
+      expect(defaultSessions).toHaveLength(1);
+      expect(defaultSessions[0].messaging_group_id).toBe('mg-default');
+      const dDb = new Database(inboundDbPath('ag-1', defaultSessions[0].id));
+      const dRow = dDb.prepare('SELECT thread_id FROM messages_in').get() as { thread_id: string | null };
+      dDb.close();
+      expect(dRow.thread_id).toBe('thread-9');
+    } finally {
+      await teardownChannelAdapters();
+    }
+  });
+
+  it('auto-create persists the receiving instance instead of hijacking the default row', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { getMessagingGroupByPlatform } = await import('./db/messaging-groups.js');
+
+    // No row exists for this address on ANY instance yet; create an
+    // unwired default row to prove the named event doesn't reuse it.
+    createMessagingGroup({
+      id: 'mg-plain',
+      channel_type: 'slack',
+      platform_id: 'slack:C-NEW',
+      name: null,
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    await routeInbound({
+      channelType: 'slack',
+      instance: 'slack-tester',
+      platformId: 'slack:C-NEW',
+      threadId: null,
+      message: {
+        id: 'msg-mention',
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'U', text: '@tester hi' }),
+        timestamp: now(),
+        isMention: true,
+      },
+    });
+
+    const created = getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack-tester');
+    expect(created).toBeDefined();
+    expect(created!.instance).toBe('slack-tester');
+    expect(created!.id).not.toBe('mg-plain');
+    // The default row is untouched.
+    expect(getMessagingGroupByPlatform('slack', 'slack:C-NEW', 'slack')!.id).toBe('mg-plain');
+  });
+});
+
 describe('routing metadata preservation', () => {
   beforeEach(() => {
     createAgentGroup({

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -677,16 +677,12 @@ describe('router — channel instances', () => {
     });
     registerChannelAdapter('slack', { factory: () => makeAdapter(undefined, true) });
     registerChannelAdapter('slack-tester', { factory: () => makeAdapter('slack-tester', false) });
-    vi.useFakeTimers();
-    const init = initChannelAdapters(() => ({
+    await initChannelAdapters(() => ({
       onInbound: () => {},
       onInboundEvent: () => {},
       onMetadata: () => {},
       onAction: () => {},
     }));
-    await vi.runAllTimersAsync();
-    await init;
-    vi.useRealTimers();
 
     try {
       // Inbound on the named instance, with a threadId the non-threaded

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,9 @@ async function main(): Promise<void> {
       onInbound(platformId, threadId, message) {
         routeInbound({
           channelType: adapter.channelType,
+          // The one host-side stamping seam: adapters stay instance-blind,
+          // the host stamps the receiving instance on every inbound event.
+          instance: adapter.instance ?? adapter.channelType,
           platformId,
           threadId,
           message: {
@@ -155,16 +158,22 @@ async function main(): Promise<void> {
       kind: string,
       content: string,
       files?: import('./channels/adapter.js').OutboundFile[],
+      instance?: string,
     ): Promise<string | undefined> {
-      const adapter = getChannelAdapter(channelType);
+      const adapter = getChannelAdapter(instance ?? channelType);
       if (!adapter) {
-        log.warn('No adapter for channel type', { channelType });
+        log.warn('No adapter for channel type', { channelType, instance });
         return;
       }
       return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
     },
-    async setTyping(channelType: string, platformId: string, threadId: string | null): Promise<void> {
-      const adapter = getChannelAdapter(channelType);
+    async setTyping(
+      channelType: string,
+      platformId: string,
+      threadId: string | null,
+      instance?: string,
+    ): Promise<void> {
+      const adapter = getChannelAdapter(instance ?? channelType);
       await adapter?.setTyping?.(platformId, threadId);
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,11 @@ import './cli/delivery-action.js';
 import { startCliServer, stopCliServer } from './cli/socket-server.js';
 
 import type { ChannelAdapter, ChannelSetup } from './channels/adapter.js';
-import { initChannelAdapters, teardownChannelAdapters, getChannelAdapter } from './channels/channel-registry.js';
+import {
+  initChannelAdapters,
+  teardownChannelAdapters,
+  createChannelDeliveryAdapter,
+} from './channels/channel-registry.js';
 
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
@@ -149,35 +153,11 @@ async function main(): Promise<void> {
     };
   });
 
-  // 4. Delivery adapter bridge — dispatches to channel adapters
-  const deliveryAdapter = {
-    async deliver(
-      channelType: string,
-      platformId: string,
-      threadId: string | null,
-      kind: string,
-      content: string,
-      files?: import('./channels/adapter.js').OutboundFile[],
-      instance?: string,
-    ): Promise<string | undefined> {
-      const adapter = getChannelAdapter(instance ?? channelType);
-      if (!adapter) {
-        log.warn('No adapter for channel type', { channelType, instance });
-        return;
-      }
-      return adapter.deliver(platformId, threadId, { kind, content: JSON.parse(content), files });
-    },
-    async setTyping(
-      channelType: string,
-      platformId: string,
-      threadId: string | null,
-      instance?: string,
-    ): Promise<void> {
-      const adapter = getChannelAdapter(instance ?? channelType);
-      await adapter?.setTyping?.(platformId, threadId);
-    },
-  };
-  setDeliveryAdapter(deliveryAdapter);
+  // 4. Delivery adapter bridge — dispatches to channel adapters by EXACT
+  // registry key (instance ?? channelType): a named instance with an
+  // offline adapter is never rerouted through a sibling bot. See
+  // createChannelDeliveryAdapter in channels/channel-registry.ts.
+  setDeliveryAdapter(createChannelDeliveryAdapter());
 
   // 5. Start delivery polls
   startActiveDeliveryPoll();

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Typing-refresh instance forwarding tests.
+ *
+ * Three tick sites can fire setTyping — the immediate tick on a new
+ * refresher, the 4s interval tick, and the immediate re-trigger when
+ * startTypingRefresh is called for an already-refreshing session. All three
+ * must forward the adapter instance, or a named instance's typing indicator
+ * fires through the wrong bot.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-typing' };
+});
+
+import { setTypingAdapter, startTypingRefresh, stopTypingRefresh } from './index.js';
+
+type Call = { channelType: string; platformId: string; threadId: string | null; instance?: string };
+
+function captureAdapter() {
+  const calls: Call[] = [];
+  setTypingAdapter({
+    async setTyping(channelType, platformId, threadId, instance) {
+      calls.push({ channelType, platformId, threadId, instance });
+    },
+  });
+  return calls;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  stopTypingRefresh('sess-1');
+  vi.useRealTimers();
+});
+
+describe('startTypingRefresh — instance forwarding', () => {
+  it('immediate tick passes the instance to the adapter', async () => {
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-tester');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      channelType: 'slack',
+      platformId: 'slack:C1',
+      threadId: null,
+      instance: 'slack-tester',
+    });
+  });
+
+  it('interval ticks inside the grace window pass the stored entry instance', async () => {
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
+    await vi.advanceTimersByTimeAsync(0);
+    calls.length = 0;
+
+    // Two 4s ticks — well inside the 15s grace window, so they fire
+    // unconditionally (no heartbeat file needed) from the stored entry.
+    await vi.advanceTimersByTimeAsync(8_500);
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const c of calls) {
+      expect(c.instance).toBe('slack-tester');
+      expect(c.threadId).toBe('T1');
+    }
+  });
+
+  it('re-trigger on an active session passes (and stores) the new instance', async () => {
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-tester');
+    await vi.advanceTimersByTimeAsync(0);
+    calls.length = 0;
+
+    // Second call for the same session: immediate tick with the new value.
+    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-worker');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].instance).toBe('slack-worker');
+
+    // And the stored entry was updated — subsequent interval ticks carry it.
+    calls.length = 0;
+    await vi.advanceTimersByTimeAsync(4_500);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls[calls.length - 1].instance).toBe('slack-worker');
+  });
+});

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -85,4 +85,39 @@ describe('startTypingRefresh — instance forwarding', () => {
     expect(calls.length).toBeGreaterThanOrEqual(1);
     expect(calls[calls.length - 1].instance).toBe('slack-worker');
   });
+
+  it('re-trigger with a changed address updates the whole entry — interval ticks stay self-consistent', async () => {
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
+    await vi.advanceTimersByTimeAsync(0);
+    calls.length = 0;
+
+    // Same session re-triggered from a different platform and chat
+    // (agent-shared sessions span messaging groups). The stored entry must
+    // not tear: keeping the old address with the new instance would hand a
+    // telegram platformId to the slack-tester adapter on the next tick.
+    startTypingRefresh('sess-1', 'ag-1', 'telegram', 'tg:99', null, 'telegram');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      channelType: 'telegram',
+      platformId: 'tg:99',
+      threadId: null,
+      instance: 'telegram',
+    });
+
+    // Interval ticks fire from the stored entry — all four fields must
+    // have moved together.
+    calls.length = 0;
+    await vi.advanceTimersByTimeAsync(4_500);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    for (const c of calls) {
+      expect(c).toEqual({
+        channelType: 'telegram',
+        platformId: 'tg:99',
+        threadId: null,
+        instance: 'telegram',
+      });
+    }
+  });
 });

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -45,7 +45,7 @@ const HEARTBEAT_FRESH_MS = 6000;
 const POST_DELIVERY_PAUSE_MS = 10000;
 
 interface TypingAdapter {
-  setTyping?(channelType: string, platformId: string, threadId: string | null): Promise<void>;
+  setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
 }
 
 interface TypingTarget {
@@ -53,6 +53,8 @@ interface TypingTarget {
   channelType: string;
   platformId: string;
   threadId: string | null;
+  /** Adapter instance that owns the chat; undefined = default (= channelType). */
+  instance?: string;
   interval: NodeJS.Timeout;
   startedAt: number;
   pausedUntil: number; // epoch ms; 0 = not paused
@@ -72,9 +74,14 @@ export function setTypingAdapter(a: TypingAdapter): void {
   adapter = a;
 }
 
-async function triggerTyping(channelType: string, platformId: string, threadId: string | null): Promise<void> {
+async function triggerTyping(
+  channelType: string,
+  platformId: string,
+  threadId: string | null,
+  instance?: string,
+): Promise<void> {
   try {
-    await adapter?.setTyping?.(channelType, platformId, threadId);
+    await adapter?.setTyping?.(channelType, platformId, threadId, instance);
   } catch {
     // Typing is best-effort — don't let it fail delivery or routing.
   }
@@ -96,6 +103,7 @@ export function startTypingRefresh(
   channelType: string,
   platformId: string,
   threadId: string | null,
+  instance?: string,
 ): void {
   const existing = typingRefreshers.get(sessionId);
   if (existing) {
@@ -104,14 +112,15 @@ export function startTypingRefresh(
     // the container-wake latency budget. Also clear any lingering
     // post-delivery pause: a new inbound means the user expects
     // typing to show immediately.
-    triggerTyping(channelType, platformId, threadId).catch(() => {});
+    triggerTyping(channelType, platformId, threadId, instance).catch(() => {});
     existing.startedAt = Date.now();
     existing.pausedUntil = 0;
+    existing.instance = instance;
     return;
   }
 
   // Immediate tick + periodic refresh.
-  triggerTyping(channelType, platformId, threadId).catch(() => {});
+  triggerTyping(channelType, platformId, threadId, instance).catch(() => {});
   const startedAt = Date.now();
   const interval = setInterval(() => {
     const entry = typingRefreshers.get(sessionId);
@@ -124,7 +133,7 @@ export function startTypingRefresh(
 
     const withinGrace = Date.now() - entry.startedAt < TYPING_GRACE_MS;
     if (withinGrace || isHeartbeatFresh(entry.agentGroupId, sessionId)) {
-      triggerTyping(entry.channelType, entry.platformId, entry.threadId).catch(() => {});
+      triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
       return;
     }
 
@@ -139,6 +148,7 @@ export function startTypingRefresh(
     channelType,
     platformId,
     threadId,
+    instance,
     interval,
     startedAt,
     pausedUntil: 0,

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -115,6 +115,15 @@ export function startTypingRefresh(
     triggerTyping(channelType, platformId, threadId, instance).catch(() => {});
     existing.startedAt = Date.now();
     existing.pausedUntil = 0;
+    // Keep the stored entry self-consistent: a re-trigger can arrive from
+    // a different chat address (agent-shared sessions span messaging
+    // groups, possibly on different platforms/instances), so the address
+    // fields and the owning instance must move together — a torn entry
+    // (old address + new instance) would hand e.g. a telegram platformId
+    // to a Slack instance's setTyping on the next interval tick.
+    existing.channelType = channelType;
+    existing.platformId = platformId;
+    existing.threadId = threadId;
     existing.instance = instance;
     return;
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -161,8 +161,10 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   if (messageInterceptor && (await messageInterceptor(event))) return;
 
   // 0. Apply the adapter's thread policy. Non-threaded adapters (Telegram,
-  //    WhatsApp, iMessage, email) collapse threads to the channel.
-  const adapter = getChannelAdapter(event.channelType);
+  //    WhatsApp, iMessage, email) collapse threads to the channel. Resolved
+  //    by the RECEIVING instance — sibling instances of one platform can
+  //    differ in thread support.
+  const adapter = getChannelAdapter(event.instance ?? event.channelType);
   if (adapter && !adapter.supportsThreads) {
     event = { ...event, threadId: null };
   }
@@ -172,8 +174,14 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   // 1. Combined lookup: messaging_group row + count of wired agents in a
   //    single query. Cheap short-circuit for the common "unwired channel"
   //    case — one DB read and we're out, no auto-create, no sender
-  //    resolution, no log spam.
-  const found = getMessagingGroupWithAgentCount(event.channelType, event.platformId);
+  //    resolution, no log spam. Exact-on-instance: an unknown named
+  //    instance falls through to auto-create rather than hijacking a
+  //    sibling instance's row.
+  const found = getMessagingGroupWithAgentCount(
+    event.channelType,
+    event.platformId,
+    event.instance ?? event.channelType,
+  );
 
   let mg: MessagingGroup;
   let agentCount: number;
@@ -187,6 +195,9 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
       id: mgId,
       channel_type: event.channelType,
       platform_id: event.platformId,
+      // Persist the receiving instance — without this, the first bot's row
+      // would absorb every sibling instance's traffic.
+      instance: event.instance ?? event.channelType,
       name: null,
       is_group: event.message.isGroup ? 1 : 0,
       unknown_sender_policy: 'request_approval',
@@ -472,7 +483,15 @@ async function deliverToAgent(
   if (wake) {
     // Typing indicator + wake are only for the engaged branch; accumulated
     // messages sit silently until a real trigger fires.
-    startTypingRefresh(session.id, session.agent_group_id, event.channelType, event.platformId, event.threadId);
+    // Typing fires via the adapter instance that owns this chat's row.
+    startTypingRefresh(
+      session.id,
+      session.agent_group_id,
+      event.channelType,
+      event.platformId,
+      event.threadId,
+      mg.instance,
+    );
     const freshSession = getSession(session.id);
     if (freshSession) {
       const woke = await wakeContainer(freshSession);

--- a/src/state-sqlite.test.ts
+++ b/src/state-sqlite.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SqliteStateAdapter namespace tests.
+ *
+ * All Chat SDK bridges share the chat_sdk_* tables in data/v2.db. Two
+ * same-platform adapter instances see identical thread/message ids, so the
+ * SDK's `dedupe:${adapter.name}:${message.id}` keys collide — the second
+ * bot silently drops every message the first processed — unless each named
+ * instance gets its own key namespace.
+ *
+ * The inverse constraint is just as load-bearing: the DEFAULT instance must
+ * keep today's UNPREFIXED keys byte-identically, or live installs orphan
+ * every existing subscription/lock/kv row on upgrade.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { initTestDb, closeDb, getDb } from './db/connection.js';
+import { runMigrations } from './db/migrations/index.js';
+import { SqliteStateAdapter } from './state-sqlite.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+async function makeAdapter(namespace?: string): Promise<SqliteStateAdapter> {
+  const state = new SqliteStateAdapter(namespace);
+  await state.connect();
+  return state;
+}
+
+describe('default instance — legacy unprefixed keys (live-install regression arm)', () => {
+  it('reads rows written before the namespace dimension existed', async () => {
+    // A pre-existing install's subscription row: bare thread id.
+    getDb().prepare("INSERT INTO chat_sdk_subscriptions (thread_id) VALUES ('T-raw')").run();
+    const state = await makeAdapter();
+    expect(await state.isSubscribed('T-raw')).toBe(true);
+  });
+
+  it('writes raw keys — kv, subscriptions, lists bind the exact input strings', async () => {
+    const state = await makeAdapter();
+    await state.set('k1', { v: 1 });
+    await state.subscribe('slack:T1');
+    await state.appendToList('l1', 'item');
+
+    const kv = getDb().prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
+    expect(kv.map((r) => r.key)).toEqual(['k1']);
+    const subs = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+      thread_id: string;
+    }>;
+    expect(subs.map((r) => r.thread_id)).toEqual(['slack:T1']);
+    const lists = getDb().prepare('SELECT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    expect(lists.map((r) => r.key)).toEqual(['l1']);
+  });
+});
+
+describe('namespaced instance — round-trips and raw-key shape', () => {
+  it('kv get/set/setIfNotExists/delete round-trip under a prefixed key', async () => {
+    const state = await makeAdapter('slack-tester');
+    await state.set('k1', { v: 42 });
+    expect(await state.get('k1')).toEqual({ v: 42 });
+
+    const raw = getDb().prepare('SELECT key FROM chat_sdk_kv').all() as Array<{ key: string }>;
+    expect(raw.map((r) => r.key)).toEqual(['slack-tester:k1']);
+
+    expect(await state.setIfNotExists('k1', 'other')).toBe(false);
+    expect(await state.setIfNotExists('k2', 'fresh')).toBe(true);
+    await state.delete('k1');
+    expect(await state.get('k1')).toBeNull();
+    expect(await state.get('k2')).toBe('fresh');
+  });
+
+  it('subscribe/isSubscribed/unsubscribe round-trip under a prefixed thread_id', async () => {
+    const state = await makeAdapter('slack-tester');
+    await state.subscribe('slack:T1');
+    expect(await state.isSubscribed('slack:T1')).toBe(true);
+
+    const raw = getDb().prepare('SELECT thread_id FROM chat_sdk_subscriptions').all() as Array<{
+      thread_id: string;
+    }>;
+    expect(raw.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1']);
+
+    await state.unsubscribe('slack:T1');
+    expect(await state.isSubscribed('slack:T1')).toBe(false);
+  });
+
+  it('lists round-trip under a prefixed key', async () => {
+    const state = await makeAdapter('slack-tester');
+    await state.appendToList('history', 'a');
+    await state.appendToList('history', 'b');
+    expect(await state.getList('history')).toEqual(['a', 'b']);
+    const raw = getDb().prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    expect(raw.map((r) => r.key)).toEqual(['slack-tester:history']);
+  });
+});
+
+describe('cross-namespace isolation', () => {
+  it('setIfNotExists succeeds in BOTH namespaces (the SDK-dedupe collision fix)', async () => {
+    const a = await makeAdapter('slack-worker');
+    const b = await makeAdapter('slack-tester');
+    // Same SDK dedupe key from both bots — each must win in its own space.
+    expect(await a.setIfNotExists('dedupe:slack:m1', 1)).toBe(true);
+    expect(await b.setIfNotExists('dedupe:slack:m1', 1)).toBe(true);
+    // And re-asserting within one namespace still dedupes.
+    expect(await a.setIfNotExists('dedupe:slack:m1', 1)).toBe(false);
+  });
+
+  it("one namespace's subscription is invisible to the other (and to the default)", async () => {
+    const a = await makeAdapter('slack-worker');
+    const b = await makeAdapter('slack-tester');
+    const def = await makeAdapter();
+    await a.subscribe('slack:T1');
+    expect(await a.isSubscribed('slack:T1')).toBe(true);
+    expect(await b.isSubscribed('slack:T1')).toBe(false);
+    expect(await def.isSubscribed('slack:T1')).toBe(false);
+  });
+});
+
+describe('locks under a namespace', () => {
+  it('acquire returns the RAW threadId; extend and release hit the prefixed row', async () => {
+    const state = await makeAdapter('slack-tester');
+    const lock = await state.acquireLock('slack:T1', 5000);
+    expect(lock).not.toBeNull();
+    // Raw id on the Lock object — release/extend apply the prefix at their
+    // own SQL sites. A prefixed id here would double-prefix on release.
+    expect(lock!.threadId).toBe('slack:T1');
+
+    const raw = getDb().prepare('SELECT thread_id FROM chat_sdk_locks').all() as Array<{ thread_id: string }>;
+    expect(raw.map((r) => r.thread_id)).toEqual(['slack-tester:slack:T1']);
+
+    expect(await state.extendLock(lock!, 10_000)).toBe(true);
+    await state.releaseLock(lock!);
+    expect(getDb().prepare('SELECT COUNT(*) AS c FROM chat_sdk_locks').get()).toEqual({ c: 0 });
+  });
+
+  it('same-thread locks in different namespaces do not contend', async () => {
+    const a = await makeAdapter('slack-worker');
+    const b = await makeAdapter('slack-tester');
+    expect(await a.acquireLock('slack:T1', 5000)).not.toBeNull();
+    expect(await b.acquireLock('slack:T1', 5000)).not.toBeNull();
+    // Within one namespace the second acquire still fails.
+    expect(await a.acquireLock('slack:T1', 5000)).toBeNull();
+  });
+});
+
+describe('queue under a namespace', () => {
+  it('enqueue → queueDepth → dequeue drains to empty; raw key is ns:queue:<tid>', async () => {
+    const state = await makeAdapter('slack-tester');
+    const entry = { message: { id: 'm1' } } as never;
+    expect(await state.enqueue('slack:T1', entry, 10)).toBe(1);
+
+    const raw = getDb().prepare('SELECT DISTINCT key FROM chat_sdk_lists').all() as Array<{ key: string }>;
+    // Single prefix: enqueue must NOT apply k() itself (appendToList does);
+    // a double prefix ('slack-tester:slack-tester:queue:…') never drains.
+    expect(raw.map((r) => r.key)).toEqual(['slack-tester:queue:slack:T1']);
+
+    expect(await state.queueDepth('slack:T1')).toBe(1);
+    const out = await state.dequeue('slack:T1');
+    expect(out).toEqual(entry);
+    expect(await state.queueDepth('slack:T1')).toBe(0);
+    expect(await state.dequeue('slack:T1')).toBeNull();
+  });
+});

--- a/src/state-sqlite.ts
+++ b/src/state-sqlite.ts
@@ -20,6 +20,28 @@ interface Lock {
 export class SqliteStateAdapter implements StateAdapter {
   private db!: Database.Database;
 
+  /**
+   * namespace = adapter-instance name; undefined ⇒ legacy unprefixed keys.
+   *
+   * All bridges share the same chat_sdk_* tables, and two same-platform
+   * instances see identical thread/message ids — the SDK's dedupe key is
+   * `dedupe:${adapter.name}:${message.id}`, so without a namespace the
+   * second bot silently drops every message the first processed, locks
+   * serialize across bots, and subscriptions leak engagement between them.
+   *
+   * The default instance MUST stay unprefixed: prefixing it would orphan
+   * every live install's existing chat_sdk_subscriptions/kv/locks/lists
+   * rows (silently killing engaged threads) with no clean way to rewrite
+   * them. `k()` is the single choke point between every public method and
+   * its SQL parameter — with namespace undefined it is the identity
+   * function, so every statement binds the exact same strings as before.
+   */
+  constructor(private readonly namespace?: string) {}
+
+  private k(key: string): string {
+    return this.namespace ? `${this.namespace}:${key}` : key;
+  }
+
   async connect(): Promise<void> {
     this.db = getDb();
     this.cleanup();
@@ -31,12 +53,13 @@ export class SqliteStateAdapter implements StateAdapter {
 
   async get<T = unknown>(key: string): Promise<T | null> {
     this.cleanup();
-    const row = this.db.prepare('SELECT value, expires_at FROM chat_sdk_kv WHERE key = ?').get(key) as
+    const k = this.k(key);
+    const row = this.db.prepare('SELECT value, expires_at FROM chat_sdk_kv WHERE key = ?').get(k) as
       | { value: string; expires_at: number | null }
       | undefined;
     if (!row) return null;
     if (row.expires_at && row.expires_at < Date.now()) {
-      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(key);
+      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(k);
       return null;
     }
     return JSON.parse(row.value) as T;
@@ -46,39 +69,42 @@ export class SqliteStateAdapter implements StateAdapter {
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
     this.db
       .prepare('INSERT OR REPLACE INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)')
-      .run(key, JSON.stringify(value), expiresAt);
+      .run(this.k(key), JSON.stringify(value), expiresAt);
   }
 
   async setIfNotExists(key: string, value: unknown, ttlMs?: number): Promise<boolean> {
-    const existing = this.db.prepare('SELECT expires_at FROM chat_sdk_kv WHERE key = ?').get(key) as
+    const k = this.k(key);
+    const existing = this.db.prepare('SELECT expires_at FROM chat_sdk_kv WHERE key = ?').get(k) as
       | { expires_at: number | null }
       | undefined;
     if (existing?.expires_at && existing.expires_at < Date.now()) {
-      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(key);
+      this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(k);
     }
     const expiresAt = ttlMs ? Date.now() + ttlMs : null;
     const result = this.db
       .prepare('INSERT OR IGNORE INTO chat_sdk_kv (key, value, expires_at) VALUES (?, ?, ?)')
-      .run(key, JSON.stringify(value), expiresAt);
+      .run(k, JSON.stringify(value), expiresAt);
     return result.changes > 0;
   }
 
   async delete(key: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(key);
+    this.db.prepare('DELETE FROM chat_sdk_kv WHERE key = ?').run(this.k(key));
   }
 
   // --- Subscriptions ---
 
   async subscribe(threadId: string): Promise<void> {
-    this.db.prepare('INSERT OR REPLACE INTO chat_sdk_subscriptions (thread_id) VALUES (?)').run(threadId);
+    this.db.prepare('INSERT OR REPLACE INTO chat_sdk_subscriptions (thread_id) VALUES (?)').run(this.k(threadId));
   }
 
   async unsubscribe(threadId: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_subscriptions WHERE thread_id = ?').run(threadId);
+    this.db.prepare('DELETE FROM chat_sdk_subscriptions WHERE thread_id = ?').run(this.k(threadId));
   }
 
   async isSubscribed(threadId: string): Promise<boolean> {
-    const row = this.db.prepare('SELECT 1 FROM chat_sdk_subscriptions WHERE thread_id = ? LIMIT 1').get(threadId);
+    const row = this.db
+      .prepare('SELECT 1 FROM chat_sdk_subscriptions WHERE thread_id = ? LIMIT 1')
+      .get(this.k(threadId));
     return !!row;
   }
 
@@ -88,23 +114,28 @@ export class SqliteStateAdapter implements StateAdapter {
     const now = Date.now();
     const token = crypto.randomUUID();
     const expiresAt = now + ttlMs;
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND expires_at < ?').run(threadId, now);
+    const k = this.k(threadId);
+    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND expires_at < ?').run(k, now);
     const result = this.db
       .prepare('INSERT OR IGNORE INTO chat_sdk_locks (thread_id, token, expires_at) VALUES (?, ?, ?)')
-      .run(threadId, token, expiresAt);
+      .run(k, token, expiresAt);
     if (result.changes === 0) return null;
+    // The Lock carries the RAW threadId; release/extend re-apply k() at
+    // their own SQL sites. Uniform — no un/re-prefixing on the caller side.
     return { threadId, token, expiresAt };
   }
 
   async releaseLock(lock: Lock): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND token = ?').run(lock.threadId, lock.token);
+    this.db
+      .prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ? AND token = ?')
+      .run(this.k(lock.threadId), lock.token);
   }
 
   async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
     const newExpiry = Date.now() + ttlMs;
     const result = this.db
       .prepare('UPDATE chat_sdk_locks SET expires_at = ? WHERE thread_id = ? AND token = ?')
-      .run(newExpiry, lock.threadId, lock.token);
+      .run(newExpiry, this.k(lock.threadId), lock.token);
     if (result.changes > 0) {
       lock.expiresAt = newExpiry;
       return true;
@@ -113,24 +144,25 @@ export class SqliteStateAdapter implements StateAdapter {
   }
 
   async forceReleaseLock(threadId: string): Promise<void> {
-    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ?').run(threadId);
+    this.db.prepare('DELETE FROM chat_sdk_locks WHERE thread_id = ?').run(this.k(threadId));
   }
 
   // --- Lists ---
 
   async appendToList(key: string, value: unknown, options?: { maxLength?: number; ttlMs?: number }): Promise<void> {
     const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : null;
-    const maxRow = this.db.prepare('SELECT MAX(idx) as maxIdx FROM chat_sdk_lists WHERE key = ?').get(key) as
+    const k = this.k(key);
+    const maxRow = this.db.prepare('SELECT MAX(idx) as maxIdx FROM chat_sdk_lists WHERE key = ?').get(k) as
       | { maxIdx: number | null }
       | undefined;
     const nextIdx = (maxRow?.maxIdx ?? -1) + 1;
     this.db
       .prepare('INSERT INTO chat_sdk_lists (key, idx, value, expires_at) VALUES (?, ?, ?, ?)')
-      .run(key, nextIdx, JSON.stringify(value), expiresAt);
+      .run(k, nextIdx, JSON.stringify(value), expiresAt);
     if (options?.maxLength) {
       const cutoff = nextIdx - options.maxLength;
       if (cutoff >= 0) {
-        this.db.prepare('DELETE FROM chat_sdk_lists WHERE key = ? AND idx <= ?').run(key, cutoff);
+        this.db.prepare('DELETE FROM chat_sdk_lists WHERE key = ? AND idx <= ?').run(k, cutoff);
       }
     }
   }
@@ -141,20 +173,23 @@ export class SqliteStateAdapter implements StateAdapter {
       .prepare(
         'SELECT value FROM chat_sdk_lists WHERE key = ? AND (expires_at IS NULL OR expires_at > ?) ORDER BY idx ASC',
       )
-      .all(key, now) as { value: string }[];
+      .all(this.k(key), now) as { value: string }[];
     return rows.map((r) => JSON.parse(r.value) as T);
   }
 
   // --- Queue ---
 
   async enqueue(threadId: string, entry: QueueEntry, maxSize: number): Promise<number> {
+    // No k() here: appendToList prefixes at its own SQL boundary. Prefixing
+    // twice would write `ns:ns:queue:<tid>` and the queue would never drain.
+    // Resulting on-disk layout is `ns:queue:<tid>`.
     const key = `queue:${threadId}`;
     await this.appendToList(key, entry, { maxLength: maxSize });
     return await this.queueDepth(threadId);
   }
 
   async dequeue(threadId: string): Promise<QueueEntry | null> {
-    const key = `queue:${threadId}`;
+    const key = this.k(`queue:${threadId}`);
     const row = this.db
       .prepare('SELECT idx, value FROM chat_sdk_lists WHERE key = ? ORDER BY idx ASC LIMIT 1')
       .get(key) as { idx: number; value: string } | undefined;
@@ -164,7 +199,7 @@ export class SqliteStateAdapter implements StateAdapter {
   }
 
   async queueDepth(threadId: string): Promise<number> {
-    const key = `queue:${threadId}`;
+    const key = this.k(`queue:${threadId}`);
     const row = this.db.prepare('SELECT COUNT(*) as count FROM chat_sdk_lists WHERE key = ?').get(key) as {
       count: number;
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,14 @@ export interface MessagingGroup {
   id: string;
   channel_type: string;
   platform_id: string;
+  /**
+   * Adapter-instance name. Defaults to channel_type (the "default instance").
+   * Column is NOT NULL (migration 016 backfills instance = channel_type);
+   * optional on the TS type per the denied_at convention so fixtures that
+   * build MessagingGroup objects don't need updating — createMessagingGroup
+   * stamps the default.
+   */
+  instance?: string;
   name: string | null;
   is_group: number; // 0 | 1
   unknown_sender_policy: UnknownSenderPolicy;

--- a/src/webhook-server.test.ts
+++ b/src/webhook-server.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Webhook server route/handler split tests.
+ *
+ * The route key (URL segment, `/webhook/<routingPath>`) and the handler key
+ * (`chat.webhooks[adapterName]`) are independent: a named adapter instance
+ * registers its own Chat under its own URL while dispatching to the same
+ * SDK adapter name. The 2-arg default keeps the historical single-instance
+ * route byte-identical. Conventions follow PR #2617: real HTTP server on a
+ * fixed WEBHOOK_PORT, real fetch.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import type { Chat } from 'chat';
+
+import { registerWebhookAdapter, stopWebhookServer } from './webhook-server.js';
+
+const PORT = 3917;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+/** Minimal Chat stand-in: only `webhooks` is touched by the server. */
+function stubChat(tag: string, adapterName = 'slack'): { chat: Chat; calls: string[] } {
+  const calls: string[] = [];
+  const chat = {
+    webhooks: {
+      [adapterName]: async (req: Request) => {
+        calls.push(await req.text());
+        return new Response(JSON.stringify({ via: tag }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    },
+  } as unknown as Chat;
+  return { chat, calls };
+}
+
+async function post(path: string, body: string): Promise<Response> {
+  // The server starts listening asynchronously after registration — retry
+  // briefly on connection refusal instead of sleeping a fixed amount.
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fetch(`${BASE}${path}`, { method: 'POST', body });
+    } catch (err) {
+      if (attempt >= 20) throw err;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+  }
+}
+
+beforeEach(() => {
+  process.env.WEBHOOK_PORT = String(PORT);
+});
+
+afterEach(async () => {
+  await stopWebhookServer();
+  delete process.env.WEBHOOK_PORT;
+});
+
+describe('registerWebhookAdapter — route/handler split', () => {
+  it('2-arg default: /webhook/<adapterName> dispatches to chat.webhooks[adapterName]', async () => {
+    const { chat, calls } = stubChat('default');
+    registerWebhookAdapter(chat, 'slack');
+
+    const res = await post('/webhook/slack', 'payload-default');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ via: 'default' });
+    expect(calls).toEqual(['payload-default']);
+  });
+
+  it('3-arg: routes by routingPath, dispatches by adapterName; the bare route stays unregistered', async () => {
+    const { chat, calls } = stubChat('tester');
+    registerWebhookAdapter(chat, 'slack', 'slack-tester');
+
+    const res = await post('/webhook/slack-tester', 'payload-tester');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ via: 'tester' });
+    expect(calls).toEqual(['payload-tester']);
+
+    // Only the routed entry exists — /webhook/slack must 404, not leak into
+    // the named instance's Chat.
+    const miss = await post('/webhook/slack', 'stray');
+    expect(miss.status).toBe(404);
+    expect(calls).toEqual(['payload-tester']);
+  });
+
+  it('two same-adapterName registrations under distinct paths hit their own Chat instances', async () => {
+    const worker = stubChat('worker');
+    const tester = stubChat('tester');
+    registerWebhookAdapter(worker.chat, 'slack');
+    registerWebhookAdapter(tester.chat, 'slack', 'slack-tester');
+
+    const r1 = await post('/webhook/slack', 'to-worker');
+    const r2 = await post('/webhook/slack-tester', 'to-tester');
+    expect(await r1.json()).toEqual({ via: 'worker' });
+    expect(await r2.json()).toEqual({ via: 'tester' });
+    expect(worker.calls).toEqual(['to-worker']);
+    expect(tester.calls).toEqual(['to-tester']);
+  });
+
+  it('unregistered path 404s', async () => {
+    const { chat } = stubChat('only');
+    registerWebhookAdapter(chat, 'slack');
+    const res = await post('/webhook/nope', 'x');
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -69,11 +69,19 @@ async function fromWebResponse(webRes: Response, nodeRes: http.ServerResponse): 
 /**
  * Register a webhook adapter on the shared server.
  * Starts the server lazily on first call.
+ *
+ * `routingPath` is the URL segment (`/webhook/<routingPath>`); `adapterName`
+ * stays the handler key into `chat.webhooks`. The split lets N instances of
+ * one platform (each with its own Chat + signing secret) listen on distinct
+ * URLs while dispatching to the same SDK adapter name. Defaulting
+ * routingPath to adapterName keeps the historical single-instance route
+ * byte-identical. Signature adopted verbatim from PR #2617 (@davekim917's
+ * #1804 prototype) so the two changes converge textually.
  */
-export function registerWebhookAdapter(chat: Chat, adapterName: string): void {
-  routes.set(adapterName, { chat, adapterName });
+export function registerWebhookAdapter(chat: Chat, adapterName: string, routingPath: string = adapterName): void {
+  routes.set(routingPath, { chat, adapterName });
   ensureServer();
-  log.info('Webhook adapter registered', { adapter: adapterName, path: `/webhook/${adapterName}` });
+  log.info('Webhook adapter registered', { adapter: adapterName, path: `/webhook/${routingPath}` });
 }
 
 function ensureServer(): void {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

*(None of the boxes fit: this is core substrate — the "watch for hotspots → add a proper hook" maintainer commitment from docs/skills-model.md. It adds a dimension that turns multi-bot skills into clean adds; the bots themselves stay skills.)*

## Description

### What

A native **channel-instance dimension**: N adapter instances per platform (e.g. three Slack apps in one workspace), keyed by an `instance` name that defaults to `channelType`.

- `messaging_groups.instance` — NOT NULL, backfilled to `channel_type`, `UNIQUE(channel_type, platform_id, instance)` (migration 016: FK-OFF table recreate; the runner gains `disableForeignKeys` and fails only on FK violations a migration *introduces* — pre-existing latent orphans are logged and carried, never a boot crash-loop)
- Adapter registry keyed by `instance ?? channelType`; delivery/typing dispatch by **exact** key (a named instance with an offline adapter gets offline handling — never a cross-identity send through a sibling bot); the channelType fallback survives only for channelType-only callers (cold DMs, approval delivery) and warns when it crosses instances
- `ChatSdkBridgeConfig.instance` — one field driving the registry key, the webhook route (`/webhook/<instance>`), and the Chat SDK state namespace. State keys are namespaced **only when** `instance !== adapter.name`, so existing installs' `chat_sdk_*` rows stay byte-identical
- `registerWebhookAdapter(chat, adapterName, routingPath?)` — adopted verbatim from #2617 (credit: @mmahmed); routes by path, dispatches by adapter name
- `instance` threaded through router (lookup + auto-create), delivery (origin-session-first resolution), and typing

`channelType` stays the semantic platform key everywhere — user ids (`<channel>:<handle>`), formatting, container config. Containers stay instance-blind: zero session-DB and zero `container/` changes.

### Why

Same-channel multi-bot is the one shape the current keying can't express: the registry, `UNIQUE(channel_type, platform_id)`, webhook routes, and Chat SDK state all assume one adapter per platform. A real fork (PR Factory: worker/supervisor/tester Slack trio) needed reach-ins across 12 core files to add this dimension — the definition of a hotspot under docs/skills-model.md's maintainer commitments. With this substrate, that becomes a channel skill that just registers two more adapters. Refs #1804, refs #2653 (both are instance-shaped demand). Complementary to #2617, which targets multi-*workspace* (where changing the effective channelType is correct); this PR covers multi-bot *within* one workspace/channel, where channelType must stay stable or user identity fractures.

### How it was tested

- 397 host tests (48 new: migration fresh/aged/idempotent + seeded-FK-children recreate, registry exact-vs-fallback, bridge identity/state-namespace/URL-safety, webhook path-vs-name split, delivery origin-instance preference, typing threading, router no-hijack auto-create)
- Every new integration point **mutation-verified**: each guard was confirmed to go red when its wiring is deleted/reverted, then green on restore (~30 mutations executed)
- `build`, `typecheck` clean; `lint` byte-identical to the dc34ceb baseline (114/13, all pre-existing)
- Container suite: 101 tests, code untouched (`git diff dc34ceb -- container/` is empty). Note: `poll-loop — /upload-trace` flaked during verification — it makes a live Hugging Face call and races a 5s timeout; reproduces on pristine dc34ceb code, unrelated to this PR (worth a separate issue)
- channels-branch compat verified: all native adapters and all 13 Chat-SDK channel modules use the default path unchanged. One follow-up for the branch: it carries a stale copy of `chat-sdk-bridge.ts` that should be synced after this lands

### Notes for review

- An earlier draft staggered same-platform gateway boots by 10s (rate-limit etiquette); cut as operational policy, not substrate — reintroducible skill-side if gateway-mode multi-instance lands.
- `.claude/skills/add-github` and `add-linear` wiring INSERTs gain the `instance` column (NOT NULL has no SQL default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
