### PR TITLE
fix(agent-runner): honor "(current conversation)" as a message destination alias

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -454,3 +454,24 @@ describe('isCorruptionError', () => {
     expect(isCorruptionError('')).toBe(false);
   });
 });
+
+describe('"(current conversation)" destination alias', () => {
+  it('delivers a <message to="(current conversation)"> block to the triggering channel', async () => {
+    // The send_message MCP tool echoes "(current conversation)" as the
+    // resolved name of a default send; agents mirror it in <message> blocks.
+    const { query, pushes } = makeResultQuery({
+      type: 'result',
+      text: '<message to="(current conversation)">on my way!</message>',
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0].content).text).toBe('on my way!');
+    expect(out[0].platform_id).toBe('chan-1');
+    expect(out[0].channel_type).toBe('discord');
+    // Delivered as a real message — no re-wrap nudge.
+    expect(pushes).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -618,6 +618,23 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
 
     const dest = findByName(toName);
     if (!dest) {
+      // The send_message MCP tool echoes "(current conversation)" as the
+      // resolved name of a default (to-omitted) send, and agents mirror
+      // that label in <message> blocks. Honor it as the batch's own channel
+      // instead of dropping the reply.
+      if (toName === '(current conversation)' && routing.channelType && routing.platformId) {
+        writeMessageOut({
+          id: generateId(),
+          in_reply_to: routing.inReplyTo,
+          kind: 'chat',
+          platform_id: routing.platformId,
+          channel_type: routing.channelType,
+          thread_id: routing.threadId,
+          content: JSON.stringify({ text: body }),
+        });
+        sent++;
+        continue;
+      }
       log(`Unknown destination in <message to="${toName}">, dropping block`);
       scratchpadParts.push(`[dropped: unknown destination "${toName}"] ${body}`);
       continue;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

## Problem

The `send_message` MCP tool echoes `(current conversation)` as the resolved destination name when the agent omits `to` (resolveRouting in `mcp-tools/core.ts`). Agents learn that label from the tool feedback and mirror it in the `<message to="...">` blocks of their final text. `dispatchResultText` only knows named destinations, so those blocks are silently dropped as scratchpad:

```
[poll-loop] Unknown destination in <message to="(current conversation)">, dropping block
[poll-loop] WARNING: agent output had no <message to="..."> blocks — nothing was sent
```

From the user's side the agent simply never replies — the worst kind of failure to debug, since the agent did generate a response and the container exits clean.

## Repro

Observed in production with a fresh group on a Discord channel: the agent's replies were generated and then dropped at dispatch. Any model that reuses the tool-echoed label can trigger it.

## Fix

Treat `(current conversation)` in a `<message>` block as the batch's own channel (same semantics as the MCP tool's default routing) and deliver via the batch routing context, instead of dropping the reply.

## Tests

New bun:test case in `poll-loop.test.ts` (via the existing `makeResultQuery`/`processQuery` harness): a `(current conversation)` block is delivered to the triggering channel with no re-wrap nudge. 34/34 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
