### PR TITLE
fix(security): confine send_file reads to workspace

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.test.ts
+++ b/container/agent-runner/src/mcp-tools/core.test.ts
@@ -5,12 +5,13 @@
  * send_file) must pick it up so a2a return-path routing on the host can
  * correlate replies back to the originating session.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import fs from 'fs';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb } from '../db/connection.js';
 import { getUndeliveredMessages } from '../db/messages-out.js';
 import { setCurrentInReplyTo, clearCurrentInReplyTo } from '../current-batch.js';
-import { sendMessage } from './core.js';
+import { sendMessage, sendFile } from './core.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -25,6 +26,7 @@ beforeEach(() => {
 
 afterEach(() => {
   clearCurrentInReplyTo();
+  mock.restore();
   closeSessionDb();
 });
 
@@ -46,5 +48,53 @@ describe('send_message MCP tool — in_reply_to plumbing', () => {
     const out = getUndeliveredMessages();
     expect(out).toHaveLength(1);
     expect(out[0].in_reply_to).toBeNull();
+  });
+});
+
+describe('send_file MCP tool — workspace confinement', () => {
+  function mockFile(realPath: string) {
+    spyOn(fs, 'existsSync').mockReturnValue(true);
+    spyOn(fs, 'realpathSync').mockReturnValue(realPath);
+    spyOn(fs, 'mkdirSync').mockReturnValue(undefined as never);
+    return spyOn(fs, 'copyFileSync').mockReturnValue(undefined as never);
+  }
+
+  it('rejects absolute paths whose canonical location is outside /workspace', async () => {
+    mockFile('/etc/passwd');
+
+    const result = await sendFile.handler({ to: 'peer', path: '/etc/passwd' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('path must be within /workspace');
+    expect(getUndeliveredMessages()).toHaveLength(0);
+  });
+
+  it('rejects /workspace symlinks that resolve outside /workspace', async () => {
+    mockFile('/host/secrets/token');
+
+    const result = await sendFile.handler({ to: 'peer', path: '/workspace/agent/link-to-secret' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('path must be within /workspace');
+    expect(getUndeliveredMessages()).toHaveLength(0);
+  });
+
+  it('basenames caller-provided filenames before writing to the outbox', async () => {
+    const copyFile = mockFile('/workspace/agent/report.txt');
+
+    const result = await sendFile.handler({
+      to: 'peer',
+      path: '/workspace/agent/report.txt',
+      filename: '../../skills/evil/SKILL.md',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(copyFile).toHaveBeenCalledTimes(1);
+    expect(copyFile.mock.calls[0][0]).toBe('/workspace/agent/report.txt');
+    expect(String(copyFile.mock.calls[0][1])).toMatch(/^\/workspace\/outbox\/[^/]+\/SKILL\.md$/);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).files).toEqual(['SKILL.md']);
   });
 });

--- a/container/agent-runner/src/mcp-tools/core.ts
+++ b/container/agent-runner/src/mcp-tools/core.ts
@@ -156,12 +156,24 @@ export const sendFile: McpToolDefinition = {
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve('/workspace/agent', filePath);
     if (!fs.existsSync(resolvedPath)) return err(`File not found: ${filePath}`);
 
+    let sourcePath: string;
+    try {
+      sourcePath = fs.realpathSync(resolvedPath);
+    } catch {
+      return err(`File not found: ${filePath}`);
+    }
+    if (sourcePath !== '/workspace' && !sourcePath.startsWith('/workspace/')) {
+      return err('path must be within /workspace');
+    }
+
     const id = generateId();
-    const filename = (args.filename as string) || path.basename(resolvedPath);
+    const requestedFilename = (args.filename as string | undefined) || path.basename(sourcePath);
+    const filename = path.basename(requestedFilename);
+    if (!filename || filename === '.' || filename === '..') return err('filename must be a file name');
 
     const outboxDir = path.join('/workspace/outbox', id);
     fs.mkdirSync(outboxDir, { recursive: true });
-    fs.copyFileSync(resolvedPath, path.join(outboxDir, filename));
+    fs.copyFileSync(sourcePath, path.join(outboxDir, filename));
 
     writeMessageOut({
       id,


### PR DESCRIPTION
Replaces #2799 with stricter canonical-path validation and regression tests.\n\n## Summary\n- resolves source paths with realpath before enforcing /workspace confinement\n- blocks /workspace symlinks that point outside the workspace\n- basenames caller-provided filenames before outbox writes\n\n## Tests\n- bun test container/agent-runner/src/mcp-tools/core.test.ts\n- cd container/agent-runner && bun run typecheck