### PR TITLE
docs(CLAUDE.md): fix two relocated Key Files paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,8 @@ For ad-hoc queries from skills or scripts, use the in-tree wrapper rather than t
 | `src/modules/permissions/access.ts` | `canAccessAgentGroup` — owner / global admin / scoped admin / member resolution against `user_roles` + `agent_group_members` |
 | `src/modules/approvals/primitive.ts` | `pickApprover`, `pickApprovalDelivery`, `requestApproval`, approval-handler registry |
 | `src/command-gate.ts` | Router-side admin command gate — queries `user_roles` directly (no env var, no container-side check) |
-| `src/onecli-approvals.ts` | OneCLI credentialed-action approval bridge |
-| `src/user-dm.ts` | Cold-DM resolution + `user_dms` cache |
+| `src/modules/approvals/onecli-approvals.ts` | OneCLI credentialed-action approval bridge |
+| `src/modules/permissions/user-dm.ts` | Cold-DM resolution + `user_dms` cache |
 | `src/group-init.ts` | Per-agent-group filesystem scaffold (CLAUDE.md, skills, agent-runner-src overlay) |
 | `src/db/container-configs.ts` | CRUD for `container_configs` table (per-group container runtime config) |
 | `src/backfill-container-configs.ts` | Migrates legacy `container.json` files into the DB on startup |
@@ -152,7 +152,7 @@ Key files: `src/container-restart.ts`, `src/container-runner.ts` (`killContainer
 
 ## Secrets / Credentials / OneCLI
 
-API keys, OAuth tokens, and auth credentials are managed by the OneCLI gateway. Secrets are injected into per-agent containers at request time — none are passed in env vars or through chat context. The container agent sees this via the `onecli-gateway` container skill (`container/skills/onecli-gateway/SKILL.md`), which teaches it how the proxy works, how to handle auth errors, and to never ask for raw credentials. Host-side wiring: `src/onecli-approvals.ts`, `ensureAgent()` in `container-runner.ts`. Run `onecli --help`.
+API keys, OAuth tokens, and auth credentials are managed by the OneCLI gateway. Secrets are injected into per-agent containers at request time — none are passed in env vars or through chat context. The container agent sees this via the `onecli-gateway` container skill (`container/skills/onecli-gateway/SKILL.md`), which teaches it how the proxy works, how to handle auth errors, and to never ask for raw credentials. Host-side wiring: `src/modules/approvals/onecli-approvals.ts`, `ensureAgent()` in `container-runner.ts`. Run `onecli --help`.
 
 ### Secret modes
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`CLAUDE.md` references two source files at paths that no longer exist. Both were
moved under `src/modules/`, but the **Key Files** table and one prose mention
weren't updated, so a reader (or AI assistant) following the table opens a
nonexistent path.

The same `onecli-approvals.ts` file is already cited at its correct new path
elsewhere in the same doc, so this is a partial-rename miss — not an open question
about where the files belong.

**Changes (docs only, no code):**

| Reference | Was | Now |
|-----------|-----|-----|
| Key Files table | `src/onecli-approvals.ts` | `src/modules/approvals/onecli-approvals.ts` |
| Key Files table | `src/user-dm.ts` | `src/modules/permissions/user-dm.ts` |
| Secrets/OneCLI prose | `src/onecli-approvals.ts` | `src/modules/approvals/onecli-approvals.ts` |

**Verification** (clean checkout of `main`):

```bash
git cat-file -e HEAD:src/onecli-approvals.ts                     # fails — gone
git cat-file -e HEAD:src/modules/approvals/onecli-approvals.ts   # ok
git cat-file -e HEAD:src/modules/permissions/user-dm.ts          # ok
```

A full sweep of `` `src/*.ts` `` references in `CLAUDE.md` finds exactly these two
broken; all others resolve. No code, tests, or behavior touched.

Closes #2763

## For Skills

N/A — not a skill.

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
