### PR TITLE
fix: channel-registered new agents inherit the install's provider (avoid 401 on single-provider installs)

### DIFF
--- a/src/modules/permissions/channel-approval-provider.test.ts
+++ b/src/modules/permissions/channel-approval-provider.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `createNewAgentGroup` provider inheritance.
+ *
+ * Bug: channel-registered "Connect new agent" always created the group with
+ * the built-in default provider (claude). On a single-provider install where
+ * claude isn't authenticated (e.g. codex-only), the new agent's first turn
+ * died with `401 No credentials configured for api.anthropic.com`.
+ *
+ * Fix (mirrors create_agent's parent-inheritance intent): with no parent to
+ * inherit from, derive a default from the install's existing container configs.
+ * If every config that declares a provider declares the SAME non-default one,
+ * adopt it; otherwise (none, or mixed) keep the claude default — no behavior
+ * change for multi-provider or Claude installs.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetAllContainerConfigs = vi.fn();
+const mockUpdateScalars = vi.fn();
+const mockInitGroupFilesystem = vi.fn();
+
+vi.mock('../../db/container-configs.js', () => ({
+  getAllContainerConfigs: () => mockGetAllContainerConfigs(),
+  updateContainerConfigScalars: (...a: unknown[]) => mockUpdateScalars(...a),
+}));
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: (id: string) => ({ id, name: id, folder: id, agent_provider: null, created_at: '' }),
+  getAgentGroupByFolder: () => undefined,
+  getAllAgentGroups: () => [],
+  createAgentGroup: vi.fn(),
+}));
+vi.mock('../../group-init.js', () => ({
+  initGroupFilesystem: (...a: unknown[]) => mockInitGroupFilesystem(...a),
+}));
+
+beforeEach(() => {
+  mockGetAllContainerConfigs.mockReset();
+  mockUpdateScalars.mockReset();
+  mockInitGroupFilesystem.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('createNewAgentGroup provider inheritance', () => {
+  it('single-provider install → new channel agent inherits that provider', async () => {
+    // Every existing group runs codex (built-in claude leaves the column unset).
+    mockGetAllContainerConfigs.mockReturnValue([{ provider: 'codex' }, { provider: 'codex' }]);
+
+    const { createNewAgentGroup } = await import('./channel-approval.js');
+    createNewAgentGroup('New Agent');
+
+    expect(mockInitGroupFilesystem).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ provider: 'codex' }),
+    );
+    expect(mockUpdateScalars).toHaveBeenCalledWith(expect.any(String), { provider: 'codex' });
+  });
+
+  it('mixed-provider install → keeps the built-in claude default (provider unset)', async () => {
+    mockGetAllContainerConfigs.mockReturnValue([{ provider: 'codex' }, { provider: 'opencode' }]);
+
+    const { createNewAgentGroup } = await import('./channel-approval.js');
+    createNewAgentGroup('New Agent');
+
+    expect(mockInitGroupFilesystem).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ provider: undefined }),
+    );
+    expect(mockUpdateScalars).not.toHaveBeenCalled();
+  });
+
+  it('claude-only install (no providers set) → keeps the built-in claude default', async () => {
+    // Existing groups all run the built-in default → provider column unset/empty.
+    mockGetAllContainerConfigs.mockReturnValue([{ provider: null }, { provider: '' }]);
+
+    const { createNewAgentGroup } = await import('./channel-approval.js');
+    createNewAgentGroup('New Agent');
+
+    expect(mockInitGroupFilesystem).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ provider: undefined }),
+    );
+    expect(mockUpdateScalars).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -47,6 +47,7 @@
 import { normalizeOptions, type NormalizedOption, type RawOption } from '../../channels/ask-question.js';
 import { createAgentGroup, getAgentGroup, getAgentGroupByFolder, getAllAgentGroups } from '../../db/agent-groups.js';
 import { getChannelAdapter } from '../../channels/channel-registry.js';
+import { getAllContainerConfigs, updateContainerConfigScalars } from '../../db/container-configs.js';
 import { getMessagingGroup, updateMessagingGroup } from '../../db/messaging-groups.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { initGroupFilesystem } from '../../group-init.js';
@@ -292,8 +293,36 @@ export function createNewAgentGroup(name: string): AgentGroup {
   });
 
   const ag = getAgentGroup(agId)!;
-  // Channel-approved groups get the built-in default provider (claude); the
-  // operator flips a group with `ncl groups config update --provider`.
-  initGroupFilesystem(ag);
+  // Channel-approved groups have no "parent" to inherit a provider from (unlike
+  // the agent-to-agent `create_agent` tool, where a child adopts its creator's
+  // runtime). So derive a sensible default from the install itself: if every
+  // existing group that declares a provider declares the SAME non-default one,
+  // adopt it — mirroring create_agent's intent that a single-provider install
+  // (e.g. codex-only, where claude isn't authenticated) doesn't spawn an agent
+  // on a runtime it can't reach. If providers are mixed, or none are set, fall
+  // back to the built-in default (claude) — no behavior change for multi-provider
+  // or Claude installs. The operator can flip a group later with
+  // `ncl groups config update --provider`.
+  const inheritedProvider = deriveDefaultProvider();
+  initGroupFilesystem(ag, { provider: inheritedProvider });
+  if (inheritedProvider) {
+    updateContainerConfigScalars(ag.id, { provider: inheritedProvider });
+  }
   return ag;
+}
+
+/**
+ * Derive a default provider for a channel-registered agent from the install's
+ * existing groups. Returns the single non-default provider in use across all
+ * container configs, or `undefined` if there are none or the install runs a
+ * mix (in which case the caller keeps the built-in claude default). Provider-
+ * agnostic — it never names a specific runtime.
+ */
+function deriveDefaultProvider(): string | undefined {
+  const providers = new Set<string>();
+  for (const config of getAllContainerConfigs()) {
+    // An unset/empty provider means the built-in default (claude); ignore it.
+    if (config.provider) providers.add(config.provider);
+  }
+  return providers.size === 1 ? [...providers][0] : undefined;
 }


### PR DESCRIPTION
## The bug

When a user connects NanoClaw to a new chat channel and picks **"Connect new agent"** during the registration/approval flow, `createNewAgentGroup` (in `src/modules/permissions/channel-approval.ts`) always created the new agent group with the built-in default provider (Claude). On a single-provider install where Claude is **not** authenticated (e.g. a Codex-only install), the new agent's first turn dies with:

```
401 No credentials configured for api.anthropic.com in OneCLI
```

and the user gets an error reply instead of a working agent.

## The fix

There's already a precedent for the correct behavior: the agent-to-agent `create_agent` tool (`src/modules/agent-to-agent/create-agent.ts`) makes a newly-created child agent **inherit its creator's provider**, so "a single-provider install (e.g. codex-only, where claude isn't authenticated) doesn't spawn a child on a runtime it can't reach."

The channel-registration path has no parent to inherit from, so instead it derives a sensible default from the install itself:

- Scan all existing `container_configs` rows.
- If every config that **declares** a provider declares the **same** non-default one, adopt it (apply the same `initGroupFilesystem(ag, { provider })` + `updateContainerConfigScalars(ag.id, { provider })` pattern as `create_agent`).
- If providers are **mixed**, or **none** are set, fall back to the built-in Claude default — **no behavior change** for multi-provider or Claude installs.

**Provider-agnostic:** the logic never names a specific runtime; it just adopts whatever single non-default provider the install already runs.

## Tests

Added `src/modules/permissions/channel-approval-provider.test.ts` covering:

- single-provider install (all configs = codex) -> new channel agent inherits `codex`
- mixed-provider install (codex + opencode) -> keeps Claude default (provider unset)
- Claude-only install (no providers set) -> keeps Claude default

`pnpm test` -> 540 passed. `pnpm run build` (tsc) -> clean. Prettier + eslint clean on the touched files.
