### PR TITLE
fix(opencode): rotate stale session on ceiling-kill signal and age threshold

### DIFF
--- a/container/agent-runner/src/db/session-state.ts
+++ b/container/agent-runner/src/db/session-state.ts
@@ -77,3 +77,12 @@ export function setContinuation(providerName: string, id: string): void {
 export function clearContinuation(providerName: string): void {
   deleteValue(continuationKey(providerName));
 }
+
+export function getContinuationAge(providerName: string): number | null {
+  const row = getOutboundDb()
+    .prepare('SELECT updated_at FROM session_state WHERE key = ?')
+    .get(continuationKey(providerName)) as { updated_at: string } | undefined;
+  if (!row?.updated_at) return null;
+  const t = Date.parse(row.updated_at.endsWith('Z') ? row.updated_at : row.updated_at + 'Z');
+  return Number.isNaN(t) ? null : Date.now() - t;
+}

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -7,6 +7,7 @@ import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk';
 import { registerProvider } from './provider-registry.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 import { mcpServersToOpenCodeConfig } from './mcp-to-opencode.js';
+import { getContinuationAge } from '../db/session-state.js';
 
 function log(msg: string): void {
   console.error(`[opencode-provider] ${msg}`);
@@ -211,6 +212,18 @@ function sessionErrorMessage(props: { error?: unknown }): string {
   return JSON.stringify(props.error) || 'OpenCode session error';
 }
 
+// Default: 90 minutes. Matches Google AI Studio's context cache TTL — after
+// that window, resuming costs as much as starting fresh, so rotation is free.
+// Override with OPENCODE_SESSION_MAX_AGE_MS (milliseconds).
+const DEFAULT_SESSION_MAX_AGE_MS = 90 * 60 * 1000;
+
+function sessionMaxAgeMs(): number {
+  const v = process.env.OPENCODE_SESSION_MAX_AGE_MS;
+  if (!v) return DEFAULT_SESSION_MAX_AGE_MS;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_SESSION_MAX_AGE_MS;
+}
+
 export class OpenCodeProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
@@ -236,6 +249,13 @@ export class OpenCodeProvider implements AgentProvider {
     } catch {
       // best effort
     }
+
+    const ageMs = getContinuationAge('opencode');
+    const maxAge = sessionMaxAgeMs();
+    if (ageMs !== null && ageMs > maxAge) {
+      return `session ${(ageMs / 3_600_000).toFixed(1)}h old > ${(maxAge / 3_600_000).toFixed(1)}h cap`;
+    }
+
     return null;
   }
 

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk';
 
@@ -222,6 +224,19 @@ export class OpenCodeProvider implements AgentProvider {
   isSessionInvalid(err: unknown): boolean {
     const msg = err instanceof Error ? err.message : String(err);
     return STALE_SESSION_RE.test(msg);
+  }
+
+  maybeRotateContinuation(_continuation: string, cwd: string): string | null {
+    const signalPath = path.join(cwd, '.clear-provider-session');
+    try {
+      if (fs.existsSync(signalPath)) {
+        fs.rmSync(signalPath, { force: true });
+        return 'host ceiling-kill signal';
+      }
+    } catch {
+      // best effort
+    }
+    return null;
   }
 
   query(input: QueryInput): AgentQuery {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Implements `maybeRotateContinuation` on `OpenCodeProvider` with two
rotation conditions, matching the proactive pattern from `ClaudeProvider`:

**1. Host ceiling-kill signal** — on container startup, checks for a
`.clear-provider-session` file written by the host sweep when the
previous container was ceiling-killed (see companion PR on main). Deletes
the file and returns a rotation reason, causing the poll-loop to discard
the stored continuation and start a fresh session.

**2. Age-based rotation** — rotates sessions older than
`OPENCODE_SESSION_MAX_AGE_MS` (default: 90 min). After Google AI
Studio's context cache TTL expires (1 hour), resuming an old session
costs as much as starting fresh — the full context must be re-uploaded
either way. Rotating proactively avoids replaying long conversation
histories for no cache benefit. Configurable so operators can tune to
their provider's actual TTL.

Also adds `getContinuationAge()` to `session-state.ts`, which reads the
existing `updated_at` column on the `session_state` row — no schema
changes required.

**Depends on:** the `host-sweep.ts` + `poll-loop.ts` changes on main
that write the signal file and clear continuations on empty results.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone