### PR TITLE
fix(telegram): drop legacy markdown sanitizer — adapter now uses MarkdownV2

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -11,7 +11,6 @@ import { createMessagingGroup, getMessagingGroupByPlatform, updateMessagingGroup
 import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js';
 import { upsertUser } from '../modules/permissions/db/users.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
-import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import type { ChannelAdapter, ChannelSetup, InboundMessage } from './adapter.js';
 import { tryConsume } from './telegram-pairing.js';
@@ -209,7 +208,6 @@ registerChannelAdapter('telegram', {
       concurrency: 'concurrent',
       extractReplyContext,
       supportsThreads: false,
-      transformOutboundText: sanitizeTelegramLegacyMarkdown,
       maxTextLength: 4000,
     });
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

`@chat-adapter/telegram` v4.29.0 (shipped in the recent SDK bump) defaulted to MarkdownV2 and handles CommonMark→MarkdownV2 conversion internally. The `sanitizeTelegramLegacyMarkdown` transform was written for the old legacy Markdown mode and now causes the opposite problem: `**bold**` gets pre-processed to `*bold*` (CommonMark italic syntax), which the adapter then renders as `_bold_`, and Telegram displays as italic.

Removing `transformOutboundText` lets the adapter's built-in MarkdownV2 pipeline handle formatting correctly.

Changes: remove the `sanitizeTelegramLegacyMarkdown` import and the `transformOutboundText` option from `createChatSdkBridge` in `src/channels/telegram.ts` (2 lines deleted).