### PR TITLE
fix: forward positional params in q.ts

### DIFF
--- a/scripts/q.ts
+++ b/scripts/q.ts
@@ -20,10 +20,10 @@
  */
 import Database from 'better-sqlite3';
 
-const [, , dbPath, sql] = process.argv;
+const [, , dbPath, sql, ...params] = process.argv;
 
 if (!dbPath || sql === undefined) {
-  console.error('Usage: pnpm exec tsx scripts/q.ts <db-path> "<sql>"');
+  console.error('Usage: pnpm exec tsx scripts/q.ts <db-path> "<sql>" [param1] [param2] ...');
   process.exit(2);
 }
 
@@ -32,7 +32,7 @@ try {
   try {
     const stmt = db.prepare(sql);
     if (stmt.reader) {
-      const rows = stmt.all() as Record<string, unknown>[];
+      const rows = stmt.all(...params) as Record<string, unknown>[];
       for (const row of rows) {
         console.log(
           Object.values(row)
@@ -41,7 +41,7 @@ try {
         );
       }
     } else {
-      stmt.run();
+      stmt.run(...params);
     }
   } catch (e: unknown) {
     // better-sqlite3 throws on compound statements ("contains more than


### PR DESCRIPTION
Accept extra CLI args and pass them as positional parameters to stmt.all() / stmt.run() to enable parameterized queries.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`scripts/q.ts` accepted a SQL string but silently ignored any extra CLI arguments, making parameterized queries impossible. Extra args are now destructured as `...params` and forwarded to `stmt.all(...params)` / `stmt.run(...params)`. Usage string updated to document the new positional args.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone