### PR TITLE
fix(approvals): claim pending approvals before running the handler

### DIFF
--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -211,6 +211,25 @@ export function deletePendingApproval(approvalId: string): void {
   getDb().prepare('DELETE FROM pending_approvals WHERE approval_id = ?').run(approvalId);
 }
 
+/**
+ * Atomically claim a still-pending approval, returning true only for the caller
+ * that wins. better-sqlite3 `.run()` is synchronous, so this conditional delete
+ * is a compare-and-set: of two concurrent resolution events for the same id
+ * (a fast double-tap, or a button click racing a text reply), only one sees
+ * `changes === 1`. The loser must not proceed to the approval handler, which
+ * for actions like sending or deleting mail is irreversible and has no
+ * idempotency key. The `status = 'pending'` guard also skips a row a concurrent
+ * "reject with reason" hold already moved to `awaiting_reason`. This just moves
+ * the row removal ahead of the handler; the handler already ran with the row
+ * deleted afterwards regardless of outcome.
+ */
+export function claimPendingApproval(approvalId: string): boolean {
+  const result = getDb()
+    .prepare("DELETE FROM pending_approvals WHERE approval_id = ? AND status = 'pending'")
+    .run(approvalId);
+  return result.changes === 1;
+}
+
 export function getPendingApprovalsByAction(action: string): PendingApproval[] {
   return getDb().prepare('SELECT * FROM pending_approvals WHERE action = ?').all(action) as PendingApproval[];
 }

--- a/src/modules/approvals/response-handler.test.ts
+++ b/src/modules/approvals/response-handler.test.ts
@@ -204,4 +204,54 @@ describe('approval response authorization', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     expect(getPendingApproval('appr-4')).toBeUndefined();
   });
+
+  it('runs the approve handler exactly once under concurrent double-resolution', async () => {
+    upsertUser({ id: 'telegram:owner', kind: 'telegram', display_name: 'Owner', created_at: now() });
+    grantRole({ user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+
+    const { registerApprovalHandler } = await import('./primitive.js');
+    const { handleApprovalsResponse } = await import('./response-handler.js');
+
+    // Gate the handler open so both resolutions are in flight before it settles:
+    // the guard must be the up-front claim, not handler timing. Without the
+    // claim-before-apply CAS, the second resolution reads the still-present row
+    // (the row was deleted only after the handler) and runs the irreversible
+    // handler a second time.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const handler = vi.fn().mockImplementation(() => gate);
+    registerApprovalHandler('irreversible_send', handler);
+
+    createPendingApproval({
+      approval_id: 'appr-race',
+      session_id: 'sess-1',
+      request_id: 'appr-race',
+      action: 'irreversible_send',
+      payload: JSON.stringify({ to: 'x@example.com' }),
+      created_at: now(),
+      title: 'Send mail',
+      options_json: JSON.stringify([]),
+    });
+
+    const fire = () =>
+      handleApprovalsResponse({
+        questionId: 'appr-race',
+        value: 'approve',
+        userId: 'owner',
+        channelType: 'telegram',
+        platformId: 'dm-owner',
+        threadId: null,
+      });
+
+    const first = fire();
+    const second = fire();
+    release();
+    const [firstClaimed] = await Promise.all([first, second]);
+
+    expect(firstClaimed).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(getPendingApproval('appr-race')).toBeUndefined();
+  });
 });

--- a/src/modules/approvals/response-handler.ts
+++ b/src/modules/approvals/response-handler.ts
@@ -16,7 +16,7 @@
  * core iterates handlers and the first one to return `true` claims the response.
  */
 import { wakeContainer } from '../../container-runner.js';
-import { deletePendingApproval, getPendingApproval, getSession } from '../../db/sessions.js';
+import { claimPendingApproval, deletePendingApproval, getPendingApproval, getSession } from '../../db/sessions.js';
 import type { ResponsePayload } from '../../response-registry.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
@@ -84,7 +84,21 @@ async function handleRegisteredApproval(
     return;
   }
 
-  // Approved — dispatch to the module that registered for this action.
+  // Approved — dispatch to the module that registered for this action. Claim
+  // the row atomically FIRST: two concurrent resolutions (a fast double-tap, or
+  // a button click racing a text reply) both read the row via getPendingApproval
+  // above, so without an up-front compare-and-set both would invoke the handler
+  // — and approve handlers include irreversible, no-idempotency-key actions
+  // (e.g. sending or deleting mail). Only the winner proceeds; this replaces the
+  // post-handler deletePendingApproval calls below.
+  if (!claimPendingApproval(approval.approval_id)) {
+    log.info('Approval already resolved by a concurrent event — skipping duplicate apply', {
+      approvalId: approval.approval_id,
+      action: approval.action,
+    });
+    return;
+  }
+
   const notify = (text: string): void => {
     writeSessionMessage(session.agent_group_id, session.id, {
       id: `appr-note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -104,7 +118,6 @@ async function handleRegisteredApproval(
       action: approval.action,
     });
     notify(`Your ${approval.action} was approved, but no handler is installed to apply it.`);
-    deletePendingApproval(approval.approval_id);
     await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
     await wakeContainer(session);
     return;
@@ -121,7 +134,6 @@ async function handleRegisteredApproval(
     );
   }
 
-  deletePendingApproval(approval.approval_id);
   await notifyApprovalResolved({ approval, session, outcome: 'approve', userId });
   await wakeContainer(session);
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** Adds `claimPendingApproval()` (an atomic compare-and-set delete) and makes the approval approve-path claim the row *before* invoking the registered handler.

**Why:** `handleRegisteredApproval` reads the pending row up front (`getPendingApproval`) but deletes it only **after** `await handler(...)`. Two resolutions of the same approval arriving close together — a fast double-tap, or a button click racing a text reply — both pass the read and both reach the handler while the row still exists, so the side effect runs twice. Approve handlers include irreversible, no-idempotency-key actions (e.g. sending or deleting mail).

**How it works:** `claimPendingApproval(id)` runs `DELETE FROM pending_approvals WHERE approval_id = ? AND status = 'pending'` and returns `changes === 1`. `better-sqlite3`'s `.run()` is synchronous, so of two concurrent resolutions only one sees the delete. The approve path claims before invoking the handler and bails if it loses. This just moves the row removal ahead of the handler — the row was already deleted after the handler regardless of outcome, so the end state is unchanged. The `status = 'pending'` guard also correctly skips a row a concurrent "reject with reason" hold moved to `awaiting_reason`. The reject, reason-capture, and OneCLI paths are untouched.

**How tested:** New regression test fires two concurrent resolutions at a gated handler and asserts it runs exactly once. Confirmed it **fails on current `main`** (handler called twice) and passes with the fix; full `tsc` typecheck and the approvals response-handler suite are green (run under Node 22).
