### PR TITLE
fix(whatsapp): apply media-failure note at the inbound boundary (follow-up to #2895)

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -248,7 +248,7 @@ export function computeIsMention(isGroup: boolean, botMentionedInGroup: boolean)
 
 /**
  * Append a visible note for media that failed to download, so the agent knows
- * something was sent rather than silently losing the attachment — or the whole
+ * something was sent rather than silently losing the attachment - or the whole
  * message, when an uncaptioned image would otherwise be dropped by the
  * empty-message guard. Returns `content` unchanged when nothing failed.
  */
@@ -727,13 +727,9 @@ registerChannelAdapter('whatsapp', {
             // Download media attachments (images, video, audio, documents)
             const { attachments, failures } = await downloadInboundMedia(msg, normalized);
 
-            // Surface failed downloads as text so the agent knows media was
-            // sent even when it couldn't be fetched — instead of silently
-            // dropping the attachment (or the whole message, if uncaptioned).
-            content = appendMediaFailureNote(content, failures);
-
-            // Skip empty protocol messages (no text and no attachments)
-            if (!content && attachments.length === 0) continue;
+            // Skip empty protocol messages: no text, no downloaded
+            // attachments, and no failed downloads to report.
+            if (!content && attachments.length === 0 && failures.length === 0) continue;
 
             // Resolve sender: in groups, participant may be LID — use participantAlt
             const rawSender = msg.key.participant || msg.key.remoteJid || '';
@@ -792,7 +788,10 @@ registerChannelAdapter('whatsapp', {
               isMention: computeIsMention(isGroup, botMentionedInGroup),
               isGroup,
               content: {
-                text: content,
+                // Apply the media-failure note here, at the boundary, so the
+                // raw `content` stays intact for the slash-command and
+                // bot-message matching above.
+                text: appendMediaFailureNote(content, failures),
                 sender,
                 senderName,
                 ...(attachments.length > 0 && { attachments }),


### PR DESCRIPTION
## What

Follow-up to #2895 (merged). A high-effort review of that PR surfaced a regression on the approval-answer path, plus a minor cleanup.

## The bug

`appendMediaFailureNote` was applied to `content` **before** the pending-question slash-command handler. When an approver answers a pending question with a slash command carried as an image caption (e.g. `/approve`) and the image download fails, `content` becomes `"/approve\n[image could not be downloaded]"`. The handler does `cmd = content.trim().toLowerCase()` and exact-matches against the option commands, so the answer no longer matches: the approval is silently dropped, `pendingQuestions` is not cleared, and the raw text is forwarded to the agent. Narrow trigger (slash answer + media + download failure), but a real regression of a sensitive path.

## Fix

- Apply the media-failure note at the inbound `text` boundary, leaving `content` pristine for the slash-command and bot-message matching above.
- Tighten the empty-message guard so a message carrying only a *failed* download still survives (`failures.length === 0` added to the skip condition) — preserving the original intent of #2895.
- Swap an em-dash for a hyphen in a new comment.

The `appendMediaFailureNote` unit tests from #2895 still cover the helper itself; this change only moves where it is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdUxK4bqbgGzFEeZhjC181
