### PR TITLE
fix(agent-runner): match rate_limit_event as a top-level SDK message type

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -450,9 +450,6 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'rate_limit_event') {
-          // SDK 0.3.x ships this as a top-level message type (SDKRateLimitEvent),
-          // not a `system` subtype — matching the old shape here left this branch
-          // dead and dropped the quota signal entirely.
           yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -449,7 +449,10 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'result', text, isError: m.is_error === true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
-        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {
+        } else if (message.type === 'rate_limit_event') {
+          // SDK 0.3.x ships this as a top-level message type (SDKRateLimitEvent),
+          // not a `system` subtype — matching the old shape here left this branch
+          // dead and dropped the quota signal entirely.
           yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;


### PR DESCRIPTION
## Summary

`ClaudeProvider.translateEvents` mapped rate-limit events with:

```ts
message.type === 'system' && subtype === 'rate_limit_event'
```

but `@anthropic-ai/claude-agent-sdk` 0.3.x ships rate limits as a **top-level** message type, `SDKRateLimitEvent`:

```ts
type SDKRateLimitEvent = {
  type: 'rate_limit_event';
  rate_limit_info: SDKRateLimitInfo;
  uuid: UUID;
  session_id: string;
};
```

It is a member of the `SDKMessage` union with **no** `system` subtype, so the old condition never matched. The quota-classified provider event (`{ type: 'error', retryable: false, classification: 'quota' }`) was never emitted and rate-limit signals were silently dropped.

## Fix

Match the top-level `type` in `container/agent-runner/src/providers/claude.ts`. The emitted event is unchanged — only the matching condition is corrected. `tsc --noEmit` passes (the discriminant narrows `message` to `SDKRateLimitEvent`).

## Context

Surfaced while verifying the SDK deep-dive docs update (#2964) against `@anthropic-ai/claude-agent-sdk@0.3.197` `sdk.d.ts`.

_Assisted by Claude; reviewed and verified by a human before submission._