### PR TITLE
feat(opencode): per-group model override via container_configs.model

### DIFF
--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -41,6 +41,11 @@ registerProviderContainerConfig('opencode', (ctx) => {
     const value = ctx.hostEnv[key];
     if (value) env[key] = value;
   }
+  // Per-group model override: container_configs.model takes precedence over the
+  // global OPENCODE_MODEL env var so each group can use a different model.
+  if (ctx.containerConfig.model) {
+    env['OPENCODE_MODEL'] = ctx.containerConfig.model;
+  }
 
   return {
     mounts: [{ hostPath: opencodeDir, containerPath: '/opencode-xdg', readonly: false }],


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature** - adds source code capability (no skill)

## Description

Allows each OpenCode agent group to run a different model by reading `container_configs.model` at spawn time and injecting it as `OPENCODE_MODEL` into the container environment. The per-group value takes precedence over the global `OPENCODE_MODEL` env var, so the default still applies when no per-group model is set.

Configured via `ncl groups config update --id <id> --model <model>` (e.g. `google/gemini-2.5-pro`).

**Depends on:** #2871 `feat(providers): add containerConfig to ProviderContainerContext` — the `ctx.containerConfig` field used here is added in the companion PR to `main` (`contrib/feat-dashboard`). This PR should merge after that one (or after the providers branch is rebased onto it).

## For Skills

N/A — no skill files.