### PR TITLE
fix(approvals): persist delivery target on pending_approvals rows

### DIFF
--- a/src/db/pending-approval-delivery.test.ts
+++ b/src/db/pending-approval-delivery.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Test for persisting an approval card's delivery target onto its row.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from './index.js';
+import { createPendingApproval, getPendingApproval, updatePendingApprovalDelivery } from './sessions.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('updatePendingApprovalDelivery', () => {
+  it('records channel_type / platform_id / platform_message_id on the row', () => {
+    createPendingApproval({
+      approval_id: 'appr-1',
+      request_id: 'appr-1',
+      action: 'cli_command',
+      payload: '{}',
+      created_at: now(),
+      title: 'CLI: members-add',
+      options_json: '[]',
+    });
+    // Created without a target — columns start NULL.
+    expect(getPendingApproval('appr-1')).toMatchObject({
+      channel_type: null,
+      platform_id: null,
+      platform_message_id: null,
+    });
+
+    updatePendingApprovalDelivery('appr-1', 'whatsapp', '6594599775@s.whatsapp.net', 'wamid-1');
+
+    expect(getPendingApproval('appr-1')).toMatchObject({
+      channel_type: 'whatsapp',
+      platform_id: '6594599775@s.whatsapp.net',
+      platform_message_id: 'wamid-1',
+    });
+  });
+
+  it('accepts a null platform_message_id (adapter returned no id)', () => {
+    createPendingApproval({
+      approval_id: 'appr-2',
+      request_id: 'appr-2',
+      action: 'cli_command',
+      payload: '{}',
+      created_at: now(),
+      title: 'CLI: groups-restart',
+      options_json: '[]',
+    });
+
+    updatePendingApprovalDelivery('appr-2', 'telegram', '12345', null);
+
+    expect(getPendingApproval('appr-2')).toMatchObject({
+      channel_type: 'telegram',
+      platform_id: '12345',
+      platform_message_id: null,
+    });
+  });
+});

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -185,6 +185,26 @@ export function updatePendingApprovalStatus(approvalId: string, status: PendingA
   getDb().prepare('UPDATE pending_approvals SET status = ? WHERE approval_id = ?').run(status, approvalId);
 }
 
+/**
+ * Record where an approval card was actually delivered. requestApproval()
+ * creates the row before it knows the approver, then calls this once the
+ * channel adapter has sent the card. Without it channel_type / platform_id /
+ * platform_message_id stay NULL, so `approvals list` can't show the real
+ * destination and there's no record of which chat the card went to.
+ */
+export function updatePendingApprovalDelivery(
+  approvalId: string,
+  channelType: string,
+  platformId: string,
+  platformMessageId: string | null,
+): void {
+  getDb()
+    .prepare(
+      'UPDATE pending_approvals SET channel_type = ?, platform_id = ?, platform_message_id = ? WHERE approval_id = ?',
+    )
+    .run(channelType, platformId, platformMessageId, approvalId);
+}
+
 export function deletePendingApproval(approvalId: string): void {
   getDb().prepare('DELETE FROM pending_approvals WHERE approval_id = ?').run(approvalId);
 }

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -23,7 +23,7 @@
  */
 import { normalizeOptions, type RawOption } from '../../channels/ask-question.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
-import { createPendingApproval, getSession } from '../../db/sessions.js';
+import { createPendingApproval, getSession, updatePendingApprovalDelivery } from '../../db/sessions.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { wakeContainer } from '../../container-runner.js';
 import { log } from '../../log.js';
@@ -243,7 +243,7 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
   const adapter = getDeliveryAdapter();
   if (adapter) {
     try {
-      await adapter.deliver(
+      const platformMessageId = await adapter.deliver(
         target.messagingGroup.channel_type,
         target.messagingGroup.platform_id,
         null,
@@ -255,6 +255,14 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
           question,
           options: APPROVAL_OPTIONS,
         }),
+      );
+      // Record where the card landed so the row reflects its real destination
+      // (channel_type / platform_id / platform_message_id) instead of NULL.
+      updatePendingApprovalDelivery(
+        approvalId,
+        target.messagingGroup.channel_type,
+        target.messagingGroup.platform_id,
+        platformMessageId ?? null,
       );
     } catch (err) {
       log.error('Failed to deliver approval card', { action, approvalId, err });


### PR DESCRIPTION
## Problem
`requestApproval()` creates the `pending_approvals` row *before* it picks an approver, and never records where the card was ultimately delivered. So `channel_type`, `platform_id`, and `platform_message_id` stay `NULL` on every approval row.

Consequences:
- `approvals list` (and `approval get`) can't show the real destination — the columns documented as "Channel the approval card was delivered on" are always empty.
- There's no record of which chat a given card went to, which is needed by anything that wants to locate a still-open card later (e.g. a channel adapter repopulating an in-memory reply map).

## Fix
Capture the `adapter.deliver()` return (the platform message id) and write the delivery target back to the row via a small new `updatePendingApprovalDelivery()` helper, right after the card is sent. No behavior change on the delivery path itself; purely fills in the previously-NULL columns.

## Test
`src/db/pending-approval-delivery.test.ts` — asserts the columns start NULL on create and are populated after delivery, including the null-`platform_message_id` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
