### PR TITLE
fix(security): confine send_file reads to /workspace (CVE-2026-29611)

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -154,10 +154,21 @@ export const sendFile: McpToolDefinition = {
     if ('error' in routing) return err(routing.error);
 
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve('/workspace/agent', filePath);
+    // Confine the read to the workspace. Without this, an absolute path lets the
+    // agent send ANY container-readable file (credential state, files under
+    // /workspace/extra/* mounts, other data) — a prompt-injected agent can turn
+    // send_file into arbitrary local-file exfiltration (CVE-2026-29611, #2760).
+    if (resolvedPath !== '/workspace' && !resolvedPath.startsWith('/workspace/'))
+      return err('path must be within /workspace');
     if (!fs.existsSync(resolvedPath)) return err(`File not found: ${filePath}`);
 
     const id = generateId();
-    const filename = (args.filename as string) || path.basename(resolvedPath);
+    // Strip any directory components from the display name. path.join() resolves
+    // `..`, so a filename like `../../home/node/.claude/skills/x/SKILL.md` would
+    // write outside the outbox and could overwrite an active skill (instruction
+    // injection on the next spawn). basename() collapses it to a leaf name.
+    const filename =
+      path.basename((args.filename as string) || path.basename(resolvedPath)) || path.basename(resolvedPath);
 
     const outboxDir = path.join('/workspace/outbox', id);
     fs.mkdirSync(outboxDir, { recursive: true });


### PR DESCRIPTION
## What
`send_file` accepts an absolute `path` and copies the file into the outbox after only an existence check — no root restriction, no canonicalization. A prompt-injected or compromised agent can read **any container-visible file** (credential state, files under `/workspace/extra/*` mounts) and exfiltrate it through the normal attachment path.

Reported as **CVE-2026-29611 / #2760** (High, `<= 2.0.64`, unpatched).

## How it works
- Confine the resolved source path to `/workspace` — an absolute path outside it is rejected.
- `basename()` the display name as well: `path.join(outboxDir, filename)` resolves `..`, so a crafted `filename` could otherwise write **outside** the outbox and overwrite an active skill (instruction injection on the next spawn). This closes the write-side of the same path-handling flaw.

Legitimate sends are unaffected — agent files live under `/workspace/agent`, inbox/outbox, and `/workspace/extra/*`, all within `/workspace`.

## How it was tested
Container typecheck passes. The identical change runs in a downstream fork with the existing `core.test.ts` plus the full container suite (236) green.

Closes #2760