### PR TITLE
fix(add-imessage): mkdir src/channels before writing channel files

### DIFF
--- a/.claude/skills/add-imessage/SKILL.md
+++ b/.claude/skills/add-imessage/SKILL.md
@@ -31,6 +31,7 @@ git fetch origin channels
 ### 2. Copy the adapter and its registration test
 
 ```bash
+mkdir -p src/channels
 git show origin/channels:src/channels/imessage.ts                    > src/channels/imessage.ts
 git show origin/channels:src/channels/imessage-registration.test.ts > src/channels/imessage-registration.test.ts
 ```


### PR DESCRIPTION
Fixes #2791.

Step 2's `git show ... > src/channels/imessage.ts` redirection fails on fresh checkouts that don't already have `src/channels/`. Patch prepends `mkdir -p src/channels` before the first write.