### PR TITLE
fix(opencode): dedicated OPENCODE_BASE_URL, read from .env, NO_PROXY …

### DIFF
--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -126,7 +126,7 @@ These variables are read **on the host** and passed into the container only when
 - `OPENCODE_PROVIDER` — OpenCode provider id, e.g. `openrouter`, `anthropic`, `deepseek`.
 - `OPENCODE_MODEL` — full model id in `provider/model` form, e.g. `deepseek/deepseek-chat`.
 - `OPENCODE_SMALL_MODEL` — optional second model for lighter tasks; defaults to `OPENCODE_MODEL` if unset.
-- `ANTHROPIC_BASE_URL` — **required for non-`anthropic` providers.** The opencode container provider passes this as the `baseURL` for the upstream provider config so requests route through OneCLI's credential proxy or directly to the provider's API. Set it to the provider's API base URL (e.g. `https://api.deepseek.com/v1`, `https://openrouter.ai/api/v1`).
+- `OPENCODE_BASE_URL` — **required for non-`anthropic` providers.** The opencode container provider passes this as the `baseURL` for the upstream provider config so requests route through OneCLI's credential proxy or directly to the provider's API. Set it to the provider's API base URL (e.g. `https://api.deepseek.com/v1`, `https://openrouter.ai/api/v1`, or a local router `http://host.docker.internal:4000/v1`). `ANTHROPIC_BASE_URL` is still read as a deprecated fallback, but **avoid it** — the Claude SDK also reads that var, so sharing it misroutes a Claude fallback turn to the OpenAI-shaped endpoint.
 
 Credentials: register provider API keys in OneCLI with the matching `--host-pattern` (e.g. `api.deepseek.com`, `openrouter.ai`). OneCLI injects them via `HTTPS_PROXY` in the container — the key never lives in `.env` or the container environment.
 
@@ -145,7 +145,7 @@ Always include existing secret IDs in the list — `set-secrets` replaces, not a
 OPENCODE_PROVIDER=deepseek
 OPENCODE_MODEL=deepseek/deepseek-chat
 OPENCODE_SMALL_MODEL=deepseek/deepseek-chat
-ANTHROPIC_BASE_URL=https://api.deepseek.com/v1
+OPENCODE_BASE_URL=https://api.deepseek.com/v1
 ```
 
 Register the key:
@@ -161,7 +161,7 @@ onecli secrets create --name "DeepSeek" --type generic \
 OPENCODE_PROVIDER=openrouter
 OPENCODE_MODEL=openrouter/anthropic/claude-sonnet-4
 OPENCODE_SMALL_MODEL=openrouter/anthropic/claude-haiku-4.5
-ANTHROPIC_BASE_URL=https://openrouter.ai/api/v1
+OPENCODE_BASE_URL=https://openrouter.ai/api/v1
 ```
 
 Register the key:
@@ -193,7 +193,7 @@ Zen's HTTP API (e.g. `POST …/zen/v1/messages`) expects the key in the **`x-api
 OPENCODE_PROVIDER=opencode
 OPENCODE_MODEL=opencode/big-pickle
 OPENCODE_SMALL_MODEL=opencode/big-pickle
-ANTHROPIC_BASE_URL=https://opencode.ai/zen/v1
+OPENCODE_BASE_URL=https://opencode.ai/zen/v1
 ```
 
 Use a real Zen model id from the docs; `big-pickle` is one example.
@@ -216,7 +216,7 @@ Extra MCP servers still come from **`NANOCLAW_MCP_SERVERS`** / `container_config
 
 - OpenCode keeps a local **`opencode serve`** process and SSE subscription; the provider tears down with **`stream.return`** and **SIGKILL** on the server process on **`abort()`** / shared runtime reset to avoid MCP/zombie hangs.
 - Session continuation uses UUID format (SDK 1.4.x / CLI 1.4.x). Stale sessions are cleared by `isSessionInvalid` on OpenCode-specific error patterns. If you see UUID-related errors after an accidental CLI upgrade, clear `session_state` in `outbound.db` and wipe the `opencode-xdg` directory under the session folder.
-- **`NO_PROXY`** for localhost matters when the OpenCode client talks to `127.0.0.1` inside the container while HTTP(S)_PROXY is set (e.g. OneCLI).
+- **`NO_PROXY`** for localhost + `host.docker.internal` matters when the OpenCode client talks to `127.0.0.1` or a host-side router inside the container while HTTP(S)_PROXY is set (e.g. OneCLI); the provider adds both automatically.
 
 ## Verify
 

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -87,7 +87,7 @@ function buildOpenCodeConfig(options: ProviderOptions): Record<string, unknown> 
   const provider = process.env.OPENCODE_PROVIDER || 'anthropic';
   const model = process.env.OPENCODE_MODEL;
   const smallModel = process.env.OPENCODE_SMALL_MODEL;
-  const proxyUrl = process.env.ANTHROPIC_BASE_URL;
+  const proxyUrl = process.env.OPENCODE_BASE_URL || process.env.ANTHROPIC_BASE_URL;
 
   const providerModelId = model ? model.replace(new RegExp(`^${provider}/`), '') : undefined;
   const providerSmallModelId = smallModel ? smallModel.replace(new RegExp(`^${provider}/`), '') : undefined;

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -3,15 +3,28 @@
  *
  * OpenCode's `opencode serve` process stores state under XDG_DATA_HOME, which
  * we pin to a per-session host directory mounted at /opencode-xdg. The
- * OPENCODE_* env vars tell the CLI which provider/model to use at runtime
- * (read on the host, injected into the container). NO_PROXY / no_proxy are
- * merged with host values so the in-container OpenCode client can talk to
- * 127.0.0.1 even when HTTPS_PROXY is set by OneCLI.
+ * OPENCODE_* env vars tell the CLI which provider/model/endpoint to use at
+ * runtime, injected into the container. They are read from the .env FILE
+ * (this host keeps .env out of process.env — see env.ts), falling back to a
+ * real environment var. NO_PROXY / no_proxy are merged with host values so the
+ * in-container OpenCode client can reach 127.0.0.1 and a host-side router via
+ * host.docker.internal even when HTTPS_PROXY is set by OneCLI.
  */
 import fs from 'fs';
 import path from 'path';
 
+import { readEnvFile } from '../env.js';
 import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+const OPENCODE_ENV_KEYS = [
+  'OPENCODE_PROVIDER',
+  'OPENCODE_MODEL',
+  'OPENCODE_SMALL_MODEL',
+  // Upstream endpoint for a non-anthropic provider (e.g. a local LiteLLM
+  // router). Deliberately its own var, NOT ANTHROPIC_BASE_URL: the Claude SDK
+  // reads that one, so sharing it misroutes a Claude fallback turn.
+  'OPENCODE_BASE_URL',
+] as const;
 
 function mergeNoProxy(current: string | undefined, additions: string): string {
   if (!current?.trim()) return additions;
@@ -32,13 +45,18 @@ registerProviderContainerConfig('opencode', (ctx) => {
   const opencodeDir = path.join(ctx.sessionDir, 'opencode-xdg');
   fs.mkdirSync(opencodeDir, { recursive: true });
 
+  const dotenv = readEnvFile([...OPENCODE_ENV_KEYS]);
+
   const env: Record<string, string> = {
     XDG_DATA_HOME: '/opencode-xdg',
-    NO_PROXY: mergeNoProxy(ctx.hostEnv.NO_PROXY, '127.0.0.1,localhost'),
-    no_proxy: mergeNoProxy(ctx.hostEnv.no_proxy, '127.0.0.1,localhost'),
+    // host.docker.internal included so calls to a host-side router (e.g. a
+    // LiteLLM endpoint via OPENCODE_BASE_URL) bypass the OneCLI HTTPS_PROXY hop
+    // instead of being dropped ("socket connection closed unexpectedly").
+    NO_PROXY: mergeNoProxy(ctx.hostEnv.NO_PROXY, '127.0.0.1,localhost,host.docker.internal'),
+    no_proxy: mergeNoProxy(ctx.hostEnv.no_proxy, '127.0.0.1,localhost,host.docker.internal'),
   };
-  for (const key of ['OPENCODE_PROVIDER', 'OPENCODE_MODEL', 'OPENCODE_SMALL_MODEL'] as const) {
-    const value = ctx.hostEnv[key];
+  for (const key of OPENCODE_ENV_KEYS) {
+    const value = dotenv[key] || ctx.hostEnv[key];
     if (value) env[key] = value;
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [X] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
Minimal fix so an agent group on the opencode provider can reach a host-side OpenAI-compatible router (e.g. a local LiteLLM endpoint) — which is what /add-opencode-stack wires.

Three defects, all in the opencode provider's env handling:

1. The host provider read OPENCODE_* from process.env, but this host keeps .env out of process.env by design (env.ts). Read them from the .env file via readEnvFile, falling back to a real env var. (claude.ts already does this.)
2. The upstream endpoint was carried on ANTHROPIC_BASE_URL — which the Claude SDK also reads, so a Claude fallback turn got misrouted to the OpenAI-shaped endpoint. Introduce a dedicated OPENCODE_BASE_URL (container still falls back to ANTHROPIC_BASE_URL for compatibility) and forward it to the container.
NOTE: this new environment variable will allow a later feature to have "fallback" routing in case opencode is returning an error.
4. host.docker.internal was not in NO_PROXY, so a keyless local router call was routed through the OneCLI HTTPS_PROXY and dropped ("socket connection closed unexpectedly"). Add it.

Docs (add-opencode SKILL.md) updated to OPENCODE_BASE_URL. Scope is limited to the env/routing contract — no MCP or session-lifecycle changes.


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
