### PR TITLE
fix(delivery): isolate per-session failures so one bad session can't stall delivery for all

### DIFF
--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -159,6 +159,27 @@ export async function deliverSessionMessages(session: Session): Promise<void> {
 
   try {
     await drainSession(session);
+  } catch (err) {
+    // Isolate per-session delivery failures. The active/sweep poll loops call
+    // this for every session in a plain for-loop; an unhandled throw here
+    // aborts the entire tick, so a single unhealthy session silently stalls
+    // delivery for every other agent until the daemon restarts.
+    //
+    // The known trigger: a crashed container can leave an orphaned hot journal
+    // (outbound.db-journal) next to its outbound.db. drainSession opens that DB
+    // read-only (single-writer invariant), but even a read SELECT must roll the
+    // journal back — a write — which fails with "attempt to write a readonly
+    // database". That throw then poisons delivery for all sessions ordered
+    // after the broken one in the loop.
+    //
+    // Containment: log and move on. The broken session self-heals on its next
+    // container start (the writer opens the DB read-write and rolls the journal
+    // back), instead of taking the whole install down with it.
+    log.error('Session delivery failed, skipping until next tick', {
+      sessionId: session.id,
+      agentGroupId: session.agent_group_id,
+      err,
+    });
   } finally {
     inflightDeliveries.delete(session.id);
   }


### PR DESCRIPTION
Fixes #2796.

## Problem

`pollActive`/`pollSweep` iterate every session in a plain `for` loop wrapped in a single `try/catch`. `deliverSessionMessages` re-threw on failure, so an unhandled error for **one** session aborted the entire delivery tick and silently halted message delivery for **every other agent** until a daemon restart.

The trigger we hit in production: a crashed container left an orphaned hot journal (`outbound.db-journal`). `drainSession` opens `outbound.db` read-only (single-writer invariant), but rolling back a hot journal requires a write — so even the `SELECT` in `getDueOutboundMessages` threw `attempt to write a readonly database` on every tick (~1.3s), poisoning delivery for all sessions ordered after the broken one. An unrelated monitoring agent stopped receiving scheduled tasks and delivering messages for hours, despite its own container being perfectly healthy.

## Fix

Catch and log at the per-session boundary in `deliverSessionMessages`, so a single unhealthy session is contained instead of taking the whole install down. The broken session self-heals on its next container start, when the writer opens the DB read-write and rolls the journal back.

Minimal and surgical — no behavior change for healthy sessions; the existing `inflightDeliveries` cleanup stays in `finally`.

## Testing

Deployed to a live multi-agent Raspberry Pi install that was exhibiting the stall. After deploy: delivery errors dropped to zero, the previously-starved monitoring agent immediately resumed receiving its cron tasks and delivering messages, and the unhealthy session recovered on its next container spawn.

## Follow-ups (not in this PR)
- Proactively detect/clear orphaned hot journals for dead sessions.
- Reconcile `sessions.container_status = 'running'` when the container no longer exists.