### PR TITLE
fix(setup): allow env-selected agent provider

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -12,6 +12,8 @@
  *   NANOCLAW_AGENT_NAME    messaging-channel agent name (consumed by the
  *                          channel flow). The CLI scratch agent is always
  *                          "Terminal Agent".
+ *   NANOCLAW_AGENT_PROVIDER preselect the setup provider and skip the picker
+ *                          (for packaged flows). Example: claude.
  *   NANOCLAW_SKIP          comma-separated step names to skip
  *                          (environment|container|onecli|auth|mounts|
  *                           service|cli-agent|timezone|channel|
@@ -816,6 +818,15 @@ async function askAgentProviderChoice(): Promise<string> {
     ...installed.map(({ value, label, hint }) => ({ value, label, hint })),
     ...available.map((prov) => ({ value: prov.value, label: prov.label, hint: `${prov.hint} — installs now` })),
   ];
+  const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
+  if (preset) {
+    if (!options.some((option) => option.value === preset)) {
+      throw new Error(`NANOCLAW_AGENT_PROVIDER=${preset} is not available in this NanoClaw install`);
+    }
+    setupLog.userInput('agent_provider', preset);
+    phEmit('agent_provider_chosen', { provider: preset, preset: true });
+    return preset;
+  }
   // The pick installs and authenticates a runtime — it is not an
   // install-wide default, so re-runs safely Enter-through on claude (its
   // auth flow short-circuits when the secret already exists).

--- a/setup/lib/setup-config.ts
+++ b/setup/lib/setup-config.ts
@@ -124,6 +124,14 @@ export const CONFIG: Entry[] = [
     type: 'string',
   },
   {
+    key: 'agentProvider',
+    envVar: 'NANOCLAW_AGENT_PROVIDER',
+    label: 'Agent provider',
+    help: 'Preselect the setup provider and skip the provider picker.',
+    surface: 'flag',
+    type: 'string',
+  },
+  {
     key: 'assistMode',
     envVar: 'NANOCLAW_SETUP_ASSIST_MODE',
     label: 'Assist mode',

--- a/setup/providers/registry.test.ts
+++ b/setup/providers/registry.test.ts
@@ -32,8 +32,15 @@ describe('setup flow consumes the registry (structural)', () => {
     const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'auto.ts'), 'utf-8');
     expect(src).toContain('listSetupProviders()');
     expect(src).toContain("import './providers/index.js'");
+    expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
     // The capability-keyed branch — a provider's own auth runs iff it declares one.
     expect(src).toMatch(/providerEntry\?\.runAuth/);
+  });
+
+  it('the provider preset is exposed as an env setup knob', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'setup', 'lib', 'setup-config.ts'), 'utf-8');
+    expect(src).toContain('NANOCLAW_AGENT_PROVIDER');
+    expect(src).toContain("key: 'agentProvider'");
   });
 
   it('the standalone provider-auth step is reachable from the STEPS map', () => {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

What: Adds `NANOCLAW_AGENT_PROVIDER` as an env-only setup knob so packaged setup flows can preselect an agent provider and skip the provider picker.

Why: Docker Sandbox and other packaged flows may need to keep the standard auth path while avoiding an interactive provider choice.

How it works: `setup:auto` validates the env value against the same provider options shown by the picker, records the selected provider, and then continues through the existing provider auth flow.

Usage: `NANOCLAW_AGENT_PROVIDER=claude pnpm run setup:auto`.

Tested:
- `pnpm run typecheck`
- `pnpm exec vitest run setup/providers/registry.test.ts setup/provider-contract.test.ts`
- Smoke checked invalid `NANOCLAW_AGENT_PROVIDER` exits before showing the picker
