### PR TITLE
fix(security): contain inbox symlink escapes in attachment writes (#2828)

### DIFF
--- a/src/inbox-safety.ts
+++ b/src/inbox-safety.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared containment guards for per-message inbox directories.
+ *
+ * Session dirs are mounted writable into agent containers, so a compromised
+ * agent can pre-place a symlink inside its own session dir and wait for the
+ * host to write through it — landing attacker-influenced bytes outside the
+ * sandbox (CWE-59). Both inbound paths that materialise files into a session's
+ * `inbox/<messageId>/` directory route through `ensureContainedInboxDir`:
+ *   - channel-inbound attachments (`extractAttachmentFiles` in session-manager)
+ *   - agent-to-agent forwarded files (`forwardAttachedFiles` in agent-route)
+ *
+ * Keeping the guard in one place means both paths defend identically; the fix
+ * for GHSA #2828 originally lived only in the A2A path and the channel path had
+ * the same gap (a symlinked `inbox` root was followed silently).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { log } from './log.js';
+
+/** True if `child` is `parent` itself or nested within it (no traversal/escape). */
+export function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+/**
+ * Resolve and create `<inboxRoot>/<messageId>`, refusing pre-placed symlinks a
+ * compromised container could use to redirect host writes outside the session.
+ *
+ * Guards, in order:
+ *   1. lstat the inbox ROOT — reject if it is a symlink or a non-directory.
+ *      Without this, a symlinked `inbox` is silently followed by mkdir AND the
+ *      containment check in step 4 passes, because it compares against the
+ *      already-followed (escaped) root. This is the gap that affected the
+ *      channel-inbound path.
+ *   2. lstat the per-message subdir — reject a pre-placed symlink/non-dir.
+ *      lstat does not follow the final path component, so it sees the link
+ *      itself even when the link target does not exist.
+ *   3. mkdir the subdir (recursive).
+ *   4. realpath containment — the resolved subdir must stay within the resolved
+ *      inbox root (defence in depth; symlinks are already ruled out above).
+ *
+ * Returns the resolved, contained subdir path (write into it with an exclusive
+ * flag — `COPYFILE_EXCL` / `wx` — so a pre-existing symlinked *file* can't be
+ * followed either), or `null` if any guard tripped. On `null` the caller logs
+ * its own context and skips; `context` is merged into the warn logs here so
+ * each call site stays diagnosable.
+ */
+export function ensureContainedInboxDir(
+  inboxRoot: string,
+  messageId: string,
+  context: Record<string, unknown>,
+): string | null {
+  const inboxDir = path.join(inboxRoot, messageId);
+
+  for (const dir of [inboxRoot, inboxDir]) {
+    try {
+      const st = fs.lstatSync(dir);
+      if (st.isSymbolicLink() || !st.isDirectory()) {
+        log.warn('inbox-safety: rejecting unsafe inbox path', { ...context, dir });
+        return null;
+      }
+    } catch {
+      // Does not exist yet — fine, mkdir below creates it.
+    }
+  }
+
+  fs.mkdirSync(inboxDir, { recursive: true });
+
+  try {
+    const realInboxDir = fs.realpathSync(inboxDir);
+    const realInboxRoot = fs.realpathSync(inboxRoot);
+    if (!isPathInside(realInboxRoot, realInboxDir)) {
+      log.warn('inbox-safety: inbox dir escaped inbox root', { ...context, inboxDir });
+      return null;
+    }
+    return realInboxDir;
+  } catch (err) {
+    log.warn('inbox-safety: failed to resolve inbox dir', { ...context, inboxDir, err });
+    return null;
+  }
+}

--- a/src/modules/agent-to-agent/agent-route.test.ts
+++ b/src/modules/agent-to-agent/agent-route.test.ts
@@ -3,7 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 
-import { isSafeAttachmentName, routeAgentMessage } from './agent-route.js';
+import { forwardAttachedFiles, isSafeAttachmentName, routeAgentMessage } from './agent-route.js';
+import { log } from '../../log.js';
 import { createDestination } from './db/agent-destinations.js';
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from '../../db/index.js';
 import { createSession, updateSession } from '../../db/sessions.js';
@@ -466,5 +467,130 @@ describe('routeAgentMessage return-path', () => {
     expect(bRows).toHaveLength(1);
     const parsed = JSON.parse(bRows[0].content);
     expect(parsed.attachments).toHaveLength(0);
+  });
+
+  // #2828 — target-side symlink containment. A compromised target agent can
+  // write inside its own session dir; these tests prove it cannot redirect a
+  // forwarded attachment outside the session sandbox via a pre-placed symlink.
+
+  it('file forwarding (#2828): skips a symlinked target inbox dir, writes nothing outside', async () => {
+    const warnSpy = vi.spyOn(log, 'warn');
+    const canaryDir = path.join(TEST_DIR, 'canary-outside-inbox');
+    fs.mkdirSync(canaryDir, { recursive: true });
+
+    // Source has a real attachment to forward.
+    const outboxDir = path.join(sessionDir(A, S1.id), 'outbox', 'msg-evil-inbox');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, 'pwn.txt'), 'attacker-bytes');
+
+    // Target pre-places its whole `inbox` as a symlink pointing outside.
+    const targetInbox = path.join(sessionDir(B, SB.id), 'inbox');
+    fs.rmSync(targetInbox, { recursive: true, force: true });
+    fs.symlinkSync(canaryDir, targetInbox);
+
+    await routeAgentMessage(
+      {
+        id: 'msg-evil-inbox',
+        platform_id: B,
+        content: JSON.stringify({ text: 'see attached', files: ['pwn.txt'] }),
+        in_reply_to: null,
+      },
+      S1,
+    );
+
+    // Message still routes — just with no attachments.
+    const bRows = readInbound(B, SB.id);
+    expect(bRows).toHaveLength(1);
+    expect(JSON.parse(bRows[0].content).attachments).toHaveLength(0);
+
+    // Nothing was written through the symlink to the canary location.
+    expect(fs.readdirSync(canaryDir)).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('file forwarding (#2828): skips a symlinked inbox/<msgId> subdir, writes nothing outside', async () => {
+    const warnSpy = vi.spyOn(log, 'warn');
+    const canaryDir = path.join(TEST_DIR, 'canary-outside-subdir');
+    fs.mkdirSync(canaryDir, { recursive: true });
+
+    const outboxDir = path.join(sessionDir(A, S1.id), 'outbox', 'msg-evil-subdir');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, 'pwn.txt'), 'attacker-bytes');
+
+    // The forwarded a2a msg id generated inside routeAgentMessage is random, so
+    // a symlink can't be pre-placed at inbox/<that-id>. Drive forwardAttachedFiles
+    // directly with a fixed target message id and plant the symlink at that path.
+    const targetMsgId = 'evil-subdir-msg';
+    const realInbox = path.join(sessionDir(B, SB.id), 'inbox');
+    fs.mkdirSync(realInbox, { recursive: true });
+    fs.symlinkSync(canaryDir, path.join(realInbox, targetMsgId));
+
+    const attachments = forwardAttachedFiles(
+      { agentGroupId: A, sessionId: S1.id, messageId: 'msg-evil-subdir', filenames: ['pwn.txt'] },
+      { agentGroupId: B, sessionId: SB.id, messageId: targetMsgId },
+    );
+
+    expect(attachments).toHaveLength(0);
+    expect(fs.readdirSync(canaryDir)).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('file forwarding (#2828): refuses a pre-existing symlinked dst file (COPYFILE_EXCL)', async () => {
+    const warnSpy = vi.spyOn(log, 'warn');
+    const canaryFile = path.join(TEST_DIR, 'canary-dst-target.txt');
+    fs.writeFileSync(canaryFile, 'original-canary');
+
+    const outboxDir = path.join(sessionDir(A, S1.id), 'outbox', 'msg-evil-dst');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, 'doc.txt'), 'attacker-bytes');
+
+    // inbox/<msgId>/ is a real dir, but contains a pre-placed symlink named
+    // exactly like the incoming attachment, pointing at the canary file.
+    // We can only do this once we know the a2a msg id, which is generated
+    // inside routeAgentMessage. So we instead drive forwardAttachedFiles
+    // directly with a fixed target message id.
+    const targetMsgId = 'fixed-evil-dst';
+    const realInboxSubdir = path.join(sessionDir(B, SB.id), 'inbox', targetMsgId);
+    fs.mkdirSync(realInboxSubdir, { recursive: true });
+    fs.symlinkSync(canaryFile, path.join(realInboxSubdir, 'doc.txt'));
+
+    const attachments = forwardAttachedFiles(
+      { agentGroupId: A, sessionId: S1.id, messageId: 'msg-evil-dst', filenames: ['doc.txt'] },
+      { agentGroupId: B, sessionId: SB.id, messageId: targetMsgId },
+    );
+
+    // The exclusive write failed → nothing forwarded.
+    expect(attachments).toHaveLength(0);
+    // Canary file untouched (symlink not followed/overwritten).
+    expect(fs.readFileSync(canaryFile, 'utf-8')).toBe('original-canary');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('file forwarding (#2828 regression): a normal forward still works end-to-end', async () => {
+    const outboxDir = path.join(sessionDir(A, S1.id), 'outbox', 'msg-ok-file');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, 'ok.txt'), 'legit-bytes');
+
+    await routeAgentMessage(
+      {
+        id: 'msg-ok-file',
+        platform_id: B,
+        content: JSON.stringify({ text: 'see attached', files: ['ok.txt'] }),
+        in_reply_to: null,
+      },
+      S1,
+    );
+
+    const bRows = readInbound(B, SB.id);
+    expect(bRows).toHaveLength(1);
+    const parsed = JSON.parse(bRows[0].content);
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].name).toBe('ok.txt');
+    const targetPath = path.join(sessionDir(B, SB.id), parsed.attachments[0].localPath);
+    expect(fs.existsSync(targetPath)).toBe(true);
+    expect(fs.readFileSync(targetPath, 'utf-8')).toBe('legit-bytes');
   });
 });

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -98,8 +98,60 @@ export function forwardAttachedFiles(
     return [];
   }
 
-  const targetInboxDir = path.join(sessionDir(target.agentGroupId, target.sessionId), 'inbox', target.messageId);
+  // Target-side containment — mirror of saveAttachments() in session-manager.ts.
+  // A compromised target agent can write inside its own session dir; without
+  // these checks it could pre-place `inbox` (or `inbox/<future-msgId>`) as a
+  // symlink pointing anywhere host-writable, and mkdirSync({recursive}) would
+  // silently no-op on it while the subsequent copyFileSync followed it and
+  // landed attacker-influenced bytes outside the sandbox (#2828).
+  const inboxRoot = path.join(sessionDir(target.agentGroupId, target.sessionId), 'inbox');
+  const targetInboxDir = path.join(inboxRoot, target.messageId);
+
+  // Reject a pre-placed symlink (or non-directory) at either the inbox root or
+  // the per-message subdir BEFORE mkdir. lstatSync does not follow the final
+  // path component, so it sees the link itself even if its target is missing.
+  for (const dir of [inboxRoot, targetInboxDir]) {
+    try {
+      const dirStat = fs.lstatSync(dir);
+      if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) {
+        log.warn('agent-route: rejecting unsafe target inbox path', {
+          targetGroup: target.agentGroupId,
+          targetSession: target.sessionId,
+          targetMsgId: target.messageId,
+          dir,
+        });
+        return [];
+      }
+    } catch {
+      // Does not exist yet — fine, mkdir below will create it.
+    }
+  }
+
   fs.mkdirSync(targetInboxDir, { recursive: true });
+
+  // Defense in depth: the resolved inbox subdir must stay within the resolved
+  // inbox root. Having ruled out symlinks above, realpathSync is trustworthy.
+  try {
+    const realInboxDir = fs.realpathSync(targetInboxDir);
+    const realInboxRoot = fs.realpathSync(inboxRoot);
+    if (!isPathInside(realInboxRoot, realInboxDir)) {
+      log.warn('agent-route: target inbox dir escaped inbox root', {
+        targetGroup: target.agentGroupId,
+        targetSession: target.sessionId,
+        targetMsgId: target.messageId,
+        targetInboxDir,
+      });
+      return [];
+    }
+  } catch (err) {
+    log.warn('agent-route: failed to resolve target inbox dir', {
+      targetGroup: target.agentGroupId,
+      targetSession: target.sessionId,
+      targetMsgId: target.messageId,
+      err,
+    });
+    return [];
+  }
 
   const attachments: ForwardedAttachment[] = [];
   for (const filename of source.filenames) {
@@ -137,7 +189,20 @@ export function forwardAttachedFiles(
       continue;
     }
     const dst = path.join(targetInboxDir, filename);
-    fs.copyFileSync(realSrc, dst);
+    try {
+      // COPYFILE_EXCL: fail with EEXIST rather than follow or overwrite a
+      // pre-placed symlink / existing file at dst — the host is the sole
+      // writer of these attachments.
+      fs.copyFileSync(realSrc, dst, fs.constants.COPYFILE_EXCL);
+    } catch (err) {
+      log.warn('agent-route: refusing to write target inbox file', {
+        sourceMsgId: source.messageId,
+        targetMsgId: target.messageId,
+        filename,
+        err,
+      });
+      continue;
+    }
     attachments.push({
       name: filename,
       filename,

--- a/src/modules/agent-to-agent/agent-route.ts
+++ b/src/modules/agent-to-agent/agent-route.ts
@@ -22,6 +22,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { isSafeAttachmentName } from '../../attachment-safety.js';
+import { ensureContainedInboxDir, isPathInside } from '../../inbox-safety.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getInboundSourceSessionId, getMostRecentPeerSourceSessionId } from '../../db/session-db.js';
 import { getSession } from '../../db/sessions.js';
@@ -40,11 +41,6 @@ export interface ForwardedAttachment {
   filename: string;
   type: 'file';
   localPath: string;
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
 /**
@@ -98,58 +94,18 @@ export function forwardAttachedFiles(
     return [];
   }
 
-  // Target-side containment — mirror of saveAttachments() in session-manager.ts.
-  // A compromised target agent can write inside its own session dir; without
-  // these checks it could pre-place `inbox` (or `inbox/<future-msgId>`) as a
-  // symlink pointing anywhere host-writable, and mkdirSync({recursive}) would
-  // silently no-op on it while the subsequent copyFileSync followed it and
-  // landed attacker-influenced bytes outside the sandbox (#2828).
+  // Target-side containment — shared with the channel-inbound path. A
+  // compromised target agent can write inside its own session dir, so it could
+  // pre-place `inbox` (or `inbox/<future-msgId>`) as a symlink pointing
+  // anywhere host-writable; ensureContainedInboxDir refuses the symlink before
+  // any copy lands outside the sandbox (#2828, CWE-59).
   const inboxRoot = path.join(sessionDir(target.agentGroupId, target.sessionId), 'inbox');
-  const targetInboxDir = path.join(inboxRoot, target.messageId);
-
-  // Reject a pre-placed symlink (or non-directory) at either the inbox root or
-  // the per-message subdir BEFORE mkdir. lstatSync does not follow the final
-  // path component, so it sees the link itself even if its target is missing.
-  for (const dir of [inboxRoot, targetInboxDir]) {
-    try {
-      const dirStat = fs.lstatSync(dir);
-      if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) {
-        log.warn('agent-route: rejecting unsafe target inbox path', {
-          targetGroup: target.agentGroupId,
-          targetSession: target.sessionId,
-          targetMsgId: target.messageId,
-          dir,
-        });
-        return [];
-      }
-    } catch {
-      // Does not exist yet — fine, mkdir below will create it.
-    }
-  }
-
-  fs.mkdirSync(targetInboxDir, { recursive: true });
-
-  // Defense in depth: the resolved inbox subdir must stay within the resolved
-  // inbox root. Having ruled out symlinks above, realpathSync is trustworthy.
-  try {
-    const realInboxDir = fs.realpathSync(targetInboxDir);
-    const realInboxRoot = fs.realpathSync(inboxRoot);
-    if (!isPathInside(realInboxRoot, realInboxDir)) {
-      log.warn('agent-route: target inbox dir escaped inbox root', {
-        targetGroup: target.agentGroupId,
-        targetSession: target.sessionId,
-        targetMsgId: target.messageId,
-        targetInboxDir,
-      });
-      return [];
-    }
-  } catch (err) {
-    log.warn('agent-route: failed to resolve target inbox dir', {
-      targetGroup: target.agentGroupId,
-      targetSession: target.sessionId,
-      targetMsgId: target.messageId,
-      err,
-    });
+  const targetInboxDir = ensureContainedInboxDir(inboxRoot, target.messageId, {
+    targetGroup: target.agentGroupId,
+    targetSession: target.sessionId,
+    targetMsgId: target.messageId,
+  });
+  if (!targetInboxDir) {
     return [];
   }
 

--- a/src/session-manager.attachments.test.ts
+++ b/src/session-manager.attachments.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Security regression for the channel-inbound attachment path (#2828 sibling).
+ *
+ * `extractAttachmentFiles` (via `writeSessionMessage`) hardens the per-message
+ * inbox subdir against pre-placed symlinks, but NOT the `inbox` root itself.
+ * A compromised container can write inside its own session dir, so it can
+ * replace `inbox` with a symlink pointing outside the session sandbox. The
+ * existing guard then:
+ *   - skips the lstat branch (it only lstats `inbox/<msgId>`, not `inbox`),
+ *   - mkdirs `inbox/<msgId>` *through* the symlink,
+ *   - passes the containment check, because it compares against
+ *     `realpathSync(inboxRoot)` which has already followed the symlink, and
+ *   - writes a brand-new file (the `wx` flag only blocks an existing dst).
+ *
+ * Result: the host writes attacker-influenced bytes outside the session root —
+ * the same class of bug fixed for the A2A path in forwardAttachedFiles (#2828).
+ *
+ * This test asserts the SECURE behaviour (nothing written outside). It FAILS
+ * against the current code, demonstrating the gap.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-saveatt-gap' };
+});
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { createSession } from './db/sessions.js';
+import { initSessionFolder, sessionDir, writeSessionMessage } from './session-manager.js';
+import type { Session } from './types.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-saveatt-gap';
+const AG = 'ag-saveatt';
+const SESS = 'sess-saveatt';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({ id: AG, name: 'SaveAtt', folder: 'saveatt', agent_provider: null, created_at: now() });
+  const sess: Session = {
+    id: SESS,
+    agent_group_id: AG,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: now(),
+  };
+  createSession(sess);
+  initSessionFolder(AG, SESS);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('extractAttachmentFiles — inbox-root symlink containment (#2828 sibling)', () => {
+  it('does not write an attachment outside the session root via a symlinked inbox root', () => {
+    // Attacker-controlled location outside the session sandbox.
+    const canaryDir = path.join(TEST_DIR, 'canary-outside');
+    fs.mkdirSync(canaryDir, { recursive: true });
+
+    // Container pre-places its whole `inbox` as a symlink pointing outside.
+    const inboxRoot = path.join(sessionDir(AG, SESS), 'inbox');
+    fs.rmSync(inboxRoot, { recursive: true, force: true });
+    fs.symlinkSync(canaryDir, inboxRoot);
+
+    const content = JSON.stringify({
+      text: 'see attached',
+      attachments: [{ name: 'pwn.txt', data: Buffer.from('attacker-bytes').toString('base64') }],
+    });
+
+    writeSessionMessage(AG, SESS, {
+      id: 'evil-inbox-root',
+      kind: 'chat',
+      timestamp: now(),
+      platformId: 'whatsapp:123',
+      channelType: 'whatsapp',
+      threadId: null,
+      content,
+    });
+
+    // SECURE expectation: nothing was written through the symlink to the
+    // attacker-controlled canary location.
+    const escaped = path.join(canaryDir, 'evil-inbox-root', 'pwn.txt');
+    expect(fs.existsSync(escaped)).toBe(false);
+    expect(fs.readdirSync(canaryDir)).toHaveLength(0);
+  });
+});

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -18,6 +18,7 @@ import { deriveAttachmentName } from './attachment-naming.js';
 import { isSafeAttachmentName } from './attachment-safety.js';
 import type { OutboundFile } from './channels/adapter.js';
 import { DATA_DIR } from './config.js';
+import { ensureContainedInboxDir, isPathInside } from './inbox-safety.js';
 import { getMessagingGroup } from './db/messaging-groups.js';
 import {
   createSession,
@@ -37,11 +38,6 @@ import {
 } from './db/session-db.js';
 import { log } from './log.js';
 import type { Session } from './types.js';
-
-function isPathInside(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
-}
 
 /** Root directory for all session data. */
 export function sessionsBaseDir(): string {
@@ -288,6 +284,14 @@ function extractAttachmentFiles(
     return contentStr;
   }
 
+  const inboxRoot = path.join(sessionDir(agentGroupId, sessionId), 'inbox');
+  // Resolved lazily on the first attachment that actually carries bytes, so a
+  // message whose attachments have no inline `data` never creates an inbox dir.
+  // ensureContainedInboxDir refuses a pre-placed symlink at the inbox root or
+  // the per-message subdir before any write lands outside the sandbox (#2828).
+  let inboxDir: string | null = null;
+  let inboxResolved = false;
+
   let changed = false;
   for (const att of attachments) {
     if (typeof att.data !== 'string') continue;
@@ -302,32 +306,12 @@ function extractAttachmentFiles(
       });
     }
 
-    const inboxDir = path.join(sessionDir(agentGroupId, sessionId), 'inbox', messageId);
-
-    // Refuse to mkdir through a symlink that the container may have pre placed
-    // at inboxDir. With recursive:true, mkdirSync would silently no op on a
-    // pre existing symlink and the subsequent writeFileSync would follow it.
-    if (fs.existsSync(inboxDir)) {
-      const stat = fs.lstatSync(inboxDir);
-      if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        log.warn('Rejecting unsafe inbox directory', { messageId, inboxDir });
-        continue;
-      }
+    if (!inboxResolved) {
+      inboxDir = ensureContainedInboxDir(inboxRoot, messageId, { messageId });
+      inboxResolved = true;
     }
-    fs.mkdirSync(inboxDir, { recursive: true });
-
-    let realInboxDir: string;
-    try {
-      realInboxDir = fs.realpathSync(inboxDir);
-    } catch (err) {
-      log.warn('Failed to resolve inbox directory', { messageId, err });
-      continue;
-    }
-    const inboxRoot = path.join(sessionDir(agentGroupId, sessionId), 'inbox');
-    if (!isPathInside(fs.realpathSync(inboxRoot), realInboxDir)) {
-      log.warn('Inbox directory escaped session inbox root', { messageId, inboxDir });
-      continue;
-    }
+    // Unsafe inbox (symlink / escape) — no attachment can be written safely.
+    if (!inboxDir) break;
 
     const filePath = path.join(inboxDir, filename);
     try {


### PR DESCRIPTION
## Summary

Fixes #2828 (CWE-59, symlink-follow → arbitrary host file write). Session dirs are mounted writable into agent containers, so a compromised agent can pre-place a symlink inside its own session dir and wait for the host to write through it. This PR closes that on **both** inbound file-write paths:

- **A2A forwarding** (`forwardAttachedFiles` in `src/modules/agent-to-agent/agent-route.ts`) — the original advisory. It hardened the source side but did nothing on the target side: `mkdirSync({recursive})` followed a symlinked target `inbox`/`inbox/<msgId>` and `copyFileSync` landed bytes outside the sandbox.
- **Channel-inbound attachments** (`extractAttachmentFiles` in `src/session-manager.ts`) — the same class of bug, reachable from ordinary inbound messages. The existing guard `lstat`-checked only `inbox/<msgId>`, not the `inbox` **root**; a symlinked root was silently followed and the containment check passed because it compared against `realpathSync(inboxRoot)`, which had already followed the link. The `wx` flag only blocks an existing dst, so a brand-new attachment file still escaped.

## Approach

Both paths now route through a single shared guard, `ensureContainedInboxDir` in `src/inbox-safety.ts`:

1. `lstat`-reject a pre-placed symlink/non-dir at the inbox **root** *and* the per-message subdir (lstat doesn't follow the final component, so it catches a link even when its target is missing).
2. `mkdir` the subdir, then a `realpath` containment check.
3. Callers write with an exclusive flag (`COPYFILE_EXCL` / `wx`) so a pre-existing symlinked *file* can't be followed either, and skip-with-`warn` on any failure (a bad attachment never kills the batch).

Keeping the guard in one module means both inbound paths defend identically and removes the duplicated logic.

## Test plan

- [x] `src/session-manager.attachments.test.ts` (new) — reproduces the symlinked-inbox-root write escape on the channel path; red before, green after.
- [x] `src/modules/agent-to-agent/agent-route.test.ts` — adds symlinked target inbox dir, symlinked `inbox/<msgId>` subdir, pre-existing symlinked dst file, and a normal end-to-end regression.
- [x] Full host suite green (`pnpm test`: 540/540).
- [x] `pnpm exec tsc --noEmit` clean.