### PR TITLE
fix: rotate stale provider session on ceiling-kill and empty result

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -252,6 +252,13 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         continuation = result.continuation;
         setContinuation(config.providerName, continuation);
       }
+      // Provider returned nothing — session is likely degraded. Clear so the
+      // next container starts a fresh session rather than resuming a dead one.
+      if (result.hadEmptyResult && continuation) {
+        log(`Empty result with active session (${continuation}) — clearing for fresh retry`);
+        continuation = undefined;
+        clearContinuation(config.providerName);
+      }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       log(`Query error: ${errMsg}`);
@@ -321,6 +328,8 @@ function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommand
 
 interface QueryResult {
   continuation?: string;
+  /** True if every result event had empty text — provider returned nothing. */
+  hadEmptyResult: boolean;
 }
 
 export async function processQuery(
@@ -335,6 +344,8 @@ export async function processQuery(
   let queryContinuation: string | undefined;
   let done = false;
   let unwrappedNudged = false;
+  let resultCount = 0;
+  let emptyResultCount = 0;
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -481,6 +492,7 @@ export async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        resultCount++;
         if (event.text) {
           const { sent, hasUnwrapped } = dispatchResultText(event.text, routing);
           if (sent === 0 && event.isError === true) {
@@ -520,6 +532,7 @@ export async function processQuery(
             if (!willRetryWrapping) archivePrompts.shift();
           }
         } else {
+          emptyResultCount++;
           archivePrompts.shift();
         }
       }
@@ -538,7 +551,7 @@ export async function processQuery(
     clearInterval(pollHandle);
   }
 
-  return { continuation: queryContinuation };
+  return { continuation: queryContinuation, hadEmptyResult: resultCount > 0 && emptyResultCount === resultCount };
 }
 
 function notifyExchangeComplete(

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -28,6 +28,7 @@
  */
 import type Database from 'better-sqlite3';
 import fs from 'fs';
+import path from 'path';
 
 import { ensureEgressNetwork } from './egress-lockdown.js';
 import { getActiveSessions } from './db/sessions.js';
@@ -46,6 +47,7 @@ import {
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbeatPath } from './session-manager.js';
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { GROUPS_DIR } from './config.js';
 import type { Session } from './types.js';
 
 /**
@@ -206,7 +208,7 @@ async function sweepSession(session: Session): Promise<void> {
     // yet. Without this grace period, stale claims cause an immediate
     // spawn-kill loop.
     if (alive && outDb && !justWoke) {
-      enforceRunningContainerSla(inDb, outDb, session, agentGroup.id);
+      enforceRunningContainerSla(inDb, outDb, session, agentGroup.id, agentGroup.folder);
     }
 
     // 4. Crashed-container cleanup: processing rows left behind get retried.
@@ -242,11 +244,21 @@ function bashTimeoutMs(state: ContainerState | null): number | null {
   return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : null;
 }
 
+function writeClearSessionSignal(agentGroupFolder: string): void {
+  const signalPath = path.join(GROUPS_DIR, agentGroupFolder, '.clear-provider-session');
+  try {
+    fs.writeFileSync(signalPath, new Date().toISOString());
+  } catch {
+    // best effort — if the group dir doesn't exist yet the next container will start fresh anyway
+  }
+}
+
 function enforceRunningContainerSla(
   inDb: Database.Database,
   outDb: Database.Database,
   session: Session,
   agentGroupId: string,
+  agentGroupFolder: string,
 ): void {
   const decision = decideStuckAction({
     now: Date.now(),
@@ -264,6 +276,7 @@ function enforceRunningContainerSla(
       ceilingMs: decision.ceilingMs,
     });
     killContainer(session.id, 'absolute-ceiling');
+    writeClearSessionSignal(agentGroupFolder);
     resetStuckProcessingRows(inDb, outDb, session, 'absolute-ceiling');
     return;
   }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

When a container hits the 30-minute absolute ceiling and is killed, it
may have had an active provider session stored in `session_state`. On
respawn the agent resumes that session, which is now stale — the
provider returns empty results silently, the host kills the container
again at the next ceiling, and the cycle repeats indefinitely.

Two provider-agnostic changes:

**`src/host-sweep.ts`** — on a `kill-ceiling` decision, write a
`.clear-provider-session` signal file to the agent group's workspace
directory (mounted at `/workspace/agent` inside the container).
Providers that implement `maybeRotateContinuation` read and delete this
file at next startup to discard stale continuations. Best-effort write —
if the group directory doesn't exist the next container starts fresh
anyway.

**`container/agent-runner/src/poll-loop.ts`** — track whether every
result event in a query returned empty text. If so, and an active
continuation was in use, clear it immediately so the next message starts
a fresh session rather than resuming a dead one. This catches the
silent-failure case where `isSessionInvalid` never fires (no exception
thrown, just empty output).

The provider-side implementation of `maybeRotateContinuation` for
OpenCode is in a companion PR against the `providers` branch.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone