### PR TITLE
fix(whatsapp): keep native participant addressing for group encryption

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -368,19 +368,20 @@ registerChannelAdapter('whatsapp', {
       const cached = groupMetadataCache.get(jid);
       if (cached && cached.expiresAt > Date.now()) return cached.metadata;
 
+      // IMPORTANT: this metadata is consumed ONLY by Baileys' `cachedGroupMetadata`
+      // hook, which uses the participant list to encrypt outbound group messages
+      // (sender-key distribution). It MUST keep participants in their native
+      // addressing (LID for v7 LID-addressed groups). Translating participant
+      // IDs to phone JIDs here misdirects sender-key distribution, so the message
+      // gets a server ID ("delivered") but no member can decrypt it — the reply
+      // silently never appears in the group. Inbound sender→phone-JID mapping is
+      // handled separately via translateJid at message-receive time.
       const metadata = await sock.groupMetadata(jid);
-      const participants = await Promise.all(
-        metadata.participants.map(async (p) => ({
-          ...p,
-          id: await translateJid(p.id),
-        })),
-      );
-      const normalized = { ...metadata, participants };
       groupMetadataCache.set(jid, {
-        metadata: normalized,
+        metadata,
         expiresAt: Date.now() + GROUP_METADATA_CACHE_TTL_MS,
       });
-      return normalized;
+      return metadata;
     }
 
     async function syncGroupMetadata(force = false): Promise<void> {


### PR DESCRIPTION
## Problem
WhatsApp **group** replies were logged as delivered (Baileys returned a server message id) but never appeared in the group. WhatsApp **DMs** worked fine.

## Root cause
`getNormalizedGroupMetadata()` is the sole provider for Baileys' `cachedGroupMetadata` socket hook, which Baileys uses to encrypt outbound group messages via sender-key distribution. It rewrote every participant's `id` through `translateJid()` (LID `@lid` → phone `@s.whatsapp.net`).

For WhatsApp v7 LID-addressed groups, that misdirects sender-key distribution — the server accepts the message (assigns an id, hence the "delivered" log) but no group member can decrypt it, so the reply is silently invisible. 1:1 DMs are unaffected because they use signal sessions, not group sender keys.

## Fix
Return the raw `sock.groupMetadata(jid)` to Baileys (native participant addressing). Inbound sender→phone-JID mapping still uses `translateJid()` at message-receive time, so mention matching and sender identity are unchanged.

## Testing
On Baileys `7.0.0-rc.9`: before, group @-mention replies logged as "delivered" but never showed in the group; after the change, the reply appears. DM behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)