### PR TITLE
feat(approvals): approval-resolved callback registry — modules observe resolution additively

### DIFF
--- a/src/modules/approvals/approval-resolved.test.ts
+++ b/src/modules/approvals/approval-resolved.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Approval-resolved callback registry.
+ *
+ * Drives the real response-handler entry (`handleApprovalsResponse`) and
+ * asserts that callbacks registered via `registerApprovalResolvedHandler`
+ * fire when an admin resolves a pending approval — the hook modules use to
+ * observe approval resolution (e.g. clearing an "awaiting approval" status
+ * indicator). Goes red if the response handler stops calling
+ * `notifyApprovalResolved`.
+ */
+import * as fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createSession, createPendingApproval } from '../../db/sessions.js';
+import { upsertUser } from '../permissions/db/users.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { initSessionFolder } from '../../session-manager.js';
+import { handleApprovalsResponse } from './response-handler.js';
+import { registerApprovalHandler, registerApprovalResolvedHandler, type ApprovalResolvedEvent } from './primitive.js';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-approval-resolved' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-approval-resolved';
+
+function now() {
+  return new Date().toISOString();
+}
+
+function seedApproval(approvalId: string, action: string): void {
+  createPendingApproval({
+    approval_id: approvalId,
+    session_id: 'sess-1',
+    request_id: approvalId,
+    action,
+    payload: JSON.stringify({}),
+    created_at: now(),
+    title: 'Test approval',
+    options_json: JSON.stringify([]),
+  });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  createSession({
+    id: 'sess-1',
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: now(),
+    created_at: now(),
+  });
+  initSessionFolder('ag-1', 'sess-1');
+
+  // Resolution only happens for authorized clicks — seed the clicking admin.
+  upsertUser({ id: 'slack:admin-1', kind: 'slack', display_name: 'Admin', created_at: now() });
+  grantRole({ user_id: 'slack:admin-1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('approval-resolved callbacks', () => {
+  it('fires registered callbacks on reject with the approval, session, and outcome', async () => {
+    const events: ApprovalResolvedEvent[] = [];
+    registerApprovalResolvedHandler((event) => {
+      events.push(event);
+    });
+
+    seedApproval('appr-reject-1', 'test_reject_action');
+    const claimed = await handleApprovalsResponse({
+      questionId: 'appr-reject-1',
+      value: 'reject',
+      userId: 'slack:admin-1',
+      channelType: 'slack',
+      platformId: 'slack:C1',
+      threadId: null,
+    });
+
+    expect(claimed).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0].outcome).toBe('reject');
+    expect(events[0].approval.approval_id).toBe('appr-reject-1');
+    expect(events[0].approval.action).toBe('test_reject_action');
+    expect(events[0].session.id).toBe('sess-1');
+    expect(events[0].userId).toBe('slack:admin-1');
+  });
+
+  it('fires registered callbacks on approve after the action handler ran', async () => {
+    const calls: string[] = [];
+    registerApprovalHandler('test_approve_action', async () => {
+      calls.push('handler');
+    });
+    registerApprovalResolvedHandler(({ outcome }) => {
+      calls.push(`resolved:${outcome}`);
+    });
+
+    seedApproval('appr-approve-1', 'test_approve_action');
+    await handleApprovalsResponse({
+      questionId: 'appr-approve-1',
+      value: 'approve',
+      userId: 'slack:admin-1',
+      channelType: 'slack',
+      platformId: 'slack:C1',
+      threadId: null,
+    });
+
+    expect(calls).toEqual(['handler', 'resolved:approve']);
+  });
+
+  it('isolates a throwing callback so later callbacks still fire', async () => {
+    const events: string[] = [];
+    registerApprovalResolvedHandler(() => {
+      events.push('boom');
+      throw new Error('callback exploded');
+    });
+    registerApprovalResolvedHandler(() => {
+      events.push('after');
+    });
+
+    seedApproval('appr-reject-2', 'test_isolation_action');
+    const claimed = await handleApprovalsResponse({
+      questionId: 'appr-reject-2',
+      value: 'reject',
+      userId: 'slack:admin-1',
+      channelType: 'slack',
+      platformId: 'slack:C1',
+      threadId: null,
+    });
+
+    expect(claimed).toBe(true);
+    expect(events).toEqual(['boom', 'after']);
+  });
+});

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -28,7 +28,7 @@ import { getDeliveryAdapter } from '../../delivery.js';
 import { wakeContainer } from '../../container-runner.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
-import type { MessagingGroup, Session } from '../../types.js';
+import type { MessagingGroup, PendingApproval, Session } from '../../types.js';
 import { getAdminsOfAgentGroup, getGlobalAdmins, getOwners } from '../permissions/db/user-roles.js';
 import { ensureUserDm } from '../permissions/user-dm.js';
 
@@ -65,6 +65,50 @@ export function registerApprovalHandler(action: string, handler: ApprovalHandler
 
 export function getApprovalHandler(action: string): ApprovalHandler | undefined {
   return approvalHandlers.get(action);
+}
+
+// ── Approval-resolved callbacks ──
+// Modules that want to observe approval resolution (any action, approve or
+// reject) register here at import time. The response handler fires every
+// registered callback after the admin's decision is applied — e.g. a module
+// clearing an "awaiting approval" status indicator it set when the card went
+// out. Callback errors are logged and isolated; they never block resolution.
+//
+// Only authorized clicks resolve an approval (the response handler's
+// isAuthorizedApprovalClick gate runs first), so callbacks never fire for
+// unauthorized responses.
+
+export interface ApprovalResolvedEvent {
+  approval: PendingApproval;
+  session: Session;
+  outcome: 'approve' | 'reject';
+  /** Namespaced user ID (`<channel>:<handle>`) of the resolving admin. Empty string if unknown. */
+  userId: string;
+}
+
+export type ApprovalResolvedHandler = (event: ApprovalResolvedEvent) => Promise<void> | void;
+
+const approvalResolvedHandlers: ApprovalResolvedHandler[] = [];
+
+export function registerApprovalResolvedHandler(handler: ApprovalResolvedHandler): void {
+  approvalResolvedHandlers.push(handler);
+}
+
+/** Fire every registered approval-resolved callback. Called by the response handler. */
+export async function notifyApprovalResolved(event: ApprovalResolvedEvent): Promise<void> {
+  for (const handler of approvalResolvedHandlers) {
+    try {
+      await handler(event);
+      // eslint-disable-next-line no-catch-all/no-catch-all -- isolation is the contract: one bad callback must not block resolution or other callbacks
+    } catch (err) {
+      log.error('Approval-resolved handler threw', {
+        approvalId: event.approval.approval_id,
+        action: event.approval.action,
+        outcome: event.outcome,
+        err,
+      });
+    }
+  }
 }
 
 // ── Approver picking ──

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -20,7 +20,7 @@ import { writeSessionMessage } from '../../session-manager.js';
 import type { PendingApproval } from '../../types.js';
 import { hasAdminPrivilege, isGlobalAdmin, isOwner } from '../permissions/db/user-roles.js';
 import { ONECLI_ACTION, resolveOneCLIApproval } from './onecli-approvals.js';
-import { getApprovalHandler } from './primitive.js';
+import { getApprovalHandler, notifyApprovalResolved } from './primitive.js';
 
 export async function handleApprovalsResponse(payload: ResponsePayload): Promise<boolean> {
   const approval = getPendingApproval(payload.questionId);
@@ -81,6 +81,7 @@ async function handleRegisteredApproval(
     notify(`Your ${approval.action} request was rejected by admin.`);
     log.info('Approval rejected', { approvalId: approval.approval_id, action: approval.action, userId });
     deletePendingApproval(approval.approval_id);
+    await notifyApprovalResolved({ approval, session, outcome: 'reject', userId });
     await wakeContainer(session);
     return;
   }
@@ -94,6 +95,7 @@ async function handleRegisteredApproval(
     });
     notify(`Your ${approval.action} was approved, but no handler is installed to apply it.`);
     deletePendingApproval(approval.approval_id);
+    await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
     await wakeContainer(session);
     return;
   }
@@ -110,6 +112,7 @@ async function handleRegisteredApproval(
   }
 
   deletePendingApproval(approval.approval_id);
+  await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
   await wakeContainer(session);
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

None of the above: core hook enabling additive module observation.

## Description

**What:** An approval-resolved callback registry in the approvals primitive — `registerApprovalResolvedHandler` / `notifyApprovalResolved` — fired by the response handler at all three resolution exits (reject, approve with no handler installed, approve after the handler ran).

**Why:** Modules today can only observe approval resolution by core importing module code — this inverts it into a clean registry add, per docs/skills-model.md's hooks-over-reach-ins commitment ("when lots of skills reach into the same spot in the core, that's the signal to add a proper hook there"). Concretely: a module that sets an "awaiting approval" status indicator when its card goes out has no way to clear it when the admin clicks, whatever the outcome — `registerApprovalHandler` only covers the approve-with-handler arm of its own action.

**How:** Mirrors the existing `registerApprovalHandler` registry in `src/modules/approvals/primitive.ts`. The event carries the `PendingApproval` row, resolved `Session`, `outcome` (`'approve' | 'reject'`), and the namespaced user id of the resolving admin. Callback errors are logged and isolated — one bad callback never blocks resolution or other callbacks. Because the calls sit after the `isAuthorizedApprovalClick` gate, callbacks never fire for unauthorized clicks. Zero behavior change for installs with no registered callbacks.

**Tested:** New guard test `src/modules/approvals/approval-resolved.test.ts` drives the real `handleApprovalsResponse` entry against a migrated test DB with a role-seeded admin: reject fires the callback with the full event, approve fires it after the action handler ran, and a throwing callback is isolated so later callbacks still fire. Removing the three `notifyApprovalResolved` call sites turns all three red. Full host suite 352 passed, container suite green, build/typecheck/lint clean at baseline.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
