### PR TITLE
fix(setup): wait for the host socket before failing the first chat

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -39,7 +39,7 @@ import { runSlackChannel } from './channels/slack.js';
 import { runTeamsChannel } from './channels/teams.js';
 import { runTelegramChannel } from './channels/telegram.js';
 import { runWhatsAppChannel } from './channels/whatsapp.js';
-import { pingCliAgent, type PingResult } from './lib/agent-ping.js';
+import { pingCliAgent, waitForPing, type PingResult } from './lib/agent-ping.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
@@ -710,7 +710,11 @@ async function confirmAssistantResponds(): Promise<PingResult> {
     s.message(`${fitToWidth(label, suffix)}${k.dim(suffix)}`);
   }, 1000);
 
-  const result = await pingCliAgent();
+  // The service step returns before the host binds its CLI socket, so the
+  // first ping can land early and come back socket_error. Retry on that one
+  // result for a bounded window before giving up; the spinner's elapsed
+  // counter keeps the wait legible.
+  const result = await waitForPing(() => pingCliAgent());
 
   clearInterval(tick);
   const suffix = ` (${fmtDuration(Date.now() - start)})`;

--- a/setup/lib/agent-ping.test.ts
+++ b/setup/lib/agent-ping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyPingResult } from './agent-ping.js';
+import { classifyPingResult, waitForPing, type PingResult } from './agent-ping.js';
 
 describe('classifyPingResult', () => {
   it('treats a normal text reply as ok', () => {
@@ -35,5 +35,46 @@ describe('classifyPingResult', () => {
 
   it('treats empty output as no reply', () => {
     expect(classifyPingResult(0, '')).toBe('no_reply');
+  });
+});
+
+describe('waitForPing', () => {
+  // Injected clock so the bounded window is exercised without real sleeping.
+  function fakeClock() {
+    let t = 0;
+    return {
+      now: () => t,
+      sleep: (ms: number) => {
+        t += ms;
+        return Promise.resolve();
+      },
+    };
+  }
+
+  it('retries past early socket_error and returns ok once the socket is ready', async () => {
+    const sequence: PingResult[] = ['socket_error', 'socket_error', 'ok'];
+    let calls = 0;
+    const clock = fakeClock();
+    const result = await waitForPing(() => Promise.resolve(sequence[calls++]), {
+      windowMs: 45_000,
+      intervalMs: 1_000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('gives up with socket_error after the window if the socket never binds', async () => {
+    const clock = fakeClock();
+    const result = await waitForPing(() => Promise.resolve<PingResult>('socket_error'), {
+      windowMs: 5_000,
+      intervalMs: 1_000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result).toBe('socket_error');
+    // The loop advanced the clock to (or past) the deadline before giving up.
+    expect(clock.now()).toBeGreaterThanOrEqual(5_000);
   });
 });

--- a/setup/lib/agent-ping.ts
+++ b/setup/lib/agent-ping.ts
@@ -32,6 +32,42 @@ export function classifyPingResult(exitCode: number | null, stdout: string, stde
   return 'no_reply';
 }
 
+/**
+ * Retry a ping while the host is still booting.
+ *
+ * The `service` step reports success the moment `launchctl load` / `systemctl
+ * start` returns — before the host process has bound its CLI socket. A ping
+ * fired immediately after therefore often hits a missing socket and comes back
+ * `socket_error`, even though the host is up a moment later. Retry on that one
+ * result for a bounded window before giving up; any other result (ok, auth,
+ * no_reply) is conclusive and returns immediately.
+ *
+ * `now` and `sleep` are injectable so the retry loop can be unit-tested
+ * without real timers.
+ */
+export async function waitForPing(
+  ping: () => Promise<PingResult>,
+  {
+    windowMs = 10_000,
+    intervalMs = 1_000,
+    now = Date.now,
+    sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+  }: {
+    windowMs?: number;
+    intervalMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<PingResult> {
+  const deadline = now() + windowMs;
+  let result = await ping();
+  while (result === 'socket_error' && now() < deadline) {
+    await sleep(intervalMs);
+    result = await ping();
+  }
+  return result;
+}
+
 export function pingCliAgent(timeoutMs = 30_000): Promise<PingResult> {
   return new Promise((resolve) => {
     const child = spawn('pnpm', ['run', 'chat', 'ping'], {


### PR DESCRIPTION
## Problem

The setup "first chat" step pings the host CLI socket (`data/cli.sock`) immediately after the `service` step. But the `service` step reports success the moment `launchctl load` / `systemctl start` returns — **before** the host process has finished booting and bound the socket. So the first ping frequently lands early, comes back `socket_error`, and setup prints:

```
◇  Skipping the first chat
   The NanoClaw service isn't listening on its local socket. Try restarting it...
```

…even though the host is up a second or two later. It's a startup race, not a real failure. It's especially reliable to hit when a provider install rebuilds the container image right before the service step.

## Fix

Add `waitForPing()` in `setup/lib/agent-ping.ts`: retry **only** on the `socket_error` result, on a 1s interval, for a bounded 10s window. The instant the socket binds and the ping returns `ok` it returns immediately; any conclusive result (`ok` / auth / no-reply) returns without retrying. If the host genuinely never comes up, it still falls through to the exact same `socket_error` note after the window.

`confirmAssistantResponds()` swaps its single `pingCliAgent()` call for `waitForPing(() => pingCliAgent())`. The existing spinner + elapsed-time counter is reused unchanged, so the wait stays legible. `now`/`sleep` are injectable so the retry loop is unit-tested without real timers.

## Tests

- `setup/lib/agent-ping.test.ts`: (a) returns `ok` as soon as the injected ping succeeds on the Nth attempt; (b) returns `socket_error` after the deadline if it never binds — fake clock, no real sleeping.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)