### PR TITLE
fix(codex): allow reconnect when OneCLI already has a stale OpenAI secret

### DIFF
--- a/setup/providers/codex.test.ts
+++ b/setup/providers/codex.test.ts
@@ -20,7 +20,26 @@ vi.mock('child_process', () => ({
 // Keep the auth flow's structured logging out of logs/setup.log.
 vi.mock('../logs.js', () => ({ step: vi.fn(), userInput: vi.fn() }));
 
-import { buildCodexFailurePrompt, runCodexLoginAuth, verifyCodexInstall } from './codex.js';
+// Drive both prompts in runCodexAuthStep — the keep/reconnect choice and the
+// auth-method picker — without an interactive session.
+const mockBrightSelect = vi.fn();
+vi.mock('../lib/bright-select.js', () => ({
+  brightSelect: (...args: unknown[]) => mockBrightSelect(...args),
+}));
+
+// Stub p.password for the API-key path; leave everything else (p.log,
+// p.isCancel, p.confirm, p.cancel) real so the existing runCodexLoginAuth
+// tests keep working unchanged.
+const mockPassword = vi.fn();
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clack/prompts')>();
+  return {
+    ...actual,
+    password: (...args: unknown[]) => mockPassword(...args),
+  };
+});
+
+import { buildCodexFailurePrompt, runCodexAuthStep, runCodexLoginAuth, verifyCodexInstall } from './codex.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -134,5 +153,94 @@ describe('runCodexLoginAuth', () => {
     expect(vaultArgs[vaultArgs.indexOf('--id') + 1]).toBe('secret-123');
     expect(vaultArgs[vaultArgs.indexOf('--value') + 1]).toBe('{"tokens":{"access":"fresh"}}');
     expect(fs.existsSync(loginEnv!.CODEX_HOME!)).toBe(false);
+  });
+});
+
+// Recovery-flow coverage: when an OpenAI/Codex secret already exists in the
+// vault, runCodexAuthStep must surface a keep/reconnect choice rather than
+// short-circuit as success. Stale credentials would otherwise leave the only
+// documented recovery path (re-run the auth step) unreachable.
+describe('runCodexAuthStep', () => {
+  // Stub `onecli secrets list` to return one matching OpenAI secret. Other
+  // onecli calls (secrets create/update) return empty on success.
+  function withExistingSecret(
+    secret = { id: 'secret-123', name: 'OpenAI', type: 'openai', hostPattern: 'chatgpt.com' },
+  ): void {
+    mockExecFileSync.mockImplementation((...args: unknown[]) => {
+      const cmd = args[0] as string;
+      const cmdArgs = args[1] as string[];
+      if (cmd === 'onecli' && cmdArgs[0] === 'secrets' && cmdArgs[1] === 'list') {
+        return JSON.stringify({ data: [secret] });
+      }
+      return '';
+    });
+  }
+
+  it('offers keep/reconnect when a secret already exists and skips when user picks keep', async () => {
+    withExistingSecret();
+    mockBrightSelect.mockResolvedValueOnce('keep');
+
+    await runCodexAuthStep();
+
+    // The user saw the keep/reconnect prompt.
+    expect(mockBrightSelect).toHaveBeenCalledTimes(1);
+    const promptArgs = mockBrightSelect.mock.calls[0][0] as { message: string };
+    expect(promptArgs.message).toContain('already exists in OneCLI');
+
+    // No login spawned, no vault mutation.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    const vaultWrite = mockExecFileSync.mock.calls.find((c) => {
+      const cmdArgs = c[1] as string[];
+      return c[0] === 'onecli' && cmdArgs[0] === 'secrets' && (cmdArgs[1] === 'create' || cmdArgs[1] === 'update');
+    });
+    expect(vaultWrite).toBeUndefined();
+  });
+
+  it('routes reconnect + browser through runCodexLoginAuth(existing) and writes secrets update --id', async () => {
+    withExistingSecret();
+    mockBrightSelect
+      .mockResolvedValueOnce('reconnect') // keep/reconnect prompt
+      .mockResolvedValueOnce('browser'); // method picker
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    mockSpawn.mockImplementation((...args: unknown[]) => {
+      const opts = args[2] as { env?: NodeJS.ProcessEnv };
+      fs.writeFileSync(path.join(opts.env!.CODEX_HOME!, 'auth.json'), '{"tokens":{"access":"fresh"}}');
+      const child = new EventEmitter();
+      setImmediate(() => child.emit('close', 0));
+      return child;
+    });
+
+    await runCodexAuthStep();
+
+    const vaultCall = mockExecFileSync.mock.calls.find((c) => {
+      const cmdArgs = c[1] as string[];
+      return c[0] === 'onecli' && cmdArgs[0] === 'secrets' && cmdArgs[1] === 'update';
+    });
+    expect(vaultCall).toBeDefined();
+    const vaultArgs = vaultCall![1] as string[];
+    expect(vaultArgs[vaultArgs.indexOf('--id') + 1]).toBe('secret-123');
+    expect(vaultArgs[vaultArgs.indexOf('--value') + 1]).toBe('{"tokens":{"access":"fresh"}}');
+  });
+
+  it('routes reconnect + api through runCodexApiKeyAuth(existing) and writes secrets update --id with the new key', async () => {
+    withExistingSecret();
+    mockBrightSelect
+      .mockResolvedValueOnce('reconnect')
+      .mockResolvedValueOnce('api');
+    mockPassword.mockResolvedValueOnce('sk-fresh-key');
+
+    await runCodexAuthStep();
+
+    const vaultCall = mockExecFileSync.mock.calls.find((c) => {
+      const cmdArgs = c[1] as string[];
+      return c[0] === 'onecli' && cmdArgs[0] === 'secrets' && cmdArgs[1] === 'update';
+    });
+    expect(vaultCall).toBeDefined();
+    const vaultArgs = vaultCall![1] as string[];
+    expect(vaultArgs[vaultArgs.indexOf('--id') + 1]).toBe('secret-123');
+    expect(vaultArgs[vaultArgs.indexOf('--value') + 1]).toBe('sk-fresh-key');
+
+    // The login flow never spawned a real codex CLI on the API-key path.
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 });

--- a/setup/providers/codex.test.ts
+++ b/setup/providers/codex.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock child_process so runCodexLoginAuth never spawns a real codex CLI; the
 // spawn stand-in plays `codex login` writing auth.json into whatever
@@ -21,6 +21,10 @@ vi.mock('child_process', () => ({
 vi.mock('../logs.js', () => ({ step: vi.fn(), userInput: vi.fn() }));
 
 import { buildCodexFailurePrompt, runCodexLoginAuth, verifyCodexInstall } from './codex.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 // Structural guard for the codex payload wiring: provider files, both barrel
 // imports, and the pinned Dockerfile install. Goes red if any of them is
@@ -97,5 +101,38 @@ describe('runCodexLoginAuth', () => {
 
     // The isolated dir holds a live credential — gone once vaulted.
     expect(fs.existsSync(codexHome!)).toBe(false);
+  });
+
+  it('updates an existing vault secret when reconnecting', async () => {
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    mockExecFileSync.mockReturnValue('');
+
+    let loginEnv: NodeJS.ProcessEnv | undefined;
+    mockSpawn.mockImplementation((...args: unknown[]) => {
+      const opts = args[2] as { env?: NodeJS.ProcessEnv };
+      loginEnv = opts.env;
+      fs.writeFileSync(path.join(opts.env!.CODEX_HOME!, 'auth.json'), '{"tokens":{"access":"fresh"}}');
+      const child = new EventEmitter();
+      setImmediate(() => child.emit('close', 0));
+      return child;
+    });
+
+    await runCodexLoginAuth('browser', {
+      id: 'secret-123',
+      name: 'OpenAI',
+      type: 'openai',
+      hostPattern: 'chatgpt.com',
+    });
+
+    const vaultCall = mockExecFileSync.mock.calls.find((c) => {
+      const args = c[1] as string[];
+      return c[0] === 'onecli' && args[0] === 'secrets' && args[1] === 'update';
+    });
+    expect(vaultCall).toBeDefined();
+    const vaultArgs = vaultCall![1] as string[];
+    expect(vaultArgs).toContain('--id');
+    expect(vaultArgs[vaultArgs.indexOf('--id') + 1]).toBe('secret-123');
+    expect(vaultArgs[vaultArgs.indexOf('--value') + 1]).toBe('{"tokens":{"access":"fresh"}}');
+    expect(fs.existsSync(loginEnv!.CODEX_HOME!)).toBe(false);
   });
 });

--- a/setup/providers/codex.ts
+++ b/setup/providers/codex.ts
@@ -66,11 +66,11 @@ function findOpenAISecret(secrets: OnecliSecret[]): OnecliSecret | undefined {
   });
 }
 
-function openAISecretExists(): boolean {
+function existingOpenAISecret(): OnecliSecret | undefined {
   try {
-    return findOpenAISecret(listSecrets()) !== undefined;
+    return findOpenAISecret(listSecrets());
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -85,10 +85,31 @@ function ensureAnswer<T>(value: T | symbol): T {
 }
 
 export async function runCodexAuthStep(): Promise<void> {
-  if (openAISecretExists()) {
-    p.log.success(brandBody('Your OpenAI account is already connected.'));
-    setupLog.step('auth', 'skipped', 0, { REASON: 'openai-secret-already-present', PROVIDER: 'codex' });
-    return;
+  const existing = existingOpenAISecret();
+  if (existing) {
+    const action = ensureAnswer(
+      await brightSelect<'keep' | 'reconnect'>({
+        message: 'An OpenAI/Codex credential already exists in OneCLI. What should setup do?',
+        options: [
+          {
+            value: 'keep',
+            label: 'Keep existing credential',
+            hint: 'use this if Codex is already working',
+          },
+          {
+            value: 'reconnect',
+            label: 'Reconnect OpenAI account',
+            hint: 'refresh a stale or revoked ChatGPT login',
+          },
+        ],
+      }),
+    );
+    setupLog.userInput('codex_existing_secret_action', action);
+    if (action === 'keep') {
+      p.log.success(brandBody('Your OpenAI account is already connected.'));
+      setupLog.step('auth', 'skipped', 0, { REASON: 'openai-secret-already-present', PROVIDER: 'codex' });
+      return;
+    }
   }
 
   const method = ensureAnswer(
@@ -134,14 +155,14 @@ export async function runCodexAuthStep(): Promise<void> {
   }
 
   if (method === 'api') {
-    await runCodexApiKeyAuth();
+    await runCodexApiKeyAuth(existing);
     return;
   }
 
-  await runCodexLoginAuth(method);
+  await runCodexLoginAuth(method, existing);
 }
 
-async function runCodexApiKeyAuth(): Promise<void> {
+async function runCodexApiKeyAuth(existing?: OnecliSecret): Promise<void> {
   const key = ensureAnswer(
     await p.password({
       message: 'Paste your OpenAI API key (sk-…)',
@@ -150,22 +171,30 @@ async function runCodexApiKeyAuth(): Promise<void> {
   ) as string;
 
   try {
-    execFileSync(
-      'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Codex',
-        '--type',
-        'openai',
-        '--value',
-        key.trim(),
-        '--host-pattern',
-        'api.openai.com',
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
-    );
+    if (existing) {
+      execFileSync(
+        'onecli',
+        ['secrets', 'update', '--id', existing.id, '--value', key.trim(), '--host-pattern', 'api.openai.com'],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    } else {
+      execFileSync(
+        'onecli',
+        [
+          'secrets',
+          'create',
+          '--name',
+          'Codex',
+          '--type',
+          'openai',
+          '--value',
+          key.trim(),
+          '--host-pattern',
+          'api.openai.com',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    }
   } catch (err) {
     setupLog.step('auth', 'failed', 0, { PROVIDER: 'codex', METHOD: 'api', ERROR: String(err) });
     p.log.error(
@@ -179,7 +208,7 @@ async function runCodexApiKeyAuth(): Promise<void> {
   p.log.success(brandBody('OpenAI account connected.'));
 }
 
-export async function runCodexLoginAuth(method: 'browser' | 'device'): Promise<void> {
+export async function runCodexLoginAuth(method: 'browser' | 'device', existing?: OnecliSecret): Promise<void> {
   const codexCheck = spawnSync('codex', ['--version'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
   if (codexCheck.status !== 0) {
     p.log.error(
@@ -237,22 +266,39 @@ export async function runCodexLoginAuth(method: 'browser' | 'device'): Promise<v
   }
 
   try {
-    execFileSync(
-      'onecli',
-      [
-        'secrets',
-        'create',
-        '--name',
-        'Codex',
-        '--type',
-        'openai',
-        '--file',
-        authJsonPath,
-        '--host-pattern',
-        'chatgpt.com',
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
-    );
+    if (existing) {
+      execFileSync(
+        'onecli',
+        [
+          'secrets',
+          'update',
+          '--id',
+          existing.id,
+          '--value',
+          fs.readFileSync(authJsonPath, 'utf-8'),
+          '--host-pattern',
+          'chatgpt.com',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    } else {
+      execFileSync(
+        'onecli',
+        [
+          'secrets',
+          'create',
+          '--name',
+          'Codex',
+          '--type',
+          'openai',
+          '--file',
+          authJsonPath,
+          '--host-pattern',
+          'chatgpt.com',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    }
   } catch (err) {
     removeLoginHome();
     setupLog.step('auth', 'failed', durationMs, { PROVIDER: 'codex', METHOD: method, ERROR: String(err) });


### PR DESCRIPTION
## Summary

`runCodexAuthStep()` returns success whenever any matching OneCLI secret is present, regardless of whether the credential is still valid. When the token is stale or revoked, Codex agents fail mid-conversation with `Your access token could not be refreshed. Please log out and sign in again.` — but re-running the auth step says "already connected" and never reaches the browser/device login. The recovery path documented in `add-codex/SKILL.md` is unreachable.

This PR removes the unconditional short-circuit, gives the user a keep / reconnect choice when a secret already exists, and routes the reconnect through `onecli secrets update --id <id> --value <new>` so the existing vault row is updated in place rather than orphaned by a `secrets create`.

## What

In `setup/providers/codex.ts` (lines 88–92 prior to this PR):

```ts
if (openAISecretExists()) {
  p.log.success(brandBody('Your OpenAI account is already connected.'));
  setupLog.step('auth', 'skipped', 0, { REASON: 'openai-secret-already-present', PROVIDER: 'codex' });
  return;
}
```

`openAISecretExists()` reduces to boolean what `findOpenAISecret()` already returns as an `OnecliSecret` object — silent on validity, silent on which secret matched.

Both auth entry points hit the same dead end:
- `pnpm exec tsx setup/index.ts --step provider-auth codex` (`setup/provider-auth.ts:78`)
- Full setup auto-runner (`setup/auto.ts:372–374`)

Both call `runCodexAuthStep()` through the registry. The fix sits at that convergence point, so both paths are covered.

`/update-skills` and container restart do not invoke auth, so this is scoped to setup/auth flows only.

## Why it matters

Headless / device-auth is the only practical recovery path for remote or containerized installs, but it's unreachable once a stale secret exists. The Troubleshooting guidance in `add-codex/SKILL.md` already describes the correct intent:

> Auth errors mid-conversation: the vault secret is missing or stale — re-run `pnpm exec tsx setup/index.ts --step provider-auth codex` (subscription re-login updates the vault copy).

This PR makes that documented behavior actually work.

Distinct from #2534, which addresses pre-OneCLI runtime auth.json copy vs. bind-mount semantics. That's a different code path (`src/providers/codex.ts`, container runtime) and a different era — the OneCLI migration since then made its premise obsolete. This PR is the setup-time vault create-vs-update gap and is not addressed by the OneCLI migration.

## Repro

1. Authenticate Codex normally; vault secret is created.
2. Revoke the OpenAI/Codex token externally (or wait for the refresh token to be invalidated by another login).
3. Run a Codex agent — see `Your access token could not be refreshed`.
4. Run `pnpm exec tsx setup/index.ts --step provider-auth codex` to recover.
5. See "Your OpenAI account is already connected." Auth step returns success; nothing changes; agents still fail.

After this PR: step 5 instead presents a `Keep existing credential` / `Reconnect OpenAI account` prompt; picking reconnect runs the normal login flow and updates the existing vault row in place.

## Fix in this PR

- Replace `openAISecretExists() → boolean` with `existingOpenAISecret() → OnecliSecret | undefined` so callers can act on the secret's `id`.
- Replace the unconditional short-circuit with a keep / reconnect prompt; only `keep` exits early.
- Thread the existing secret through `runCodexLoginAuth(method, existing?)` and `runCodexApiKeyAuth(existing?)`. When `existing` is set, call `onecli secrets update --id <id> --value <new> --host-pattern <…>` instead of `secrets create`. (`onecli secrets update` is already supported by the OneCLI CLI; NanoClaw just hadn't called it from any auth path.)
- Update `setup/provider-auth.ts` docstring to reflect that auth steps are now reconnectable, not just idempotent-on-presence.

### Why the API-key path is included

The draft analysis only repro'd the OAuth / ChatGPT login path, but the same `secrets create`-vs-orphan bug existed in `runCodexApiKeyAuth` — a user pasting a fresh API key during recovery would also end up with an orphaned secret. Fixing one path without the other would leave a confusing partial recovery. Same shape of fix on both.

## Test plan

- [x] New `codex.test.ts → runCodexLoginAuth → 'updates an existing vault secret when reconnecting'` — asserts `onecli secrets update --id <id> --value <auth.json contents>` when called with an existing `OnecliSecret`, and that the throwaway `CODEX_HOME` is cleaned up.
- [x] New `codex.test.ts → runCodexAuthStep` describe — three cases:
  - keep path returns without spawning a login or mutating the vault;
  - reconnect + browser routes through `runCodexLoginAuth(existing)` and writes `secrets update --id <existing.id>`;
  - reconnect + api routes through `runCodexApiKeyAuth(existing)` and writes `secrets update --id <existing.id>` with the pasted key.
- [x] Manually verified end-to-end on a live install via this code path: stale `OpenAI` secret → fresh `codex login` → `secrets update` against the existing vault row → fresh codex container spawn produces a normal agent reply with no `refresh_token_reused` in the run.

## Out of scope

- `findOpenAISecret()` matches permissively (any secret named `'codex'` / `'openai'` case-insensitive, type `'openai'`, or `hostPattern` containing `api.openai.com` / `chatgpt.com`). A user who manually created an unrelated secret matching those rules would also trigger the existing-secret path. Tightening the matcher is independent of this PR and can be a follow-up; flagging here so it doesn't get lost.
