### PR TITLE
fix(security): validate group folders and forbid implicit image pulls

### DIFF
--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -12,6 +12,7 @@
  * with the host caller — same code path a real approval would take.
  */
 import fs from 'fs';
+import path from 'path';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('../../container-runner.js', () => ({
@@ -24,7 +25,11 @@ vi.mock('../../container-runner.js', () => ({
 
 vi.mock('../../config.js', async () => {
   const actual = await vi.importActual('../../config.js');
-  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-cli-groups' };
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-cli-groups',
+    GROUPS_DIR: '/tmp/nanoclaw-test-cli-groups/groups',
+  };
 });
 
 const TEST_DIR = '/tmp/nanoclaw-test-cli-groups';
@@ -257,5 +262,46 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     );
     expect(rm.ok).toBe(true);
     expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([]);
+  });
+});
+
+describe('groups CLI create validates and provisions folders', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    runMigrations(initTestDb());
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('rejects traversal before creating database or filesystem state', async () => {
+    const resp = await dispatch(
+      { id: 'req-traversal', command: 'groups-create', args: { folder: '../escaped', name: 'escaped' } },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(false);
+    expect(count('SELECT COUNT(*) AS c FROM agent_groups')).toBe(0);
+    expect(count('SELECT COUNT(*) AS c FROM container_configs')).toBe(0);
+    expect(fs.existsSync(path.join(TEST_DIR, 'escaped'))).toBe(false);
+  });
+
+  it('still provisions a valid group and its container config', async () => {
+    const resp = await dispatch(
+      { id: 'req-valid', command: 'groups-create', args: { folder: 'valid-agent', name: 'Valid Agent' } },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(true);
+    const group = getDb().prepare('SELECT id, folder FROM agent_groups WHERE folder = ?').get('valid-agent') as {
+      id: string;
+      folder: string;
+    };
+    expect(group.folder).toBe('valid-agent');
+    expect(getContainerConfig(group.id)).not.toBeNull();
+    expect(fs.existsSync(path.join(TEST_DIR, 'groups', 'valid-agent'))).toBe(true);
   });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -13,6 +13,7 @@ import {
   updateContainerConfigJson,
 } from '../../db/container-configs.js';
 import { initGroupFilesystem } from '../../group-init.js';
+import { assertValidGroupFolder } from '../../group-folder.js';
 import { createAgentFromTemplate } from '../../templates/create-agent.js';
 import type { AgentGroup, ContainerConfigRow } from '../../types.js';
 import { registerResource } from '../crud.js';
@@ -83,6 +84,7 @@ registerResource({
         }
         const folder = args.folder as string;
         if (!folder) throw new Error('--folder is required');
+        assertValidGroupFolder(folder);
         const name = (args.name as string) ?? folder;
         const existing = getAgentGroupByFolder(folder);
         if (existing) {

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -47,6 +47,16 @@ describe('buildContainerArgs ordering invariant (structural)', () => {
   });
 });
 
+describe('container image pull policy (structural)', () => {
+  it('forbids implicit registry pulls before the configured image argument', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'src', 'container-runner.ts'), 'utf-8');
+    const pullPolicy = src.indexOf("'--pull=never'");
+    const imageArgument = src.indexOf('args.push(imageTag)');
+    expect(pullPolicy).toBeGreaterThan(-1);
+    expect(imageArgument).toBeGreaterThan(pullPolicy);
+  });
+});
+
 describe('per-container resource limits (structural)', () => {
   // CONTAINER_CPU_LIMIT / CONTAINER_MEMORY_LIMIT pass through to `docker run` as
   // --cpus / --memory, but only when set. The default is empty string → no flag →

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -440,7 +440,10 @@ async function buildContainerArgs(
   providerContribution: ProviderContainerContribution,
   agentIdentifier?: string,
 ): Promise<string[]> {
-  const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
+  // Configured image tags may name registry images. Never let container spawn
+  // turn a configuration change into an implicit network pull; operators must
+  // make the image available locally through the explicit build/pull path.
+  const args: string[] = ['run', '--rm', '--pull=never', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
 
   // Per-container resource caps (opt-in; empty = unbounded, today's behavior).
   // Only --memory is set. Whether that's a hard cap depends on the host having no


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** Validates group folders before any database or filesystem mutation and prevents Docker from implicitly pulling configured container images during spawn.

**Why:** The CLI create path accepted traversal folders that later became read-write host mounts. Separately, Docker defaults to pulling a missing image, so an arbitrary image_tag could trigger registry access before container egress controls apply.

**How it works:** The create handler now uses the existing group-folder validator while preserving current idempotent provisioning. Container spawn always passes --pull=never, covering CLI, backfill, and direct database image-tag sources without rejecting valid locally available image names.

**How tested:** Added traversal/no-side-effect and valid-provisioning regression tests, plus a structural image pull-policy test. The two targeted suites pass (19 tests), TypeScript typecheck passes, Prettier passes, and ESLint reports zero errors (four pre-existing catch-all warnings in container-runner.ts).