### PR TITLE
fix(init-onecli): declare OneCLI service port up-front

### DIFF
--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -9,6 +9,10 @@ This skill installs OneCLI, configures the Agent Vault gateway, and migrates any
 
 **Principle:** When something is broken or missing, fix it. Don't tell the user to go fix it themselves unless it genuinely requires their manual action (e.g. pasting a token).
 
+## Service details
+
+OneCLI runs as a local HTTP service listening on **port `10254`** by default. Other steps in this skill assume that port is free — see the Troubleshooting note at the bottom of this file for what to do if the port is already in use.
+
 ## Phase 1: Pre-flight
 
 ### Check if OneCLI is already working


### PR DESCRIPTION
Fixes #2787.

Port 10254 appeared only in the Troubleshooting section at the end of the file, with no prior declaration of OneCLI's service port. Patch adds a small Service details section near the top so the Troubleshooting note has context.