### PR TITLE
feat(channels): add optional resolveChannelName to ChannelAdapter interface

### DIFF
--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -163,6 +163,7 @@ export interface ChannelAdapter {
    * Returning the same platform_id on repeated calls is expected.
    */
   openDM?(userHandle: string): Promise<string>;
+  resolveChannelName?: (platformId: string) => Promise<string | null>;
 }
 
 /** Factory function that creates a channel adapter (returns null if credentials missing). */


### PR DESCRIPTION
## Summary
Adds an optional `resolveChannelName(platformId): Promise<string | null>` to the `ChannelAdapter` interface.

## Why
`slack.ts` and `telegram.ts` on this branch already reference `resolveChannelName`, but the interface doesn't declare it — so a `tsc` build currently fails:

- `slack.ts(29): Property 'resolveChannelName' does not exist on type 'ChannelAdapter'`
- `telegram.ts(220): Object literal may only specify known properties, and 'resolveChannelName' does not exist in type 'ChannelAdapter'`

This one-line, **optional** addition resolves those latent type errors; no adapter is required to implement the method.

## Test
- `pnpm run build` clean.
