### PR TITLE
feat(telegram): support multiple bot instances via TELEGRAM_BOT_TOKEN_<SUFFIX>

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -5,7 +5,7 @@
  */
 import { createTelegramAdapter } from '@chat-adapter/telegram';
 
-import { readEnvFile } from '../env.js';
+import { readEnvFile, listEnvKeys } from '../env.js';
 import { log } from '../log.js';
 import { createMessagingGroup, getMessagingGroupByPlatform, updateMessagingGroup } from '../db/messaging-groups.js';
 import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js';
@@ -195,51 +195,82 @@ function createPairingInterceptor(
   };
 }
 
+/**
+ * Build a Telegram adapter for one bot token. `instance` is undefined for the
+ * default bot (registry key = channelType "telegram") and a URL-safe slug for
+ * additional bots, so N Telegram bots coexist in one host process. The instance
+ * flows through the Chat SDK bridge into the registry key, the state namespace,
+ * and every messaging_groups row that addresses this bot.
+ */
+function buildTelegramAdapter(token: string, instance?: string): ChannelAdapter {
+  const telegramAdapter = createTelegramAdapter({
+    botToken: token,
+    mode: 'polling',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: telegramAdapter,
+    instance,
+    concurrency: 'concurrent',
+    extractReplyContext,
+    supportsThreads: false,
+    maxTextLength: 4000,
+  });
+
+  const botUsernamePromise = fetchBotUsername(token);
+
+  return {
+    ...bridge,
+    resolveChannelName: async (platformId: string) => {
+      const chatId = platformId.split(':').slice(1).join(':');
+      if (!chatId) return null;
+      try {
+        const res = await fetch(`https://api.telegram.org/bot${token}/getChat`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId }),
+        });
+        const data = (await res.json()) as { ok?: boolean; result?: { title?: string } };
+        return data.ok ? (data.result?.title ?? null) : null;
+      } catch {
+        return null;
+      }
+    },
+    async setup(hostConfig: ChannelSetup) {
+      const intercepted: ChannelSetup = {
+        ...hostConfig,
+        onInbound: createPairingInterceptor(botUsernamePromise, hostConfig.onInbound, token),
+      };
+      return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+    },
+  };
+}
+
+// Default bot: TELEGRAM_BOT_TOKEN → registry key "telegram".
 registerChannelAdapter('telegram', {
   factory: () => {
     const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
     if (!env.TELEGRAM_BOT_TOKEN) return null;
-    const token = env.TELEGRAM_BOT_TOKEN;
-    const telegramAdapter = createTelegramAdapter({
-      botToken: token,
-      mode: 'polling',
-    });
-    const bridge = createChatSdkBridge({
-      adapter: telegramAdapter,
-      concurrency: 'concurrent',
-      extractReplyContext,
-      supportsThreads: false,
-      transformOutboundText: sanitizeTelegramLegacyMarkdown,
-      maxTextLength: 4000,
-    });
-
-    const botUsernamePromise = fetchBotUsername(token);
-
-    const wrapped: ChannelAdapter = {
-      ...bridge,
-      resolveChannelName: async (platformId: string) => {
-        const chatId = platformId.split(':').slice(1).join(':');
-        if (!chatId) return null;
-        try {
-          const res = await fetch(`https://api.telegram.org/bot${token}/getChat`, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ chat_id: chatId }),
-          });
-          const data = (await res.json()) as { ok?: boolean; result?: { title?: string } };
-          return data.ok ? (data.result?.title ?? null) : null;
-        } catch {
-          return null;
-        }
-      },
-      async setup(hostConfig: ChannelSetup) {
-        const intercepted: ChannelSetup = {
-          ...hostConfig,
-          onInbound: createPairingInterceptor(botUsernamePromise, hostConfig.onInbound, token),
-        };
-        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
-      },
-    };
-    return wrapped;
+    return buildTelegramAdapter(env.TELEGRAM_BOT_TOKEN);
   },
 });
+
+// Additional bots: any TELEGRAM_BOT_TOKEN_<SUFFIX> in .env registers a named
+// instance "<suffix>" (lowercased). The instance string must match the
+// `instance` column on the messaging_groups rows wired to that bot. Skips the
+// bare TELEGRAM_BOT_TOKEN (no suffix) and any suffix that isn't URL-safe.
+for (const key of listEnvKeys()) {
+  const match = /^TELEGRAM_BOT_TOKEN_(.+)$/.exec(key);
+  if (!match) continue;
+  const instance = match[1]!.toLowerCase();
+  if (!/^[a-z0-9._-]+$/.test(instance)) {
+    log.warn('Skipping Telegram instance with non-URL-safe name', { key, instance });
+    continue;
+  }
+  registerChannelAdapter(`telegram:${instance}`, {
+    factory: () => {
+      const env = readEnvFile([key]);
+      if (!env[key]) return null;
+      return buildTelegramAdapter(env[key], instance);
+    },
+  });
+}

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -213,6 +213,7 @@ function buildTelegramAdapter(token: string, instance?: string): ChannelAdapter 
     concurrency: 'concurrent',
     extractReplyContext,
     supportsThreads: false,
+    transformOutboundText: sanitizeTelegramLegacyMarkdown,
     maxTextLength: 4000,
   });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,3 +40,28 @@ export function readEnvFile(keys: string[]): Record<string, string> {
 
   return result;
 }
+
+/**
+ * Return the names of all keys defined in the .env file (without reading their
+ * values into memory beyond what's needed to find the key). Used by adapters
+ * that discover multiple instances from a naming convention (e.g. Telegram's
+ * TELEGRAM_BOT_TOKEN_<INSTANCE>). Returns [] if .env is absent.
+ */
+export function listEnvKeys(): string[] {
+  const envFile = path.join(process.cwd(), '.env');
+  let content: string;
+  try {
+    content = fs.readFileSync(envFile, 'utf-8');
+  } catch {
+    return [];
+  }
+  const keys: string[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    keys.push(trimmed.slice(0, eqIdx).trim());
+  }
+  return keys;
+}


### PR DESCRIPTION
Add support for running multiple Telegram bots from a single NanoClaw instance by discovering TELEGRAM_BOT_TOKEN_<SUFFIX> entries in .env.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The channel registry and `messaging_groups` schema already support multiple instances of the same channel type — adapters key by `instance ?? channelType` and the DB has a `UNIQUE(channel_type, platform_id, instance)` index with fallback resolution. This PR wires that infrastructure up for Telegram.

**How it works:**
- `TELEGRAM_BOT_TOKEN` registers the default adapter as before (key: `"telegram"`)
- Each `TELEGRAM_BOT_TOKEN_<SUFFIX>` in `.env` registers an additional adapter as `"telegram:<suffix>"` (lowercased, URL-safe slugs only)
- The suffix flows through the Chat SDK bridge into the registry key, state namespace, and `messaging_groups.instance`

The factory is extracted into `buildTelegramAdapter(token, instance?)` so the default and named instances share identical setup logic.

**`listEnvKeys()` in `src/env.ts`** returns `.env` key names without reading values into memory. It's reusable — Discord, Slack, and other channels can adopt the same `_<SUFFIX>` pattern by calling it the same way.

**To add a second bot:** add `TELEGRAM_BOT_TOKEN_WORK=<token>` to `.env`, create a `messaging_group` with `channel_type: telegram` and `instance: work`, wire it to an agent group, restart.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone