### PR TITLE
fix: make tailscale-docker routing service self-healing

### DIFF
--- a/.claude/skills/fix-tailscale-docker-routing/SKILL.md
+++ b/.claude/skills/fix-tailscale-docker-routing/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: fix-tailscale-docker-routing
+description: Fix Docker container networking when Tailscale exit node (e.g. Mullvad) is active. Containers can't reach the internet because Tailscale's catch-all routing rule intercepts return packets destined for the Docker bridge subnet. Installs a persistent ip rule and systemd service to fix this. Triggers on "docker containers can't connect", "exit node breaks docker", "tailscale mullvad docker", "containers no internet with tailscale".
+---
+
+# Fix Tailscale Exit Node + Docker Routing
+
+When a Tailscale exit node is active, Tailscale inserts an ip rule (`5270: from all lookup 52`) that routes all traffic — including return packets to Docker containers — through `tailscale0`. Since the Mullvad exit node has no knowledge of `172.16.0.0/12` (Docker's private bridge range), those packets are dropped. The fix is a higher-priority rule that routes Docker-destined packets via the main table before Tailscale intercepts them.
+
+This only affects Linux hosts using a Tailscale exit node. macOS uses a different networking stack and is unaffected.
+
+## Phase 1: Pre-flight
+
+### Check platform
+
+```bash
+uname -s
+```
+
+If not `Linux`, tell the user this fix is Linux-only and exit.
+
+### Check Tailscale is installed and exit node is active
+
+```bash
+tailscale status --json 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+exit_id = d.get('ExitNodeStatus', {}).get('ID', '')
+prefs_exit = ''
+# also check via prefs
+print('exit_node_active:', bool(exit_id))
+"
+```
+
+Also check prefs directly:
+
+```bash
+tailscale debug prefs 2>/dev/null | grep -i ExitNode
+```
+
+If no exit node is configured, tell the user this fix only applies when using a Tailscale exit node.
+
+### Check if Docker is installed
+
+```bash
+docker info &>/dev/null && echo "docker_ok" || echo "docker_missing"
+```
+
+If Docker is missing, exit — nothing to fix.
+
+### Check if the routing issue is present
+
+```bash
+ip rule show | grep "5270"
+ip route show table 52 | grep -E "^default|172.16"
+```
+
+If rule 5270 exists and table 52 has a `default dev tailscale0` entry, the issue is present.
+
+### Check if the fix is already applied
+
+```bash
+ip rule show | grep "5269.*172.16.0.0/12"
+```
+
+If the rule already exists and the systemd service is active:
+
+```bash
+systemctl is-active docker-tailscale-routing-patch.service 2>/dev/null
+```
+
+If both are present, skip to Phase 3 (Verify).
+
+## Phase 2: Apply Fix
+
+### Add the ip rule immediately
+
+This takes effect without a reboot:
+
+```bash
+sudo ip rule add to 172.16.0.0/12 lookup main priority 5269
+```
+
+Verify it was added:
+
+```bash
+ip rule show | grep 5269
+```
+
+Expected: `5269: from all to 172.16.0.0/12 lookup main`
+
+### Install the systemd service for persistence
+
+The rule is lost on reboot without a service to restore it. Create the service file:
+
+```bash
+sudo tee /etc/systemd/system/docker-tailscale-routing-patch.service > /dev/null << 'EOF'
+[Unit]
+Description=Fix Docker bridge routing when Tailscale exit node is active
+After=network.target tailscaled.service docker.service
+Wants=tailscaled.service docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/sbin/ip rule show | grep -q "5269.*172.16.0.0/12" || /sbin/ip rule add to 172.16.0.0/12 lookup main priority 5269'
+ExecStop=/sbin/ip rule del to 172.16.0.0/12 lookup main priority 5269
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+Enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now docker-tailscale-routing-patch.service
+```
+
+Verify:
+
+```bash
+systemctl is-active docker-tailscale-routing-patch.service
+```
+
+Expected: `active`
+
+## Phase 3: Verify
+
+### Test container connectivity
+
+```bash
+docker run --rm alpine sh -c "nslookup api.anthropic.com && wget -qO- --timeout=5 https://api.anthropic.com 2>&1 | head -2"
+```
+
+Expected:
+- DNS resolves `api.anthropic.com` to an IP
+- `wget` gets `HTTP/1.1 404` (correct — no API key, but TCP connected successfully)
+
+If DNS fails (`EAI_AGAIN`) or TCP times out (`ETIMEDOUT`), the fix did not take effect — check that the rule is present with `ip rule show | grep 5269`.
+
+### Restart NanoClaw
+
+```bash
+systemctl --user restart nanoclaw
+```
+
+Then send a test message from WhatsApp.
+
+## How it works
+
+Tailscale's exit node inserts `5270: from all lookup 52` which makes table 52 the catch-all for all outgoing packets. Table 52 contains `default dev tailscale0`, so return packets destined for `172.17.0.2` (a container) get sent to Tailscale rather than back to `docker0`. Tailscale drops them because the Mullvad exit node doesn't know about Docker's private subnet.
+
+The fix adds `5269: from all to 172.16.0.0/12 lookup main` — checked one step before Tailscale's rule — which routes packets destined for any Docker bridge address via the main routing table, where `172.16.0.0/12 dev docker0` correctly delivers them locally.
+
+Internet-bound traffic from containers (source-NATed to the host's Tailscale IP by Docker's MASQUERADE rule) is unaffected — its destination is never in `172.16.0.0/12`, so it continues to flow through Tailscale and out via Mullvad as intended.
+
+## Troubleshooting
+
+### Service fails to start
+
+The rule may already exist from a previous manual run. The `ExecStart` command is idempotent — it checks before adding. If the service still fails:
+
+```bash
+journalctl -u docker-tailscale-routing-patch.service --no-pager
+```
+
+### Rule disappears after Tailscale restarts
+
+Tailscale may flush and re-add its routing rules on reconnect. If this happens, the service ordering (`After=tailscaled.service`) should handle it — but if Tailscale restarts mid-session you may need to manually re-run:
+
+```bash
+sudo ip rule add to 172.16.0.0/12 lookup main priority 5269
+```
+
+Consider filing an issue with Tailscale — this is a known conflict tracked at https://github.com/tailscale/tailscale/issues/13367.
+
+### Still broken after applying fix
+
+Check that Tailscale is actually using an exit node (not just installed):
+
+```bash
+tailscale status | grep "exit node"
+```
+
+If no exit node is shown, this fix is not the right one for your issue — use `/debug` to investigate further.

--- a/.claude/skills/fix-tailscale-docker-routing/SKILL.md
+++ b/.claude/skills/fix-tailscale-docker-routing/SKILL.md
@@ -71,6 +71,22 @@ systemctl is-active docker-tailscale-routing-patch.service 2>/dev/null
 
 If both are present, skip to Phase 3 (Verify).
 
+**Edge case — service active but rule missing:** Older installs of this fix used a `Type=oneshot` unit that only ran at boot, so it couldn't react when Tailscale flushed the rule mid-session (e.g. on exit-node reconnect). Check which version is installed:
+
+```bash
+systemctl cat docker-tailscale-routing-patch.service 2>/dev/null | grep "^Type="
+```
+
+If it shows `Type=oneshot`, this is the old non-self-healing version — proceed to Phase 2 and reinstall it as the watch-based version (the same install command upgrades it in place). If it already shows `Type=simple`, the watch loop should keep the rule in place automatically; if the rule is still missing, restart it and check logs:
+
+```bash
+sudo systemctl restart docker-tailscale-routing-patch.service
+journalctl -u docker-tailscale-routing-patch.service --no-pager -n 30
+ip rule show | grep 5269
+```
+
+Then skip to Phase 3 (Verify).
+
 ## Phase 2: Apply Fix
 
 ### Add the ip rule immediately
@@ -89,9 +105,9 @@ ip rule show | grep 5269
 
 Expected: `5269: from all to 172.16.0.0/12 lookup main`
 
-### Install the systemd service for persistence
+### Install the systemd service for persistence and self-healing
 
-The rule is lost on reboot without a service to restore it. Create the service file:
+A oneshot service that only runs at boot isn't enough: Tailscale can flush and rebuild its own ip rules at any time (exit-node switches, reconnects, sleep/wake), silently dropping rule 5269 while `systemctl is-active` keeps reporting `active`. Instead, install a long-running service that watches for ip rule changes via `ip monitor rule` and re-applies the fix the moment it's needed:
 
 ```bash
 sudo tee /etc/systemd/system/docker-tailscale-routing-patch.service > /dev/null << 'EOF'
@@ -101,17 +117,19 @@ After=network.target tailscaled.service docker.service
 Wants=tailscaled.service docker.service
 
 [Service]
-Type=oneshot
-ExecStart=/bin/sh -c '/sbin/ip rule show | grep -q "5269.*172.16.0.0/12" || /sbin/ip rule add to 172.16.0.0/12 lookup main priority 5269'
+Type=simple
+ExecStartPre=/bin/sh -c '/sbin/ip rule show | grep -q "5269.*172.16.0.0/12" || /sbin/ip rule add to 172.16.0.0/12 lookup main priority 5269'
+ExecStart=/bin/sh -c '/sbin/ip monitor rule | while read -r _line; do /sbin/ip rule show | grep -q "5269.*172.16.0.0/12" || /sbin/ip rule add to 172.16.0.0/12 lookup main priority 5269; done'
 ExecStop=/sbin/ip rule del to 172.16.0.0/12 lookup main priority 5269
-RemainAfterExit=yes
+Restart=always
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target
 EOF
 ```
 
-Enable and start it:
+Enable and start it (idempotent — this also upgrades an existing oneshot install in place):
 
 ```bash
 sudo systemctl daemon-reload
@@ -124,7 +142,7 @@ Verify:
 systemctl is-active docker-tailscale-routing-patch.service
 ```
 
-Expected: `active`
+Expected: `active`. Unlike the old oneshot unit, this process stays running — `ip monitor rule` blocks waiting for the next rule-table change — so `is-active` now reflects live protection rather than "ran once at boot".
 
 ## Phase 3: Verify
 
@@ -156,6 +174,8 @@ The fix adds `5269: from all to 172.16.0.0/12 lookup main` — checked one step 
 
 Internet-bound traffic from containers (source-NATed to the host's Tailscale IP by Docker's MASQUERADE rule) is unaffected — its destination is never in `172.16.0.0/12`, so it continues to flow through Tailscale and out via Mullvad as intended.
 
+Because Tailscale can flush and rebuild its own ip rules at any time, a boot-time-only fix isn't sufficient. The installed service runs `ip monitor rule` as a long-lived process, which emits a line on stdout the instant any ip rule is added or removed system-wide. On each line it re-checks for rule 5269 and re-adds it if missing — reacting within the same second the conflict reappears, instead of requiring a manual restart or reboot.
+
 ## Troubleshooting
 
 ### Service fails to start
@@ -168,7 +188,14 @@ journalctl -u docker-tailscale-routing-patch.service --no-pager
 
 ### Rule disappears after Tailscale restarts
 
-Tailscale may flush and re-add its routing rules on reconnect. If this happens, the service ordering (`After=tailscaled.service`) should handle it — but if Tailscale restarts mid-session you may need to manually re-run:
+The service watches `ip monitor rule` and re-applies the fix automatically whenever any ip rule changes — including Tailscale flushing its own rules on reconnect or exit-node switch. If the rule still goes missing and stays missing:
+
+```bash
+systemctl is-active docker-tailscale-routing-patch.service
+journalctl -u docker-tailscale-routing-patch.service --no-pager -n 50
+```
+
+Confirm the unit is actually the watch-based version and not the old oneshot one (`systemctl cat docker-tailscale-routing-patch.service | grep Type=`) — reinstall via Phase 2 if it's stale. As a last resort, reapply manually:
 
 ```bash
 sudo ip rule add to 172.16.0.0/12 lookup main priority 5269

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Four types of skills exist in NanoClaw. See [CONTRIBUTING.md](CONTRIBUTING.md) f
 | `/init-onecli` | Install OneCLI Agent Vault and migrate `.env` credentials to it |
 | `/qodo-pr-resolver` | Fetch and fix Qodo PR review issues interactively or in batch |
 | `/get-qodo-rules` | Load org- and repo-level coding rules from Qodo before code tasks |
+| `/fix-tailscale-docker-routing` | Fix Docker containers losing internet when Tailscale exit node (e.g. Mullvad) is active |
 
 ## Contributing
 

--- a/docker-tailscale-routing-patch.service
+++ b/docker-tailscale-routing-patch.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fix Docker bridge routing when Tailscale exit node is active
+After=network.target tailscaled.service docker.service
+Wants=tailscaled.service docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/sbin/ip rule show | grep -q "5269.*172.16.0.0/12" || /sbin/ip rule add to 172.16.0.0/12 lookup main priority 5269'
+ExecStop=/sbin/ip rule del to 172.16.0.0/12 lookup main priority 5269
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- The `fix-tailscale-docker-routing` skill installed a `Type=oneshot` systemd unit that only reapplied the Docker bridge ip rule at boot.
- Tailscale can flush ip rules mid-session (exit-node reconnect/switch), silently dropping the rule while `systemctl is-active` kept reporting `active` — leaving Docker container networking broken with no visible signal.
- Switches the installed unit to a long-running `Type=simple` service that watches `ip monitor rule` and reasserts the fix the instant any ip rule changes, instead of requiring a manual restart or reboot. The skill now also detects and upgrades old oneshot installs in place.

## Why
Hit this live: a NanoClaw host's OneCLI gateway became unreachable from Docker because the patch rule had silently disappeared after a Tailscale exit-node reconnect, even though the patch service reported `active`. Every agent container run failed with an auth error until the rule was manually reapplied.

## How it works
The new unit's `ExecStart` runs `ip monitor rule | while read -r _line; do <idempotent re-check-and-add> ; done` as a foreground process under `Restart=always`. `ip monitor rule` blocks and emits a line on stdout whenever any ip rule is added/removed system-wide, so the loop re-asserts rule 5269 within the same second a conflict reappears.

## How it was tested
Verified the failure mode and root cause live on a real host (rule missing, service still "active", `onecli auth status` timing out; confirmed fixed once a leftover separate watcher rule was manually reasserted). The new self-healing unit design itself has **not yet been deployed/verified live** on that host — sudo access to install the new unit wasn't available in this session. Recommend a maintainer test-install before merging:
```bash
sudo cp docker-tailscale-routing-patch.service /etc/systemd/system/docker-tailscale-routing-patch.service
sudo systemctl daemon-reload
sudo systemctl restart docker-tailscale-routing-patch.service
systemctl is-active docker-tailscale-routing-patch.service   # expect: active, and stays running (not oneshot-exited)
```

## Usage
No change to invocation — still triggered via `/fix-tailscale-docker-routing` or by Claude detecting the relevant symptoms. Existing oneshot installs are upgraded automatically by re-running Phase 2's install step (same unit name, idempotent).