### PR TITLE
fix(agent-runner): suppress duplicate delivery when the final output repeats tool-sent content

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -76,6 +76,46 @@ export function writeMessageOut(msg: WriteMessageOut): number {
   return nextSeq;
 }
 
+/** Highest seq currently in messages_out — the floor for a per-turn dedup window. */
+export function getMaxMessageOutSeq(): number {
+  return (getOutboundDb().prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+}
+
+/**
+ * Trimmed text bodies send_message / send_file delivered since `floorSeq`
+ * — the poll loop's view of "content already sent during the turn in
+ * flight", used for exact-content duplicate suppression.
+ *
+ * This is read from messages_out rather than tracked in memory because
+ * the MCP tools run in a separate process (the SDK spawns the tools
+ * server via `bun run`); the rows those tools write to outbound.db are
+ * the only ledger both processes can see. (Same reason the a2a
+ * in_reply_to stamp lives in session_state — see db/session-state.ts.)
+ *
+ * Excludes scheduled sends (deliver_after set — nothing was delivered
+ * now) and edit/reaction operations.
+ */
+export function getToolSentTextsSince(floorSeq: number): string[] {
+  const rows = getOutboundDb()
+    .prepare(`SELECT content FROM messages_out WHERE seq > ? AND kind = 'chat' AND deliver_after IS NULL`)
+    .all(floorSeq) as { content: string }[];
+
+  const texts: string[] = [];
+  for (const row of rows) {
+    let parsed: { text?: unknown; operation?: unknown };
+    try {
+      parsed = JSON.parse(row.content);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object' || parsed.operation) continue;
+    if (typeof parsed.text === 'string' && parsed.text.trim()) {
+      texts.push(parsed.text.trim());
+    }
+  }
+  return texts;
+}
+
 /**
  * Look up a message's platform ID by seq number.
  * Searches both inbound and outbound DBs since seq spans both.

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
-import { getUndeliveredMessages } from './db/messages-out.js';
+import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
 import { isCorruptionError, processQuery } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
@@ -435,6 +435,127 @@ describe('error result with no <message> envelope', () => {
     expect(getUndeliveredMessages()).toHaveLength(0);
     expect(pushes).toHaveLength(1);
     expect(pushes[0]).toContain('was not delivered');
+  });
+});
+
+/**
+ * Build a stub query that simulates the agent calling send_message mid-turn
+ * and then ending the turn with `result`. In production the MCP tool runs
+ * in a SEPARATE process, so the only signal the poll loop can see is the
+ * messages_out row the tool writes — which is exactly what this helper
+ * writes, after the query has started (i.e. after the dedup floor was
+ * snapshotted at processQuery entry).
+ */
+function makeToolSendingQuery(
+  toolTexts: string[],
+  result: ProviderEvent,
+): { query: AgentQuery; pushes: string[] } {
+  const pushes: string[] = [];
+  async function* events(): AsyncGenerator<ProviderEvent> {
+    yield { type: 'init', continuation: 'sess-1' };
+    for (const [i, text] of toolTexts.entries()) {
+      writeMessageOut({
+        id: `tool-sent-${i}-${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'chat',
+        platform_id: ERR_ROUTING.platformId,
+        channel_type: ERR_ROUTING.channelType,
+        thread_id: null,
+        content: JSON.stringify({ text }),
+      });
+    }
+    yield result;
+  }
+  return {
+    pushes,
+    query: {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    },
+  };
+}
+
+describe('duplicate-send suppression (tool send + restated final output)', () => {
+  it('does not deliver a wrapped <message> block that repeats content already sent via the tool', async () => {
+    // The real-world shape: the agent sends the reply via send_message,
+    // then ALSO wraps the same text in its own <message> block as the
+    // turn's final output — previously delivered twice.
+    getInboundDb()
+      .prepare('INSERT INTO destinations (name, display_name, type, channel_type, platform_id) VALUES (?, ?, ?, ?, ?)')
+      .run('discord-test', 'Discord', 'channel', ERR_ROUTING.channelType, ERR_ROUTING.platformId);
+
+    const { query, pushes } = makeToolSendingQuery(['Here is your briefing.'], {
+      type: 'result',
+      text: '<message to="discord-test">Here is your briefing.</message>',
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('still delivers a wrapped <message> block whose content differs from what the tool sent', async () => {
+    // A tool-based ack followed by genuinely different final content must
+    // not be treated as a duplicate — dedup is content-exact, not "a tool
+    // fired at some point."
+    getInboundDb()
+      .prepare('INSERT INTO destinations (name, display_name, type, channel_type, platform_id) VALUES (?, ?, ?, ?, ?)')
+      .run('discord-test', 'Discord', 'channel', ERR_ROUTING.channelType, ERR_ROUTING.platformId);
+
+    const { query } = makeToolSendingQuery(['On it, checking now…'], {
+      type: 'result',
+      text: '<message to="discord-test">Here is the actual answer.</message>',
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(2);
+    expect(out.map((m) => JSON.parse(m.content).text)).toEqual(
+      expect.arrayContaining(['On it, checking now…', 'Here is the actual answer.']),
+    );
+  });
+
+  it('treats bare text that repeats tool-sent content as delivered — no re-wrap nudge', async () => {
+    // Without this, the restatement flags hasUnwrapped, the loop nudges,
+    // and the agent's dutiful re-wrap of the same text delivers the
+    // duplicate after all.
+    const { query, pushes } = makeToolSendingQuery(['Here is your briefing.'], {
+      type: 'result',
+      text: 'Here is your briefing.',
+    });
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('does not leak tool-sent content into the next turn', async () => {
+    getInboundDb()
+      .prepare('INSERT INTO destinations (name, display_name, type, channel_type, platform_id) VALUES (?, ?, ?, ?, ?)')
+      .run('discord-test', 'Discord', 'channel', ERR_ROUTING.channelType, ERR_ROUTING.platformId);
+
+    // Turn 1: tool send + identical wrapped restatement → suppressed.
+    const first = makeToolSendingQuery(['same text'], {
+      type: 'result',
+      text: '<message to="discord-test">same text</message>',
+    });
+    await processQuery(first.query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+    expect(getUndeliveredMessages()).toHaveLength(1);
+
+    // Turn 2 (new query): the same wrapped text with no tool call this
+    // turn must deliver — the dedup window is per turn, not forever.
+    const second = makeResultQuery({
+      type: 'result',
+      text: '<message to="discord-test">same text</message>',
+    });
+    await processQuery(second.query, ERR_ROUTING, ['m2'], 'claude', undefined, 'prompt', undefined);
+    expect(getUndeliveredMessages()).toHaveLength(2);
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,6 +1,6 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
-import { writeMessageOut } from './db/messages-out.js';
+import { getMaxMessageOutSeq, getToolSentTextsSince, writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import {
   clearContinuation,
@@ -340,6 +340,13 @@ export async function processQuery(
   let queryContinuation: string | undefined;
   let done = false;
   let unwrappedNudged = false;
+  // Floor of the per-turn duplicate-send window: any chat row the MCP tools
+  // write above this seq was delivered during the turn in flight. Read from
+  // the DB (not in-memory state) because the tools run in a separate process
+  // — see getToolSentTextsSince in db/messages-out.ts. Advanced past this
+  // turn's own writes after each result event so one turn's sends never
+  // dedup a later turn's.
+  let toolSentFloorSeq = getMaxMessageOutSeq();
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -486,8 +493,9 @@ export async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        const toolSentTexts = getToolSentTextsSince(toolSentFloorSeq);
         if (event.text) {
-          const { sent, hasUnwrapped } = dispatchResultText(event.text, routing);
+          const { sent, hasUnwrapped } = dispatchResultText(event.text, routing, toolSentTexts);
           if (sent === 0 && event.isError === true) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
@@ -527,6 +535,9 @@ export async function processQuery(
         } else {
           archivePrompts.shift();
         }
+        // Move the dedup floor past everything this turn wrote (tool sends
+        // and dispatched blocks alike) so the next turn starts clean.
+        toolSentFloorSeq = getMaxMessageOutSeq();
       }
     }
   } catch (err) {
@@ -605,8 +616,20 @@ function deliverErrorResult(text: string, routing: RoutingContext): void {
  * The agent must always wrap output in <message to="name">...</message>
  * blocks, even with a single destination. Bare text is scratchpad only.
  */
-function dispatchResultText(text: string, routing: RoutingContext): { sent: number; hasUnwrapped: boolean } {
+function dispatchResultText(
+  text: string,
+  routing: RoutingContext,
+  alreadySent: string[],
+): { sent: number; hasUnwrapped: boolean } {
   const MESSAGE_RE = /<message\s+to="([^"]+)"\s*>([\s\S]*?)<\/message>/g;
+
+  // `alreadySent` — exact bodies send_message/send_file delivered earlier
+  // in this same turn, read from messages_out (the tools run in a separate
+  // process, so the DB rows are the only ledger both sides see). A turn
+  // that calls the tool and then *also* repeats that content in a
+  // <message> block of its final output was delivering it a second time —
+  // the "double message" bug. Dedup is content-exact, so a tool-based ack
+  // followed by a genuinely different wrapped message is untouched.
 
   let match: RegExpExecArray | null;
   let sent = 0;
@@ -627,6 +650,10 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
       scratchpadParts.push(`[dropped: unknown destination "${toName}"] ${body}`);
       continue;
     }
+    if (alreadySent.includes(body)) {
+      log(`Dropping <message to="${toName}"> — identical content already sent via send_message/send_file this turn`);
+      continue;
+    }
     sendToDestination(dest, body, routing);
     sent++;
   }
@@ -635,12 +662,23 @@ function dispatchResultText(text: string, routing: RoutingContext): { sent: numb
   }
 
   const scratchpad = stripInternalTags(scratchpadParts.join(''));
+  // Bare text that verbatim repeats tool-sent content is a restatement of
+  // something already delivered, not an undelivered response — flagging it
+  // hasUnwrapped would trigger the re-wrap nudge, and the agent's dutiful
+  // re-wrap of the same text would deliver the duplicate after all.
+  const scratchpadIsDuplicate = !!scratchpad && alreadySent.includes(scratchpad.trim());
 
   if (scratchpad) {
-    log(`[scratchpad] ${scratchpad.slice(0, 500)}${scratchpad.length > 500 ? '…' : ''}`);
+    if (scratchpadIsDuplicate) {
+      log(
+        `[scratchpad, already sent via send_message/send_file this turn] ${scratchpad.slice(0, 500)}${scratchpad.length > 500 ? '…' : ''}`,
+      );
+    } else {
+      log(`[scratchpad] ${scratchpad.slice(0, 500)}${scratchpad.length > 500 ? '…' : ''}`);
+    }
   }
 
-  const hasUnwrapped = sent === 0 && !!scratchpad;
+  const hasUnwrapped = sent === 0 && !!scratchpad && !scratchpadIsDuplicate;
   if (hasUnwrapped) {
     log(`WARNING: agent output had no <message to="..."> blocks — nothing was sent`);
   }


### PR DESCRIPTION
## Problem

An agent that sends its reply via the `send_message` MCP tool and then **also** repeats the same text in its final output delivers it twice:

- a wrapped `<message>` block goes straight through `dispatchResultText`'s send loop with no duplicate check, and
- bare restated text flags `hasUnwrapped`, triggering the re-wrap nudge — after which the agent dutifully re-wraps the same text and the duplicate goes out anyway.

Scheduled-task agents hit this shape routinely (send the briefing via the tool, then restate it as the turn's final answer). #2910 added an instruction-level guard for this; the comment thread there confirms other installs reproduce the same failure. This PR adds the deterministic, code-level guard — the two are complementary (instructions reduce the attempts, this makes the harm impossible).

## Why the ledger is in the DB, not in memory

The nanoclaw MCP tools server runs as a **separate bun subprocess** — module-level state written by a tool handler is invisible to the poll loop (each process gets its own module instance). Any coordination between the two must go through the session DB, the same reason the a2a `in_reply_to` stamp lives in `session_state`.

## Change

- `processQuery` snapshots the max `messages_out` seq at query start; everything the tools write above that floor is "content already delivered this turn" (`getToolSentTextsSince`, new in `db/messages-out.ts` — excludes scheduled sends and edit/reaction operations).
- `dispatchResultText` drops wrapped blocks whose body **exactly** matches tool-sent content, and treats bare text that exactly matches as already-delivered rather than undelivered — suppressing the nudge that would otherwise resurrect the duplicate.
- The floor advances past each turn's writes after every result event, so the window never leaks into later turns (deliberately re-sending the same text in a later turn still works).

Dedup is content-exact, not "did a tool fire": a tool-based ack followed by genuinely different final content is untouched.

## Tests

New `duplicate-send suppression` suite in `poll-loop.test.ts`. The tool send is simulated the way production works — a `messages_out` row written mid-turn (i.e. after the floor snapshot), which is the only signal the poll loop can observe from the other process. Covers: wrapped identical (dropped), wrapped different (delivered), bare identical (no nudge, no re-hammer), and no cross-turn leakage.

`bun test`: 117 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)