### PR TITLE
feat: add /add-strava skill for official Strava MCP

### DIFF
--- a/.claude/skills/add-strava/SKILL.md
+++ b/.claude/skills/add-strava/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: add-strava
+description: Add Strava as an MCP tool (activities, stats, routes, training zones) using the official Strava MCP endpoint. OAuth tokens are managed host-side and injected at container spawn time — no raw credentials reach the container.
+---
+
+# Add Strava (Official MCP Endpoint)
+
+This skill wires the official Strava MCP endpoint (`https://mcp.strava.com/mcp`) into selected agent groups using HTTP transport. Unlike stdio-based MCP servers, this is a remote endpoint — the container connects directly to Strava's hosted MCP service.
+
+Authentication uses Strava's standard OAuth 2.0 flow. A one-time script obtains tokens, then the host-side `strava-token.ts` module auto-refreshes them before expiry. At container spawn time, `materializeContainerJson` resolves the `Bearer {{strava}}` placeholder in MCP headers to a fresh access token.
+
+**Why this pattern:** v2's invariant is that containers never receive raw API keys. Strava client credentials (`client_id`, `client_secret`) stay in `data/strava-tokens.json` on the host; only the short-lived access token is injected into the materialized `container.json` at spawn time.
+
+**Dependency:** This skill requires remote MCP type support (`McpServerRemoteConfig` in `src/container-config.ts`). If the types aren't present, apply the remote MCP types PR first.
+
+## Phase 1: Pre-flight
+
+### Check remote MCP type support
+
+```bash
+grep -q 'McpServerRemoteConfig' src/container-config.ts && echo "OK — remote MCP types present" || echo "MISSING — apply remote MCP types PR first"
+```
+
+If missing, tell the user:
+
+> Remote MCP types (`McpServerRemoteConfig` with `url` and `headers` fields) are required for Strava's hosted MCP endpoint. Apply the remote MCP types PR first, then re-run this skill.
+
+**STOP** if the types are missing. The rest of this skill depends on them.
+
+### Check if Strava is already configured
+
+```bash
+ls -la data/strava-tokens.json 2>&1
+```
+
+If the file exists and contains valid tokens, skip to Phase 3 (wiring). If it exists but is stale or corrupt, delete it and proceed to Phase 2.
+
+## Phase 2: Strava API App + OAuth
+
+### Create a Strava API app
+
+Tell the user:
+
+> 1. Go to https://www.strava.com/settings/api
+> 2. Create an application:
+>    - **Application Name**: anything (e.g., "NanoClaw")
+>    - **Category**: pick any
+>    - **Website**: `http://localhost`
+>    - **Authorization Callback Domain**: `localhost`
+> 3. Note the **Client ID** and **Client Secret** from the app page.
+
+Ask the user for `client_id` and `client_secret`.
+
+### Run the OAuth flow
+
+```bash
+pnpm exec tsx scripts/strava-oauth.ts <client_id> <client_secret>
+```
+
+This opens a browser for Strava authorization, captures the callback on `localhost:9876`, exchanges for tokens, and saves them to `data/strava-tokens.json`.
+
+### Verify tokens were saved
+
+```bash
+cat data/strava-tokens.json | head -5
+```
+
+Expected: a JSON object with `access_token`, `refresh_token`, `expires_at`, and athlete info.
+
+## Phase 3: Wire to Agent Group(s)
+
+### List groups
+
+```bash
+ncl groups list
+```
+
+Ask the user which agent group(s) should get Strava access.
+
+### Add the Strava MCP server
+
+For each chosen `<group-id>`:
+
+```bash
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name strava \
+  --type http \
+  --url https://mcp.strava.com/mcp \
+  --headers '{"Authorization": "Bearer {{strava}}"}'
+```
+
+The `Bearer {{strava}}` placeholder is resolved at container spawn time by `resolveRemoteMcpTokens` in `src/container-config.ts`. Each spawn gets a fresh access token (auto-refreshed if expired).
+
+### Restart the group
+
+```bash
+ncl groups restart --id <group-id> --message "Strava MCP added — you now have access to Strava activity data, stats, routes, and training zones."
+```
+
+## Phase 4: Build and Restart
+
+```bash
+pnpm run build
+```
+
+Restart the host so the new `strava-token.ts` module is loaded:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
+```
+
+## Phase 5: Verify
+
+### Test from a wired agent
+
+Tell the user:
+
+> In your agent chat, send: **"What were my last 5 Strava activities?"** or **"Show my Strava stats for this year"**.
+>
+> The agent should use Strava MCP tools. The first call may take a moment while the MCP connection is established.
+
+### Check logs if the tool isn't working
+
+```bash
+tail -100 logs/nanoclaw.log logs/nanoclaw.error.log | grep -iE 'strava|mcp'
+```
+
+Common signals:
+- `Strava token refresh failed` → check that `data/strava-tokens.json` has valid `client_id`, `client_secret`, and `refresh_token`. Re-run the OAuth script if needed.
+- `Bearer {{strava}}` appears literally in logs → the `resolveRemoteMcpTokens` function didn't run. Ensure `src/strava-token.ts` exists and `pnpm run build` completed.
+- Connection timeout to `mcp.strava.com` → verify the container has outbound internet access.
+- Agent says "I don't have Strava tools" → the `strava` MCP server isn't registered in this group's `mcpServers` (re-run the `ncl groups config add-mcp-server` step).
+
+## Removal
+
+1. For each group that had Strava wired, remove the MCP server:
+   ```bash
+   ncl groups config remove-mcp-server --id <group-id> --name strava
+   ```
+2. Remove the token file:
+   ```bash
+   rm data/strava-tokens.json
+   ```
+3. Optionally remove `src/strava-token.ts` and the `resolveRemoteMcpTokens` block from `src/container-config.ts` if no other remote MCP integrations use the token resolution pattern.
+4. `pnpm run build` and restart the host.
+5. Optionally delete the Strava API app at https://www.strava.com/settings/api.
+
+## Notes
+
+- **Token refresh is automatic.** The host refreshes the access token 5 minutes before expiry. Strava access tokens last 6 hours; refresh tokens don't expire (unless the user deauthorizes the app).
+- **No container image rebuild needed.** Unlike stdio MCP servers (gmail, calendar), the Strava MCP runs remotely — no binary is installed in the container image.
+- **No additional mounts needed.** Tokens live in `data/strava-tokens.json` on the host. The resolved access token is injected into `container.json` at spawn time — the container never reads the token file directly.
+- **Scope is read-only.** The OAuth scopes requested are `read,read_all,activity:read,activity:read_all,profile:read_all`. No write access to Strava data.
+- **One athlete per install.** The token file holds credentials for a single Strava account. Multi-athlete support would need per-group token files (not implemented).

--- a/scripts/strava-oauth.ts
+++ b/scripts/strava-oauth.ts
@@ -1,0 +1,130 @@
+/**
+ * One-time Strava OAuth flow.
+ *
+ * Creates a Strava API app at https://www.strava.com/settings/api, then run:
+ *   pnpm exec tsx scripts/strava-oauth.ts <client_id> <client_secret>
+ *
+ * Opens a browser for authorization, captures the callback, exchanges for
+ * tokens, and saves them to data/strava-tokens.json.
+ */
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { exec } from 'child_process';
+
+const REDIRECT_PORT = 9876;
+const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/callback`;
+const TOKEN_PATH = path.join(process.cwd(), 'data', 'strava-tokens.json');
+
+const clientId = process.argv[2];
+const clientSecret = process.argv[3];
+
+if (!clientId || !clientSecret) {
+  console.error('Usage: pnpm exec tsx scripts/strava-oauth.ts <client_id> <client_secret>');
+  console.error('\nCreate a Strava API app at https://www.strava.com/settings/api');
+  console.error('Set Authorization Callback Domain to: localhost');
+  process.exit(1);
+}
+
+const authUrl =
+  `https://www.strava.com/oauth/authorize?client_id=${clientId}` +
+  `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+  `&response_type=code&approval_prompt=auto` +
+  `&scope=read,read_all,activity:read,activity:read_all,profile:read_all`;
+
+console.log('\nOpening browser for Strava authorization...');
+console.log(`If the browser doesn't open, visit:\n${authUrl}\n`);
+
+const openCmd =
+  process.platform === 'darwin'
+    ? `open "${authUrl}"`
+    : process.platform === 'win32'
+      ? `start "${authUrl}"`
+      : `xdg-open "${authUrl}" 2>/dev/null || sensible-browser "${authUrl}" 2>/dev/null || echo "Open this URL in your browser: ${authUrl}"`;
+exec(openCmd);
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url!, `http://localhost:${REDIRECT_PORT}`);
+
+  if (url.pathname !== '/callback') {
+    res.writeHead(404);
+    res.end('Not found');
+    return;
+  }
+
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+
+  if (error || !code) {
+    res.writeHead(400, { 'Content-Type': 'text/html' });
+    res.end('<h1>Authorization failed</h1><p>You can close this tab.</p>');
+    console.error('Authorization failed:', error || 'no code received');
+    process.exit(1);
+  }
+
+  try {
+    const tokenRes = await fetch('https://www.strava.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      const body = await tokenRes.text();
+      throw new Error(`Token exchange failed (${tokenRes.status}): ${body}`);
+    }
+
+    const data = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_at: number;
+      athlete: { id: number; firstname: string; lastname: string };
+    };
+
+    const tokens = {
+      client_id: clientId,
+      client_secret: clientSecret,
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+      expires_at: data.expires_at,
+      athlete_id: data.athlete.id,
+      athlete_name: `${data.athlete.firstname} ${data.athlete.lastname}`,
+      updated_at: new Date().toISOString(),
+    };
+
+    fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2) + '\n');
+    console.log(`\nTokens saved to ${TOKEN_PATH}`);
+    console.log(`Athlete: ${tokens.athlete_name} (ID: ${tokens.athlete_id})`);
+    console.log(`Access token expires: ${new Date(data.expires_at * 1000).toISOString()}`);
+
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(
+      `<h1>Strava connected!</h1>` +
+        `<p>Athlete: ${tokens.athlete_name}</p>` +
+        `<p>You can close this tab.</p>`,
+    );
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'text/html' });
+    res.end('<h1>Token exchange failed</h1><p>Check the terminal for details.</p>');
+    console.error('Token exchange error:', err);
+    process.exit(1);
+  }
+
+  server.close();
+  process.exit(0);
+});
+
+server.listen(REDIRECT_PORT, () => {
+  console.log(`Waiting for callback on port ${REDIRECT_PORT}...`);
+});
+
+setTimeout(() => {
+  console.error('\nTimeout: no callback received after 2 minutes.');
+  server.close();
+  process.exit(1);
+}, 120_000);

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -67,11 +67,32 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
 }
 
 /**
+ * Resolve dynamic token placeholders in remote MCP server headers.
+ * Currently supports `Bearer {{strava}}` — replaced with a fresh Strava
+ * access token at spawn time.
+ */
+async function resolveRemoteMcpTokens(config: ContainerConfig): Promise<void> {
+  for (const mcp of Object.values(config.mcpServers)) {
+    if (!('url' in mcp) || !(mcp as Record<string, unknown>).headers) continue;
+    const headers = (mcp as Record<string, unknown>).headers as Record<string, string>;
+    for (const [key, value] of Object.entries(headers)) {
+      if (value === 'Bearer {{strava}}') {
+        const { getStravaAccessToken } = await import('./strava-token.js');
+        const token = await getStravaAccessToken();
+        if (token) {
+          headers[key] = `Bearer ${token}`;
+        }
+      }
+    }
+  }
+}
+
+/**
  * Materialize `container.json` from the DB. Called at spawn time so the
  * container always sees fresh config. Returns the `ContainerConfig` for
  * use by the caller (buildMounts, buildContainerArgs, etc.).
  */
-export function materializeContainerJson(agentGroupId: string): ContainerConfig {
+export async function materializeContainerJson(agentGroupId: string): Promise<ContainerConfig> {
   const group = getAgentGroup(agentGroupId);
   if (!group) throw new Error(`Agent group not found: ${agentGroupId}`);
 
@@ -79,6 +100,8 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);
+
+  await resolveRemoteMcpTokens(config);
 
   const p = path.join(GROUPS_DIR, group.folder, 'container.json');
   const dir = path.dirname(p);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -126,7 +126,7 @@ async function spawnContainer(session: Session): Promise<void> {
   // Materialize container.json from DB — writes fresh file and returns
   // the config object, threaded through provider resolution, buildMounts,
   // and buildContainerArgs so we don't re-read.
-  const containerConfig = materializeContainerJson(agentGroup.id);
+  const containerConfig = await materializeContainerJson(agentGroup.id);
 
   // Per-group filesystem state lives forever after first creation. Init is
   // idempotent: it only writes paths that don't already exist, so this call

--- a/src/strava-token.ts
+++ b/src/strava-token.ts
@@ -1,0 +1,117 @@
+/**
+ * Strava token management — refreshes access tokens on demand.
+ *
+ * Reads credentials from data/strava-tokens.json (written by the one-time
+ * OAuth script). Refreshes automatically when the token is expired or about
+ * to expire (5-minute buffer). Persists refreshed tokens back to disk.
+ *
+ * Used by materializeContainerJson to inject a fresh access token into
+ * remote MCP server headers at container spawn time.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { log } from './log.js';
+
+const TOKEN_PATH = path.join(DATA_DIR, 'strava-tokens.json');
+const REFRESH_BUFFER_SECONDS = 300;
+
+interface StravaTokens {
+  client_id: string;
+  client_secret: string;
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  athlete_id?: number;
+  athlete_name?: string;
+  updated_at?: string;
+}
+
+let cached: StravaTokens | null = null;
+
+function readTokens(): StravaTokens | null {
+  try {
+    if (!fs.existsSync(TOKEN_PATH)) return null;
+    const raw = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8')) as StravaTokens;
+    if (!raw.client_id || !raw.client_secret || !raw.refresh_token) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function writeTokens(tokens: StravaTokens): void {
+  tokens.updated_at = new Date().toISOString();
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(tokens, null, 2) + '\n');
+  cached = tokens;
+}
+
+function isExpired(tokens: StravaTokens): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  return now >= tokens.expires_at - REFRESH_BUFFER_SECONDS;
+}
+
+async function refreshAccessToken(tokens: StravaTokens): Promise<StravaTokens> {
+  const res = await fetch('https://www.strava.com/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: tokens.client_id,
+      client_secret: tokens.client_secret,
+      refresh_token: tokens.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Strava token refresh failed (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_at: number;
+  };
+
+  const updated: StravaTokens = {
+    ...tokens,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: data.expires_at,
+  };
+
+  writeTokens(updated);
+  log.info('Strava access token refreshed', {
+    expiresAt: new Date(data.expires_at * 1000).toISOString(),
+  });
+
+  return updated;
+}
+
+/**
+ * Get a valid Strava access token. Refreshes automatically if expired.
+ * Returns null if no Strava tokens are configured.
+ */
+export async function getStravaAccessToken(): Promise<string | null> {
+  let tokens = cached ?? readTokens();
+  if (!tokens) return null;
+
+  if (isExpired(tokens)) {
+    try {
+      tokens = await refreshAccessToken(tokens);
+    } catch (err) {
+      log.error('Failed to refresh Strava token', { err });
+      return tokens.access_token;
+    }
+  }
+
+  cached = tokens;
+  return tokens.access_token;
+}
+
+/** Check if Strava tokens are configured (without refreshing). */
+export function hasStravaTokens(): boolean {
+  return readTokens() !== null;
+}


### PR DESCRIPTION
## Summary

- Adds `/add-strava` skill that wires the official Strava MCP endpoint (`https://mcp.strava.com/mcp`) into agent groups via HTTP transport
- Host-side OAuth flow (`scripts/strava-oauth.ts`) — one-time browser auth, saves tokens to `data/strava-tokens.json`
- Auto-refreshing token module (`src/strava-token.ts`) — refreshes 5 min before expiry, persists to disk
- `Bearer {{strava}}` placeholder in MCP headers resolved at container spawn time — no raw credentials reach the container
- Makes `materializeContainerJson` async to support token resolution

**Depends on:** #2776 (remote MCP type support)

## What the skill does

1. Checks remote MCP types are present (prerequisite)
2. Walks user through creating a Strava API app
3. Runs one-time OAuth flow to obtain tokens
4. Wires `strava` MCP server to chosen agent group(s) via `ncl groups config add-mcp-server`
5. Restarts the group so the agent picks up Strava tools (activities, stats, routes, zones)

## Test plan

- [ ] `pnpm run build` passes
- [ ] `pnpm test` passes
- [ ] `scripts/strava-oauth.ts` completes OAuth flow and saves tokens
- [ ] Token refresh works when `expires_at` is in the past
- [ ] `materializeContainerJson` resolves `Bearer {{strava}}` to a real token
- [ ] Agent inside container can call Strava MCP tools (list activities, get activity details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)