### PR TITLE
fix(router): harden untrusted router input (safeParseContent + engage_pattern)

### DIFF
--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -426,6 +426,39 @@ describe('router', () => {
     expect(wakeContainer).toHaveBeenCalled();
   });
 
+  it('routes a message whose content is primitive JSON (not an object) as raw text', async () => {
+    // Without the safeParseContent object-guard, JSON.parse('"hi"') returns a
+    // bare string, callers read `.text` off it as undefined, and the message
+    // loses its text. The guard falls back to { text: raw }, so it still routes.
+    const { routeInbound } = await import('./router.js');
+    const { wakeContainer } = await import('./container-runner.js');
+    (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    const event: InboundEvent = {
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-primitive-json',
+        kind: 'chat',
+        content: JSON.stringify('hello from a primitive'),
+        timestamp: now(),
+      },
+    };
+
+    await routeInbound(event);
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeDefined();
+    expect(wakeContainer).toHaveBeenCalledTimes(1);
+
+    const db = new Database(inboundDbPath('ag-1', session!.id));
+    const rows = db.prepare('SELECT id, content FROM messages_in').all() as Array<{ id: string; content: string }>;
+    db.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe(JSON.stringify('hello from a primitive'));
+  });
+
   it('auto-creates messaging group only when the bot is addressed (mention/DM)', async () => {
     // The router's no-mg branch is escalation-gated: plain chatter on an
     // unknown channel stays silent (no DB writes) so a bot that sits in

--- a/src/router.ts
+++ b/src/router.ts
@@ -145,7 +145,12 @@ export function setChannelRequestGate(fn: ChannelRequestGateFn): void {
 
 function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
   try {
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    // JSON.parse on a primitive ("5", "true", "\"hi\"") succeeds but returns a
+    // non-object; callers read .text/.sender off the result, so anything that
+    // isn't a plain object must fall back to treating raw as the text body.
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    return { text: raw };
   } catch {
     return { text: raw };
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -386,10 +386,17 @@ function evaluateEngage(
 ): boolean {
   switch (agent.engage_mode) {
     case 'pattern': {
-      const pat = agent.engage_pattern ?? '.';
+      // `?? '.'` left an empty or whitespace-only pattern intact, so a blank
+      // engage_pattern compiled to `new RegExp('')` / `new RegExp('   ')` and
+      // matched (nearly) every message. Normalize blank/whitespace to the
+      // explicit always-engage sentinel instead.
+      const pat = agent.engage_pattern?.trim() || '.';
       if (pat === '.') return true;
       try {
-        return new RegExp(pat).test(text);
+        // Bound the input a (possibly mistyped, catastrophic-backtracking) regex
+        // tests against, so a huge inbound message can't drive a ReDoS hang.
+        const probe = text.length > 8192 ? text.slice(0, 8192) : text;
+        return new RegExp(pat).test(probe);
       } catch {
         // Bad regex: fail open so admin sees the agent responding + can fix.
         return true;


### PR DESCRIPTION
## What
`safeParseContent` returns `JSON.parse(raw)` directly. For a primitive payload (`"5"`, `"true"`, a bare quoted string) the parse succeeds but yields a non-object, and callers that read `.text`/`.sender` off the result get `undefined` rather than the intended raw-text fallback.

## How it works
Return the parsed value only when it's a plain object (not null, not an array); otherwise fall back to `{ text: raw }` — the same fallback the catch block uses.

## How it was tested
Host typecheck passes; the identical change runs in a downstream fork with the host suite green. Low blast radius (channel content is JSON objects in practice; this just hardens the edge).

## Update: engage_pattern hardening (follow-up commit a746ee8)
Two more untrusted-input guards on the same `evaluateEngage` path, same downstream-fork coverage:
- A blank or whitespace-only `engage_pattern` survived `?? '.'` and compiled to `new RegExp('')` / `new RegExp('   ')`, so an agent configured with an empty pattern silently engaged on (nearly) every message. Normalize blank/whitespace to the explicit always-engage sentinel.
- Bound the input the operator-supplied regex tests against (8KB prefix) so a very large inbound message can't drive catastrophic backtracking into a hang.
