### PR TITLE
fix(ncl): default messaging-groups create instance to channel_type

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -30,6 +30,8 @@ export interface ColumnDef {
   updatable?: boolean;
   /** Default value on create when not provided. */
   default?: unknown;
+  /** Default to another column's resolved value on create when not provided. */
+  defaultFrom?: string;
   /** Allowed values (shown in help). */
   enum?: string[];
 }
@@ -150,6 +152,8 @@ function genericCreate(def: ResourceDef) {
         throw new Error(`--${col.name.replace(/_/g, '-')} is required`);
       } else if (col.default !== undefined) {
         values[col.name] = col.default;
+      } else if (col.defaultFrom !== undefined && values[col.defaultFrom] !== undefined) {
+        values[col.name] = values[col.defaultFrom];
       }
     }
 

--- a/src/cli/resources/messaging-groups.test.ts
+++ b/src/cli/resources/messaging-groups.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test: `ncl messaging-groups create` must satisfy the NOT NULL
+ * `instance` column without an operator-supplied `--instance`. The column has
+ * no CLI flag at the operator's altitude (the default instance IS the channel
+ * type), so the generic CRUD insert defaults it to `channel_type` — matching
+ * `createMessagingGroup`'s `instance ?? channel_type` fallback on the router
+ * path. Delete the `instance` column / `defaultFrom` wiring in
+ * `messaging-groups.ts` and this goes red: the insert fails the NOT NULL.
+ */
+import fs from 'fs';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(undefined),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-cli-msggroups' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-cli-msggroups';
+
+import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
+import { getMessagingGroupByPlatform } from '../../db/messaging-groups.js';
+import { dispatch } from '../dispatch.js';
+// Side-effect import: registers the `messaging-groups-create` command.
+import './messaging-groups.js';
+
+describe('messaging-groups CLI create defaults instance to channel_type', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    runMigrations(initTestDb());
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('create without --instance sets instance = channel_type', async () => {
+    // caller: 'host' is the post-approval re-entry path for create (approval op).
+    const resp = await dispatch(
+      {
+        id: 'req-1',
+        command: 'messaging-groups-create',
+        args: { channel_type: 'telegram', platform_id: '12345' },
+      },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(true);
+    const row = getMessagingGroupByPlatform('telegram', '12345');
+    expect(row).toBeDefined();
+    expect(row?.instance).toBe('telegram');
+  });
+
+  it('create with an explicit --instance keeps that value', async () => {
+    const resp = await dispatch(
+      {
+        id: 'req-2',
+        command: 'messaging-groups-create',
+        args: { channel_type: 'telegram', platform_id: '67890', instance: 'work' },
+      },
+      { caller: 'host' },
+    );
+
+    expect(resp.ok).toBe(true);
+    expect(getMessagingGroupByPlatform('telegram', '67890', 'work')?.instance).toBe('work');
+  });
+});

--- a/src/cli/resources/messaging-groups.ts
+++ b/src/cli/resources/messaging-groups.ts
@@ -24,6 +24,14 @@ registerResource({
       required: true,
     },
     {
+      name: 'instance',
+      type: 'string',
+      description:
+        'Adapter instance that owns this chat, when running N adapters of one channel type. Defaults to channel_type (the default instance) when omitted.',
+      defaultFrom: 'channel_type',
+      updatable: true,
+    },
+    {
       name: 'name',
       type: 'string',
       description: 'Display name. Often auto-populated by the channel adapter.',


### PR DESCRIPTION
## Problem
`ncl messaging-groups create` fails with a `NOT NULL` constraint violation. The `instance` column (added in migration 016) is `TEXT NOT NULL`, but the generic CRUD insert builds its column list from the resource definition — and `instance` was never declared there, so the `INSERT` omitted the column entirely.

The router/adapter path never hit this because it goes through `createMessagingGroup`, which has its own `instance ?? channel_type` fallback. Only the CLI create path was broken.

## Why default instead of adding a required `--instance` flag
There is no operator-facing reason to require `--instance`. The **default instance *is* the channel type** — this is encoded in three places already: migration 016's comment ("The default instance IS the channel type"), `createMessagingGroup`'s `instance ?? channel_type` fallback, and the default-instance resolver's `ORDER BY (instance = channel_type) DESC`. Forcing a flag would diverge the CLI from the rest of the system. So we default it and keep `--instance` available for genuine multi-instance setups.

## Changes
- **`crud.ts`** — add `defaultFrom` to `ColumnDef`: on create, default a column to another already-resolved column's value. Generic and reusable, not a messaging-groups special-case.
- **`messaging-groups.ts`** — declare the `instance` column with `defaultFrom: 'channel_type'` (placed after `channel_type` so it resolves first), `updatable: true`.
- **`messaging-groups.test.ts`** — drives the real `dispatch('messaging-groups-create')` path: asserts omitting `--instance` → `channel_type`, and an explicit `--instance` is preserved. Goes **red** if the column/`defaultFrom` wiring is removed (insert fails the NOT NULL), so the wiring stays protected.

## Verification
- `pnpm test src/cli/` — 38 pass
- `pnpm run build` — clean
- Exercised end-to-end through the real `ncl` socket→dispatch→CRUD→SQLite path: create without `--instance` → `instance: "telegram"`; create with `--instance work` → `instance: "work"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
