### PR TITLE
fix(container-config): let bare-created groups spawn — ensure config row at materialize time

### DIFF
--- a/src/container-config.test.ts
+++ b/src/container-config.test.ts
@@ -1,0 +1,74 @@
+/**
+ * materializeContainerJson must not depend on the group's creation path.
+ *
+ * A bare `ncl groups create` (no template) inserts only the agent_groups
+ * row. The spawn path calls materializeContainerJson before
+ * initGroupFilesystem gets a chance to backfill the config row, so a hard
+ * throw here means a bare-created group can never spawn a container.
+ */
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return {
+    ...actual,
+    DATA_DIR: '/tmp/nanoclaw-test-container-config',
+    GROUPS_DIR: '/tmp/nanoclaw-test-container-config/groups',
+  };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-container-config';
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { getContainerConfig } from './db/container-configs.js';
+import { materializeContainerJson } from './container-config.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('materializeContainerJson — bare group without a config row', () => {
+  it('creates the default config row instead of throwing', () => {
+    createAgentGroup({
+      id: 'ag-bare',
+      name: 'Bare Group',
+      folder: 'bare-group',
+      agent_provider: null,
+      created_at: now(),
+    });
+    expect(getContainerConfig('ag-bare')).toBeFalsy();
+
+    const config = materializeContainerJson('ag-bare');
+
+    expect(config).toBeTruthy();
+    expect(getContainerConfig('ag-bare')).toBeTruthy();
+    expect(fs.existsSync(`${TEST_DIR}/groups/bare-group/container.json`)).toBe(true);
+  });
+
+  it('still materializes normally when the row already exists', () => {
+    createAgentGroup({
+      id: 'ag-cfg',
+      name: 'Configured Group',
+      folder: 'configured-group',
+      agent_provider: null,
+      created_at: now(),
+    });
+    // First call creates the row; second call exercises the normal path.
+    materializeContainerJson('ag-cfg');
+    const config = materializeContainerJson('ag-cfg');
+    expect(config).toBeTruthy();
+  });
+});

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -12,7 +12,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
-import { getContainerConfig } from './db/container-configs.js';
+import { ensureContainerConfig, getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
@@ -75,7 +75,15 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   const group = getAgentGroup(agentGroupId);
   if (!group) throw new Error(`Agent group not found: ${agentGroupId}`);
 
-  const row = getContainerConfig(agentGroupId);
+  let row = getContainerConfig(agentGroupId);
+  if (!row) {
+    // A group created without a template (bare `ncl groups create`) has no
+    // container_configs row yet. initGroupFilesystem would create it, but
+    // that runs after this materialize in the spawn path — so a bare group
+    // could never spawn. Ensure the default row here.
+    ensureContainerConfig(agentGroupId);
+    row = getContainerConfig(agentGroupId);
+  }
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

## Problem

A group created without a template (bare `ncl groups create --name ... --folder ...`) inserts only the `agent_groups` row. At spawn time the order is:

1. `materializeContainerJson(agentGroup.id)` — **throws** `Container config not found` if the `container_configs` row is missing
2. `initGroupFilesystem(...)` — would have created that row via `ensureContainerConfig`, but never runs

So a bare-created group can never start a container. Every message wake fails with:

```
wakeContainer failed — host-sweep will retry
err: Container config not found for agent group: <id>
```

and host-sweep retries forever (60s loop) while the user's messages pile up unanswered.

## Repro

```
ncl groups create --name Test --folder test-group
ncl wirings create --messaging-group-id <mg> --agent-group-id <new-group-id>
# send a message to the wired channel → container never spawns, error above repeats
```

## Fix

In `materializeContainerJson`, create the default row via `ensureContainerConfig` (idempotent `INSERT OR IGNORE`, same call initGroupFilesystem uses) instead of throwing when the row is missing. Spawn no longer depends on which path created the group.

## Tests

New `src/container-config.test.ts`: a bare group (no config row) materializes successfully and the row + `container.json` exist afterwards; the existing-row path is unchanged. Full suite green (571 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
