### PR TITLE
fix: DB connection leak in container restart, stale docs, duplicate script

### DIFF
--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -4,7 +4,7 @@ import { TIMEZONE, formatLocalTime } from './timezone.js';
 
 /**
  * Command categories for messages starting with '/'.
- * - admin: sender must be in NANOCLAW_ADMIN_USER_IDS
+ * - admin: gated by the host router via user roles
  * - filtered: silently drop (mark completed without processing)
  * - passthrough: pass raw to the agent (no XML wrapping)
  * - none: not a command — format normally
@@ -25,8 +25,8 @@ export interface CommandInfo {
  * Categorize a message as a command or not.
  * Only applies to chat/chat-sdk messages.
  *
- * The extracted `senderId` is compared against `NANOCLAW_ADMIN_USER_IDS`
- * which stores ids in the namespaced form `<channel_type>:<raw>` (see
+ * Admin commands are gated by the host router via user roles.
+ * The extracted `senderId` is namespaced as `<channel_type>:<raw>` (see
  * src/db/users.ts). chat-sdk-bridge serializes `author.userId` as a raw
  * platform id with no prefix, so we prefix it here. If the id already
  * contains a `:` we assume it's pre-namespaced (non-chat-sdk adapters

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "prepare": "husky",

--- a/src/container-restart.ts
+++ b/src/container-restart.ts
@@ -45,7 +45,13 @@ export function restartAgentGroupContainers(agentGroupId: string, reason: string
     // explicit wake message, or in-flight messages the dying container had
     // claimed. Without this, a provider switch mid-conversation leaves the
     // claimed messages dark until the next inbound or a slow sweep backoff.
-    const hasPending = countDueMessages(openInboundDb(session.agent_group_id, session.id)) > 0;
+    const inboundDb = openInboundDb(session.agent_group_id, session.id);
+    let hasPending: boolean;
+    try {
+      hasPending = countDueMessages(inboundDb) > 0;
+    } finally {
+      inboundDb.close();
+    }
     killContainer(
       session.id,
       reason,


### PR DESCRIPTION
Found a few things:

- \`openInboundDb()\` in container-restart.ts was never being closed after checking for pending messages. Each restart check leaked a file descriptor. Wrapped it in try/finally.
- formatter.ts comments still referenced \`NANOCLAW_ADMIN_USER_IDS\` which no longer exists in v2 — admin command gating happens host-side via user roles now. Updated the comments to reflect the current architecture.
- the \`format\` and \`format:fix\` npm scripts were identical (both \`prettier --write\`). Changed \`format\` to \`prettier --check\` so there's actually a difference between checking and fixing.