### PR TITLE
fix(slack): reload thread history from platform on @mention

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,15 @@
+# Decisions
+
+Non-obvious design choices, recorded where they land. Newest entries at the top. If a later entry supersedes an earlier one, it says so explicitly.
+
+## Reload thread from platform on @mention, instead of relying on session continuation (2026-07-01)
+
+**Decision:** For chat-sdk channels (Slack, Discord), when `chat.onNewMention` fires, fetch the thread's prior messages directly from the platform (`adapter.fetchMessages`) and prepend them as context, rather than depending on the agent provider's own multi-turn session/continuation state to carry memory forward. Implemented in `src/channels/chat-sdk-bridge.ts` (`fetchThreadContext`).
+
+**Why:** An `engage_mode: 'mention'` wiring (bot only replies when explicitly `@`-tagged, every turn) never calls `adapter.subscribe()`, so it never dispatches through `onSubscribedMessage`. That means any message posted in the thread without a mention is invisible to the agent — not stored, not forwarded — even though humans keep discussing the bot's answer in that thread. The bot's own continuation chain (Claude Code's `--resume`) only ever contained the messages actually sent to it, so it was already missing the human back-and-forth; it also turned out to be fragile in its own right — a container hitting its lifecycle ceiling and getting killed mid-turn corrupted the stored resume id, and the next `@mention` came back with `No conversation found with session ID: ...` and a fully wiped conversation.
+
+**Alternative considered and rejected:** Set `ignored_message_policy: 'accumulate'` so un-tagged messages get stored and included in the next turn's prompt. Rejected because it still routes all memory through the same continuation chain that's already shown itself to be fragile under container-lifecycle churn (kills, restarts, provider swaps) — it would have narrowed the gap without removing the failure mode that actually caused the visible incident.
+
+**Trade-off accepted:** Every `@mention` now costs one extra platform read (`conversations.replies` on Slack) and the agent starts each turn without the model's own cached reasoning/tool state from its previous turn — it re-derives from source data if asked to explain an earlier answer. Considered acceptable: thread reads are cheap for the thread sizes this bot handles, and re-deriving avoids restating a possibly-stale cached number.
+
+**Verified by:** `src/channels/chat-sdk-bridge.test.ts` — `fetchThreadContext` unit tests cover: no prior messages → `undefined`; prior messages formatted and ordered, current message excluded; missing author name falls back to `'unknown'`; adapter read failure → `undefined`, not a thrown error. The `onNewMention` wiring itself (the two-line splice into `content.text`) is not separately covered — none of this file's four SDK dispatch handlers are exercised by a test harness today (dispatch logic is intentionally deferred to `host-core.test.ts`'s end-to-end router tests per this file's existing top-of-suite comment), and building that harness was out of scope for this fix.

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
+import type { Adapter, AdapterPostableMessage, Message, RawMessage } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, fetchThreadContext, splitForLimit } from './chat-sdk-bridge.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -10,6 +10,30 @@ vi.mock('../webhook-server.js', () => ({
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
+}
+
+interface FakeMessageOverrides {
+  id: string;
+  text?: string;
+  author?: { fullName?: string; userName?: string };
+  dateSent?: string;
+}
+
+// fetchThreadContext only reads id/text/author/metadata.dateSent — this fake
+// covers exactly that surface and is cast to Message since building a full
+// Message (formatted/raw/attachments/links) adds nothing this test reads.
+function fakeMessage({
+  id,
+  text = 'default message text',
+  author = { fullName: 'Default Author' },
+  dateSent = '2026-01-01T09:05:00.000Z',
+}: FakeMessageOverrides): Message {
+  return {
+    id,
+    text,
+    author,
+    metadata: { dateSent: new Date(dateSent) },
+  } as unknown as Message;
 }
 
 interface PostCall {
@@ -51,6 +75,65 @@ describe('splitForLimit', () => {
     expect(chunks.length).toBe(Math.ceil(100 / 30));
     for (const c of chunks) expect(c.length).toBeLessThanOrEqual(30);
     expect(chunks.join('')).toBe(text);
+  });
+});
+
+describe('fetchThreadContext', () => {
+  it('returns undefined when the thread has no messages besides the one that triggered the fetch', async () => {
+    const adapter = stubAdapter({
+      fetchMessages: async () => ({ messages: [fakeMessage({ id: 'm1' })] }),
+    });
+
+    const context = await fetchThreadContext(adapter, 'thread-1', 'm1');
+
+    expect(context).toBeUndefined();
+  });
+
+  it('formats prior messages in chronological order, excluding the triggering message', async () => {
+    const adapter = stubAdapter({
+      fetchMessages: async () => ({
+        messages: [
+          fakeMessage({ id: 'm1', text: 'what are the most viewed flags?', author: { fullName: 'Greg' } }),
+          fakeMessage({ id: 'm2', text: 'maybe ask about instances instead', author: { fullName: 'Alice' } }),
+          fakeMessage({ id: 'm3', text: 'the re-mention that triggered this fetch' }),
+        ],
+      }),
+    });
+
+    const context = await fetchThreadContext(adapter, 'thread-1', 'm3');
+
+    expect(context).toContain('2 earlier message(s)');
+    expect(context).toContain('Greg: what are the most viewed flags?');
+    expect(context).toContain('Alice: maybe ask about instances instead');
+    expect(context).not.toContain('the re-mention that triggered this fetch');
+    expect(context!.indexOf('Greg:')).toBeLessThan(context!.indexOf('Alice:'));
+  });
+
+  it("falls back to 'unknown' when the message has no author name", async () => {
+    const adapter = stubAdapter({
+      fetchMessages: async () => ({
+        messages: [
+          fakeMessage({ id: 'm1', author: {}, text: 'a message with no author name' }),
+          fakeMessage({ id: 'm2' }),
+        ],
+      }),
+    });
+
+    const context = await fetchThreadContext(adapter, 'thread-1', 'm2');
+
+    expect(context).toContain('unknown: a message with no author name');
+  });
+
+  it('returns undefined, not a thrown error, when the platform read fails', async () => {
+    const adapter = stubAdapter({
+      fetchMessages: async () => {
+        throw new Error('Slack API rate limited');
+      },
+    });
+
+    const context = await fetchThreadContext(adapter, 'thread-1', 'm1');
+
+    expect(context).toBeUndefined();
   });
 });
 

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -112,6 +112,42 @@ function resolveSelectedOption(
   return candidate;
 }
 
+/**
+ * Render a thread's prior messages (fetched fresh from the platform, not
+ * from our own session/continuation state) as a text block, for a wiring
+ * that requires re-mention on every turn and so never sees un-tagged
+ * messages. See DECISIONS.md "Reload thread from platform on @mention"
+ * for why this replaces continuation-based memory for that case.
+ *
+ * Returns undefined when there's nothing to add (thread has no messages
+ * besides the one that triggered this fetch) or when the platform read
+ * fails — callers treat this as a best-effort enrichment, never a
+ * precondition for delivering the triggering message.
+ */
+export async function fetchThreadContext(
+  adapter: Pick<Adapter, 'fetchMessages'>,
+  threadId: string,
+  currentMessageId: string,
+): Promise<string | undefined> {
+  try {
+    const { messages } = await adapter.fetchMessages(threadId, { direction: 'forward', limit: 200 });
+    const prior = messages.filter((m) => m.id !== currentMessageId);
+    if (prior.length === 0) return undefined;
+    const lines = prior.map((m) => {
+      const name = m.author?.fullName ?? m.author?.userName ?? 'unknown';
+      const time = m.metadata?.dateSent ? new Date(m.metadata.dateSent).toISOString().slice(11, 16) : '';
+      return `[${time}] ${name}: ${m.text}`;
+    });
+    return (
+      `[Thread context — ${prior.length} earlier message(s) in this thread, fetched fresh from the platform]\n` +
+      `${lines.join('\n')}\n[End of thread context]`
+    );
+  } catch (err) {
+    log.warn('Failed to fetch thread history for mention context', { threadId, err });
+    return undefined;
+  }
+}
+
 export function splitForLimit(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];
@@ -259,9 +295,23 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       });
 
       // @mention in an unsubscribed thread — SDK-confirmed bot mention.
+      //
+      // engage_mode='mention' wirings never subscribe the thread (see
+      // router.ts subscribe-on-mention-sticky comment), so every reply here
+      // — including a re-mention deep in an existing thread — would
+      // otherwise only see this one message. Reload the thread from the
+      // platform so re-tagging picks up everything since the bot last
+      // spoke, without depending on the agent's own (fragile,
+      // container-lifecycle-bound) session continuation.
       chat.onNewMention(async (thread, message) => {
         const channelId = adapter.channelIdFromThreadId(thread.id);
-        await setupConfig.onInbound(channelId, thread.id, await messageToInbound(message, true, true));
+        const inbound = await messageToInbound(message, true, true);
+        const threadContext = await fetchThreadContext(adapter, thread.id, message.id);
+        if (threadContext) {
+          const content = inbound.content as Record<string, unknown>;
+          content.text = `${threadContext}\n\n[New tagged message]: ${content.text ?? ''}`;
+        }
+        await setupConfig.onInbound(channelId, thread.id, inbound);
       });
 
       // DMs — by definition addressed to the bot. Thread id flows through


### PR DESCRIPTION
## Summary

- `engage_mode: 'mention'` wirings (bot only replies when explicitly `@`-tagged, every turn) never subscribe their Slack thread, so re-tagging the bot deep in an existing thread only ever delivered the single tagged message — everything humans said in between was invisible.
- Worse: the only other source of memory (the agent provider's own `--resume` continuation) is fragile — a container hitting its lifecycle ceiling and getting SIGKILL'd mid-turn orphans the resume id, surfacing as `No conversation found with session ID: ...` and wiping the conversation on the next mention.
- Fix: on every `onNewMention` dispatch, fetch the thread's prior messages directly from the platform (`adapter.fetchMessages`) and prepend them as context, so each re-mention is self-contained and immune to continuation-chain corruption. See `DECISIONS.md` for full rationale and the rejected alternative (`ignored_message_policy: 'accumulate'`).
- Extracted the fetch/format logic into a standalone exported `fetchThreadContext` (previously drafted as a closure) so it's directly unit-testable with the existing `stubAdapter` test helper, rather than living only inside the untested SDK dispatch closures.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/channels/chat-sdk-bridge.test.ts` — 24 passed (20 pre-existing + 4 new covering: no-prior-history → undefined, chronological formatting excluding the triggering message, missing-author fallback to `'unknown'`, platform-read failure → undefined not thrown)
- [x] `npx eslint` — no new warning classes vs. baseline (one additional `no-catch-all` warning, matching the file's existing best-effort-catch pattern)
- [x] `npx prettier --check` clean
- [x] Deployed to the production nanoclaw instance running `FlightRecorderAgent` ahead of this PR (box has no snapshots, so verified live before merging here): clean restart, both channel adapters up, Slack auth succeeded, manually tested `@mention` → discussion → re-`@mention` in the same thread picks up full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)