### PR TITLE
fix(signal): set isMention and isGroup on inbound group messages

### DIFF
--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -659,9 +659,15 @@ export function createSignalAdapter(config: {
       attachmentRefs.push({ path: imagePath, contentType: img.contentType || 'image/jpeg' });
     }
 
+    const botMentionedInGroup =
+      isGroup &&
+      !!dataMessage.mentions?.some((m) => m.number === config.account);
+
     const msg: InboundMessage = {
       id: String(dataMessage.timestamp ?? Date.now()),
       kind: 'chat',
+      isMention: !isGroup || botMentionedInGroup ? true : undefined,
+      isGroup,
       content: {
         text: content,
         sender,


### PR DESCRIPTION
Signal group messages were missing isMention and isGroup on InboundMessage, so the router had no way to distinguish messages directed at the bot from ambient group traffic.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Without these fields, the agent responded to every message in a Signal group rather than only those directed at it.

- `isGroup` is set on every inbound message (true for group chats, absent for DMs)
- `isMention` is set to `true` when the message is a DM (always addressed to the bot) or when the bot's phone number appears in `dataMessage.mentions`

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone