### PR TITLE
fix(container): warn when a real entry blocks a shared skill symlink

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -95,3 +95,22 @@ describe('container boot-failure tripwire (structural)', () => {
     expect(src).toMatch(/Container exited non-zero.*stderrTail/s);
   });
 });
+
+describe('syncSkillSymlinks blocked-entry warning (structural)', () => {
+  // Real directories in .claude-shared/skills/ block the managed symlinks:
+  // the prune loop only removes symlinks and the create loop skips any
+  // existing entry. Template overlays depend on surviving that (see
+  // src/group-skills.ts); stale pre-refactor skill copies (#3001) get served
+  // forever with no trace. Driving syncSkillSymlinks needs a real group
+  // filesystem, and importing more of the module pulls the provider side
+  // effects, so guard the wiring structurally: the create loop must warn
+  // when a non-symlink entry occupies a desired skill path.
+  it('warns instead of silently skipping when a real entry blocks a desired skill', () => {
+    const src = fs.readFileSync(path.join(process.cwd(), 'src', 'container-runner.ts'), 'utf-8');
+    const createLoop = src.indexOf('// Create symlinks for desired skills');
+    expect(createLoop).toBeGreaterThan(-1);
+    const tail = src.slice(createLoop);
+    expect(tail).toMatch(/else if \(!entry\.isSymbolicLink\(\)\)/);
+    expect(tail).toMatch(/log\.warn\(\s*'Shared skill not symlinked/);
+  });
+});

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -389,15 +389,26 @@ function syncSkillSymlinks(claudeDir: string, containerConfig: import('./contain
   // Create symlinks for desired skills (container path targets)
   for (const skill of desired) {
     const linkPath = path.join(skillsDir, skill);
-    let exists = false;
+    let entry: fs.Stats | undefined;
     try {
-      fs.lstatSync(linkPath);
-      exists = true;
+      entry = fs.lstatSync(linkPath);
     } catch {
       /* missing */
     }
-    if (!exists) {
+    if (!entry) {
       fs.symlinkSync(`/app/skills/${skill}`, linkPath);
+    } else if (!entry.isSymbolicLink()) {
+      // A real entry here is either a template overlay (intentional; see
+      // src/group-skills.ts) or a stale pre-refactor skill copy that shadows
+      // the shared skill (#3001). No marker distinguishes them yet, so
+      // surface the skip instead of staying silent.
+      log.warn(
+        'Shared skill not symlinked: real entry occupies the path (template overlay or stale pre-refactor copy)',
+        {
+          skill,
+          path: linkPath,
+        },
+      );
     }
   }
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

First layer of #3001. Does not close it.

**What this does.** `syncSkillSymlinks` now logs a warning when a non-symlink entry occupies the path of a desired shared skill. The entry is left in place, so template overlays (`src/group-skills.ts`) keep working exactly as before. No other behavior changes.

**Why.** Groups created before the shared-skills refactor (8a12fa61) still hold real skill copies in `.claude-shared/skills/`. The prune loop only unlinks symlinks and the create loop skips any existing entry, so those groups run stale skill content on every spawn and nothing in the logs says so. #3001 has the full trace and a repro.

The message names both possible causes (template overlay or stale pre-refactor copy) because no marker distinguishes them yet. That ownership marker is the second layer suggested in #3001 and is not attempted here.

One tradeoff to be aware of: groups that use template overlays will see this warning on every spawn, for an intentional state. The layer-2 marker removes that noise. If you would rather gate or phrase the warning differently, happy to adjust.

**How I verified it.**

- Verified against main at 14f528c8.
- New structural test in `src/container-runner.test.ts`, matching the existing structural tests for this module (importing it pulls the provider side effects, so the file guards wiring by reading the source). The test fails before the change and passes after.
- Full host suite: 689/689 passed. `tsc --noEmit` clean. Prettier clean. The 4 eslint `no-catch-all` warnings on `container-runner.ts` are already on `main` and are not touched here.
- Live end-to-end on a test install of this branch: replaced the `welcome` skill symlink in a group's `.claude-shared/skills/` with a real directory and triggered a fresh container spawn. The warning appeared in `nanoclaw.log` with the exact skill name and path. Restored the symlink, forced another spawn: no warning, delivery unaffected.

Assisted by Claude; reviewed and verified by a human before submission.