### PR TITLE
feat(codex): persona prepend + git-independent skill discovery for template agents

### DIFF
--- a/src/providers/codex-agents-md.test.ts
+++ b/src/providers/codex-agents-md.test.ts
@@ -56,9 +56,10 @@ describe('composeGroupAgentsMd cap handling', () => {
       composeGroupAgentsMd(g, groupDir);
       const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
       expect(doc).not.toContain('Omitted for size');
-      // Agent-authored skills must be told their persistent home — without
-      // this, authored skills land on ephemeral container paths and vanish.
-      expect(doc).toContain('/workspace/agent/skills');
+      // Agent-authored skills must be told a home that is BOTH persistent and
+      // codex-discovered (~/.codex/skills). /workspace/agent/skills is not
+      // scanned by codex, so authored skills there never trigger.
+      expect(doc).toContain('~/.codex/skills');
       expect(Buffer.byteLength(doc, 'utf-8')).toBeLessThanOrEqual(CODEX_PROJECT_DOC_MAX_BYTES);
     } finally {
       fs.rmSync(groupDir, { recursive: true, force: true });

--- a/src/providers/codex-agents-md.test.ts
+++ b/src/providers/codex-agents-md.test.ts
@@ -19,6 +19,7 @@ vi.mock('../config.js', async (importOriginal) => ({
 import { composeGroupAgentsMd, CODEX_PROJECT_DOC_MAX_BYTES } from './codex-agents-md.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../db/index.js';
 import { ensureContainerConfig, updateContainerConfigJson } from '../db/container-configs.js';
+import { PERSONA_PREPEND_FILE } from '../group-persona.js';
 import type { AgentGroup } from '../types.js';
 
 const TEST_ROOT = '/tmp/nanoclaw-agents-md-test';
@@ -105,6 +106,71 @@ describe('composeGroupAgentsMd cap handling', () => {
       expect(doc).toContain('MCP Server: bloated');
       expect(doc).toContain('short and useful');
       expect(doc).toContain('Memory System');
+    } finally {
+      fs.rmSync(groupDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('composeGroupAgentsMd persona', () => {
+  beforeEach(() => {
+    if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
+    fs.mkdirSync(path.join(TEST_ROOT, 'data'), { recursive: true });
+    runMigrations(initTestDb());
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true });
+  });
+
+  it('inlines the persona as the first section, before the runtime contract', () => {
+    const g = group('persona');
+    createAgentGroup(g);
+    ensureContainerConfig(g.id);
+    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
+    try {
+      fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'You are an SDR agent.\n');
+      composeGroupAgentsMd(g, groupDir);
+      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
+      expect(doc).toContain('You are an SDR agent.');
+      // First markdown heading (the HEADER is an HTML comment, not a `# ` heading).
+      const firstHeading = doc.split('\n').find((line) => line.startsWith('# '));
+      expect(firstHeading).toBe('# Persona');
+    } finally {
+      fs.rmSync(groupDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never evicts the persona even when the doc exceeds the cap', () => {
+    const g = group('persona-big');
+    createAgentGroup(g);
+    ensureContainerConfig(g.id);
+    updateContainerConfigJson(g.id, 'mcp_servers', {
+      bloat: { command: 'x', instructions: 'B'.repeat(CODEX_PROJECT_DOC_MAX_BYTES + 1024) },
+    });
+    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
+    try {
+      fs.writeFileSync(path.join(groupDir, PERSONA_PREPEND_FILE), 'PERSONA_MARKER body');
+      composeGroupAgentsMd(g, groupDir);
+      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
+      expect(Buffer.byteLength(doc, 'utf-8')).toBeLessThanOrEqual(CODEX_PROJECT_DOC_MAX_BYTES);
+      expect(doc).toContain('PERSONA_MARKER'); // survived eviction
+      expect(doc).toContain('Omitted for size');
+    } finally {
+      fs.rmSync(groupDir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits the persona section when no prepend file is present', () => {
+    const g = group('no-persona');
+    createAgentGroup(g);
+    ensureContainerConfig(g.id);
+    const groupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-'));
+    try {
+      composeGroupAgentsMd(g, groupDir);
+      const doc = fs.readFileSync(path.join(groupDir, 'AGENTS.md'), 'utf-8');
+      expect(doc).not.toContain('# Persona');
     } finally {
       fs.rmSync(groupDir, { recursive: true, force: true });
     }

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -56,7 +56,7 @@ const NATIVE_RUNTIME_SKILLS_POINTER = [
   'Selected NanoClaw runtime skills are available as Codex-native skills at `/workspace/agent/.agents/skills`.',
   'Each skill directory contains a `SKILL.md` with its trigger description plus any supporting files, and points to the read-only shared skill source under `/app/skills`.',
   'Use skill discovery to load these skills only when their descriptions match the task. Full skill instructions live in the skill directories, not in `AGENTS.md`.',
-  'Skills YOU author or install yourself go in `/workspace/agent/skills/<name>/SKILL.md` — persistent, provider-neutral (they load under any agent provider this group runs on), and yours to write and update over time. They are linked into `$CODEX_HOME/skills` automatically at boot. Never write skills anywhere else: paths outside your workspace and `$CODEX_HOME` are ephemeral.',
+  'Skills YOU author or install yourself go in `~/.codex/skills/<name>/SKILL.md` — persistent across sessions and discovered by Codex automatically. Never write skills elsewhere: paths outside `~/.codex` and `~/.agents` are ephemeral or not discovered.',
 ].join('\n\n');
 
 interface AgentsMdSection {

--- a/src/providers/codex-agents-md.ts
+++ b/src/providers/codex-agents-md.ts
@@ -19,6 +19,7 @@ import path from 'path';
 
 import type { McpServerConfig } from '../container-config.js';
 import { getContainerConfig } from '../db/container-configs.js';
+import { readGroupPersona } from '../group-persona.js';
 import { log } from '../log.js';
 import type { AgentGroup } from '../types.js';
 
@@ -79,6 +80,11 @@ export function composeGroupAgentsMd(group: AgentGroup, groupDir: string): void 
       .join('\n\n');
     if (body) sections.push({ name, content: `# ${name}\n\n${body}` });
   };
+
+  // Template persona first — the top of the system prompt. 'Persona' is not a
+  // droppable prefix (see fitAgentsMdToCap.isDroppable), so it is never evicted.
+  const persona = readGroupPersona(groupDir);
+  if (persona) pushSection('Persona', persona);
 
   const sharedBase = path.join(process.cwd(), 'container', 'AGENTS.md');
   if (fs.existsSync(sharedBase)) {

--- a/src/providers/codex-host-contribution.test.ts
+++ b/src/providers/codex-host-contribution.test.ts
@@ -88,11 +88,41 @@ describe('codex host contribution against real core', () => {
 
     // The full mount set: codex surfaces in, default claude surfaces out.
     const session = { id: 'session-1', agent_group_id: ag.id } as Session;
-    const config: ContainerConfig = { mcpServers: {}, packages: { apt: [], npm: [] }, additionalMounts: [], skills: [] };
+    const config: ContainerConfig = {
+      mcpServers: {},
+      packages: { apt: [], npm: [] },
+      additionalMounts: [],
+      skills: [],
+    };
     const mounts = buildMounts(ag, session, config, 'codex', contribution);
     const containerPaths = mounts.map((m) => m.containerPath);
     expect(containerPaths).toContain('/home/node/.codex');
     expect(containerPaths.some((p) => p.endsWith('AGENTS.md'))).toBe(true);
     expect(containerPaths).not.toContain('/home/node/.claude');
+  });
+
+  it('mirrors per-group template skills from the Claude plane into .agents/skills', () => {
+    const ag = group('ag-codex-skills', 'codex-skills-group');
+    createAgentGroup(ag);
+    ensureContainerConfig(ag.id);
+    // A template stamps its skills as real dirs on the Claude plane; codex reads
+    // .agents/skills (RO-mounted), so the contribution must mirror them there.
+    const templateSkill = path.join(DATA_DIR, 'v2-sessions', ag.id, '.claude-shared', 'skills', 'widget');
+    fs.mkdirSync(templateSkill, { recursive: true });
+    fs.writeFileSync(path.join(templateSkill, 'SKILL.md'), '---\nname: widget\n---\n');
+
+    const contributionFn = getProviderContainerConfig('codex');
+    contributionFn!({
+      sessionDir: path.join(DATA_DIR, 'v2-sessions', ag.id, 'session-1'),
+      agentGroupId: ag.id,
+      groupDir: path.join(GROUPS_DIR, ag.folder),
+      selectedSkills: [],
+      hostEnv: process.env,
+    });
+
+    const mirrored = path.join(GROUPS_DIR, ag.folder, '.agents', 'skills', 'widget');
+    expect(fs.existsSync(path.join(mirrored, 'SKILL.md'))).toBe(true);
+    // A real dir, not a symlink — so it survives syncCodexSkillLinks' symlink-only prune.
+    expect(fs.lstatSync(mirrored).isSymbolicLink()).toBe(false);
   });
 });

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -31,6 +31,7 @@ import path from 'path';
 
 import { DATA_DIR } from '../config.js';
 import { getAgentGroup } from '../db/agent-groups.js';
+import { materializeTemplateSkills } from '../group-skills.js';
 import { composeGroupAgentsMd } from './codex-agents-md.js';
 import { registerProviderContainerConfig } from './provider-container-registry.js';
 
@@ -52,6 +53,11 @@ registerProviderContainerConfig(
     const group = getAgentGroup(ctx.agentGroupId);
     if (group) composeGroupAgentsMd(group, ctx.groupDir);
     syncCodexSkillLinks(ctx.groupDir, ctx.selectedSkills);
+    // Template skills live on the Claude plane (.claude-shared/skills); codex
+    // reads .agents/skills (RO-mounted), so mirror them here, host-side, via the
+    // shared provider-agnostic helper. Real dirs survive the symlink-only prune
+    // above and coexist with the shared-skill symlinks it creates.
+    materializeTemplateSkills(ctx.agentGroupId, path.join(ctx.groupDir, '.agents', 'skills'));
 
     // No credential env here — OneCLI's container-config drives auth end to
     // end: the gateway serves a sentinel auth.json stub into ~/.codex for

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -76,6 +76,14 @@ registerProviderContainerConfig(
     const agentsDir = path.join(ctx.groupDir, '.agents');
     if (fs.existsSync(agentsDir)) {
       mounts.push({ hostPath: agentsDir, containerPath: '/workspace/agent/.agents', readonly: true });
+      // Codex only scans the CWD-level `.agents/skills` when the CWD is inside a
+      // git repo; the agent workspace (/workspace/agent) is not one, so skills
+      // materialized there are invisible. Codex DOES scan the user-level
+      // `$HOME/.agents/skills` unconditionally, so mount the same dir at $HOME
+      // to make the group's template + shared skills discoverable. Verified
+      // against codex-cli 0.141: user-level `.agents/skills` resolves at a
+      // non-git CWD. Skill materialization stays provider-neutral (group-skills.ts).
+      mounts.push({ hostPath: agentsDir, containerPath: '/home/node/.agents', readonly: true });
     }
 
     return { mounts };


### PR DESCRIPTION
## Summary

Makes the **agent-templates** feature work end-to-end under the **Codex** provider. Two commits, scoped entirely to `src/providers/codex*` (4 files, +122/−5):

- `ed2e3b4` — persona prepend + provider-agnostic skills mirror
- `40b6a57` — expose group skills at `$HOME/.agents/skills` so Codex discovers them

## What & why

- **Persona → AGENTS.md.** A template's `instructions.prepend.md` is now inlined as a non-droppable `# Persona` section at the top of the composed `AGENTS.md` (system-prompt tier), via the shared `readGroupPersona` seam — mirroring how Claude inlines it into `CLAUDE.md`.
- **Skills discovery.** Template + shared skills are materialized by the shared, provider-neutral `group-skills.ts` seam, then the group's `.agents` dir is mounted **also** at `/home/node/.agents`. Codex scans `<cwd>/.agents/skills` only inside a git repo (the agent workspace `/workspace/agent` is not one), but scans `$HOME/.agents/skills` **unconditionally** — verified live with `codex-cli 0.141` (non-git cwd → not found; under `$HOME/.agents/skills` → found). The AGENTS.md self-authored-skills pointer is corrected to `~/.codex/skills` (writable via the `.codex-shared` mount and scanned); the never-implemented `$CODEX_HOME/skills` boot-link claim is removed.

## Testing

- Host tests green: `codex-host-contribution`, `codex-agents-md`, `codex-registration`.
- **Full standard install passed under Codex**: persona present in AGENTS.md, the `sdr-agent` template skill triggers, and both template MCP servers (HubSpot + Exa) are available.

## Notes

- Donor branch on top of `upstream/providers` (0 behind, 2 ahead); diff is codex-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
