### PR TITLE
Unregister the mock provider from the production container barrel

### DIFF
--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -3,4 +3,3 @@
 // level. Skills add a new provider by appending one import line below.
 
 import './claude.js';
-import './mock.js';

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -31,7 +31,7 @@ flowchart TB
   subgraph Session["Per-Session Container (Docker / Apple Container)"]
     direction TB
     PollLoop["Poll Loop<br/>(container/agent-runner)"]
-    Provider["Agent providers<br/>(claude, opencode, mock; todo: codex)"]
+    Provider["Agent providers<br/>(claude, opencode; todo: codex)"]
     MCP["MCP Tools<br/>send_message, send_file, edit_message,<br/>add_reaction, send_card, ask_user_question,<br/>schedule_task, create_agent,<br/>install_packages, add_mcp_server"]
     Skills["Container Skills<br/>(container/skills/)"]
     InDB[("inbound.db<br/>host writes<br/>even seq<br/>messages_in<br/>destinations<br/>processing_ack")]

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,6 @@
 // Host-side provider container-config barrel.
 // Providers that need host-side container setup (extra mounts, env passthrough,
 // per-session directories) self-register on import. Providers with no host
-// needs (claude, mock) don't appear here.
+// needs (claude) don't appear here.
 //
 // Skills add a new provider by appending one import line below.

--- a/src/providers/provider-container-registry.ts
+++ b/src/providers/provider-container-registry.ts
@@ -7,7 +7,7 @@
  * the registered config fn, and merges the returned mounts/env into the spawn
  * args.
  *
- * Providers without host-side needs (e.g. `claude`, `mock`) don't appear in
+ * Providers without host-side needs (e.g. `claude`) don't appear in
  * this registry at all — the lookup returns `undefined` and the spawn path
  * proceeds with only the default mounts and env.
  *


### PR DESCRIPTION
**What** — Remove `import './mock.js';` from the container agent-runner provider self-registration barrel so the `mock` provider is no longer registered in production containers. Also tidy two now-stale host comments and one docs line that still list `mock` as a first-class provider. `mock.ts` itself stays (tests import it directly).

**Why** — Because the barrel registered `mock`, every container had a working `mock` provider that returns canned text. A typo'd `--provider mock` (or any accidental selection) would silently "succeed" with fake output instead of failing loudly.

**Risk** — Touches the container provider barrel plus three comment/doc lines; a container image rebuild is needed to deploy the barrel change to running agents. No host restart required for the comment/doc edits.

**Verification** — `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` (exit 0); `bun test src/providers/factory.test.ts` (3 pass) and `bun test src/providers/` (7 pass across 2 files); `pnpm exec prettier --write` on the three changed `.ts` files (all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)