### PR TITLE
fix(container-runner): support Docker-in-Docker agent groups

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -347,10 +347,23 @@ export function buildMounts(
     mounts.push({ hostPath: skillsSrc, containerPath: '/app/skills', readonly: true });
   }
 
-  // Additional mounts from container config
+  // Additional mounts from container config.
+  // Docker socket is a special case: it must mount at an exact absolute path
+  // (/var/run/docker.sock) and bypasses the allowlist validator (which only
+  // handles user-data mounts under /workspace/extra/). All other mounts go
+  // through the normal security validation.
   if (containerConfig.additionalMounts && containerConfig.additionalMounts.length > 0) {
-    const validated = validateAdditionalMounts(containerConfig.additionalMounts, agentGroup.name);
-    mounts.push(...validated);
+    const dockerSocketMounts = containerConfig.additionalMounts.filter((m) => m.hostPath === '/var/run/docker.sock');
+    const otherMounts = containerConfig.additionalMounts.filter((m) => m.hostPath !== '/var/run/docker.sock');
+
+    for (const m of dockerSocketMounts) {
+      mounts.push({ hostPath: '/var/run/docker.sock', containerPath: '/var/run/docker.sock', readonly: false });
+    }
+
+    if (otherMounts.length > 0) {
+      const validated = validateAdditionalMounts(otherMounts, agentGroup.name);
+      mounts.push(...validated);
+    }
   }
 
   // Provider-contributed mounts (e.g. opencode-xdg)
@@ -468,6 +481,16 @@ async function buildContainerArgs(
       args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
     } else {
       args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  const hasDockerSocket = mounts.some((m) => m.hostPath === '/var/run/docker.sock');
+  if (hasDockerSocket) {
+    try {
+      const dockerGid = fs.statSync('/var/run/docker.sock').gid;
+      args.push('--group-add', String(dockerGid));
+    } catch {
+      /* best-effort fallback if file does not exist or stat fails */
     }
   }
 


### PR DESCRIPTION
Mount /var/run/docker.sock at its exact absolute path and add --group-add <docker-gid> so the container user has permission to use it.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Agent groups that need Docker access (e.g. to run containers from within the agent) previously couldn't mount `/var/run/docker.sock` because the allowlist validator only handles user-data mounts under `/workspace/extra/`. This PR:

- Short-circuits the validator for `/var/run/docker.sock` so it mounts at its required absolute path
- Reads the socket's GID via `fs.statSync` and passes `--group-add <gid>` to Docker so the container user can actually use the socket

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone