### PR TITLE
fix(discord): unwrap forwarded-message snapshots so agents see forwarded content

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { unwrapForwardedSnapshot } from './discord.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function forwardPayload(snapshotMessage: Record<string, any> | null, overrides: Record<string, any> = {}) {
+  return {
+    id: '123',
+    content: '',
+    attachments: [],
+    message_reference: { type: 1, channel_id: 'c1', message_id: 'm1' },
+    ...(snapshotMessage ? { message_snapshots: [{ message: snapshotMessage }] } : {}),
+    ...overrides,
+  };
+}
+
+describe('unwrapForwardedSnapshot', () => {
+  it('unwraps forwarded text into content with a label', () => {
+    const data = forwardPayload({ content: 'hello from the past', attachments: [] });
+    unwrapForwardedSnapshot(data);
+    expect(data.content).toBe('[Forwarded message]\nhello from the past');
+  });
+
+  it('unwraps attachment-only forwards: label + merged attachments', () => {
+    const att = { filename: 'photo.png', content_type: 'image/png', size: 1234, url: 'https://cdn.example/photo.png' };
+    const data = forwardPayload({ content: '', attachments: [att] });
+    unwrapForwardedSnapshot(data);
+    expect(data.content).toBe('[Forwarded message]');
+    expect(data.attachments).toEqual([att]);
+  });
+
+  it('merges snapshot attachments after existing ones', () => {
+    const existing = { filename: 'own.txt', content_type: 'text/plain', size: 1, url: 'https://cdn.example/own.txt' };
+    const fwd = { filename: 'fwd.jpg', content_type: 'image/jpeg', size: 2, url: 'https://cdn.example/fwd.jpg' };
+    const data = forwardPayload({ content: 'look', attachments: [fwd] }, { attachments: [existing] });
+    unwrapForwardedSnapshot(data);
+    expect(data.attachments).toEqual([existing, fwd]);
+    expect(data.content).toBe('[Forwarded message]\nlook');
+  });
+
+  it('leaves plain messages untouched', () => {
+    const data = { id: '1', content: 'hi', attachments: [] };
+    unwrapForwardedSnapshot(data);
+    expect(data).toEqual({ id: '1', content: 'hi', attachments: [] });
+  });
+
+  it('leaves normal replies (type 0) untouched', () => {
+    const data = {
+      id: '1',
+      content: 'a reply',
+      attachments: [],
+      message_reference: { type: 0, message_id: 'm0' },
+      referenced_message: { content: 'original', author: { username: 'alice' } },
+    };
+    unwrapForwardedSnapshot(data);
+    expect(data.content).toBe('a reply');
+  });
+
+  it('is a no-op when a forward has no snapshots', () => {
+    const data = forwardPayload(null);
+    unwrapForwardedSnapshot(data);
+    expect(data.content).toBe('');
+    expect(data.attachments).toEqual([]);
+  });
+
+  it('joins multiple snapshots', () => {
+    const data = forwardPayload(null, {
+      message_snapshots: [
+        { message: { content: 'one', attachments: [] } },
+        { message: { content: 'two', attachments: [] } },
+      ],
+    });
+    unwrapForwardedSnapshot(data);
+    expect(data.content).toBe('[Forwarded message]\none\ntwo');
+  });
+});

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -18,6 +18,47 @@ function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
   };
 }
 
+/**
+ * Discord message forwards carry their content in `message_snapshots`, not
+ * `content` (`message_reference.type === 1` means FORWARD; 0 is a normal
+ * reply). The adapter only reads `content`/`attachments`, so without this the
+ * agent sees an empty message. Unwrap the snapshot back into the payload so
+ * text, attachment download, and formatting all ride the existing path.
+ * Note: snapshots contain no author, so the original sender is unavailable.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function unwrapForwardedSnapshot(data: Record<string, any>): void {
+  if (data.message_reference?.type !== 1) return;
+  const snaps = (data.message_snapshots ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((s: any) => s?.message)
+    .filter(Boolean);
+  if (snaps.length === 0) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const text = snaps
+    .map((m: any) => m.content)
+    .filter(Boolean)
+    .join('\n');
+  const label = '[Forwarded message]';
+  data.content = text ? `${label}\n${text}` : data.content || label;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fwdAttachments = snaps.flatMap((m: any) => m.attachments ?? []);
+  if (fwdAttachments.length > 0) {
+    data.attachments = [...(data.attachments ?? []), ...fwdAttachments];
+  }
+}
+
+function unwrapForwards(adapter: ReturnType<typeof createDiscordAdapter>): void {
+  const a = adapter as unknown as {
+    handleForwardedMessage: (data: Record<string, unknown>, options?: unknown) => Promise<void>;
+  };
+  const orig = a.handleForwardedMessage.bind(adapter);
+  a.handleForwardedMessage = async (data, options) => {
+    unwrapForwardedSnapshot(data);
+    return orig(data, options);
+  };
+}
+
 registerChannelAdapter('discord', {
   factory: () => {
     const env = readEnvFile(['DISCORD_BOT_TOKEN', 'DISCORD_PUBLIC_KEY', 'DISCORD_APPLICATION_ID']);
@@ -27,6 +68,7 @@ registerChannelAdapter('discord', {
       publicKey: env.DISCORD_PUBLIC_KEY,
       applicationId: env.DISCORD_APPLICATION_ID,
     });
+    unwrapForwards(discordAdapter);
     return createChatSdkBridge({
       adapter: discordAdapter,
       concurrency: 'concurrent',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** Forwarded Discord messages arrived as empty inbound messages — agents saw nothing. This unwraps the forward's `message_snapshots` so forwarded text and attachments come through.

**Why:** Discord puts a forward's content in `message_snapshots` and leaves top-level `content` empty (`message_reference.type === 1` means FORWARD). The adapter only reads `content`/`attachments`.

**How it works:** Wraps the adapter's `handleForwardedMessage` and copies snapshot text/attachments into `content`/`attachments` before the adapter processes the payload, so attachment download and formatting all ride the existing path. Snapshots carry no author, so forwarded content is labeled `[Forwarded message]`.

**How it was tested:** 7 unit tests in `src/channels/discord.test.ts` (text, attachment-only, attachment merge order, reply/no-op cases, multi-snapshot), plus end-to-end on a live install by forwarding text and image messages to the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)