### PR TITLE
feat(providers): add Manifest model router provider

### DIFF
--- a/.claude/skills/add-manifest/REMOVE.md
+++ b/.claude/skills/add-manifest/REMOVE.md
@@ -1,0 +1,36 @@
+# Remove Manifest Provider
+
+1. Remove the barrel import from `src/providers/index.ts`:
+   Delete the line `import './manifest.js';`
+
+2. Remove the barrel import from `container/agent-runner/src/providers/index.ts`:
+   Delete the line `import './manifest.js';`
+
+3. Remove the provider files:
+
+```bash
+rm src/providers/manifest.ts
+rm container/agent-runner/src/providers/manifest.ts
+```
+
+4. Remove the test files:
+
+```bash
+rm src/providers/manifest-registration.test.ts
+rm container/agent-runner/src/providers/manifest-registration.test.ts
+rm container/agent-runner/src/providers/manifest.factory.test.ts
+```
+
+5. Remove `MANIFEST_BASE_URL` from `.env` if present.
+
+6. Remove the OneCLI secret for the Manifest host:
+
+```bash
+onecli secret remove --host-pattern "YOUR_MANIFEST_HOST"
+```
+
+7. Rebuild:
+
+```bash
+pnpm run build
+```

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: add-manifest
+description: Add the Manifest model router as a provider
+type: feature
+---
+
+# Add Manifest Provider
+
+Manifest is a model router for AI agents. It scores each request by complexity
+and routes it to the best model. It exposes an OpenAI-compatible endpoint at
+`/v1/chat/completions`.
+
+## Install
+
+1. Fetch the provider files from the providers branch:
+
+```bash
+git fetch origin providers
+git show origin/providers:src/providers/manifest.ts > src/providers/manifest.ts
+git show origin/providers:container/agent-runner/src/providers/manifest.ts > container/agent-runner/src/providers/manifest.ts
+```
+
+2. Append the barrel imports:
+
+```bash
+echo "import './manifest.js';" >> src/providers/index.ts
+```
+
+In `container/agent-runner/src/providers/index.ts`, add before the mock import:
+
+```typescript
+import './manifest.js';
+```
+
+3. Set your Manifest endpoint in `.env`:
+
+```
+MANIFEST_BASE_URL=http://localhost:3001/v1
+```
+
+4. Register your Manifest API key as a OneCLI secret so the real key never
+   enters the container:
+
+```bash
+onecli secret add \
+  --host-pattern "localhost:3001" \
+  --header-name Authorization \
+  --value-format "Bearer {value}" \
+  --value "mnfst_YOUR_KEY"
+```
+
+Replace `localhost:3001` with your Manifest instance hostname and
+`mnfst_YOUR_KEY` with your actual API key.
+
+5. Rebuild the container:
+
+```bash
+pnpm run build
+```
+
+6. Start a session with the manifest provider:
+
+```bash
+nanoclaw --provider manifest
+```
+
+The `auto` model is used by default. Manifest routes each request through its
+scoring engine to the best available model.

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -3,4 +3,5 @@
 // level. Skills add a new provider by appending one import line below.
 
 import './claude.js';
+import './manifest.js';
 import './mock.js';

--- a/container/agent-runner/src/providers/manifest-registration.test.ts
+++ b/container/agent-runner/src/providers/manifest-registration.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'bun:test';
+import { listProviderNames } from './provider-registry.js';
+
+describe('manifest container-side registration', () => {
+  it('registers the manifest provider', async () => {
+    // Import the barrel to trigger all registrations
+    await import('./index.js');
+    const names = listProviderNames();
+    expect(names).toContain('manifest');
+  });
+});

--- a/container/agent-runner/src/providers/manifest.factory.test.ts
+++ b/container/agent-runner/src/providers/manifest.factory.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'bun:test';
+import { ManifestProvider } from './manifest.js';
+
+describe('ManifestProvider', () => {
+  it('constructs with default options', () => {
+    const provider = new ManifestProvider();
+    expect(provider.supportsNativeSlashCommands).toBe(false);
+    expect(provider.usesMemoryScaffold).toBe(true);
+  });
+
+  it('constructs with custom env options', () => {
+    const provider = new ManifestProvider({
+      env: {
+        MANIFEST_BASE_URL: 'https://my-instance.example.com/v1',
+        MANIFEST_AUTH_TOKEN: 'mnfst_test',
+      },
+      model: 'auto',
+    });
+    expect(provider.supportsNativeSlashCommands).toBe(false);
+  });
+
+  it('isSessionInvalid always returns false', () => {
+    const provider = new ManifestProvider();
+    expect(provider.isSessionInvalid(new Error('test'))).toBe(false);
+    expect(provider.isSessionInvalid(null)).toBe(false);
+  });
+
+  it('query returns an AgentQuery with expected shape', () => {
+    const provider = new ManifestProvider();
+    const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+    expect(typeof query.push).toBe('function');
+    expect(typeof query.end).toBe('function');
+    expect(typeof query.abort).toBe('function');
+    expect(query.events).toBeDefined();
+    expect(typeof query.events[Symbol.asyncIterator]).toBe('function');
+    // Clean up
+    query.abort();
+  });
+});

--- a/container/agent-runner/src/providers/manifest.ts
+++ b/container/agent-runner/src/providers/manifest.ts
@@ -1,0 +1,199 @@
+/**
+ * Manifest provider — routes requests through a Manifest model router
+ * via its OpenAI-compatible /v1/chat/completions endpoint.
+ *
+ * Manifest scores each request by complexity and routes it to the best
+ * model that can handle it. The provider sends standard OpenAI chat
+ * completion requests and streams SSE responses back as provider events.
+ */
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatCompletionChunk {
+  choices?: Array<{
+    delta?: { content?: string; role?: string };
+    finish_reason?: string | null;
+  }>;
+  id?: string;
+}
+
+export class ManifestProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+  readonly usesMemoryScaffold = true;
+
+  private baseUrl: string;
+  private authToken: string;
+  private model: string;
+
+  constructor(options: ProviderOptions = {}) {
+    this.baseUrl = (options.env?.MANIFEST_BASE_URL ?? 'http://localhost:3001/v1').replace(/\/+$/, '');
+    this.authToken = options.env?.MANIFEST_AUTH_TOKEN ?? 'placeholder';
+    this.model = options.model ?? 'auto';
+  }
+
+  isSessionInvalid(_err: unknown): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let ended = false;
+    let aborted = false;
+    let abortController: AbortController | null = null;
+
+    const self = this;
+
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        const sessionId = `manifest-${Date.now()}`;
+        yield { type: 'activity' };
+        yield { type: 'init', continuation: sessionId };
+
+        const history: ChatMessage[] = [];
+
+        if (input.systemContext?.instructions) {
+          history.push({ role: 'system', content: input.systemContext.instructions });
+        }
+        history.push({ role: 'user', content: input.prompt });
+
+        yield* self.streamCompletion(history, abortController = new AbortController());
+
+        while (!ended && !aborted) {
+          if (pending.length > 0) {
+            const msg = pending.shift()!;
+            history.push({ role: 'user', content: msg });
+            yield* self.streamCompletion(history, abortController = new AbortController());
+            continue;
+          }
+          await new Promise<void>((resolve) => {
+            waiting = resolve;
+          });
+          waiting = null;
+        }
+
+        while (pending.length > 0) {
+          const msg = pending.shift()!;
+          history.push({ role: 'user', content: msg });
+          yield* self.streamCompletion(history, abortController = new AbortController());
+        }
+      },
+    };
+
+    return {
+      push(message: string) {
+        pending.push(message);
+        waiting?.();
+      },
+      end() {
+        ended = true;
+        waiting?.();
+      },
+      events,
+      abort() {
+        aborted = true;
+        abortController?.abort();
+        waiting?.();
+      },
+    };
+  }
+
+  private async *streamCompletion(
+    messages: ChatMessage[],
+    abortController: AbortController,
+  ): AsyncIterable<ProviderEvent> {
+    yield { type: 'activity' };
+
+    const url = `${this.baseUrl}/chat/completions`;
+    const body = JSON.stringify({
+      model: this.model,
+      messages,
+      stream: true,
+    });
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.authToken}`,
+        },
+        body,
+        signal: abortController.signal,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      yield { type: 'error', message: `Manifest request failed: ${message}`, retryable: true };
+      return;
+    }
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      yield {
+        type: 'error',
+        message: `Manifest returned ${response.status}: ${detail.slice(0, 500)}`,
+        retryable: response.status >= 500 || response.status === 429,
+      };
+      return;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      yield { type: 'error', message: 'Manifest response has no body', retryable: false };
+      return;
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        yield { type: 'activity' };
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+          if (!trimmed.startsWith('data: ')) continue;
+
+          try {
+            const chunk: ChatCompletionChunk = JSON.parse(trimmed.slice(6));
+            const content = chunk.choices?.[0]?.delta?.content;
+            if (content) {
+              fullText += content;
+              yield { type: 'progress', message: content };
+            }
+          } catch {
+            // Skip malformed chunks
+          }
+        }
+      }
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        const message = err instanceof Error ? err.message : String(err);
+        yield { type: 'error', message: `Stream error: ${message}`, retryable: true };
+        return;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    messages.push({ role: 'assistant', content: fullText });
+    yield { type: 'result', text: fullText || null };
+  }
+}
+
+registerProvider('manifest', (opts) => new ManifestProvider(opts));

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,3 +4,4 @@
 // needs (claude, mock) don't appear here.
 //
 // Skills add a new provider by appending one import line below.
+import './manifest.js';

--- a/src/providers/manifest-registration.test.ts
+++ b/src/providers/manifest-registration.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { listProviderContainerConfigNames } from './provider-container-registry.js';
+
+describe('manifest host-side registration', () => {
+  it('registers the manifest provider container config', async () => {
+    // Import the barrel to trigger all registrations
+    await import('./index.js');
+    const names = listProviderContainerConfigNames();
+    expect(names).toContain('manifest');
+  });
+});

--- a/src/providers/manifest.ts
+++ b/src/providers/manifest.ts
@@ -1,0 +1,23 @@
+/**
+ * Manifest provider container config — passes the Manifest endpoint URL
+ * and a placeholder auth token into the container.
+ *
+ * The real API key (mnfst_*) never enters the container. Setup creates a
+ * OneCLI generic secret (host-pattern = base URL hostname, header-name =
+ * Authorization, value-format = "Bearer {value}") so the proxy rewrites
+ * the Authorization header on the wire. The container only needs:
+ *   - MANIFEST_BASE_URL — so the provider knows where to call
+ *   - MANIFEST_AUTH_TOKEN=placeholder — so the provider adds an
+ *     Authorization: Bearer header for OneCLI to overwrite
+ */
+import { readEnvFile } from '../env.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+registerProviderContainerConfig('manifest', () => {
+  const dotenv = readEnvFile(['MANIFEST_BASE_URL']);
+  const env: Record<string, string> = {};
+  const baseUrl = dotenv.MANIFEST_BASE_URL ?? 'http://localhost:3001/v1';
+  env.MANIFEST_BASE_URL = baseUrl;
+  env.MANIFEST_AUTH_TOKEN = 'placeholder';
+  return { env };
+});


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds [Manifest](https://manifest.build) as a provider. Manifest is a model router for AI agents that scores each request by complexity and routes it to the best model. It exposes an OpenAI-compatible `/v1/chat/completions` endpoint.

**Host side** (`src/providers/manifest.ts`): Passes `MANIFEST_BASE_URL` and a placeholder auth token into the container. The real API key (`mnfst_*`) stays on the host via OneCLI secret.

**Container side** (`container/agent-runner/src/providers/manifest.ts`): `ManifestProvider` implements the `AgentProvider` interface. Streams SSE chat completions, maintains conversation history, supports the full push/end/abort lifecycle.

**Skill** (`.claude/skills/add-manifest/`): SKILL.md with install instructions and REMOVE.md with uninstall steps.

### Files changed

| File | Purpose |
|------|---------|
| `src/providers/manifest.ts` | Host-side container config (env passthrough) |
| `src/providers/index.ts` | Barrel import for host registration |
| `src/providers/manifest-registration.test.ts` | Host registration guard (vitest) |
| `container/agent-runner/src/providers/manifest.ts` | Container-side AgentProvider |
| `container/agent-runner/src/providers/index.ts` | Barrel import for container registration |
| `container/agent-runner/src/providers/manifest-registration.test.ts` | Container registration guard (bun:test) |
| `container/agent-runner/src/providers/manifest.factory.test.ts` | Factory unit tests (bun:test) |
| `.claude/skills/add-manifest/SKILL.md` | Install instructions |
| `.claude/skills/add-manifest/REMOVE.md` | Uninstall instructions |

### Validation

```
pnpm run format:check          → All matched files use Prettier code style!
pnpm exec tsc --noEmit          → clean
pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit → clean
pnpm exec vitest run            → 517 passed (58 files)
cd container/agent-runner && bun test → 117 passed (14 files)
```

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone