### PR TITLE
feat(skills): add /setup-system-digest and /system-digest skills

### DIFF
--- a/.claude/skills/setup-system-digest/REMOVE.md
+++ b/.claude/skills/setup-system-digest/REMOVE.md
@@ -1,0 +1,35 @@
+# Remove: system-digest
+
+Reverses everything `/system-digest` installs.
+
+## Linux (systemd)
+
+```bash
+systemctl --user disable --now nanoclaw-snapshot.timer
+rm ~/.config/systemd/user/nanoclaw-snapshot.timer
+rm ~/.config/systemd/user/nanoclaw-snapshot.service
+systemctl --user daemon-reload
+```
+
+## macOS (launchd)
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.snapshot.plist
+rm ~/Library/LaunchAgents/com.nanoclaw.snapshot.plist
+```
+
+## Snapshot state
+
+```bash
+rm -f data/system-digest.json
+```
+
+## Script
+
+If `scripts/system-digest.ts` was copied in by this skill (i.e. it did not exist before install):
+
+```bash
+rm scripts/system-digest.ts
+```
+
+If you customized the script after install, review before deleting.

--- a/.claude/skills/setup-system-digest/SKILL.md
+++ b/.claude/skills/setup-system-digest/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: setup-system-digest
+description: Install the daily system-state digest — sets up the script and timer that diffs agent groups, channels, wirings, and scheduled tasks, then delivers a summary message to your primary channel only when something changed. Zero LLM tokens when nothing changed.
+---
+
+# System Digest
+
+Installs a daily script that diffs NanoClaw's configuration state and delivers a summary to your primary channel when anything changes. If nothing changed, it exits silently — no message, no tokens.
+
+The script (`scripts/system-digest.ts`) writes directly to the delivery agent's `outbound.db`, bypassing the agent container entirely.
+
+## What it tracks
+
+- Agent groups (name, provider, model, CLI scope, MCP servers, packages)
+- Messaging groups (name, access policy)
+- Wirings (session mode, engage mode/pattern)
+- Scheduled tasks (recurrence changes, new/removed tasks)
+- Global model defaults from `.env`
+- Alerts: pending approvals, new unregistered sender attempts
+
+## Install Steps
+
+### 1. Discover the delivery target
+
+Find the owner and their primary DM channel:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "
+  SELECT mg.id AS mg_id, mg.channel_type, mg.platform_id,
+         mga.agent_group_id
+  FROM messaging_groups mg
+  JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
+  WHERE mg.is_group = 0
+  ORDER BY mg.created_at ASC
+"
+```
+
+Pick the preferred DM channel. Note the `mg_id`, `channel_type`, `platform_id`, and `agent_group_id`.
+
+### 2. Copy the script (new installs only)
+
+If `scripts/system-digest.ts` does not already exist:
+
+```bash
+cp "${CLAUDE_SKILL_DIR}/scripts/system-digest.ts" scripts/system-digest.ts
+```
+
+### 3. Patch the delivery constants
+
+Edit the four `PLACEHOLDER_*` constants at the top of `scripts/system-digest.ts`:
+
+```typescript
+const DELIVERY_AGENT_GROUP_ID = '<agent_group_id from step 1>';
+const DELIVERY_MG_ID = '<mg_id from step 1>';
+const DELIVERY_PLATFORM_ID = '<platform_id from step 1>';
+const DELIVERY_CHANNEL_TYPE = '<channel_type from step 1>';
+```
+
+### 4. Choose a daily delivery time
+
+Ask the user what time they want the digest delivered. Compute the UTC equivalent using `TIMEZONE` from `src/config.ts`:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT 1" 2>/dev/null
+node -e "
+const { TIMEZONE } = require('./src/config.js');
+const d = new Date();
+d.setHours(<desired_local_hour>, 0, 0, 0);
+const utcH = d.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'UTC' });
+console.log('UTC hour:', utcH, '(TIMEZONE:', TIMEZONE + ')');
+"
+```
+
+### 5a. Linux (systemd) — create timer
+
+```bash
+cat > ~/.config/systemd/user/nanoclaw-snapshot.service << 'EOF'
+[Unit]
+Description=NanoClaw system snapshot
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/<USER>/nanoclaw-v2/node_modules/.bin/tsx /home/<USER>/nanoclaw-v2/scripts/system-digest.ts
+WorkingDirectory=/home/<USER>/nanoclaw-v2
+Environment=HOME=/home/<USER>
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/<USER>/.local/bin
+StandardOutput=append:/home/<USER>/nanoclaw-v2/logs/system-digest.log
+StandardError=append:/home/<USER>/nanoclaw-v2/logs/system-digest.log
+EOF
+
+cat > ~/.config/systemd/user/nanoclaw-snapshot.timer << 'EOF'
+[Unit]
+Description=Daily NanoClaw system snapshot
+
+[Timer]
+OnCalendar=*-*-* <UTC_HOUR>:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now nanoclaw-snapshot.timer
+```
+
+Replace `<USER>` with the actual username (`echo $USER`) and `<UTC_HOUR>` with the value from step 4.
+
+### 5b. macOS (launchd) — create plist
+
+```bash
+cat > ~/Library/LaunchAgents/com.nanoclaw.snapshot.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.nanoclaw.snapshot</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/<USER>/nanoclaw-v2/node_modules/.bin/tsx</string>
+    <string>/Users/<USER>/nanoclaw-v2/scripts/system-digest.ts</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/<USER>/nanoclaw-v2</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer><LOCAL_HOUR></integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/<USER>/nanoclaw-v2/logs/system-digest.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/<USER>/nanoclaw-v2/logs/system-digest.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/<USER></string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>
+EOF
+
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.snapshot.plist
+```
+
+Replace `<USER>` with the actual username and `<LOCAL_HOUR>` with the desired local hour (integer, 24h).
+
+### 6. Run once to initialize the baseline
+
+```bash
+pnpm exec tsx scripts/system-digest.ts
+```
+
+This saves `data/system-digest.json` as the baseline. The first run never delivers a message — it only stores state to diff against.
+
+Verify the snapshot was written:
+```bash
+ls -lh data/system-digest.json
+```
+
+### 7. Verify delivery
+
+Make a small traceable change (e.g., rename a messaging group with `ncl messaging-groups update --id <id> --name "test"`), run the script again, then revert:
+
+```bash
+pnpm exec tsx scripts/system-digest.ts
+```
+
+A message should arrive on the delivery channel. Revert the test change and run once more to reset the baseline.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/system-digest.ts` | The snapshot + diff + delivery script |
+| `data/system-digest.json` | Persisted baseline snapshot |
+| `logs/system-digest.log` | Script output log |
+| `${CLAUDE_SKILL_DIR}/scripts/system-digest.ts` | Skill's generalized template |

--- a/.claude/skills/setup-system-digest/scripts/system-digest.ts
+++ b/.claude/skills/setup-system-digest/scripts/system-digest.ts
@@ -170,7 +170,7 @@ function readState(db: Database.Database): Snapshot {
     }
   }
 
-  const pendingApprovals = (db.prepare('SELECT COUNT(*) as c FROM pending_approvals').get() as any).c as number;
+  const pendingApprovals = (db.prepare("SELECT COUNT(*) as c FROM pending_approvals WHERE status = 'pending'").get() as any).c as number;
   const unregisteredSenders = (db.prepare('SELECT COUNT(*) as c FROM unregistered_senders').get() as any).c as number;
 
   const env = readEnvFile(['OPENCODE_MODEL', 'OPENCODE_SMALL_MODEL']);

--- a/.claude/skills/setup-system-digest/scripts/system-digest.ts
+++ b/.claude/skills/setup-system-digest/scripts/system-digest.ts
@@ -62,6 +62,8 @@ interface WiringSnap {
 
 interface TaskSnap {
   id: string;
+  seriesId: string | null;
+  stableKey: string;
   recurrence: string | null;
   processAfter: string | null;
 }
@@ -148,7 +150,7 @@ function readState(db: Database.Database): Snapshot {
     try {
       inDb.pragma('journal_mode = DELETE');
       const tasks = inDb.prepare(
-        "SELECT id, recurrence, process_after FROM messages_in WHERE kind='task' ORDER BY id",
+        "SELECT id, series_id, recurrence, process_after FROM messages_in WHERE kind='task' AND status='pending' ORDER BY id",
       ).all() as any[];
 
       scheduledTasks.push({
@@ -156,6 +158,8 @@ function readState(db: Database.Database): Snapshot {
         agentGroupName: group.name,
         tasks: tasks.map(t => ({
           id: t.id,
+          seriesId: t.series_id ?? null,
+          stableKey: t.series_id ?? t.id,
           recurrence: t.recurrence ?? null,
           // For one-shot tasks only — recurring process_after advances daily, not meaningful to diff
           processAfter: t.recurrence ? null : (t.process_after ?? null),
@@ -254,8 +258,8 @@ function diffState(prev: Snapshot, curr: Snapshot): Record<string, Change[]> {
     const prevGroup = prevGroupMap.get(gid);
     const prevTasks = prevGroup ? prevGroup.tasks : [];
     const inner = diffArrayByKey(
-      prevTasks, group.tasks, 'id',
-      t => `[${group.agentGroupName}] ${t.id}`,
+      prevTasks, group.tasks, 'stableKey',
+      t => `[${group.agentGroupName}] ${t.seriesId ?? t.id}`,
       ['recurrence', 'processAfter'],
     );
     taskChanges.push(...inner);

--- a/.claude/skills/setup-system-digest/scripts/system-digest.ts
+++ b/.claude/skills/setup-system-digest/scripts/system-digest.ts
@@ -1,0 +1,363 @@
+/**
+ * Daily NanoClaw system state snapshot + diff.
+ *
+ * Reads agent groups, messaging groups, wirings, scheduled tasks, and env
+ * defaults. Compares against data/system-snapshot.json. If nothing changed,
+ * exits silently (0 tokens). If something changed, formats the diff as plain
+ * text and writes it directly to the delivery agent's outbound.db so the host
+ * delivery poller sends it — no agent container, no LLM.
+ *
+ * Run via systemd timer or launchd plist daily at your chosen time.
+ *
+ * CONFIGURE: The four constants below are patched by the /system-digest skill
+ * install step. Do not edit them by hand unless you know what you're doing.
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+import Database from 'better-sqlite3';
+
+import { DATA_DIR } from '../src/config.js';
+import { initDb, getDb } from '../src/db/index.js';
+import { readEnvFile } from '../src/env.js';
+import { writeOutboundDirect } from '../src/session-manager.js';
+
+// --- Delivery target (patched by skill install) ---
+const DELIVERY_AGENT_GROUP_ID = 'PLACEHOLDER_AGENT_GROUP_ID';
+const DELIVERY_MG_ID = 'PLACEHOLDER_MG_ID';
+const DELIVERY_PLATFORM_ID = 'PLACEHOLDER_PLATFORM_ID';
+const DELIVERY_CHANNEL_TYPE = 'PLACEHOLDER_CHANNEL_TYPE';
+
+const SNAPSHOT_PATH = path.join(DATA_DIR, 'system-snapshot.json');
+
+// --- Types ---
+
+interface AgentGroupSnap {
+  id: string;
+  name: string;
+  provider: string | null;
+  model: string | null;
+  cliScope: string | null;
+  mcpServers: string[];
+  packagesApt: string[];
+  packagesNpm: string[];
+}
+
+interface MessagingGroupSnap {
+  id: string;
+  channelType: string;
+  name: string;
+  unknownSenderPolicy: string;
+}
+
+interface WiringSnap {
+  id: string;
+  agentGroupName: string;
+  messagingGroupName: string;
+  sessionMode: string;
+  engageMode: string | null;
+  engagePattern: string | null;
+}
+
+interface TaskSnap {
+  id: string;
+  recurrence: string | null;
+  processAfter: string | null;
+}
+
+interface GroupTasksSnap {
+  agentGroupId: string;
+  agentGroupName: string;
+  tasks: TaskSnap[];
+}
+
+interface Snapshot {
+  capturedAt: string;
+  agentGroups: AgentGroupSnap[];
+  messagingGroups: MessagingGroupSnap[];
+  wirings: WiringSnap[];
+  scheduledTasks: GroupTasksSnap[];
+  pendingApprovals: number;
+  unregisteredSenders: number;
+  defaults: { model: string; smallModel: string };
+}
+
+// --- State reading ---
+
+function readState(db: Database.Database): Snapshot {
+  const rawGroups = db.prepare(`
+    SELECT ag.id, ag.name,
+           cc.provider, cc.model, cc.cli_scope,
+           cc.mcp_servers, cc.packages_apt, cc.packages_npm
+    FROM agent_groups ag
+    LEFT JOIN container_configs cc ON cc.agent_group_id = ag.id
+    ORDER BY ag.id
+  `).all() as any[];
+
+  const agentGroups: AgentGroupSnap[] = rawGroups.map(g => ({
+    id: g.id,
+    name: g.name,
+    provider: g.provider ?? null,
+    model: g.model ?? null,
+    cliScope: g.cli_scope ?? null,
+    mcpServers: g.mcp_servers ? Object.keys(JSON.parse(g.mcp_servers)) : [],
+    packagesApt: g.packages_apt ? JSON.parse(g.packages_apt) : [],
+    packagesNpm: g.packages_npm ? JSON.parse(g.packages_npm) : [],
+  }));
+
+  const messagingGroups: MessagingGroupSnap[] = (db.prepare(`
+    SELECT id, channel_type, name, unknown_sender_policy
+    FROM messaging_groups ORDER BY id
+  `).all() as any[]).map(g => ({
+    id: g.id,
+    channelType: g.channel_type,
+    name: g.name ?? '',
+    unknownSenderPolicy: g.unknown_sender_policy,
+  }));
+
+  const rawWirings = db.prepare(`
+    SELECT mga.id, mga.session_mode, mga.engage_mode, mga.engage_pattern,
+           mg.name as mg_name, ag.name as ag_name
+    FROM messaging_group_agents mga
+    JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+    JOIN agent_groups ag ON ag.id = mga.agent_group_id
+    ORDER BY mga.id
+  `).all() as any[];
+
+  const wirings: WiringSnap[] = rawWirings.map(w => ({
+    id: w.id,
+    agentGroupName: w.ag_name,
+    messagingGroupName: w.mg_name ?? '',
+    sessionMode: w.session_mode,
+    engageMode: w.engage_mode ?? null,
+    engagePattern: w.engage_pattern ?? null,
+  }));
+
+  const scheduledTasks: GroupTasksSnap[] = [];
+  for (const group of rawGroups) {
+    const session = db.prepare(
+      'SELECT id FROM sessions WHERE agent_group_id = ? ORDER BY created_at DESC LIMIT 1',
+    ).get(group.id) as { id: string } | undefined;
+    if (!session) continue;
+
+    const inDbPath = path.join(DATA_DIR, 'v2-sessions', group.id, session.id, 'inbound.db');
+    if (!fs.existsSync(inDbPath)) continue;
+
+    const inDb = new Database(inDbPath, { readonly: true });
+    try {
+      inDb.pragma('journal_mode = DELETE');
+      const tasks = inDb.prepare(
+        "SELECT id, recurrence, process_after FROM messages_in WHERE kind='task' ORDER BY id",
+      ).all() as any[];
+
+      scheduledTasks.push({
+        agentGroupId: group.id,
+        agentGroupName: group.name,
+        tasks: tasks.map(t => ({
+          id: t.id,
+          recurrence: t.recurrence ?? null,
+          // For one-shot tasks only — recurring process_after advances daily, not meaningful to diff
+          processAfter: t.recurrence ? null : (t.process_after ?? null),
+        })),
+      });
+    } finally {
+      inDb.close();
+    }
+  }
+
+  const pendingApprovals = (db.prepare('SELECT COUNT(*) as c FROM pending_approvals').get() as any).c as number;
+  const unregisteredSenders = (db.prepare('SELECT COUNT(*) as c FROM unregistered_senders').get() as any).c as number;
+
+  const env = readEnvFile(['OPENCODE_MODEL', 'OPENCODE_SMALL_MODEL']);
+  const defaults = {
+    model: env.OPENCODE_MODEL ?? '',
+    smallModel: env.OPENCODE_SMALL_MODEL ?? '',
+  };
+
+  return {
+    capturedAt: new Date().toISOString(),
+    agentGroups,
+    messagingGroups,
+    wirings,
+    scheduledTasks,
+    pendingApprovals,
+    unregisteredSenders,
+    defaults,
+  };
+}
+
+// --- Diff ---
+
+type Change = string;
+
+function diffArrayByKey<T extends Record<string, any>>(
+  prev: T[],
+  curr: T[],
+  key: string,
+  label: (item: T) => string,
+  fields: string[],
+): Change[] {
+  const changes: Change[] = [];
+  const prevMap = new Map(prev.map(i => [i[key], i]));
+  const currMap = new Map(curr.map(i => [i[key], i]));
+
+  for (const [id, item] of currMap) {
+    if (!prevMap.has(id)) {
+      changes.push(`+ ${label(item)} added`);
+    } else {
+      const p = prevMap.get(id)!;
+      for (const f of fields) {
+        const pv = JSON.stringify(p[f] ?? null);
+        const cv = JSON.stringify(item[f] ?? null);
+        if (pv !== cv) {
+          const display = (v: string) => (v === 'null' ? 'none' : v.replace(/^"|"$/g, ''));
+          changes.push(`~ ${label(item)}: ${f} ${display(pv)} → ${display(cv)}`);
+        }
+      }
+    }
+  }
+
+  for (const [id, item] of prevMap) {
+    if (!currMap.has(id)) changes.push(`- ${label(item)} removed`);
+  }
+
+  return changes;
+}
+
+function diffState(prev: Snapshot, curr: Snapshot): Record<string, Change[]> {
+  const sections: Record<string, Change[]> = {};
+
+  sections['Agent groups'] = diffArrayByKey(
+    prev.agentGroups, curr.agentGroups, 'id',
+    g => g.name,
+    ['name', 'provider', 'model', 'cliScope', 'mcpServers', 'packagesApt', 'packagesNpm'],
+  );
+
+  sections['Messaging groups'] = diffArrayByKey(
+    prev.messagingGroups, curr.messagingGroups, 'id',
+    g => `${g.name || g.id} (${g.channelType})`,
+    ['name', 'unknownSenderPolicy'],
+  );
+
+  sections['Wirings'] = diffArrayByKey(
+    prev.wirings, curr.wirings, 'id',
+    w => `${w.messagingGroupName} → ${w.agentGroupName}`,
+    ['sessionMode', 'engageMode', 'engagePattern'],
+  );
+
+  const taskChanges: Change[] = [];
+  const prevGroupMap = new Map(prev.scheduledTasks.map(g => [g.agentGroupId, g]));
+  const currGroupMap = new Map(curr.scheduledTasks.map(g => [g.agentGroupId, g]));
+
+  for (const [gid, group] of currGroupMap) {
+    const prevGroup = prevGroupMap.get(gid);
+    const prevTasks = prevGroup ? prevGroup.tasks : [];
+    const inner = diffArrayByKey(
+      prevTasks, group.tasks, 'id',
+      t => `[${group.agentGroupName}] ${t.id}`,
+      ['recurrence', 'processAfter'],
+    );
+    taskChanges.push(...inner);
+  }
+  for (const [gid, group] of prevGroupMap) {
+    if (!currGroupMap.has(gid)) {
+      taskChanges.push(`- All tasks for ${group.agentGroupName} removed`);
+    }
+  }
+  sections['Scheduled tasks'] = taskChanges;
+
+  sections['Defaults'] = [];
+  if (prev.defaults.model !== curr.defaults.model) {
+    sections['Defaults'].push(`~ default model: ${prev.defaults.model || 'none'} → ${curr.defaults.model || 'none'}`);
+  }
+  if (prev.defaults.smallModel !== curr.defaults.smallModel) {
+    sections['Defaults'].push(`~ small model: ${prev.defaults.smallModel || 'none'} → ${curr.defaults.smallModel || 'none'}`);
+  }
+
+  const alertChanges: Change[] = [];
+  if (curr.pendingApprovals > 0) {
+    alertChanges.push(`⚠ ${curr.pendingApprovals} pending approval(s) waiting`);
+  }
+  if (curr.unregisteredSenders > prev.unregisteredSenders) {
+    alertChanges.push(`⚠ ${curr.unregisteredSenders - prev.unregisteredSenders} new unregistered sender attempt(s)`);
+  }
+  sections['Alerts'] = alertChanges;
+
+  return sections;
+}
+
+function formatDiff(sections: Record<string, Change[]>, capturedAt: string): string {
+  const date = new Date(capturedAt).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  });
+
+  const lines: string[] = [`*NanoClaw system update — ${date}*`, ''];
+
+  for (const [section, changes] of Object.entries(sections)) {
+    if (changes.length === 0) continue;
+    lines.push(`*${section}*`);
+    for (const c of changes) lines.push(`  ${c}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
+}
+
+// --- Deliver ---
+
+function deliver(db: Database.Database, text: string): void {
+  const session = db.prepare(
+    'SELECT id FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? ORDER BY created_at DESC LIMIT 1',
+  ).get(DELIVERY_AGENT_GROUP_ID, DELIVERY_MG_ID) as { id: string } | undefined;
+
+  if (!session) {
+    console.log('No delivery session found — cannot deliver. Message:\n', text);
+    return;
+  }
+
+  writeOutboundDirect(DELIVERY_AGENT_GROUP_ID, session.id, {
+    id: `system-snapshot-${Date.now()}`,
+    kind: 'chat',
+    platformId: DELIVERY_PLATFORM_ID,
+    channelType: DELIVERY_CHANNEL_TYPE,
+    threadId: null,
+    content: JSON.stringify({ text }),
+  });
+
+  console.log(`Delivered system change notification (session ${session.id})`);
+}
+
+// --- Main ---
+
+async function main(): Promise<void> {
+  initDb(path.join(process.cwd(), 'data', 'v2.db'));
+  const db = getDb();
+
+  const current = readState(db);
+
+  if (!fs.existsSync(SNAPSHOT_PATH)) {
+    fs.writeFileSync(SNAPSHOT_PATH, JSON.stringify(current, null, 2));
+    console.log('First run — snapshot saved. Nothing to compare yet.');
+    return;
+  }
+
+  const previous: Snapshot = JSON.parse(fs.readFileSync(SNAPSHOT_PATH, 'utf8'));
+  const sections = diffState(previous, current);
+  const totalChanges = Object.values(sections).reduce((n, arr) => n + arr.length, 0);
+
+  if (totalChanges === 0) {
+    console.log('No changes. Exiting. (0 tokens)');
+    return;
+  }
+
+  const message = formatDiff(sections, current.capturedAt);
+  deliver(db, message);
+
+  fs.writeFileSync(SNAPSHOT_PATH, JSON.stringify(current, null, 2));
+}
+
+main().catch(err => {
+  console.error('system-snapshot failed:', err);
+  process.exit(1);
+});

--- a/.claude/skills/system-digest/SKILL.md
+++ b/.claude/skills/system-digest/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: system-digest
+description: Show current NanoClaw system state — agent groups, channels, wirings, scheduled tasks, and any pending alerts. On-demand view of what /setup-system-digest monitors daily.
+---
+
+# System Digest
+
+Show the current NanoClaw system state. This is the on-demand counterpart to the daily digest delivered by the automated timer.
+
+## Output
+
+Query and display each section in order:
+
+### Agent Groups
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "
+  SELECT ag.name, ag.folder, cc.provider, cc.model, cc.cli_scope,
+         cc.mcp_servers, cc.packages_apt, cc.packages_npm
+  FROM agent_groups ag
+  LEFT JOIN container_configs cc ON cc.agent_group_id = ag.id
+  ORDER BY ag.name
+"
+```
+
+For each group show: name, folder, provider/model (note if inheriting global default), CLI scope, MCP server names, packages.
+
+### Channels & Wirings
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "
+  SELECT ag.name AS agent, mg.channel_type, mg.name AS channel,
+         mga.session_mode, mg.unknown_sender_policy
+  FROM messaging_group_agents mga
+  JOIN agent_groups ag ON ag.id = mga.agent_group_id
+  JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+  ORDER BY ag.name, mg.channel_type
+"
+```
+
+### Scheduled Tasks
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "
+  SELECT ag.id AS group_id, ag.name, s.id AS session_id
+  FROM agent_groups ag
+  LEFT JOIN sessions s ON s.id = (
+    SELECT id FROM sessions WHERE agent_group_id = ag.id ORDER BY created_at DESC LIMIT 1
+  )
+  ORDER BY ag.name
+"
+```
+
+For each group with a session:
+```bash
+pnpm exec tsx scripts/q.ts \
+  "data/v2-sessions/<group_id>/<session_id>/inbound.db" \
+  "SELECT id, status, recurrence, process_after,
+          substr(json_extract(content, '$.prompt'), 1, 60) AS prompt
+   FROM messages_in WHERE kind='task' AND status != 'completed'
+   ORDER BY process_after"
+```
+
+Show: task ID, recurrence pattern (human-readable), next fire time in local time, prompt preview. Group by agent. Note if a group has no tasks.
+
+### Alerts
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT COUNT(*) FROM pending_approvals"
+pnpm exec tsx scripts/q.ts data/v2.db "SELECT COUNT(*) FROM unregistered_senders"
+```
+
+Flag if either is non-zero.
+
+### Last Digest Delivery
+
+```bash
+ls -lh data/system-digest.json 2>/dev/null || echo "No baseline snapshot yet — run /setup-system-digest"
+```
+
+Show when the baseline was last updated (last time something changed and was delivered).
+
+## Format
+
+Present output as a readable summary, not raw SQL rows. Use headers per section. Summarize rather than dump — one line per agent group, one line per wiring, etc. Highlight anything unusual: `cli_scope = 'global'` on any agent that is **not** the owner's primary agent (global scope is expected and correct for the owner agent), `unknown_sender_policy = 'public'` on group channels, overdue tasks, pending alerts.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [x] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds two companion skills for passive system observability:

**`/setup-system-digest`** — installs a daily script
(`.claude/skills/setup-system-digest/scripts/system-digest.ts`) that diffs
NanoClaw config state (agent groups, messaging groups, wirings, scheduled
tasks, env defaults) and delivers a change summary to the owner's primary
channel. If nothing changed, the script exits silently — zero LLM tokens, no
message sent. Writes directly to the delivery agent's `outbound.db`, bypassing
the agent container entirely. Includes `REMOVE.md`. Supports both Linux
(systemd timer) and macOS (launchd plist). The install step discovers the
owner's preferred DM channel from `user_roles`/`user_dms` rather than
hardcoding a platform ID.

**`/system-digest`** — on-demand companion: shows current system state without
requiring the timer to be installed. Useful for a quick audit or for installs
that don't want daily delivery.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone