### PR TITLE
feat(render): host-mediated document rendering via ephemeral container

### DIFF
--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -10,6 +10,7 @@ import './scheduling.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+import './render.js';
 import { startMcpServer } from './server.js';
 
 function log(msg: string): void {

--- a/container/agent-runner/src/mcp-tools/render.ts
+++ b/container/agent-runner/src/mcp-tools/render.ts
@@ -1,0 +1,91 @@
+/**
+ * Document rendering MCP tool: render_document.
+ *
+ * Fire-and-forget — writes a `render` system action and returns. The host runs
+ * a dedicated, network-isolated render container (Quarto + LaTeX + Chromium)
+ * over this session's workspace and notifies you when the artifact is ready,
+ * which you can then attach to a message. Rendering is NOT in the agent image
+ * (kept lean); it happens host-side.
+ *
+ * Write the source (.qmd/.md, plus any assets it references) into your
+ * workspace first, then call this with a workspace-relative path.
+ */
+import { writeMessageOut } from '../db/messages-out.js';
+import { registerTools } from './server.js';
+import type { McpToolDefinition } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[mcp-tools] ${msg}`);
+}
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+const FORMATS = new Set(['pdf', 'html', 'docx', 'typst']);
+
+export const renderDocument: McpToolDefinition = {
+  tool: {
+    name: 'render_document',
+    description:
+      'Render a document you have written into your workspace (.qmd or .md) to PDF, HTML, or DOCX via Quarto. Fire-and-forget: rendering runs host-side in an isolated container and you are notified when the artifact is ready in your workspace, then you can attach it. Write the source file (and any images/assets it references) into your workspace BEFORE calling this.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        source: {
+          type: 'string',
+          description: 'Workspace-relative path to the source file, e.g. "report.qmd" or "docs/spec.md"',
+        },
+        format: {
+          type: 'string',
+          enum: ['pdf', 'html', 'docx', 'typst'],
+          description: 'Output format (default "pdf")',
+        },
+        output: {
+          type: 'string',
+          description: 'Optional output filename (defaults to the source name with the new extension)',
+        },
+      },
+      required: ['source'],
+    },
+  },
+  handler: async (args) => {
+    const source = String(args.source ?? '').trim();
+    const format = String(args.format ?? 'pdf').trim().toLowerCase();
+    const output = args.output ? String(args.output).trim() : '';
+
+    if (!source) return err('source is required');
+    // Keep paths inside the workspace — no absolute paths or parent escapes.
+    if (source.startsWith('/') || source.split('/').includes('..')) {
+      return err('source must be a workspace-relative path (no leading / or ..)');
+    }
+    if (output && (output.startsWith('/') || output.split('/').includes('..'))) {
+      return err('output must be a workspace-relative path (no leading / or ..)');
+    }
+    if (!FORMATS.has(format)) {
+      return err(`unsupported format "${format}" (use ${[...FORMATS].join(', ')})`);
+    }
+
+    const requestId = generateId();
+    writeMessageOut({
+      id: requestId,
+      kind: 'system',
+      content: JSON.stringify({ action: 'render', source, format, output, requestId }),
+    });
+
+    log(`render: ${requestId} → ${source} (${format})`);
+    return ok(
+      `Rendering "${source}" to ${format}. I'll let you know when it's ready in the workspace, then I can attach it.`,
+    );
+  },
+};
+
+registerTools([renderDocument]);

--- a/container/render/Dockerfile
+++ b/container/render/Dockerfile
@@ -1,0 +1,53 @@
+# nanoclaw-render — standalone document-rendering image (Quarto + LaTeX + Chromium).
+#
+# Host-mediated, ephemeral. The host runs `docker run --rm --network none` of
+# this image over a session's workspace to render .qmd/.md → PDF/HTML/DOCX; the
+# artifact lands back in the mounted workspace. Deliberately kept OUT of the
+# agent image so the agent stays lean and this heavy, attack-prone toolchain
+# (LaTeX shell-escape via \write18, chromium) is isolated, run with no network,
+# and never sees agent secrets.
+FROM debian:bookworm-slim
+
+ARG QUARTO_VERSION=1.9.38
+
+# Base tools + chromium (mermaid/diagrams, HTML→PDF) + base fonts.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        chromium \
+        fonts-liberation \
+        fonts-dejavu-core \
+        lmodern \
+    && rm -rf /var/lib/apt/lists/*
+
+# Quarto: the .deb bundles pandoc, dart-sass and esbuild (HTML + Word work
+# standalone). Asset arch (arm64/amd64) matches `dpkg --print-architecture`.
+RUN ARCH="$(dpkg --print-architecture)" && \
+    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${ARCH}.deb" -o /tmp/quarto.deb && \
+    apt-get update && apt-get install -y --no-install-recommends /tmp/quarto.deb && \
+    rm -f /tmp/quarto.deb && rm -rf /var/lib/apt/lists/*
+
+# Curated TeX Live subset for PDF (Quarto's default engine is lualatex). Build
+# the luaotfload font DB now, as root, into the system cache so `quarto render
+# --to pdf` works offline under any runtime UID (no per-user cache write).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        texlive-luatex \
+        texlive-xetex \
+        texlive-latex-recommended \
+        texlive-latex-extra \
+        texlive-fonts-recommended \
+    && rm -rf /var/lib/apt/lists/* \
+    && luaotfload-tool --update --force
+
+# Run renders unprivileged. HOME/XDG under /tmp so quarto/deno/chromium caches
+# are writable regardless of the (arbitrary) runtime UID; only /work is mounted.
+ENV HOME=/tmp \
+    XDG_CACHE_HOME=/tmp/.cache \
+    CHROMIUM_PATH=/usr/bin/chromium \
+    QUARTO_CHROMIUM=/usr/bin/chromium
+
+WORKDIR /work
+# Default to the quarto CLI; the host passes `render <src> --to <fmt> ...`.
+# Override with `--entrypoint` for direct chromium/pandoc invocations.
+ENTRYPOINT ["quarto"]
+CMD ["--version"]

--- a/container/render/build.sh
+++ b/container/render/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Build the standalone document-rendering image (Quarto + LaTeX + Chromium).
+# Used by the host's `render` system-action handler via `docker run --rm`.
+set -euo pipefail
+cd "$(dirname "$0")"
+IMAGE="${RENDER_IMAGE:-nanoclaw-render:latest}"
+echo "Building $IMAGE ..."
+docker build -t "$IMAGE" .
+echo "Done: $IMAGE"

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -22,3 +22,4 @@ import './scheduling/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './render/index.js';

--- a/src/modules/render/index.ts
+++ b/src/modules/render/index.ts
@@ -1,0 +1,107 @@
+/**
+ * Document rendering module — applies `render` system actions from the agent.
+ *
+ * The agent's `render_document` MCP tool writes a `render` system action; this
+ * handler runs the standalone `nanoclaw-render` image (Quarto + LaTeX +
+ * Chromium) over the session's workspace, ephemerally and host-mediated:
+ *
+ *   docker run --rm --network none --user <host uid> -v <workspace>:/work \
+ *     nanoclaw-render render <source> --to <format> [-o <output>]
+ *
+ * Rendering is kept OUT of the agent image (lean agent, isolated toolchain).
+ * The agent never touches docker; the container is network-isolated, holds no
+ * secrets, mounts only the agent's workspace, and is destroyed after each run.
+ * On completion the agent is notified (so it can attach the artifact).
+ */
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { registerDeliveryAction } from '../../delivery.js';
+import { CONTAINER_RUNTIME_BIN } from '../../container-runtime.js';
+import { sessionDir, writeSessionMessage } from '../../session-manager.js';
+import { log } from '../../log.js';
+import type { Session } from '../../types.js';
+
+const execFileAsync = promisify(execFile);
+
+const RENDER_IMAGE = process.env.RENDER_IMAGE?.trim() || 'nanoclaw-render:latest';
+const RENDER_TIMEOUT_MS = 180_000;
+// Output extension by format (typst renders to PDF).
+const EXT: Record<string, string> = { pdf: 'pdf', html: 'html', docx: 'docx', typst: 'pdf' };
+
+function unsafe(p: string): boolean {
+  return !p || p.startsWith('/') || p.split('/').includes('..');
+}
+
+function notify(session: Session, text: string): void {
+  writeSessionMessage(session.agent_group_id, session.id, {
+    id: `render-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    kind: 'chat',
+    timestamp: new Date().toISOString(),
+    platformId: session.agent_group_id,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
+  });
+}
+
+async function handleRender(content: Record<string, unknown>, session: Session): Promise<void> {
+  const source = String(content.source ?? '').trim();
+  const format = String(content.format ?? 'pdf')
+    .trim()
+    .toLowerCase();
+  const output = content.output ? String(content.output).trim() : '';
+
+  // Defense in depth: re-validate paths host-side (the tool also checks).
+  if (unsafe(source) || (output && unsafe(output))) {
+    log.warn('render: rejected unsafe path', { source, output });
+    notify(session, `Couldn't render "${source}": paths must be workspace-relative (no leading / or ..).`);
+    return;
+  }
+  if (!EXT[format]) {
+    notify(session, `Couldn't render "${source}": unsupported format "${format}".`);
+    return;
+  }
+
+  const workspace = path.join(sessionDir(session.agent_group_id, session.id), 'agent');
+  const uid = process.getuid?.() ?? 0;
+  const gid = process.getgid?.() ?? 0;
+  const args = [
+    'run',
+    '--rm',
+    '--network',
+    'none', // no network while rendering — isolates LaTeX/chromium
+    '--user',
+    `${uid}:${gid}`, // artifact owned by the host user, so the agent can read it back
+    '--memory',
+    '2g',
+    '-v',
+    `${workspace}:/work`,
+    '-w',
+    '/work',
+    RENDER_IMAGE,
+    'render',
+    source,
+    '--to',
+    format,
+    ...(output ? ['-o', output] : []),
+  ];
+
+  const outName = output || `${source.replace(/\.[^./]+$/, '')}.${EXT[format]}`;
+  log.info('render: starting', { agentGroupId: session.agent_group_id, source, format });
+  try {
+    await execFileAsync(CONTAINER_RUNTIME_BIN, args, {
+      timeout: RENDER_TIMEOUT_MS,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    log.info('render: completed', { source, out: outName });
+    notify(session, `Rendered "${source}" → ${outName} in your workspace. Attach it to share it with the user.`);
+  } catch (e) {
+    const stderr = (e as { stderr?: string }).stderr;
+    const msg = (stderr && stderr.trim()) || (e instanceof Error ? e.message : String(e));
+    log.error('render: failed', { source, error: msg.slice(0, 500) });
+    notify(session, `Rendering "${source}" failed: ${msg.slice(0, 400)}`);
+  }
+}
+
+registerDeliveryAction('render', handleRender);


### PR DESCRIPTION
## Summary
Adds a `render_document` MCP tool plus a host module that renders documents (Quarto / LaTeX / Chromium) in a **dedicated, ephemeral, network-isolated container** over the session's workspace, then notifies the agent.

## Why
Keeps the heavy, attack-prone document toolchain out of the agent image. The agent never touches Docker; the render container runs:

- `--network none` (no SSRF / no exfil channel)
- `--user <host uid>` (non-root; artifacts owned by the host user so the agent can read them back)
- `--rm` (ephemeral; torn down after each render)
- `--memory 2g`, and only the session's own workspace is mounted

## Files
- `container/render/{Dockerfile,build.sh}` — the render image
- `src/modules/render/index.ts` — host orchestration (arg-array `execFile`, no shell)
- `container/agent-runner/src/mcp-tools/render.ts` — the agent-facing tool

## Test
- Host `pnpm run build` clean; container `tsc --noEmit` clean.

## Possible follow-up
Resource limits beyond `--memory` (`--cpus`, `--pids-limit`) plus a render-concurrency cap would further harden against a malicious document hogging the host — not included here.
