### PR TITLE
fix(webhook): honor WEBHOOK_PORT from .env

### DIFF
--- a/src/config-webhook-port.test.ts
+++ b/src/config-webhook-port.test.ts
@@ -1,0 +1,49 @@
+/**
+ * #2901: a WEBHOOK_PORT in .env used to be silently ignored. Drive the real
+ * config module from a temp cwd with its own .env to check it's picked up.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('config WEBHOOK_PORT resolution (#2901)', () => {
+  const origCwd = process.cwd();
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-cfg-'));
+    delete process.env.WEBHOOK_PORT;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads WEBHOOK_PORT from .env when no process env var is set', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'WEBHOOK_PORT=3097\n');
+    process.chdir(dir);
+
+    const { WEBHOOK_PORT } = await import('./config.js');
+    expect(WEBHOOK_PORT).toBe(3097);
+  });
+
+  it('defaults to 3000 with no .env and no env var', async () => {
+    process.chdir(dir);
+
+    const { WEBHOOK_PORT } = await import('./config.js');
+    expect(WEBHOOK_PORT).toBe(3000);
+  });
+
+  it('process env var wins over .env', async () => {
+    fs.writeFileSync(path.join(dir, '.env'), 'WEBHOOK_PORT=3097\n');
+    process.chdir(dir);
+    process.env.WEBHOOK_PORT = '4111';
+
+    const { WEBHOOK_PORT } = await import('./config.js');
+    expect(WEBHOOK_PORT).toBe(4111);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const envConfig = readEnvFile([
   'NANOCLAW_EGRESS_LOCKDOWN',
   'NANOCLAW_EGRESS_NETWORK',
   'ONECLI_GATEWAY_CONTAINER',
+  'WEBHOOK_PORT',
 ]);
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
@@ -63,6 +64,9 @@ export const EGRESS_NETWORK =
   process.env.NANOCLAW_EGRESS_NETWORK || envConfig.NANOCLAW_EGRESS_NETWORK || 'nanoclaw-egress';
 export const ONECLI_GATEWAY_CONTAINER =
   process.env.ONECLI_GATEWAY_CONTAINER || envConfig.ONECLI_GATEWAY_CONTAINER || 'onecli';
+
+// Shared webhook server port. Env var wins, then .env, then default.
+export const WEBHOOK_PORT = parseInt(process.env.WEBHOOK_PORT || envConfig.WEBHOOK_PORT || '3000', 10);
 
 // Timezone for scheduled tasks, message formatting, etc.
 // Validates each candidate is a real IANA identifier before accepting.

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -14,9 +14,8 @@ import http from 'http';
 
 import type { Chat } from 'chat';
 
+import { WEBHOOK_PORT } from './config.js';
 import { log } from './log.js';
-
-const DEFAULT_PORT = 3000;
 
 interface WebhookEntry {
   chat: Chat;
@@ -110,7 +109,9 @@ export function registerWebhookHandler(path: string, handler: RawWebhookHandler)
 function ensureServer(): void {
   if (server) return;
 
-  const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
+  // A live env var still overrides here; otherwise fall back to config, which
+  // has already folded in .env (readEnvFile never touches process.env).
+  const port = process.env.WEBHOOK_PORT ? parseInt(process.env.WEBHOOK_PORT, 10) : WEBHOOK_PORT;
 
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';


### PR DESCRIPTION
Setting WEBHOOK_PORT in .env did nothing — the server always came up on
3000. The reason is that readEnvFile keeps its values local to config and never writes them into process.env (on purpose, so secrets don't leak to child processes), but the webhook server was reading the port straight from process.env. So the .env value had nowhere to land.

Pull the port through config like the other settings. A real env var still wins when you need to override on the fly.

Fixes #2901

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
