### PR TITLE
feat(telegram): native rich rendering via Bot API 10.1 sendRichMessage

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -89,8 +89,13 @@ export interface ChatSdkBridgeConfig {
    * adapters like Discord (2000) and Telegram (4096) silently truncate
    * mid-response. The returned id is the first chunk's id so subsequent edits
    * and reactions still target the head of the reply.
+   *
+   * A function form resolves the limit per message — for adapters whose cap
+   * depends on the send path (e.g. Telegram rich messages accept 32k while
+   * the plain path caps at ~4k). `hasFiles` is true when file uploads ride
+   * on this message, which typically forces the conservative path.
    */
-  maxTextLength?: number;
+  maxTextLength?: number | ((text: string, hasFiles: boolean) => number);
 }
 
 /**
@@ -445,10 +450,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         }));
         // Split if over the adapter's max length. Files ride on the first
         // chunk so the head of the reply still carries them.
-        const chunks =
-          config.maxTextLength && text.length > config.maxTextLength
-            ? splitForLimit(text, config.maxTextLength)
-            : [text];
+        const limit =
+          typeof config.maxTextLength === 'function'
+            ? config.maxTextLength(text, !!(fileUploads && fileUploads.length > 0))
+            : config.maxTextLength;
+        const chunks = limit && text.length > limit ? splitForLimit(text, limit) : [text];
         let firstId: string | undefined;
         for (let i = 0; i < chunks.length; i++) {
           const chunk = chunks[i];

--- a/src/channels/telegram-rich-message.test.ts
+++ b/src/channels/telegram-rich-message.test.ts
@@ -11,6 +11,8 @@ import {
   sendRichMessageRaw,
   wrapTelegramRichSend,
   RICH_MESSAGE_MAX_CHARS,
+  TELEGRAM_PLAIN_MAX_CHARS,
+  richRoutable,
 } from './telegram-rich-message.js';
 
 const TABLE = ['| # | Titel | Typ |', '|---|-------|-----|', '| 1 | foo | bug |'].join('\n');
@@ -148,5 +150,149 @@ describe('wrapTelegramRichSend', () => {
     const a = wrapTelegramRichSend(stubAdapter(calls), { token: 'T', richTables: false, richConstructs: false });
     await a.postMessage('telegram:123', { markdown: TABLE });
     expect(calls.plain).toBe(1);
+  });
+
+  it('sends a long rich message (over the plain cap) as ONE rich send', async () => {
+    const longRich = `# Release notes\n\n${'lorem ipsum dolor sit amet. '.repeat(400)}`; // ~11k chars, heading → rich
+    expect(longRich.length).toBeGreaterThan(TELEGRAM_PLAIN_MAX_CHARS);
+    const richFetch = vi.fn(async () => ({
+      json: async () => ({ ok: true, result: { message_id: 7 } }),
+    })) as unknown as typeof fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = richFetch;
+    try {
+      const calls = { rich: 0, plain: 0 };
+      const a = wrapTelegramRichSend(stubAdapter(calls), { token: 'T', richTables: true, richConstructs: true });
+      const out = await a.postMessage('telegram:123', { markdown: longRich });
+      expect((richFetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+      expect(calls.plain).toBe(0);
+      expect(out.id).toBe('7');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('splits (not truncates) an over-4k message on rich fallback', async () => {
+    const longRich = `# Heading\n\n${'paragraph of prose here. '.repeat(400)}`; // > 4k, rich-routable
+    const richFetch = vi.fn(async () => ({
+      json: async () => ({ ok: false, error_code: 400, description: 'Bad Request' }),
+    })) as unknown as typeof fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = richFetch;
+    try {
+      const seen: string[] = [];
+      const adapter = {
+        postMessage: async (_tid: string, m: { markdown?: string }) => {
+          seen.push(m.markdown ?? '');
+          return { id: `p${seen.length}`, threadId: _tid, raw: {} };
+        },
+      };
+      const a = wrapTelegramRichSend(adapter, { token: 'T', richTables: true, richConstructs: true });
+      const out = await a.postMessage('telegram:123', { markdown: longRich });
+      expect(seen.length).toBeGreaterThan(1); // split, not a single truncated send
+      for (const chunk of seen) expect(chunk.length).toBeLessThanOrEqual(TELEGRAM_PLAIN_MAX_CHARS);
+      expect(seen.join(' ').replace(/\s+/g, ' ')).toBe(longRich.replace(/\s+/g, ' ')); // no content lost
+      expect(out.id).toBe('p1'); // head chunk id returned for edits/reactions
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe('wrapTelegramRichSend path-specific sanitization', () => {
+  const sanitize = (t: string) => t.replace(/^- /gm, '• ');
+
+  it('rich path gets RAW markdown; plain path gets sanitized text', async () => {
+    const richBodies: string[] = [];
+    const richFetch = vi.fn(async (_url: string, init: { body: string }) => {
+      richBodies.push(JSON.parse(init.body).rich_message.markdown);
+      return { json: async () => ({ ok: true, result: { message_id: 7 } }) };
+    }) as unknown as typeof fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = richFetch;
+    try {
+      const plainSeen: string[] = [];
+      const adapter = {
+        postMessage: async (_tid: string, m: { markdown?: string }) => {
+          plainSeen.push(m.markdown ?? '');
+          return { id: 'p', threadId: _tid, raw: {} };
+        },
+      };
+      const a = wrapTelegramRichSend(adapter, {
+        token: 'T',
+        richTables: true,
+        richConstructs: true,
+        sanitizeForPlain: sanitize,
+      });
+      const richMsg = '# Release\n\n- one\n- two'; // heading → rich
+      const plainMsg = 'hello\n- one\n- two'; // no rich construct → plain
+      await a.postMessage('telegram:123', { markdown: richMsg });
+      await a.postMessage('telegram:123', { markdown: plainMsg });
+      expect(richBodies).toEqual([richMsg]); // raw bullets survive to the rich renderer
+      expect(plainSeen).toEqual(['hello\n• one\n• two']); // plain path sanitized
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('sanitizes each chunk on rich fallback', async () => {
+    const richFetch = vi.fn(async () => ({
+      json: async () => ({ ok: false, error_code: 400, description: 'Bad Request' }),
+    })) as unknown as typeof fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = richFetch;
+    try {
+      const plainSeen: string[] = [];
+      const adapter = {
+        postMessage: async (_tid: string, m: { markdown?: string }) => {
+          plainSeen.push(m.markdown ?? '');
+          return { id: `p${plainSeen.length}`, threadId: _tid, raw: {} };
+        },
+      };
+      const a = wrapTelegramRichSend(adapter, {
+        token: 'T',
+        richTables: true,
+        richConstructs: true,
+        sanitizeForPlain: sanitize,
+      });
+      const long = `# Heading\n\n${'- a bullet item with some prose\n'.repeat(200)}`; // > 4k, rich-routable
+      await a.postMessage('telegram:123', { markdown: long });
+      expect(plainSeen.length).toBeGreaterThan(1);
+      for (const chunk of plainSeen) expect(chunk).not.toMatch(/^- /m); // every chunk sanitized
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('sanitizes edits (always plain path)', async () => {
+    const edits: string[] = [];
+    const adapter = {
+      postMessage: async (_tid: string, _m: unknown) => ({ id: 'p', threadId: _tid, raw: {} }),
+      editMessage: async (_tid: string, _id: string, m: { markdown?: string }) => {
+        edits.push(m.markdown ?? '');
+        return { id: _id, threadId: _tid, raw: {} };
+      },
+    };
+    const a = wrapTelegramRichSend(adapter, {
+      token: 'T',
+      richTables: true,
+      richConstructs: true,
+      sanitizeForPlain: sanitize,
+    });
+    await a.editMessage!('telegram:123', '9', { markdown: '- one\n- two' });
+    expect(edits).toEqual(['• one\n• two']);
+  });
+});
+
+describe('richRoutable', () => {
+  it('true for rich constructs within the cap, false for plain / oversize / crash shape', () => {
+    const opts = { richTables: true, richConstructs: true };
+    expect(richRoutable('# heading\n\nbody', opts)).toBe(true);
+    expect(richRoutable(TABLE, opts)).toBe(true);
+    expect(richRoutable('plain text', opts)).toBe(false);
+    expect(richRoutable('', opts)).toBe(false);
+    expect(richRoutable(`# h\n${'x'.repeat(RICH_MESSAGE_MAX_CHARS)}`, opts)).toBe(false);
+    expect(richRoutable('<details>\n$$x^2$$\n</details>', opts)).toBe(false); // TDesktop crash shape
+    expect(richRoutable(TABLE, { richTables: false, richConstructs: true })).toBe(false);
   });
 });

--- a/src/channels/telegram-rich-message.test.ts
+++ b/src/channels/telegram-rich-message.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isTablePrimary,
+  hasRichOnlyConstruct,
+  hasTDesktopCrashShape,
+  stripCode,
+  richTablesEnabled,
+  richConstructsEnabled,
+  isRichCapabilityError,
+  chatIdFromTid,
+  sendRichMessageRaw,
+  wrapTelegramRichSend,
+  RICH_MESSAGE_MAX_CHARS,
+} from './telegram-rich-message.js';
+
+const TABLE = ['| # | Titel | Typ |', '|---|-------|-----|', '| 1 | foo | bug |'].join('\n');
+
+describe('isTablePrimary', () => {
+  it('detects a GFM pipe table (with or without prose around it)', () => {
+    expect(isTablePrimary(TABLE)).toBe(true);
+    expect(isTablePrimary('intro\n\n' + TABLE + '\n\noutro')).toBe(true);
+    expect(isTablePrimary('a | b | c\n:--- | ---: | :--:\nx | y | z')).toBe(true);
+  });
+  it('rejects prose, single-dash rows, and a table shown inside code', () => {
+    expect(isTablePrimary('just text')).toBe(false);
+    expect(isTablePrimary('| a | b |\n| - | - |\n| 1 | 2 |')).toBe(false);
+    expect(isTablePrimary('example:\n```\n' + TABLE + '\n```')).toBe(false);
+  });
+});
+
+describe('hasRichOnlyConstruct', () => {
+  it('matches MarkdownV2-impossible constructs', () => {
+    expect(hasRichOnlyConstruct('## Heading\ntext')).toBe(true);
+    expect(hasRichOnlyConstruct('<details><summary>x</summary>y</details>')).toBe(true);
+    expect(hasRichOnlyConstruct('above\n\n---\n\nbelow')).toBe(true);
+    expect(hasRichOnlyConstruct('a $$x^2$$ b')).toBe(true);
+    expect(hasRichOnlyConstruct('- [ ] todo')).toBe(true);
+  });
+  it('leaves plain MarkdownV2 content alone', () => {
+    expect(hasRichOnlyConstruct('*bold* _italic_ `code`')).toBe(false);
+    expect(hasRichOnlyConstruct('- one\n- two')).toBe(false);
+    expect(hasRichOnlyConstruct('> a quote')).toBe(false);
+  });
+  it('does not match constructs shown inside code (copyability fix)', () => {
+    expect(hasRichOnlyConstruct('discuss `<details>` and `##` in backticks')).toBe(false);
+    expect(hasRichOnlyConstruct('fenced:\n```\n## h\n---\n```\ntext')).toBe(false);
+  });
+});
+
+describe('stripCode', () => {
+  it('removes fenced blocks and inline spans', () => {
+    expect(stripCode('a `x` b\n```\nblock\n```\nc').includes('block')).toBe(false);
+    expect(stripCode('a `x` b').includes('x')).toBe(false);
+  });
+});
+
+describe('hasTDesktopCrashShape', () => {
+  it('flags math inside a details fold, ignores other shapes', () => {
+    expect(hasTDesktopCrashShape('<details><summary>m</summary>\n$$x$$\n</details>')).toBe(true);
+    expect(hasTDesktopCrashShape('$$x$$\n\n<details>plain</details>')).toBe(false);
+    expect(hasTDesktopCrashShape('docs: `<details>$$x$$</details>` span')).toBe(false);
+  });
+});
+
+describe('toggles', () => {
+  it('default ON, OFF for explicit falsey', () => {
+    expect(richTablesEnabled({})).toBe(true);
+    expect(richConstructsEnabled({})).toBe(true);
+    for (const v of ['false', '0', 'off', 'no', 'FALSE']) {
+      expect(richTablesEnabled({ TELEGRAM_RICH_TABLES: v })).toBe(false);
+      expect(richConstructsEnabled({ TELEGRAM_RICH_CONSTRUCTS: v })).toBe(false);
+    }
+  });
+});
+
+describe('isRichCapabilityError', () => {
+  it('latches on a genuine missing-method, NOT on per-message 400s', () => {
+    expect(isRichCapabilityError({ errorCode: 404 })).toBe(true);
+    expect(isRichCapabilityError(new Error('Bad Request: unknown method sendRichMessage'))).toBe(true);
+    // our own error text contains "RichMessage" — must not be misread as capability
+    expect(isRichCapabilityError(new Error('sendRichMessage failed: 400 Bad Request: chat not found'))).toBe(false);
+    expect(isRichCapabilityError({ errorCode: 400, message: "can't parse rich_message" })).toBe(false);
+  });
+});
+
+describe('chatIdFromTid', () => {
+  it('strips the telegram: prefix to a numeric chat_id', () => {
+    expect(chatIdFromTid('telegram:7754134287')).toBe(7754134287);
+    expect(chatIdFromTid('telegram:-1001234567890')).toBe(-1001234567890);
+    expect(chatIdFromTid('7754134287')).toBe(7754134287);
+  });
+});
+
+describe('sendRichMessageRaw', () => {
+  it('POSTs raw markdown + numeric chat_id, returns a RawMessage', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    })) as unknown as typeof fetch;
+    const out = await sendRichMessageRaw({ token: 'T', fetchImpl }, 'telegram:-100123', TABLE, 9);
+    expect(out).toEqual({ id: '42', raw: { message_id: 42 }, threadId: 'telegram:-100123' });
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('/botT/sendRichMessage');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.chat_id).toBe(-100123);
+    expect(body.rich_message).toEqual({ markdown: TABLE });
+    expect(body.reply_parameters).toEqual({ message_id: 9 });
+  });
+  it('throws (caller falls back) on ok:false, tagging the code', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      json: async () => ({ ok: false, error_code: 404, description: 'Not Found' }),
+    })) as unknown as typeof fetch;
+    await expect(sendRichMessageRaw({ token: 'T', fetchImpl }, '1', TABLE)).rejects.toMatchObject({ errorCode: 404 });
+  });
+  it('respects the char cap constant', () => {
+    expect(RICH_MESSAGE_MAX_CHARS).toBe(32768);
+  });
+});
+
+describe('wrapTelegramRichSend', () => {
+  function stubAdapter(calls: { rich: number; plain: number }) {
+    return {
+      postMessage: async (_tid: string, _m: { markdown?: string }) => {
+        calls.plain++;
+        return { id: 'p', threadId: _tid, raw: {} };
+      },
+    };
+  }
+  it('routes a table to the rich endpoint, falls back on non-table', async () => {
+    const richFetch = vi.fn(async () => ({
+      json: async () => ({ ok: true, result: { message_id: 7 } }),
+    })) as unknown as typeof fetch;
+    // patch global fetch used by sendRichMessageRaw
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = richFetch;
+    try {
+      const calls = { rich: 0, plain: 0 };
+      const a = wrapTelegramRichSend(stubAdapter(calls), { token: 'T', richTables: true, richConstructs: true });
+      await a.postMessage('telegram:123', { markdown: TABLE }); // table → rich
+      await a.postMessage('telegram:123', { markdown: 'plain text' }); // → original
+      expect((richFetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+      expect(calls.plain).toBe(1);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+  it('is a no-op passthrough when both toggles are off', async () => {
+    const calls = { rich: 0, plain: 0 };
+    const a = wrapTelegramRichSend(stubAdapter(calls), { token: 'T', richTables: false, richConstructs: false });
+    await a.postMessage('telegram:123', { markdown: TABLE });
+    expect(calls.plain).toBe(1);
+  });
+});

--- a/src/channels/telegram-rich-message.ts
+++ b/src/channels/telegram-rich-message.ts
@@ -1,0 +1,217 @@
+/**
+ * Native rich rendering for outbound Telegram messages (Bot API 10.1
+ * `sendRichMessage`).
+ *
+ * MarkdownV2 (the normal send path) cannot express several constructs an agent
+ * naturally produces: GFM **tables**, ATX **headings**, collapsible
+ * **`<details>`** folds, horizontal **dividers**, **block math** and GFM
+ * **task lists**. Under MarkdownV2 these degrade (a table becomes an unreadable
+ * monospace block, headings vanish, etc.).
+ *
+ * Bot API 10.1 added `sendRichMessage`, which renders RAW markdown natively —
+ * real, selectable tables/headings/folds on supporting clients. We auto-route a
+ * message to the rich path ONLY when it carries one of those
+ * MarkdownV2-impossible constructs, and fall back transparently to the normal
+ * path on ANY failure (unsupported endpoint, parser error, oversize) so a
+ * message is never lost. Plain bold/italic/links/bullets/blockquotes render fine
+ * under MarkdownV2 and stay on the proven path.
+ *
+ * Toggles (both default ON): `TELEGRAM_RICH_TABLES` (tables) and
+ * `TELEGRAM_RICH_CONSTRUCTS` (headings/details/dividers/math/task-lists).
+ */
+import type { RawMessage } from 'chat';
+
+import { log } from '../log.js';
+
+/** A GFM table divider line, e.g. `|---|:--:|`, `--- | ---`. Requires ≥2 columns. */
+const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$/;
+
+/** Telegram Bot API 10.1 raw rich-message char cap. */
+export const RICH_MESSAGE_MAX_CHARS = 32768;
+
+/**
+ * Strip fenced code blocks (``` … ```) and inline code spans (` … `) before
+ * construct-detection. A message that merely *discusses* a construct inside code
+ * — e.g. a sentence containing `<details>` or a divider shown in backticks —
+ * must NOT route to the rich path (which would make the whole message
+ * non-copyable on Telegram clients). Order: fenced first, then inline.
+ */
+export function stripCode(markdown: string): string {
+  return markdown.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
+}
+
+/**
+ * True when the message's primary rich construct is a GFM pipe table. Needs a
+ * real divider line (pipe/colon/dash structure with a run of ≥2 hyphens — this
+ * rejects ambiguous single-dash rows like `| - | - |` that appear in prose).
+ * Constructs requiring the broader opt-in are excluded here (handled by
+ * hasRichOnlyConstruct).
+ */
+export function isTablePrimary(markdown: string): boolean {
+  const md = stripCode(markdown);
+  if (!md || md.indexOf('|') === -1) return false;
+  const lines = md.split('\n');
+  if (!lines.some((l) => TABLE_SEPARATOR_RE.test(l) && /-{2,}/.test(l))) return false;
+  if (/(^|\n)\s*[-*]\s+\[[ xX]\]\s+/.test(md)) return false; // task list
+  if (/(^|\n)\s*<\/?(details|summary)\b/i.test(md)) return false; // collapsible
+  if (md.includes('$$')) return false; // block math
+  return true;
+}
+
+/**
+ * True when the message carries a construct MarkdownV2 simply CANNOT render but
+ * Bot API 10.1 rich messages can: ATX headings, collapsible `<details>`,
+ * horizontal dividers, block math, GFM task lists. Plain
+ * bold/italic/links/bullets/blockquotes are intentionally NOT matched — that
+ * keeps ordinary chat on the proven (copyable) MarkdownV2 path and only routes
+ * messages that genuinely gain from the rich renderer.
+ */
+export function hasRichOnlyConstruct(markdown: string): boolean {
+  if (!markdown) return false;
+  const md = stripCode(markdown);
+  if (/(^|\n)#{1,6}[ \t]+\S/.test(md)) return true; // ATX heading
+  if (/<details\b/i.test(md)) return true; // collapsible fold
+  if (/(^|\n)[ \t]*([-*_])\2{2,}[ \t]*(\n|$)/.test(md)) return true; // hr divider --- *** ___
+  if (md.includes('$$')) return true; // block math
+  if (/(^|\n)[ \t]*[-*][ \t]+\[[ xX]\][ \t]+/.test(md)) return true; // GFM task list
+  return false;
+}
+
+/**
+ * Telegram Desktop crashes on block math nested INSIDE a `<details>` fold
+ * (upstream chat-adapter issue). Such messages skip the rich path and degrade to
+ * MarkdownV2 rather than crash the client.
+ */
+export function hasTDesktopCrashShape(markdown: string): boolean {
+  const block = stripCode(markdown).match(/<details\b[^>]*>[\s\S]*?<\/details>/i);
+  return block ? block[0].includes('$$') : false;
+}
+
+/** Read the `TELEGRAM_RICH_TABLES` toggle (default ON). */
+export function richTablesEnabled(env: Record<string, string | undefined>): boolean {
+  const v = (env.TELEGRAM_RICH_TABLES ?? '').toLowerCase();
+  return v !== 'false' && v !== '0' && v !== 'off' && v !== 'no';
+}
+
+/** Read the `TELEGRAM_RICH_CONSTRUCTS` toggle (default ON) — broad rich routing. */
+export function richConstructsEnabled(env: Record<string, string | undefined>): boolean {
+  const v = (env.TELEGRAM_RICH_CONSTRUCTS ?? '').toLowerCase();
+  return v !== 'false' && v !== '0' && v !== 'off' && v !== 'no';
+}
+
+/**
+ * The endpoint itself is unavailable (a Bot API server without 10.1) — as
+ * opposed to a per-message rejection. Callers latch rich OFF on these so they
+ * don't pay a failed roundtrip on every send. NOTE: must NOT key off a bare
+ * "rich" substring — our own error text contains "RichMessage", which would
+ * misclassify every per-message 400 ("chat not found" etc.) as a capability
+ * failure and latch rich off process-wide.
+ */
+export function isRichCapabilityError(e: unknown): boolean {
+  const code = (e as { errorCode?: number })?.errorCode;
+  const msg = String((e as { message?: string })?.message ?? e);
+  if (code === 404) return true;
+  return /unknown method|method not found|method is not (available|supported)/i.test(msg);
+}
+
+/**
+ * Resolve a Telegram `chat_id` from the bridge thread id. The bridge passes
+ * `tid` = `telegram:<chatId>`; the normal adapter strips the prefix internally,
+ * and the rich endpoint needs the same. Returns a number for numeric ids.
+ */
+export function chatIdFromTid(tid: string): number | string {
+  const raw = tid.includes(':') ? tid.split(':').slice(1).join(':') : tid;
+  return /^-?\d+$/.test(raw) ? Number(raw) : raw;
+}
+
+export interface RichSendDeps {
+  token: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send `markdown` via Bot API 10.1 `sendRichMessage`. Returns a RawMessage in
+ * the shape the chat-sdk bridge expects from `adapter.postMessage`. Throws on a
+ * non-`ok` Bot API response (caller decides fallback).
+ */
+export async function sendRichMessageRaw(
+  deps: RichSendDeps,
+  tid: string,
+  markdown: string,
+  replyToMessageId?: number,
+): Promise<RawMessage<unknown>> {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const payload: Record<string, unknown> = {
+    chat_id: chatIdFromTid(tid),
+    // RAW markdown — never the MarkdownV2-escaped form, which would destroy pipes.
+    rich_message: { markdown },
+  };
+  if (replyToMessageId != null) {
+    payload.reply_parameters = { message_id: replyToMessageId };
+  }
+  const res = await doFetch(`https://api.telegram.org/bot${deps.token}/sendRichMessage`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const json = (await res.json()) as {
+    ok: boolean;
+    result?: { message_id?: number };
+    description?: string;
+    error_code?: number;
+  };
+  if (!json.ok || !json.result || json.result.message_id == null) {
+    const err = new Error(`sendRichMessage failed: ${json.error_code ?? res.status} ${json.description ?? ''}`.trim());
+    (err as { errorCode?: number }).errorCode = json.error_code ?? res.status;
+    throw err;
+  }
+  return { id: String(json.result.message_id), raw: json.result as unknown, threadId: tid };
+}
+
+export interface RichWrapDeps {
+  token: string;
+  richTables: boolean;
+  richConstructs: boolean;
+}
+
+/**
+ * Wrap an adapter's `postMessage` so messages carrying a MarkdownV2-impossible
+ * construct route to `sendRichMessage`, with transparent fallback to the
+ * original send on any failure. A genuine capability error latches rich OFF for
+ * the process. No-op (returns the adapter unchanged) when both toggles are off.
+ */
+export function wrapTelegramRichSend<A extends { postMessage: (...args: any[]) => Promise<any> }>(
+  adapter: A,
+  deps: RichWrapDeps,
+): A {
+  if (!deps.richTables && !deps.richConstructs) return adapter;
+  const origPost = adapter.postMessage.bind(adapter) as (tid: string, m: any) => Promise<any>;
+  let richDisabled = false;
+  adapter.postMessage = (async (tid: string, message: any): Promise<any> => {
+    const md = typeof message?.markdown === 'string' ? message.markdown : '';
+    const hasMedia = !!(message?.attachments?.length || message?.files?.length);
+    const route =
+      !richDisabled &&
+      md.length > 0 &&
+      md.length <= RICH_MESSAGE_MAX_CHARS &&
+      !hasMedia &&
+      ((deps.richTables && isTablePrimary(md)) ||
+        (deps.richConstructs && hasRichOnlyConstruct(md) && !hasTDesktopCrashShape(md)));
+    if (route) {
+      try {
+        return await sendRichMessageRaw({ token: deps.token }, tid, md);
+      } catch (re: unknown) {
+        const errMsg = String((re as { message?: string })?.message ?? re);
+        if (isRichCapabilityError(re)) {
+          richDisabled = true;
+          log.warn('Telegram sendRichMessage unsupported — latching rich OFF, using MarkdownV2', { tid, err: errMsg });
+        } else {
+          log.warn('Telegram sendRichMessage failed — falling back to MarkdownV2', { tid, err: errMsg });
+        }
+        // fall through to the normal send path
+      }
+    }
+    return await origPost(tid, message);
+  }) as A['postMessage'];
+  return adapter;
+}

--- a/src/channels/telegram-rich-message.ts
+++ b/src/channels/telegram-rich-message.ts
@@ -22,6 +22,12 @@
 import type { RawMessage } from 'chat';
 
 import { log } from '../log.js';
+import { splitForLimit } from './chat-sdk-bridge.js';
+
+/** Effective outbound cap for the normal (MarkdownV2) path — mirrors the
+ * bridge's maxTextLength for Telegram. Used when a rich-routed message falls
+ * back: the adapter would otherwise silently truncate anything longer. */
+export const TELEGRAM_PLAIN_MAX_CHARS = 4000;
 
 /** A GFM table divider line, e.g. `|---|:--:|`, `--- | ---`. Requires ≥2 columns. */
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$/;
@@ -100,6 +106,23 @@ export function richConstructsEnabled(env: Record<string, string | undefined>): 
 }
 
 /**
+ * True when `markdown` would route to the rich path under these toggles: carries
+ * a rich-only construct, fits the rich char cap, and doesn't hit the TDesktop
+ * crash shape. Shared by wrapTelegramRichSend and the bridge's per-message
+ * chunk-limit hook so the two can never disagree on what counts as "rich" —
+ * a rich-routable message must be chunked against RICH_MESSAGE_MAX_CHARS, not
+ * the 4k plain-text limit.
+ */
+export function richRoutable(markdown: string, opts: { richTables: boolean; richConstructs: boolean }): boolean {
+  return (
+    markdown.length > 0 &&
+    markdown.length <= RICH_MESSAGE_MAX_CHARS &&
+    ((opts.richTables && isTablePrimary(markdown)) ||
+      (opts.richConstructs && hasRichOnlyConstruct(markdown) && !hasTDesktopCrashShape(markdown)))
+  );
+}
+
+/**
  * The endpoint itself is unavailable (a Bot API server without 10.1) — as
  * opposed to a per-message rejection. Callers latch rich OFF on these so they
  * don't pay a failed roundtrip on every send. NOTE: must NOT key off a bare
@@ -172,33 +195,46 @@ export interface RichWrapDeps {
   token: string;
   richTables: boolean;
   richConstructs: boolean;
+  /**
+   * Sanitizer for the plain (legacy Markdown parse mode) path — applied to
+   * sends that do NOT route rich, and to message edits. Must NOT be applied
+   * upstream of this wrapper (e.g. via the bridge's transformOutboundText):
+   * the rich path needs the agent's raw markdown, and the sanitizer's
+   * `- item` → `• item` rewrite turns markdown lists into soft-wrapped prose
+   * that the rich renderer collapses onto a single line.
+   */
+  sanitizeForPlain?: (text: string) => string;
 }
 
 /**
  * Wrap an adapter's `postMessage` so messages carrying a MarkdownV2-impossible
- * construct route to `sendRichMessage`, with transparent fallback to the
- * original send on any failure. A genuine capability error latches rich OFF for
- * the process. No-op (returns the adapter unchanged) when both toggles are off.
+ * construct route to `sendRichMessage` (with the agent's RAW markdown), with
+ * transparent fallback to the original send on any failure. A genuine
+ * capability error latches rich OFF for the process.
+ *
+ * The plain path (non-rich sends, rich fallbacks, and message edits) gets
+ * `deps.sanitizeForPlain` applied here — NOT in the bridge — so the two paths
+ * can receive different text: raw markdown for the rich renderer, sanitized
+ * text for the legacy Markdown parse mode.
  */
-export function wrapTelegramRichSend<A extends { postMessage: (...args: any[]) => Promise<any> }>(
-  adapter: A,
-  deps: RichWrapDeps,
-): A {
-  if (!deps.richTables && !deps.richConstructs) return adapter;
+export function wrapTelegramRichSend<
+  A extends {
+    postMessage: (...args: any[]) => Promise<any>;
+    editMessage?: (...args: any[]) => Promise<any>;
+  },
+>(adapter: A, deps: RichWrapDeps): A {
+  const sanitize = deps.sanitizeForPlain ?? ((t: string) => t);
   const origPost = adapter.postMessage.bind(adapter) as (tid: string, m: any) => Promise<any>;
+  const postPlain = (tid: string, message: any, md: string): Promise<any> =>
+    origPost(tid, md ? { ...message, markdown: sanitize(md) } : message);
   let richDisabled = false;
   adapter.postMessage = (async (tid: string, message: any): Promise<any> => {
     const md = typeof message?.markdown === 'string' ? message.markdown : '';
     const hasMedia = !!(message?.attachments?.length || message?.files?.length);
-    const route =
-      !richDisabled &&
-      md.length > 0 &&
-      md.length <= RICH_MESSAGE_MAX_CHARS &&
-      !hasMedia &&
-      ((deps.richTables && isTablePrimary(md)) ||
-        (deps.richConstructs && hasRichOnlyConstruct(md) && !hasTDesktopCrashShape(md)));
+    const route = !richDisabled && !hasMedia && richRoutable(md, deps);
     if (route) {
       try {
+        // RAW markdown — the rich renderer needs real `- ` list items etc.
         return await sendRichMessageRaw({ token: deps.token }, tid, md);
       } catch (re: unknown) {
         const errMsg = String((re as { message?: string })?.message ?? re);
@@ -210,8 +246,30 @@ export function wrapTelegramRichSend<A extends { postMessage: (...args: any[]) =
         }
         // fall through to the normal send path
       }
+      // Rich-routable messages bypass the bridge's 4k chunking (the bridge's
+      // per-message limit hook allows up to RICH_MESSAGE_MAX_CHARS), so on
+      // fallback anything longer than the plain-path cap must be split here —
+      // the underlying adapter would silently truncate it otherwise.
+      if (md.length > TELEGRAM_PLAIN_MAX_CHARS) {
+        const parts = splitForLimit(md, TELEGRAM_PLAIN_MAX_CHARS);
+        let first: RawMessage<unknown> | undefined;
+        for (let i = 0; i < parts.length; i++) {
+          const res = await postPlain(tid, message, parts[i]);
+          if (i === 0) first = res;
+        }
+        return first;
+      }
     }
-    return await origPost(tid, message);
+    return await postPlain(tid, message, md);
   }) as A['postMessage'];
+  // Edits always take the plain path — sanitize them here since the bridge
+  // no longer does.
+  if (deps.sanitizeForPlain && typeof adapter.editMessage === 'function') {
+    const origEdit = adapter.editMessage.bind(adapter) as (tid: string, id: string, m: any) => Promise<any>;
+    adapter.editMessage = (async (tid: string, id: string, m: any): Promise<any> => {
+      const md = typeof m?.markdown === 'string' ? m.markdown : '';
+      return origEdit(tid, id, md ? { ...m, markdown: sanitize(md) } : m);
+    }) as A['editMessage'];
+  }
   return adapter;
 }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -12,7 +12,14 @@ import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js'
 import { upsertUser } from '../modules/permissions/db/users.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
-import { wrapTelegramRichSend, richTablesEnabled, richConstructsEnabled } from './telegram-rich-message.js';
+import {
+  wrapTelegramRichSend,
+  richTablesEnabled,
+  richConstructsEnabled,
+  richRoutable,
+  RICH_MESSAGE_MAX_CHARS,
+  TELEGRAM_PLAIN_MAX_CHARS,
+} from './telegram-rich-message.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
 import { tryConsume } from './telegram-pairing.js';
@@ -218,12 +225,13 @@ registerChannelAdapter('telegram', {
     // Route messages carrying MarkdownV2-impossible constructs (tables, headings,
     // <details>, dividers, math, task lists) to Bot API 10.1 sendRichMessage,
     // with transparent fallback to the normal path. No-op when both toggles off.
+    const richOpts = { richTables: richTablesEnabled(env), richConstructs: richConstructsEnabled(env) };
     const telegramAdapter = wrapTelegramRichSend(
       createTelegramAdapter({
         botToken: token,
         mode: 'polling',
       }),
-      { token, richTables: richTablesEnabled(env), richConstructs: richConstructsEnabled(env) },
+      { token, ...richOpts, sanitizeForPlain: sanitizeTelegramLegacyMarkdown },
     );
     const bridge = createChatSdkBridge({
       adapter: telegramAdapter,
@@ -231,8 +239,17 @@ registerChannelAdapter('telegram', {
       extractReplyContext,
       supportsThreads: false,
       defaults: TELEGRAM_DEFAULTS,
-      transformOutboundText: sanitizeTelegramLegacyMarkdown,
-      maxTextLength: 4000,
+      // No transformOutboundText here: legacy-Markdown sanitization is applied
+      // inside wrapTelegramRichSend on the plain path only. Sanitizing at the
+      // bridge would mangle the raw markdown the rich path must receive
+      // (`- item` → `• item` turns lists into soft-wrapped prose that
+      // sendRichMessage collapses onto one line).
+      // Rich-routable messages (tables/headings/etc.) go out via
+      // sendRichMessage, which accepts 32k — chunking those at the plain-path
+      // 4k limit would split one coherent rich message into several. Messages
+      // with file uploads always take the plain path, so they keep the 4k cap.
+      maxTextLength: (text, hasFiles) =>
+        !hasFiles && richRoutable(text, richOpts) ? RICH_MESSAGE_MAX_CHARS : TELEGRAM_PLAIN_MAX_CHARS,
     });
 
     const botUsernamePromise = fetchBotUsername(token);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -12,6 +12,7 @@ import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js'
 import { upsertUser } from '../modules/permissions/db/users.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
+import { wrapTelegramRichSend, richTablesEnabled, richConstructsEnabled } from './telegram-rich-message.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
 import { tryConsume } from './telegram-pairing.js';
@@ -211,13 +212,19 @@ function createPairingInterceptor(
 
 registerChannelAdapter('telegram', {
   factory: () => {
-    const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+    const env = readEnvFile(['TELEGRAM_BOT_TOKEN', 'TELEGRAM_RICH_TABLES', 'TELEGRAM_RICH_CONSTRUCTS']);
     if (!env.TELEGRAM_BOT_TOKEN) return null;
     const token = env.TELEGRAM_BOT_TOKEN;
-    const telegramAdapter = createTelegramAdapter({
-      botToken: token,
-      mode: 'polling',
-    });
+    // Route messages carrying MarkdownV2-impossible constructs (tables, headings,
+    // <details>, dividers, math, task lists) to Bot API 10.1 sendRichMessage,
+    // with transparent fallback to the normal path. No-op when both toggles off.
+    const telegramAdapter = wrapTelegramRichSend(
+      createTelegramAdapter({
+        botToken: token,
+        mode: 'polling',
+      }),
+      { token, richTables: richTablesEnabled(env), richConstructs: richConstructsEnabled(env) },
+    );
     const bridge = createChatSdkBridge({
       adapter: telegramAdapter,
       concurrency: 'concurrent',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Enhancement to an existing channel adapter** (Telegram, on the `channels` branch)

## What

Render native rich content in outbound **Telegram** messages via **Bot API 10.1 `sendRichMessage`** — real, selectable **tables**, **headings**, collapsible **`<details>`** folds, **dividers**, **block math** and **task lists** — constructs MarkdownV2 cannot express (a GFM table degrades to an unreadable monospace block; headings vanish; etc.).

A message is auto-routed to the rich path **only** when it carries one of those MarkdownV2-impossible constructs, and falls back **transparently** to the normal MarkdownV2 send on *any* failure (endpoint unsupported, parser error, oversize, media present) — so a message is never lost. Plain bold/italic/links/bullets/blockquotes render fine under MarkdownV2 and stay on the proven, copyable path.

## Why

`@chat-adapter/telegram@4.30` gives us native MarkdownV2, but MarkdownV2 still has no table/heading/fold syntax. This adds the one capability tier above it, gated and reversible, without changing anything for messages that don't need it.

## How

- New self-contained module `src/channels/telegram-rich-message.ts`:
  - Detection: `isTablePrimary`, `hasRichOnlyConstruct` (+ `stripCode` so a message *discussing* a construct in backticks/code doesn't route), `hasTDesktopCrashShape` (excludes block-math-inside-`<details>`, a Telegram-Desktop crash shape).
  - Transport: `sendRichMessageRaw` (+ `chatIdFromTid`, `isRichCapabilityError` with a process-wide latch-off on a genuine missing-method only — never on per-message 400s).
  - `wrapTelegramRichSend(adapter, deps)` — wraps `postMessage`; no-op when toggles off.
- One minimal reach-in in `src/channels/telegram.ts`: 1 import + wrap the adapter in the factory (3 lines), plus two env reads.
- Toggles (both default ON, independently disable-able): `TELEGRAM_RICH_TABLES`, `TELEGRAM_RICH_CONSTRUCTS`.

## Scope notes

- **Send path only.** No edit/streaming/tool-vis behaviour — keeps this one focused thing.
- **Builds on** the MarkdownV2 migration (#2767 / #2866) — the rich layer sits on top with MarkdownV2 as the transparent fallback; compatible with the legacy-sanitizer removal.
- Different, more capable approach than the older HTML-parse-mode rendering in #301.

## Tests

- `src/channels/telegram-rich-message.test.ts` — **15 tests** covering detection (incl. code-span exclusion + crash-shape), toggles, capability-error classification, `chat_id` resolution, the `sendRichMessage` payload + fallback, and the wrapper's route-vs-fallback behaviour. All green.
- `tsc --noEmit`: no new errors introduced (verified via stash comparison against the branch baseline).
- Live-verified against the Bot API: tables/headings/dividers/quotes/details/math/task-lists all render natively; transparent MarkdownV2 fallback confirmed.
