### PR TITLE
chore(logging): silence libsignal session debug spam (incl. key material)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
+// Must be first: installs a console filter that drops libsignal's session
+// debug spam (incl. raw key material) before any channel adapter can run.
+import './silence-libsignal.js';
+
 import path from 'path';
 
 import { backfillContainerConfigs } from './backfill-container-configs.js';

--- a/src/silence-libsignal.ts
+++ b/src/silence-libsignal.ts
@@ -1,0 +1,40 @@
+/**
+ * Silence libsignal's debug console spam.
+ *
+ * The bundled `libsignal` dep (WhatsApp/Baileys crypto) ships leftover debug
+ * logging in `session_record.js` — `console.info("Closing session:", session)`
+ * and friends — each of which pretty-prints the entire Signal SessionEntry,
+ * including raw key material (rootKey / chainKey / baseKey buffers). On a busy
+ * install this was ~54% of the host log volume AND leaked crypto material into
+ * a plaintext file.
+ *
+ * The host's own structured logger (src/log.ts) writes directly to
+ * process.stdout / process.stderr and never touches console.*, so filtering
+ * console here is safe: it only ever suppresses third-party console output,
+ * not our logs. We match on the known first-argument labels so unrelated
+ * console output (if any dep ever emits it) still passes through.
+ *
+ * Imported first in src/index.ts so the patch is installed before any channel
+ * adapter (and thus libsignal) can run.
+ */
+const SILENCED_PREFIXES = [
+  'Closing session:',
+  'Opening session:',
+  'Migrating session to:',
+  'Session already closed',
+  'Session already open',
+  'Removing old closed session:',
+];
+
+function shouldSilence(args: unknown[]): boolean {
+  const first = args[0];
+  return typeof first === 'string' && SILENCED_PREFIXES.some((p) => first.startsWith(p));
+}
+
+for (const method of ['info', 'warn', 'log'] as const) {
+  const original = console[method].bind(console);
+  console[method] = (...args: unknown[]): void => {
+    if (shouldSilence(args)) return;
+    original(...args);
+  };
+}


### PR DESCRIPTION
## Problem
The bundled `libsignal` dependency (`session_record.js`) ships leftover debug logging that fires on every Signal session open/close:

```js
console.info("Closing session:", session);
console.info("Opening session:", session);
console.info("Migrating session to:", ...);
// + "Session already closed/open", "Removing old closed session:"
```

Each call pretty-prints the **entire `SessionEntry`**, including raw key material (`rootKey` / `chainKey` / `baseKey` buffers). On a busy install this was observed as **~54% of total host-log volume** (≈155k lines / 22 MB) and, more importantly, **leaks crypto key material into a plaintext logfile**.

## Fix
Add `src/silence-libsignal.ts` — a small console filter that drops `console.info/warn/log` calls whose first argument matches the known libsignal session labels — and import it first in `src/index.ts` so it's installed before any channel adapter (hence libsignal) can run.

This is safe because the host's own structured logger (`src/log.ts`) writes **directly to `process.stdout` / `process.stderr` and never uses `console.*`**, so the filter only ever suppresses third-party console output, never our logs. Unrelated console output (matched by label prefix, not blanket) still passes through.

## Verification
On a live install: after applying, a host restart (peak Signal session churn) produced **0 buffer-dump lines** where it previously emitted thousands, while normal structured `INFO`/`WARN` logging continued unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
