### PR TITLE
fix(core-instructions): explicitly forbid repeating send_message content in the final message block

### DIFF
--- a/container/agent-runner/src/mcp-tools/core.instructions.md
+++ b/container/agent-runner/src/mcp-tools/core.instructions.md
@@ -14,6 +14,8 @@ Use the `mcp__nanoclaw__send_message` tool to send a message while you're still 
 
 **Outcomes, not play-by-play.** When the turn is done, the final message should be about the result, not a transcript of what you did.
 
+**Never repeat delivered content.** If you already sent something via `send_message`, don't write it again in your final `<message>` block — that delivers it to the user twice. Your final message should cover what the tool call didn't (a short outcome note is fine); verbatim repetition is not.
+
 ### Sending files (`send_file`)
 
 Use `mcp__nanoclaw__send_file({ path, text?, filename?, to? })` to deliver a file from your workspace. `path` is absolute or relative to `/workspace/agent/`; `filename` overrides the display name shown in chat (defaults to the file's basename); `text` is an optional accompanying message. Use this for artifacts you produce (charts, PDFs, generated images, reports) rather than dumping contents into chat.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

We had multiple scheduled-task agent groups (a daily briefing, a news digest, a channel-report agent) independently and repeatedly send every response to the user twice. Root cause: the agent called `send_message` mid-turn with the real content, then restated the same content again in its final output. On our install this collided with a local fallback that auto-delivers unwrapped final text, producing a literal duplicate delivery — but the underlying agent behavior (repeating content already sent via `send_message`) is not install-specific, and it's foreseeable given the current instructions.

`core.instructions.md` already tells the agent that `send_message` is for updates sent "while you're still working (before your final output)" and that the final message should be "about the result, not a transcript of what you did" — but it never explicitly says not to repeat content already delivered. Each group that hit this had to independently rediscover the same lesson.

This adds one explicit sentence to the `send_message` section stating the rule directly, so it's covered once, centrally, for every agent group rather than needing to be rediscovered and patched per group.

No code changes — this is a system-prompt instruction fragment injected into every agent's runtime context (`core.instructions.md`), not traditional docs.