### PR TITLE
fix(whatsapp): end the old socket on reconnect (host memory leak)

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -519,6 +519,26 @@ registerChannelAdapter('whatsapp', {
     // --- Socket creation ---
 
     async function connectSocket(): Promise<void> {
+      // End the previous socket before creating a new one. Reconnects re-enter
+      // this function and reassign `sock`. Without ending the old socket and
+      // removing its listeners, each orphaned graph (the WebSocket, Baileys'
+      // keep-alive and query timers, and the four sock.ev.on() closures) stays
+      // referenced by those internal timers and is never collected. WhatsApp
+      // closes with reason 408 often, so on a long-running host this grows
+      // without bound until the process runs out of memory.
+      // removeAllListeners() runs first so end()'s own connection.update
+      // 'close' cannot re-enter the reconnect path and loop.
+      if (sock) {
+        try {
+          // Baileys' typed emitter requires an event name on removeAllListeners;
+          // at runtime it is a Node EventEmitter, so the no-arg form clears all.
+          (sock.ev as unknown as import('events').EventEmitter).removeAllListeners();
+          sock.end(undefined);
+        } catch {
+          // Old socket already closing or closed. Nothing to tear down.
+        }
+      }
+
       const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
       const version = await resolveWaWebVersion();


### PR DESCRIPTION
## Problem

`connectSocket()` reassigns the module-scope `sock` on every reconnect and never ends the previous socket. WhatsApp closes with `reason: 408` frequently, so each reconnect orphans a full Baileys socket graph: the WebSocket, its keep-alive and query timers, and the four `sock.ev.on(...)` listeners. Baileys' internal timers reference the socket, so the old graph is never garbage-collected. `sock.end()` frees it, and today that runs only in `teardown()` on shutdown.

On a long-running host the heap grows without bound. One instance reached a 4GB heap and OOM-crashed after about 14.6h of uptime; its log held 571k "Reconnecting" events.

## Fix

End the existing socket at the top of `connectSocket()`, before creating the new one. `removeAllListeners()` runs first so `end()`'s own `connection.update` close event cannot re-enter the reconnect path and loop. Baileys' typed emitter requires an event name on `removeAllListeners`; at runtime it is a Node `EventEmitter`, so the no-arg form clears all listeners.

## Validation

- Reconnects still succeed (`Connected to WhatsApp` follows each close).
- Host RSS settled from 588MB to about 115MB and held across the ongoing 408 churn.
- `pnpm run build` clean (the unrelated `deltachat.ts` optional-dependency error is pre-existing on `channels`); whatsapp adapter tests pass.

Base is `channels` because the adapter lives there, not on `main`.
