### PR TITLE
refactor: remove dead resolveGroupIpcPath

### DIFF
--- a/src/group-folder.test.ts
+++ b/src/group-folder.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { describe, expect, it } from 'vitest';
 
-import { isValidGroupFolder, resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { isValidGroupFolder, resolveGroupFolderPath } from './group-folder.js';
 
 describe('group folder validation', () => {
   it('accepts normal group folder names', () => {
@@ -23,13 +23,7 @@ describe('group folder validation', () => {
     expect(resolved.endsWith(`${path.sep}groups${path.sep}family-chat`)).toBe(true);
   });
 
-  it('resolves safe paths under data ipc directory', () => {
-    const resolved = resolveGroupIpcPath('family-chat');
-    expect(resolved.endsWith(`${path.sep}data${path.sep}ipc${path.sep}family-chat`)).toBe(true);
-  });
-
   it('throws for unsafe folder names', () => {
     expect(() => resolveGroupFolderPath('../../etc')).toThrow();
-    expect(() => resolveGroupIpcPath('/tmp')).toThrow();
   });
 });

--- a/src/group-folder.ts
+++ b/src/group-folder.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { DATA_DIR, GROUPS_DIR } from './config.js';
+import { GROUPS_DIR } from './config.js';
 
 const GROUP_FOLDER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const RESERVED_FOLDERS = new Set(['global']);
@@ -33,12 +33,4 @@ export function resolveGroupFolderPath(folder: string): string {
   const groupPath = path.resolve(GROUPS_DIR, folder);
   ensureWithinBase(GROUPS_DIR, groupPath);
   return groupPath;
-}
-
-export function resolveGroupIpcPath(folder: string): string {
-  assertValidGroupFolder(folder);
-  const ipcBaseDir = path.resolve(DATA_DIR, 'ipc');
-  const ipcPath = path.resolve(ipcBaseDir, folder);
-  ensureWithinBase(ipcBaseDir, ipcPath);
-  return ipcPath;
 }


### PR DESCRIPTION
## What
`resolveGroupIpcPath` in `group-folder.ts` has no production callers — only its own test references it. IPC was removed in the v2 architecture (host and container communicate solely through the two session DBs), so the path helper is dead.

## How it works
Remove the function, the now-unused `DATA_DIR` import, and the two tests that only exercised it. `resolveGroupFolderPath` and the validators are untouched.

## How it was tested
`group-folder.test.ts` passes; host typecheck passes (confirming no remaining references).