### PR TITLE
fix(opencode): cwd and .env fallback for provider/model env vars

### DIFF
--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -38,6 +38,7 @@ function spawnOpencodeServer(config: Record<string, unknown>, timeoutMs = 10_000
         ...process.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
       },
+      cwd: '/workspace/agent',
       detached: true,
     });
 

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { registerProviderContainerConfig } from './provider-container-registry.js';
+import { readEnvFile } from '../env.js';
 
 function mergeNoProxy(current: string | undefined, additions: string): string {
   if (!current?.trim()) return additions;
@@ -32,13 +33,15 @@ registerProviderContainerConfig('opencode', (ctx) => {
   const opencodeDir = path.join(ctx.sessionDir, 'opencode-xdg');
   fs.mkdirSync(opencodeDir, { recursive: true });
 
+  const envVars = readEnvFile(['OPENCODE_PROVIDER', 'OPENCODE_MODEL', 'OPENCODE_SMALL_MODEL']);
+
   const env: Record<string, string> = {
     XDG_DATA_HOME: '/opencode-xdg',
     NO_PROXY: mergeNoProxy(ctx.hostEnv.NO_PROXY, '127.0.0.1,localhost'),
     no_proxy: mergeNoProxy(ctx.hostEnv.no_proxy, '127.0.0.1,localhost'),
   };
   for (const key of ['OPENCODE_PROVIDER', 'OPENCODE_MODEL', 'OPENCODE_SMALL_MODEL'] as const) {
-    const value = ctx.hostEnv[key];
+    const value = ctx.hostEnv[key] || envVars[key];
     if (value) env[key] = value;
   }
 


### PR DESCRIPTION
Two small fixes to the OpenCode provider that surfaced during real use.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**`fix(opencode): set cwd to /workspace/agent when spawning server`**

Without an explicit `cwd`, the OpenCode server inherits the process working directory from the container entrypoint. File operations inside agent turns (reads, writes, tool calls) resolve relative to that directory rather than the agent's workspace. Setting `cwd: '/workspace/agent'` aligns OpenCode's working directory with where the agent's files actually live.

**`fix(opencode): fall back to .env for OPENCODE_PROVIDER/MODEL/SMALL_MODEL`**

When the host process is started by a service manager (launchd, systemd) that doesn't source `.env`, `ctx.hostEnv` won't contain `OPENCODE_PROVIDER`, `OPENCODE_MODEL`, or `OPENCODE_SMALL_MODEL` even if they're defined in `.env`. The provider/model selection was silently ignored. This reads `.env` as a fallback via the existing `readEnvFile` utility so the correct model is used regardless of how the host starts.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone