### PR TITLE
fix(cli): wirings create silently skips the agent_destinations side effect — agent sends to the new chat are dropped

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -69,6 +69,13 @@ export interface ResourceDef {
   };
   /** Non-standard verbs (grant, revoke, add, remove, restart, etc.). */
   customOperations?: Record<string, CustomOperation>;
+  /**
+   * Replace the generic INSERT with a domain helper. Use when creating a row
+   * has REQUIRED side effects the generic path can't know about — e.g. a
+   * wiring's companion agent_destinations row, without which the delivery
+   * ACL silently blocks the agent's sends to the newly wired chat.
+   */
+  customInsert?: (values: Record<string, unknown>) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,6 +160,10 @@ function genericCreate(def: ResourceDef) {
       }
     }
 
+    if (def.customInsert) {
+      def.customInsert(values);
+      return values;
+    }
     const colNames = Object.keys(values);
     const placeholders = colNames.map((c) => `@${c}`);
     getDb()

--- a/src/cli/resources/wirings.test.ts
+++ b/src/cli/resources/wirings.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Guard for the wirings-create side effect: `ncl wirings create` must route
+ * through createMessagingGroupAgent so the companion agent_destinations row
+ * exists. With the generic INSERT alone, a CLI-created wiring receives
+ * messages but delivery's ACL silently drops every send the agent addresses
+ * to the chat (found live 2026-06-11 — the agent looked mute, no error
+ * anywhere).
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup, getDb } from '../../db/index.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { dispatch } from '../dispatch.js';
+// Side-effect import: registers the wirings commands.
+import './wirings.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+describe('wirings create → destination side effect', () => {
+  beforeEach(() => {
+    initTestDb();
+    runMigrations(getDb());
+    createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+    createMessagingGroup({
+      id: 'mg-1',
+      channel_type: 'telegram',
+      platform_id: 'telegram:-100',
+      name: 'Group',
+      is_group: 1,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('creates the wiring AND the companion agent_destinations row', async () => {
+    const res = await dispatch(
+      {
+        id: 'req-wire-1',
+        command: 'wirings-create',
+        args: { messaging_group_id: 'mg-1', agent_group_id: 'ag-1', engage_mode: 'mention' },
+      },
+      { caller: 'host' },
+    );
+    expect(res.ok, JSON.stringify(res)).toBe(true);
+
+    const wiring = getDb()
+      .prepare('SELECT * FROM messaging_group_agents WHERE messaging_group_id = ? AND agent_group_id = ?')
+      .get('mg-1', 'ag-1');
+    expect(wiring).toBeTruthy();
+
+    const dest = getDb()
+      .prepare("SELECT * FROM agent_destinations WHERE agent_group_id = 'ag-1' AND target_id = 'mg-1'")
+      .get();
+    expect(dest).toBeTruthy();
+  });
+});

--- a/src/cli/resources/wirings.ts
+++ b/src/cli/resources/wirings.ts
@@ -1,4 +1,6 @@
 import { registerResource } from '../crud.js';
+import { createMessagingGroupAgent } from '../../db/messaging-groups.js';
+import type { MessagingGroupAgent } from '../../types.js';
 
 registerResource({
   name: 'wiring',
@@ -67,4 +69,19 @@ registerResource({
     { name: 'created_at', type: 'string', description: 'Auto-set.', generated: true },
   ],
   operations: { list: 'open', get: 'open', create: 'approval', update: 'approval', delete: 'approval' },
+  // The generic INSERT is not enough for wirings: createMessagingGroupAgent
+  // also creates the companion agent_destinations row that delivery's ACL
+  // checks. Without it a CLI-created wiring RECEIVES fine but every send the
+  // agent addresses to the chat is silently dropped (no error at create time,
+  // none visible to the agent) — found live 2026-06-11.
+  customInsert: (values) =>
+    createMessagingGroupAgent({
+      // The helper's INSERT names every column; fill the ones the CLI def
+      // leaves optional with the same defaults setup/register.ts uses.
+      engage_pattern: null,
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      priority: 0,
+      ...values,
+    } as unknown as MessagingGroupAgent),
 });


### PR DESCRIPTION
## Bug

`ncl wirings create` goes through the generic CRUD layer — a plain INSERT into `messaging_group_agents`. But creating a wiring has a required side effect that only `createMessagingGroupAgent` (src/db/messaging-groups.ts) performs: the companion `agent_destinations` row that `deliverSessionMessages`' permission check consults.

Result: a CLI-created wiring **receives** inbound messages normally, but every message the agent addresses to the newly wired chat is **silently dropped** by the delivery ACL — no error at create time, nothing visible to the agent, no operator-facing signal. Found live while wiring a multi-bot group (#2733 substrate): the bot looked mute for twenty minutes until we traced the missing destination row.

The setup paths (`setup/register.ts`, `scripts/init-first-agent.ts`) don't have this bug because they call the helper; only the CLI path bypasses it.

## Fix

- `ResourceDef.customInsert`: an optional hook letting a resource replace the generic INSERT with a domain helper when row creation has required side effects. (Generalizable: any future resource whose insert needs invariants gets the same escape hatch instead of a one-off handler.)
- `wirings.ts` routes create through `createMessagingGroupAgent`, filling the columns the CLI def leaves optional with the same defaults `setup/register.ts` uses.

## Testing

- New guard test (`src/cli/resources/wirings.test.ts`) drives the real `dispatch()` path and asserts both the wiring row AND the destination row exist — it fails on the generic-INSERT behavior (it actually caught a second issue during development: the helper's named-parameter INSERT requires every column, hence the explicit defaults).
- `pnpm run build` clean; full vitest suite green on the patched tree.
- Verified live: re-creating the wiring with the destination row present un-muted the agent immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)