### PR TITLE
fix(cli): ncl messaging-groups create always throws (NOT NULL instance)

### DIFF
--- a/src/cli/resources/messaging-groups.ts
+++ b/src/cli/resources/messaging-groups.ts
@@ -24,6 +24,14 @@ registerResource({
       required: true,
     },
     {
+      name: 'instance',
+      type: 'string',
+      description:
+        'Adapter-instance name (which bot/account). Schema is NOT NULL; for a single-bot channel pass the channel_type (e.g. "telegram").',
+      required: true,
+      updatable: true,
+    },
+    {
       name: 'name',
       type: 'string',
       description: 'Display name. Often auto-populated by the channel adapter.',


### PR DESCRIPTION
## What
Every `ncl messaging-groups create` throws `NOT NULL constraint failed: messaging_groups.instance` — the CLI create path is completely dead.

## Why
The `messaging-group` resource's columns omit `instance`, but the schema declares `instance TEXT NOT NULL` (migration 016). `genericCreate` builds the INSERT only from the declared columns, so it emits no `instance` value and the insert fails.

## How it works
Add `instance` as a required column on the resource so the operator supplies it. The generic create path has no per-column *dynamic* default, so this can't auto-default to `channel_type` the way the `createMessagingGroup` domain helper does; requiring it is the minimal self-contained fix that makes the command work. (Programmatic callers using the helper keep the channel_type default.)

## How it was tested
Host typecheck passes; the column addition makes the create path emit `instance`, satisfying the NOT NULL constraint.