### PR TITLE
fix(router): guard safeParseContent against primitive JSON

### DIFF
--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -426,6 +426,34 @@ describe('router', () => {
     expect(wakeContainer).toHaveBeenCalled();
   });
 
+  it('treats primitive JSON message content as raw text for engage matching', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { wakeContainer } = await import('./container-runner.js');
+    (wakeContainer as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'chan-123',
+      threadId: null,
+      message: {
+        id: 'msg-primitive-json',
+        kind: 'chat',
+        content: JSON.stringify('hello from a primitive'),
+        timestamp: now(),
+      },
+    });
+
+    const session = findSession('mg-1', null);
+    expect(session).toBeDefined();
+    expect(wakeContainer).toHaveBeenCalledTimes(1);
+
+    const db = new Database(inboundDbPath('ag-1', session!.id));
+    const rows = db.prepare('SELECT id, content FROM messages_in').all() as Array<{ id: string; content: string }>;
+    db.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe(JSON.stringify('hello from a primitive'));
+  });
+
   it('auto-creates messaging group only when the bot is addressed (mention/DM)', async () => {
     // The router's no-mg branch is escalation-gated: plain chatter on an
     // unknown channel stays silent (no DB writes) so a bot that sits in

--- a/src/router.ts
+++ b/src/router.ts
@@ -145,7 +145,9 @@ export function setChannelRequestGate(fn: ChannelRequestGateFn): void {
 
 function safeParseContent(raw: string): { text?: string; sender?: string; senderId?: string } {
   try {
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    return { text: raw };
   } catch {
     return { text: raw };
   }


### PR DESCRIPTION
Replacement for #2801 with a regression test.

Changes:
- Treat JSON primitives/arrays as raw text in `safeParseContent`; only parsed objects are returned.
- Adds router regression coverage for primitive JSON content still matching engage rules and routing.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run src/host-core.test.ts`
- `pnpm run typecheck`