### PR TITLE
fix: idempotent insertMessage + stamp agent_group_id on approval rows

### DIFF
--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -10,7 +10,13 @@ import fs from 'fs';
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { getInboundSourceSessionId, migrateMessagesInTable } from './session-db.js';
+import {
+  ensureSchema,
+  getInboundSourceSessionId,
+  insertMessage,
+  migrateMessagesInTable,
+  openInboundDb,
+} from './session-db.js';
 
 const TEST_DIR = '/tmp/nanoclaw-session-db-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
@@ -89,6 +95,50 @@ describe('migrateMessagesInTable', () => {
 
     expect(getInboundSourceSessionId(db, 'legacy-2')).toBeNull();
     expect(getInboundSourceSessionId(db, 'does-not-exist')).toBeNull();
+    db.close();
+  });
+});
+
+describe('insertMessage', () => {
+  function freshInboundDb(): Database.Database {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    ensureSchema(DB_PATH, 'inbound');
+    return openInboundDb(DB_PATH);
+  }
+
+  const baseMsg = {
+    kind: 'chat',
+    timestamp: '2026-06-18T00:00:00.000Z',
+    platformId: 'whatsapp:6594599775@s.whatsapp.net',
+    channelType: 'whatsapp',
+    threadId: null,
+    content: '{}',
+    processAfter: null,
+    recurrence: null,
+  };
+
+  it('is idempotent on a duplicate id — second insert is a no-op, not a throw', () => {
+    const db = freshInboundDb();
+
+    expect(insertMessage(db, { id: 'dup-1', ...baseMsg })).toBe(true);
+    // A redelivery / sender-approval replay re-inserts the same id. Must not
+    // throw UNIQUE-constraint and must not create a second row.
+    expect(insertMessage(db, { id: 'dup-1', ...baseMsg })).toBe(false);
+
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM messages_in WHERE id = ?').get('dup-1') as { c: number }).c;
+    expect(count).toBe(1);
+    db.close();
+  });
+
+  it('keeps the first write: a duplicate does not overwrite existing content', () => {
+    const db = freshInboundDb();
+
+    insertMessage(db, { id: 'dup-2', ...baseMsg, content: '{"v":1}' });
+    insertMessage(db, { id: 'dup-2', ...baseMsg, content: '{"v":2}' });
+
+    const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get('dup-2') as { content: string };
+    expect(row.content).toBe('{"v":1}');
     db.close();
   });
 });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -120,17 +120,29 @@ export function insertMessage(
      */
     onWake?: 0 | 1;
   },
-): void {
-  db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
-     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)`,
-  ).run({
-    ...message,
-    trigger: message.trigger ?? 1,
-    onWake: message.onWake ?? 0,
-    sourceSessionId: message.sourceSessionId ?? null,
-    seq: nextEvenSeq(db),
-  });
+): boolean {
+  // INSERT OR IGNORE makes the write idempotent on the id primary key. The
+  // same message id can legitimately arrive twice — e.g. a sender-approval
+  // replay re-routes a message already written on the original delivery, and
+  // a channel can redeliver an inbound with the same client-generated id. The
+  // first write wins; a duplicate is a silent no-op rather than a thrown
+  // UNIQUE-constraint error that would crash routeInbound / the approval
+  // replay. Mirrors how messages_out and delivered already dedup. Returns
+  // true when a row was actually inserted, false when an existing id was
+  // ignored, so callers can avoid re-waking on a redelivery.
+  const info = db
+    .prepare(
+      `INSERT OR IGNORE INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
+       VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)`,
+    )
+    .run({
+      ...message,
+      trigger: message.trigger ?? 1,
+      onWake: message.onWake ?? 0,
+      sourceSessionId: message.sourceSessionId ?? null,
+      seq: nextEvenSeq(db),
+    });
+  return info.changes > 0;
 }
 
 export function countDueMessages(db: Database.Database): number {

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -230,6 +230,12 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     approval_id: approvalId,
     session_id: session.id,
     request_id: approvalId,
+    // Stamp the originating group so the response handler's approve-path
+    // authorization (hasAdminPrivilege(clicker, agent_group_id)) can run.
+    // Without it the row's agent_group_id is NULL, the gate fails closed, and
+    // every clicked Approve is dropped as "unauthorized" — the card can be
+    // delivered but never resolved.
+    agent_group_id: session.agent_group_id,
     action,
     payload: JSON.stringify(payload),
     created_at: new Date().toISOString(),

--- a/src/modules/approvals/request-approval.test.ts
+++ b/src/modules/approvals/request-approval.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for requestApproval() persisting agent_group_id on the
+ * pending_approvals row.
+ *
+ * The bug: the row was created without agent_group_id (defaulting to NULL).
+ * The response handler's approve-path gate is
+ *   authorized = clicker && approval.agent_group_id !== null && hasAdminPrivilege(...)
+ * so a NULL agent_group_id makes EVERY clicked Approve fail closed as
+ * "unauthorized" — the card delivers but can never be resolved. Stamping the
+ * originating group is what lets a legitimate admin/owner actually approve.
+ */
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+
+import {
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from '../../channels/channel-registry.js';
+import type { ChannelAdapter } from '../../channels/adapter.js';
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createSession, getPendingApprovalsByAction } from '../../db/sessions.js';
+import { createUser } from '../permissions/db/users.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import { requestApproval } from './primitive.js';
+import type { Session } from '../../types.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  closeDb();
+});
+
+async function mountMockAdapter(channelType: string): Promise<void> {
+  const adapter: ChannelAdapter = {
+    name: channelType,
+    channelType,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected() {
+      return true;
+    },
+    async deliver() {
+      return undefined;
+    },
+    async setTyping() {},
+  };
+  registerChannelAdapter(channelType, { factory: () => adapter });
+  await initChannelAdapters(() => ({
+    conversations: [],
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+describe('requestApproval', () => {
+  it('stamps agent_group_id (the session group) onto the pending_approvals row', async () => {
+    await mountMockAdapter('telegram');
+    createAgentGroup({ id: 'ag-1', name: 'AG-1', folder: 'ag-1', agent_provider: null, created_at: now() });
+    // A reachable owner so pickApprovalDelivery returns a target and the row is created.
+    createUser({ id: 'telegram:111', kind: 'telegram', display_name: null, created_at: now() });
+    grantRole({ user_id: 'telegram:111', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+
+    const session: Session = {
+      id: 'sess-1',
+      agent_group_id: 'ag-1',
+      messaging_group_id: null,
+      thread_id: null,
+      agent_provider: null,
+      status: 'active',
+      container_status: 'running',
+      last_active: now(),
+      created_at: now(),
+    };
+    createSession(session);
+
+    await requestApproval({
+      session,
+      agentName: 'AG-1',
+      action: 'cli_command',
+      payload: { frame: { id: 'cli-1', command: 'members-add', args: {} } },
+      title: 'CLI: members-add',
+      question: 'approve?',
+    });
+
+    const rows = getPendingApprovalsByAction('cli_command');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].agent_group_id).toBe('ag-1');
+  });
+});


### PR DESCRIPTION
Two independent, self-contained bug fixes found while operating a live install. Each has a regression test; both apply cleanly on `main` (v2.1.18).

## 1. `fix(session-db)`: make `insertMessage` idempotent on duplicate id

`insertMessage` used a bare `INSERT INTO messages_in`, so re-inserting the same message id threw `UNIQUE constraint failed: messages_in.id` and crashed `routeInbound` and the sender-approval replay path. The same id legitimately arrives twice — a sender-approval replay re-routes a message already written on the original delivery, and a channel can redeliver an inbound with the same client-generated id.

**Fix:** switch to `INSERT OR IGNORE` (matching how `messages_out` and `delivered` already dedup) and return a `boolean` so callers can distinguish a fresh insert from an ignored duplicate (and avoid re-waking on a redelivery). First write wins; duplicates are silent no-ops. Existing callers treat the return as `void`, so they're unaffected.

## 2. `fix(approvals)`: stamp `agent_group_id` on `pending_approvals` so taps can authorize

`requestApproval()` created the `pending_approvals` row **without** `agent_group_id`, defaulting it to `NULL`. The response handler's approve-path gate is:

```js
authorized = clicker && approval.agent_group_id !== null && hasAdminPrivilege(clicker, approval.agent_group_id)
```

With `agent_group_id = NULL`, `authorized` is **always false** — every clicked Approve is silently dropped as *"Ignoring unauthorized approval click."* `cli_command` cards were delivered to the admin DM but could **never** be resolved, accumulating as `pending` indefinitely. (Reject still worked — it doesn't pass the auth gate.)

**Fix:** stamp `session.agent_group_id` on the row at creation so a legitimate admin/owner click can authorize. Observed live as a large backlog of un-actionable `cli_command` approvals plus repeated "unauthorized click" warnings on owner taps.

## Tests
- `src/db/session-db.test.ts` — duplicate id is a no-op (returns `false`, no throw, one row); first write wins.
- `src/modules/approvals/request-approval.test.ts` — drives `requestApproval()` end-to-end and asserts the row carries the originating group (fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
