### PR TITLE
fix(signal): deliver agent reactions and forward inbound reactions

### DIFF
--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -958,4 +958,152 @@ describe('SignalAdapter', () => {
       expect(adapter.supportsThreads).toBe(false);
     });
   });
+  // --- Reactions ---
+
+  describe('reactions', () => {
+    beforeEach(() => {
+      tcpRef.rpcResponses.set('sendReaction', { timestamp: 999 });
+    });
+
+    it('sends an outbound DM reaction via sendReaction RPC, resolving shortcodes', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: { operation: 'reaction', messageId: '1700000000001:ag-abc123', emoji: 'thumbs_up' },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls.length).toBe(1);
+      expect(calls[0].params).toEqual(
+        expect.objectContaining({
+          emoji: '👍',
+          targetAuthor: '+15555550123',
+          targetTimestamp: 1700000000001,
+          recipient: ['+15555550123'],
+          account: '+15551234567',
+        }),
+      );
+
+      await adapter.teardown();
+    });
+
+    it('passes raw unicode emoji through unchanged', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: { operation: 'reaction', messageId: '1700000000002', emoji: '🪱' },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls.length).toBe(1);
+      expect(calls[0].params).toEqual(expect.objectContaining({ emoji: '🪱' }));
+
+      await adapter.teardown();
+    });
+
+    it('drops unknown emoji shortcodes without calling the daemon', async () => {
+      const adapter = createAdapter();
+      await adapter.setup(createMockSetup());
+
+      await adapter.deliver('+15555550123', null, {
+        kind: 'chat',
+        content: { operation: 'reaction', messageId: '1700000000003', emoji: 'not_a_real_shortcode' },
+      });
+
+      expect(getRpcCallsForMethod('sendReaction').length).toBe(0);
+
+      await adapter.teardown();
+    });
+
+    it('targets group reactions with the author remembered from inbound', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      // Inbound group message caches its author for later reaction targeting.
+      pushEvent({
+        sourceNumber: '+15550001111',
+        sourceName: 'Bob',
+        dataMessage: {
+          timestamp: 1700000000004,
+          message: 'group hello',
+          groupV2: { id: 'grp1' },
+        },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      await adapter.deliver('group:grp1', null, {
+        kind: 'chat',
+        content: { operation: 'reaction', messageId: '1700000000004:ag-abc123', emoji: 'heart' },
+      });
+
+      const calls = getRpcCallsForMethod('sendReaction');
+      expect(calls.length).toBe(1);
+      expect(calls[0].params).toEqual(
+        expect.objectContaining({
+          emoji: '❤️',
+          groupId: 'grp1',
+          targetAuthor: '+15550001111',
+          targetTimestamp: 1700000000004,
+        }),
+      );
+
+      await adapter.teardown();
+    });
+
+    it('forwards inbound reactions as formatted chat events', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000000005,
+          reaction: { emoji: '👍', targetSentTimestamp: 1700000000001 },
+        },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(cfg.onInbound).toHaveBeenCalledWith(
+        '+15555550123',
+        null,
+        expect.objectContaining({
+          kind: 'chat',
+          content: expect.objectContaining({
+            text: '[Alice reacted 👍 to your message]',
+            sender: '+15555550123',
+          }),
+        }),
+      );
+
+      await adapter.teardown();
+    });
+
+    it('ignores reaction removals', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000000006,
+          reaction: { emoji: '👍', targetSentTimestamp: 1700000000001, isRemove: true },
+        },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(cfg.onInbound).not.toHaveBeenCalled();
+
+      await adapter.teardown();
+    });
+  });
+
 });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -296,6 +296,120 @@ interface SignalMention {
   name?: string;
 }
 
+/**
+ * Shortcode names the agent's add_reaction tool emits (e.g. "thumbs_up") →
+ * the unicode emoji Signal's sendReaction expects. Raw unicode passes
+ * through untouched; unknown shortcodes are dropped with a warning.
+ */
+const EMOJI_SHORTCODES: Record<string, string> = {
+  thumbs_up: '👍',
+  '+1': '👍',
+  thumbs_down: '👎',
+  '-1': '👎',
+  heart: '❤️',
+  eyes: '👀',
+  white_check_mark: '✅',
+  heavy_check_mark: '✔️',
+  tada: '🎉',
+  fire: '🔥',
+  joy: '😂',
+  laughing: '😆',
+  smile: '😄',
+  pray: '🙏',
+  clap: '👏',
+  thinking_face: '🤔',
+  wave: '👋',
+  rocket: '🚀',
+  sparkles: '✨',
+  ok_hand: '👌',
+  sob: '😭',
+  cry: '😢',
+  star: '⭐',
+  '100': '💯',
+  warning: '⚠️',
+  question: '❓',
+  exclamation: '❗',
+  worm: '🪱',
+  bug: '🐛',
+  snake: '🐍',
+  raised_hands: '🙌',
+  muscle: '💪',
+  salute: '🫡',
+  handshake: '🤝',
+  point_up: '☝️',
+  raised_hand: '✋',
+  v: '✌️',
+  crossed_fingers: '🤞',
+  heart_eyes: '😍',
+  smiling_face_with_hearts: '🥰',
+  grin: '😁',
+  grinning: '😀',
+  sweat_smile: '😅',
+  rofl: '🤣',
+  wink: '😉',
+  slightly_smiling_face: '🙂',
+  upside_down_face: '🙃',
+  neutral_face: '😐',
+  grimacing: '😬',
+  scream: '😱',
+  astonished: '😲',
+  exploding_head: '🤯',
+  mind_blown: '🤯',
+  zany_face: '🤪',
+  sunglasses: '😎',
+  nerd_face: '🤓',
+  robot: '🤖',
+  alien: '👽',
+  ghost: '👻',
+  skull: '💀',
+  poop: '💩',
+  egg: '🥚',
+  hatching_chick: '🐣',
+  chicken: '🐔',
+  party: '🥳',
+  partying_face: '🥳',
+  confetti_ball: '🎊',
+  balloon: '🎈',
+  gift: '🎁',
+  trophy: '🏆',
+  medal: '🏅',
+  crown: '👑',
+  gem: '💎',
+  zap: '⚡',
+  boom: '💥',
+  bulb: '💡',
+  hourglass: '⏳',
+  alarm_clock: '⏰',
+  checkered_flag: '🏁',
+  dart: '🎯',
+  eyes_rolling: '🙄',
+  roll_eyes: '🙄',
+  shrug: '🤷',
+  facepalm: '🤦',
+  pleading_face: '🥺',
+  hot_face: '🥵',
+  cold_face: '🥶',
+  green_heart: '💚',
+  blue_heart: '💙',
+  purple_heart: '💜',
+  yellow_heart: '💛',
+  orange_heart: '🧡',
+  black_heart: '🖤',
+  broken_heart: '💔',
+  sparkling_heart: '💖',
+  red_circle: '🔴',
+  green_circle: '🟢',
+  x: '❌',
+  no_entry: '⛔',
+  white_circle: '⚪',
+};
+
+function resolveEmoji(raw: string): string | null {
+  if (!raw) return null;
+  if (/[^\x00-\x7f]/.test(raw)) return raw; // already unicode — pass through
+  return EMOJI_SHORTCODES[raw.toLowerCase().replace(/^:|:$/g, '')] ?? null;
+}
+
 interface SignalDataMessage {
   timestamp?: number;
   message?: string;
@@ -303,6 +417,12 @@ interface SignalDataMessage {
   groupInfo?: { groupId?: string; groupName?: string; type?: string };
   groupV2?: { id?: string };
   quote?: SignalQuote;
+  reaction?: {
+    emoji?: string;
+    targetAuthor?: string;
+    targetSentTimestamp?: number;
+    isRemove?: boolean;
+  };
   attachments?: Array<{
     id?: string;
     contentType?: string;
@@ -532,6 +652,19 @@ export function createSignalAdapter(config: {
   const echoCache = new EchoCache();
   let setup: ChannelSetup | null = null;
 
+  // Inbound message id -> author, so outbound reactions in GROUPS can supply
+  // signal-cli's required targetAuthor (in DMs the peer is always the author).
+  // Bounded FIFO — reactions target recent messages in practice.
+  const reactionTargets = new Map<string, string>();
+  function rememberReactionTarget(id: string, author: string): void {
+    if (!id || !author) return;
+    reactionTargets.set(id, author);
+    if (reactionTargets.size > 500) {
+      const oldest = reactionTargets.keys().next().value;
+      if (oldest !== undefined) reactionTargets.delete(oldest);
+    }
+  }
+
   // -- inbound handling --
 
   function handleNotification(method: string, params: unknown): void {
@@ -584,6 +717,36 @@ export function createSignalAdapter(config: {
 
     const dataMessage = envelope.dataMessage;
     if (!dataMessage) return;
+
+    // Reactions arrive as dataMessage.reaction with no message text — handle
+    // them before the empty-content gate below would silently drop them.
+    // The host has no dedicated reaction kind, so forward as a formatted
+    // chat event the agent can interpret (mirrors how voice notes become
+    // "[Voice: …]" lines).
+    if (dataMessage.reaction?.emoji) {
+      if (dataMessage.reaction.isRemove) return; // un-reacting is noise
+      const rSender = (envelope.sourceNumber ?? envelope.sourceUuid ?? envelope.source ?? '').trim();
+      if (!rSender) return;
+      const rSenderName = (envelope.sourceName?.trim() || rSender).trim();
+      const rGroupId = dataMessage.groupV2?.id ?? dataMessage.groupInfo?.groupId;
+      const rPlatformId = rGroupId ? `group:${rGroupId}` : rSender;
+      const rMsg: InboundMessage = {
+        id: String(dataMessage.timestamp ?? Date.now()),
+        kind: 'chat',
+        content: {
+          text: `[${rSenderName} reacted ${dataMessage.reaction.emoji} to your message]`,
+          sender: rSender,
+          senderId: `signal:${rSender}`,
+          senderName: rSenderName,
+        },
+        timestamp: dataMessage.timestamp
+          ? new Date(dataMessage.timestamp).toISOString()
+          : new Date().toISOString(),
+      };
+      await setup.onInbound(rPlatformId, null, rMsg);
+      log.info('Signal reaction received', { platformId: rPlatformId, emoji: dataMessage.reaction.emoji });
+      return;
+    }
 
     const rawText = (dataMessage.message ?? '').trim();
     const text = rawText ? resolveMentions(rawText, dataMessage.mentions) : '';
@@ -673,6 +836,7 @@ export function createSignalAdapter(config: {
       timestamp,
     };
     await setup.onInbound(platformId, null, msg);
+    rememberReactionTarget(msg.id, sender);
 
     log.info('Signal message received', { platformId, sender: senderName });
   }
@@ -700,6 +864,45 @@ export function createSignalAdapter(config: {
   }
 
   // -- send helpers --
+
+  async function sendReaction(platformId: string, targetMsgId: string, rawEmoji: string): Promise<void> {
+    if (!connected || !tcp) return;
+    const emoji = resolveEmoji(rawEmoji);
+    // The host namespaces message ids as "<signal-timestamp>:<agent-group-id>"
+    // by the time they reach the outbound queue — strip back to the timestamp
+    // signal-cli targets by.
+    const bareId = targetMsgId.split(':')[0];
+    const targetTimestamp = Number(bareId);
+    if (!emoji || !Number.isFinite(targetTimestamp) || targetTimestamp <= 0) {
+      log.warn('Signal: dropping malformed reaction', { platformId, targetMsgId, rawEmoji });
+      return;
+    }
+
+    // signal-cli targets reactions by (author, timestamp). In a DM the peer
+    // authored everything we react to; in groups, use the author remembered
+    // at inbound time (bounded cache — very old messages can miss).
+    const isGroup = platformId.startsWith('group:');
+    const targetAuthor = isGroup ? reactionTargets.get(bareId) : platformId;
+    if (!targetAuthor) {
+      log.warn('Signal: no author known for reaction target', { platformId, targetMsgId });
+      return;
+    }
+
+    const params: Record<string, unknown> = { emoji, targetAuthor, targetTimestamp };
+    if (config.account) params.account = config.account;
+    if (isGroup) {
+      params.groupId = platformId.slice('group:'.length);
+    } else {
+      params.recipient = [platformId];
+    }
+
+    try {
+      await tcp.rpc('sendReaction', params);
+      log.info('Signal reaction sent', { platformId, emoji, targetTimestamp });
+    } catch (err) {
+      log.error('Signal: sendReaction failed', { platformId, emoji, err });
+    }
+  }
 
   async function sendText(platformId: string, text: string): Promise<void> {
     if (!connected || !tcp) return;
@@ -893,6 +1096,15 @@ export function createSignalAdapter(config: {
 
     async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
       const content = message.content as Record<string, unknown> | string | undefined;
+
+      // Reaction operation from the agent's add_reaction tool — an emoji on
+      // an existing message, not a text send. content:
+      //   { operation: 'reaction', messageId: <inbound msg id>, emoji: <shortcode> }
+      if (content && typeof content === 'object' && content.operation === 'reaction') {
+        await sendReaction(platformId, String(content.messageId ?? ''), String(content.emoji ?? ''));
+        return undefined;
+      }
+
       let text: string | null = null;
       if (typeof content === 'string') {
         text = content;


### PR DESCRIPTION
## Summary

The Signal adapter silently drops the agent's `add_reaction` tool output, and ignores inbound reaction envelopes. Every agent on a Signal channel is offered `add_reaction` (core MCP tools) and believes the reaction was queued — but `deliver()` has no `operation: 'reaction'` handling, so the row resolves as a no-op (the host then logs "Message delivered"). Inbound reactions die at the empty-text gate in `handleEnvelope`. This PR implements both directions, following the same `content.operation === 'reaction'` contract the WhatsApp adapter uses.

## What's in the change

**Outbound** (`deliver()` → signal-cli `sendReaction`):
- Message ids reach the adapter namespaced as `"<timestamp>:<agent-group-id>"` (router `messageIdForAgent`); the adapter strips back to the timestamp signal-cli targets by.
- The tool contract is shortcode names (`thumbs_up`, per `core.instructions.md`) but signal-cli requires actual unicode — added a shortcode→emoji map (~100 common names); raw unicode passes through; unknown shortcodes drop with a warn instead of sending garbage.
- Group reactions need `(targetAuthor, targetTimestamp)`: authors are remembered from inbound messages in a bounded FIFO cache (500 entries). DMs always target the peer.

**Inbound** (`handleEnvelope`):
- `dataMessage.reaction` envelopes are forwarded as `[<name> reacted <emoji> to your message]` chat events — mirroring the existing `[Voice: …]` text convention, since `InboundMessage.kind` has no reaction variant. Reaction removals are ignored.

## Tests

6 new tests in `signal.test.ts` (outbound DM + shortcode resolution, unicode passthrough, unknown-shortcode drop, group targeting via remembered author, inbound forwarding, removal ignore). Full signal suite: **43/43 pass**. The pre-existing `tsc` errors on this branch (`resolveChannelName` in slack.ts/telegram.ts) are untouched.

## Verification

Running in production on a live deployment (signal-cli 0.14.x daemon, multi-account TCP mode, external daemon via `SIGNAL_MANAGE_DAEMON=false`): reactions confirmed delivered on-device in both directions, including the namespaced-id and group-author paths.

## Attribution

This work was implemented by **Claude (Fable 5)** running in Claude Code, directed and reviewed by **Alexis Mather** (@WormyOne), who operates the deployment it was verified on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
