### PR TITLE
fix(whatsapp-cloud): register bridge under distinct 'whatsapp-cloud' instance key

### DIFF
--- a/.claude/skills/add-whatsapp-cloud/SKILL.md
+++ b/.claude/skills/add-whatsapp-cloud/SKILL.md
@@ -53,6 +53,22 @@ pnpm install @chat-adapter/whatsapp@4.29.0
 pnpm run build
 ```
 
+## Upgrading an existing install
+
+Older installs registered this bridge under the bare `whatsapp` key, which
+collided with the native Baileys adapter. It now registers under a distinct
+`whatsapp-cloud` instance (channelType stays `whatsapp`). Two consequences for
+an install that ran the previous version:
+
+- **Webhook route moves** from `/webhook/whatsapp` to `/webhook/whatsapp-cloud`.
+  Update the callback URL in your Meta App dashboard (WhatsApp > Configuration)
+  accordingly.
+- **Chat SDK state namespace moves.** Subscriptions in the `chat_sdk_*` tables
+  re-key under the new instance, so previously-subscribed threads may need to
+  re-engage the bot.
+
+Fresh installs need none of this.
+
 ## Credentials
 
 1. Go to [Meta for Developers](https://developers.facebook.com/apps/) and create an app (type: Business).
@@ -61,7 +77,7 @@ pnpm run build
    - Note the **Phone Number ID** (not the phone number itself).
    - Generate a **permanent System User access token** with `whatsapp_business_messaging` permission.
 4. Go to **WhatsApp** > **Configuration**:
-   - Set webhook URL: `https://your-domain/webhook/whatsapp`.
+   - Set webhook URL: `https://your-domain/webhook/whatsapp-cloud`.
    - Set a **Verify Token** (any random string you choose).
    - Subscribe to webhook fields: `messages`.
 5. Copy the **App Secret** from **Settings** > **Basic**.

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -166,7 +166,8 @@ export interface ChannelAdapter {
 
   /**
    * Adapter-instance name — distinguishes N adapters of one platform
-   * (e.g. three Slack apps in one workspace). Defaults to channelType.
+   * (e.g. a native WhatsApp bridge alongside the WhatsApp Cloud bridge, or
+   * three Slack apps in one workspace). Defaults to channelType.
    * channelType stays the SEMANTIC platform key (user ids '<channelType>:<handle>',
    * formatting, container config); instance is a host-side routing key only.
    * Must be unique across active adapters and URL-safe (no '/', '?', ':').

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -116,6 +116,11 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
   return registry.get(name)?.containerConfig;
 }
 
+/** Get a channel's registration (factory + container config) by its registry name. */
+export function getChannelRegistration(name: string): ChannelRegistration | undefined {
+  return registry.get(name);
+}
+
 /**
  * Instantiate and set up all registered channel adapters.
  * Skips adapters that return null (missing credentials).

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -45,6 +45,19 @@ export type ReplyContextExtractor = (raw: Record<string, any>) => ReplyContext |
 
 export interface ChatSdkBridgeConfig {
   adapter: Adapter;
+  /**
+   * Adapter-instance name for running multiple bridges of one platform
+   * whose underlying Chat SDK adapters share a hardcoded `name` (e.g. the
+   * WhatsApp Cloud bridge, whose `@chat-adapter/whatsapp` reports
+   * `name = "whatsapp"`, running next to the native Baileys `whatsapp`
+   * adapter). Sets the returned adapter's registry key — `activeAdapters`
+   * is keyed by `instance ?? channelType`, so a named instance no longer
+   * collides with a sibling adapter of the same platform. Defaults to the
+   * platform name. channelType is NOT affected — user identity, formatting,
+   * and container config stay keyed on the platform.
+   * Must be URL-safe: non-empty, only letters, digits, '.', '_' or '-'.
+   */
+  instance?: string;
   concurrency?: ConcurrencyStrategy;
   /** Bot token for authenticating forwarded Gateway events (required for interaction handling). */
   botToken?: string;
@@ -125,6 +138,18 @@ export function splitForLimit(text: string, limit: number): string[] {
 
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
+  // The instance name becomes the registry key (and, once the core
+  // instance-routing infra lands, a webhook route segment and the
+  // state-namespace delimiter). Reject anything non-URL-safe at construction
+  // time rather than at first webhook. Positive allow-list (not a deny-list):
+  // also rejects '' and whitespace-only names, which are config bugs that
+  // would silently collapse back onto the default instance's keyspace.
+  if (config.instance !== undefined && !/^[A-Za-z0-9._-]+$/.test(config.instance)) {
+    throw new Error(
+      `chat-sdk bridge instance ${JSON.stringify(config.instance)} must be URL-safe: ` +
+        `non-empty, only letters, digits, '.', '_' or '-'`,
+    );
+  }
   const transformText = (t: string): string => (config.transformOutboundText ? config.transformOutboundText(t) : t);
   let chat: Chat;
   let state: SqliteStateAdapter;
@@ -197,8 +222,9 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
   }
 
   const bridge: ChannelAdapter = {
-    name: adapter.name,
-    channelType: adapter.name,
+    name: config.instance ?? adapter.name,
+    channelType: adapter.name, // unchanged — semantic platform key
+    instance: config.instance, // undefined ⇒ default instance (keyed by channelType)
     supportsThreads: config.supportsThreads,
     defaults: config.defaults,
 

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -31,7 +31,7 @@ import './linear.js';
 // import './teams.js';
 
 // whatsapp cloud api
-// import './whatsapp-cloud.js';
+import './whatsapp-cloud.js';
 
 // resend (email)
 // import './resend.js';

--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -21,14 +21,47 @@
  * `createChatSdkBridge(...)` from ./chat-sdk-bridge.js. That core-consumption is a
  * typed call, so the build/typecheck leg (`pnpm run build`) guards it against upstream
  * drift, not this test. Every Chat SDK channel follows this same shape.
+ *
+ * Beyond registration, this file also asserts the *instance key* whatsapp-cloud.ts hands the
+ * bridge (#2911). `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', so the bridge's
+ * channelType is 'whatsapp' — shared with the native Baileys adapter. The factory must pass
+ * `instance: 'whatsapp-cloud'` so the registry keys the two apart (`instance ?? channelType`)
+ * instead of last-write-wins. We build the adapter through its registered factory (the real
+ * code path) with credentials mocked in, since the factory returns null when they are absent.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { getRegisteredChannelNames } from './channel-registry.js';
+// The factory reads credentials via readEnvFile (off disk) and returns null when
+// they are missing. Supply dummy values so the factory builds the real bridge —
+// createWhatsAppAdapter constructs purely (no network) once all four are present.
+vi.mock('../env.js', () => ({
+  readEnvFile: () => ({
+    WHATSAPP_ACCESS_TOKEN: 'test-access-token',
+    WHATSAPP_PHONE_NUMBER_ID: 'test-phone-number-id',
+    WHATSAPP_APP_SECRET: 'test-app-secret',
+    WHATSAPP_VERIFY_TOKEN: 'test-verify-token',
+  }),
+}));
+
+import { getRegisteredChannelNames, getChannelRegistration } from './channel-registry.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
 
 describe('whatsapp-cloud channel registration', () => {
   it('registers whatsapp-cloud via the channel barrel', () => {
     expect(getRegisteredChannelNames()).toContain('whatsapp-cloud');
+  });
+
+  it('builds under a distinct instance key while keeping channelType whatsapp', async () => {
+    const registration = getChannelRegistration('whatsapp-cloud');
+    expect(registration).toBeDefined();
+
+    const adapter = await registration!.factory();
+    expect(adapter).not.toBeNull();
+
+    // instance keeps this bridge off the native Baileys adapter's 'whatsapp'
+    // registry key (last-write-wins collision, #2911).
+    expect(adapter!.instance).toBe('whatsapp-cloud');
+    // channelType stays the semantic platform key, shared with native whatsapp.
+    expect(adapter!.channelType).toBe('whatsapp');
   });
 });

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -36,8 +36,15 @@ registerChannelAdapter('whatsapp-cloud', {
       appSecret: env.WHATSAPP_APP_SECRET,
       verifyToken: env.WHATSAPP_VERIFY_TOKEN,
     });
+    // `@chat-adapter/whatsapp` hardcodes name = 'whatsapp', which the bridge
+    // uses as channelType. Without a distinct instance the registry would key
+    // this bridge under 'whatsapp' and collide with the native Baileys adapter
+    // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
+    // silently kills one channel. The instance key keeps them apart while
+    // channelType stays 'whatsapp' (the semantic platform key). See #2911.
     return createChatSdkBridge({
       adapter: whatsappAdapter,
+      instance: 'whatsapp-cloud',
       concurrency: 'concurrent',
       supportsThreads: false,
       defaults: WHATSAPP_CLOUD_DEFAULTS,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The WhatsApp Cloud bridge wraps `@chat-adapter/whatsapp`, which hardcodes `name = "whatsapp"`. The bridge derives `channelType` from that name, and the channel registry keyed live adapters by `channelType`, so the Cloud bridge registered under `whatsapp` and collided with the native Baileys adapter (`src/channels/whatsapp.ts`, also `channelType` `whatsapp`). Installing both silently killed one channel (last-write-wins in `activeAdapters`) and misrouted its `messaging_groups` through the surviving, incompatible adapter.

The fix passes `instance: 'whatsapp-cloud'` to the bridge, so the registry (keyed by `instance ?? channelType`) keeps the two adapters apart. `channelType` stays `whatsapp` (the semantic platform key; user identity, formatting, and container config are unaffected). Backward-compatible: every existing single-instance adapter has `instance === undefined`, so its registry key is still its `channelType`.

This PR also re-enables the `whatsapp-cloud` import in the self-registration barrel (`src/channels/index.ts`). It was parked commented-out while the collision was unfixed, and the registration test guards exactly that import.

Note on branch topology (updated after the 2026-07-16 rebase): `main` already has the full instance mechanism (`ChannelAdapter.instance`, bridge instance config with per-instance webhook route and state namespace, registry keying). Since this PR was opened, the `channels` branch absorbed the adapter field and the registry keying through its core sync, so the PR no longer carries those. What it still back-ports is the bridge-level `instance` config, registry key only; the per-instance webhook route and state namespace on this branch arrive with the next core sync. Installs are unaffected either way: the `/add-whatsapp-cloud` installer copies only `src/channels/whatsapp-cloud.ts` onto a `main`-based host, which already has the full instance routing.

**Migration caveat for existing installs** (which run `main`): with a named instance the webhook route moves from `/webhook/whatsapp` to `/webhook/whatsapp-cloud` (update the callback URL in the Meta App dashboard), and the Chat SDK state namespace re-keys (subscriptions in `chat_sdk_*` tables move; previously-subscribed threads may need to re-engage the bot). Verified against `main`: the webhook route segment is `config.instance ?? adapter.name` and the state adapter is constructed with the instance name (`src/channels/chat-sdk-bridge.ts`). The `/add-whatsapp-cloud` skill documents the upgrade steps.

## Tests

- `whatsapp-cloud-registration.test.ts` asserts the barrel actually registers the channel, then builds the adapter through its registered factory and asserts `instance === 'whatsapp-cloud'` with `channelType === 'whatsapp'` (2/2 pass).
- Targeted channel suite after the rebase: 91/91 across the registry, bridge, defaults, declarations, and registration test files. Typecheck is identical to the base branch (its one pre-existing `deltachat` error is unrelated to this change).
- Rebased 2026-07-16 onto `channels` @ 2989242a (post #3011), resolved against the upstream instance-key seam.

Fixes #2911.

Assisted by Claude; reviewed and verified by a human before submission.
