### PR TITLE
feat(providers): operator-driven provider selection, switching, and memory migration

### DIFF
--- a/.claude/skills/add-codex/REMOVE.md
+++ b/.claude/skills/add-codex/REMOVE.md
@@ -1,83 +1,68 @@
-# Remove Codex provider
+# Remove the Codex agent provider
 
-Idempotent — safe to run even if some steps were never applied. Reverses both the host (`src/providers/`) and container (`container/agent-runner/src/providers/`) trees, plus the Dockerfile CLI install.
+Reverses every change `/add-codex` makes and returns every group to the default provider. Safe to run when partially installed — skip any step whose target is already absent.
 
-## 1. Delete the barrel import lines (both trees)
+## 1. Switch codex groups back to the default
 
-Delete (do not comment out) the `import './codex.js';` line from each barrel:
+List groups still on codex and switch each one (each group's `memory/` tree stays on disk and readable; run `/migrate-memory` per group if its memory should carry back to Claude — see [docs/provider-migration.md](../../docs/provider-migration.md)):
+
+```bash
+ncl groups list
+# for each group whose config shows provider=codex:
+ncl groups config update --id <group-id> --provider claude
+ncl groups restart --id <group-id>
+```
+
+## 2. Delete the barrel imports
+
+Delete (do not comment out) the `import './codex.js';` line from each of:
 
 - `src/providers/index.ts`
 - `container/agent-runner/src/providers/index.ts`
+- `setup/providers/index.ts`
 
-This unregisters the provider from both `listProviderContainerConfigNames()` (host) and `listProviderNames()` (container).
-
-## 2. Delete the copied files (both trees)
+## 3. Delete every copied file
 
 ```bash
 rm -f src/providers/codex.ts \
+      src/providers/codex-agents-md.ts \
       src/providers/codex-registration.test.ts \
+      src/providers/codex-host-contribution.test.ts \
+      src/providers/codex-agents-md.test.ts \
       container/agent-runner/src/providers/codex.ts \
       container/agent-runner/src/providers/codex-app-server.ts \
-      container/agent-runner/src/providers/codex.factory.test.ts \
+      container/agent-runner/src/providers/exchange-archive.ts \
+      container/agent-runner/src/providers/exchange-archive.test.ts \
       container/agent-runner/src/providers/codex-registration.test.ts \
-      container/agent-runner/src/providers/codex-dockerfile.test.ts
+      container/agent-runner/src/providers/codex.factory.test.ts \
+      container/agent-runner/src/providers/codex.turns.test.ts \
+      container/agent-runner/src/providers/codex-app-server.test.ts \
+      container/agent-runner/src/providers/codex-dockerfile.test.ts \
+      setup/providers/codex.ts \
+      setup/providers/codex.test.ts \
+      setup/providers/codex-registration.test.ts
 ```
 
-## 3. Revert the Dockerfile CLI install
+This skill itself (`.claude/skills/add-codex/`) stays — it ships with trunk so the provider can be re-added later.
 
-In `container/Dockerfile`, remove both Codex edits (skip whichever is already gone):
+`container/AGENTS.md` stays only if another installed provider uses agent surfaces; otherwise remove it too.
 
-**(a)** Delete the version ARG from the "Pin CLI versions" block:
+## 4. Revert the Dockerfile
 
-```dockerfile
-ARG CODEX_VERSION=0.124.0
-```
+Delete the `ARG CODEX_VERSION=...` line and the `RUN pnpm install -g "@openai/codex@${CODEX_VERSION}"` line from `container/Dockerfile`.
 
-**(b)** Delete the standalone Codex install layer:
+## 5. Vault secret (optional)
 
-```dockerfile
-RUN --mount=type=cache,target=/root/.cache/pnpm \
-    pnpm install -g "@openai/codex@${CODEX_VERSION}"
-```
+The ChatGPT/OpenAI secret in the OneCLI vault grants nothing once the provider is gone. To remove it: `onecli secrets list`, then `onecli secrets delete --id <id>` for the `chatgpt.com` / `api.openai.com` entry.
 
-Leave the other per-CLI install layers (claude-code, agent-browser, vercel) untouched.
-
-## 4. Dependency
-
-Codex is a CLI binary installed via the Dockerfile — there is no agent-runner package dependency to uninstall. Step 3 removes the only install surface; no `bun remove` / `pnpm uninstall` is needed.
-
-## 5. Unset Codex env vars
-
-Remove any Codex-specific lines you added to `.env` (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_MODEL`) if no other integration uses them, then re-sync to the container:
+## 6. Rebuild and verify
 
 ```bash
-mkdir -p data/env && cp .env data/env/env
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
+pnpm test
+cd container/agent-runner && bun test
 ```
 
-Switch any group still on Codex back to the default provider — set `"provider": "claude"` in `groups/<folder>/container.json` and clear `agent_provider` on the group/session in the DB.
-
-## 6. Rebuild and restart
-
-Run from your NanoClaw project root:
-
-```bash
-pnpm run build && ./container/build.sh
-source setup/lib/install-slug.sh
-
-# macOS
-launchctl kickstart -k gui/$(id -u)/$(launchd_label)
-
-# Linux
-systemctl --user restart $(systemd_unit)
-```
-
-## Verification
-
-After removal, the registration guards no longer apply (their files are gone). Confirm the provider is fully unwired:
-
-```bash
-grep -R "codex.js" src/providers/index.ts container/agent-runner/src/providers/index.ts   # no output
-grep "@openai/codex" container/Dockerfile                                                  # no output
-```
-
-In a wired agent, requesting `agent_provider = 'codex'` should fall back to the default provider since `codex` is no longer in the registry.
+All suites green and `ncl groups list` showing no codex groups means the removal is complete. Restart the service (`launchctl kickstart -k gui/$(id -u)/<label>` on macOS, `systemctl --user restart <unit>` on Linux).

--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -1,186 +1,117 @@
 ---
 name: add-codex
-description: Use Codex (CLI + AppServer) as the full agent provider — planning, tool orchestration, native compaction, MCP tools, session resume — in place of the Claude Agent SDK. ChatGPT subscription or OPENAI_API_KEY. Per-group via agent_provider. Distinct from using OpenAI as an MCP tool (where Claude remains the planner).
+description: Use Codex (OpenAI's codex app-server) as a full agent provider — planning, tool orchestration, MCP tools, server-side history, session resume — alongside or instead of Claude. ChatGPT subscription or OpenAI API key, vault-only via OneCLI. Per-group via `ncl groups config update --provider codex`. Distinct from using OpenAI as an MCP tool (where Claude remains the planner).
 ---
 
 # Codex agent provider
 
-NanoClaw runs agents in a long-lived **poll loop** inside the container. The backend is selected with **`AGENT_PROVIDER`** (`claude` | `opencode` | `codex` | `mock`).
+> Shortcut: `pnpm exec tsx setup/index.ts --step provider-auth codex` performs this whole install (manifest-driven from the providers branch: files, barrels, Dockerfile pin, image rebuild) plus auth in one command. The steps below are the same operations, for agent-driven or manual application.
 
-Trunk ships with only the `claude` provider baked in. This skill copies the Codex provider files in from the `providers` branch, wires them into the host and container barrels, updates the Dockerfile to install the Codex CLI, and rebuilds the image.
+NanoClaw selects each group's agent backend from `container_configs.provider` (default `claude`). This skill installs the Codex provider: copy the payload from the `providers` branch, append one import to each of the three provider barrels, add the pinned Codex CLI to the Dockerfile, rebuild, then run the vault auth walk-through.
 
-The Codex provider runs `codex app-server` as a child process and speaks JSON-RPC over stdio. That gives it native session resume, streaming events, MCP tool access, and `thread/compact/start` compaction — same feature bar as the Claude Agent SDK, without the Anthropic-only lock-in.
+The provider runs `codex app-server` as a child process speaking JSON-RPC over stdio: native streaming, MCP tools, server-side conversation history (the continuation is a thread id, no on-disk transcript). Credentials are **vault-only**: OneCLI serves a sentinel `auth.json` stub into the container and swaps the real ChatGPT token or API key on the wire — no key in `.env`, nothing readable in the container.
 
 ## Install
 
 ### Pre-flight
 
-If all of the following are already present, skip to **Configuration**:
+Check whether the payload is already wired (a prior apply, or a trunk that still carries it). All of these present means installed — skip to **Authenticate**:
 
-- `src/providers/codex.ts`
-- `src/providers/codex-registration.test.ts`
-- `container/agent-runner/src/providers/codex.ts`
-- `container/agent-runner/src/providers/codex-app-server.ts`
-- `container/agent-runner/src/providers/codex.factory.test.ts`
-- `container/agent-runner/src/providers/codex-registration.test.ts`
-- `container/agent-runner/src/providers/codex-dockerfile.test.ts`
-- `import './codex.js';` line in `src/providers/index.ts`
-- `import './codex.js';` line in `container/agent-runner/src/providers/index.ts`
-- `ARG CODEX_VERSION` and `"@openai/codex@${CODEX_VERSION}"` in the pnpm global-install block in `container/Dockerfile`
+- `src/providers/codex.ts` and `src/providers/codex-agents-md.ts`
+- `container/agent-runner/src/providers/codex.ts` and `codex-app-server.ts`
+- `setup/providers/codex.ts`
+- `import './codex.js';` in `src/providers/index.ts`, `container/agent-runner/src/providers/index.ts`, and `setup/providers/index.ts`
+- `ARG CODEX_VERSION=` in `container/Dockerfile`
 
-Missing pieces — continue below. All steps are idempotent; re-running is safe.
-
-### 1. Fetch the providers branch
+### Fetch and copy
 
 ```bash
 git fetch origin providers
 ```
 
-### 2. Copy the Codex source files and tests
+Copy each file with `git show origin/providers:<path> > <path>` (additive — never merge the branch):
 
-Wholesale copies (owned entirely by this skill — user edits to these files won't survive a re-run, as designed):
+Host (`src/providers/`):
+- `codex.ts` — provider contribution: per-group `.codex-shared` state dir, AGENTS.md compose, skill links
+- `codex-agents-md.ts` — AGENTS.md composition (32KB Codex cap: degrades by dropping the largest instruction sections, never blocks a spawn)
+- `codex-registration.test.ts` — barrel-driven host registration guard
+- `codex-host-contribution.test.ts` — drives the real contribution against a real test DB (the "consumes core" leg)
+- `codex-agents-md.test.ts` — cap-degradation behavior
 
-```bash
-git show origin/providers:src/providers/codex.ts                                         > src/providers/codex.ts
-git show origin/providers:src/providers/codex-registration.test.ts                       > src/providers/codex-registration.test.ts
-git show origin/providers:container/agent-runner/src/providers/codex.ts                  > container/agent-runner/src/providers/codex.ts
-git show origin/providers:container/agent-runner/src/providers/codex-app-server.ts       > container/agent-runner/src/providers/codex-app-server.ts
-git show origin/providers:container/agent-runner/src/providers/codex.factory.test.ts     > container/agent-runner/src/providers/codex.factory.test.ts
-git show origin/providers:container/agent-runner/src/providers/codex-registration.test.ts > container/agent-runner/src/providers/codex-registration.test.ts
-```
+Container (`container/agent-runner/src/providers/`):
+- `codex.ts` — the provider (turn loop, steering, memory scaffold + `onExchangeComplete` archiving)
+- `codex-app-server.ts` — JSON-RPC child-process wrapper
+- `exchange-archive.ts` — per-exchange markdown writer the `onExchangeComplete` hook uses (provider-owned, not runner code)
+- `exchange-archive.test.ts` — writer behavior
+- `codex-registration.test.ts` — barrel-driven container registration guard
+- `codex.factory.test.ts`, `codex.turns.test.ts`, `codex-app-server.test.ts` — provider behavior
+- `codex-dockerfile.test.ts` — structural guard for the Dockerfile install
 
-The two `codex-registration.test.ts` files are the **registration guards**. Each imports only the real barrel — the host one calls `listProviderContainerConfigNames()` from `src/providers/index.ts`, the container one calls `listProviderNames()` from `container/agent-runner/src/providers/index.ts` — and asserts `codex` is present. They go red the instant a barrel import line is deleted or drifts. (`codex.factory.test.ts` imports `./codex.js` directly and self-registers, so it stays green even if the barrel line is gone — keep it as a unit test of provider behavior, but it is **not** the registration guard.)
+Setup (`setup/providers/`):
+- `codex.ts` — picker entry self-registration + the vault auth walk-through + install check
+- `codex.test.ts` — install-check coverage
+- `codex-registration.test.ts` — barrel-driven setup registration guard
 
-If `git show origin/providers:.../codex-registration.test.ts` errors with `path ... does not exist`, the registration tests have not landed on `origin/providers` yet. Run `git fetch origin providers` again; once the branch carries them, the copies above succeed. The rest of the install proceeds regardless — the Dockerfile and factory tests still run.
+Shared base (skip if present):
+- `container/AGENTS.md` — the runtime-contract base the composed AGENTS.md embeds
 
-Copy the Dockerfile structural test that ships with this skill into the container provider tree:
+### Wire the barrels
 
-```bash
-cp .claude/skills/add-codex/codex-dockerfile.test.ts container/agent-runner/src/providers/codex-dockerfile.test.ts
-```
+Append `import './codex.js';` to each of:
+- `src/providers/index.ts`
+- `container/agent-runner/src/providers/index.ts`
+- `setup/providers/index.ts`
 
-`codex-dockerfile.test.ts` reads the real `container/Dockerfile` and asserts the `ARG CODEX_VERSION=` line and the `pnpm install -g "@openai/codex@${CODEX_VERSION}"` line are both present. The Codex CLI is a binary, not an importable package, so the registration tests cannot see it — this structural test is what guards the Dockerfile edits in step 4.
+### Dockerfile
 
-### 3. Append the self-registration imports
-
-Each barrel gets one line — alphabetical placement keeps diffs small.
-
-`src/providers/index.ts`:
-
-```typescript
-import './codex.js';
-```
-
-`container/agent-runner/src/providers/index.ts`:
-
-```typescript
-import './codex.js';
-```
-
-### 4. Add the Codex CLI to the container Dockerfile
-
-Two edits to `container/Dockerfile`, both idempotent (skip if already present):
-
-**(a)** In the "Pin CLI versions" ARG block (around line 18), add after `ARG CLAUDE_CODE_VERSION=...`:
-
-```dockerfile
-ARG CODEX_VERSION=0.124.0
-```
-
-**(b)** Add a new standalone `RUN` block for the Codex CLI, after the existing per-CLI install blocks (around line 106, right after the `@anthropic-ai/claude-code` block). The Dockerfile splits each global CLI into its own layer for cache granularity — keep that pattern; do not collapse them into a single combined `pnpm install -g` call:
-
-```dockerfile
-RUN --mount=type=cache,target=/root/.cache/pnpm \
-    pnpm install -g "@openai/codex@${CODEX_VERSION}"
-```
-
-Note: **no agent-runner package dependency** — Codex is a CLI binary, not a library. Unlike OpenCode, there's nothing to add to `container/agent-runner/package.json`.
-
-### 5. Build and validate
+Copy the two Codex lines verbatim from the branch (the branch's Dockerfile is the canonical pin — do not hand-type a version):
 
 ```bash
-pnpm run build                                                          # host
-pnpm exec vitest run src/providers/codex-registration.test.ts          # host registration guard
-pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit         # container typecheck
-cd container/agent-runner && bun test src/providers/codex-registration.test.ts && cd -   # container registration guard
-cd container/agent-runner && bun test src/providers/codex-dockerfile.test.ts && cd -      # Dockerfile structural guard
-./container/build.sh                                                    # agent image
+git show origin/providers:container/Dockerfile | grep -A1 'ARG CODEX_VERSION'
 ```
 
-All must be clean before proceeding.
+Add the `ARG CODEX_VERSION=<pinned>` line to the version-args block and the `RUN pnpm install -g "@openai/codex@${CODEX_VERSION}"` line to the global-install block (its own layer).
 
-- The **host** `codex-registration.test.ts` imports the real host barrel (`src/providers/index.ts`) and asserts `listProviderContainerConfigNames()` contains `codex`. It goes red if the `import './codex.js';` line is deleted or drifts, or if the barrel fails to evaluate.
-- The **container** `codex-registration.test.ts` imports the real container barrel (`container/agent-runner/src/providers/index.ts`) and asserts `listProviderNames()` contains `codex`. Same failure surface for the container-side import line.
-- The **Dockerfile** `codex-dockerfile.test.ts` reads `container/Dockerfile` and asserts the `ARG CODEX_VERSION=` and `@openai/codex@${CODEX_VERSION}` install lines are present — red if either edit is dropped.
-
-The `@openai/codex` CLI binary is guarded by the Dockerfile structural test plus the container build (`./container/build.sh` fails if the install line is bad), **not** by the registration test — Codex is a CLI binary, not an importable package, so nothing imports it for the registration guard to trip on. To confirm the binary is actually present after the image rebuild, probe it inside a running container with `docker exec <container> codex --version`.
-
-The host-side provider also consumes core APIs (per-session `~/.codex` mount, env passthrough); that typed core-API consumption is guarded by `pnpm run build`.
-
-## Configuration
-
-Codex supports two primary auth paths and one experimental BYO-endpoint path. Pick the one that matches your setup.
-
-### Option A — ChatGPT subscription (recommended for individuals)
-
-On the host (not inside the container), run Codex's OAuth login:
+### Build
 
 ```bash
-codex login
+pnpm run build
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit
+./container/build.sh
 ```
 
-This writes `~/.codex/auth.json` with a subscription token. The host-side Codex provider ([src/providers/codex.ts](../../../src/providers/codex.ts)) copies `auth.json` into a per-session `~/.codex` directory mounted into the container — your host's own Codex CLI is never touched.
+### Validate
 
-No `.env` variables required for this mode.
-
-### Option B — API key (recommended for CI or API billing)
-
-```env
-OPENAI_API_KEY=sk-...
-CODEX_MODEL=gpt-5.4-mini
+```bash
+pnpm vitest run src/providers/codex-registration.test.ts src/providers/codex-host-contribution.test.ts src/providers/codex-agents-md.test.ts setup/providers/
+cd container/agent-runner && bun test src/providers/
 ```
 
-The host forwards both variables into the container. If both subscription (`auth.json`) and `OPENAI_API_KEY` are present, Codex prefers the subscription.
+The registration tests import only the real barrels — they go red if a barrel line is missing, a barrel fails to evaluate, or the payload is broken.
 
-### Option C — BYO OpenAI-compatible endpoint (experimental)
+## Authenticate
 
-Codex's built-in `openai` provider honors the `OPENAI_BASE_URL` env var directly. Point it at any OpenAI-compatible endpoint — Groq, Together, self-hosted vLLM, an OpenAI proxy, etc.
-
-```env
-OPENAI_API_KEY=...
-OPENAI_BASE_URL=https://api.groq.com/openai/v1
-CODEX_MODEL=llama-3.3-70b-versatile
+```bash
+pnpm exec tsx setup/index.ts --step provider-auth codex
 ```
 
-Codex also ships first-class local-runner flags — `codex --oss --local-provider ollama` or `--local-provider lmstudio` — that auto-detect a local server. To use those inside NanoClaw, set `CODEX_MODEL` to a model your local runner serves and add the corresponding base URL; see the Codex CLI docs for the full `model_provider = oss` configuration.
+The same walk-through fresh installs get from the setup picker: ChatGPT subscription (browser login or device pairing) or an OpenAI API key, landed in the OneCLI vault. Idempotent — it short-circuits when a matching secret already exists. It finishes with the install check.
 
-**Experimental caveat:** tool-calling quality depends on the model and endpoint. Not every OpenAI-compat provider implements the full function-calling spec, and smaller models (< 30B) often struggle with multi-step tool orchestration. Test before committing.
+## Use it
 
-### Per group / per session
+Per group:
 
-Set `"provider": "codex"` in the group's **`container.json`** (`groups/<folder>/container.json`) — the in-container runner reads `provider` from there, not from the DB. The DB columns **`agent_groups.agent_provider`** and **`sessions.agent_provider`** (session overrides group) only drive host-side provider contribution — per-session `~/.codex` mount, `OPENAI_*` / `CODEX_MODEL` env passthrough — and do not propagate into `container.json` at spawn time. Set both, or just edit `container.json`; if they disagree, the runner uses `container.json` and the host-side resolver falls back through session → group → `container.json` → `'claude'`.
+```bash
+ncl groups config update --id <group-id> --provider codex
+ncl groups restart --id <group-id>
+```
 
-`CODEX_MODEL` applies process-wide via `.env`; if you need different models for different groups, set them via `container_config.env` on the group.
+Switching is an operator action — run it from the host. Memory does NOT carry over automatically — each provider keeps its own store; run `/migrate-memory` to carry it across. See [docs/provider-migration.md](../../docs/provider-migration.md) for the carry-over table and rollback.
 
-Extra MCP servers still come from **`NANOCLAW_MCP_SERVERS`** / `container_config.mcpServers` on the host. The runner merges them into the same `mcpServers` object passed to all providers.
+There is no install-wide default provider. Setup's provider picker sets codex on the first agent it creates; creation itself is provider-agnostic (no `--provider` flag — provider is a DB property). Any group switches afterward via `ncl groups config update --provider` as above.
 
-## Operational notes
+## Troubleshooting
 
-- **Spawn-per-query:** Codex's app-server is spawned fresh per query invocation, matching the OpenCode pattern. No long-lived daemon to keep healthy across sessions.
-- **Per-session `~/.codex` isolation:** each group gets its own copy of the host's `auth.json`. The container can rewrite `config.toml` freely on every wake without touching the host's Codex config.
-- **Native compaction:** kicks in automatically at 40K cumulative input tokens between turns, via `thread/compact/start`. If compaction fails, the provider logs and continues uncompacted — no fatal error.
-- **Approvals:** auto-accepted inside the container (the container is the sandbox; same posture as Claude/OpenCode).
-- **Mid-turn input:** Codex turns don't accept mid-turn messages. Follow-up `push()` calls queue and drain between turns, matching the OpenCode pattern. The poll-loop only pushes between turns anyway, so no messages are dropped.
-- **Stale thread recovery:** `isSessionInvalid` matches on stale-thread-ID errors (`thread not found`, `unknown thread`, etc.) so a cold-started app-server can recover cleanly when it sees a stored continuation it no longer has.
-
-## Next Steps
-
-The registration and Dockerfile guards in **Build and validate** confirm the wiring. For a live end-to-end check, set `agent_provider = 'codex'` on a test group and send a message after the image rebuild. A successful round-trip looks like:
-
-- `init` event with a stable thread ID as continuation
-- One or more `activity` / `progress` events during the turn
-- `result` event with the model's reply
-
-If the agent hangs or errors, check `~/.codex/auth.json` exists on the host (Option A) or that `OPENAI_API_KEY` is forwarding correctly (Option B) — `docker exec` into a running container and `env | grep -i openai` to confirm. To confirm the CLI binary itself landed in the image, `docker exec <container> codex --version`.
-
-To back this provider out, follow [REMOVE.md](REMOVE.md).
+- **Container dies at boot, channel silent:** `grep 'Container exited non-zero' logs/nanoclaw.error.log` — the `stderrTail` carries the reason (e.g. `Unknown provider: codex. Registered: claude` means the barrels aren't wired in the running build).
+- **In-channel `Error: spawn codex ENOENT` on every message:** the image predates the Dockerfile edit — re-run `./container/build.sh`.
+- **Auth errors mid-conversation:** the vault secret is missing or stale — re-run `pnpm exec tsx setup/index.ts --step provider-auth codex` (subscription re-login updates the vault copy).

--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -71,6 +71,8 @@ Parse the `PAIR_TELEGRAM_ISSUED` status block for `CODE` and follow the `REMINDE
 
 ## 4. Run the init script
 
+First, pick the agent provider. Read `src/providers/index.ts` and collect the installed providers from its `import './<name>.js';` lines — `claude` is always available as the built-in default. If a non-default provider is installed (e.g. codex), ask the user which one this agent should run on; if only claude is available, skip the question and omit the flag.
+
 ```bash
 npx tsx scripts/init-first-agent.ts \
   --channel "${CHANNEL}" \
@@ -80,7 +82,7 @@ npx tsx scripts/init-first-agent.ts \
   --agent-name "${AGENT_NAME}"
 ```
 
-Add `--welcome "System instruction: ..."` to override the default welcome prompt.
+Add `--provider <name>` when the user picked a non-default provider (there is no install-wide default — the choice is explicit per group). Add `--welcome "System instruction: ..."` to override the default welcome prompt.
 
 The script:
 1. Upserts the `users` row and grants `owner` role if no owner exists.

--- a/.claude/skills/manage-channels/SKILL.md
+++ b/.claude/skills/manage-channels/SKILL.md
@@ -67,6 +67,8 @@ pnpm exec tsx setup/index.ts --step register -- \
 
 The `register` step creates the agent group (reusing it if the folder already exists), the messaging group, and the wiring row. `createMessagingGroupAgent` auto-creates the companion `agent_destinations` row so the agent can address the channel by name.
 
+When creating a NEW agent group on a non-default provider, append `--provider <name>` (e.g. `--provider codex`) — there is no install-wide default; existing groups switch via `ncl groups config update --provider` instead.
+
 For separate agents, also ask for a folder name and optionally a different assistant name.
 
 ## Add Channel Group

--- a/.claude/skills/migrate-memory/SKILL.md
+++ b/.claude/skills/migrate-memory/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: migrate-memory
+description: Carry an agent group's memory across a provider switch, in either direction (e.g. Claude ↔ Codex, or any provider to/from another). Run after the operator switches a group's provider with `ncl groups config update --provider`. The coding agent reads the source provider's memory store, distills it into the target provider's store, and restarts the group. Triggers on "migrate memory", "carry memory over", "the agent forgot everything after the switch".
+---
+
+# Migrate memory across a provider switch
+
+NanoClaw does not migrate memory at runtime — each provider keeps its own store, and carrying content across is the operator's move, executed by you (the coding agent). This skill is the whole mechanism: read the source store, **infer** what is durable, write it into the target store, restart.
+
+You translate between **store shapes**, not provider names. There are two:
+
+- **Flat file** — `CLAUDE.local.md` at the group workspace root (the Claude provider; may reference satellite files in the workspace).
+- **Scaffold tree** — `memory/` (any provider with `usesMemoryScaffold`, e.g. Codex). `memory/index.md` is the index; durable notes live under `memory/memories/`; `memory/memories/imported-agent-memory.md` is the conventional landing file for imported memory.
+
+A switch only needs migration when it **crosses shapes**. Two providers that both use the scaffold share the same `memory/` tree, so switching between them carries nothing — the memory is already there. The work is always one of: flat → scaffold, or scaffold → flat.
+
+Principles: **copy, never move** (the source store stays intact — it IS the rollback), **idempotent** (re-running must not duplicate), **distill, don't dump** (you are the inference step: keep identity/seed instructions, user preferences, durable facts; drop conversational residue).
+
+## Step 1: Identify the group, both providers, and the direction
+
+- `ncl groups list`, then `ncl groups config get --id <group-id>` — note the current (target) `provider`. Ask the operator which group, and which provider it switched *from*, if either is ambiguous.
+- Map each provider to its store shape (flat `CLAUDE.local.md` vs `memory/` scaffold), then inspect `groups/<folder>/`:
+  - **Same shape on both sides** (e.g. scaffold → scaffold) → the store is shared; nothing to migrate. Tell the operator and stop.
+  - **Flat → scaffold** (source has `CLAUDE.local.md` content, target uses the scaffold) → Step 2.
+  - **Scaffold → flat** (source has a `memory/` tree, target is Claude) → Step 3.
+  - Source missing or empty → nothing to migrate; tell the operator and stop.
+
+## Step 2: flat → scaffold (`CLAUDE.local.md` → `memory/`)
+
+1. Read `groups/<folder>/CLAUDE.local.md` and any workspace files it references.
+2. If `memory/memories/imported-agent-memory.md` already exists, a previous import happened — show the operator what's there and ask before overwriting; integrate only what's new.
+3. Distill the content into `groups/<folder>/memory/memories/imported-agent-memory.md` (create the directories if missing — the container scaffolds the rest of the tree at boot and never clobbers your files). Lead with anything that defines who the agent is or how it must behave; references to satellite files keep their workspace-root paths.
+4. If `memory/index.md` exists, add (once): `- [Imported agent memory](memories/imported-agent-memory.md) - seed instructions and memory carried over from a previous provider`.
+5. Leave the source store exactly as it is.
+
+## Step 3: scaffold → flat (`memory/` → `CLAUDE.local.md`)
+
+1. Read `memory/index.md`, then the files it points to under `memory/memories/` (and `memory/data/` where durable).
+2. Integrate the durable facts into `groups/<folder>/CLAUDE.local.md` under a clearly marked section (e.g. `## Imported from memory/ (<date>)`), deduplicating against what's already there. If the section already exists, update it instead of appending a second one.
+3. Leave the source store exactly as it is.
+
+## Step 4: Restart and verify
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+Tell the operator to send the group a quick test message that depends on a migrated fact (a preference, a project name). If the agent doesn't know it, re-check that the target file landed in the right group folder.
+
+Note: switching the provider is an operator action — `ncl groups config update --id <group-id> --provider <name>` from the host. See [docs/provider-migration.md](../../../docs/provider-migration.md) for what carries over automatically.

--- a/.claude/skills/migrate-memory/SKILL.md
+++ b/.claude/skills/migrate-memory/SKILL.md
@@ -30,7 +30,7 @@ Principles: **copy, never move** (the source store stays intact — it IS the ro
 1. Read `groups/<folder>/CLAUDE.local.md` and any workspace files it references.
 2. If `memory/memories/imported-agent-memory.md` already exists, a previous import happened — show the operator what's there and ask before overwriting; integrate only what's new.
 3. Distill the content into `groups/<folder>/memory/memories/imported-agent-memory.md` (create the directories if missing — the container scaffolds the rest of the tree at boot and never clobbers your files). Lead with anything that defines who the agent is or how it must behave; references to satellite files keep their workspace-root paths.
-4. If `memory/index.md` exists, add (once) — this is what tells the agent the imported file exists and how to treat it (the agent inlines `index.md` into its prompt each turn): `- [Imported agent memory](memories/imported-agent-memory.md) — seed instructions and memory carried over from a previous provider. Read it first and treat it as binding; it may define who you are and how to behave. Integrate its facts into your memory as you work; never modify files that belong to another provider's memory system.`
+4. If `memory/index.md` exists, add the following: `- [Imported agent memory](memories/imported-agent-memory.md) — seed instructions and memory carried over from a previous provider. Read it first and treat it as binding; it may define who you are and how to behave. Integrate its facts into your memory as you work; never modify files that belong to another provider's memory system.`
 5. Leave the source store exactly as it is.
 
 ## Step 3: scaffold → flat (`memory/` → `CLAUDE.local.md`)

--- a/.claude/skills/migrate-memory/SKILL.md
+++ b/.claude/skills/migrate-memory/SKILL.md
@@ -30,7 +30,7 @@ Principles: **copy, never move** (the source store stays intact — it IS the ro
 1. Read `groups/<folder>/CLAUDE.local.md` and any workspace files it references.
 2. If `memory/memories/imported-agent-memory.md` already exists, a previous import happened — show the operator what's there and ask before overwriting; integrate only what's new.
 3. Distill the content into `groups/<folder>/memory/memories/imported-agent-memory.md` (create the directories if missing — the container scaffolds the rest of the tree at boot and never clobbers your files). Lead with anything that defines who the agent is or how it must behave; references to satellite files keep their workspace-root paths.
-4. If `memory/index.md` exists, add (once): `- [Imported agent memory](memories/imported-agent-memory.md) - seed instructions and memory carried over from a previous provider`.
+4. If `memory/index.md` exists, add (once) — this is what tells the agent the imported file exists and how to treat it (the agent inlines `index.md` into its prompt each turn): `- [Imported agent memory](memories/imported-agent-memory.md) — seed instructions and memory carried over from a previous provider. Read it first and treat it as binding; it may define who you are and how to behave. Integrate its facts into your memory as you work; never modify files that belong to another provider's memory system.`
 5. Leave the source store exactly as it is.
 
 ## Step 3: scaffold → flat (`memory/` → `CLAUDE.local.md`)

--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -33,7 +33,7 @@ Run `/update-nanoclaw` in Claude Code.
 
 **Validation**: runs `pnpm run build` and `pnpm test`. If container files changed, also runs the container typecheck and `./container/build.sh`.
 
-**Breaking changes check**: after validation, reads CHANGELOG.md for any `[BREAKING]` entries introduced by the update and diffs `versions.json` for moved component pins. Each entry carries its migration path — a skill to run or a `docs/` page to follow (per CONTRIBUTING.md, "Breaking Changes") — and the skill walks you through them.
+**Breaking changes check**: after validation, reads CHANGELOG.md for any `[BREAKING]` entries introduced by the update. If found, shows each breaking change and offers to run the recommended skill to migrate.
 
 ## Rollback
 
@@ -221,31 +221,24 @@ After validation succeeds, check if the update introduced any breaking changes.
 Determine which CHANGELOG entries are new by diffing against the backup tag:
 - `git diff <backup-tag-from-step-1>..HEAD -- CHANGELOG.md`
 
-Parse the diff output for lines that contain `[BREAKING]` anywhere in the line. Each such line is one breaking change entry, and per CONTRIBUTING.md ("Breaking Changes") it references its migration path in one of two forms:
+Parse the diff output for lines that contain `[BREAKING]` anywhere in the line. Each such line is one breaking change entry. The format is:
 ```
 [BREAKING] <description>. Run `/<skill-name>` to <action>.
-[BREAKING] <description>. **Migration:** follow [docs/<page>.md](docs/<page>.md) ...
 ```
 
-Also diff the component version pins:
-- `git diff <backup-tag-from-step-1>..HEAD -- versions.json`
-
-Each changed pin is a breaking component update (e.g. `onecli-gateway` moving means the OneCLI gateway must be upgraded). Its migration path is the `[BREAKING]` CHANGELOG entry covering it; if no new entry mentions it, search `docs/` for the pin name (convention: `docs/<component>-upgrades.md`) and treat that doc as the migration path.
-
-If no `[BREAKING]` lines are found and `versions.json` did not change:
+If no `[BREAKING]` lines are found:
 - Skip this step silently. Proceed to Step 7 (skill updates check).
 
-Otherwise:
+If one or more `[BREAKING]` lines are found:
 - Display a warning header to the user: "This update includes breaking changes that may require action:"
-- For each breaking change, display the full description (for a moved pin without its own entry: the component name, old → new version, and the doc that covers it).
-- Use AskUserQuestion to ask the user which migrations to run now. Options:
+- For each breaking change, display the full description.
+- Collect all skill names referenced in the breaking change entries (the `/<skill-name>` part).
+- Use AskUserQuestion to ask the user which migration skills they want to run now. Options:
   - One option per referenced skill (e.g., "Run /add-whatsapp to re-add WhatsApp channel")
-  - One option per referenced doc (e.g., "Upgrade the OneCLI gateway (docs/onecli-upgrades.md)")
   - "Skip — I'll handle these manually"
-- Set `multiSelect: true` so the user can pick multiple migrations if there are several breaking changes.
+- Set `multiSelect: true` so the user can pick multiple skills if there are several breaking changes.
 - For each skill the user selects, invoke it using the Skill tool.
-- For each doc the user selects, read the doc and execute it top to bottom — these docs are written to be executed verbatim by a coding agent (detect → fix → verify → rollback). Stop and report if a verify step fails.
-- After all selected migrations complete (or if user chose Skip), proceed to Step 7 (skill updates check).
+- After all selected skills complete (or if user chose Skip), proceed to Step 7 (skill updates check).
 
 # Step 7: Check for skill and channel/provider updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to NanoClaw will be documented in this file.
 ## [Unreleased]
 
 - [BREAKING] **`@onecli-sh/sdk` 0.5.0 -> 2.2.1 — requires a OneCLI server with the `/v1` API** (older servers 404 every SDK call). The sanctioned gateway and CLI versions are pinned in `versions.json`; the `onecli` setup step enforces them. **Migration:** [docs/onecli-upgrades.md](docs/onecli-upgrades.md).
+- **New agent provider: Codex (OpenAI) — run `/add-codex`.** Full runtime via `codex app-server` (planning, MCP tools, server-side history, resume). Trunk ships the seams and the skill; the payload installs from the `providers` branch (the skill, the setup picker, or `--step provider-auth codex`). Auth is vault-only — no credential ever enters a container.
+- **Setup can now select, install, and authenticate a non-default agent provider.** A provider registry feeds the setup picker, an installer pulls the provider's payload from its branch, a vault auth walkthrough runs (`--step provider-auth`), and the picked provider is set on the first agent (a DB property) before its first spawn. Default (Claude) installs are unaffected — picking Claude changes nothing.
+- **Provider choice is explicit per group — no install-wide default.** Provider is a DB property set via `ncl groups config update --provider` + restart; creation is provider-agnostic.
+- **Memory migrates via `/migrate-memory`, never at runtime.** Each provider keeps its own store; fresh groups on a surfaces-owning provider see no stale `CLAUDE.*` files. See [docs/provider-migration.md](docs/provider-migration.md).
+- **Per-exchange archiving is provider-owned** — the `onExchangeComplete` hook; the markdown writer ships with the codex payload.
+- **Container boot failures now say why** — the last stderr lines are logged at `warn` on a non-zero exit instead of a silent crash loop.
 - **Slash commands now interrupt an in-flight turn.** A runner-handled command (`/clear`, `/compact`, `/cost`, …) arriving mid-turn aborts the active stream and runs immediately instead of waiting out the turn.
 
 ## [2.1.0] - 2026-06-07

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ Four types of skills. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full taxono
 | `/debug` | Container issues, logs, troubleshooting |
 | `/update-nanoclaw` | Bring upstream updates into a customized install |
 | `/init-onecli` | Install OneCLI Agent Vault and migrate `.env` credentials |
+| `/migrate-memory` | Carry a group's agent memory across a provider switch (operator-run, both directions) |
 
 ## Contributing
 
@@ -275,6 +276,7 @@ This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspac
 | [docs/build-and-runtime.md](docs/build-and-runtime.md) | Runtime split (Node host + Bun container), lockfiles, image build surface, CI, key invariants |
 | [docs/v1-to-v2-changes.md](docs/v1-to-v2-changes.md) | v1→v2 architecture diff — vocabulary for where v1 things moved |
 | [docs/migration-dev.md](docs/migration-dev.md) | Migration development guide — testing, debugging, dev loop |
+| [docs/provider-migration.md](docs/provider-migration.md) | Switching a live agent group between providers (e.g. Claude → Codex) — what carries over, rollback |
 | [docs/customizing.md](docs/customizing.md) | Short intro to customizing via skills |
 | [docs/skills-model.md](docs/skills-model.md) | The skills model in full: recipes, tests, upgrades, migrations |
 | [docs/skill-guidelines.md](docs/skill-guidelines.md) | Authoritative checklist for writing a skill |

--- a/container/agent-runner/src/memory-scaffold.test.ts
+++ b/container/agent-runner/src/memory-scaffold.test.ts
@@ -20,6 +20,22 @@ describe('ensureMemoryScaffold', () => {
     }
   });
 
+  it('never touches workspace memory it did not create — CLAUDE.local.md stays untouched', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-mem-'));
+    try {
+      fs.writeFileSync(path.join(base, 'CLAUDE.local.md'), '# group memory\nuser prefers terse replies\n');
+
+      ensureMemoryScaffold(base);
+
+      // Migration between memory stores is the operator's move (/migrate-memory),
+      // never a boot side effect.
+      expect(fs.existsSync(path.join(base, 'memory', 'memories', 'imported-agent-memory.md'))).toBe(false);
+      expect(fs.readFileSync(path.join(base, 'CLAUDE.local.md'), 'utf-8')).toContain('terse replies');
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it('is idempotent and never clobbers the agent edits', () => {
     const base = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-mem-'));
     try {

--- a/container/agent-runner/src/memory-templates/definition.md
+++ b/container/agent-runner/src/memory-templates/definition.md
@@ -21,3 +21,13 @@ If a fact is corrected, update the memory and keep only useful history.
 When you add, move, or remove memory, update the nearest index.
 Before answering from memory, read the relevant index or file instead of guessing;
 if memory is missing or uncertain, say so and verify when it matters.
+
+## Imported agent memory
+
+If `memory/memories/imported-agent-memory.md` exists, it holds this group's seed
+instructions and/or memory carried over from a previous agent provider — placed
+there by the operator's tooling (group creation, or the operator running
+`/migrate-memory`). Read it on your first turn and treat its contents as binding:
+it may define who you are and how to behave. Integrate its facts into your memory
+files as you work. Files it references live in the workspace root and remain
+readable; never modify files that belong to another provider's memory system.

--- a/container/agent-runner/src/memory-templates/definition.md
+++ b/container/agent-runner/src/memory-templates/definition.md
@@ -21,13 +21,3 @@ If a fact is corrected, update the memory and keep only useful history.
 When you add, move, or remove memory, update the nearest index.
 Before answering from memory, read the relevant index or file instead of guessing;
 if memory is missing or uncertain, say so and verify when it matters.
-
-## Imported agent memory
-
-If `memory/memories/imported-agent-memory.md` exists, it holds this group's seed
-instructions and/or memory carried over from a previous agent provider — placed
-there by the operator's tooling (group creation, or the operator running
-`/migrate-memory`). Read it on your first turn and treat its contents as binding:
-it may define who you are and how to behave. Integrate its facts into your memory
-files as you work. Files it references live in the workspace root and remain
-readable; never modify files that belong to another provider's memory system.

--- a/docs/provider-migration.md
+++ b/docs/provider-migration.md
@@ -1,0 +1,44 @@
+# Switching an agent group between providers
+
+How an **operator** moves a live agent group from one agent provider to another (e.g. Claude → Codex) and back. Switching is an operator action: it runs from the host via `ncl groups config update --provider` + restart.
+
+NanoClaw's runtime does not migrate anything when you switch. Provider-neutral state simply stays where it is; provider-specific state (memory, in-flight context) stays with its provider, and carrying memory across is a separate, explicit operator step (`/migrate-memory`, executed by your coding agent).
+
+## Preconditions
+
+1. **The target provider is installed** — run its `/add-<provider>` skill and rebuild the container image (`./container/build.sh`). If the provider isn't installed (or the name is a typo), the container fails at boot and the host surfaces its last words in the logs: look for `Container exited non-zero` with a `stderrTail` like `Unknown provider: codexx. Registered: claude, codex`.
+2. **Auth is configured** — each provider documents its own auth in its install skill (for Codex: a ChatGPT-subscription or API-key secret in the OneCLI vault).
+
+## Switching
+
+```bash
+ncl groups config update --id <group-id> --provider codex
+ncl groups restart --id <group-id>
+```
+
+Sessions resolve their provider at container spawn (`sessions.agent_provider` is only set when you've explicitly pinned a session), so existing sessions pick up the new provider on their next wake.
+
+## What carries over automatically
+
+| State | How |
+|-------|-----|
+| Group identity, wiring, members, roles, destinations | Provider-neutral, in the central DB — untouched |
+| Container config (model aside), skills, MCP servers, packages, mounts, cli_scope | Provider-neutral — untouched |
+| Workspace files (`groups/<folder>/` — notes, data files the agent created) | Same workspace, mounted for every provider |
+| Conversation archives (`conversations/`) | Provider-neutral markdown — readable by the new provider |
+| Agent surfaces (system instructions / project docs) | Composed fresh at every spawn from the same sources — nothing to migrate |
+
+## What does NOT carry over
+
+- **Agent memory.** Each provider keeps its own store: Claude's per-group memory is `CLAUDE.local.md` in the workspace; scaffold providers (e.g. Codex) keep a `memory/` tree. Neither is touched by a switch — the old store sits intact, the new provider starts with its own. To carry memory across, run **`/migrate-memory`**: your coding agent reads the source store, distills it into the target store (copy, never move), and restarts the group. Both directions work.
+- **In-flight conversation context.** Continuations are provider-specific (a Claude SDK session, a Codex thread) and stored in separate per-provider slots — the new provider starts a fresh thread. The old slot is kept, not deleted. Recent context is recoverable from `conversations/` archives.
+- **Provider state dirs** (`.claude-shared/`, `.codex-shared/`). Each provider keeps its own; they sit idle while unused and are reused if you switch back.
+
+## Rolling back
+
+```bash
+ncl groups config update --id <group-id> --provider claude
+ncl groups restart --id <group-id>
+```
+
+Rollback is lossless by construction: the per-provider continuation slot means Claude resumes its previous session (subject to normal transcript-rotation age limits), and `CLAUDE.local.md` was never modified by the switch. Memory written **while on the other provider** lives in that provider's store — run `/migrate-memory` again if you want it carried back.

--- a/scripts/init-cli-agent.ts
+++ b/scripts/init-cli-agent.ts
@@ -21,6 +21,7 @@ import path from 'path';
 
 import { DATA_DIR } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { updateContainerConfigScalars } from '../src/db/container-configs.js';
 import { initDb } from '../src/db/connection.js';
 import {
   createMessagingGroup,
@@ -102,6 +103,7 @@ async function main(): Promise<void> {
 
   // 2. Agent group + filesystem.
   const folder = args.folder || `cli-with-${normalizeName(args.displayName)}`;
+  const pickedProvider = process.env.NANOCLAW_PICKED_PROVIDER?.trim().toLowerCase();
   let ag: AgentGroup | undefined = getAgentGroupByFolder(folder);
   if (!ag) {
     const agId = generateId('ag');
@@ -123,6 +125,10 @@ async function main(): Promise<void> {
       `You are ${args.agentName}, a personal NanoClaw agent for ${args.displayName}. ` +
       'When the user first reaches out, introduce yourself briefly and invite them to chat. Keep replies concise.',
   });
+  // Runtime provider lives on the config row, not the deprecated agent_provider.
+  if (pickedProvider && pickedProvider !== 'claude') {
+    updateContainerConfigScalars(ag.id, { provider: pickedProvider });
+  }
 
   // 3. CLI messaging group + wiring.
   let cliMg: MessagingGroup | undefined = getMessagingGroupByPlatform(CLI_CHANNEL, CLI_PLATFORM_ID);

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -30,10 +30,11 @@
  * For direct-addressable channels (telegram, whatsapp, etc.), --platform-id
  * is typically the same as the handle in --user-id, with the channel prefix.
  */
+import fs from 'fs';
 import net from 'net';
 import path from 'path';
 
-import { DATA_DIR } from '../src/config.js';
+import { DATA_DIR, GROUPS_DIR } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
 import { initDb } from '../src/db/connection.js';
 import {
@@ -47,8 +48,7 @@ import { normalizeName } from '../src/modules/agent-to-agent/db/agent-destinatio
 import { addMember } from '../src/modules/permissions/db/agent-group-members.js';
 import { getUserRoles, grantRole } from '../src/modules/permissions/db/user-roles.js';
 import { upsertUser } from '../src/modules/permissions/db/users.js';
-import { updateContainerConfigScalars } from '../src/db/container-configs.js';
-import { initGroupFilesystem } from '../src/group-init.js';
+import { ensureContainerConfig, updateContainerConfigScalars } from '../src/db/container-configs.js';
 import { namespacedPlatformId } from '../src/platform-id.js';
 import type { AgentGroup, MessagingGroup } from '../src/types.js';
 
@@ -189,6 +189,7 @@ async function main(): Promise<void> {
 
   // 2. Agent group + filesystem.
   const folder = `dm-with-${normalizeName(args.displayName)}`;
+  const pickedProvider = process.env.NANOCLAW_PICKED_PROVIDER?.trim().toLowerCase();
   let ag: AgentGroup | undefined = getAgentGroupByFolder(folder);
   if (!ag) {
     const agId = generateId('ag');
@@ -204,12 +205,23 @@ async function main(): Promise<void> {
   } else {
     console.log(`Reusing agent group: ${ag.id} (${folder})`);
   }
-  initGroupFilesystem(ag, {
-    instructions:
-      `# ${args.agentName}\n\n` +
+  // Ensure the config row exists; defer workspace scaffolding to the first
+  // spawn (group-init), where the DB-resolved provider decides the surface
+  // (Claude: CLAUDE.local.md; a surfaces-owning provider: the memory scaffold)
+  // — so a non-Claude group never gets stale CLAUDE.* files written here.
+  ensureContainerConfig(ag.id);
+  // Runtime provider lives on the config row, not the deprecated agent_provider.
+  if (pickedProvider && pickedProvider !== 'claude') {
+    updateContainerConfigScalars(ag.id, { provider: pickedProvider });
+  }
+  const groupDir = path.resolve(GROUPS_DIR, folder);
+  fs.mkdirSync(groupDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(groupDir, '.seed.md'),
+    `# ${args.agentName}\n\n` +
       `You are ${args.agentName}, a personal NanoClaw agent for ${args.displayName}. ` +
-      'When the user first reaches out (or you receive a system welcome prompt), introduce yourself briefly and invite them to chat. Keep replies concise.',
-  });
+      'When the user first reaches out (or you receive a system welcome prompt), introduce yourself briefly and invite them to chat. Keep replies concise.\n',
+  );
 
   // 2b. Assign the user a role for this agent group. The caller picks via
   // --role; the channel drivers default to 'owner' for the self-host case.

--- a/setup/add-codex.sh
+++ b/setup/add-codex.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Install the Codex agent provider non-interactively: copy the payload from the
+# `providers` branch, wire the three provider barrels, and pin the Codex CLI in
+# the Dockerfile. The image rebuild is the caller's job (the setup container
+# step / `./container/build.sh`).
+#
+# Emits exactly one status block on stdout (ADD_CODEX); all chatty progress
+# goes to stderr. Keep in sync with .claude/skills/add-codex/SKILL.md.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Keep in sync with the providers-branch Dockerfile and add-codex SKILL.md.
+CODEX_VERSION="0.138.0"
+
+# Resolve the remote carrying the providers branch (same nanoclaw remote that
+# carries channels — handles forks where it isn't `origin`).
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+REMOTE=$(resolve_channels_remote)
+BRANCH="${REMOTE}/providers"
+
+# The codex payload — host provider, container runtime, setup module, doctrine.
+# Barrels are appended to, not copied.
+PAYLOAD_FILES=(
+  src/providers/codex.ts
+  src/providers/codex-agents-md.ts
+  src/providers/codex-registration.test.ts
+  src/providers/codex-host-contribution.test.ts
+  src/providers/codex-agents-md.test.ts
+  container/agent-runner/src/providers/codex.ts
+  container/agent-runner/src/providers/codex-app-server.ts
+  container/agent-runner/src/providers/exchange-archive.ts
+  container/agent-runner/src/providers/exchange-archive.test.ts
+  container/agent-runner/src/providers/codex-registration.test.ts
+  container/agent-runner/src/providers/codex.factory.test.ts
+  container/agent-runner/src/providers/codex.turns.test.ts
+  container/agent-runner/src/providers/codex-app-server.test.ts
+  container/agent-runner/src/providers/codex-dockerfile.test.ts
+  setup/providers/codex.ts
+  setup/providers/codex.test.ts
+  setup/providers/codex-registration.test.ts
+  container/AGENTS.md
+)
+BARRELS=(
+  src/providers/index.ts
+  container/agent-runner/src/providers/index.ts
+  setup/providers/index.ts
+)
+
+ALREADY_INSTALLED=true
+emit_status() {
+  local status=$1 error=${2:-}
+  echo "=== NANOCLAW SETUP: ADD_CODEX ==="
+  echo "STATUS: ${status}"
+  echo "CODEX_VERSION: ${CODEX_VERSION}"
+  echo "ALREADY_INSTALLED: ${ALREADY_INSTALLED}"
+  [ -n "$error" ] && echo "ERROR: ${error}"
+  echo "=== END ==="
+}
+log() { echo "[add-codex] $*" >&2; }
+
+# Idempotent: a complete install has the host provider file, the host barrel
+# import, and the Dockerfile pin. Any missing → (re)install.
+need_install() {
+  [ ! -f src/providers/codex.ts ] && return 0
+  ! grep -q "^import './codex.js';" src/providers/index.ts 2>/dev/null && return 0
+  ! grep -q '@openai/codex@' container/Dockerfile 2>/dev/null && return 0
+  return 1
+}
+
+if need_install; then
+  ALREADY_INSTALLED=false
+
+  log "Fetching providers branch from ${REMOTE}…"
+  git fetch "$REMOTE" providers >&2 2>/dev/null || {
+    emit_status failed "git fetch ${REMOTE} providers failed"
+    exit 1
+  }
+
+  log "Copying Codex payload from ${BRANCH}…"
+  for f in "${PAYLOAD_FILES[@]}"; do
+    mkdir -p "$(dirname "$f")"
+    git show "${BRANCH}:$f" > "$f" 2>/dev/null || {
+      emit_status failed "providers branch is missing ${f}"
+      exit 1
+    }
+  done
+
+  log "Wiring provider barrels…"
+  for b in "${BARRELS[@]}"; do
+    grep -q "^import './codex.js';" "$b" || printf "import './codex.js';\n" >> "$b"
+  done
+
+  log "Pinning Codex CLI in the Dockerfile…"
+  DF=container/Dockerfile
+  if ! grep -q "^ARG CODEX_VERSION=" "$DF"; then
+    # Version ARG ahead of the first ARG in the version-args block.
+    awk -v ins="ARG CODEX_VERSION=${CODEX_VERSION}" \
+      'add!=1 && /^ARG /{print ins; add=1} {print}' "$DF" > "$DF.tmp" && mv "$DF.tmp" "$DF"
+  fi
+  if ! grep -q '@openai/codex@' "$DF"; then
+    # Install RUN block (its own cache layer) before the ncl CLI wrapper anchor.
+    awk 'add!=1 && /# ---- ncl CLI wrapper/ {
+           print "RUN --mount=type=cache,target=/root/.cache/pnpm \\"
+           print "    pnpm install -g \"@openai/codex@${CODEX_VERSION}\""
+           print ""
+           add=1
+         } {print}' "$DF" > "$DF.tmp" && mv "$DF.tmp" "$DF"
+  fi
+fi
+
+emit_status ok

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -38,8 +38,12 @@ import { runTeamsChannel } from './channels/teams.js';
 import { runTelegramChannel } from './channels/telegram.js';
 import { runWhatsAppChannel } from './channels/whatsapp.js';
 import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
+import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+// Provider payloads self-register their picker entry + auth on import.
+import './providers/index.js';
 import { brightSelect } from './lib/bright-select.js';
 import { offerClaudeOnFailure } from './lib/claude-handoff.js';
+import { setPickedProvider } from './lib/picked-provider.js';
 import {
   applyToEnv,
   parseFlags,
@@ -321,8 +325,54 @@ async function main(): Promise<void> {
     }
   }
 
+  let agentProvider: string | undefined;
   if (!skip.has('auth')) {
-    await runAuthStep();
+    // Agent runtime pick. Claude is the default and a no-op — choosing it
+    // runs the existing Claude auth flow unchanged. A branch provider walks
+    // its own auth (e.g. Codex: ChatGPT subscription or API key, vault-only)
+    // and verifies its payload is wired. The pick installs and authenticates
+    // the runtime; it is NOT an install-wide default — and it is NOT a
+    // creation flag. Provider is a DB property of a group: the creation flows
+    // create provider-agnostic groups, and setup sets the picked provider on
+    // each via `ncl groups config update --provider` right after creating it
+    // (the creation scripts inherit it and apply at create — see picked-provider). Existing groups switch the
+    // same way (docs/provider-migration.md).
+    agentProvider = await askAgentProviderChoice();
+    setPickedProvider(agentProvider);
+    let providerEntry = getSetupProvider(agentProvider);
+    if (agentProvider !== 'claude' && !providerEntry) {
+      // A non-claude provider picked from the hard-wired list isn't wired in
+      // this install yet — install it via its self-contained script (channel
+      // style, idempotent: self-skips if already installed), rebuild the image
+      // (the container step already ran, the Dockerfile just changed), then
+      // load the payload's setup module so it self-registers.
+      const install = await runQuietChild(
+        `add-${agentProvider}`,
+        'bash',
+        [`setup/add-${agentProvider}.sh`],
+        {
+          running: `Installing ${agentProvider}…`,
+          done: `${agentProvider} installed.`,
+        },
+      );
+      if (!install.ok) {
+        await fail(
+          `add-${agentProvider}`,
+          `Couldn't install ${agentProvider}.`,
+          'See logs/setup-steps/ for details, then retry setup.',
+        );
+      }
+      p.log.info(brandBody('Rebuilding the container image with the new provider…'));
+      spawnSync('./container/build.sh', [], { stdio: 'inherit' });
+      await import(`./providers/${agentProvider}.js`);
+      providerEntry = getSetupProvider(agentProvider);
+    }
+    if (providerEntry?.runAuth) {
+      await providerEntry.runAuth();
+      await providerEntry.runInstallCheck?.();
+    } else {
+      await runAuthStep();
+    }
   }
 
   if (!skip.has('mounts')) {
@@ -747,6 +797,39 @@ function sendChatMessage(message: string): Promise<void> {
 }
 
 // ─── auth step (select → branch) ────────────────────────────────────────
+
+// Providers offered for install are hard-wired in trunk — an audited control
+// surface (no branch enumeration that anyone with write access could extend).
+// Codex is the only one offered here; opencode/ollama install via their own
+// /add-* skills. Each is installed by its self-contained setup/add-<name>.sh.
+const INSTALLABLE_PROVIDERS = [
+  { value: 'codex', label: 'Codex', hint: 'OpenAI — ChatGPT subscription or API key' },
+] as const;
+
+async function askAgentProviderChoice(): Promise<string> {
+  const installed = listSetupProviders();
+  const installedNames = new Set(installed.map((entry) => entry.value));
+  // Offer the hard-wired installable providers this install hasn't wired yet —
+  // selecting one installs it via setup/add-<name>.sh.
+  const available = INSTALLABLE_PROVIDERS.filter((prov) => !installedNames.has(prov.value));
+  const options = [
+    ...installed.map(({ value, label, hint }) => ({ value, label, hint })),
+    ...available.map((prov) => ({ value: prov.value, label: prov.label, hint: `${prov.hint} — installs now` })),
+  ];
+  // The pick installs and authenticates a runtime — it is not an
+  // install-wide default, so re-runs safely Enter-through on claude (its
+  // auth flow short-circuits when the secret already exists).
+  const choice = ensureAnswer(
+    await brightSelect<string>({
+      message: 'Which agent runtime should power your assistant?',
+      options,
+      initialValue: 'claude',
+    }),
+  ) as string;
+  setupLog.userInput('agent_provider', choice);
+  phEmit('agent_provider_chosen', { provider: choice });
+  return choice;
+}
 
 async function runAuthStep(): Promise<void> {
   if (anthropicSecretExists()) {
@@ -1261,7 +1344,7 @@ function detectExistingOnecli(): { version: string; apiHost: string } | null {
     } catch {
       // not JSON — try to extract a URL directly
     }
-    const m = raw.match(/https?:\/\/[\w.\-]+(?::\d+)?/);
+    const m = raw.match(/https?:\/\/[\w.-]+(?::\d+)?/);
     return m ? { version, apiHost: m[0] } : null;
   } catch {
     return null;

--- a/setup/cli-agent.ts
+++ b/setup/cli-agent.ts
@@ -68,8 +68,12 @@ export async function run(args: string[]): Promise<void> {
 
   log.info('Invoking init-cli-agent', { displayName, agentName });
 
+  // Provider-agnostic: init-cli-agent creates a default group and emits its id.
+  // Surface that id so the orchestrator can set the picked provider on it (via
+  // ncl) before the ping — provider is a DB property, never a creation flag.
+  let stdout = '';
   try {
-    execFileSync('pnpm', scriptArgs, {
+    stdout = execFileSync('pnpm', scriptArgs, {
       cwd: projectRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf-8',
@@ -90,10 +94,13 @@ export async function run(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const agentGroupId = stdout.match(/^AGENT_GROUP_ID:\s*(\S+)/m)?.[1];
+
   emitStatus('CLI_AGENT', {
     DISPLAY_NAME: displayName,
     AGENT_NAME: agentName || displayName,
     CHANNEL: 'cli/local',
+    ...(agentGroupId ? { AGENT_GROUP_ID: agentGroupId } : {}),
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -35,6 +35,29 @@ export function readEnvKey(key: string, projectRoot?: string): string | null {
   return null;
 }
 
+/**
+ * Set (or replace) a single `KEY=value` line in `.env`, creating the file if
+ * needed. Non-secret config only — secrets belong in the OneCLI vault.
+ */
+export function upsertEnvKey(key: string, value: string, projectRoot?: string): void {
+  const envPath = path.join(projectRoot ?? process.cwd(), '.env');
+  let content = '';
+  try {
+    content = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    /* no .env yet */
+  }
+  const line = `${key}=${value}`;
+  const lines = content.split('\n');
+  const idx = lines.findIndex((l) => l.trim().startsWith(`${key}=`));
+  if (idx >= 0) lines[idx] = line;
+  else {
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop();
+    lines.push(line);
+  }
+  fs.writeFileSync(envPath, lines.join('\n') + '\n');
+}
+
 export function detectExistingDisplayName(projectRoot: string): string | null {
   const dbPath = path.join(projectRoot, 'data', 'v2.db');
   if (!fs.existsSync(dbPath)) return null;

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -23,6 +23,7 @@ const STEPS: Record<
   verify: () => import('./verify.js'),
   onecli: () => import('./onecli.js'),
   auth: () => import('./auth.js'),
+  'provider-auth': () => import('./provider-auth.js'),
   'cli-agent': () => import('./cli-agent.js'),
 };
 

--- a/setup/lib/bright-select.ts
+++ b/setup/lib/bright-select.ts
@@ -67,16 +67,42 @@ export interface BrightSelectOptions<T> {
 }
 
 /**
+ * Discard any stdin buffered while no prompt was reading — keypresses made
+ * during spinners and installs otherwise get consumed by the next select the
+ * instant it opens, submitting it before it ever renders for the user (a
+ * stray `↓`+`Enter` silently picks option 2). Raw-mode reads only see kernel
+ * tty data via the event loop, so the drain needs a real (short) window.
+ */
+export function flushStdin(windowMs = 50): Promise<void> {
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    if (!stdin.isTTY) return resolve();
+    const wasRaw = stdin.isRaw === true;
+    stdin.setRawMode?.(true);
+    const discard = (): void => {};
+    stdin.on('data', discard);
+    stdin.resume();
+    setTimeout(() => {
+      stdin.off('data', discard);
+      stdin.pause();
+      if (!wasRaw) stdin.setRawMode?.(false);
+      resolve();
+    }, windowMs);
+  });
+}
+
+/**
  * Matches the return shape of `p.select` — resolves to the selected value
  * on submit, or to clack's cancel symbol on Ctrl-C / Esc. Callers pass
  * the result through `ensureAnswer(...)` the same way they do for
  * `p.select`.
  */
-export function brightSelect<T>(
+export async function brightSelect<T>(
   opts: BrightSelectOptions<T>,
 ): Promise<T | symbol> {
   const { message, options, initialValue } = opts;
 
+  await flushStdin();
   return new SelectPrompt({
     options: options as Array<{ value: T; label?: string; hint?: string }>,
     initialValue,

--- a/setup/lib/picked-provider.ts
+++ b/setup/lib/picked-provider.ts
@@ -1,0 +1,28 @@
+/**
+ * The agent runtime the operator picked in THIS setup run.
+ *
+ * There is no install-wide default provider and no `--provider` in the
+ * creation contract — provider is a DB property of a group. Setup is the one
+ * orchestrator that knows the operator's pick, so it stashes it here (set once
+ * at the auth step). The group-creation scripts (`init-first-agent`,
+ * `init-cli-agent`) run as **child processes**, so the pick is carried over the
+ * process boundary via an environment variable they inherit; they apply it to
+ * the group at creation, before the welcome wakes the container. This is the
+ * only place the value lives — a setup-run-scoped global, NOT a persisted
+ * install default. `undefined` / `'claude'` means the built-in default and no
+ * provider write at all.
+ */
+const ENV_KEY = 'NANOCLAW_PICKED_PROVIDER';
+
+export function setPickedProvider(provider: string | undefined): void {
+  const normalized = provider?.trim().toLowerCase() || undefined;
+  if (normalized && normalized !== 'claude') {
+    process.env[ENV_KEY] = normalized;
+  } else {
+    delete process.env[ENV_KEY];
+  }
+}
+
+export function getPickedProvider(): string | undefined {
+  return process.env[ENV_KEY]?.trim().toLowerCase() || undefined;
+}

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -1,0 +1,80 @@
+/**
+ * Standalone provider auth — the late-adopter entry point.
+ *
+ * Fresh installs reach a provider's auth walk-through via the setup picker;
+ * an existing install adding a provider later runs THIS instead:
+ *
+ *   pnpm exec tsx setup/index.ts --step provider-auth codex
+ *
+ * Same walk-through, same vault-only invariant, idempotent (each provider's
+ * runAuth short-circuits when its secret already exists) — and unlike
+ * re-running full setup, it touches nothing else: no install-wide default
+ * provider rewrite, no service changes. Provider install skills call this as
+ * their auth step so there is exactly one auth implementation per provider.
+ */
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { getSetupProvider, listSetupProviders } from './providers/registry.js';
+// Provider payloads self-register on import.
+import './providers/index.js';
+
+// Hard-wired install scripts — the audited control surface (no branch
+// enumeration). Each setup/add-<name>.sh is idempotent and self-skips when the
+// payload is already wired. Codex is the only manifest-style provider today.
+const INSTALL_SCRIPTS: Record<string, string> = {
+  codex: 'setup/add-codex.sh',
+};
+
+export async function run(args: string[]): Promise<void> {
+  const name = args[0]?.trim().toLowerCase();
+  const withAuth = listSetupProviders().filter((entry) => entry.runAuth);
+
+  if (!name) {
+    console.error(
+      `Usage: pnpm exec tsx setup/index.ts --step provider-auth <provider>\n` +
+        `Providers with an auth step: ${withAuth.map((entry) => entry.value).join(', ') || '(none installed)'}`,
+    );
+    process.exit(1);
+  }
+
+  let entry = getSetupProvider(name);
+  const script = INSTALL_SCRIPTS[name];
+  if (script) {
+    // Install OR refresh: the script is idempotent and is also the upgrade
+    // path — payload files resync and a bumped Dockerfile pin replaces the
+    // local one. Rebuild the image only when the Dockerfile actually changed
+    // (payload code is mounted, not baked).
+    const dfPath = path.join(process.cwd(), 'container', 'Dockerfile');
+    const dfBefore = fs.readFileSync(dfPath, 'utf-8');
+    console.log(`${entry ? 'Refreshing' : 'Installing'} ${name}…`);
+    execSync(`bash ${script}`, { stdio: 'inherit' });
+    if (fs.readFileSync(dfPath, 'utf-8') !== dfBefore) {
+      console.log('Dockerfile pin changed — rebuilding the container image…');
+      execSync('./container/build.sh', { stdio: 'inherit' });
+    }
+    if (!entry) {
+      await import(`./providers/${name}.js`);
+      entry = getSetupProvider(name);
+    }
+    if (!entry) {
+      console.error(`Install completed but ${name} did not register — check setup/providers/${name}.ts`);
+      process.exit(1);
+    }
+  } else if (!entry) {
+    console.error(
+      `Unknown provider: ${name}. Installed: ${listSetupProviders()
+        .map((e) => e.value)
+        .join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  if (!entry.runAuth) {
+    console.error(`Provider "${name}" uses the standard auth flow — run the full setup, or /add-${name}'s steps.`);
+    process.exit(1);
+  }
+
+  await entry.runAuth();
+  await entry.runInstallCheck?.();
+}

--- a/setup/provider-contract.test.ts
+++ b/setup/provider-contract.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Provider is a DB property of a group, set only via
+ * `ncl groups config update --provider`. The group-creation contract that a
+ * fork's coding agent and its skills depend on must carry zero provider
+ * vocabulary — no `--provider` flag passed to, parsed by, or threaded through
+ * any creation path. These guards go red if that flag creeps back in.
+ *
+ * (Prose references to the ncl surface in comments are fine — we assert the
+ * absence of the `'--provider'` arg *literal*, not the substring.)
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf-8');
+}
+
+const CREATION_FILES = [
+  'scripts/init-first-agent.ts',
+  'scripts/init-cli-agent.ts',
+  'setup/register.ts',
+  'setup/cli-agent.ts',
+  'setup/channels/telegram.ts',
+  'setup/channels/discord.ts',
+  'setup/channels/slack.ts',
+  'setup/channels/whatsapp.ts',
+  'setup/channels/signal.ts',
+  'setup/channels/imessage.ts',
+  'setup/channels/teams.ts',
+];
+
+describe('creation is provider-agnostic', () => {
+  for (const file of CREATION_FILES) {
+    it(`${file} passes/parses no --provider flag`, () => {
+      const src = read(file);
+      expect(src).not.toContain("'--provider'");
+      expect(src).not.toMatch(/case '--provider'/);
+    });
+  }
+});
+
+describe('setup carries the picked provider to creation via a setup-run env var', () => {
+  it('picked-provider stashes/reads the pick in the NANOCLAW_PICKED_PROVIDER env var', () => {
+    const src = read('setup/lib/picked-provider.ts');
+    expect(src).toContain('NANOCLAW_PICKED_PROVIDER');
+    // The pick is set into process.env so child creation scripts inherit it —
+    // an in-process module global can't cross the process boundary.
+    expect(src).toMatch(/process\.env\[/);
+  });
+
+  // The creation scripts run as child processes, inherit the env var, and apply
+  // it to the group's runtime config — container_configs.provider, the source of
+  // truth materialized into container.json (agent_provider is deprecated) — before
+  // the welcome wakes the container. No `--provider` flag in the contract (above).
+  for (const file of ['scripts/init-first-agent.ts', 'scripts/init-cli-agent.ts']) {
+    it(`${file} applies the env-carried provider to container_configs.provider`, () => {
+      const src = read(file);
+      expect(src).toContain('NANOCLAW_PICKED_PROVIDER');
+      expect(src).toMatch(/updateContainerConfigScalars\([^)]*provider:\s*pickedProvider/);
+    });
+  }
+});
+
+describe('codex installs from a hard-wired self-contained script', () => {
+  // The provider picker no longer enumerates a remote manifest branch (an
+  // unaudited control surface). Codex is offered in trunk and installed by its
+  // own setup/add-<name>.sh, exactly like a channel adapter.
+  it('setup/add-codex.sh exists', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'setup/add-codex.sh'))).toBe(true);
+  });
+
+  it('setup/auto.ts installs the picked provider by running setup/add-<name>.sh', () => {
+    const src = read('setup/auto.ts');
+    expect(src).toContain('setup/add-${agentProvider}.sh');
+    // The removed branch-enumeration machinery must not creep back in.
+    expect(src).not.toContain('listBranchProviderManifests');
+    expect(src).not.toContain('installProviderFromBranch');
+  });
+});

--- a/setup/providers/index.ts
+++ b/setup/providers/index.ts
@@ -1,0 +1,3 @@
+// Setup-side provider barrel. Provider payloads with their own setup surface
+// (picker entry, auth walk-through, install check) self-register on import.
+// Skills add a provider by appending one import line below.

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Setup-side provider registration guards.
+ *
+ * Behavior (barrel-driven): imports the real setup/providers barrel and
+ * asserts the built-in default — red if the barrel fails to evaluate.
+ * Per-provider registration guards ship WITH each provider payload (the
+ * skill copies them in), same archetype as the host/container registration
+ * tests.
+ *
+ * Structural: the picker and the standalone provider-auth step are wiring
+ * inside non-invocable entry flows (setup main, STEPS map) — assert their
+ * consumption of the registry in source, so deleting either reach-in goes red.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { getSetupProvider, listSetupProviders } from './registry.js';
+import './index.js'; // the real setup provider barrel — triggers self-registration
+
+describe('setup provider registry', () => {
+  it('always carries claude as the built-in default with the standard auth flow', () => {
+    const claude = getSetupProvider('claude');
+    expect(claude).toBeDefined();
+    expect(claude!.runAuth).toBeUndefined();
+    expect(listSetupProviders()[0]!.value).toBe('claude');
+  });
+});
+
+describe('setup flow consumes the registry (structural)', () => {
+  it('the picker renders options from listSetupProviders', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'auto.ts'), 'utf-8');
+    expect(src).toContain('listSetupProviders()');
+    expect(src).toContain("import './providers/index.js'");
+    // The capability-keyed branch — a provider's own auth runs iff it declares one.
+    expect(src).toMatch(/providerEntry\?\.runAuth/);
+  });
+
+  it('the standalone provider-auth step is reachable from the STEPS map', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'index.ts'), 'utf-8');
+    expect(src).toContain("'provider-auth'");
+  });
+});

--- a/setup/providers/registry.ts
+++ b/setup/providers/registry.ts
@@ -1,0 +1,59 @@
+/**
+ * Setup-side provider registry — the picker and the standalone `provider-auth`
+ * step render from this map instead of hardcoding provider names in the setup
+ * flow (same capability-not-name rule as the host provider-container registry).
+ *
+ * `claude` is the built-in default: it has no `runAuth` of its own, which the
+ * setup flow reads as "run the standard auth step". A provider payload adds
+ * itself by shipping a `setup/providers/<name>.ts` with a top-level
+ * `registerSetupProvider(...)` call and appending one import line to the
+ * `setup/providers/index.ts` barrel — the same shape as the host and container
+ * provider registries, guarded the same way (a barrel-driven registration test).
+ */
+import type { AssistContext } from '../lib/claude-assist.js'; // type-only — registry stays runtime-dependency-free
+
+/**
+ * Outcome of a provider-owned failure-assist hook:
+ *   - 'launched'    — the provider's debugger ran (user may have fixed things).
+ *   - 'declined'    — the user said no; do NOT offer another debugger.
+ *   - 'unavailable' — the provider's CLI can't be used here; the dispatcher
+ *                     falls back to the guarded Claude offer (never install/sign-in).
+ */
+export type FailureAssistResult = 'launched' | 'declined' | 'unavailable';
+
+export interface SetupProviderEntry {
+  value: string;
+  label: string;
+  hint: string;
+  /** Provider-owned auth walk-through (vault-only). Absent → standard auth step. */
+  runAuth?: () => Promise<void>;
+  /** Verifies the provider's payload is wired (files, barrels, Dockerfile pin). */
+  runInstallCheck?: () => Promise<void>;
+  /** Provider-owned interactive failure debugger. 'unavailable' → dispatcher
+   *  falls back to the guarded Claude offer (never install/sign-in). */
+  offerFailureAssist?: (ctx: AssistContext, projectRoot: string) => Promise<FailureAssistResult>;
+}
+
+const registry = new Map<string, SetupProviderEntry>();
+
+registry.set('claude', {
+  value: 'claude',
+  label: 'Claude',
+  hint: 'default — Anthropic subscription or API key',
+});
+
+export function registerSetupProvider(entry: SetupProviderEntry): void {
+  if (registry.has(entry.value)) {
+    throw new Error(`Setup provider already registered: ${entry.value}`);
+  }
+  registry.set(entry.value, entry);
+}
+
+export function getSetupProvider(name: string): SetupProviderEntry | undefined {
+  return registry.get(name.toLowerCase());
+}
+
+/** Claude (the default) first, then the rest in registration order. */
+export function listSetupProviders(): SetupProviderEntry[] {
+  return [...registry.values()];
+}

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -11,6 +11,7 @@ import { DATA_DIR } from '../src/config.js';
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
+import { ensureContainerConfig } from '../src/db/container-configs.js';
 import {
   createMessagingGroup,
   createMessagingGroupAgent,
@@ -18,7 +19,6 @@ import {
   getMessagingGroupAgentByPair,
 } from '../src/db/messaging-groups.js';
 import { isValidGroupFolder } from '../src/group-folder.js';
-import { initGroupFilesystem } from '../src/group-init.js';
 import { log } from '../src/log.js';
 import { namespacedPlatformId } from '../src/platform-id.js';
 import { resolveSession, writeSessionMessage } from '../src/session-manager.js';
@@ -118,7 +118,7 @@ export async function run(args: string[]): Promise<void> {
   // Chat SDK adapters prefix, native adapters (WhatsApp/iMessage/Signal) don't.
   parsed.platformId = namespacedPlatformId(parsed.channel, parsed.platformId);
 
-  log.info('Registering channel', parsed);
+  log.info('Registering channel', { ...parsed });
 
   // Init v2 central DB
   fs.mkdirSync(path.join(projectRoot, 'data'), { recursive: true });
@@ -126,7 +126,11 @@ export async function run(args: string[]): Promise<void> {
   const db = initDb(dbPath);
   runMigrations(db);
 
-  // 1. Create or find agent group
+  // 1. Create or find agent group. Provider-agnostic: provider is a DB
+  // property set via `ncl groups config update --provider`, not a creation
+  // flag. The workspace is scaffolded at the first spawn (group-init), where
+  // the DB-resolved provider is known; here we only ensure the config row
+  // exists so that update has a row to write.
   let agentGroup = getAgentGroupByFolder(parsed.folder);
   if (!agentGroup) {
     const agId = generateId('ag');
@@ -140,7 +144,7 @@ export async function run(args: string[]): Promise<void> {
     agentGroup = getAgentGroupByFolder(parsed.folder)!;
     log.info('Created agent group', { id: agId, folder: parsed.folder });
   }
-  initGroupFilesystem(agentGroup);
+  ensureContainerConfig(agentGroup.id);
 
   // 2. Create or find messaging group
   let messagingGroup = getMessagingGroupByPlatform(parsed.channel, parsed.platformId);

--- a/src/container-restart.test.ts
+++ b/src/container-restart.test.ts
@@ -26,6 +26,12 @@ vi.mock('./db/sessions.js', () => ({
 const mockWriteSessionMessage = vi.fn();
 vi.mock('./session-manager.js', () => ({
   writeSessionMessage: (...args: unknown[]) => mockWriteSessionMessage(...args),
+  openInboundDb: () => ({}),
+}));
+
+const mockCountDueMessages = vi.fn((..._args: unknown[]) => 0);
+vi.mock('./db/session-db.js', () => ({
+  countDueMessages: (...args: unknown[]) => mockCountDueMessages(...args),
 }));
 
 import { restartAgentGroupContainers } from './container-restart.js';
@@ -147,5 +153,22 @@ describe('restartAgentGroupContainers', () => {
     // Each session gets its own on-wake message
     expect(mockWriteSessionMessage.mock.calls[0][1]).toBe('s1');
     expect(mockWriteSessionMessage.mock.calls[1][1]).toBe('s2');
+  });
+
+  it('wakes even without a wake message when in-flight messages are pending', () => {
+    // A provider switch mid-conversation kills a container holding claimed
+    // messages — without an immediate respawn those messages stay dark until
+    // the next inbound or a slow sweep backoff.
+    mockGetSessionsByAgentGroup.mockReturnValue([makeSession('s1', 'ag1')]);
+    mockIsContainerRunning.mockReturnValue(true);
+    mockCountDueMessages.mockReturnValue(2);
+
+    restartAgentGroupContainers('ag1', 'provider switch');
+
+    const onExit = mockKillContainer.mock.calls[0][2] as () => void;
+    expect(typeof onExit).toBe('function');
+    mockGetSession.mockReturnValue(makeSession('s1', 'ag1'));
+    onExit();
+    expect(mockWakeContainer).toHaveBeenCalled();
   });
 });

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -5,9 +5,10 @@
  * wakes a fresh container via the onExit callback — race-free.
  */
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { countDueMessages } from './db/session-db.js';
 import { getSession, getSessionsByAgentGroup } from './db/sessions.js';
 import { log } from './log.js';
-import { writeSessionMessage } from './session-manager.js';
+import { openInboundDb, writeSessionMessage } from './session-manager.js';
 
 /**
  * Kill all running containers for an agent group and respawn them.
@@ -40,10 +41,15 @@ export function restartAgentGroupContainers(agentGroupId: string, reason: string
         onWake: 1,
       });
     }
+    // Always respawn after the kill when there is anything to process: an
+    // explicit wake message, or in-flight messages the dying container had
+    // claimed. Without this, a provider switch mid-conversation leaves the
+    // claimed messages dark until the next inbound or a slow sweep backoff.
+    const hasPending = countDueMessages(openInboundDb(session.agent_group_id, session.id)) > 0;
     killContainer(
       session.id,
       reason,
-      wakeMessage
+      wakeMessage || hasPending
         ? () => {
             const s = getSession(session.id);
             if (s) wakeContainer(s);

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -46,3 +46,17 @@ describe('buildContainerArgs ordering invariant (structural)', () => {
     expect(gatewayApply).toBeGreaterThan(mountsLoop);
   });
 });
+
+describe('container boot-failure tripwire (structural)', () => {
+  // A container that dies at boot (unknown provider, missing CLI binary, bad
+  // config) explains itself only on stderr — which logs at debug, below the
+  // default level. The spawn handler must keep a stderr tail and surface it
+  // at warn on a non-zero exit, or the operator sees only "exited code 1" on
+  // repeat. Driving a real failing spawn needs a container runtime, so this
+  // guards the wiring structurally, matching the invariant test above.
+  it('surfaces the stderr tail when the container exits non-zero', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'src', 'container-runner.ts'), 'utf-8');
+    expect(src).toContain('stderrTail.push(line)');
+    expect(src).toMatch(/Container exited non-zero.*stderrTail/s);
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -21,7 +21,7 @@ import {
 } from './config.js';
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
-import { updateContainerConfigScalars, updateContainerConfigJson } from './db/container-configs.js';
+import { updateContainerConfigScalars } from './db/container-configs.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from './egress-lockdown.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
@@ -168,10 +168,16 @@ async function spawnContainer(session: Session): Promise<void> {
   activeContainers.set(session.id, { process: container, containerName });
   markContainerRunning(session.id);
 
-  // Log stderr
+  // Log stderr. A container that dies at boot (unknown provider, missing
+  // binary, bad config) explains itself only here — and debug is below the
+  // default log level — so keep a tail to surface on a non-zero exit.
+  const stderrTail: string[] = [];
   container.stderr?.on('data', (data) => {
     for (const line of data.toString().trim().split('\n')) {
-      if (line) log.debug(line, { container: agentGroup.folder });
+      if (!line) continue;
+      log.debug(line, { container: agentGroup.folder });
+      stderrTail.push(line);
+      if (stderrTail.length > 10) stderrTail.shift();
     }
   });
 
@@ -187,7 +193,12 @@ async function spawnContainer(session: Session): Promise<void> {
     activeContainers.delete(session.id);
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
-    log.info('Container exited', { sessionId: session.id, code, containerName });
+    // code null = killed by signal (normal shutdown path), not a boot failure.
+    if (code !== 0 && code !== null && stderrTail.length > 0) {
+      log.warn('Container exited non-zero', { sessionId: session.id, code, containerName, stderrTail });
+    } else {
+      log.info('Container exited', { sessionId: session.id, code, containerName });
+    }
   });
 
   container.on('error', (err) => {
@@ -417,7 +428,7 @@ async function buildContainerArgs(
   containerName: string,
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
-  provider: string,
+  _provider: string,
   providerContribution: ProviderContainerContribution,
   agentIdentifier?: string,
 ): Promise<string[]> {

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -66,13 +66,43 @@ export function initGroupFilesystem(
     initialized.push('groupDir');
   }
 
-  // groups/<folder>/CLAUDE.local.md — per-group agent memory, auto-loaded by
-  // Claude Code. Seeded with caller-provided instructions on first creation.
-  const claudeLocalFile = path.join(groupDir, 'CLAUDE.local.md');
-  if (defaultSurfaces && !fs.existsSync(claudeLocalFile)) {
-    const body = opts?.instructions ? opts.instructions + '\n' : '';
-    fs.writeFileSync(claudeLocalFile, body);
-    initialized.push('CLAUDE.local.md');
+  // Seed instructions land in the provider's OWN memory surface. Default
+  // (Claude) surfaces auto-load CLAUDE.local.md natively. A surfaces-owning
+  // provider must never see stale CLAUDE.* files in its workspace — its seed
+  // goes into the memory scaffold's conventional landing file instead
+  // (memory/memories/imported-agent-memory.md): the container-side scaffold
+  // preserves pre-existing files, and the doctrine tells the agent to read
+  // that file on its first turn.
+  //
+  // Creation stays provider-agnostic: a DM-agent creator drops the seed in a
+  // neutral `.seed.md`, and placement is deferred to here (the first spawn,
+  // where the DB-resolved provider is known). Once placed it's consumed.
+  // `opts.instructions` still wins for any caller that passes it inline.
+  const neutralSeedFile = path.join(groupDir, '.seed.md');
+  const seed =
+    opts?.instructions ??
+    (fs.existsSync(neutralSeedFile) ? fs.readFileSync(neutralSeedFile, 'utf-8').trimEnd() : undefined);
+
+  if (defaultSurfaces) {
+    const claudeLocalFile = path.join(groupDir, 'CLAUDE.local.md');
+    if (!fs.existsSync(claudeLocalFile)) {
+      fs.writeFileSync(claudeLocalFile, seed ? seed + '\n' : '');
+      initialized.push('CLAUDE.local.md');
+    }
+  } else if (seed) {
+    const seedFile = path.join(groupDir, 'memory', 'memories', 'imported-agent-memory.md');
+    if (!fs.existsSync(seedFile)) {
+      fs.mkdirSync(path.dirname(seedFile), { recursive: true });
+      fs.writeFileSync(seedFile, seed + '\n');
+      initialized.push('memory/memories/imported-agent-memory.md');
+    }
+  }
+
+  // The neutral seed is single-use — drop it once the surface it belonged in
+  // has been resolved, so it can't re-seed after the operator edits theirs.
+  if (fs.existsSync(neutralSeedFile)) {
+    fs.rmSync(neutralSeedFile);
+    initialized.push('.seed.md consumed');
   }
 
   // Ensure container_configs row exists in the DB. Idempotent — no-op if

--- a/src/modules/agent-to-agent/create-agent.test.ts
+++ b/src/modules/agent-to-agent/create-agent.test.ts
@@ -16,6 +16,7 @@ const mockRequestApproval = vi.fn().mockResolvedValue(undefined);
 const mockGetContainerConfig = vi.fn();
 const mockCreateAgentGroup = vi.fn();
 const mockInitGroupFilesystem = vi.fn();
+const mockUpdateScalars = vi.fn();
 const mockWriteDestinations = vi.fn();
 const mockNotifyWrite = vi.fn();
 
@@ -24,6 +25,8 @@ vi.mock('../approvals/index.js', () => ({
 }));
 vi.mock('../../db/container-configs.js', () => ({
   getContainerConfig: (...a: unknown[]) => mockGetContainerConfig(...a),
+  ensureContainerConfig: () => {},
+  updateContainerConfigScalars: (...a: unknown[]) => mockUpdateScalars(...a),
 }));
 vi.mock('../../db/agent-groups.js', () => ({
   getAgentGroup: (id: string) => ({ id, name: id.toUpperCase(), folder: id, agent_provider: null, created_at: '' }),
@@ -73,6 +76,29 @@ describe('handleCreateAgent — scope-based authorization', () => {
     expect(mockRequestApproval).not.toHaveBeenCalled();
     expect(mockCreateAgentGroup).toHaveBeenCalledTimes(1);
     expect(mockInitGroupFilesystem).toHaveBeenCalledTimes(1);
+  });
+
+  it('child inherits the creator provider (codex parent → codex child)', async () => {
+    // A subagent must run on the same authenticated runtime as its creator —
+    // on a codex-only install a claude default would 401. Red-on-delete:
+    // dropping the inheritance leaves the child provider-less (→ claude).
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'global', provider: 'codex' });
+
+    await handleCreateAgent({ name: 'Scout', instructions: 'help' }, SESSION);
+
+    expect(mockInitGroupFilesystem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'codex' }),
+    );
+    expect(mockUpdateScalars).toHaveBeenCalledWith(expect.any(String), { provider: 'codex' });
+  });
+
+  it('claude creator leaves the child provider unset (built-in default)', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'global' }); // no provider
+
+    await handleCreateAgent({ name: 'Scout', instructions: 'help' }, SESSION);
+
+    expect(mockUpdateScalars).not.toHaveBeenCalled();
   });
 
   it('group scope (default): requires approval, does NOT create directly', async () => {

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -16,7 +16,7 @@ import path from 'path';
 
 import { GROUPS_DIR } from '../../config.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder } from '../../db/agent-groups.js';
-import { getContainerConfig } from '../../db/container-configs.js';
+import { getContainerConfig, updateContainerConfigScalars } from '../../db/container-configs.js';
 import { getSession } from '../../db/sessions.js';
 import { wakeContainer } from '../../container-runner.js';
 import { initGroupFilesystem } from '../../group-init.js';
@@ -163,7 +163,17 @@ async function performCreateAgent(
     created_at: now,
   };
   createAgentGroup(newGroup);
-  initGroupFilesystem(newGroup, { instructions: instructions ?? undefined });
+  // A subagent inherits its creator's provider. Provider is a DB property; the
+  // child is created provider-agnostic, then stamped with the parent's runtime
+  // so a single-provider install (e.g. codex-only, where claude isn't
+  // authenticated) doesn't spawn a child on a runtime it can't reach. The
+  // operator can still flip a child later with `ncl groups config update
+  // --provider`. claude (the built-in default) leaves the column unset.
+  const parentProvider = getContainerConfig(sourceGroup.id)?.provider ?? undefined;
+  initGroupFilesystem(newGroup, { instructions: instructions ?? undefined, provider: parentProvider });
+  if (parentProvider) {
+    updateContainerConfigScalars(newGroup.id, { provider: parentProvider });
+  }
 
   // Insert bidirectional destination rows (= ACL grants).
   // Creator refers to child by the name it chose; child refers to creator as "parent".

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -292,6 +292,8 @@ export function createNewAgentGroup(name: string): AgentGroup {
   });
 
   const ag = getAgentGroup(agId)!;
+  // Channel-approved groups get the built-in default provider (claude); the
+  // operator flips a group with `ncl groups config update --provider`.
   initGroupFilesystem(ag);
   return ag;
 }

--- a/src/provider-surfaces.test.ts
+++ b/src/provider-surfaces.test.ts
@@ -71,7 +71,7 @@ describe('initGroupFilesystem agent surfaces', () => {
     expect(fs.existsSync(path.join(claudeDir, 'skills'))).toBe(true);
   });
 
-  it('skips the default surfaces for a provider that provides its own', () => {
+  it('writes the seed into the memory scaffold — never CLAUDE.* — for a provider with its own surfaces', () => {
     const ag = group('ag-surfy', 'surfy-group');
     createAgentGroup(ag);
 
@@ -80,8 +80,25 @@ describe('initGroupFilesystem agent surfaces', () => {
     const groupDir = path.join(GROUPS_DIR, ag.folder);
     const sessionRoot = path.join(DATA_DIR, 'v2-sessions', ag.id);
     expect(fs.existsSync(groupDir)).toBe(true);
+    // A fresh group on a surfaces-owning provider must not contain stale
+    // Claude surfaces; its seed lands in the scaffold's conventional file,
+    // which the container-side scaffold preserves at boot.
     expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(groupDir, 'memory', 'memories', 'imported-agent-memory.md'), 'utf-8')).toBe(
+      'hello\n',
+    );
     expect(fs.existsSync(path.join(sessionRoot, '.claude-shared'))).toBe(false);
+  });
+
+  it('writes nothing at all for a surfaces-owning provider without instructions', () => {
+    const ag = group('ag-surfy-bare', 'surfy-bare-group');
+    createAgentGroup(ag);
+
+    initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
+
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(false);
+    expect(fs.existsSync(path.join(groupDir, 'memory'))).toBe(false);
   });
 
   it('treats an unregistered provider name as default surfaces', () => {
@@ -91,6 +108,41 @@ describe('initGroupFilesystem agent surfaces', () => {
     initGroupFilesystem(ag, { provider: 'not-registered' });
 
     expect(fs.existsSync(path.join(GROUPS_DIR, ag.folder, 'CLAUDE.local.md'))).toBe(true);
+  });
+});
+
+describe('initGroupFilesystem deferred seed (.seed.md)', () => {
+  // Creation is provider-agnostic: the DM-agent creators drop a neutral
+  // `.seed.md` and defer placement to the first spawn, where the DB-resolved
+  // provider is known. group-init places it into the right surface and
+  // consumes it. Red-on-delete: if that placement is removed, these fail.
+  it('places .seed.md into CLAUDE.local.md for the default provider, then consumes it', () => {
+    const ag = group('ag-seed-default', 'seed-default');
+    createAgentGroup(ag);
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(path.join(groupDir, '.seed.md'), 'seeded identity\n');
+
+    initGroupFilesystem(ag, {}); // no inline instructions — must read .seed.md
+
+    expect(fs.readFileSync(path.join(groupDir, 'CLAUDE.local.md'), 'utf-8')).toBe('seeded identity\n');
+    expect(fs.existsSync(path.join(groupDir, '.seed.md'))).toBe(false);
+  });
+
+  it('places .seed.md into the memory scaffold (never CLAUDE.*) for a surfaces-owning provider, then consumes it', () => {
+    const ag = group('ag-seed-surfy', 'seed-surfy');
+    createAgentGroup(ag);
+    const groupDir = path.join(GROUPS_DIR, ag.folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(path.join(groupDir, '.seed.md'), 'seeded identity\n');
+
+    initGroupFilesystem(ag, { provider: 'surfaces-test-provider' });
+
+    expect(fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(groupDir, 'memory', 'memories', 'imported-agent-memory.md'), 'utf-8')).toBe(
+      'seeded identity\n',
+    );
+    expect(fs.existsSync(path.join(groupDir, '.seed.md'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What this does

Turns the agent provider into an explicit, operator-chosen property. Trunk ships the **seams** — a provider registry, a setup picker, an installer, a vault auth walkthrough, and the memory-migration skill — while the non-default provider **payloads** (Codex first) install from the `providers` branch.

**Picking Claude changes nothing.** Default installs are unaffected; everything here is additive.

## Surface area

**Setup**
- `setup/providers/registry.ts` (+ tests) — provider registry behind the picker
- `setup/provider-auth.ts`, `setup/lib/picked-provider.ts` — vault auth walkthrough + the seam that carries the pick to agent creation
- `setup/add-codex.sh` — channel-style installer that copies the Codex payload from the `providers` branch, wires the barrels, and pins the Codex CLI
- `setup/auto.ts`, `setup/cli-agent.ts`, `setup/environment.ts`, `setup/register.ts` — picker wiring

**Provider as a DB property**
- `scripts/init-first-agent.ts`, `scripts/init-cli-agent.ts`, `src/modules/agent-to-agent/create-agent.ts` — set `container_configs.provider` at creation; creation itself stays provider-agnostic
- `src/container-restart.ts`, `src/container-runner.ts`, `src/group-init.ts` — restart + per-group scaffold honor the chosen provider

**Switching + memory**
- `.claude/skills/migrate-memory/SKILL.md` — bidirectional memory carry across a provider switch
- `container/agent-runner/src/memory-templates/definition.md` — read the imported-memory seed first turn
- `docs/provider-migration.md` — what carries over, how to roll back

## Compatibility

Additive. Existing Claude installs need no action. Provider choice is per-group (`ncl groups config update --provider` + restart), never install-wide, and memory is carried explicitly via `/migrate-memory` — never silently at runtime. Full notes in `CHANGELOG.md` and `docs/provider-migration.md`.

## Testing

`pnpm test` (host) + container suite green. Validated end-to-end on a clean VM: setup → pick Codex → install → build → a live Codex agent answering, vault-only auth, zero credential in-container.
