### PR TITLE
fix(telegram): enable thread support

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -208,7 +208,7 @@ registerChannelAdapter('telegram', {
       adapter: telegramAdapter,
       concurrency: 'concurrent',
       extractReplyContext,
-      supportsThreads: false,
+      supportsThreads: true,
       transformOutboundText: sanitizeTelegramLegacyMarkdown,
       maxTextLength: 4000,
     });


### PR DESCRIPTION
## Summary
Sets `supportsThreads: true` for the Telegram adapter so forum/topic threads are tracked. The bridge already threads `message_thread_id` through inbound routing; this flips the capability flag on.

## Test
- `pnpm run build` clean.
