### PR TITLE
perf(container): configurable --shm-size (default 1g) + --init for agent containers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,11 @@ export const MAX_CONCURRENT_CONTAINERS = Math.max(1, parseInt(process.env.MAX_CO
 // Operators opt in: CONTAINER_CPU_LIMIT=2, CONTAINER_MEMORY_LIMIT=8g.
 export const CONTAINER_CPU_LIMIT = process.env.CONTAINER_CPU_LIMIT || '';
 export const CONTAINER_MEMORY_LIMIT = process.env.CONTAINER_MEMORY_LIMIT || '';
+// How much shared memory (/dev/shm) each agent container gets. Docker's default
+// is only 64MB, which headless Chromium (agent-browser, in every image) runs out
+// of on large pages and then spills to disk or crashes. Defaults to 1g; the
+// memory is only actually used as Chromium needs it. Set to empty to disable.
+export const CONTAINER_SHM_SIZE = process.env.CONTAINER_SHM_SIZE || '1g';
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,7 @@ import {
   CONTAINER_IMAGE_BASE,
   CONTAINER_INSTALL_LABEL,
   CONTAINER_MEMORY_LIMIT,
+  CONTAINER_SHM_SIZE,
   DATA_DIR,
   GROUPS_DIR,
   ONECLI_API_KEY,
@@ -435,6 +436,19 @@ async function buildContainerArgs(
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+
+  // Every agent image runs headless Chromium (via agent-browser). Two container
+  // flags keep it stable on heavy pages:
+  //   --init runs a tiny init as PID 1, so the many short-lived helper processes
+  //     Chromium spawns get cleaned up instead of piling up as zombie processes
+  //     over a long run. This is always on, since it's just a flag with nothing
+  //     to configure.
+  //   --shm-size sets the shared-memory size. Docker gives a container only 64MB
+  //     of /dev/shm by default, which Chromium runs out of on large pages and
+  //     then either spills to disk (slow) or crashes. Defaults to 1g; set
+  //     CONTAINER_SHM_SIZE to empty to turn it off.
+  args.push('--init');
+  if (CONTAINER_SHM_SIZE) args.push(`--shm-size=${CONTAINER_SHM_SIZE}`);
 
   // Per-container resource caps (opt-in; empty = unbounded, today's behavior).
   // Only --memory is set. Whether that's a hard cap depends on the host having no


### PR DESCRIPTION
## What

Add `--init` and a configurable `--shm-size` to the agent container `docker run` args (`buildContainerArgs`).

## Why

Every agent image ships `agent-browser` (headless Chromium).

- **`--shm-size`** — Docker defaults a container's `/dev/shm` to 64MB, which Chromium runs out of on large pages and then spills to disk (slow) or crashes the renderer. Exposed as `CONTAINER_SHM_SIZE` with a default of `1g`, matching the `CONTAINER_CPU_LIMIT` / `CONTAINER_MEMORY_LIMIT` knob convention added recently. Set it to empty to disable. (Unlike the CPU/mem caps, it defaults *on*, since the 64MB starvation affects every browser workload; the memory is only used as Chromium actually needs it.)
- **`--init`** — runs a minimal init as PID 1 to reap the short-lived helper processes Chromium spawns, so they don't accumulate as zombie processes over long runs. Always on (nothing to configure).

## Notes

- No new config surface beyond `CONTAINER_SHM_SIZE`; effective on next container spawn.
- Rebased onto current `main`, so it slots in cleanly alongside the new per-container CPU/mem knobs (`CONTAINER_CPU_LIMIT` / `CONTAINER_MEMORY_LIMIT`).
