### PR TITLE
docs: correct stale mount topology row + removed env var

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,10 @@
 # NanoClaw Security Model
 
+> The canonical, continuously-verified version of this model lives at
+> [docs.nanoclaw.dev/concepts/security](https://docs.nanoclaw.dev/concepts/security).
+> This in-repo copy can drift; if the two disagree, verify against
+> `src/container-runner.ts` (`buildMounts`).
+
 ## Trust Model
 
 Privilege is **user-level**, persisted in the `user_roles` table (owner /
@@ -39,7 +44,6 @@ spawn. For the default (Claude) provider these are:
 | `/workspace/agent/container.json` | group `container.json` | RO | Container config — readable, not writable |
 | `/workspace/agent/CLAUDE.md` | composed `CLAUDE.md` | RO | Regenerated every spawn; agent edits would be clobbered |
 | `/workspace/agent/.claude-fragments` | group `.claude-fragments/` | RO | Composer skill/MCP fragments |
-| `/workspace/global` | `groups/global/` | RO | Shared global memory |
 | `/app/CLAUDE.md` | `container/CLAUDE.md` | RO | Shared base doc imported by the composed entry point |
 | `/home/node/.claude` | `data/v2-sessions/<group>/.claude-shared/` | RW | Claude state, settings, skill symlinks |
 | `/app/src` | `container/agent-runner/src/` | RO | Shared agent-runner source (same for all groups) |
@@ -51,7 +55,13 @@ The config mounts (`container.json`, `CLAUDE.md`, `.claude-fragments`) are
 read its config but cannot modify it. The project root is **never mounted**: the
 container only ever sees the paths above plus any provider-contributed mounts
 (e.g. an OpenCode XDG dir). Host application source (`src/`, `dist/`,
-`package.json`) is not reachable.
+`package.json`) is not reachable. There is no per-group split for a "main"
+group — every agent group's mounts are built the same way.
+
+The old `groups/global/` shared-memory mount no longer exists; that content
+was folded into `container/CLAUDE.md`, which every group already gets
+read-only at `/app/CLAUDE.md` (see `migrateGroupsToClaudeLocal` in
+`src/claude-md-compose.ts`).
 
 **Additional-mount allowlist** — extra mounts from a group's container config
 are validated against an allowlist at `~/.config/nanoclaw/mount-allowlist.json`,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -55,13 +55,7 @@ The config mounts (`container.json`, `CLAUDE.md`, `.claude-fragments`) are
 read its config but cannot modify it. The project root is **never mounted**: the
 container only ever sees the paths above plus any provider-contributed mounts
 (e.g. an OpenCode XDG dir). Host application source (`src/`, `dist/`,
-`package.json`) is not reachable. There is no per-group split for a "main"
-group — every agent group's mounts are built the same way.
-
-The old `groups/global/` shared-memory mount no longer exists; that content
-was folded into `container/CLAUDE.md`, which every group already gets
-read-only at `/app/CLAUDE.md` (see `migrateGroupsToClaudeLocal` in
-`src/claude-md-compose.ts`).
+`package.json`) is not reachable.
 
 **Additional-mount allowlist** — extra mounts from a group's container config
 are validated against an allowlist at `~/.config/nanoclaw/mount-allowlist.json`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -556,7 +556,7 @@ const DISCORD_TOKEN = process.env.DISCORD_BOT_TOKEN;
 const GMAIL_CREDS = process.env.GMAIL_CREDENTIALS_PATH;
 ```
 
-Shared config (DATA_DIR, TIMEZONE, MAX_CONCURRENT_CONTAINERS) stays in `config.ts`. Channel/skill-specific config stays in the module that uses it.
+Shared config (DATA_DIR, TIMEZONE) stays in `config.ts`. Channel/skill-specific config stays in the module that uses it.
 
 ### Code Style
 


### PR DESCRIPTION
Two small doc corrections found during a code-grounded docs sweep vs main @ 08a1ac9 (v2.1.38):

- **`docs/SECURITY.md`** — remove the leftover `/workspace/global` mount-table row. The recent SECURITY.md rewrite (3906104) updated the mount topology, but this row survived; the mount no longer exists in `mount-security`/container setup.
- **`docs/architecture.md:559`** — drop `MAX_CONCURRENT_CONTAINERS` from the shared-config list; the var was removed from code when host-sweep replaced the old timeout/concurrency machinery (it no longer appears anywhere in `src/`).

Both re-verified against fresh upstream HEAD (still 08a1ac9) immediately before opening this PR.

_Assisted by Claude; reviewed and verified by a human before submission._
