### PR TITLE
feat(host): expand ${VAR_NAME} refs in MCP server env at spawn time

### DIFF
--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -117,8 +117,8 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   const referencedVars = [
     ...new Set(
       Object.values(config.mcpServers)
-        .flatMap(srv => Object.values(srv.env ?? {}))
-        .flatMap(v => [...v.matchAll(/\$\{([^}]+)\}/g)].map(m => m[1])),
+        .flatMap((srv) => Object.values(srv.env ?? {}))
+        .flatMap((v) => [...v.matchAll(/\$\{([^}]+)\}/g)].map((m) => m[1])),
     ),
   ];
   const envFileVars = referencedVars.length > 0 ? readEnvFile(referencedVars) : {};

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import { GROUPS_DIR } from './config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
+import { readEnvFile } from './env.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
 export interface McpServerConfig {
@@ -67,11 +68,15 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
 }
 
 /**
- * Expand `${VAR_NAME}` references in MCP server env values using process.env.
- * Called at materialize time so the DB stores references, not secrets.
+ * Expand `${VAR_NAME}` references in MCP server env values.
+ * process.env takes precedence; envFile values are the fallback so secrets
+ * stay in .env and never enter process.env (which would leak them to children).
  * Unresolved references are left as-is.
  */
-function expandMcpEnvRefs(mcpServers: Record<string, McpServerConfig>): Record<string, McpServerConfig> {
+function expandMcpEnvRefs(
+  mcpServers: Record<string, McpServerConfig>,
+  envFile: Record<string, string>,
+): Record<string, McpServerConfig> {
   return Object.fromEntries(
     Object.entries(mcpServers).map(([name, cfg]) => [
       name,
@@ -81,7 +86,7 @@ function expandMcpEnvRefs(mcpServers: Record<string, McpServerConfig>): Record<s
           ? Object.fromEntries(
               Object.entries(cfg.env).map(([k, v]) => [
                 k,
-                v.replace(/\$\{([^}]+)\}/g, (_, varName) => process.env[varName] ?? v),
+                v.replace(/\$\{([^}]+)\}/g, (_, varName) => process.env[varName] ?? envFile[varName] ?? v),
               ]),
             )
           : undefined,
@@ -106,9 +111,21 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);
+
+  // Collect ${VAR_NAME} refs across all MCP env blocks and resolve them from
+  // .env — secrets stay out of process.env so they don't leak to children.
+  const referencedVars = [
+    ...new Set(
+      Object.values(config.mcpServers)
+        .flatMap(srv => Object.values(srv.env ?? {}))
+        .flatMap(v => [...v.matchAll(/\$\{([^}]+)\}/g)].map(m => m[1])),
+    ),
+  ];
+  const envFileVars = referencedVars.length > 0 ? readEnvFile(referencedVars) : {};
+
   const serialized = {
     ...config,
-    mcpServers: expandMcpEnvRefs(config.mcpServers),
+    mcpServers: expandMcpEnvRefs(config.mcpServers, envFileVars),
   };
 
   const p = path.join(GROUPS_DIR, group.folder, 'container.json');

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -71,9 +71,7 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
  * Called at materialize time so the DB stores references, not secrets.
  * Unresolved references are left as-is.
  */
-function expandMcpEnvRefs(
-  mcpServers: Record<string, McpServerConfig>,
-): Record<string, McpServerConfig> {
+function expandMcpEnvRefs(mcpServers: Record<string, McpServerConfig>): Record<string, McpServerConfig> {
   return Object.fromEntries(
     Object.entries(mcpServers).map(([name, cfg]) => [
       name,

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -67,9 +67,38 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
 }
 
 /**
+ * Expand `${VAR_NAME}` references in MCP server env values using process.env.
+ * Called at materialize time so the DB stores references, not secrets.
+ * Unresolved references are left as-is.
+ */
+function expandMcpEnvRefs(
+  mcpServers: Record<string, McpServerConfig>,
+): Record<string, McpServerConfig> {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, cfg]) => [
+      name,
+      {
+        ...cfg,
+        env: cfg.env
+          ? Object.fromEntries(
+              Object.entries(cfg.env).map(([k, v]) => [
+                k,
+                v.replace(/\$\{([^}]+)\}/g, (_, varName) => process.env[varName] ?? v),
+              ]),
+            )
+          : undefined,
+      },
+    ]),
+  );
+}
+
+/**
  * Materialize `container.json` from the DB. Called at spawn time so the
  * container always sees fresh config. Returns the `ContainerConfig` for
  * use by the caller (buildMounts, buildContainerArgs, etc.).
+ *
+ * MCP server env values support `${VAR_NAME}` references — resolved from
+ * process.env so secrets live in `.env`, not the DB.
  */
 export function materializeContainerJson(agentGroupId: string): ContainerConfig {
   const group = getAgentGroup(agentGroupId);
@@ -79,11 +108,15 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);
+  const serialized = {
+    ...config,
+    mcpServers: expandMcpEnvRefs(config.mcpServers),
+  };
 
   const p = path.join(GROUPS_DIR, group.folder, 'container.json');
   const dir = path.dirname(p);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(config, null, 2) + '\n');
+  fs.writeFileSync(p, JSON.stringify(serialized, null, 2) + '\n');
 
   return config;
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`ncl groups config add-mcp-server --env KEY=<value>` stored raw secret values
in the central DB. This adds `expandMcpEnvRefs()` in `src/container-config.ts`,
called inside `materializeContainerJson()` at spawn time: MCP server `env` values
can now contain `${VAR_NAME}` references that are resolved against `process.env`
before writing `container.json`. Unresolved references are left as-is.

Operators store `KEY=${MY_SECRET}` in the DB and keep the actual value in `.env`,
which is never committed and never written to the central DB.

## For Skills

N/A — source change only.