### PR TITLE
fix(discord): chunk replies over 2000 chars instead of truncating

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for the Discord adapter's `maxTextLength` wiring.
+ *
+ * Discord hard-caps a message at 2000 chars; `@chat-adapter/discord` silently
+ * truncates anything longer with an ellipsis. The Chat SDK bridge only engages
+ * its `splitForLimit` chunker when the channel passes `maxTextLength`, so
+ * discord.ts must hand that value into `createChatSdkBridge` — drop the line and
+ * long replies regress to being truncated with no error.
+ *
+ * discord-registration.test.ts imports the real barrel to prove the channel
+ * registers. This test instead needs to observe the *config* the factory builds,
+ * so it stubs the factory's collaborators and captures the `createChatSdkBridge`
+ * argument. The bridge/adapter are constructed only inside the factory (never at
+ * import), so invoking it here is side-effect free.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { ChannelRegistration } from './adapter.js';
+import type { ChatSdkBridgeConfig } from './chat-sdk-bridge.js';
+
+const createDiscordAdapter = vi.fn(() => ({ name: 'discord-adapter' }));
+const createChatSdkBridge = vi.fn((config: ChatSdkBridgeConfig) => ({ config }));
+const registerChannelAdapter = vi.fn();
+const readEnvFile = vi.fn(() => ({
+  DISCORD_BOT_TOKEN: 'bot-token',
+  DISCORD_PUBLIC_KEY: 'public-key',
+  DISCORD_APPLICATION_ID: 'app-id',
+}));
+
+vi.mock('@chat-adapter/discord', () => ({ createDiscordAdapter }));
+vi.mock('../env.js', () => ({ readEnvFile }));
+vi.mock('./chat-sdk-bridge.js', () => ({ createChatSdkBridge }));
+vi.mock('./channel-registry.js', () => ({ registerChannelAdapter }));
+
+describe('discord adapter maxTextLength', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes maxTextLength: 2000 to createChatSdkBridge so long replies chunk instead of truncating', async () => {
+    await import('./discord.js'); // self-registers the factory on import
+
+    const registration = registerChannelAdapter.mock.calls.find(([name]) => name === 'discord')?.[1] as
+      | ChannelRegistration
+      | undefined;
+    expect(registration?.factory).toBeTypeOf('function');
+
+    registration!.factory();
+
+    expect(createChatSdkBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ supportsThreads: true, maxTextLength: 2000 }),
+    );
+  });
+});

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -33,6 +33,11 @@ registerChannelAdapter('discord', {
       botToken: env.DISCORD_BOT_TOKEN,
       extractReplyContext,
       supportsThreads: true,
+      // Discord hard-caps a message at 2000 chars. Without a limit set here,
+      // @chat-adapter/discord silently truncates longer replies with an
+      // ellipsis. Setting maxTextLength engages the bridge's splitForLimit,
+      // which chunks long replies across multiple messages instead.
+      maxTextLength: 2000,
     });
   },
 });


### PR DESCRIPTION
## What

The Chat SDK bridge ships a `splitForLimit` chunker (`src/channels/chat-sdk-bridge.ts`) that splits a reply longer than `maxTextLength` across multiple platform messages. It only runs when the adapter passes `maxTextLength` into `createChatSdkBridge`. The Discord adapter never set it, so any reply over Discord's 2000-char hard cap was silently truncated with an ellipsis by `@chat-adapter/discord` instead of being chunked.

This sets `maxTextLength: 2000` on the Discord adapter so long replies chunk across multiple messages.

## Why

Whenever an agent emits a single reply over 2000 chars, the message is cut off mid-sentence with `…` and the remainder is lost — no error, no log. It shows up more often with more verbose models that tend to write longer single messages. Observed in production.

## Note — same omission in other adapters

Several other adapters call `createChatSdkBridge` without `maxTextLength` and have the same latent truncation: `gchat`, `github`, `imessage`, `linear`, `matrix`, `resend`, `slack`, `teams`, `webex`, `whatsapp-cloud`. Only `discord` (after this PR) and `telegram` set it.

I scoped this PR to Discord — the confirmed, production-verified case — rather than guess each platform's character limit. Flagging it here in case you'd like to extend the fix across the fleet.

## Testing

Verified across three production installs: with `maxTextLength` set, `splitForLimit` engages and replies over the cap arrive as multiple messages instead of one truncated message. No behavior change for replies under the cap.
