### PR TITLE
fix(security): validate group folders in CLI create

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -69,6 +69,8 @@ export interface ResourceDef {
   };
   /** Non-standard verbs (grant, revoke, add, remove, restart, etc.). */
   customOperations?: Record<string, CustomOperation>;
+  /** Optional pre-insert validation for generic create. Throw to reject. */
+  validateCreate?: (values: Record<string, unknown>) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -152,6 +154,8 @@ function genericCreate(def: ResourceDef) {
         values[col.name] = col.default;
       }
     }
+
+    def.validateCreate?.(values);
 
     const colNames = Object.keys(values);
     const placeholders = colNames.map((c) => `@${c}`);

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -61,6 +61,28 @@ describe('groups CLI delete cascades dependent rows (#2525)', () => {
     if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
   });
 
+  it('rejects path-traversal folders on create', async () => {
+    const resp = await dispatch(
+      { id: 'req-create-bad-folder', command: 'groups-create', args: { name: 'bad', folder: '../../etc' } },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(false);
+    expect((resp as { ok: false; error: { code: string; message: string } }).error.code).toBe('handler-error');
+    expect((resp as { ok: false; error: { message: string } }).error.message).toMatch(/invalid group folder/i);
+    expect(count('SELECT COUNT(*) AS c FROM agent_groups')).toBe(0);
+  });
+
+  it('accepts valid folders on create', async () => {
+    const resp = await dispatch(
+      { id: 'req-create-good-folder', command: 'groups-create', args: { name: 'good', folder: 'good-group' } },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(true);
+    expect(count('SELECT COUNT(*) AS c FROM agent_groups WHERE folder = ?', 'good-group')).toBe(1);
+  });
+
   it('deletes a group with sessions, destinations, approvals, members, roles, and wirings', async () => {
     const GID = 'ag-victim';
     const SID = 'sess-victim-1';

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -3,6 +3,7 @@ import { buildAgentGroupImage, killContainer, wakeContainer } from '../../contai
 import { restartAgentGroupContainers } from '../../container-restart.js';
 import { getDb, hasTable } from '../../db/connection.js';
 import { getSession } from '../../db/sessions.js';
+import { assertValidGroupFolder } from '../../group-folder.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import {
   getContainerConfig,
@@ -61,6 +62,7 @@ registerResource({
   // `delete` is intentionally not in `operations` — the generic single-table
   // DELETE violates FK constraints (see #2525). The cascading handler is
   // provided as `customOperations.delete` below.
+  validateCreate: (values) => assertValidGroupFolder(String(values.folder ?? '')),
   operations: { list: 'open', get: 'open', create: 'approval', update: 'approval' },
   customOperations: {
     delete: {


### PR DESCRIPTION
Replaces/backs #2800 with focused regression tests.\n\n## Summary\n- adds a generic create validation hook\n- enforces existing assertValidGroupFolder for ncl groups create\n- covers traversal rejection and valid create behavior\n\n## Tests\n- pnpm exec vitest run src/cli/resources/groups.test.ts src/group-folder.test.ts\n- pnpm exec tsc --noEmit