### PR TITLE
fix(scheduling): stop recurring tasks forking into duplicates

### DIFF
--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -125,6 +125,20 @@ export function getCompletedRecurring(db: Database.Database): RecurringMessage[]
     .all() as RecurringMessage[];
 }
 
+// True if the series already has a live (pending/paused) occurrence carrying the
+// recurrence forward. Guards handleRecurrence against forking a series into
+// parallel chains when two completed-recurring rows of the same series coexist
+// (e.g. a retry after a container kill double-completes an occurrence).
+export function hasLivePendingRecurrence(db: Database.Database, seriesId: string): boolean {
+  return (
+    db
+      .prepare(
+        "SELECT 1 FROM messages_in WHERE series_id = ? AND status IN ('pending', 'paused') AND recurrence IS NOT NULL LIMIT 1",
+      )
+      .get(seriesId) !== undefined
+  );
+}
+
 export function insertRecurrence(
   db: Database.Database,
   msg: RecurringMessage,

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -77,6 +77,44 @@ describe('handleRecurrence', () => {
     expect(new Date(follow.process_after).getTime()).toBeGreaterThan(Date.now());
   });
 
+  it('does not fork a series when two completed-recurring rows share a series_id', async () => {
+    // Simulates the fork bug: a retry after a container kill leaves two
+    // completed rows carrying the same series_id + recurrence. handleRecurrence
+    // must fan out exactly ONE next occurrence, not one per completed row.
+    const db = freshDb();
+    for (const id of ['task-a', 'task-b']) {
+      insertTask(db, {
+        id,
+        processAfter: '2020-01-01T00:00:00.000Z',
+        recurrence: '0 9 * * *',
+        platformId: null,
+        channelType: null,
+        threadId: null,
+        content: JSON.stringify({ prompt: 'daily digest' }),
+      });
+    }
+    // Both rows belong to the same series and are completed but still recurring.
+    db.prepare(
+      `UPDATE messages_in SET status='completed', series_id='series-x' WHERE id IN ('task-a','task-b')`,
+    ).run();
+
+    await handleRecurrence(db, fakeSession());
+
+    const pending = db
+      .prepare(`SELECT id FROM messages_in WHERE status='pending' AND recurrence IS NOT NULL`)
+      .all() as Array<{ id: string }>;
+    expect(pending).toHaveLength(1); // exactly one next occurrence, not two
+
+    const stillRecurringCompleted = (
+      db
+        .prepare(
+          `SELECT COUNT(*) AS c FROM messages_in WHERE status='completed' AND recurrence IS NOT NULL`,
+        )
+        .get() as { c: number }
+    ).c;
+    expect(stillRecurringCompleted).toBe(0); // both completed rows retired
+  });
+
   it('does not clone rows whose recurrence is already cleared', async () => {
     const db = freshDb();
     insertTask(db, {

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -16,13 +16,28 @@ import type Database from 'better-sqlite3';
 import { TIMEZONE } from '../../config.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
-import { clearRecurrence, getCompletedRecurring, insertRecurrence } from './db.js';
+import {
+  clearRecurrence,
+  getCompletedRecurring,
+  hasLivePendingRecurrence,
+  insertRecurrence,
+} from './db.js';
 
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
   const recurring = getCompletedRecurring(inDb);
 
   for (const msg of recurring) {
     try {
+      // Idempotency guard: at most one live occurrence per series. Without it,
+      // two completed-recurring rows of the same series each fan out a next
+      // occurrence, permanently forking the series into parallel chains that
+      // only grow. Retire the extra completed row instead of cloning it. The
+      // insertRecurrence below makes the guard true for the rest of this pass.
+      if (hasLivePendingRecurrence(inDb, msg.series_id)) {
+        clearRecurrence(inDb, msg.id);
+        continue;
+      }
+
       const { CronExpressionParser } = await import('cron-parser');
       // Interpret the cron expression in the user's timezone. v1 did this
       // (src/v1/task-scheduler.ts:20-49); without it, a task written "0 9 * * *"


### PR DESCRIPTION
## Problem

`handleRecurrence` fanned out a next occurrence for **every** completed row that still had a `recurrence` cron, with no per-series dedup. Whenever two completed-recurring rows of the same series coexisted — e.g. a retry after a container hit the 30-min absolute-ceiling kill and double-completed an occurrence — each one cloned its own "next", permanently forking the series into parallel chains that only grow.

Observed live in a session with 8× "morning brief", 4× "evening check-in", and 4× a scheduled script job, all sharing one `series_id`, six created in the same second.

## Fix

Add a per-series idempotency guard `hasLivePendingRecurrence`: if a series already has a live pending/paused occurrence, retire the extra completed row instead of cloning it. The insert makes the guard true for the rest of the pass, so multiple completed rows in one sweep collapse to a single next occurrence.

## Test

New test in `recurrence.test.ts` reproduces two completed rows sharing a `series_id` and asserts exactly one occurrence fans out (previously two). All scheduling tests pass; typecheck clean.

Note: the underlying trigger (containers hitting the absolute-ceiling kill) is a separate issue tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)