### PR TITLE
fix(router): mention-sticky must not subscribe the channel root or accumulate-only sessions

### DIFF
--- a/src/router-engage.test.ts
+++ b/src/router-engage.test.ts
@@ -1,0 +1,113 @@
+/**
+ * mention-sticky scope tests.
+ *
+ * A session can exist without the thread ever engaging: (1) at channel
+ * level, threadId equals the messaging group's platform id, so one
+ * channel-level mention would subscribe the entire channel; (2) with
+ * ignored_message_policy='accumulate', sessions are created just to store
+ * silent context (trigger=0). Sticky must fire only for genuine sub-threads
+ * that have seen a triggered message.
+ */
+import fs from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-router-engage' };
+});
+
+const TEST_DIR = '/tmp/nanoclaw-test-router-engage';
+
+import { initTestDb, closeDb, runMigrations, createAgentGroup, createMessagingGroup } from './db/index.js';
+import { resolveSession, writeSessionMessage } from './session-manager.js';
+import { evaluateEngage } from './router.js';
+import type { MessagingGroup, MessagingGroupAgent } from './types.js';
+
+const CHANNEL = 'discord:guild-1:chan-1';
+
+function stickyAgent(): MessagingGroupAgent {
+  return {
+    id: 'wiring-1',
+    messaging_group_id: 'mg-1',
+    agent_group_id: 'ag-1',
+    engage_mode: 'mention-sticky',
+    engage_pattern: null,
+    sender_scope: 'all',
+    ignored_message_policy: 'accumulate',
+    session_mode: 'shared',
+    created_at: new Date().toISOString(),
+  } as MessagingGroupAgent;
+}
+
+function groupChat(): MessagingGroup {
+  return {
+    id: 'mg-1',
+    channel_type: 'discord',
+    platform_id: CHANNEL,
+    instance: 'discord',
+    name: null,
+    is_group: 1,
+    unknown_sender_policy: 'public',
+    denied_at: null,
+    created_at: new Date().toISOString(),
+  } as MessagingGroup;
+}
+
+function seedSessionWithMessage(threadId: string, trigger: 0 | 1): void {
+  const { session } = resolveSession('ag-1', 'mg-1', threadId, 'per-thread');
+  writeSessionMessage('ag-1', session.id, {
+    id: `m-${trigger}-${threadId}`,
+    kind: 'chat-sdk',
+    timestamp: new Date().toISOString(),
+    platformId: CHANNEL,
+    channelType: 'discord',
+    threadId,
+    content: JSON.stringify({ text: 'hi' }),
+    trigger,
+  });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+  createAgentGroup({
+    id: 'ag-1',
+    name: 'Agent',
+    folder: 'agent-1',
+    agent_provider: null,
+    created_at: new Date().toISOString(),
+  });
+  createMessagingGroup(groupChat());
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('evaluateEngage — mention-sticky scope', () => {
+  it('fires on a platform mention regardless of session state', () => {
+    expect(evaluateEngage(stickyAgent(), 'hey', true, groupChat(), `${CHANNEL}:thread-9`)).toBe(true);
+  });
+
+  it('does not fire without a mention when no session exists', () => {
+    expect(evaluateEngage(stickyAgent(), 'hey', false, groupChat(), `${CHANNEL}:thread-9`)).toBe(false);
+  });
+
+  it('does not subscribe the channel root even when a channel-root session exists', () => {
+    seedSessionWithMessage(CHANNEL, 1);
+    expect(evaluateEngage(stickyAgent(), 'hey', false, groupChat(), CHANNEL)).toBe(false);
+  });
+
+  it('does not treat an accumulate-only session (trigger=0 rows) as subscribed', () => {
+    seedSessionWithMessage(`${CHANNEL}:thread-1`, 0);
+    expect(evaluateEngage(stickyAgent(), 'hey', false, groupChat(), `${CHANNEL}:thread-1`)).toBe(false);
+  });
+
+  it('stays sticky in a sub-thread that has seen a triggered message', () => {
+    seedSessionWithMessage(`${CHANNEL}:thread-2`, 1);
+    expect(evaluateEngage(stickyAgent(), 'hey', false, groupChat(), `${CHANNEL}:thread-2`)).toBe(true);
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,7 +29,7 @@ import {
 import { findSessionForAgent } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import { openInboundDb, resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
@@ -380,7 +380,7 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
  *                      a thread has engaged us once, follow-ups arrive
  *                      with no mention and should still fire.
  */
-function evaluateEngage(
+export function evaluateEngage(
   agent: MessagingGroupAgent,
   text: string,
   isMention: boolean,
@@ -405,11 +405,34 @@ function evaluateEngage(
       // Sticky follow-up: session already exists for this (agent, mg, thread)
       // — the thread was activated before, keep firing.
       if (mg.is_group === 0) return false; // DMs never use mention-sticky sensibly
+      // Only genuine sub-threads are sticky. At channel level threadId equals
+      // the channel's own platform id, so a channel-root session would
+      // subscribe the entire channel to every message after a single mention.
+      if (!threadId || threadId === mg.platform_id) return false;
       const existing = findSessionForAgent(agent.agent_group_id, mg.id, threadId);
-      return existing !== undefined;
+      if (!existing) return false;
+      // ignored_message_policy='accumulate' creates sessions for
+      // non-engaging messages (silent context), so session existence alone
+      // doesn't prove the thread ever engaged. Only a session that has seen
+      // a triggered message counts as subscribed.
+      return sessionHasEngagedMessage(agent.agent_group_id, existing.id);
     }
     default:
       return false;
+  }
+}
+
+/**
+ * True when the session's inbound DB contains at least one triggered
+ * (engaged) message. Sessions created purely by 'accumulate' hold only
+ * trigger=0 context rows and must not count as a sticky subscription.
+ */
+function sessionHasEngagedMessage(agentGroupId: string, sessionId: string): boolean {
+  try {
+    const db = openInboundDb(agentGroupId, sessionId);
+    return db.prepare('SELECT 1 FROM messages_in WHERE trigger = 1 LIMIT 1').get() !== undefined;
+  } catch {
+    return false; // no inbound DB yet — the session never engaged
   }
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What/Why.** `evaluateEngage`'s mention-sticky branch treats bare session existence as the thread's subscription state. Two ways a session exists without the thread ever engaging:

1. **Channel root**: on threaded adapters a channel-level message's threadId equals the messaging group's own platform id. One channel-level mention creates a channel-root session — after which *every* message in the channel matches the sticky lookup. The whole channel is permanently subscribed.
2. **Accumulate**: `ignored_message_policy='accumulate'` creates sessions just to store silent context (`trigger=0`, `wake=false`). The sticky check then fires on the very next message even though the agent was never mentioned.

Observed on Discord (Slack masks case 1 because replies land in threads): after enabling accumulate, a single non-mention channel message created a channel-root session at `wake=false`, and the agent answered every subsequent channel message.

**How it works.** Two guards in the sticky branch:
- sticky only applies to genuine sub-threads (`threadId !== mg.platform_id`) — the channel root always requires a mention;
- the matched session must contain at least one `trigger=1` row (`sessionHasEngagedMessage`, a LIMIT-1 read of the session's inbound DB) — accumulate-only sessions don't count.

`evaluateEngage` is now exported for the tests.

**How it was tested.** New `src/router-engage.test.ts` covers: mention always fires; no session → no fire; channel-root session → no fire; accumulate-only (trigger=0) session → no fire; engaged sub-thread session → sticky fires. Full suite green (574 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)