### PR TITLE
feat(channels): add LINE Official Account channel (native adapter + /add-line skill)

### DIFF
--- a/.claude/skills/add-line/REMOVE.md
+++ b/.claude/skills/add-line/REMOVE.md
@@ -1,0 +1,54 @@
+# Remove LINE
+
+## 1. Remove the adapter
+
+Delete the self-registration import from `src/channels/index.ts` (skip if already gone):
+
+```typescript
+import './line.js';
+```
+
+Then delete the copied adapter and its tests:
+
+```bash
+rm -f src/channels/line.ts \
+      src/channels/line-signature.ts \
+      src/channels/line-signature.test.ts \
+      src/channels/line-registration.test.ts
+```
+
+## 2. Remove credentials
+
+Remove these lines from `.env` (and re-sync the container copy: `cp .env data/env/env`):
+
+```bash
+LINE_CHANNEL_SECRET
+LINE_CHANNEL_ACCESS_TOKEN
+```
+
+## 3. Rebuild and restart
+
+Run from your NanoClaw project root:
+
+```bash
+pnpm run build
+source setup/lib/install-slug.sh
+
+# Linux
+systemctl --user restart $(systemd_unit)
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+```
+
+## 4. Clean up on the LINE side (optional)
+
+In the [LINE Developers console](https://developers.line.biz/console/): clear the channel's **Webhook URL**, disable **Use webhook**, and revoke the channel access token if it won't be reused. If you ran a tunnel just for LINE (e.g. a zrok share), stop it and release the reserved name.
+
+## Verification
+
+```bash
+grep -i "line channel" logs/nanoclaw.log | tail -3
+```
+
+Expected: no `LINE channel ready` entry after the last restart.

--- a/.claude/skills/add-line/SKILL.md
+++ b/.claude/skills/add-line/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: add-line
+description: Add LINE Official Account channel integration via the LINE Messaging API. Native adapter — no Chat SDK bridge, zero new npm dependencies. Requires a public HTTPS webhook endpoint.
+---
+
+# Add LINE Channel
+
+Adds LINE messaging support via a native adapter that talks to the [LINE Messaging API](https://developers.line.biz/en/docs/messaging-api/) directly — webhook in, push out. There is no `@chat-adapter/line` package, so no Chat SDK bridge; the adapter uses only Node builtins (`node:crypto`, `node:http`) and global `fetch`. Zero new npm dependencies.
+
+LINE is the dominant messaging platform in Japan, Taiwan, and Thailand. Bots run as **Official Accounts** (OAs) that users add as friends; NanoClaw acts as the webhook backend of an Official Account.
+
+## Prerequisites
+
+### 1. A LINE Official Account with a Messaging API channel
+
+1. Create an Official Account at https://manager.line.biz (free)
+2. Enable the **Messaging API** for it — this creates a Messaging API channel in the [LINE Developers console](https://developers.line.biz/console/)
+3. From the channel's **Basic settings** tab, copy the **Channel secret**
+4. From the **Messaging API** tab, issue a long-lived **Channel access token**
+
+### 2. A public HTTPS webhook endpoint
+
+LINE delivers inbound messages **only via webhook over public HTTPS** — there is no polling mode (unlike Telegram). The adapter serves `/webhook/line` on the shared webhook server (`WEBHOOK_PORT`, default 3000); a public HTTPS URL must reach it.
+
+- **Production:** a domain + reverse proxy (Caddy/nginx) in front of `127.0.0.1:3000`.
+- **Local development:** use a tunnel **with a stable URL**, e.g. a [zrok](https://zrok.io) reserved name (free) or Tailscale Funnel:
+
+  ```bash
+  zrok enable <account-token>                 # one-time
+  zrok create name my-nanoclaw-line           # reserves a permanent hostname
+  zrok share public localhost:3000 -n public:my-nanoclaw-line --headless
+  # → https://my-nanoclaw-line.shares.zrok.io — survives restarts, set once in the console
+  ```
+
+> ⚠ Avoid ephemeral tunnels (`cloudflared tunnel --url`, random-URL ngrok) beyond a first smoke test. Their hostname dies with the process, LINE keeps POSTing to the dead URL, and inbound messages are **silently lost** — webhook redelivery is off by default, and the host logs show nothing because nothing arrives.
+
+## Install
+
+### Pre-flight (idempotent)
+
+Skip to **Credentials** if all of these are already in place:
+
+- `src/channels/line.ts`, `src/channels/line-signature.ts`,
+  `src/channels/line-signature.test.ts`, and `src/channels/line-registration.test.ts` all exist
+- `src/channels/index.ts` contains `import './line.js';`
+
+Otherwise continue. Every step below is safe to re-run.
+
+### 1. Fetch the channels branch
+
+```bash
+git fetch origin channels
+```
+
+### 2. Copy the adapter and its tests
+
+```bash
+git show origin/channels:src/channels/line.ts                    > src/channels/line.ts
+git show origin/channels:src/channels/line-signature.ts          > src/channels/line-signature.ts
+git show origin/channels:src/channels/line-signature.test.ts     > src/channels/line-signature.test.ts
+git show origin/channels:src/channels/line-registration.test.ts  > src/channels/line-registration.test.ts
+```
+
+### 3. Append the self-registration import
+
+Append to `src/channels/index.ts` (skip if already present):
+
+```typescript
+import './line.js';
+```
+
+### 4. Build and validate
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/line-registration.test.ts src/channels/line-signature.test.ts
+```
+
+Both must be clean before proceeding. `line-registration.test.ts` is the integration test: it imports the real channel barrel and asserts the registry contains `line` — it goes red if the `import './line.js';` line is deleted or the barrel fails to evaluate. Importing is safe: the factory returns null without credentials, and the webhook route is registered only in `setup()`, never at import. There is no npm package to guard — the adapter has zero dependencies.
+
+## Credentials
+
+Add to `.env`:
+
+```bash
+LINE_CHANNEL_SECRET=your-channel-secret
+LINE_CHANNEL_ACCESS_TOKEN=your-long-lived-access-token
+```
+
+The adapter reads them from the process environment first, then falls back to `.env`, so it works under launchd/systemd without extra sourcing.
+
+Sync to container: `mkdir -p data/env && cp .env data/env/env`
+
+### Restart
+
+Run from your NanoClaw project root:
+
+```bash
+source setup/lib/install-slug.sh
+
+# Linux
+systemctl --user restart $(systemd_unit)
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+```
+
+The log should show `LINE channel ready { path: '/webhook/line' }`.
+
+## Point LINE at the webhook
+
+In the [LINE Developers console](https://developers.line.biz/console/), open the channel → **Messaging API** tab → **Webhook settings**:
+
+1. Set **Webhook URL** to `https://<your-public-host>/webhook/line` → **Update**
+2. Click **Verify** — expect **Success**
+3. Enable **Use webhook**
+4. Under the OA's response settings (LINE Official Account Manager), disable **Auto-reply messages** so LINE's canned replies don't interleave with the agent's
+
+> The **Verify** button is not a GET — it sends a **signed POST with an empty `events` array**. A passing Verify therefore proves the whole inbound chain at once: the URL resolves, the tunnel/proxy reaches the host, the adapter is up, and the channel secret matches the signature.
+
+## Wiring
+
+### DMs
+
+Add the OA as a friend (QR code on the console's Messaging API tab), then send it any message. The router auto-creates a `messaging_groups` row for the chat. Then:
+
+```bash
+ncl messaging-groups list --channel line
+```
+
+Pass the `mg-…` id to `/init-first-agent` (first agent) or `/manage-channels` (wire to an existing agent group).
+
+New LINE senders are dropped until granted access — grant membership (and a role, if this is the operator):
+
+```bash
+ncl users list                                   # find line:U… (or: ncl dropped-messages list)
+ncl members add --user "line:U…" --group <agent-group-id>
+ncl roles grant --user "line:U…" --role owner    # operator identity only
+```
+
+### Group chats
+
+Enable **Allow bot to join group chats** in the OA settings, invite the OA to the group, and @mention it. Group/room chats route with `isGroup: true`; the bot engages on explicit @mentions (LINE reports these via mention metadata). Wire the auto-created messaging group the same way as DMs.
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now.
+
+Otherwise, run `/init-first-agent` to create an agent wired to your LINE DM, or `/manage-channels` to wire this channel to an existing agent group.
+
+## Channel Info
+
+- **type**: `line`
+- **terminology**: 1:1 chats with friends, group chats, and multi-person rooms
+- **supports-threads**: no
+- **platform-id-format**:
+  - DM: the sender's LINE userId (`U` + 32 hex chars); user ids are `line:U…`
+  - Group: `C…` groupId · Room: `R…` roomId
+- **how-to-find-id**: message the OA, then `ncl messaging-groups list --channel line` (or `ncl dropped-messages list` for ungranted senders)
+- **typical-use**: personal assistant or team inbox in markets where LINE is the default messenger (JP/TW/TH)
+- **default-isolation**: one agent group per OA is typical; group chats with other people should use `isolated` session mode
+
+### Features
+
+- Text in / text out; long replies are chunked to LINE's 5000-char limit and batched (up to 5 message objects per push)
+- Webhook signature verification (constant-time HMAC-SHA256, diagnosable reason codes)
+- Group @mention detection via LINE's mention metadata (`isMention`)
+- Delivery returns the platform message id (`sentMessages[0].id`), on par with bridge channels
+- Media (image/file/video/audio) arrives as a typed placeholder — `[attachment:image] message_id=…` — content is **not** downloaded. The message id is exactly what a future media integration needs to fetch the binary from LINE's content endpoint (`api-data.line.me`); note LINE expires stored content, so any such fetch must happen promptly at webhook time.
+
+### Design notes and limits
+
+- **Push-only outbound, and push costs quota.** LINE reply tokens are single-use with a ~1-minute TTL; NanoClaw's host delivers asynchronously (it polls `outbound.db`), so reply tokens are stale by delivery time and every outbound message is a push. Pushes count against the OA plan's monthly free message allowance (e.g. 200/month on the free plan, counted **per recipient**, not per message object). When the cap is hit, LINE returns an error and the message is not sent — upgrade the OA plan for heavier traffic. Check live usage anytime:
+
+  ```bash
+  curl -s -H "Authorization: Bearer $LINE_CHANNEL_ACCESS_TOKEN" \
+    https://api.line.me/v2/bot/message/quota/consumption
+  ```
+
+- Not supported: outbound file attachments (text only), Flex/rich messages (if needed later, the pinned `@line/bot-sdk` is the upgrade path), follow/unfollow events, typing indicator.
+
+## Troubleshooting
+
+### Console "Verify" fails
+
+The chain is URL → tunnel/proxy → host → adapter → secret. Test from outside:
+
+```bash
+curl -i https://<your-public-host>/webhook/line   # expect HTTP 200, body "ok"
+```
+
+- Connection/DNS error → tunnel or proxy is down (ephemeral tunnel URLs die with their process)
+- 200 here but Verify fails → check `grep "LINE channel ready" logs/nanoclaw.log` (adapter running?) and the signature warning below (wrong secret)
+
+### `LINE webhook signature rejected` in logs
+
+The `reason` field says why: `no_secret` (env var missing), `no_signature` (request didn't come from LINE), `mismatch` (LINE_CHANNEL_SECRET doesn't match this channel — re-copy it from the console's Basic settings tab).
+
+### First DM does nothing
+
+The messaging group is auto-created but the sender isn't granted access yet — messages drop until membership is granted. Check `ncl dropped-messages list`, then grant as shown in Wiring.
+
+### Messages stopped arriving after a restart
+
+If you use a tunnel: did its URL change? The console still points at the old hostname and LINE's deliveries vanish silently. Re-check the webhook URL and re-Verify. This is the failure mode the stable-tunnel recommendation exists for.
+
+### Push fails / quota
+
+`LINE push failed` with status 429 or a quota message means the monthly free push allowance is exhausted — it's a hard wall, not overage billing. Note the OA console's billing page shows **charges** (zero while inside the free tier) and its daily stats aggregate with a day's delay; for real-time usage use the `quota/consumption` endpoint shown above.

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,3 +7,4 @@
 // self-registration import below.
 
 import './cli.js';
+import './line.js';

--- a/src/channels/line-registration.test.ts
+++ b/src/channels/line-registration.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Integration test for the line channel's single reach-in: the self-registration
+ * import in the `src/channels/index.ts` barrel. Importing the barrel runs line.ts's
+ * top-level `registerChannelAdapter('line', …)`; without the import the channel is
+ * silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './line.js';` line is deleted, or the barrel fails to evaluate for any
+ * reason (so the channel genuinely would not register), this goes red. A structural
+ * check of the import line would falsely pass in that second case.
+ *
+ * line is a native adapter with zero npm dependencies (node `crypto`/`http` plus
+ * global `fetch` against the LINE Messaging API), so there is no adapter package
+ * to guard here. Importing the barrel is safe: registration is a pure top-level
+ * call; the factory returns null when LINE credentials are absent, and the webhook
+ * route is registered only inside setup() (run at host startup), never at import.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('line channel registration', () => {
+  it('registers line via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('line');
+  });
+});

--- a/src/channels/line-signature.test.ts
+++ b/src/channels/line-signature.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeLineSignature, verifyLineSignature, verifyLineSignatureResult } from './line-signature.js';
+
+const SECRET = 'test-channel-secret-0123456789';
+const BODY = JSON.stringify({ destination: 'U123', events: [{ type: 'message' }] });
+
+describe('LINE signature verification', () => {
+  it('accepts a signature it computed for the same body + secret', () => {
+    const sig = computeLineSignature(BODY, SECRET);
+    expect(verifyLineSignature(BODY, SECRET, sig)).toBe(true);
+    expect(verifyLineSignatureResult(BODY, SECRET, sig)).toBe('ok');
+  });
+
+  it('accepts a Buffer body identically to a string body', () => {
+    const sig = computeLineSignature(BODY, SECRET);
+    expect(verifyLineSignature(Buffer.from(BODY, 'utf8'), SECRET, sig)).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    const sig = computeLineSignature(BODY, SECRET);
+    const tampered = BODY.replace('U123', 'U999');
+    expect(verifyLineSignature(tampered, SECRET, sig)).toBe(false);
+    expect(verifyLineSignatureResult(tampered, SECRET, sig)).toBe('mismatch');
+  });
+
+  it('rejects a signature made with a different secret', () => {
+    const sig = computeLineSignature(BODY, 'some-other-secret');
+    expect(verifyLineSignature(BODY, SECRET, sig)).toBe(false);
+    expect(verifyLineSignatureResult(BODY, SECRET, sig)).toBe('mismatch');
+  });
+
+  it('reports no_secret when the channel secret is missing', () => {
+    const sig = computeLineSignature(BODY, SECRET);
+    expect(verifyLineSignatureResult(BODY, '', sig)).toBe('no_secret');
+    expect(verifyLineSignatureResult(BODY, undefined, sig)).toBe('no_secret');
+    expect(verifyLineSignature(BODY, '', sig)).toBe(false);
+  });
+
+  it('reports no_signature when the header is absent', () => {
+    expect(verifyLineSignatureResult(BODY, SECRET, undefined)).toBe('no_signature');
+    expect(verifyLineSignatureResult(BODY, SECRET, '')).toBe('no_signature');
+    expect(verifyLineSignature(BODY, SECRET, null)).toBe(false);
+  });
+
+  it('rejects garbage / wrong-length signatures without throwing', () => {
+    expect(verifyLineSignature(BODY, SECRET, 'not-base64-!!!')).toBe(false);
+    expect(verifyLineSignature(BODY, SECRET, 'AAAA')).toBe(false); // valid base64, wrong length
+  });
+
+  it('is sensitive to the exact secret (no truncation collisions)', () => {
+    const sig = computeLineSignature(BODY, SECRET);
+    expect(verifyLineSignature(BODY, SECRET + 'x', sig)).toBe(false);
+  });
+});

--- a/src/channels/line-signature.ts
+++ b/src/channels/line-signature.ts
@@ -1,0 +1,70 @@
+/**
+ * LINE webhook signature verification.
+ *
+ * LINE signs every webhook delivery: HMAC-SHA256 over the *raw* request body,
+ * keyed by the channel secret, base64-encoded, sent in the `x-line-signature`
+ * header. We recompute the MAC and compare in constant time.
+ *
+ * This is the security boundary for inbound LINE traffic — the bot's official-
+ * account id and QR are public and non-rotatable, so "a message arrived" proves
+ * nothing. Only a valid signature proves the request actually came from LINE.
+ *
+ * Kept as a standalone, dependency-free module (node `crypto` only) so it is
+ * unit-testable without the running adapter, the webhook server, or any network.
+ */
+import crypto from 'crypto';
+
+/** Why a signature check failed — lets callers log a diagnosable reason. */
+export type LineSignatureResult =
+  | 'ok'
+  | 'no_secret' // LINE_CHANNEL_SECRET not configured (deployment gap)
+  | 'no_signature' // request carried no x-line-signature header (probably not LINE)
+  | 'mismatch'; // secret + signature present but the MAC does not match
+
+/**
+ * Verify an `x-line-signature` header against the raw body and channel secret.
+ * Returns a reason code rather than a bare boolean so the adapter can tell a
+ * missing-secret misconfiguration apart from a genuine forgery.
+ */
+export function verifyLineSignatureResult(
+  body: Buffer | string,
+  channelSecret: string | undefined | null,
+  signature: string | undefined | null,
+): LineSignatureResult {
+  if (!channelSecret) return 'no_secret';
+  if (!signature) return 'no_signature';
+
+  const bodyBuf = typeof body === 'string' ? Buffer.from(body, 'utf8') : body;
+  const expected = crypto.createHmac('sha256', channelSecret).update(bodyBuf).digest(); // 32 raw bytes
+
+  // Decode the provided base64 to raw bytes and compare those. Comparing decoded
+  // bytes (not the base64 strings) sidesteps any padding/whitespace variation and
+  // keeps the comparison constant-time via timingSafeEqual.
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(signature, 'base64');
+  } catch {
+    return 'mismatch';
+  }
+  if (provided.length !== expected.length) return 'mismatch';
+  return crypto.timingSafeEqual(provided, expected) ? 'ok' : 'mismatch';
+}
+
+/** Boolean wrapper around {@link verifyLineSignatureResult}. */
+export function verifyLineSignature(
+  body: Buffer | string,
+  channelSecret: string | undefined | null,
+  signature: string | undefined | null,
+): boolean {
+  return verifyLineSignatureResult(body, channelSecret, signature) === 'ok';
+}
+
+/**
+ * Compute the base64 `x-line-signature` value for a body + secret. Not used by
+ * the adapter (LINE signs; we only verify) — exported for tests and for any
+ * local tooling that needs to forge a valid signature against a test server.
+ */
+export function computeLineSignature(body: Buffer | string, channelSecret: string): string {
+  const bodyBuf = typeof body === 'string' ? Buffer.from(body, 'utf8') : body;
+  return crypto.createHmac('sha256', channelSecret).update(bodyBuf).digest('base64');
+}

--- a/src/channels/line.ts
+++ b/src/channels/line.ts
@@ -1,0 +1,237 @@
+/**
+ * LINE Official Account (Messaging API) channel — native adapter.
+ *
+ * Why native (not a Chat SDK bridge): there is no `@chat-adapter/line` package,
+ * so this adapter talks to the LINE Messaging API directly. Zero new npm
+ * dependencies — node `http`/`crypto` plus global `fetch`.
+ *
+ * Inbound  — LINE POSTs webhook events to `/webhook/line` (LINE has no polling
+ *            mode; a public HTTPS endpoint is required — see the /add-line
+ *            skill). We register a raw handler on the shared webhook server,
+ *            verify `x-line-signature` (HMAC-SHA256 over the raw body), ACK
+ *            fast, then route each message event through `onInbound`.
+ * Outbound — host delivery is asynchronous (it polls outbound.db well after the
+ *            event arrived), by which time LINE reply tokens (~1 min TTL,
+ *            single-use) are stale. So `deliver()` always uses the PUSH
+ *            endpoint, never reply. Push counts against the Official Account
+ *            plan's monthly message quota; reply would be free but is
+ *            architecturally unusable here.
+ *
+ * Credentials come from LINE_CHANNEL_SECRET + LINE_CHANNEL_ACCESS_TOKEN
+ * (process env or .env). The factory returns null when either is missing, so
+ * the host boots cleanly on an install that hasn't wired LINE yet.
+ */
+import { log } from '../log.js';
+import { readEnvFile } from '../env.js';
+import type { ChannelAdapter, ChannelSetup, OutboundMessage } from './adapter.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import { registerWebhookHandler } from '../webhook-server.js';
+import { verifyLineSignatureResult } from './line-signature.js';
+
+const CHANNEL_TYPE = 'line';
+const WEBHOOK_PATH = 'line'; // → /webhook/line
+const PUSH_URL = 'https://api.line.me/v2/bot/message/push';
+const LINE_TEXT_LIMIT = 5000; // LINE caps a single text message at 5000 chars
+
+interface LineSource {
+  type?: 'user' | 'group' | 'room';
+  userId?: string;
+  groupId?: string;
+  roomId?: string;
+}
+
+interface LineEventMessage {
+  type?: string; // 'text' | 'image' | 'file' | 'video' | 'audio' | 'location' | ...
+  id?: string;
+  text?: string;
+  fileName?: string;
+  mention?: { mentionees?: { isSelf?: boolean }[] };
+}
+
+interface LineWebhookEvent {
+  type?: string; // 'message' | 'follow' | 'unfollow' | 'join' | ...
+  message?: LineEventMessage;
+  source?: LineSource;
+  replyToken?: string;
+  timestamp?: number;
+}
+
+/** The conversation id LINE addresses: groupId / roomId for group chats, else the userId. */
+function destinationId(source?: LineSource): string | null {
+  if (!source) return null;
+  if (source.type === 'group') return source.groupId ?? null;
+  if (source.type === 'room') return source.roomId ?? null;
+  return source.userId ?? null;
+}
+
+/** Read the raw request body off the Node stream (needed verbatim for signature checks). */
+function readRawBody(req: import('http').IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function extractText(message: OutboundMessage): string | null {
+  const content = message.content as Record<string, unknown> | string | undefined;
+  if (typeof content === 'string') return content;
+  if (content && typeof content === 'object' && typeof content.text === 'string') {
+    return content.text;
+  }
+  return null;
+}
+
+/** Split a long body into LINE-sized chunks (one push carries up to 5 messages). */
+function chunkText(text: string, size = LINE_TEXT_LIMIT): string[] {
+  if (text.length <= size) return [text];
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += size) out.push(text.slice(i, i + size));
+  return out.slice(0, 5); // LINE rejects > 5 messages per push; truncate defensively
+}
+
+function createAdapter(channelSecret: string, accessToken: string): ChannelAdapter {
+  let live = false;
+
+  const adapter: ChannelAdapter = {
+    name: 'line',
+    channelType: CHANNEL_TYPE,
+    supportsThreads: false,
+
+    async setup(config: ChannelSetup): Promise<void> {
+      registerWebhookHandler(WEBHOOK_PATH, async (req, res) => {
+        // GET (health probes) — answer 200 without a body.
+        if ((req.method ?? 'GET').toUpperCase() === 'GET') {
+          res.writeHead(200, { 'Content-Type': 'text/plain' });
+          res.end('ok');
+          return;
+        }
+
+        const raw = await readRawBody(req);
+        const signature = req.headers['x-line-signature'];
+        const sigHeader = Array.isArray(signature) ? signature[0] : signature;
+        const verdict = verifyLineSignatureResult(raw, channelSecret, sigHeader);
+        if (verdict !== 'ok') {
+          log.warn('LINE webhook signature rejected', { reason: verdict });
+          res.writeHead(403, { 'Content-Type': 'text/plain' });
+          res.end('invalid signature');
+          return;
+        }
+
+        // ACK fast — LINE expects a prompt 200; do the routing work afterwards.
+        // This also covers the console's "Verify" button, which sends a signed
+        // POST with an empty `events` array (not a GET).
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('ok');
+
+        let payload: { events?: LineWebhookEvent[] };
+        try {
+          payload = JSON.parse(raw.toString('utf8'));
+        } catch (err) {
+          log.warn('LINE webhook: body is not JSON', { err });
+          return;
+        }
+
+        for (const ev of payload.events ?? []) {
+          if (ev.type !== 'message' || !ev.message) continue;
+          const platformId = destinationId(ev.source);
+          if (!platformId) continue;
+
+          const userId = ev.source?.userId;
+          const senderId = userId ? `${CHANNEL_TYPE}:${userId}` : `${CHANNEL_TYPE}:unknown`;
+          const isGroup = ev.source?.type === 'group' || ev.source?.type === 'room';
+          // DMs are by definition addressed to the bot (the router's
+          // auto-create and 'mention' trigger mode both key off isMention —
+          // without it a first DM is silently dropped). In group/room chats
+          // only an explicit @mention of the bot counts, which LINE reports
+          // via message.mention.mentionees[].isSelf.
+          const isMention = !isGroup || (ev.message.mention?.mentionees?.some((m) => m.isSelf === true) ?? false);
+
+          let text: string;
+          if (ev.message.type === 'text' && typeof ev.message.text === 'string') {
+            text = ev.message.text;
+          } else {
+            // Media (image/file/video/audio/...) carries no text. Surface a
+            // typed placeholder including the message id, which is exactly
+            // what a later media integration needs to fetch the binary from
+            // LINE's content endpoint (api-data.line.me). Content download is
+            // deliberately out of scope here — text intake is the core.
+            const kind = ev.message.type ?? 'unknown';
+            const name = ev.message.fileName ? ` (${ev.message.fileName})` : '';
+            text = `[attachment:${kind}${name}] message_id=${ev.message.id ?? ''}`;
+          }
+
+          try {
+            await config.onInbound(platformId, null, {
+              id: `line-${ev.message.id ?? ev.timestamp ?? ''}`,
+              kind: 'chat',
+              timestamp: new Date(ev.timestamp ?? Date.now()).toISOString(),
+              content: { text, sender: userId ?? 'line', senderId },
+              isMention,
+              isGroup,
+            });
+          } catch (err) {
+            log.error('LINE webhook: onInbound threw', { err });
+          }
+        }
+      });
+
+      live = true;
+      log.info('LINE channel ready', { path: `/webhook/${WEBHOOK_PATH}` });
+    },
+
+    async teardown(): Promise<void> {
+      // The shared webhook server owns route lifecycle (cleared by
+      // stopWebhookServer on host shutdown). There is no single-route
+      // unregister, so teardown just marks the adapter offline.
+      live = false;
+    },
+
+    isConnected(): boolean {
+      return live;
+    },
+
+    async deliver(platformId, _threadId, message: OutboundMessage): Promise<string | undefined> {
+      const text = extractText(message);
+      if (text === null || text.length === 0) return undefined;
+
+      const messages = chunkText(text).map((t) => ({ type: 'text', text: t }));
+      try {
+        const res = await fetch(PUSH_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ to: platformId, messages }),
+        });
+        if (!res.ok) {
+          const detail = await res.text().catch(() => '');
+          log.warn('LINE push failed', { status: res.status, detail: detail.slice(0, 500) });
+          return undefined;
+        }
+        // LINE echoes the ids of the sent messages — surface the first so
+        // delivery records a platformMsgId (parity with bridge channels).
+        const body = (await res.json().catch(() => null)) as { sentMessages?: { id?: string }[] } | null;
+        return body?.sentMessages?.[0]?.id;
+      } catch (err) {
+        log.warn('LINE push threw', { err });
+      }
+      return undefined;
+    },
+  };
+
+  return adapter;
+}
+
+/** Factory: only activates when both LINE credentials are present (process env or .env). */
+function createAdapterOrNull(): ChannelAdapter | null {
+  const env = readEnvFile(['LINE_CHANNEL_SECRET', 'LINE_CHANNEL_ACCESS_TOKEN']);
+  const channelSecret = process.env.LINE_CHANNEL_SECRET || env.LINE_CHANNEL_SECRET;
+  const accessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN || env.LINE_CHANNEL_ACCESS_TOKEN;
+  if (!channelSecret || !accessToken) return null;
+  return createAdapter(channelSecret, accessToken);
+}
+
+registerChannelAdapter('line', { factory: createAdapterOrNull });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Adds a **LINE Official Account** channel: a native adapter for the LINE Messaging API (webhook in, push out), plus the `/add-line` install skill.

- `src/channels/line.ts` — native adapter (self-registering; factory returns null when credentials are absent, so trunk boots unchanged)
- `src/channels/line-signature.ts` + `line-signature.test.ts` — `x-line-signature` HMAC-SHA256 verification over the raw body, constant-time compare, diagnosable reason codes (`no_secret` / `no_signature` / `mismatch`)
- `src/channels/line-registration.test.ts` — behavior test: imports the real channel barrel and asserts the registry contains `line`
- `.claude/skills/add-line/` — SKILL.md + REMOVE.md (fetch-and-copy install; REMOVE reverses every change)
- `src/channels/index.ts` — one appended self-registration import

### Why

LINE is the default messenger in Japan, Taiwan, and Thailand, and the channels registry doesn't cover it. There is no `@chat-adapter/line` package, so a native adapter is the only route — same family as signal / whatsapp / deltachat.

Zero new npm dependencies: node `crypto` / `http` plus global `fetch`.

### How it works

- **Inbound** — LINE POSTs webhook events to `/webhook/line` on the shared webhook server. The adapter verifies the signature, ACKs immediately (LINE expects a prompt 200 — and the console's **Verify** button is itself a signed POST with an empty `events` array), then routes message events through `onInbound`. DMs are flagged `isMention: true`, matching the Chat SDK bridge's `onDirectMessage` contract — without this the router silently drops a first DM. Group chats detect @mentions via LINE's `message.mention.mentionees[].isSelf`.
- **Outbound** — always the push endpoint. This is deliberate: host delivery is asynchronous (it polls `outbound.db`), so by delivery time LINE's reply token (single-use, ~1-minute TTL) is already stale. Push is the only correct choice in this architecture; the OA-plan quota implications are documented in the skill, including a live `quota/consumption` check.
- Long replies are chunked to LINE's 5000-char text limit (up to 5 message objects per push, which LINE counts as one message per recipient). `deliver()` returns `sentMessages[0].id` so delivery records a platform message id, on par with bridge channels.
- Media (image/file/video/audio) arrives as a typed placeholder carrying the LINE message id — exactly what a future media integration needs to fetch content from `api-data.line.me`. Content download is deliberately out of scope for this PR.

### How it was tested

- `pnpm build` and the full `pnpm test` suite are green on this branch; the two shipped LINE test files cover signature verification (8 cases) and barrel registration.
- Verified end-to-end against a real LINE Official Account on a live install running this adapter: console Verify (signed empty-events POST) passes; inbound DMs route (messaging-group auto-create + membership gating); agent replies push back and record platform message ids; media placeholders route cleanly; group-@mention field mapping confirmed against live webhook payloads; quota metering confirmed via `GET /v2/bot/message/quota/consumption`.

### Usage

Run `/add-line`. The skill walks through: Official Account + Messaging API channel creation, credentials (`LINE_CHANNEL_SECRET`, `LINE_CHANNEL_ACCESS_TOKEN` in `.env`), the public-HTTPS webhook requirement (LINE has no polling mode — stable-URL tunnel guidance included for local dev, since an ephemeral tunnel's death silently black-holes inbound messages), console webhook setup + Verify, and wiring via `/init-first-agent` or `/manage-channels`.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
