### PR TITLE
fix(setup): parse Claude OAuth token from wrapped PTY capture

### DIFF
--- a/setup/lib/captured-token.test.ts
+++ b/setup/lib/captured-token.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractClaudeOAuthToken } from './captured-token.js';
+
+// A syntactically valid token: sk-ant-oat + 93 token chars + AA.
+const TOKEN = `sk-ant-oat01-${'a'.repeat(90)}AA`;
+
+describe('extractClaudeOAuthToken', () => {
+  it('extracts the token from clean single-line output (normal terminal)', () => {
+    const raw = `Login successful.\nYour token:\n${TOKEN}\n`;
+    expect(extractClaudeOAuthToken(raw)).toBe(TOKEN);
+  });
+
+  // The actual sbx failure shape: the real token wrapped across two lines AND
+  // the `export CLAUDE_CODE_OAUTH_TOKEN=<token>` placeholder in the same
+  // capture. The old parser returned null (matched only the first fragment);
+  // the normalizer must un-wrap the real token and never mistake the
+  // placeholder for it.
+  it('extracts the real wrapped token from sbx capture and ignores the placeholder export', () => {
+    const head = TOKEN.slice(0, 72);
+    const tail = TOKEN.slice(72);
+    const raw = `
+\x1b[?2026h✓ Long-lived authentication token created successfully!
+
+  Your OAuth token (valid for 1 year):
+
+  ${head}
+  ${tail}
+
+Store this token securely. You won't be able to see it again.
+
+Use this token by setting: export CLAUDE_CODE_OAUTH_TOKEN=<token>
+`;
+    expect(extractClaudeOAuthToken(raw)).toBe(TOKEN);
+  });
+
+  it('returns null for the placeholder env-var line, not a real token', () => {
+    expect(extractClaudeOAuthToken('export CLAUDE_CODE_OAUTH_TOKEN=<token>\n')).toBeNull();
+  });
+
+  it('returns null when no token is present', () => {
+    expect(extractClaudeOAuthToken('claude: authentication cancelled\n')).toBeNull();
+  });
+});

--- a/setup/lib/captured-token.ts
+++ b/setup/lib/captured-token.ts
@@ -1,0 +1,73 @@
+/**
+ * Parse a provider auth token out of interactive CLI output captured through
+ * a PTY (`script(1)`).
+ *
+ * Secret this module hides: the menagerie of PTY-capture artifacts that
+ * corrupt an otherwise whitespace-free secret. A real terminal wraps long
+ * lines, pads with spaces, and interleaves ANSI/control sequences, so a token
+ * the CLI printed as one string lands in the capture split across lines with
+ * escape codes embedded. Provider login itself succeeds — only our parse of
+ * the human-oriented output fails.
+ *
+ * A normalize step strips the capture artifacts; the extractor matches the
+ * token shape against the clean string. A future provider adds its own
+ * extractor here rather than regexing raw `script(1)` output.
+ *
+ * Runnable as a CLI for the bash callers that can't import TS:
+ *   tsx setup/lib/captured-token.ts claude <capture-file>
+ * Prints the token and exits 0, or exits 1 with nothing on stdout.
+ */
+import fs from 'fs';
+import { pathToFileURL } from 'url';
+
+/* eslint-disable no-control-regex -- these patterns exist precisely to match
+   the ESC/control bytes a PTY capture is full of. */
+// CSI sequences (colors, cursor moves): ESC [ , optional private '?' /
+// parameter bytes, optional intermediate bytes, one final byte. Stripped
+// explicitly because a colour reset mid-token (sk…\x1b[0m…AA) would otherwise
+// leave a `[` that breaks the token's character run.
+const CSI = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+// Everything <= space (control bytes incl. any stray ESC, CR/LF, tabs, and the
+// wrap-padding spaces inserted mid-token) plus DEL. Tokens contain none of these.
+const CONTROL_AND_SPACE = /[\x00-\x20\x7f]/g;
+/* eslint-enable no-control-regex */
+
+/**
+ * Collapse PTY-capture artifacts so a whitespace-free secret printed across
+ * wrapped lines becomes a single contiguous string. Drops ALL whitespace by
+ * design — these captures exist only to recover a token, never prose.
+ */
+function normalizeCapturedTerminalOutput(raw: string): string {
+  return raw.replace(CSI, '').replace(CONTROL_AND_SPACE, '');
+}
+
+// Claude subscription OAuth tokens: sk-ant-oat<base64url>AA. Bounded length
+// keeps a greedy match from running off the end of the token.
+const CLAUDE_OAUTH_TOKEN = /sk-ant-oat[A-Za-z0-9_-]{80,500}AA/g;
+
+/**
+ * Extract the Claude OAuth token from a PTY capture of `claude setup-token`,
+ * or `null` if none is present. Returns the LAST match — setup-token can echo
+ * partial/intermediate output before the final token. Placeholder strings like
+ * `<token>` never match (they lack the `sk-ant-oat` prefix).
+ */
+export function extractClaudeOAuthToken(raw: string): string | null {
+  const matches = normalizeCapturedTerminalOutput(raw).match(CLAUDE_OAUTH_TOKEN);
+  return matches ? matches[matches.length - 1] : null;
+}
+
+function runCli(argv: string[]): number {
+  const [provider, file] = argv;
+  if (provider !== 'claude' || !file) {
+    process.stderr.write('usage: captured-token.ts claude <capture-file>\n');
+    return 2;
+  }
+  const token = extractClaudeOAuthToken(fs.readFileSync(file, 'utf-8'));
+  if (!token) return 1;
+  process.stdout.write(token);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exit(runCli(process.argv.slice(2)));
+}

--- a/setup/lib/claude-assist.ts
+++ b/setup/lib/claude-assist.ts
@@ -27,6 +27,7 @@ import path from 'path';
 import * as p from '@clack/prompts';
 import k from 'kleur';
 
+import { extractClaudeOAuthToken } from './captured-token.js';
 import { ensureAnswer } from './runner.js';
 import { brandBody, fitToWidth, fmtDuration, note } from './theme.js';
 
@@ -207,16 +208,11 @@ export async function ensureClaudeReady(projectRoot: string): Promise<boolean> {
       });
 
       if (!isClaudeAuthenticated() && fs.existsSync(tmpfile)) {
-        const raw = fs.readFileSync(tmpfile, 'utf-8');
-        const stripped = raw
-          .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
-          .replace(/[\n\r]/g, '');
-        const matches = stripped.match(/(sk-ant-oat[A-Za-z0-9_-]{80,500}AA)/g);
-        if (matches) {
-          process.env.CLAUDE_CODE_OAUTH_TOKEN = matches[matches.length - 1];
-        }
+        const token = extractClaudeOAuthToken(fs.readFileSync(tmpfile, 'utf-8'));
+        if (token) process.env.CLAUDE_CODE_OAUTH_TOKEN = token;
       }
     } finally {
+      // eslint-disable-next-line no-empty -- best-effort temp cleanup
       try { fs.unlinkSync(tmpfile); } catch {}
     }
 

--- a/setup/register-claude-token.sh
+++ b/setup/register-claude-token.sh
@@ -9,7 +9,8 @@ set -euo pipefail
 # Flow:
 #   1. Run `claude setup-token` under a PTY (via script(1)) so the browser
 #      OAuth dance works and its token is captured into a tempfile.
-#   2. Regex the sk-ant-oat…AA token out of the ANSI-stripped capture.
+#   2. Parse the sk-ant-oat…AA token out of the capture via the shared
+#      PTY-capture parser (setup/lib/captured-token.ts).
 #   3. Register it with OneCLI.
 #
 # Env overrides:
@@ -99,12 +100,11 @@ else
   script -q "$tmpfile" $cmd
 fi
 
-# Strip ANSI codes + newlines (TTY wraps the token mid-string), then match
-# the sk-ant-oat…AA token. perl because BSD grep caps {n,m} at 255.
-token=$(sed $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' "$tmpfile" \
-        | tr -d '\n\r' \
-        | perl -ne 'print "$1\n" while /(sk-ant-oat[A-Za-z0-9_-]{80,500}AA)/g' \
-        | tail -1 || true)
+# Extract the token via the shared PTY-capture parser (setup/lib/captured-token.ts),
+# so this script and setup/lib/claude-assist.ts stay in lockstep on the
+# normalization rules (ANSI/control stripping, un-wrapping the token).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+token=$(pnpm exec tsx "$SCRIPT_DIR/lib/captured-token.ts" claude "$tmpfile" || true)
 
 if [ -z "$token" ]; then
   keep=$(mktemp -t claude-setup-token-log.XXXXXX)


### PR DESCRIPTION
## What
Fix Claude subscription token parsing when `claude setup-token`'s output is captured through a PTY that wraps long lines (observed under sbx).

## Why
The browser OAuth login succeeds and a valid `sk-ant-oat…AA` token is printed, but setup fails with `No sk-ant-oat…AA token found`. The token registration runs `claude setup-token` under `script(1)` to keep a TTY while capturing the printed token. On terminals that wrap long lines, the token lands split across lines with padding spaces. The old parser stripped only ANSI codes and newlines, so it matched just the first fragment and failed the trailing `AA` check. This is a parse bug, not an auth failure — login works.

## How it works
New `setup/lib/captured-token.ts`:
- A normalize step strips ANSI/CSI + all control bytes **and whitespace**, collapsing a wrapped token back into one contiguous string.
- The Claude extractor matches `sk-ant-oat…AA` on the clean string and ignores placeholder lines like `export CLAUDE_CODE_OAUTH_TOKEN=<token>`.

Both callers now share it so the normalization rules can't drift: `setup/lib/claude-assist.ts` imports it, and `setup/register-claude-token.sh` calls it via `tsx` (replacing its own `sed`/`perl` regex).

## How it was tested
`setup/lib/captured-token.test.ts` (vitest): clean single-line capture, the real sbx wrapped-token + placeholder shape, placeholder-only → null, no-token → null. Verified red on the old parser and green on the fix. `eslint` + `tsc` clean; the bash CLI path confirmed end-to-end against a wrapped fixture.

This is a **Fix**.