### PR TITLE
security: gate agent-requested npm installs by package release age

### DIFF
--- a/src/modules/self-mod/apply.ts
+++ b/src/modules/self-mod/apply.ts
@@ -18,6 +18,7 @@ import type { McpServerConfig } from '../../container-config.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { ApprovalHandler } from '../approvals/index.js';
+import { checkNpmReleaseAge, DEFAULT_RELEASE_AGE_MS } from './release-age.js';
 
 export const applyInstallPackages: ApprovalHandler = async ({ session, payload, userId, notify }) => {
   const agentGroup = getAgentGroup(session.agent_group_id);
@@ -30,6 +31,30 @@ export const applyInstallPackages: ApprovalHandler = async ({ session, payload, 
   if (!configRow) {
     notify('install_packages approved but container config missing.');
     return;
+  }
+
+  // Supply-chain gate: agent-requested npm packages must satisfy the same
+  // 3-day release-age policy the host tree enforces. Fail closed.
+  const npmSpecs = (payload.npm as string[] | undefined) ?? [];
+  if (npmSpecs.length > 0) {
+    const overrides = (payload.allowReleaseAge as string[] | undefined) ?? [];
+    const check = await checkNpmReleaseAge(npmSpecs, { thresholdMs: DEFAULT_RELEASE_AGE_MS, overrides });
+    if (check.violations.length > 0 || check.unverifiable.length > 0) {
+      const tooNew = check.violations.map((p) => `${p.name}@${p.version} (published ${p.publishedAt})`).join(', ');
+      const unv = check.unverifiable.join(', ');
+      notify(
+        `install_packages blocked by supply-chain policy (min age ${DEFAULT_RELEASE_AGE_MS / 60000} min). ` +
+          (tooNew ? `Too new: ${tooNew}. ` : '') +
+          (unv ? `Could not verify: ${unv}. ` : '') +
+          `To override, re-request with an exact-pinned allowlist (allowReleaseAge: ["name@version"]) — human sign-off required.`,
+      );
+      log.warn('install_packages blocked by release-age gate', {
+        agentGroupId: session.agent_group_id,
+        violations: check.violations,
+        unverifiable: check.unverifiable,
+      });
+      return;
+    }
   }
 
   // Append new packages to existing lists in the DB (deduplicated)

--- a/src/modules/self-mod/release-age.test.ts
+++ b/src/modules/self-mod/release-age.test.ts
@@ -73,4 +73,15 @@ describe('checkNpmReleaseAge', () => {
     });
     expect(r.unverifiable).toEqual(['ghost']);
   });
+
+  it('resolves a scoped package end-to-end', async () => {
+    const r = await checkNpmReleaseAge(['@scope/pkg'], {
+      thresholdMs: DEFAULT_RELEASE_AGE_MS,
+      overrides: [],
+      now: NOW,
+      fetchImpl: fakeFetch({ '@scope/pkg': oldPkg }),
+    });
+    expect(r.unverifiable).toHaveLength(0);
+    expect(r.resolved[0].name).toBe('@scope/pkg');
+  });
 });

--- a/src/modules/self-mod/release-age.test.ts
+++ b/src/modules/self-mod/release-age.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkNpmReleaseAge, parseSpec, DEFAULT_RELEASE_AGE_MS } from './release-age.js';
+
+const NOW = Date.parse('2026-06-11T00:00:00Z');
+
+function fakeFetch(map: Record<string, unknown>): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const name = decodeURIComponent(String(url).split('/').pop() as string);
+    const body = map[name];
+    if (!body) return { ok: false, status: 404, json: async () => ({}) } as Response;
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as typeof fetch;
+}
+
+describe('parseSpec', () => {
+  it('parses unversioned', () => {
+    expect(parseSpec('left-pad')).toEqual({ name: 'left-pad', version: null });
+  });
+  it('parses versioned', () => {
+    expect(parseSpec('left-pad@1.3.0')).toEqual({ name: 'left-pad', version: '1.3.0' });
+  });
+  it('parses scoped versioned', () => {
+    expect(parseSpec('@scope/pkg@2.0.0')).toEqual({ name: '@scope/pkg', version: '2.0.0' });
+  });
+  it('parses scoped unversioned', () => {
+    expect(parseSpec('@scope/pkg')).toEqual({ name: '@scope/pkg', version: null });
+  });
+});
+
+describe('checkNpmReleaseAge', () => {
+  const oldPkg = { 'dist-tags': { latest: '1.0.0' }, time: { '1.0.0': '2026-01-01T00:00:00Z' } };
+  const newPkg = { 'dist-tags': { latest: '9.9.9' }, time: { '9.9.9': '2026-06-10T20:00:00Z' } };
+
+  it('passes a package older than the threshold', async () => {
+    const r = await checkNpmReleaseAge(['old'], {
+      thresholdMs: DEFAULT_RELEASE_AGE_MS,
+      overrides: [],
+      now: NOW,
+      fetchImpl: fakeFetch({ old: oldPkg }),
+    });
+    expect(r.violations).toHaveLength(0);
+    expect(r.unverifiable).toHaveLength(0);
+    expect(r.resolved[0]).toEqual({ name: 'old', version: '1.0.0', publishedAt: '2026-01-01T00:00:00Z' });
+  });
+
+  it('flags a package newer than the threshold', async () => {
+    const r = await checkNpmReleaseAge(['new'], {
+      thresholdMs: DEFAULT_RELEASE_AGE_MS,
+      overrides: [],
+      now: NOW,
+      fetchImpl: fakeFetch({ new: newPkg }),
+    });
+    expect(r.violations.map((p) => p.name)).toEqual(['new']);
+  });
+
+  it('exempts a too-new package present in the exact-pinned override list', async () => {
+    const r = await checkNpmReleaseAge(['new@9.9.9'], {
+      thresholdMs: DEFAULT_RELEASE_AGE_MS,
+      overrides: ['new@9.9.9'],
+      now: NOW,
+      fetchImpl: fakeFetch({ new: newPkg }),
+    });
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it('reports a package as unverifiable when the registry lookup fails (fail closed)', async () => {
+    const r = await checkNpmReleaseAge(['ghost'], {
+      thresholdMs: DEFAULT_RELEASE_AGE_MS,
+      overrides: [],
+      now: NOW,
+      fetchImpl: fakeFetch({}),
+    });
+    expect(r.unverifiable).toEqual(['ghost']);
+  });
+});

--- a/src/modules/self-mod/release-age.ts
+++ b/src/modules/self-mod/release-age.ts
@@ -11,6 +11,8 @@ const NPM_REGISTRY = 'https://registry.npmjs.org';
 /** 3 days in ms — matches `minimumReleaseAge: 4320` (minutes) in pnpm-workspace.yaml. */
 export const DEFAULT_RELEASE_AGE_MS = 4320 * 60 * 1000;
 
+type NpmMeta = { 'dist-tags'?: { latest?: string }; time?: Record<string, string> };
+
 export interface ResolvedPkg {
   name: string;
   version: string;
@@ -44,13 +46,18 @@ export async function checkNpmReleaseAge(
 
   for (const spec of specs) {
     const { name, version } = parseSpec(spec);
-    type NpmMeta = { 'dist-tags'?: { latest?: string }; time?: Record<string, string> };
     let meta: NpmMeta | null = null;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10_000);
     try {
-      const res = await doFetch(`${NPM_REGISTRY}/${encodeURIComponent(name).replace('%40', '@')}`);
+      const res = await doFetch(`${NPM_REGISTRY}/${encodeURIComponent(name).replace('%40', '@')}`, {
+        signal: controller.signal,
+      });
       if (res.ok) meta = (await res.json()) as NpmMeta;
     } catch {
       meta = null;
+    } finally {
+      clearTimeout(timer);
     }
 
     if (!meta) {
@@ -69,7 +76,7 @@ export async function checkNpmReleaseAge(
     resolved.push(pkg);
 
     const pinned = `${name}@${v}`;
-    if (overrides.has(pinned) || overrides.has(spec)) continue; // explicit human-pinned exemption
+    if (overrides.has(pinned)) continue; // exact-pinned (name@version) human-signed exemption only
 
     if (now - new Date(publishedAt).getTime() < opts.thresholdMs) {
       violations.push(pkg);

--- a/src/modules/self-mod/release-age.ts
+++ b/src/modules/self-mod/release-age.ts
@@ -1,0 +1,80 @@
+/**
+ * Supply-chain release-age gate for agent-requested npm packages.
+ *
+ * Mirrors the host's pnpm `minimumReleaseAge` policy (pnpm-workspace.yaml):
+ * a package version must have existed on the registry for at least 3 days
+ * before it may be installed into an agent container. Fails closed —
+ * unresolvable packages are reported and the caller blocks the install.
+ */
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+
+/** 3 days in ms — matches `minimumReleaseAge: 4320` (minutes) in pnpm-workspace.yaml. */
+export const DEFAULT_RELEASE_AGE_MS = 4320 * 60 * 1000;
+
+export interface ResolvedPkg {
+  name: string;
+  version: string;
+  publishedAt: string | null;
+}
+
+export interface ReleaseAgeResult {
+  resolved: ResolvedPkg[];
+  violations: ResolvedPkg[]; // verified but under threshold and not overridden
+  unverifiable: string[]; // registry lookup or version resolution failed
+}
+
+/** Split a package spec into name + optional version. Handles `@scope/name[@version]`. */
+export function parseSpec(spec: string): { name: string; version: string | null } {
+  const at = spec.lastIndexOf('@');
+  if (at <= 0) return { name: spec, version: null };
+  return { name: spec.slice(0, at), version: spec.slice(at + 1) };
+}
+
+export async function checkNpmReleaseAge(
+  specs: string[],
+  opts: { thresholdMs: number; overrides: string[]; now?: number; fetchImpl?: typeof fetch },
+): Promise<ReleaseAgeResult> {
+  const now = opts.now ?? Date.now();
+  const doFetch = opts.fetchImpl ?? fetch;
+  const overrides = new Set(opts.overrides);
+
+  const resolved: ResolvedPkg[] = [];
+  const violations: ResolvedPkg[] = [];
+  const unverifiable: string[] = [];
+
+  for (const spec of specs) {
+    const { name, version } = parseSpec(spec);
+    type NpmMeta = { 'dist-tags'?: { latest?: string }; time?: Record<string, string> };
+    let meta: NpmMeta | null = null;
+    try {
+      const res = await doFetch(`${NPM_REGISTRY}/${encodeURIComponent(name).replace('%40', '@')}`);
+      if (res.ok) meta = (await res.json()) as NpmMeta;
+    } catch {
+      meta = null;
+    }
+
+    if (!meta) {
+      unverifiable.push(spec);
+      continue;
+    }
+
+    const v = version ?? meta['dist-tags']?.latest;
+    const publishedAt = v && meta.time ? (meta.time[v] ?? null) : null;
+    if (!v || !publishedAt) {
+      unverifiable.push(spec);
+      continue;
+    }
+
+    const pkg: ResolvedPkg = { name, version: v, publishedAt };
+    resolved.push(pkg);
+
+    const pinned = `${name}@${v}`;
+    if (overrides.has(pinned) || overrides.has(spec)) continue; // explicit human-pinned exemption
+
+    if (now - new Date(publishedAt).getTime() < opts.thresholdMs) {
+      violations.push(pkg);
+    }
+  }
+
+  return { resolved, violations, unverifiable };
+}


### PR DESCRIPTION
## Summary
- When an admin approves an agent `install_packages` request, requested **npm** packages are now checked against the same 3-day `minimumReleaseAge` the host's pnpm policy already enforces (`pnpm-workspace.yaml`). Packages whose selected version was published less than 3 days ago are blocked unless an exact-pinned `name@version` override is supplied (human sign-off).
- **Fail-closed:** packages the registry can't verify (404, fetch error, missing publish time) are also blocked. The npm-registry fetch is wrapped in a 10s `AbortController` timeout so the approval handler can't hang on a slow/unreachable registry.
- apt packages are unaffected (no clean release-age concept; the existing pnpm policy is npm-only too).

## Why
The host source tree already enforces `minimumReleaseAge` for supply-chain safety, but agent-requested *container* packages bypassed it entirely — a freshly-published malicious version could be installed into an agent container on a single approval. This closes that gap by reusing the same threshold, and the gate runs **before** any config mutation or image rebuild, so a blocked request changes nothing.

## Test Plan
- [x] `checkNpmReleaseAge` unit tests: old version passes, too-new flagged, exact-pinned override exempts, registry failure → unverifiable (fail-closed), scoped package resolves end-to-end
- [x] `parseSpec` unit tests for scoped/unscoped, versioned/unversioned specs
- [x] Gate placement verified: blocked installs never reach `updateContainerConfigJson` / `buildAgentGroupImage`
- [x] `pnpm run build` clean; full host test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
