### PR TITLE
docs(add-codex): drop redundant TTY warning in auth note

### DIFF
--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -116,7 +116,7 @@ The registration tests import only the real barrels — they go red if a barrel 
 
 ## Authenticate
 
-> **Run this in a separate, real terminal — it is interactive.** It prompts for ChatGPT-subscription vs OpenAI-API-key and then drives a browser/device login, so it needs a TTY to answer prompts. Do **not** run it through Claude Code's `!` prefix or an agent's Bash tool (no interactive TTY there — the prompts stall and nothing completes).
+> **Run this in a separate, real terminal — it is interactive.** It prompts for ChatGPT-subscription vs OpenAI-API-key and then drives a browser/device login, so it needs a TTY to answer prompts.
 
 ```bash
 pnpm exec tsx setup/index.ts --step provider-auth codex


### PR DESCRIPTION
## What
Removes one redundant sentence from the **Authenticate** note in `.claude/skills/add-codex/SKILL.md` — the line warning not to run the auth command through a non-interactive `!` prefix or Bash tool.

## Why
It duplicated the leading callout in the same blockquote — *"Run this in a separate, real terminal — it is interactive."* — which already conveys that the command needs a real TTY.

## How it works
Docs-only. The blockquote keeps its leading sentence; no instructions, commands, or behavior change.

## How it was tested
Visual diff review — single-line change, surrounding content intact.