### PR TITLE
feat: support remote HTTP/SSE MCP servers

### DIFF
--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -15,7 +15,7 @@ export interface RunnerConfig {
   groupName: string;
   agentGroupId: string;
   maxMessagesPerPrompt: number;
-  mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  mcpServers: Record<string, import('./providers/types.js').McpServerConfig>;
   model?: string;
   effort?: string;
 }

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -103,11 +103,19 @@ export interface QueryInput {
   };
 }
 
-export interface McpServerConfig {
+export interface McpServerStdioConfig {
   command: string;
   args: string[];
   env: Record<string, string>;
 }
+
+export interface McpServerRemoteConfig {
+  type: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServerConfig = McpServerStdioConfig | McpServerRemoteConfig;
 
 export interface AgentQuery {
   /** Push a follow-up message into the active query. */

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -1,4 +1,4 @@
-import type { McpServerConfig } from '../../container-config.js';
+import type { McpServerConfig, McpServerRemoteConfig } from '../../container-config.js';
 import { buildAgentGroupImage, killContainer, wakeContainer } from '../../container-runner.js';
 import { restartAgentGroupContainers } from '../../container-restart.js';
 import { getDb, hasTable } from '../../db/connection.js';
@@ -257,24 +257,36 @@ registerResource({
       access: 'approval',
       description:
         'Add an MCP server to a group. Requires `ncl groups restart` to take effect. ' +
-        'Use --id <group-id> --name <server-name> --command <cmd> [--args <json-array>] [--env <json-object>].',
+        'Stdio mode: --id <group-id> --name <server-name> --command <cmd> [--args <json-array>] [--env <json-object>]. ' +
+        'Remote mode: --id <group-id> --name <server-name> --type http|sse --url <url> [--headers <json-object>].',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
         const name = args.name as string;
         if (!name) throw new Error('--name is required');
-        const command = args.command as string;
-        if (!command) throw new Error('--command is required');
 
         const row = getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const servers = JSON.parse(row.mcp_servers) as Record<string, McpServerConfig>;
-        servers[name] = {
-          command,
-          args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
-          env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
-        };
+
+        const serverType = args.type as string | undefined;
+        if (serverType === 'http' || serverType === 'sse') {
+          const url = args.url as string;
+          if (!url) throw new Error('--url is required for remote MCP servers');
+          const entry: McpServerRemoteConfig = { type: serverType, url };
+          if (args.headers) entry.headers = JSON.parse(args.headers as string) as Record<string, string>;
+          servers[name] = entry;
+        } else {
+          const command = args.command as string;
+          if (!command) throw new Error('--command is required for stdio MCP servers');
+          servers[name] = {
+            command,
+            args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
+            env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
+          };
+        }
+
         updateContainerConfigJson(id, 'mcp_servers', servers);
 
         return { added: name, servers };

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -16,12 +16,21 @@ import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
-export interface McpServerConfig {
+export interface McpServerStdioConfig {
   command: string;
   args?: string[];
   env?: Record<string, string>;
   instructions?: string;
 }
+
+export interface McpServerRemoteConfig {
+  type: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, string>;
+  instructions?: string;
+}
+
+export type McpServerConfig = McpServerStdioConfig | McpServerRemoteConfig;
 
 export interface AdditionalMountConfig {
   hostPath: string;


### PR DESCRIPTION
## Summary

- Extends `McpServerConfig` to a union type supporting both stdio (existing) and remote HTTP/SSE MCP servers
- Adds `McpServerRemoteConfig` with `type`, `url`, `headers`, and optional `instructions` fields
- Updates `ncl groups config add-mcp-server` with `--type`, `--url`, and `--headers` flags for remote servers
- Mirrors the type split on the container side (`container/agent-runner/src/providers/types.ts`)

This is a prerequisite for any remote MCP integration (e.g., Strava, GitHub, or other hosted MCP endpoints). The Claude Agent SDK already supports HTTP and SSE transports natively — this change surfaces that capability through NanoClaw's config layer.

## Test plan

- [ ] `pnpm run build` passes
- [ ] `pnpm test` passes
- [ ] `ncl groups config add-mcp-server --name test --type http --url https://example.com/mcp` works
- [ ] Existing stdio MCP servers continue to work unchanged
- [ ] Container-side type imports resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)