### PR TITLE
fix(compose): gate skill fragments on group skill selection

### DIFF
--- a/src/claude-md-compose.fragments.test.ts
+++ b/src/claude-md-compose.fragments.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// --- Mocks ---
+
+vi.mock('./log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+let groupsDir = '';
+vi.mock('./config.js', () => ({
+  get GROUPS_DIR() {
+    return groupsDir;
+  },
+}));
+
+const mockGetContainerConfig = vi.fn();
+vi.mock('./db/container-configs.js', () => ({
+  getContainerConfig: (...args: unknown[]) => mockGetContainerConfig(args[0] as string),
+}));
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import type { AgentGroup } from './types.js';
+
+// Minimal config row — only the fields compose reads.
+function configRow(skills: string) {
+  return { skills, mcp_servers: '{}', cli_scope: 'group' };
+}
+
+const group = { id: 'g1', folder: 'g1' } as unknown as AgentGroup;
+
+describe('composeGroupClaudeMd skill-fragment selection', () => {
+  let tmp = '';
+  let prevCwd = '';
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-test-'));
+    // Two instruction-shipping skills under the cwd-relative skills dir.
+    for (const name of ['a', 'b']) {
+      const dir = path.join(tmp, 'container', 'skills', name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'instructions.md'), `# ${name}\n`);
+    }
+    groupsDir = path.join(tmp, 'groups');
+    fs.mkdirSync(groupsDir, { recursive: true });
+    prevCwd = process.cwd();
+    process.chdir(tmp);
+    mockGetContainerConfig.mockReset();
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function composedImports(): string[] {
+    return fs
+      .readFileSync(path.join(groupsDir, 'g1', 'CLAUDE.md'), 'utf8')
+      .split('\n')
+      .filter((l) => l.startsWith('@'));
+  }
+
+  // Fragments are symlinks to dangling container paths, so existsSync (which
+  // follows the link) is useless here — check the link itself with lstat.
+  function fragmentExists(name: string): boolean {
+    try {
+      fs.lstatSync(path.join(groupsDir, 'g1', '.claude-fragments', name));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it('imports only selected skills', () => {
+    mockGetContainerConfig.mockReturnValue(configRow('["a"]'));
+    composeGroupClaudeMd(group);
+    const imports = composedImports();
+    expect(imports).toContain('@./.claude-fragments/skill-a.md');
+    expect(imports).not.toContain('@./.claude-fragments/skill-b.md');
+    // Fragment symlink reconciliation matches the imports.
+    expect(fragmentExists('skill-a.md')).toBe(true);
+    expect(fragmentExists('skill-b.md')).toBe(false);
+  });
+
+  it("imports all instruction-shipping skills when skills is 'all'", () => {
+    mockGetContainerConfig.mockReturnValue(configRow('"all"'));
+    composeGroupClaudeMd(group);
+    const imports = composedImports();
+    expect(imports).toContain('@./.claude-fragments/skill-a.md');
+    expect(imports).toContain('@./.claude-fragments/skill-b.md');
+  });
+
+  it("defaults to 'all' when there is no config row", () => {
+    mockGetContainerConfig.mockReturnValue(undefined);
+    composeGroupClaudeMd(group);
+    const imports = composedImports();
+    expect(imports).toContain('@./.claude-fragments/skill-a.md');
+    expect(imports).toContain('@./.claude-fragments/skill-b.md');
+  });
+
+  it('prunes a previously-imported skill fragment when deselected', () => {
+    mockGetContainerConfig.mockReturnValue(configRow('"all"'));
+    composeGroupClaudeMd(group);
+    expect(fragmentExists('skill-b.md')).toBe(true);
+
+    mockGetContainerConfig.mockReturnValue(configRow('["a"]'));
+    composeGroupClaudeMd(group);
+    expect(fragmentExists('skill-b.md')).toBe(false);
+    expect(composedImports()).not.toContain('@./.claude-fragments/skill-b.md');
+  });
+});

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -66,11 +66,18 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
     : {};
   const desired = new Map<string, { type: 'symlink' | 'inline'; content: string }>();
 
-  // Skill fragments — every skill that ships an `instructions.md`.
-  // TODO (shared-source refactor): respect `container.json` skill selection.
+  // Skill fragments — every *selected* skill that ships an `instructions.md`.
+  // The selection lives in `container_configs.skills` (`string[] | 'all'`), the
+  // same value `syncSkillSymlinks` uses to gate the lazy skill mounts. Without
+  // this gate, every instruction-shipping skill would be eagerly loaded into
+  // every group regardless of its `container.json` selection. Default to 'all'
+  // when there's no config row, matching `syncSkillSymlinks`'s fallback.
+  const selectedSkills: string[] | 'all' = configRow ? (JSON.parse(configRow.skills) as string[] | 'all') : 'all';
+  const skillSelected = (name: string): boolean => selectedSkills === 'all' || selectedSkills.includes(name);
   const skillsHostDir = path.join(process.cwd(), 'container', 'skills');
   if (fs.existsSync(skillsHostDir)) {
     for (const skillName of fs.readdirSync(skillsHostDir)) {
+      if (!skillSelected(skillName)) continue;
       const hostFragment = path.join(skillsHostDir, skillName, 'instructions.md');
       if (fs.existsSync(hostFragment)) {
         desired.set(`skill-${skillName}.md`, {


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** `composeGroupClaudeMd` inlined *every* skill's `instructions.md` into *every* group's `CLAUDE.md`, ignoring the group's skill selection. This gates the fragment loop on `container_configs.skills` (`string[] | 'all'`) — the same value `syncSkillSymlinks` already uses for the lazy skill mounts.

**Why:** The code already carried the `TODO (shared-source refactor): respect container.json skill selection`. Without the gate, a group that selected only some skills still got all instruction-shipping skills eagerly loaded into its context.

**How:** Read the selection from the container config row (default `'all'` when there's no row, matching `syncSkillSymlinks`'s fallback) and `continue` past unselected skills. Fragment-symlink reconciliation then prunes any now-deselected fragment on the next compose.

**Testing:** Added `src/claude-md-compose.fragments.test.ts` (selected-only, `'all'`, no-config default, and prune-on-deselect). `pnpm run build` clean; `vitest` green (4 new + 3 existing compose tests). Verified on a branch cut directly from `main`.

Tests live in a new `claude-md-compose.fragments.test.ts` to keep them focused; happy to fold them into the existing `claude-md-compose.test.ts` if you'd prefer.
