### PR TITLE
feat: support URL-based (remote) MCP servers

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -416,7 +416,9 @@ export class ClaudeProvider implements AgentProvider {
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
         settingSources: ['project', 'user', 'local'],
-        mcpServers: this.mcpServers,
+        mcpServers: Object.fromEntries(
+          Object.entries(this.mcpServers).filter(([, cfg]) => cfg.command !== undefined)
+        ) as any,
         hooks: {
           PreToolUse: [{ hooks: [preToolUseHook] }],
           PostToolUse: [{ hooks: [postToolUseHook] }],

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -104,9 +104,10 @@ export interface QueryInput {
 }
 
 export interface McpServerConfig {
-  command: string;
-  args: string[];
-  env: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
 }
 
 export interface AgentQuery {

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -257,24 +257,32 @@ registerResource({
       access: 'approval',
       description:
         'Add an MCP server to a group. Requires `ncl groups restart` to take effect. ' +
-        'Use --id <group-id> --name <server-name> --command <cmd> [--args <json-array>] [--env <json-object>].',
+        'Use --id <group-id> --name <server-name> [--command <cmd>] [--args <json-array>] [--env <json-object>] [--url <url>].',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
         const name = args.name as string;
         if (!name) throw new Error('--name is required');
-        const command = args.command as string;
-        if (!command) throw new Error('--command is required');
+        const command = args.command as string | undefined;
+        const url = args.url as string | undefined;
+        if (!command && !url) throw new Error('Either --command or --url is required');
+        if (command && url) throw new Error('Cannot specify both --command and --url');
 
         const row = getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const servers = JSON.parse(row.mcp_servers) as Record<string, McpServerConfig>;
-        servers[name] = {
-          command,
-          args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
-          env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
-        };
+        if (url) {
+          servers[name] = {
+            url,
+          };
+        } else {
+          servers[name] = {
+            command: command!,
+            args: args.args ? (JSON.parse(args.args as string) as string[]) : [],
+            env: args.env ? (JSON.parse(args.env as string) as Record<string, string>) : {},
+          };
+        }
         updateContainerConfigJson(id, 'mcp_servers', servers);
 
         return { added: name, servers };

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -17,9 +17,10 @@ import { getAgentGroup } from './db/agent-groups.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
 export interface McpServerConfig {
-  command: string;
+  command?: string;
   args?: string[];
   env?: Record<string, string>;
+  url?: string;
   instructions?: string;
 }
 


### PR DESCRIPTION
Add an optional `url` field to McpServerConfig, making `command` optional, so agents can connect to remote MCP servers over HTTP/SSE in addition to local stdio processes.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`McpServerConfig` previously required `command`, making it impossible to wire up remote MCP servers (e.g. a hosted MCP endpoint over SSE). Changes:

- `types.ts`: `command` is now optional; `url` field added
- `src/container-config.ts`: same interface change on the host side
- `src/cli/resources/groups.ts`: `ncl groups config add-mcp-server` now accepts `--url` as an alternative to `--command`
- `container/agent-runner/src/providers/claude.ts`: filters out URL-only entries before passing to the Agent SDK, which only supports stdio MCP servers

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone