### PR TITLE
feat(delivery): getDeliveryAction read side for the action registry

### DIFF
--- a/src/delivery-actions.test.ts
+++ b/src/delivery-actions.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Delivery action registry.
+ *
+ * `registerDeliveryAction` is the hook modules use to handle system-kind
+ * outbound messages; `getDeliveryAction` is the read side that makes those
+ * registrations behavior-testable. Goes red if either half of the registry
+ * is removed or the two stop sharing the same map.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  killContainer: vi.fn(),
+  buildAgentGroupImage: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDeliveryAction, getDeliveryAction, type DeliveryActionHandler } from './delivery.js';
+
+describe('delivery action registry', () => {
+  it('getDeliveryAction returns the handler registerDeliveryAction registered', () => {
+    const handler: DeliveryActionHandler = async () => {};
+    registerDeliveryAction('test_registry_action', handler);
+    expect(getDeliveryAction('test_registry_action')).toBe(handler);
+  });
+
+  it('getDeliveryAction returns undefined for unregistered actions', () => {
+    expect(getDeliveryAction('test_never_registered_action')).toBeUndefined();
+  });
+
+  it('re-registering an action overwrites the previous handler', () => {
+    const first: DeliveryActionHandler = async () => {};
+    const second: DeliveryActionHandler = async () => {};
+    registerDeliveryAction('test_overwrite_action', first);
+    registerDeliveryAction('test_overwrite_action', second);
+    expect(getDeliveryAction('test_overwrite_action')).toBe(second);
+  });
+});

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -402,6 +402,11 @@ export function registerDeliveryAction(action: string, handler: DeliveryActionHa
   actionHandlers.set(action, handler);
 }
 
+/** Look up a registered delivery-action handler. Lets module registrations be behavior-tested. */
+export function getDeliveryAction(action: string): DeliveryActionHandler | undefined {
+  return actionHandlers.get(action);
+}
+
 /**
  * Handle system actions from the container agent.
  * These are written to messages_out because the container can't write to inbound.db.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds `getDeliveryAction(action)` next to `registerDeliveryAction` in `src/delivery.ts` — the delivery-action registry currently has a write side only, so module registrations can't be verified through the registry itself (the behavior-test style docs/skill-guidelines.md prefers). The getter reads from the same map the register path writes to; a guard test (`src/delivery-actions.test.ts`) covers lookup, unregistered miss, and overwrite-on-re-register.

**Tested:** host suite 352 passed (349 baseline + 3 new), `pnpm run build`, `pnpm run typecheck`, lint at baseline, container bun suite unaffected (no container changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
