### PR TITLE
fix(delivery): strip agent-group namespace from reaction/edit messageId before platform delivery

### DIFF
--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -341,3 +341,61 @@ describe('deliverSessionMessages — permission check', () => {
     expect(delivered.has('out-unauth')).toBe(true);
   });
 });
+
+describe('deliverMessage — namespaced messageId strip', () => {
+  it('strips the agent-group namespace from reaction targets before delivery', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    // Inbound ids are namespaced `<platform-id>:<agent_group_id>` by the
+    // router (messageIdForAgent). The agent echoes that id when it targets
+    // a reaction; the platform must receive the raw id back.
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES (?, datetime('now'), 'chat', 'telegram:123', 'telegram', ?)`,
+    ).run(
+      'out-reaction',
+      JSON.stringify({ operation: 'reaction', messageId: '1522925583908999188:ag-1', emoji: '👀' }),
+    );
+    db.close();
+
+    const received: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_channelType, _platformId, _threadId, _kind, content) {
+        received.push(content);
+        return 'plat-1';
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    expect(received).toHaveLength(1);
+    expect(JSON.parse(received[0]).messageId).toBe('1522925583908999188');
+  });
+
+  it('leaves foreign messageIds untouched', async () => {
+    seedAgentAndChannel();
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const db = new Database(outboundDbPath('ag-1', session.id));
+    db.prepare(
+      `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES (?, datetime('now'), 'chat', 'telegram:123', 'telegram', ?)`,
+    ).run('out-plain', JSON.stringify({ operation: 'reaction', messageId: '424242', emoji: '👍' }));
+    db.close();
+
+    const received: string[] = [];
+    setDeliveryAdapter({
+      async deliver(_channelType, _platformId, _threadId, _kind, content) {
+        received.push(content);
+        return 'plat-2';
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    expect(received).toHaveLength(1);
+    expect(JSON.parse(received[0]).messageId).toBe('424242');
+  });
+});

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -254,6 +254,17 @@ async function deliverMessage(
 
   const content = JSON.parse(msg.content);
 
+  // Inbound message ids are namespaced as `<platform-id>:<agent_group_id>`
+  // (router's messageIdForAgent, for fan-out uniqueness). The agent targets
+  // reactions/edits with the id it saw, so strip the namespace before the id
+  // goes back to the platform — Discord rejects non-snowflake message ids.
+  if (typeof content.messageId === 'string' && content.messageId.endsWith(`:${session.agent_group_id}`)) {
+    content.messageId = content.messageId.slice(0, -(session.agent_group_id.length + 1));
+    // The adapter receives msg.content (the raw string), not the parsed
+    // object — re-serialize so the stripped id is what actually ships.
+    msg.content = JSON.stringify(content);
+  }
+
   // System actions — handle internally (schedule_task, cancel_task, etc.)
   if (msg.kind === 'system') {
     await handleSystemAction(content, session, inDb);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

## Problem

`messageIdForAgent` (src/router.ts) namespaces inbound message ids as `<platform-id>:<agent_group_id>` so the same platform message can fan out to multiple per-agent session DBs without PRIMARY KEY collisions. The agent, however, targets reactions and edits using the id it saw in its inbound batch — the namespaced one — and delivery passes that composite straight back to the platform.

Discord rejects it hard:

```
Discord API error: 400 {"message": "Invalid Form Body", "code": 50035,
"errors": {"message_id": {"_errors": [{"code": "NUMBER_TYPE_COERCE",
"message": "Value \"1522925583908999188:aae374d6-...\" is not snowflake."}]}}}
```

Every reaction/edit burns 3 delivery retries and is then dropped permanently. Any platform that validates message id format is affected.

## Repro

1. Wire a Discord channel to an agent group.
2. Mention the agent; have it acknowledge the message with a reaction (e.g. 👀).
3. Host error log shows the 400 above; the reaction never lands.

## Fix

Strip the `:<agent_group_id>` suffix from `content.messageId` at delivery time, and re-serialize `msg.content` (the adapter receives the raw string, not the parsed object). Foreign/unnamespaced ids are left untouched — the strip only fires on an exact `:<session.agent_group_id>` suffix match.

## Tests

Two regression tests in `src/delivery.test.ts`: namespaced reaction target is stripped before reaching the adapter; unnamespaced ids pass through unchanged. Full suite green (571 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
