### PR TITLE
feat(apple-container): Apple Container runtime + remote OneCLI gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# NanoClaw .env — copy to .env and fill in as needed.
+# NOTE: .env is NOT loaded into the process environment wholesale (env.ts reads
+# only requested keys). Container-runtime knobs below are read explicitly by
+# config.ts and emitted into the launchd/systemd service env by setup/service.ts.
+
+# ── Container runtime ────────────────────────────────────────────────────────
+# 'docker' (default) or 'container' (Apple Container, macOS only).
+CONTAINER_RUNTIME=docker
+
+# Apple Container only — usually auto-detected; set to override.
+# NANOCLAW_HOST_GATEWAY_IP=192.168.64.1   # bridge gateway the container uses to reach the host
+# ONECLI_FORWARD_BIND=192.168.64.1        # OneCLI forwarder bind IP (must be in 192.168.64.0/24)
+#
+# Where does OneCLI run? Two options under Apple Container:
+#  (a) LOCAL OneCLI — Docker Desktop must STILL be running: the gateway lives in
+#      it on 127.0.0.1:10255, and a host-side forwarder bridges 192.168.64.1:10255
+#      -> 127.0.0.1:10255 for the VM. (No RAM saved over plain Docker.)
+#  (b) REMOTE OneCLI — set ONECLI_URL below; Docker Desktop is NOT needed at all
+#      (the real RAM win). The forwarder is skipped automatically.
+# After setting CONTAINER_RUNTIME=container, re-run service setup so the plist/unit
+# is regenerated with it (a hand-edited plist is clobbered on the next setup run).
+# NANOCLAW_EGRESS_LOCKDOWN is unsupported under Apple Container (spawn throws).
+
+# ── Remote OneCLI gateway (optional) ─────────────────────────────────────────
+# Point at a OneCLI gateway on another host instead of one in local Docker Desktop
+# — frees this machine from running OneCLI at all. Works under either runtime.
+# When ONECLI_URL is non-loopback the local forwarder is skipped AND the proxy host
+# OneCLI injects (the literal "host.docker.internal", which assumes a
+# Docker-Desktop-local agent) is retargeted to ONECLI_URL's host automatically — so
+# usually ONECLI_URL is all you need.
+# ONECLI_URL=http://192.168.0.99:10254
+# ONECLI_API_KEY=...        # if the remote gateway's control API requires a key
+#
+# SECURITY: the gateway's proxy port (10255) injects vault credentials into every
+# agent request. Anything that can reach that port can spend your credentials —
+# restrict it (firewall / source allowlist) to the hosts that need it, never the
+# open LAN/internet.
+#
+# Override the auto-derived rewrite target ONLY when the gateway is reachable at a
+# DIFFERENT address than ONECLI_URL's host (e.g. a Tailscale IP). Format "from=to".
+# ONECLI_GATEWAY_REWRITE=host.docker.internal=100.x.y.z
+
+# ── Egress lockdown (Docker only) ────────────────────────────────────────────
+# Force all agent traffic through the OneCLI gateway on a no-internet network.
+# NANOCLAW_EGRESS_LOCKDOWN=true

--- a/container/build.sh
+++ b/container/build.sh
@@ -5,6 +5,11 @@
 #   INSTALL_CJK_FONTS=true   — add Chinese/Japanese/Korean fonts (~200MB)
 # setup/container.ts reads the same file, so both build paths stay in sync.
 # Callers can also override by exporting INSTALL_CJK_FONTS directly.
+#
+# Runtime: builds with $CONTAINER_RUNTIME (docker | container), default docker.
+# For Apple Container:  CONTAINER_RUNTIME=container ./container/build.sh
+# The Dockerfile + --build-arg are byte-compatible with `container build`; the
+# image lands in the Apple OCI store runnable by its slug tag — no `image load`.
 
 set -e
 

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -13,15 +13,7 @@ import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
 import { writeUpgradeState } from '../src/upgrade-state.js';
 import { cleanupUnhealthyPeers } from './peer-cleanup.js';
-import {
-  commandExists,
-  getPlatform,
-  getNodePath,
-  getServiceManager,
-  hasSystemd,
-  isRoot,
-  isWSL,
-} from './platform.js';
+import { commandExists, getPlatform, getNodePath, getServiceManager, hasSystemd, isRoot, isWSL } from './platform.js';
 import { emitStatus } from './status.js';
 
 export async function run(_args: string[]): Promise<void> {
@@ -125,21 +117,58 @@ function installCliSymlink(projectRoot: string, homeDir: string): void {
   }
 }
 
-function setupLaunchd(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+/**
+ * Read a single key from the install's .env. Used to propagate runtime-selection
+ * knobs (CONTAINER_RUNTIME etc.) into the generated service env so a manual flip
+ * survives plist/unit regeneration — .env is otherwise never loaded into the
+ * service process environment.
+ */
+function readEnvVar(projectRoot: string, key: string): string | undefined {
+  try {
+    const env = fs.readFileSync(path.join(projectRoot, '.env'), 'utf-8');
+    for (const line of env.split('\n')) {
+      const m = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*?)\s*$/);
+      if (m && m[1] === key) return m[2].replace(/^["']|["']$/g, '');
+    }
+  } catch {
+    /* no .env — fine */
+  }
+  return undefined;
+}
+
+/** Extra launchd EnvironmentVariables entries for Apple Container (empty under Docker). */
+function appleContainerLaunchdEnv(projectRoot: string): string {
+  if (readEnvVar(projectRoot, 'CONTAINER_RUNTIME') !== 'container') return '';
+  let out = '\n        <key>CONTAINER_RUNTIME</key>\n        <string>container</string>';
+  for (const key of ['NANOCLAW_HOST_GATEWAY_IP', 'ONECLI_FORWARD_BIND']) {
+    const v = readEnvVar(projectRoot, key);
+    if (v) out += `\n        <key>${key}</key>\n        <string>${v}</string>`;
+  }
+  return out;
+}
+
+/** Extra systemd Environment= lines for Apple Container (empty under Docker). */
+function appleContainerSystemdEnv(projectRoot: string): string {
+  if (readEnvVar(projectRoot, 'CONTAINER_RUNTIME') !== 'container') return '';
+  let out = '\nEnvironment=CONTAINER_RUNTIME=container';
+  for (const key of ['NANOCLAW_HOST_GATEWAY_IP', 'ONECLI_FORWARD_BIND']) {
+    const v = readEnvVar(projectRoot, key);
+    if (v) out += `\nEnvironment=${key}=${v}`;
+  }
+  return out;
+}
+
+function setupLaunchd(projectRoot: string, nodePath: string, homeDir: string): void {
   // Per-checkout service label so multiple NanoClaw installs can coexist
   // without clobbering each other's plist.
   const label = getLaunchdLabel(projectRoot);
-  const plistPath = path.join(
-    homeDir,
-    'Library',
-    'LaunchAgents',
-    `${label}.plist`,
-  );
+  const plistPath = path.join(homeDir, 'Library', 'LaunchAgents', `${label}.plist`);
   fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+
+  // CONTAINER_RUNTIME (and Apple Container knobs) emitted into the service env so
+  // the runtime flip survives plist regeneration. Empty for Docker installs → the
+  // plist is byte-identical to before.
+  const extraEnv = appleContainerLaunchdEnv(projectRoot);
 
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -163,7 +192,7 @@ function setupLaunchd(
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
-        <string>${homeDir}</string>
+        <string>${homeDir}</string>${extraEnv}
     </dict>
     <key>StandardOutPath</key>
     <string>${projectRoot}/logs/nanoclaw.log</string>
@@ -222,11 +251,7 @@ function setupLaunchd(
   });
 }
 
-function setupLinux(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupLinux(projectRoot: string, nodePath: string, homeDir: string): void {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
@@ -279,11 +304,7 @@ function checkDockerGroupStale(): boolean {
   }
 }
 
-function setupSystemd(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupSystemd(projectRoot: string, nodePath: string, homeDir: string): void {
   const runningAsRoot = isRoot();
   const unitName = getSystemdUnit(projectRoot);
   const unitFileName = `${unitName}.service`;
@@ -301,9 +322,7 @@ function setupSystemd(
     try {
       execSync('systemctl --user daemon-reload', { stdio: 'pipe' });
     } catch {
-      log.warn(
-        'systemd user session not available — falling back to nohup wrapper',
-      );
+      log.warn('systemd user session not available — falling back to nohup wrapper');
       setupNohupFallback(projectRoot, nodePath, homeDir);
       return;
     }
@@ -325,7 +344,7 @@ Restart=always
 RestartSec=5
 KillMode=process
 Environment=HOME=${homeDir}
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin${appleContainerSystemdEnv(projectRoot)}
 StandardOutput=append:${projectRoot}/logs/nanoclaw.log
 StandardError=append:${projectRoot}/logs/nanoclaw.error.log
 
@@ -344,18 +363,14 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   // normal group perms apply again).
   let dockerGroupStale = !runningAsRoot && checkDockerGroupStale();
   if (dockerGroupStale) {
-    log.warn(
-      'Docker group not active in systemd session — user was likely added to docker group mid-session',
-    );
+    log.warn('Docker group not active in systemd session — user was likely added to docker group mid-session');
     if (commandExists('setfacl')) {
       const user = execSync('whoami', { encoding: 'utf-8' }).trim();
       try {
         execSync(`sudo setfacl -m u:${user}:rw /var/run/docker.sock`, {
           stdio: 'inherit',
         });
-        log.info(
-          'Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)',
-        );
+        log.info('Applied temporary ACL to /var/run/docker.sock (resets on docker restart or reboot)');
         dockerGroupStale = false;
       } catch (err) {
         log.warn('Failed to apply setfacl workaround', { err });
@@ -375,10 +390,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
       execSync('loginctl enable-linger', { stdio: 'ignore' });
       log.info('Enabled loginctl linger for current user');
     } catch (err) {
-      log.warn(
-        'loginctl enable-linger failed — service may stop on SSH logout',
-        { err },
-      );
+      log.warn('loginctl enable-linger failed — service may stop on SSH logout', { err });
     }
   }
 
@@ -429,11 +441,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
   });
 }
 
-function setupNohupFallback(
-  projectRoot: string,
-  nodePath: string,
-  homeDir: string,
-): void {
+function setupNohupFallback(projectRoot: string, nodePath: string, homeDir: string): void {
   log.warn('No systemd detected — generating nohup wrapper script');
 
   const wrapperPath = path.join(projectRoot, 'start-nanoclaw.sh');

--- a/src/apple-container.test.ts
+++ b/src/apple-container.test.ts
@@ -30,6 +30,25 @@ describe('detectHostGateway', () => {
     });
     expect(detectHostGateway()).toBe('192.168.64.1');
   });
+
+  it('lets an explicit NANOCLAW_HOST_GATEWAY_IP override win over a detected bridge address', async () => {
+    // The override must take precedence even when a real bridge address exists —
+    // otherwise the documented override is a no-op on any host with bridge100 up.
+    // NANOCLAW_HOST_GATEWAY_IP is frozen at config-import time, so mock config and
+    // re-import the runtime module to exercise the override path.
+    vi.resetModules();
+    vi.doMock('./config.js', async () => ({
+      ...(await vi.importActual<typeof import('./config.js')>('./config.js')),
+      NANOCLAW_HOST_GATEWAY_IP: '192.168.64.250',
+    }));
+    const { detectHostGateway: detect } = await import('./container-runtime.js');
+    vi.spyOn(os, 'networkInterfaces').mockReturnValue({
+      bridge100: [{ family: 'IPv4', address: '192.168.64.1', internal: false } as os.NetworkInterfaceInfo],
+    });
+    expect(detect()).toBe('192.168.64.250');
+    vi.doUnmock('./config.js');
+    vi.resetModules();
+  });
 });
 
 describe('inBridgeSubnet', () => {

--- a/src/apple-container.test.ts
+++ b/src/apple-container.test.ts
@@ -1,0 +1,59 @@
+import os from 'os';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { deriveOneCliRemoteHost } from './config.js';
+import { detectHostGateway } from './container-runtime.js';
+import { inBridgeSubnet } from './onecli-forwarder.js';
+
+describe('detectHostGateway', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the bridge100 IPv4 in the 192.168.64.0/24 subnet when present', () => {
+    vi.spyOn(os, 'networkInterfaces').mockReturnValue({
+      bridge100: [{ family: 'IPv4', address: '192.168.64.1', internal: false } as os.NetworkInterfaceInfo],
+    });
+    expect(detectHostGateway()).toBe('192.168.64.1');
+  });
+
+  it('falls back to the .1 literal when no bridge interface exists', () => {
+    // Regression: NANOCLAW_HOST_GATEWAY_IP normalises to '' (empty string, not
+    // null), so a `??` chain would short-circuit on it and return '' — breaking
+    // the proxy-host rewrite. `||` must let the literal default win.
+    vi.spyOn(os, 'networkInterfaces').mockReturnValue({});
+    expect(detectHostGateway()).toBe('192.168.64.1');
+  });
+
+  it('ignores bridge addresses outside 192.168.64.0/24', () => {
+    vi.spyOn(os, 'networkInterfaces').mockReturnValue({
+      bridge100: [{ family: 'IPv4', address: '10.0.0.5', internal: false } as os.NetworkInterfaceInfo],
+    });
+    expect(detectHostGateway()).toBe('192.168.64.1');
+  });
+});
+
+describe('inBridgeSubnet', () => {
+  it('accepts a 192.168.64.x address', () => expect(inBridgeSubnet('192.168.64.7')).toBe(true));
+  it('accepts an IPv4-mapped IPv6 ::ffff:192.168.64.x', () => expect(inBridgeSubnet('::ffff:192.168.64.7')).toBe(true));
+  it('rejects a different subnet', () => expect(inBridgeSubnet('192.168.0.7')).toBe(false));
+  it('rejects undefined', () => expect(inBridgeSubnet(undefined)).toBe(false));
+});
+
+describe('deriveOneCliRemoteHost', () => {
+  it('returns the hostname for a non-loopback URL', () =>
+    expect(deriveOneCliRemoteHost('http://192.168.0.99:10254')).toBe('192.168.0.99'));
+  it('treats 127.0.0.1 / localhost as local', () => {
+    expect(deriveOneCliRemoteHost('http://127.0.0.1:10254')).toBe('');
+    expect(deriveOneCliRemoteHost('http://localhost:10254')).toBe('');
+  });
+  it('treats both ::1 and the bracketed [::1] IPv6 loopback as local', () => {
+    // URL.hostname returns IPv6 literals bracketed, so the guard must match "[::1]".
+    expect(deriveOneCliRemoteHost('http://[::1]:10254')).toBe('');
+  });
+  it('keeps a bracketed non-loopback IPv6 literal (valid in a proxy URL)', () =>
+    expect(deriveOneCliRemoteHost('http://[fd00::1]:10254')).toBe('[fd00::1]'));
+  it('returns empty for unset or malformed URLs', () => {
+    expect(deriveOneCliRemoteHost(undefined)).toBe('');
+    expect(deriveOneCliRemoteHost('not a url')).toBe('');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,25 @@ import { getContainerImageBase, getDefaultContainerImage, getInstallSlug } from 
 import { isValidTimezone } from './timezone.js';
 
 // Read config values from .env (falls back to process.env).
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER', 'ONECLI_URL', 'ONECLI_API_KEY', 'TZ']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'ONECLI_URL',
+  'ONECLI_API_KEY',
+  'TZ',
+  // Container runtime selection + Apple Container bridge knobs. NOTE: .env is
+  // never loaded into process.env (see env.ts), so these MUST be read here via
+  // readEnvFile to survive the launchd/systemd path; setup/service.ts also
+  // emits CONTAINER_RUNTIME into the service env so the flip is durable.
+  'CONTAINER_RUNTIME',
+  'NANOCLAW_HOST_GATEWAY_IP',
+  'ONECLI_FORWARD_BIND',
+  'NANOCLAW_EGRESS_LOCKDOWN',
+  // Remote OneCLI: rewrite the gateway host the server injects (by default the
+  // literal "host.docker.internal") to a LAN-reachable address. Format "from=to",
+  // e.g. "host.docker.internal=192.168.0.99".
+  'ONECLI_GATEWAY_REWRITE',
+]);
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
 export const ASSISTANT_HAS_OWN_NUMBER =
@@ -31,10 +49,56 @@ export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || getDefaultContaine
 // cleanupOrphans only reaps containers from this install, not peers.
 export const INSTALL_SLUG = getInstallSlug(PROJECT_ROOT);
 export const CONTAINER_INSTALL_LABEL = `nanoclaw-install=${INSTALL_SLUG}`;
+// Container runtime: 'docker' (default) or 'container' (Apple Container).
+// Single source of truth — container-runtime.ts / onecli-forwarder.ts /
+// egress-lockdown.ts import from here, never read process.env directly.
+export const CONTAINER_RUNTIME =
+  (process.env.CONTAINER_RUNTIME || envConfig.CONTAINER_RUNTIME || 'docker') === 'container' ? 'container' : 'docker';
+// Override the autodetected Apple Container bridge gateway IP (192.168.64.1).
+export const NANOCLAW_HOST_GATEWAY_IP =
+  process.env.NANOCLAW_HOST_GATEWAY_IP || envConfig.NANOCLAW_HOST_GATEWAY_IP || '';
+// Override the OneCLI forwarder bind IP (must be in the 192.168.64.0/24 bridge subnet).
+export const ONECLI_FORWARD_BIND = process.env.ONECLI_FORWARD_BIND || envConfig.ONECLI_FORWARD_BIND || '';
+// Remote OneCLI gateway-host rewrite "from=to" (e.g. "host.docker.internal=192.168.0.99").
+// An explicit OVERRIDE: when set, the host rewrites this exact gateway host in
+// OneCLI's injected proxy env. Usually unnecessary — for a remote ONECLI_URL the
+// rewrite target is derived automatically (see ONECLI_REMOTE_HOST). Use this only
+// when the gateway is reachable at a different address than the control API host
+// (e.g. a Tailscale IP). Validated eagerly so a malformed value fails fast.
+export const ONECLI_GATEWAY_REWRITE = process.env.ONECLI_GATEWAY_REWRITE || envConfig.ONECLI_GATEWAY_REWRITE || '';
+if (ONECLI_GATEWAY_REWRITE) {
+  const eq = ONECLI_GATEWAY_REWRITE.indexOf('=');
+  if (eq <= 0 || eq === ONECLI_GATEWAY_REWRITE.length - 1) {
+    throw new Error(
+      `Invalid ONECLI_GATEWAY_REWRITE="${ONECLI_GATEWAY_REWRITE}" — expected "from=to", ` +
+        `e.g. host.docker.internal=192.168.0.99`,
+    );
+  }
+}
+// Egress lockdown is Docker-bridge-only; hard-gated off under Apple Container.
+export const EGRESS_LOCKDOWN = (process.env.NANOCLAW_EGRESS_LOCKDOWN || envConfig.NANOCLAW_EGRESS_LOCKDOWN) === 'true';
 export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10);
 export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+// Hostname of a REMOTE OneCLI gateway — empty when OneCLI is local/loopback.
+// Drives two things: the forwarder skips itself when this is set, and the proxy
+// host OneCLI bakes into the injected env (the literal "host.docker.internal",
+// which assumes a Docker-Desktop-local agent) is retargeted to this address so a
+// remote agent reaches the actual gateway. ONECLI_GATEWAY_REWRITE overrides it.
+export function deriveOneCliRemoteHost(url: string | undefined): string {
+  if (!url) return '';
+  let host = '';
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return '';
+  }
+  // URL.hostname returns IPv6 literals bracketed (e.g. "[::1]"), so match both forms.
+  if (!host || host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]') return '';
+  return host;
+}
+export const ONECLI_REMOTE_HOST = deriveOneCliRemoteHost(ONECLI_URL);
 export const MAX_MESSAGES_PER_PROMPT = Math.max(1, parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10);
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
 export const MAX_CONCURRENT_CONTAINERS = Math.max(1, parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -16,13 +16,22 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   ONECLI_API_KEY,
+  ONECLI_GATEWAY_REWRITE,
+  ONECLI_REMOTE_HOST,
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  getHostGateway,
+  IS_APPLE_CONTAINER,
+  hostGatewayArgs,
+  readonlyMountArgs,
+  stopContainer,
+} from './container-runtime.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from './egress-lockdown.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
@@ -488,6 +497,54 @@ async function buildContainerArgs(
     throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');
   }
   log.info('OneCLI gateway applied', { containerName });
+
+  // OneCLI bakes a proxy host into the injected env (HTTPS_PROXY etc.) — by
+  // default the literal "host.docker.internal", which assumes the agent runs in
+  // Docker Desktop alongside the gateway. That assumption breaks for a remote
+  // gateway (wrong host) and for Apple Container (no host.docker.internal in the
+  // VM at all). Retarget it, value-driven, on -e arg VALUES only (-v mount paths
+  // are /tmp/onecli-*.pem, never touched). Runs AFTER applyContainerConfig.
+  //
+  // Precedence for the rewrite target:
+  //   1. ONECLI_GATEWAY_REWRITE  — explicit "from=to" override (e.g. Tailscale IP)
+  //   2. ONECLI_REMOTE_HOST      — remote gateway: host.docker.internal -> its host
+  //   3. Apple Container + local — host.docker.internal -> bridge gateway (forwarder)
+  let rwFrom = '';
+  let rwTo = '';
+  if (ONECLI_GATEWAY_REWRITE) {
+    const eq = ONECLI_GATEWAY_REWRITE.indexOf('='); // format validated in config.ts
+    rwFrom = ONECLI_GATEWAY_REWRITE.slice(0, eq);
+    rwTo = ONECLI_GATEWAY_REWRITE.slice(eq + 1);
+  } else if (ONECLI_REMOTE_HOST) {
+    rwFrom = 'host.docker.internal';
+    rwTo = ONECLI_REMOTE_HOST;
+  } else if (IS_APPLE_CONTAINER) {
+    rwFrom = 'host.docker.internal';
+    rwTo = getHostGateway(); // lazy — bridge is up by spawn time
+  }
+  if (rwFrom && rwTo) {
+    let n = 0;
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === '-e' && args[i + 1].includes(rwFrom)) {
+        args[i + 1] = args[i + 1].split(rwFrom).join(rwTo);
+        n++;
+      }
+    }
+    log.info('Rewrote OneCLI gateway host in injected env', { from: rwFrom, to: rwTo, count: n, containerName });
+  }
+  // Apple Container cannot resolve host.docker.internal at all — fail loud and
+  // refuse to spawn if any survived (e.g. a future OneCLI changed its injected env
+  // schema), rather than launch a container that hangs on an unreachable proxy
+  // host. Matches the fail-fast posture of the OneCLI-not-applied guard above.
+  if (IS_APPLE_CONTAINER) {
+    const stillLiteral = args.some((a, i) => i > 0 && args[i - 1] === '-e' && a.includes('host.docker.internal'));
+    if (stillLiteral) {
+      throw new Error(
+        `Apple Container: host.docker.internal still present in injected -e args after rewrite ` +
+          `(containerName=${containerName}) — refusing to spawn a container that cannot reach the OneCLI gateway`,
+      );
+    }
+  }
 
   // Override entrypoint: run v2 entry point directly via Bun (no tsc, no stdin).
   args.push('--entrypoint', 'bash');

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -19,16 +19,17 @@ export const IS_APPLE_CONTAINER = CONTAINER_RUNTIME_BIN === 'container';
 /**
  * Bridge gateway IP that Apple Container VMs use to reach the host.
  * bridge100 is vmnet-managed (192.168.64.x); the host is at the gateway (.1).
- * We extract the bridge100 (or bridge0) IPv4 in the host-only 192.168.64.0/24
- * subnet; if none is found the env override then the conventional .1 win.
+ * Precedence: an explicit NANOCLAW_HOST_GATEWAY_IP override wins (that is what
+ * "override" means); otherwise we extract the bridge100 (or bridge0) IPv4 in the
+ * host-only 192.168.64.0/24 subnet; if neither is present, the conventional .1.
  * Uses `||` (not `??`) so an unset override — which config.ts normalises to the
- * empty string, NOT null — still falls through to the .1 literal default.
+ * empty string, NOT null — is skipped rather than winning as a falsy value.
  */
 export function detectHostGateway(): string {
   const ni = os.networkInterfaces();
   const ifaces = ni['bridge100'] ?? ni['bridge0'] ?? [];
   const addr = ifaces.find((a) => a.family === 'IPv4' && a.address.startsWith('192.168.64.'))?.address;
-  return addr || NANOCLAW_HOST_GATEWAY_IP || '192.168.64.1';
+  return NANOCLAW_HOST_GATEWAY_IP || addr || '192.168.64.1';
 }
 
 /**

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -1,31 +1,70 @@
 /**
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
+ *
+ * Runtime is ENV-gated via CONTAINER_RUNTIME (docker | container). Apple Container
+ * ('container') reaches the host via the bridge gateway (192.168.64.x); Docker uses
+ * the built-in host.docker.internal.
  */
 import { execSync } from 'child_process';
 import os from 'os';
 
-import { CONTAINER_INSTALL_LABEL } from './config.js';
+import { CONTAINER_RUNTIME, CONTAINER_INSTALL_LABEL, INSTALL_SLUG, NANOCLAW_HOST_GATEWAY_IP } from './config.js';
 import { log } from './log.js';
 
-/** The container runtime binary name. */
-export const CONTAINER_RUNTIME_BIN = 'docker';
+/** The container runtime binary name ('docker' | 'container'). */
+export const CONTAINER_RUNTIME_BIN = CONTAINER_RUNTIME;
+export const IS_APPLE_CONTAINER = CONTAINER_RUNTIME_BIN === 'container';
+
+/**
+ * Bridge gateway IP that Apple Container VMs use to reach the host.
+ * bridge100 is vmnet-managed (192.168.64.x); the host is at the gateway (.1).
+ * We extract the bridge100 (or bridge0) IPv4 in the host-only 192.168.64.0/24
+ * subnet; if none is found the env override then the conventional .1 win.
+ * Uses `||` (not `??`) so an unset override — which config.ts normalises to the
+ * empty string, NOT null — still falls through to the .1 literal default.
+ */
+export function detectHostGateway(): string {
+  const ni = os.networkInterfaces();
+  const ifaces = ni['bridge100'] ?? ni['bridge0'] ?? [];
+  const addr = ifaces.find((a) => a.family === 'IPv4' && a.address.startsWith('192.168.64.'))?.address;
+  return addr || NANOCLAW_HOST_GATEWAY_IP || '192.168.64.1';
+}
+
+/**
+ * Address containers use to reach the host, resolved LAZILY at call time.
+ * Docker has built-in host.docker.internal; Apple Container has none, so we
+ * resolve to the bridge gateway IP — and crucially do so AFTER the runtime has
+ * brought bridge100 up (callers run at spawn time), never as a frozen
+ * import-time constant that would capture an empty value on a cold boot.
+ */
+export function getHostGateway(): string {
+  return IS_APPLE_CONTAINER ? detectHostGateway() : 'host.docker.internal';
+}
+if (IS_APPLE_CONTAINER) {
+  // Resolve the gateway lazily per spawn (the bridge may not be up yet at import),
+  // so log only the override here — never an eager import-time detection.
+  log.info('Apple Container runtime selected', { hostGatewayOverride: NANOCLAW_HOST_GATEWAY_IP || '(autodetect)' });
+}
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
-  if (os.platform() === 'linux') {
+  // Docker on Linux needs an explicit host.docker.internal mapping; macOS Docker
+  // Desktop and Apple Container do not (Apple resolution is handled by rewriting
+  // host.docker.internal literals in injected env values, not --add-host, which
+  // Apple Container's `run` does not support).
+  if (!IS_APPLE_CONTAINER && os.platform() === 'linux') {
     return ['--add-host=host.docker.internal:host-gateway'];
   }
   return [];
 }
 
-/** Returns CLI args for a readonly bind mount. */
+/** Returns CLI args for a readonly bind mount. `-v src:dst:ro` works on both runtimes. */
 export function readonlyMountArgs(hostPath: string, containerPath: string): string[] {
   return ['-v', `${hostPath}:${containerPath}:ro`];
 }
 
-/** Stop a container by name. Uses execFileSync to avoid shell injection. */
+/** Stop a container by name. Both runtimes support `stop -t 1` (SIGTERM grace window). */
 export function stopContainer(name: string): void {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name)) {
     throw new Error(`Invalid container name: ${name}`);
@@ -33,27 +72,78 @@ export function stopContainer(name: string): void {
   execSync(`${CONTAINER_RUNTIME_BIN} stop -t 1 ${name}`, { stdio: 'pipe' });
 }
 
+function fatalBanner(lines: string[]): void {
+  const W = 64;
+  console.error('\n╔' + '═'.repeat(W) + '╗');
+  for (const l of lines) console.error('║  ' + l.padEnd(W - 3) + '║');
+  console.error('╚' + '═'.repeat(W) + '╝\n');
+}
+
 /** Ensure the container runtime is running, starting it if needed. */
 export function ensureContainerRuntimeRunning(): void {
+  if (IS_APPLE_CONTAINER) {
+    try {
+      execSync(`${CONTAINER_RUNTIME_BIN} system status`, { stdio: 'pipe', timeout: 10000 });
+      log.debug('Apple Container runtime already running');
+    } catch {
+      log.info('Starting Apple Container runtime...');
+      try {
+        execSync(`${CONTAINER_RUNTIME_BIN} system start`, { stdio: 'pipe', timeout: 30000 });
+        log.info('Apple Container runtime started');
+      } catch (err) {
+        log.error('Failed to start Apple Container runtime', { err });
+        fatalBanner([
+          'FATAL: Apple Container runtime failed to start',
+          '',
+          '1. Ensure Apple Container is installed (brew install container)',
+          '2. Run: container system start',
+          '3. Restart NanoClaw',
+        ]);
+        throw new Error('Container runtime is required but failed to start', { cause: err });
+      }
+    }
+    // Bring the builder (and bridge100 / 192.168.64.1) up before the OneCLI forwarder binds.
+    try {
+      execSync(`${CONTAINER_RUNTIME_BIN} builder status`, { stdio: 'pipe', timeout: 10000 });
+    } catch {
+      try {
+        execSync(`${CONTAINER_RUNTIME_BIN} builder start`, { stdio: 'pipe', timeout: 30000 });
+        log.info('Apple Container builder started (bridge network up)');
+      } catch (err) {
+        log.warn('Apple Container builder start failed — bridge100 may not be up yet', { err });
+      }
+    }
+    return;
+  }
+
+  // Docker
   try {
-    execSync(`${CONTAINER_RUNTIME_BIN} info`, {
-      stdio: 'pipe',
-      timeout: 10000,
-    });
+    execSync(`${CONTAINER_RUNTIME_BIN} info`, { stdio: 'pipe', timeout: 10000 });
     log.debug('Container runtime already running');
   } catch (err) {
     log.error('Failed to reach container runtime', { err });
-    console.error('\n╔════════════════════════════════════════════════════════════════╗');
-    console.error('║  FATAL: Container runtime failed to start                      ║');
-    console.error('║                                                                ║');
-    console.error('║  Agents cannot run without a container runtime. To fix:        ║');
-    console.error('║  1. Ensure Docker is installed and running                     ║');
-    console.error('║  2. Run: docker info                                           ║');
-    console.error('║  3. Restart NanoClaw                                           ║');
-    console.error('╚════════════════════════════════════════════════════════════════╝\n');
-    throw new Error('Container runtime is required but failed to start', {
-      cause: err,
-    });
+    fatalBanner([
+      'FATAL: Container runtime failed to start',
+      '',
+      'Agents cannot run without a container runtime. To fix:',
+      '1. Ensure Docker is installed and running',
+      '2. Run: docker info',
+      '3. Restart NanoClaw',
+    ]);
+    throw new Error('Container runtime is required but failed to start', { cause: err });
+  }
+}
+
+function stopOrphans(orphans: string[]): void {
+  for (const name of orphans) {
+    try {
+      stopContainer(name);
+    } catch {
+      /* already stopped */
+    }
+  }
+  if (orphans.length > 0) {
+    log.info('Stopped orphaned containers', { count: orphans.length, names: orphans });
   }
 }
 
@@ -61,11 +151,29 @@ export function ensureContainerRuntimeRunning(): void {
  * Kill orphaned NanoClaw containers from THIS install's previous runs.
  *
  * Scoped by label `nanoclaw-install=<slug>` so a crash-looping peer install
- * cannot reap our containers, and we cannot reap theirs. The label is
- * stamped onto every container at spawn time — see container-runner.ts.
+ * cannot reap our containers, and we cannot reap theirs. Apple Container's
+ * `ls --format json` exposes labels at `configuration.labels` and state at
+ * `status.state`, so the slug-scoping is preserved under both runtimes.
  */
 export function cleanupOrphans(): void {
   try {
+    if (IS_APPLE_CONTAINER) {
+      const output = execSync(`${CONTAINER_RUNTIME_BIN} ls --all --format json`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      });
+      const containers: {
+        id: string;
+        status?: { state?: string };
+        configuration?: { labels?: Record<string, string> };
+      }[] = JSON.parse(output || '[]');
+      const orphans = containers
+        .filter((c) => c.status?.state === 'running' && c.configuration?.labels?.['nanoclaw-install'] === INSTALL_SLUG)
+        .map((c) => c.id);
+      stopOrphans(orphans);
+      return;
+    }
+
     const output = execSync(
       `${CONTAINER_RUNTIME_BIN} ps --filter label=${CONTAINER_INSTALL_LABEL} --format '{{.Names}}'`,
       {
@@ -73,17 +181,7 @@ export function cleanupOrphans(): void {
         encoding: 'utf-8',
       },
     );
-    const orphans = output.trim().split('\n').filter(Boolean);
-    for (const name of orphans) {
-      try {
-        stopContainer(name);
-      } catch {
-        /* already stopped */
-      }
-    }
-    if (orphans.length > 0) {
-      log.info('Stopped orphaned containers', { count: orphans.length, names: orphans });
-    }
+    stopOrphans(output.trim().split('\n').filter(Boolean));
   } catch (err) {
     log.warn('Failed to clean up orphaned containers', { err });
   }

--- a/src/egress-lockdown.ts
+++ b/src/egress-lockdown.ts
@@ -9,15 +9,16 @@
  */
 import { execFileSync } from 'child_process';
 
-import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
+import { CONTAINER_RUNTIME_BIN, IS_APPLE_CONTAINER } from './container-runtime.js';
+import { EGRESS_LOCKDOWN } from './config.js';
 import { log } from './log.js';
 
 /** Locked-down, no-internet network agents are placed on. */
 export const EGRESS_NETWORK = process.env.NANOCLAW_EGRESS_NETWORK || 'nanoclaw-egress';
 /** The OneCLI gateway container attached as the only egress hop. */
 const ONECLI_GATEWAY_CONTAINER = process.env.ONECLI_GATEWAY_CONTAINER || 'onecli';
-/** Off by default; set NANOCLAW_EGRESS_LOCKDOWN=true to opt in. */
-const EGRESS_LOCKDOWN = process.env.NANOCLAW_EGRESS_LOCKDOWN === 'true';
+// EGRESS_LOCKDOWN is centralized in config.ts (read via readEnvFile so it is
+// honored under launchd/systemd, where .env is never loaded into process.env).
 
 /** Raised when lockdown is requested but can't be established. */
 export class EgressLockdownError extends Error {
@@ -63,6 +64,12 @@ function gatewayAttached(): boolean {
  */
 export function ensureEgressNetwork(): boolean {
   if (!EGRESS_LOCKDOWN) return false;
+
+  // Egress lockdown is built on Docker `network --internal` primitives Apple
+  // Container does not expose. Fail fast rather than spawn with open egress.
+  if (IS_APPLE_CONTAINER) {
+    throw new EgressLockdownError('the runtime is Apple Container, which has no Docker bridge networking');
+  }
 
   if (
     !dockerOk(['network', 'inspect', EGRESS_NETWORK]) &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { backfillContainerConfigs } from './backfill-container-configs.js';
@@ -12,7 +14,8 @@ import { enforceStartupBackoff, resetCircuitBreaker } from './circuit-breaker.js
 import { migrateGroupsToClaudeLocal } from './claude-md-compose.js';
 import { initDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
-import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
+import { ensureContainerRuntimeRunning, cleanupOrphans, IS_APPLE_CONTAINER } from './container-runtime.js';
+import { startOneCliForwarder, stopOneCliForwarder } from './onecli-forwarder.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
@@ -71,6 +74,25 @@ import {
 async function main(): Promise<void> {
   log.info('NanoClaw starting');
 
+  // Apple Container only shares mount sources under the operator's home dir, and
+  // the OneCLI SDK writes its CA cert / credential stubs to os.tmpdir(). Pin
+  // TMPDIR under HOME and assert the install lives under HOME — failing fast
+  // rather than spawning containers with silently-missing mounts.
+  if (IS_APPLE_CONTAINER) {
+    const home = process.env.HOME || os.homedir();
+    const root = process.cwd();
+    if (root !== home && !root.startsWith(home + path.sep)) {
+      throw new Error(
+        `Apple Container requires the install to live under your home directory (${home}); it is at ${root}. ` +
+          `Bind mounts from outside HOME silently fail under Apple Container.`,
+      );
+    }
+    const tmpd = path.join(home, '.config', 'nanoclaw', 'tmp');
+    fs.mkdirSync(tmpd, { recursive: true });
+    process.env.TMPDIR = tmpd;
+    log.info('Apple Container: TMPDIR pinned under HOME', { tmpd });
+  }
+
   // 0. Circuit breaker — backoff on rapid restarts
   await enforceStartupBackoff();
 
@@ -94,6 +116,13 @@ async function main(): Promise<void> {
   // 2. Container runtime
   ensureContainerRuntimeRunning();
   cleanupOrphans();
+
+  // 2.5 OneCLI bridge forwarder (Apple Container only; no-op under Docker).
+  // Must listen before any container spawns; runs after the runtime is up
+  // (builder start brought bridge100 up). Throws/aborts startup if the OneCLI
+  // gateway is unreachable on loopback or its control API is exposed off-loopback.
+  await startOneCliForwarder();
+  onShutdown(() => stopOneCliForwarder());
 
   // 3. Channel adapters
   await initChannelAdapters((adapter: ChannelAdapter): ChannelSetup => {

--- a/src/onecli-forwarder.ts
+++ b/src/onecli-forwarder.ts
@@ -1,0 +1,133 @@
+/**
+ * Host-side TCP relay so an Apple Container agent on the 192.168.64.0/24 bridge
+ * can reach the OneCLI gateway, which runs INSIDE Docker Desktop and publishes
+ * 10255 only on 127.0.0.1. Binds the bridge gateway IP:10255 and pipes each
+ * connection to 127.0.0.1:10255. No-op under Docker.
+ *
+ * Security invariants (do NOT relax):
+ *  - Binds ONLY the host-only RFC1918 bridge gateway IP — NEVER 0.0.0.0. The
+ *    relayed port injects vault credentials; exposing it on a routable LAN NIC
+ *    is unacceptable. If the bridge IP isn't bindable yet, retry — never widen.
+ *  - Rejects any connection whose remote address is not in 192.168.64.0/24
+ *    (defense-in-depth even if the OS ever routes one in).
+ *  - Refuses to start unless 127.0.0.1:10255 is reachable (Docker Desktop hosts
+ *    the OneCLI gateway) AND the unauthenticated control API on 10254 is NOT
+ *    reachable off-loopback (10254 freely serves the proxy credential, so
+ *    "10254 loopback-only" — not the proxy's basic-auth — is the real boundary).
+ */
+import net from 'net';
+
+import { IS_APPLE_CONTAINER, detectHostGateway } from './container-runtime.js';
+import { ONECLI_FORWARD_BIND, ONECLI_REMOTE_HOST } from './config.js';
+import { log } from './log.js';
+
+const PROXY_PORT = 10255;
+const CONTROL_PORT = 10254;
+const TARGET = '127.0.0.1';
+
+let server: net.Server | null = null;
+let retryTimer: NodeJS.Timeout | null = null;
+let stopped = false;
+
+export function inBridgeSubnet(ip?: string): boolean {
+  if (!ip) return false;
+  return ip.replace(/^::ffff:/, '').startsWith('192.168.64.');
+}
+
+function probe(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const s = net.connect({ host, port });
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      s.destroy();
+      resolve(ok);
+    };
+    s.once('connect', () => finish(true));
+    s.once('error', () => finish(false));
+    setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+/**
+ * Start the OneCLI forwarder. No-op under Docker. Throws (aborting host startup)
+ * if the OneCLI gateway is unreachable or the control API is exposed off-loopback.
+ */
+export async function startOneCliForwarder(): Promise<void> {
+  if (!IS_APPLE_CONTAINER) return;
+
+  // The forwarder bridges a LOCAL OneCLI (gateway on 127.0.0.1) to the Apple
+  // Container bridge. A REMOTE OneCLI (ONECLI_URL points off-host) is reached
+  // directly over the LAN — no forwarder; the injected gateway host is retargeted
+  // to ONECLI_REMOTE_HOST in container-runner instead.
+  if (ONECLI_REMOTE_HOST) {
+    log.info('OneCLI is remote — skipping local forwarder', { onecliHost: ONECLI_REMOTE_HOST });
+    return;
+  }
+  stopped = false;
+
+  const bind = ONECLI_FORWARD_BIND || detectHostGateway();
+  if (!bind.startsWith('192.168.64.')) {
+    throw new Error(`OneCLI forwarder refuses to bind non-bridge address ${bind}`);
+  }
+
+  // Precondition 1: OneCLI gateway must be reachable on loopback (Docker Desktop running).
+  if (!(await probe(TARGET, PROXY_PORT, 3000))) {
+    throw new Error(
+      `OneCLI gateway not reachable on ${TARGET}:${PROXY_PORT} — Docker Desktop must be running to host the OneCLI gateway, even under Apple Container`,
+    );
+  }
+  // Precondition 2: the unauthenticated control API must NOT be reachable off-loopback.
+  if (await probe(bind, CONTROL_PORT, 2000)) {
+    throw new Error(
+      `OneCLI control API ${CONTROL_PORT} is reachable on ${bind} — refusing to start. The unauthenticated control API must stay loopback-only (it serves the proxy credential).`,
+    );
+  }
+
+  server = net.createServer((c) => {
+    if (!inBridgeSubnet(c.remoteAddress)) {
+      log.warn('OneCLI forwarder rejected off-bridge client', { remote: c.remoteAddress });
+      c.destroy();
+      return;
+    }
+    const up = net.connect(PROXY_PORT, TARGET);
+    c.pipe(up);
+    up.pipe(c);
+    const swallow = (e: NodeJS.ErrnoException) => {
+      if (e && e.code !== 'ECONNRESET') log.debug('OneCLI forwarder conn error', { err: e });
+      c.destroy();
+      up.destroy();
+    };
+    c.on('error', swallow);
+    up.on('error', swallow);
+  });
+
+  server.on('error', (e: NodeJS.ErrnoException) => {
+    if (stopped) return;
+    if (e.code === 'EADDRNOTAVAIL') {
+      // bridge100 IP not up yet — retry the SAME server on the bridge IP. Never
+      // widen to 0.0.0.0 (that would publish vault credentials on the LAN).
+      log.warn('OneCLI forwarder: bridge IP not up yet, retrying in 3s', { bind });
+      retryTimer = setTimeout(() => {
+        if (!stopped && server) server.listen(PROXY_PORT, bind);
+      }, 3000);
+    } else {
+      log.error('OneCLI forwarder listen error (refusing 0.0.0.0 fallback)', { err: e, bind });
+    }
+  });
+
+  server.listen(PROXY_PORT, bind, () =>
+    log.info('OneCLI forwarder listening', { bind, port: PROXY_PORT, target: `${TARGET}:${PROXY_PORT}` }),
+  );
+}
+
+export function stopOneCliForwarder(): void {
+  stopped = true;
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+  server?.close();
+  server = null;
+}


### PR DESCRIPTION
## What

Adds an env-gated `CONTAINER_RUNTIME` (`docker` default | `container` = Apple Container, macOS) and first-class support for pointing NanoClaw at a **remote OneCLI gateway**.

`CONTAINER_RUNTIME=docker` is the default and is byte-identical to today's behavior — existing installs are unaffected (the new code paths are all gated behind `IS_APPLE_CONTAINER` / a non-loopback `ONECLI_URL`).

### Apple Container (macOS)
- `container-runtime.ts`: runtime-binary switch, bridge100 host-gateway autodetect (192.168.64.0/24), `ls --format json` orphan cleanup scoped by install label, `system` + `builder` start.
- No `--add-host` under Apple Container, so the `host.docker.internal` literal OneCLI bakes into its injected proxy env is rewritten to the bridge gateway IP (value-driven, on `-e` values only; mount args untouched). The gateway is resolved lazily at spawn time, after the bridge is up.
- `onecli-forwarder.ts`: host-side TCP relay (bridge IP:10255 → 127.0.0.1) so the VM can reach a **local** OneCLI gateway in Docker Desktop. Binds the host-only bridge IP only — never 0.0.0.0 — rejects off-bridge clients, and refuses to start if the unauthenticated control API is reachable off-loopback.
- `index.ts`: asserts the install lives under `$HOME` and pins `TMPDIR` there (Apple Container only shares mount sources under HOME — fail fast instead of spawning with silently-missing mounts).
- Egress lockdown is hard-gated off (Apple Container has no Docker bridge network).

### Remote OneCLI gateway (works under either runtime)
- A non-loopback `ONECLI_URL` skips the local forwarder; the agent reaches the remote gateway over the LAN.
- The proxy host OneCLI injects (the literal `host.docker.internal`, which assumes a Docker-Desktop-local agent) is retargeted to the remote gateway's host, **derived automatically from `ONECLI_URL`** — so remote OneCLI usually needs only `ONECLI_URL` set.
- `ONECLI_GATEWAY_REWRITE="from=to"` is an explicit override for when the gateway is reachable at a different address than the control API host (e.g. a Tailscale IP); validated eagerly so a malformed value fails fast.

`setup/service.ts` emits `CONTAINER_RUNTIME` into the launchd/systemd service env so the runtime flip survives a service reload. `.env.example` documents every knob and the security model (the proxy port carries vault credentials — keep it off the open LAN).

## Why

Lets a macOS host run agent containers on Apple's lightweight `container` runtime, and — paired with a remote OneCLI gateway on another host — drop Docker Desktop entirely for a meaningful RAM saving, while keeping the default Docker path unchanged.

## Testing

- New `src/apple-container.test.ts`: host-gateway fallback (regression guard for the empty-string env default), bridge-subnet guard, and remote-host derivation including the bracketed IPv6 loopback `[::1]` case.
- Full host test suite green; `tsc` clean; Prettier clean.
- Verified end-to-end on a Mac mini: Apple Container runtime + a remote OneCLI gateway on another LAN host — agent containers spawned, vault credentials injected via the remote gateway, real Claude responses received, with Docker Desktop fully down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
