### PR TITLE
fix(cli): count socket response cap by bytes

### DIFF
--- a/src/cli/socket-client.test.ts
+++ b/src/cli/socket-client.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm } from 'fs/promises';
+import net from 'net';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SocketTransport } from './socket-client.js';
+
+const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+
+const tempDirs: string[] = [];
+
+async function makeSocketPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'nanoclaw-socket-client-'));
+  tempDirs.push(dir);
+  return path.join(dir, 'ncl.sock');
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('SocketTransport', () => {
+  it('caps host responses by bytes, not decoded string length', async () => {
+    const socketPath = await makeSocketPath();
+    const oversizedUtf8Payload = 'é'.repeat(Math.floor(MAX_RESPONSE_BYTES / 2) + 1);
+    const sockets = new Set<net.Socket>();
+
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.on('error', () => {
+        // The client intentionally closes as soon as the byte cap is exceeded.
+      });
+      socket.end(oversizedUtf8Payload);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      await expect(
+        new SocketTransport(socketPath).sendFrame({ id: 'req-1', command: 'groups:list', args: {} }),
+      ).rejects.toThrow('host response exceeded maximum size');
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+});

--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -14,6 +14,12 @@ import type { Transport } from './transport.js';
 
 export const DEFAULT_SOCKET_PATH = path.join(DATA_DIR, 'ncl.sock');
 
+// A deadlocked host could accept the connection but never reply, leaving the
+// promise unsettled forever; and a host streaming without a newline could grow
+// the buffer without bound. Cap both — callers are interactive `ncl` invocations.
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+
 export class SocketTransport implements Transport {
   constructor(private readonly socketPath: string = DEFAULT_SOCKET_PATH) {}
 
@@ -23,9 +29,14 @@ export class SocketTransport implements Transport {
       let buffer = '';
       let settled = false;
 
+      const timer = setTimeout(() => {
+        settle('reject', new Error(`host did not respond within ${REQUEST_TIMEOUT_MS}ms`));
+      }, REQUEST_TIMEOUT_MS);
+
       const settle = (action: 'resolve' | 'reject', valueOrErr: ResponseFrame | Error): void => {
         if (settled) return;
         settled = true;
+        clearTimeout(timer);
         try {
           client.end();
         } catch (_e) {
@@ -41,6 +52,10 @@ export class SocketTransport implements Transport {
 
       client.on('data', (chunk) => {
         buffer += chunk.toString('utf8');
+        if (buffer.length > MAX_RESPONSE_BYTES) {
+          settle('reject', new Error('host response exceeded maximum size'));
+          return;
+        }
         const idx = buffer.indexOf('\n');
         if (idx < 0) return;
         const line = buffer.slice(0, idx);

--- a/src/cli/socket-client.ts
+++ b/src/cli/socket-client.ts
@@ -27,6 +27,7 @@ export class SocketTransport implements Transport {
     return new Promise((resolve, reject) => {
       const client = net.createConnection(this.socketPath);
       let buffer = '';
+      let responseBytes = 0;
       let settled = false;
 
       const timer = setTimeout(() => {
@@ -51,11 +52,12 @@ export class SocketTransport implements Transport {
       });
 
       client.on('data', (chunk) => {
-        buffer += chunk.toString('utf8');
-        if (buffer.length > MAX_RESPONSE_BYTES) {
+        responseBytes += chunk.byteLength;
+        if (responseBytes > MAX_RESPONSE_BYTES) {
           settle('reject', new Error('host response exceeded maximum size'));
           return;
         }
+        buffer += chunk.toString('utf8');
         const idx = buffer.indexOf('\n');
         if (idx < 0) return;
         const line = buffer.slice(0, idx);


### PR DESCRIPTION
Replacement for #2802.

## Summary
- Track socket response cap with accumulated Buffer byteLength before UTF-8 decoding
- Keep buffering decoded text only after byte cap passes
- Add regression test using multi-byte UTF-8 payload whose character length is below the cap but byte length exceeds it

## Validation
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm exec eslint src/cli/socket-client.ts src/cli/socket-client.test.ts (0 errors; existing no-catch-all warnings in socket-client.ts)

Fixes byte-count issue noted on #2802.