### PR TITLE
refactor: mirror .claude skills + CLAUDE.md into .agents via symlinks

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## What

Keep `.claude` as the single source of truth and make the agents-convention paths symlinks to it:

- `.agents/skills` → `../.claude/skills`
- `AGENTS.md` → `CLAUDE.md`

## Why

Lets an agents-convention harness (e.g. Codex) read the same skills and instructions as the `.claude` setup — no duplication, no separate source-of-truth directory. New skills under `.claude/skills` appear in `.agents/skills` automatically.

`.gitignore` ignores `.agents`/`AGENTS.md`; the symlinks are committed regardless (tracked files aren't subject to gitignore). Can update the ignore rules if preferred.
