### PR TITLE
fix(hooks): pre-commit fell open when pnpm was missing from PATH

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,19 @@
+# Fail CLOSED when the formatter can't run. pnpm is often absent from a
+# plain login shell's PATH (corepack shims live inside the Node prefix), and
+# the old behavior — "pnpm: command not found" followed by a successful
+# commit — silently skipped formatting, which is worse than no hook: you
+# believe the check ran. Fall back to corepack, then block the commit.
+# Bypass deliberately with `git commit --no-verify`.
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm_cmd="pnpm"
+elif command -v corepack >/dev/null 2>&1; then
+  pnpm_cmd="corepack pnpm"
+else
+  echo "pre-commit: pnpm not found on PATH; refusing to skip format:fix (use --no-verify to bypass)" >&2
+  exit 1
+fi
 staged=$(git diff --cached --name-only --diff-filter=ACM -- 'src/**/*.ts')
-pnpm run format:fix
+$pnpm_cmd run format:fix || exit 1
 if [ -n "$staged" ]; then
   echo "$staged" | xargs git add
 fi


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** The pre-commit hook fails closed instead of open when pnpm can't run.

**Why:** The hook ran `pnpm run format:fix` and ignored its exit status. On a shell whose PATH lacks pnpm — common when pnpm is a corepack shim inside the Node prefix and the user commits from a plain login shell or GUI client — the hook printed `pnpm: command not found` and the commit proceeded anyway, with formatting silently skipped. A hook that fails open is worse than no hook: you believe the check ran. Observed live on a corepack-shim install (the formatter had been silently skipping for weeks of commits).

**How it works:** Resolve pnpm explicitly (`command -v pnpm`, falling back to `corepack pnpm`); if neither is available, or `format:fix` itself fails, block the commit with a clear message. Deliberate bypass stays available via `git commit --no-verify`.

**How it was tested:** All three branches exercised with controlled PATHs: pnpm present (runs directly), corepack only (runs via shim), neither (commit blocked with the message, exit 1). Also verified end-to-end on a real install where the old hook reproducibly fell open from a login shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
