### PR TITLE
fix(codex): per-thread conversation archive (CDX-004)

### DIFF
--- a/container/agent-runner/src/providers/exchange-archive.test.ts
+++ b/container/agent-runner/src/providers/exchange-archive.test.ts
@@ -20,7 +20,7 @@ function makeTmpDir(): string {
 }
 
 describe('provider exchange archive', () => {
-  it('writes unique exchange-level archives with provider metadata', () => {
+  it('appends same-thread exchanges into one file with a single header', () => {
     const conversationsDir = makeTmpDir();
     const timestamp = new Date('2026-06-03T12:34:56.789Z');
 
@@ -43,17 +43,47 @@ describe('provider exchange archive', () => {
       timestamp,
     });
 
-    expect(first).not.toBeNull();
-    expect(second).not.toBeNull();
-    expect(first).not.toBe(second);
+    // Same thread → same (thread-stable) file, not a new file per exchange.
+    expect(first).toBe('codex-thread-123.md');
+    expect(second).toBe(first);
+    expect(fs.readdirSync(conversationsDir)).toHaveLength(1);
 
     const content = fs.readFileSync(path.join(conversationsDir, first!), 'utf-8');
-    expect(content).toContain('# Codex Exchange');
+    // Header (thread-level metadata) written exactly once.
+    expect(content.match(/# Codex Conversation/g)).toHaveLength(1);
     expect(content).toContain('Provider: codex');
     expect(content).toContain('Continuation/thread id: thread-123');
-    expect(content).toContain('Status: completed');
+    // Both exchanges present, each with its own status line.
     expect(content).toContain('**User**: hello');
     expect(content).toContain('**Assistant**: world');
+    expect(content).toContain('**User**: hello again');
+    expect(content).toContain('**Assistant**: world again');
+    expect(content.match(/Status: completed/g)).toHaveLength(2);
+  });
+
+  it('writes a separate file per thread', () => {
+    const conversationsDir = makeTmpDir();
+
+    const a = archiveProviderExchange({
+      conversationsDir,
+      provider: 'codex',
+      prompt: 'p',
+      result: 'r',
+      continuation: 'thread-a',
+      status: 'completed',
+    });
+    const b = archiveProviderExchange({
+      conversationsDir,
+      provider: 'codex',
+      prompt: 'p',
+      result: 'r',
+      continuation: 'thread-b',
+      status: 'completed',
+    });
+
+    expect(a).toBe('codex-thread-a.md');
+    expect(b).toBe('codex-thread-b.md');
+    expect(fs.readdirSync(conversationsDir)).toHaveLength(2);
   });
 
   it('skips empty result text', () => {

--- a/container/agent-runner/src/providers/exchange-archive.test.ts
+++ b/container/agent-runner/src/providers/exchange-archive.test.ts
@@ -43,8 +43,8 @@ describe('provider exchange archive', () => {
       timestamp,
     });
 
-    // Same thread → same (thread-stable) file, not a new file per exchange.
-    expect(first).toBe('codex-thread-123.md');
+    // Same thread → same date-prefixed, thread-stable file, not one per exchange.
+    expect(first).toBe('2026-06-03-codex-thread-123.md');
     expect(second).toBe(first);
     expect(fs.readdirSync(conversationsDir)).toHaveLength(1);
 
@@ -63,6 +63,7 @@ describe('provider exchange archive', () => {
 
   it('writes a separate file per thread', () => {
     const conversationsDir = makeTmpDir();
+    const timestamp = new Date('2026-06-03T12:34:56.789Z');
 
     const a = archiveProviderExchange({
       conversationsDir,
@@ -71,6 +72,7 @@ describe('provider exchange archive', () => {
       result: 'r',
       continuation: 'thread-a',
       status: 'completed',
+      timestamp,
     });
     const b = archiveProviderExchange({
       conversationsDir,
@@ -79,11 +81,42 @@ describe('provider exchange archive', () => {
       result: 'r',
       continuation: 'thread-b',
       status: 'completed',
+      timestamp,
     });
 
-    expect(a).toBe('codex-thread-a.md');
-    expect(b).toBe('codex-thread-b.md');
+    expect(a).toBe('2026-06-03-codex-thread-a.md');
+    expect(b).toBe('2026-06-03-codex-thread-b.md');
     expect(fs.readdirSync(conversationsDir)).toHaveLength(2);
+  });
+
+  it('keeps the creation-date prefix stable when later exchanges land on another day', () => {
+    const conversationsDir = makeTmpDir();
+
+    const first = archiveProviderExchange({
+      conversationsDir,
+      provider: 'codex',
+      prompt: 'a',
+      result: 'b',
+      continuation: 'thread-x',
+      status: 'completed',
+      timestamp: new Date('2026-06-03T10:00:00.000Z'),
+    });
+    // A later exchange on a different day must append to the same file, not
+    // mint a new 2026-06-05-* one (the bug a naive date-from-timestamp scheme
+    // would introduce).
+    const second = archiveProviderExchange({
+      conversationsDir,
+      provider: 'codex',
+      prompt: 'c',
+      result: 'd',
+      continuation: 'thread-x',
+      status: 'completed',
+      timestamp: new Date('2026-06-05T10:00:00.000Z'),
+    });
+
+    expect(first).toBe('2026-06-03-codex-thread-x.md');
+    expect(second).toBe(first);
+    expect(fs.readdirSync(conversationsDir)).toHaveLength(1);
   });
 
   it('skips empty result text', () => {

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -82,13 +82,14 @@ function threadArchiveFilename(
   const thread = sanitizeSlug(continuation || 'no-thread').slice(0, 48) || 'no-thread';
   const suffix = `${sanitizeSlug(provider)}-${thread}.md`;
   // Stable across appends: reuse this thread's existing file (whatever date it
-  // was first created on) so later exchanges keep landing in one file; only
-  // stamp the creation date when none exists yet. Keeps conversations/ sortable
-  // by name (thread start date) while staying one-file-per-thread. slice(11)
-  // strips the `YYYY-MM-DD-` prefix for an exact suffix match (no substring
-  // false-positives between threads with shared prefixes).
+  // was first created on); only stamp the creation date when none exists yet.
+  // Strip the date prefix with the same `dated` regex (not a fixed offset) for
+  // an exact suffix match — no substring false-positives, no magic length to
+  // drift if the date format changes.
+  // ponytail: O(dir) scan per append — fine at hundreds of threads; cache
+  // thread→filename in memory if conversations/ ever holds thousands.
   const dated = /^\d{4}-\d{2}-\d{2}-/;
-  const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.slice(11) === suffix);
+  const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.replace(dated, '') === suffix);
   if (existing) return existing;
   return `${timestamp.toISOString().split('T')[0]}-${suffix}`;
 }

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -86,8 +86,6 @@ function threadArchiveFilename(
   // Strip the date prefix with the same `dated` regex (not a fixed offset) for
   // an exact suffix match — no substring false-positives, no magic length to
   // drift if the date format changes.
-  // ponytail: O(dir) scan per append — fine at hundreds of threads; cache
-  // thread→filename in memory if conversations/ ever holds thousands.
   const dated = /^\d{4}-\d{2}-\d{2}-/;
   const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.replace(dated, '') === suffix);
   if (existing) return existing;

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -2,10 +2,15 @@ import fs from 'fs';
 import path from 'path';
 
 /**
- * Per-exchange markdown archive for providers with no on-disk transcript —
+ * Per-thread conversation archive for providers with no on-disk transcript —
  * payload code, shipped with the provider that needs it. The provider's
  * `onExchangeComplete` hook (see types.ts) calls this with each completed
  * exchange; the runner never archives on a provider's behalf.
+ *
+ * One file per thread (keyed on the continuation id), appended to as exchanges
+ * complete — mirroring the Claude path's one-file-per-session granularity,
+ * since the Codex app-server keeps history server-side with no transcript to
+ * roll up at a compaction boundary.
  */
 
 const DEFAULT_CONVERSATIONS_DIR = '/workspace/agent/conversations';
@@ -21,8 +26,10 @@ export interface ProviderExchangeArchiveOptions {
 }
 
 /**
- * Archive a single prompt/result exchange. Returns the written filename, or
- * null when there is nothing to archive (empty result).
+ * Append a single prompt/result exchange to its thread's conversation file,
+ * writing the thread-level header once when the file is first created. Returns
+ * the (thread-stable) filename, or null when there is nothing to archive
+ * (empty result).
  */
 export function archiveProviderExchange(options: ProviderExchangeArchiveOptions): string | null {
   const result = options.result?.trim();
@@ -33,43 +40,40 @@ export function archiveProviderExchange(options: ProviderExchangeArchiveOptions)
     options.conversationsDir || process.env.NANOCLAW_CONVERSATIONS_DIR || DEFAULT_CONVERSATIONS_DIR;
   fs.mkdirSync(conversationsDir, { recursive: true });
 
-  const filename = uniqueArchiveFilename(conversationsDir, options.provider, options.continuation, timestamp);
-  const lines = [
-    `# ${titleCase(options.provider)} Exchange`,
-    '',
-    `Archived: ${timestamp.toISOString()}`,
-    `Provider: ${options.provider}`,
-    `Continuation/thread id: ${options.continuation || '(none)'}`,
-    `Status: ${options.status}`,
+  const filename = threadArchiveFilename(options.provider, options.continuation);
+  const filePath = path.join(conversationsDir, filename);
+
+  // Thread-level metadata (provider, thread id) belongs in the header, written
+  // once. Per-exchange metadata (timestamp, status) rides in each appended
+  // block. Each block leads with a blank line + `---` so the separator renders
+  // as a thematic break, not a setext heading underline on the prior line.
+  const parts: string[] = [];
+  if (!fs.existsSync(filePath)) {
+    parts.push(
+      `# ${titleCase(options.provider)} Conversation`,
+      '',
+      `Provider: ${options.provider}`,
+      `Continuation/thread id: ${options.continuation || '(none)'}`,
+    );
+  }
+  parts.push(
     '',
     '---',
+    '',
+    `Archived: ${timestamp.toISOString()} · Status: ${options.status}`,
     '',
     `**User**: ${truncate(options.prompt)}`,
     '',
     `**Assistant**: ${truncate(result)}`,
     '',
-  ];
-  fs.writeFileSync(path.join(conversationsDir, filename), lines.join('\n'));
+  );
+  fs.appendFileSync(filePath, parts.join('\n'));
   return filename;
 }
 
-function uniqueArchiveFilename(
-  dir: string,
-  provider: string,
-  continuation: string | undefined,
-  timestamp: Date,
-): string {
-  const date = timestamp.toISOString().split('T')[0];
-  const time = timestamp.toISOString().replace(/[-:.TZ]/g, '').slice(8, 17);
-  const thread = sanitizeSlug(continuation || 'no-thread').slice(0, 24) || 'no-thread';
-  const base = `${date}-${sanitizeSlug(provider)}-${time}-${thread}`;
-  let filename = `${base}.md`;
-  let counter = 2;
-  while (fs.existsSync(path.join(dir, filename))) {
-    filename = `${base}-${counter}.md`;
-    counter += 1;
-  }
-  return filename;
+function threadArchiveFilename(provider: string, continuation: string | undefined): string {
+  const thread = sanitizeSlug(continuation || 'no-thread').slice(0, 48) || 'no-thread';
+  return `${sanitizeSlug(provider)}-${thread}.md`;
 }
 
 function sanitizeSlug(value: string): string {

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -7,10 +7,12 @@ import path from 'path';
  * `onExchangeComplete` hook (see types.ts) calls this with each completed
  * exchange; the runner never archives on a provider's behalf.
  *
- * One file per thread (keyed on the continuation id), appended to as exchanges
- * complete — mirroring the Claude path's one-file-per-session granularity,
- * since the Codex app-server keeps history server-side with no transcript to
- * roll up at a compaction boundary.
+ * One file per thread (keyed on the continuation id), named
+ * `<date>-<provider>-<thread>.md` and appended to as exchanges complete —
+ * mirroring the Claude path's one-file-per-session granularity and its
+ * date-prefixed, name-sortable filenames, since the Codex app-server keeps
+ * history server-side with no transcript to roll up at a compaction boundary.
+ * The date is the thread's creation day and stays stable across later appends.
  */
 
 const DEFAULT_CONVERSATIONS_DIR = '/workspace/agent/conversations';
@@ -40,7 +42,7 @@ export function archiveProviderExchange(options: ProviderExchangeArchiveOptions)
     options.conversationsDir || process.env.NANOCLAW_CONVERSATIONS_DIR || DEFAULT_CONVERSATIONS_DIR;
   fs.mkdirSync(conversationsDir, { recursive: true });
 
-  const filename = threadArchiveFilename(options.provider, options.continuation);
+  const filename = threadArchiveFilename(conversationsDir, options.provider, options.continuation, timestamp);
   const filePath = path.join(conversationsDir, filename);
 
   // Thread-level metadata (provider, thread id) belongs in the header, written
@@ -71,9 +73,24 @@ export function archiveProviderExchange(options: ProviderExchangeArchiveOptions)
   return filename;
 }
 
-function threadArchiveFilename(provider: string, continuation: string | undefined): string {
+function threadArchiveFilename(
+  dir: string,
+  provider: string,
+  continuation: string | undefined,
+  timestamp: Date,
+): string {
   const thread = sanitizeSlug(continuation || 'no-thread').slice(0, 48) || 'no-thread';
-  return `${sanitizeSlug(provider)}-${thread}.md`;
+  const suffix = `${sanitizeSlug(provider)}-${thread}.md`;
+  // Stable across appends: reuse this thread's existing file (whatever date it
+  // was first created on) so later exchanges keep landing in one file; only
+  // stamp the creation date when none exists yet. Keeps conversations/ sortable
+  // by name (thread start date) while staying one-file-per-thread. slice(11)
+  // strips the `YYYY-MM-DD-` prefix for an exact suffix match (no substring
+  // false-positives between threads with shared prefixes).
+  const dated = /^\d{4}-\d{2}-\d{2}-/;
+  const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.slice(11) === suffix);
+  if (existing) return existing;
+  return `${timestamp.toISOString().split('T')[0]}-${suffix}`;
 }
 
 function sanitizeSlug(value: string): string {

--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -81,11 +81,8 @@ function threadArchiveFilename(
 ): string {
   const thread = sanitizeSlug(continuation || 'no-thread').slice(0, 48) || 'no-thread';
   const suffix = `${sanitizeSlug(provider)}-${thread}.md`;
-  // Stable across appends: reuse this thread's existing file (whatever date it
-  // was first created on); only stamp the creation date when none exists yet.
-  // Strip the date prefix with the same `dated` regex (not a fixed offset) for
-  // an exact suffix match — no substring false-positives, no magic length to
-  // drift if the date format changes.
+  // Reuse this thread's existing file whatever day it was created; only stamp a
+  // new date when none exists. Match on the suffix after the date prefix.
   const dated = /^\d{4}-\d{2}-\d{2}-/;
   const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.replace(dated, '') === suffix);
   if (existing) return existing;


### PR DESCRIPTION
CDX-004. Codex keeps history server-side with no transcript to roll up at a compaction boundary, so `onExchangeComplete` wrote one file per exchange — a session scattered across dozens of fragments in `conversations/`.

Fix: key the archive on the thread/continuation id and append each exchange. One file per thread (`<date>-<provider>-<thread>.md`), header written once, per-exchange timestamp+status per block, creation-date prefix stable across days. Distinct threads still get distinct files.

2 files (writer + test). `bun test` 4/0; no new type errors on the `providers` base.
