### PR TITLE
Context preview tool: render the exact agent context per scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ For ad-hoc queries from skills or scripts, use the in-tree wrapper rather than t
 | `container/skills/` | Container skills mounted into every agent session (`agent-browser`, `frontend-engineer`, `onecli-gateway`, `self-customize`, `slack-formatting`, `vercel-cli`, `welcome`, `whatsapp-formatting`) |
 | `groups/<folder>/` | Per-agent-group filesystem (CLAUDE.md, skills) — agent-runner source is a shared read-only mount, not copied per group |
 | `scripts/init-first-agent.ts` | Bootstrap the first DM-wired agent (used by `/init-first-agent` skill) |
+| `scripts/context-preview.ts` | Render the exact context an agent sees for a scenario (first message, task fire, on-wake, a2a, …) using the real code paths — no container, no live-install writes. See [docs/context-preview.md](docs/context-preview.md). |
 | `migrate-v2.sh` + `setup/migrate-v2/` | v1→v2 migration. Standalone script: `bash migrate-v2.sh`. Seeds DB, copies groups/sessions, installs channels, builds container, offers service switchover, then hands off to `/migrate-from-v1` skill for owner setup and CLAUDE.md cleanup. See [docs/migration-dev.md](docs/migration-dev.md). |
 | `nanoclaw.sh --uninstall` + `setup/uninstall/` | Uninstall this copy only (slug-scoped): service, containers + image, `data/`, `logs/`, `groups/`, this copy's OneCLI agents. Confirms per group; `--dry-run` previews, `--yes` skips prompts. Other copies and the shared OneCLI app are untouched. Bypasses bootstrap entirely; `uninstall.sh` is a pointer that execs it. |
 
@@ -282,6 +283,7 @@ This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspac
 | [docs/skills-model.md](docs/skills-model.md) | The skills model in full: recipes, tests, upgrades, migrations |
 | [docs/skill-guidelines.md](docs/skill-guidelines.md) | Authoritative checklist for writing a skill |
 | [docs/templates.md](docs/templates.md) | Agent templates: what they are, stamping via `ncl groups create --template` + the setup wizard, the OneCLI/MCP-credential model, supported providers, and how to contribute one |
+| [docs/context-preview.md](docs/context-preview.md) | Context preview tool: simulate a scenario and render the exact agent-visible context (composed CLAUDE.md, system prompt, SDK options, prompt string) |
 
 ## Container Build Cache
 

--- a/container/agent-runner/scripts/context-preview-runner.ts
+++ b/container/agent-runner/scripts/context-preview-runner.ts
@@ -1,0 +1,252 @@
+/**
+ * Bun half of the context-preview tool. Never run directly — spawned by
+ * `scripts/context-preview.ts` (host side), which stages a session (inbound.db
+ * + outbound.db) in a sandbox and passes a spec file describing where.
+ *
+ * Reproduces the container-side context assembly with the REAL production
+ * code paths — no agent-visible string is duplicated. Two pieces of WIRING
+ * are mirrored from src (kept small and commented at their use sites): the
+ * tool-module import list from mcp-tools/index.ts and the mcpServers/cwd
+ * assembly from index.ts main().
+ *   - `initTestSessionDb()` swaps the /workspace/*.db singletons for
+ *     in-memory DBs; the staged rows are copied in byte-identical.
+ *   - `runPollLoop()` (the real loop) runs against a capturing provider, so
+ *     batching, on_wake first-poll gating, the accumulate gate, and slash
+ *     command splitting are exactly what a real container does.
+ *   - `buildSystemPromptAddendum()` renders the runtime system-prompt
+ *     addendum from the staged destinations table.
+ *   - `ClaudeProvider.buildQueryOptions()` renders the exact SDK options.
+ *   - `listRegisteredTools()` renders the nanoclaw MCP tool surface.
+ *
+ * Emits one JSON object on stdout; all logging goes to stderr.
+ */
+import { Database } from 'bun:sqlite';
+import fs from 'fs';
+
+import { setTestConfig, type RunnerConfig } from '../src/config.js';
+import { initTestSessionDb } from '../src/db/connection.js';
+import { buildSystemPromptAddendum } from '../src/destinations.js';
+// Tool modules self-register on import — same set the MCP barrel loads.
+import '../src/mcp-tools/core.js';
+import '../src/mcp-tools/interactive.js';
+import '../src/mcp-tools/agents.js';
+import '../src/mcp-tools/self-mod.js';
+import { listRegisteredTools } from '../src/mcp-tools/server.js';
+import { runPollLoop } from '../src/poll-loop.js';
+import { ClaudeProvider } from '../src/providers/claude.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, QueryInput } from '../src/providers/types.js';
+
+interface PreviewSpec {
+  inboundDbPath: string;
+  outboundDbPath: string;
+  containerConfig: Partial<RunnerConfig>;
+  /** Container paths of /workspace/extra/* mounts — what index.ts would
+   *  discover by scanning that directory in a real container. */
+  additionalDirectories?: string[];
+}
+
+function log(msg: string): void {
+  console.error(`[context-preview-runner] ${msg}`);
+}
+
+/** Copy all rows of `table` between DBs, matching columns by name. */
+function copyTable(src: Database, dst: Database, table: string): number {
+  const exists = src
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(table);
+  if (!exists) return 0;
+  const dstCols = new Set(
+    (dst.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  const rows = src.prepare(`SELECT * FROM ${table}`).all() as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const cols = Object.keys(row).filter((c) => dstCols.has(c));
+    dst
+      .prepare(`INSERT INTO ${table} (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`)
+      .run(...cols.map((c) => row[c] as never));
+  }
+  return rows.length;
+}
+
+/**
+ * Records the QueryInput the poll loop hands the provider, then completes
+ * the turn like a provider would. supportsNativeSlashCommands mirrors the
+ * previewed provider (Claude handles slash commands natively; other
+ * providers get the XML-wrapped form) so command splitting matches.
+ */
+class CapturingProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands: boolean;
+  captured: QueryInput[] = [];
+  onCapture: () => void = () => {};
+
+  constructor(nativeSlashCommands: boolean) {
+    this.supportsNativeSlashCommands = nativeSlashCommands;
+  }
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    this.captured.push(input);
+    const notify = this.onCapture;
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'activity' };
+        // Null text completes the turn without dispatch (and without the
+        // re-wrap nudge); ending the stream lets processQuery return, after
+        // which the abort signal stops the outer loop.
+        yield { type: 'result', text: null };
+        notify();
+      },
+    };
+    return { push: () => {}, end: () => {}, abort: () => {}, events };
+  }
+}
+
+/** JSON-safe copy of the SDK options: functions → descriptive placeholders. */
+function sanitizeSdkOptions(options: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (key === 'hooks' && value && typeof value === 'object') {
+      out.hooks = Object.keys(value);
+    } else if (key === 'mcpServers' && value && typeof value === 'object') {
+      // Per-server env can carry credentials from a live container config —
+      // never print the values.
+      out.mcpServers = Object.fromEntries(
+        Object.entries(value as Record<string, { env?: Record<string, string> }>).map(([name, server]) => [
+          name,
+          {
+            ...server,
+            env: Object.fromEntries(Object.keys(server.env ?? {}).map((k) => [k, '<redacted>'])),
+          },
+        ]),
+      );
+    } else if (key === 'env' && value && typeof value === 'object') {
+      // Env is inherited from the real container process; here it's the
+      // harness env, so render only the keys the provider itself sets.
+      out.env = { CLAUDE_CODE_AUTO_COMPACT_WINDOW: (value as Record<string, unknown>).CLAUDE_CODE_AUTO_COMPACT_WINDOW };
+      out.envNote = 'Remaining env inherited from the container process (TZ + OneCLI proxy vars; see src/container-runner.ts buildContainerArgs).';
+    } else if (typeof value === 'function') {
+      out[key] = '<function>';
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const specPath = process.argv[2];
+  if (!specPath) {
+    console.error('Usage: bun context-preview-runner.ts <spec.json>');
+    process.exit(2);
+  }
+  const spec = JSON.parse(fs.readFileSync(specPath, 'utf8')) as PreviewSpec;
+
+  const raw = spec.containerConfig;
+  const config: RunnerConfig = {
+    provider: raw.provider || 'claude',
+    assistantName: raw.assistantName || '',
+    groupName: raw.groupName || '',
+    agentGroupId: raw.agentGroupId || '',
+    maxMessagesPerPrompt: raw.maxMessagesPerPrompt || 10,
+    mcpServers: raw.mcpServers || {},
+    model: raw.model,
+    effort: raw.effort,
+  };
+  setTestConfig(config);
+
+  // In-memory session DBs seeded from the staged files.
+  const { inbound, outbound } = initTestSessionDb();
+  const stagedInbound = new Database(spec.inboundDbPath, { readonly: true });
+  const stagedOutbound = new Database(spec.outboundDbPath, { readonly: true });
+  const nIn = copyTable(stagedInbound, inbound, 'messages_in');
+  copyTable(stagedInbound, inbound, 'destinations');
+  copyTable(stagedOutbound, outbound, 'session_state');
+  copyTable(stagedOutbound, outbound, 'processing_ack');
+  stagedInbound.close();
+  stagedOutbound.close();
+  log(`Seeded ${nIn} messages_in rows from staged session`);
+
+  // Same assembly as index.ts main(). In the container, index.ts resolves the
+  // MCP server path from its own location under /app/src — render that truth,
+  // not this script's host location.
+  const instructions = buildSystemPromptAddendum(config.assistantName || undefined);
+  const cwd = '/workspace/agent';
+  const mcpServerPath = '/app/src/mcp-tools/index.ts';
+  const mcpServers: RunnerConfig['mcpServers'] = {
+    nanoclaw: { command: 'bun', args: ['run', mcpServerPath], env: {} },
+    ...config.mcpServers,
+  };
+
+  // Drive the real poll loop until the first query is captured. Scenarios
+  // with no wake-eligible rows (e.g. subagent) skip the loop — it would
+  // never query (the accumulate gate holds trigger=0-only batches).
+  const provider = new CapturingProvider(config.provider === 'claude');
+  const hasWakeEligible =
+    (inbound.prepare("SELECT COUNT(*) AS n FROM messages_in WHERE status = 'pending' AND trigger = 1").get() as { n: number }).n > 0;
+  if (hasWakeEligible) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    provider.onCapture = () => controller.abort();
+    await runPollLoop({
+      provider,
+      providerName: config.provider,
+      cwd,
+      systemContext: { instructions },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  }
+
+  const captured = provider.captured[0] ?? null;
+
+  // The exact SDK options ClaudeProvider would run this query with.
+  let sdkOptions: Record<string, unknown> | null = null;
+  if (config.provider === 'claude') {
+    const claude = new ClaudeProvider({
+      assistantName: config.assistantName || undefined,
+      mcpServers,
+      env: { ...process.env },
+      additionalDirectories: spec.additionalDirectories?.length ? spec.additionalDirectories : undefined,
+      model: config.model,
+      effort: config.effort,
+    });
+    sdkOptions = sanitizeSdkOptions(
+      claude.buildQueryOptions({
+        prompt: captured?.prompt ?? '',
+        continuation: captured?.continuation,
+        cwd,
+        systemContext: { instructions },
+      }) as unknown as Record<string, unknown>,
+    );
+  }
+
+  const batch = inbound
+    .prepare('SELECT id, seq, kind, timestamp, status, trigger, on_wake, channel_type, platform_id FROM messages_in ORDER BY seq')
+    .all();
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        captured: captured !== null,
+        prompt: captured?.prompt ?? null,
+        continuation: captured?.continuation ?? null,
+        systemPromptAddendum: instructions,
+        sdkOptions,
+        mcpTools: listRegisteredTools().map((t) => ({ name: t.tool.name, description: t.tool.description })),
+        provider: config.provider,
+        batch,
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[context-preview-runner] Fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+  process.exit(1);
+});

--- a/container/agent-runner/src/config.ts
+++ b/container/agent-runner/src/config.ts
@@ -52,6 +52,11 @@ export function loadConfig(): RunnerConfig {
   return _config;
 }
 
+/** Inject a config directly — for tests and the context-preview harness. */
+export function setTestConfig(config: RunnerConfig): void {
+  _config = config;
+}
+
 /** Get the loaded config. Throws if loadConfig() hasn't been called. */
 export function getConfig(): RunnerConfig {
   if (!_config) throw new Error('Config not loaded — call loadConfig() first');

--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -19,6 +19,8 @@
  */
 import { Database } from 'bun:sqlite';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 const DEFAULT_INBOUND_PATH = '/workspace/inbound.db';
 const DEFAULT_OUTBOUND_PATH = '/workspace/outbound.db';
@@ -183,6 +185,10 @@ export function clearStaleProcessingAcks(): void {
 /** For tests — creates in-memory DBs with the session schemas. */
 export function initTestSessionDb(): { inbound: Database; outbound: Database } {
   _testMode = true;
+  // Redirect the heartbeat out of /workspace — on hosts where that path
+  // exists and is writable (Linux devcontainers, CI), touchHeartbeat would
+  // otherwise write outside the test/preview sandbox.
+  _heartbeatPath = path.join(os.tmpdir(), 'nanoclaw-test-heartbeat');
   _inbound = new Database(':memory:');
   _inbound.exec('PRAGMA foreign_keys = ON');
   _inbound.exec(`

--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
 import { formatMessages, stripInternalTags } from './formatter.js';
-import { TIMEZONE } from './timezone.js';
+import { TIMEZONE, formatLocalTime } from './timezone.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -106,6 +106,14 @@ describe('timestamp formatting', () => {
     insertMessage('m1', 'chat', { sender: 'Alice', text: 'hi' }, { timestamp: '2026-06-15T15:30:00.000Z' });
     const result = formatMessages(getPendingMessages());
     expect(result).toMatch(/(AM|PM)/);
+  });
+});
+
+describe('task timestamps', () => {
+  it('renders task time in the user TZ, same as chat rows', () => {
+    insertMessage('t1', 'task', { prompt: 'do the thing' }, { timestamp: '2026-01-05T12:00:00.000Z' });
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain(`time="${formatLocalTime('2026-01-05T12:00:00.000Z', TIMEZONE)}"`);
   });
 });
 

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -3,7 +3,9 @@
  * `registerTools([...])` call, then starts the MCP server.
  *
  * Adding a new tool module: create the file, call `registerTools([...])`
- * at module scope, and append the import here. No central list.
+ * at module scope, and append the import here AND to
+ * scripts/context-preview-runner.ts (which mirrors this list to render
+ * the tool surface). No central list.
  */
 import './core.js';
 import './interactive.js';

--- a/container/agent-runner/src/mcp-tools/server.ts
+++ b/container/agent-runner/src/mcp-tools/server.ts
@@ -21,6 +21,11 @@ function log(msg: string): void {
 const allTools: McpToolDefinition[] = [];
 const toolMap = new Map<string, McpToolDefinition>();
 
+/** Everything registered so far — read by the context-preview harness. */
+export function listRegisteredTools(): McpToolDefinition[] {
+  return [...allTools];
+}
+
 export function registerTools(tools: McpToolDefinition[]): void {
   for (const t of tools) {
     if (toolMap.has(t.tool.name)) {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -296,7 +296,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
  * passthrough commands are sent raw (no XML wrapping) so the SDK can
  * dispatch them. Otherwise they fall through to standard XML formatting.
  */
-function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommands: boolean): string {
+export function formatMessagesWithCommands(messages: MessageInRow[], nativeSlashCommands: boolean): string {
   const parts: string[] = [];
   const normalBatch: MessageInRow[] = [];
 

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -390,40 +390,48 @@ export class ClaudeProvider implements AgentProvider {
     return reason;
   }
 
+  /**
+   * The exact SDK options a query runs with. Public so the context-preview
+   * tool (scripts/context-preview.ts) can render the agent-visible
+   * configuration without spawning the SDK subprocess.
+   */
+  buildQueryOptions(input: QueryInput): NonNullable<Parameters<typeof sdkQuery>[0]['options']> {
+    const instructions = input.systemContext?.instructions;
+    return {
+      cwd: input.cwd,
+      additionalDirectories: this.additionalDirectories,
+      resume: input.continuation,
+      pathToClaudeCodeExecutable: '/pnpm/claude',
+      systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
+      allowedTools: [
+        ...TOOL_ALLOWLIST,
+        ...Object.keys(this.mcpServers).map(mcpAllowPattern),
+      ],
+      disallowedTools: SDK_DISALLOWED_TOOLS,
+      env: this.env,
+      model: this.model,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      effort: this.effort as any,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user', 'local'],
+      mcpServers: this.mcpServers,
+      hooks: {
+        PreToolUse: [{ hooks: [preToolUseHook] }],
+        PostToolUse: [{ hooks: [postToolUseHook] }],
+        PostToolUseFailure: [{ hooks: [postToolUseHook] }],
+        PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+      },
+    };
+  }
+
   query(input: QueryInput): AgentQuery {
     const stream = new MessageStream();
     stream.push(input.prompt);
 
-    const instructions = input.systemContext?.instructions;
-
     const sdkResult = sdkQuery({
       prompt: stream,
-      options: {
-        cwd: input.cwd,
-        additionalDirectories: this.additionalDirectories,
-        resume: input.continuation,
-        pathToClaudeCodeExecutable: '/pnpm/claude',
-        systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
-        allowedTools: [
-          ...TOOL_ALLOWLIST,
-          ...Object.keys(this.mcpServers).map(mcpAllowPattern),
-        ],
-        disallowedTools: SDK_DISALLOWED_TOOLS,
-        env: this.env,
-        model: this.model,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        effort: this.effort as any,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
-        settingSources: ['project', 'user', 'local'],
-        mcpServers: this.mcpServers,
-        hooks: {
-          PreToolUse: [{ hooks: [preToolUseHook] }],
-          PostToolUse: [{ hooks: [postToolUseHook] }],
-          PostToolUseFailure: [{ hooks: [postToolUseHook] }],
-          PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
-        },
-      },
+      options: this.buildQueryOptions(input),
     });
 
     let aborted = false;

--- a/docs/context-preview.md
+++ b/docs/context-preview.md
@@ -1,0 +1,119 @@
+# Context Preview
+
+`scripts/context-preview.ts` renders the **exact context an agent sees** for a
+given scenario — the composed CLAUDE.md with every `@`-import expanded, the
+runtime system-prompt addendum, the SDK options, the MCP tool surface, the
+container mount table, and the exact prompt string the poll loop hands the
+provider.
+
+```bash
+pnpm exec tsx scripts/context-preview.ts <scenario> [flags]
+```
+
+Use it to answer questions like *"when a scheduled task fires, does the agent
+have enough context to know it must address the user explicitly?"* or *"what
+exactly changes in the agent's context when I edit
+`container/CLAUDE.md` / a skill's `instructions.md` / the formatter?"* —
+without spawning a container or sending a real message.
+
+## Fidelity model
+
+The tool **imports the production code paths instead of duplicating strings**,
+so any edit to the composer, formatter, addendum builder, instructions files,
+or SDK options is reflected on the next run:
+
+- Host half (Node/tsx): runs the real scaffold + spawn steps —
+  `initGroupFilesystem` (the once-per-lifetime creation scaffold), then
+  `materializeContainerJson` and `buildMounts` (which calls
+  `syncSkillSymlinks` + `composeGroupClaudeMd`) — in a throwaway sandbox with
+  an in-memory central DB. Scenario messages are staged with the same writers the host uses
+  (`writeSessionMessage`, `insertTaskRow`, `taskPromptWithLog`,
+  `writeDestinations`, `writeSessionRouting`). **Nothing in the live install
+  is read-write touched**; `--group` opens `data/v2.db` read-only.
+- Container half (Bun): `container/agent-runner/scripts/context-preview-runner.ts`
+  seeds the in-memory test session DBs with the staged rows and drives the
+  **real `runPollLoop`** with a capturing provider — batching,
+  `on_wake` first-poll gating, and the accumulate gate are all production
+  behavior. Slash-command splitting follows the previewed provider's
+  native-slash-commands capability (native for Claude; XML-wrapped
+  otherwise). SDK options come from
+  `ClaudeProvider.buildQueryOptions()`; the addendum from
+  `buildSystemPromptAddendum()`; the tool list from the registered
+  `McpToolDefinition`s.
+
+The `@`-import expansion resolves each fragment symlink through the actual
+mount table returned by `buildMounts`, i.e. the same container-path → host-path
+mapping the real spawn uses.
+
+## Scenarios
+
+| Scenario | What it stages |
+|----------|----------------|
+| `first-message` | Fresh session, first user chat message (default) |
+| `followup` | Existing session: prior completed turn + stored continuation → SDK `resume` |
+| `accumulate` | Group chat: three `trigger=0` context-only rows riding in with a `trigger=1` mention |
+| `task-fire` | A due task row exactly as `ncl tasks create` writes it (isolated task session, run-log directive appended) |
+| `on-wake` | The `on_wake=1` restart message `ncl groups restart --message` / self-mod apply writes |
+| `a2a` | A message from another agent group, as `performAgentRoute` writes it (verbatim `{text}`, `source_session_id` return path) |
+| `subagent` | No messages — explains SDK-native subagents (Task tool) and points at the surfaces that enable them |
+
+## Flags
+
+| Flag | Meaning |
+|------|---------|
+| `--group <folder\|id>` | Preview a **real agent group**: its container config, cli_scope, persona, CLAUDE.local.md, template skills, and destinations are snapshotted (read-only) from `data/v2.db` and `groups/<folder>/`. Default is a synthetic group named `preview`. |
+| `--message <text>` | Override the staged message/task/wake text |
+| `--sender <name>` / `--channel <type>` | Sender display name and channel type for chat scenarios |
+| `--section <name>` | Print one section: `scenario`, `environment`, `claude-md`, `system-prompt`, `sdk-options`, `mcp-tools`, `prompt`, `notes` |
+| `--json` | Machine-readable dump of everything |
+| `--keep` | Keep the sandbox dir for inspection (path printed to stderr) |
+
+## What is NOT simulated
+
+The preview starts at the session inbound.db — everything upstream of it and
+some side flows are out of scope. When reasoning about those, read the real
+paths:
+
+- **Router-side gating** — engage-mode evaluation (mention/pattern),
+  `unknown_sender_policy`, command gating (`/help` filtering, admin denial),
+  and channel-registration escalation happen before a row is ever written
+  (`src/router.ts`, `src/command-gate.ts`). The preview stages rows as if they
+  passed.
+- **Content enrichment by real adapters** — the chat-sdk bridge writes the
+  full message serialization (author, replyTo, attachments) into `content`
+  (`src/channels/chat-sdk-bridge.ts` `messageToInbound`); the preview stages
+  the minimal `{text, sender, senderId}` shape.
+- **Attachment staging** — base64 → `inbox/<msgId>/<file>` extraction and
+  safety renames (`src/session-manager.ts` `extractAttachmentFiles`).
+- **Approval flows** — approval-outcome notifications
+  (`src/modules/approvals/`), the a2a message gate, and the `ncl` cli_request
+  round-trip all inject further context into sessions.
+- **Task pre-scripts** — a task's `script` runs before the wake and injects
+  `scriptOutput` into the `<task>` block
+  (`container/agent-runner/src/scheduling/task-script.ts`).
+- **Real container env** — OneCLI proxy vars, egress lockdown, and image
+  contents; the SDK-options `env` is rendered as the provider-set keys plus a
+  note.
+- **Non-default providers** — the SDK options section is Claude-specific;
+  providers that own their agent surfaces (e.g. Codex on the `providers`
+  branch) skip the composed-CLAUDE.md path entirely.
+
+## Maintenance seams
+
+These production exports exist specifically so no agent-visible string is
+duplicated. If you rename or restructure them, update both halves:
+
+- `ClaudeProvider.buildQueryOptions()` (`container/agent-runner/src/providers/claude.ts`)
+- `formatMessagesWithCommands` (`container/agent-runner/src/poll-loop.ts`)
+- `taskPromptWithLog` (`src/cli/resources/tasks.ts`)
+- `listRegisteredTools` (`container/agent-runner/src/mcp-tools/server.ts`)
+- `setTestConfig` (`container/agent-runner/src/config.ts`)
+- `initTestSessionDb` (`container/agent-runner/src/db/connection.ts`)
+
+Two pieces of wiring are mirrored (not imported) by the Bun harness and must
+be kept in sync by hand:
+
+- the tool-module import list from `container/agent-runner/src/mcp-tools/index.ts`
+  (that file's header points back here)
+- the `mcpServers`/`cwd` assembly from `container/agent-runner/src/index.ts`
+  `main()`

--- a/scripts/context-preview.ts
+++ b/scripts/context-preview.ts
@@ -1,0 +1,712 @@
+/**
+ * scripts/context-preview.ts — render the exact context an agent sees.
+ *
+ * For maintainers: simulates a scenario (first message, scheduled task fire,
+ * restart wake, agent-to-agent message, …) and prints every context surface
+ * the agent would receive — the composed CLAUDE.md (imports expanded), the
+ * runtime system-prompt addendum, the SDK options, the MCP tool list, and
+ * the exact prompt string — using the REAL production code paths, so edits
+ * to CLAUDE.md sources, the formatter, the composer, etc. are reflected
+ * immediately. Nothing is duplicated and nothing in the live install is
+ * touched: the whole run happens in a throwaway sandbox with an in-memory
+ * central DB, and the container half runs the real poll loop under Bun
+ * (container/agent-runner/scripts/context-preview-runner.ts).
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/context-preview.ts <scenario> [flags]
+ *
+ * Scenarios:
+ *   first-message   Fresh session, first user message         (default)
+ *   followup        Existing session (continuation on file), next message
+ *   accumulate      Group chat: silent trigger=0 rows ride in with a mention
+ *   task-fire       A scheduled task (`ncl tasks create`) comes due
+ *   on-wake         Container restart with an on_wake message
+ *   a2a             Message arriving from another agent group
+ *   subagent        What SDK-native subagents (Task tool) inherit
+ *
+ * Flags:
+ *   --group <folder|id>   Use a real agent group from data/v2.db (read-only
+ *                         snapshot of its config, persona, memory, destinations).
+ *                         Default: a synthetic group named "preview".
+ *   --message <text>      User/task/wake message text.
+ *   --sender <name>       Sender display name (default "Dana").
+ *   --channel <type>      Channel type for the messaging group (default "whatsapp").
+ *   --section <name>      Print one section: scenario|environment|claude-md|
+ *                         system-prompt|sdk-options|mcp-tools|prompt|notes
+ *   --json                Machine-readable output of everything.
+ *   --keep                Keep the sandbox dir (path printed) for inspection.
+ */
+import Database from 'better-sqlite3';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import type { AgentGroup, ContainerConfigRow, Session } from '../src/types.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const SCENARIOS = ['first-message', 'followup', 'accumulate', 'task-fire', 'on-wake', 'a2a', 'subagent'] as const;
+type Scenario = (typeof SCENARIOS)[number];
+
+interface Args {
+  scenario: Scenario;
+  group?: string;
+  message?: string;
+  sender: string;
+  channel: string;
+  section?: string;
+  json: boolean;
+  keep: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { scenario: 'first-message', sender: 'Dana', channel: 'whatsapp', json: false, keep: false };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = true;
+    else if (a === '--keep') args.keep = true;
+    else if (a === '--group') args.group = argv[++i];
+    else if (a === '--message') args.message = argv[++i];
+    else if (a === '--sender') args.sender = argv[++i];
+    else if (a === '--channel') args.channel = argv[++i];
+    else if (a === '--section') args.section = argv[++i];
+    else if (a.startsWith('--')) fail(`Unknown flag: ${a}`);
+    else positional.push(a);
+  }
+  const SECTIONS = ['scenario', 'environment', 'claude-md', 'system-prompt', 'sdk-options', 'mcp-tools', 'prompt', 'notes'];
+  if (args.section && !SECTIONS.includes(args.section)) {
+    fail(`Unknown section "${args.section}". Sections: ${SECTIONS.join(', ')}`);
+  }
+  if (positional.length > 1) fail(`Expected one scenario, got: ${positional.join(' ')}`);
+  if (positional[0]) {
+    if (!SCENARIOS.includes(positional[0] as Scenario)) {
+      fail(`Unknown scenario "${positional[0]}". Scenarios: ${SCENARIOS.join(', ')}`);
+    }
+    args.scenario = positional[0] as Scenario;
+  }
+  return args;
+}
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(2);
+}
+
+/** Snapshot of a real group read from the live central DB (read-only). */
+interface LiveGroup {
+  group: AgentGroup;
+  configRow: ContainerConfigRow | null;
+  destinations: Array<Record<string, unknown>>;
+  messagingGroups: Array<Record<string, unknown>>;
+  /** Agent groups referenced by agent-type destinations — writeDestinations
+   *  silently drops a destination whose target group row is missing. */
+  targetAgentGroups: Array<Record<string, unknown>>;
+}
+
+function snapshotLiveGroup(ref: string): LiveGroup {
+  const dbPath = path.join(REPO_ROOT, 'data', 'v2.db');
+  if (!fs.existsSync(dbPath)) fail(`--group requires a live install (${dbPath} not found)`);
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const group = db
+      .prepare('SELECT * FROM agent_groups WHERE folder = ? OR id = ?')
+      .get(ref, ref) as AgentGroup | undefined;
+    if (!group) {
+      const known = (db.prepare('SELECT folder FROM agent_groups').all() as Array<{ folder: string }>)
+        .map((r) => r.folder)
+        .join(', ');
+      fail(`Agent group "${ref}" not found. Known folders: ${known || '(none)'}`);
+    }
+    const configRow = db
+      .prepare('SELECT * FROM container_configs WHERE agent_group_id = ?')
+      .get(group.id) as ContainerConfigRow | undefined;
+    const hasDest = db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='agent_destinations'")
+      .get();
+    const destinations = hasDest
+      ? (db.prepare('SELECT * FROM agent_destinations WHERE agent_group_id = ?').all(group.id) as Array<
+          Record<string, unknown>
+        >)
+      : [];
+    // Messaging groups referenced by channel destinations (for routing rows).
+    const mgIds = destinations.filter((d) => d.target_type === 'channel').map((d) => d.target_id as string);
+    const messagingGroups = mgIds.length
+      ? (db
+          .prepare(`SELECT * FROM messaging_groups WHERE id IN (${mgIds.map(() => '?').join(',')})`)
+          .all(...mgIds) as Array<Record<string, unknown>>)
+      : [];
+    const agIds = destinations.filter((d) => d.target_type === 'agent').map((d) => d.target_id as string);
+    const targetAgentGroups = agIds.length
+      ? (db
+          .prepare(`SELECT * FROM agent_groups WHERE id IN (${agIds.map(() => '?').join(',')})`)
+          .all(...agIds) as Array<Record<string, unknown>>)
+      : [];
+    return { group, configRow: configRow ?? null, destinations, messagingGroups, targetAgentGroups };
+  } finally {
+    db.close();
+  }
+}
+
+/** Insert a raw row into the in-memory DB, keeping only columns that exist. */
+function insertRaw(db: Database.Database, table: string, row: Record<string, unknown>): void {
+  const cols = new Set(
+    (db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>).map((c) => c.name),
+  );
+  const keys = Object.keys(row).filter((k) => cols.has(k));
+  db.prepare(`INSERT OR REPLACE INTO ${table} (${keys.join(', ')}) VALUES (${keys.map((k) => `@${k}`).join(', ')})`).run(
+    Object.fromEntries(keys.map((k) => [k, row[k]])),
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Keep stdout clean for the rendered preview — src/log.ts logs info to
+  // stdout. Must be set before the first src import evaluates the threshold.
+  if (!process.env.LOG_LEVEL) process.env.LOG_LEVEL = 'warn';
+
+  // Live-group snapshot must be read BEFORE chdir (relative to real repo).
+  const live = args.group ? snapshotLiveGroup(args.group) : null;
+
+  // ── Sandbox ──
+  // GROUPS_DIR / DATA_DIR resolve from process.cwd() at src/config.js import
+  // time, and the composer discovers fragments under cwd/container/. Chdir
+  // into a throwaway root (with container/ symlinked back to the repo) before
+  // importing any src module, so every host-side write lands in the sandbox.
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'ncl-context-preview-'));
+  fs.mkdirSync(path.join(sandbox, 'groups'));
+  fs.mkdirSync(path.join(sandbox, 'data'));
+  fs.symlinkSync(path.join(REPO_ROOT, 'container'), path.join(sandbox, 'container'));
+  // Carry over only the non-secret .env keys the preview actually renders
+  // (identity + timezone). Never copy the whole file — the sandbox lives in
+  // tmp and credentials (ONECLI_API_KEY etc.) must not leave the repo.
+  const ENV_WHITELIST = new Set(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER', 'TZ']);
+  const liveEnvFile = path.join(REPO_ROOT, '.env');
+  if (fs.existsSync(liveEnvFile)) {
+    const kept = fs
+      .readFileSync(liveEnvFile, 'utf8')
+      .split('\n')
+      .filter((line) => ENV_WHITELIST.has(line.split('=')[0]?.trim()));
+    fs.writeFileSync(path.join(sandbox, '.env'), kept.join('\n') + '\n');
+  }
+  process.chdir(sandbox);
+
+  const cleanup = () => {
+    if (args.keep) {
+      console.error(`Sandbox kept: ${sandbox}`);
+    } else {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  };
+
+  try {
+    // Host modules — imported only now, with cwd = sandbox.
+    const dbMod = await import('../src/db/index.js');
+    const sessionManager = await import('../src/session-manager.js');
+    const sessionDb = await import('../src/db/session-db.js');
+    const groupInit = await import('../src/group-init.js');
+    const containerConfigMod = await import('../src/container-config.js');
+    const containerRunner = await import('../src/container-runner.js');
+    const schedulingDb = await import('../src/modules/scheduling/db.js');
+    const tasksResource = await import('../src/cli/resources/tasks.js');
+    const writeDestMod = await import('../src/modules/agent-to-agent/write-destinations.js');
+    const configMod = await import('../src/config.js');
+
+    const central = dbMod.initTestDb();
+    dbMod.runMigrations(central);
+
+    // ── Seed the agent group ──
+    let group: AgentGroup;
+    if (live) {
+      group = live.group;
+      insertRaw(central, 'agent_groups', group as unknown as Record<string, unknown>);
+      if (live.configRow) insertRaw(central, 'container_configs', live.configRow as unknown as Record<string, unknown>);
+      for (const mg of live.messagingGroups) insertRaw(central, 'messaging_groups', mg);
+      for (const ag of live.targetAgentGroups) insertRaw(central, 'agent_groups', ag);
+      for (const d of live.destinations) insertRaw(central, 'agent_destinations', d);
+      // Copy the group's real files (persona, memory, template extras) so the
+      // composed doc and CLAUDE.local.md match the install. The composed
+      // CLAUDE.md/.claude-fragments get regenerated in the sandbox anyway.
+      const liveGroupDir = path.join(REPO_ROOT, 'groups', group.folder);
+      if (fs.existsSync(liveGroupDir)) {
+        fs.cpSync(liveGroupDir, path.join(sandbox, 'groups', group.folder), { recursive: true });
+      }
+      // Per-group real skill dirs + settings live under data/v2-sessions/<id>/.claude-shared.
+      const liveClaudeShared = path.join(REPO_ROOT, 'data', 'v2-sessions', group.id, '.claude-shared');
+      if (fs.existsSync(liveClaudeShared)) {
+        fs.cpSync(liveClaudeShared, path.join(sandbox, 'data', 'v2-sessions', group.id, '.claude-shared'), {
+          recursive: true,
+        });
+      }
+    } else {
+      group = {
+        id: 'preview-group',
+        name: 'preview',
+        folder: 'preview',
+        agent_provider: null,
+        created_at: new Date().toISOString(),
+      };
+      dbMod.createAgentGroup(group);
+    }
+
+    // Messaging group for chat scenarios (synthetic mode, or when the live
+    // group has no channel destination to reuse).
+    const liveMg = live?.messagingGroups[0] as { id?: string; channel_type?: string; platform_id?: string } | undefined;
+    let mgId: string;
+    let mgChannel: string;
+    let mgPlatformId: string;
+    if (liveMg?.id) {
+      mgId = liveMg.id;
+      mgChannel = liveMg.channel_type as string;
+      mgPlatformId = liveMg.platform_id as string;
+    } else {
+      mgId = 'preview-mg';
+      mgChannel = args.channel;
+      mgPlatformId = args.scenario === 'accumulate' ? 'preview-group-chat' : 'preview-dm';
+      dbMod.createMessagingGroup({
+        id: mgId,
+        channel_type: mgChannel,
+        platform_id: mgPlatformId,
+        name: args.scenario === 'accumulate' ? 'Preview Group Chat' : 'Preview DM',
+        is_group: args.scenario === 'accumulate' ? 1 : 0,
+        unknown_sender_policy: 'strict',
+        created_at: new Date().toISOString(),
+      });
+      // Destination row so the addendum + originAttr resolve a name for the
+      // channel — mirrors what /init-first-agent and /manage-channels create.
+      insertRaw(central, 'agent_destinations', {
+        agent_group_id: group.id,
+        local_name: `${mgChannel}-main`,
+        target_type: 'channel',
+        target_id: mgId,
+        created_at: new Date().toISOString(),
+      });
+    }
+
+    // ── Filesystem scaffold ──
+    // initGroupFilesystem is the once-per-lifetime creation scaffold (also run
+    // defensively at spawn); materializeContainerJson + buildMounts below are
+    // the per-spawn steps. Pass the provider so surfaces-owning providers skip
+    // the CLAUDE.local.md scaffold exactly as production does (group-init.ts).
+    groupInit.initGroupFilesystem(group, { provider: live?.configRow?.provider ?? null });
+    const containerConfig = containerConfigMod.materializeContainerJson(group.id);
+    const runnerProvider = (containerConfig.provider || 'claude').toLowerCase();
+
+    // ── Session + scenario staging ──
+    const senderId = `${mgChannel}:15551230000`;
+    const text = args.message ?? defaultMessage(args.scenario);
+    let session: Session;
+    const notes: string[] = [];
+
+    if (args.scenario === 'task-fire') {
+      session = sessionManager.resolveTaskSession(group.id, 'preview-task').session;
+    } else {
+      session = sessionManager.resolveSession(group.id, mgId, null, 'shared').session;
+    }
+
+    const chatContent = (t: string, sender: string, sid: string) => JSON.stringify({ text: t, sender, senderId: sid });
+    const now = () => new Date().toISOString();
+
+    switch (args.scenario) {
+      case 'first-message':
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-1', kind: 'chat', timestamp: now(),
+          platformId: mgPlatformId, channelType: mgChannel, threadId: null,
+          content: chatContent(text, args.sender, senderId),
+          processAfter: null, recurrence: null,
+        });
+        notes.push(
+          'Fresh session: no continuation in session_state, so the SDK starts a new conversation (no `resume`).',
+          'Content shape here is the minimal {text, sender, senderId} that e.g. the CLI channel writes; real adapters write richer content — the chat-sdk bridge adds author/replyTo/attachments (src/channels/chat-sdk-bridge.ts messageToInbound), and native adapters (WhatsApp, Signal, …) populate equivalent fields directly.',
+        );
+        break;
+      case 'followup': {
+        // A prior completed turn + a stored continuation → the SDK resumes.
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-prior', kind: 'chat', timestamp: now(),
+          platformId: mgPlatformId, channelType: mgChannel, threadId: null,
+          content: chatContent('An earlier message, already handled.', args.sender, senderId),
+          processAfter: null, recurrence: null,
+        });
+        const inb = sessionDb.openInboundDb(sessionManager.inboundDbPath(group.id, session.id));
+        inb.prepare("UPDATE messages_in SET status = 'completed' WHERE id = 'preview-prior'").run();
+        inb.close();
+        // Keyed per provider — the poll loop looks up continuation:<provider
+        // from container.json> (container/agent-runner/src/db/session-state.ts).
+        const outb = sessionDb.openOutboundDbRw(sessionManager.outboundDbPath(group.id, session.id));
+        outb
+          .prepare('INSERT OR REPLACE INTO session_state (key, value, updated_at) VALUES (?, ?, ?)')
+          .run(`continuation:${runnerProvider}`, 'preview-continuation-id', now());
+        outb.close();
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-2', kind: 'chat', timestamp: now(),
+          platformId: mgPlatformId, channelType: mgChannel, threadId: null,
+          content: chatContent(text, args.sender, senderId),
+          processAfter: null, recurrence: null,
+        });
+        notes.push(
+          'The stored continuation (outbound.db session_state, key continuation:claude) becomes the SDK `resume` option — the agent keeps its full prior conversation.',
+          'A message arriving while the container is mid-turn takes a different path: it is pushed into the open query via formatMessages (its own <context> header), not a new query. See container/agent-runner/src/poll-loop.ts processQuery.',
+        );
+        break;
+      }
+      case 'accumulate':
+        for (let i = 1; i <= 3; i++) {
+          sessionManager.writeSessionMessage(group.id, session.id, {
+            id: `preview-acc-${i}`, kind: 'chat', timestamp: now(),
+            platformId: mgPlatformId, channelType: mgChannel, threadId: null,
+            content: chatContent(`Group chatter #${i} the agent was not mentioned in.`, `Member ${i}`, `${mgChannel}:1555999000${i}`),
+            processAfter: null, recurrence: null,
+            trigger: 0,
+          });
+        }
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-mention', kind: 'chat', timestamp: now(),
+          platformId: mgPlatformId, channelType: mgChannel, threadId: null,
+          content: chatContent(text, args.sender, senderId),
+          processAfter: null, recurrence: null,
+        });
+        notes.push(
+          'trigger=0 rows are stored by the router under ignored_message_policy=accumulate (engage_mode mention/pattern) and do NOT wake the agent; when the trigger=1 mention lands, the most recent rows ride into the same prompt as ordinary <message> blocks — the batch cap (maxMessagesPerPrompt, mention included) bounds the total, and older accumulated rows fall out of the window. See src/router.ts + container/agent-runner/src/db/messages-in.ts.',
+        );
+        break;
+      case 'task-fire': {
+        const inb = sessionDb.openInboundDb(sessionManager.inboundDbPath(group.id, session.id));
+        schedulingDb.insertTaskRow(inb, {
+          id: 'preview-task', seriesId: 'preview-task',
+          processAfter: null, recurrence: null,
+          content: JSON.stringify({
+            prompt: tasksResource.taskPromptWithLog(text, 'preview-task'),
+            script: null,
+            originSessionId: null,
+          }),
+        });
+        inb.close();
+        notes.push(
+          'Tasks run in an isolated per-series session (thread system:tasks:<seriesId>, no messaging group) — the destinations addendum is the ONLY way a task run can reach the user, which is why the appended run-log directive insists on explicit <message to>.',
+          'Tasks with a `script` run it BEFORE the agent wakes and inject scriptOutput into the <task> block (container/agent-runner/src/scheduling/task-script.ts); not staged here.',
+        );
+        break;
+      }
+      case 'on-wake':
+        // Exact payload restartAgentGroupContainers writes (src/container-restart.ts).
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-wake', kind: 'chat', timestamp: now(),
+          platformId: group.id, channelType: 'agent', threadId: null,
+          content: JSON.stringify({ text, sender: 'system', senderId: 'system' }),
+          processAfter: null, recurrence: null,
+          onWake: 1,
+        });
+        notes.push(
+          'on_wake=1 rows are only visible to a fresh container\'s FIRST poll (container/agent-runner/src/db/messages-in.ts) — a dying container in its SIGTERM grace period can never steal them.',
+          'Used by ncl groups restart --message and the self-mod apply flow (src/modules/self-mod/apply.ts).',
+        );
+        break;
+      case 'a2a': {
+        // A message from another agent group, as performAgentRoute writes it
+        // (src/modules/agent-to-agent/agent-route.ts): content is the source's
+        // verbatim {text}, channel_type='agent', platform_id=<source group id>.
+        const parent: AgentGroup = {
+          id: 'preview-parent', name: 'parent-agent', folder: 'preview-parent',
+          agent_provider: null, created_at: now(),
+        };
+        dbMod.createAgentGroup(parent);
+        insertRaw(central, 'agent_destinations', {
+          agent_group_id: group.id, local_name: 'parent-agent',
+          target_type: 'agent', target_id: parent.id, created_at: now(),
+        });
+        sessionManager.writeSessionMessage(group.id, session.id, {
+          id: 'preview-a2a', kind: 'chat', timestamp: now(),
+          platformId: parent.id, channelType: 'agent', threadId: null,
+          content: JSON.stringify({ text }),
+          processAfter: null, recurrence: null,
+          sourceSessionId: 'sess-parent-origin',
+        });
+        notes.push(
+          'A2A content carries no sender field, so the block renders sender="Unknown" with from=<the local destination name for the source agent>. source_session_id is the return path for replies.',
+          'If a message policy exists for this edge, the send is held for approval by the policy\'s approver first (routeAgentMessage in src/modules/agent-to-agent/agent-route.ts; message-gate.ts is the approve-side handler) — not simulated here.',
+        );
+        break;
+      }
+      case 'subagent':
+        notes.push(
+          'SDK-native subagents (Task tool / agent teams) run INSIDE the same container and the same provider query — there is no new NanoClaw session. They are enabled by CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in the per-group settings.json (see ENVIRONMENT section) and by Task/TaskOutput/TaskStop/TeamCreate/TeamDelete/SendMessage in the SDK allowedTools (see SDK OPTIONS).',
+          'A subagent gets the same project doc (cwd /workspace/agent → composed CLAUDE.md + CLAUDE.local.md), the same tools and MCP servers, but NOT the parent\'s conversation history — only the prompt the parent passes to Task.',
+          'The other "agent spawns an agent" mechanism is create_agent (mcp__nanoclaw__create_agent): a full new agent group with its own container, workspace, and composed context — preview that with: context-preview first-message.',
+        );
+        break;
+    }
+
+    // ── Destinations + routing into inbound.db (same as every wake) ──
+    sessionManager.writeSessionRouting(group.id, session.id);
+    writeDestMod.writeDestinations(group.id, session.id);
+
+    // ── Mounts (side effects: skill symlink sync + CLAUDE.md composition) ──
+    const provider = containerRunner.resolveProviderName(session.agent_provider, containerConfig.provider);
+    const mounts = containerRunner.buildMounts(group, session, containerConfig, provider, {});
+
+    // ── Container half: real poll loop under Bun ──
+    const spec = {
+      inboundDbPath: sessionManager.inboundDbPath(group.id, session.id),
+      outboundDbPath: sessionManager.outboundDbPath(group.id, session.id),
+      containerConfig: JSON.parse(
+        fs.readFileSync(path.join(sandbox, 'groups', group.folder, 'container.json'), 'utf8'),
+      ),
+      // index.ts discovers these by scanning /workspace/extra/* — derive the
+      // same set from the mount table so the SDK options match a real spawn.
+      additionalDirectories: mounts
+        .map((m) => m.containerPath)
+        .filter((p) => p.startsWith('/workspace/extra/')),
+    };
+    const specPath = path.join(sandbox, 'preview-spec.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    let runner: {
+      captured: boolean;
+      prompt: string | null;
+      continuation: string | null;
+      systemPromptAddendum: string;
+      sdkOptions: Record<string, unknown> | null;
+      mcpTools: Array<{ name: string; description?: string }>;
+      provider: string;
+      batch: Array<Record<string, unknown>>;
+    };
+    try {
+      // Strip host-shell CLAUDE_* overrides — a real container's env is only
+      // TZ + OneCLI vars (src/container-runner.ts buildContainerArgs), so e.g.
+      // an exported CLAUDE_CODE_AUTO_COMPACT_WINDOW must not leak into the
+      // rendered options.
+      const bunEnv: Record<string, string | undefined> = { ...process.env, TZ: configMod.TIMEZONE };
+      for (const key of Object.keys(bunEnv)) {
+        if (key.startsWith('CLAUDE_')) delete bunEnv[key];
+      }
+      const out = execFileSync('bun', [path.join(REPO_ROOT, 'container', 'agent-runner', 'scripts', 'context-preview-runner.ts'), specPath], {
+        env: bunEnv,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      runner = JSON.parse(out);
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string; code?: string };
+      // Throw (not fail/exit) so the finally-cleanup removes the sandbox.
+      if (e.code === 'ENOENT') throw new Error('bun not found on PATH — the container half of the preview runs under Bun.');
+      throw new Error(`context-preview-runner failed:\n${e.stderr || e.message}`);
+    }
+
+    // ── Read back the composed surfaces ──
+    const groupDir = path.join(sandbox, 'groups', group.folder);
+    const containerToHost = mounts
+      .map((m) => ({ containerPath: m.containerPath, hostPath: m.hostPath }))
+      .sort((a, b) => b.containerPath.length - a.containerPath.length);
+    const resolveContainerPath = (p: string): string | null => {
+      for (const m of containerToHost) {
+        if (p === m.containerPath || p.startsWith(m.containerPath + '/')) {
+          return path.join(m.hostPath, p.slice(m.containerPath.length));
+        }
+      }
+      return null;
+    };
+
+    const composedEntry = fs.readFileSync(path.join(groupDir, 'CLAUDE.md'), 'utf8');
+    const claudeMdParts: Array<{ import: string; source: string; content: string }> = [];
+    for (const line of composedEntry.split('\n')) {
+      if (!line.startsWith('@')) continue;
+      const rel = line.slice(1);
+      const abs = path.resolve(groupDir, rel);
+      let hostFile = abs;
+      let sourceLabel = rel;
+      const lst = fs.lstatSync(abs, { throwIfNoEntry: false });
+      if (lst?.isSymbolicLink()) {
+        const target = fs.readlinkSync(abs); // container path (dangling on host)
+        const mapped = resolveContainerPath(target);
+        if (!mapped) {
+          claudeMdParts.push({ import: line, source: `${target} (unresolvable — no mount)`, content: '' });
+          continue;
+        }
+        hostFile = mapped;
+        // Realpath through the sandbox's container/ symlink so the label
+        // points at the repo file the content actually comes from.
+        const real = fs.existsSync(mapped) ? fs.realpathSync(mapped) : mapped;
+        sourceLabel = `${target} → ${path.relative(REPO_ROOT, real)}`;
+      }
+      claudeMdParts.push({
+        import: line,
+        source: sourceLabel,
+        content: fs.existsSync(hostFile) ? fs.readFileSync(hostFile, 'utf8') : '(missing)',
+      });
+    }
+    const claudeLocal = fs.existsSync(path.join(groupDir, 'CLAUDE.local.md'))
+      ? fs.readFileSync(path.join(groupDir, 'CLAUDE.local.md'), 'utf8')
+      : '';
+
+    const claudeSharedDir = path.join(sandbox, 'data', 'v2-sessions', group.id, '.claude-shared');
+    const settingsJson = fs.existsSync(path.join(claudeSharedDir, 'settings.json'))
+      ? fs.readFileSync(path.join(claudeSharedDir, 'settings.json'), 'utf8')
+      : '(none)';
+    const skillsDir = path.join(claudeSharedDir, 'skills');
+    const skills: string[] = [];
+    if (fs.existsSync(skillsDir)) {
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (entry.isSymbolicLink()) {
+          skills.push(`${entry.name} → ${fs.readlinkSync(path.join(skillsDir, entry.name))}`);
+        } else {
+          skills.push(`${entry.name} (group-private dir, template-stamped)`);
+        }
+      }
+    }
+
+    const result = {
+      scenario: args.scenario,
+      group: { id: group.id, name: group.name, folder: group.folder, provider, source: live ? 'live' : 'synthetic' },
+      session: { id: session.id, thread_id: session.thread_id, messaging_group_id: session.messaging_group_id },
+      batch: runner.batch,
+      mounts,
+      settingsJson,
+      skills,
+      claudeMd: { entry: composedEntry, parts: claudeMdParts, local: claudeLocal },
+      systemPrompt: {
+        base: "Claude Code preset ({ type: 'preset', preset: 'claude_code' }) — the SDK's built-in system prompt",
+        append: runner.systemPromptAddendum,
+      },
+      sdkOptions: runner.sdkOptions,
+      mcpTools: runner.mcpTools,
+      continuation: runner.continuation,
+      prompt: runner.prompt,
+      notes,
+    };
+
+    if (args.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      render(result, args.section);
+    }
+  } finally {
+    cleanup();
+  }
+}
+
+function defaultMessage(scenario: Scenario): string {
+  switch (scenario) {
+    case 'followup': return 'And one more thing — can you also check the weather for tomorrow?';
+    case 'accumulate': return '@preview can you summarize what everyone just said?';
+    case 'task-fire': return 'Check the team calendar and flag any conflicts for today.';
+    case 'on-wake': return 'Your install_packages request was applied. Verify that `jq --version` works and report the result to the user.';
+    case 'a2a': return 'Parent agent here — please compile the weekly metrics and send them back to me.';
+    default: return 'Hey, can you help me plan a birthday dinner for Saturday?';
+  }
+}
+
+// ── Rendering ──
+
+const HR = '─'.repeat(78);
+
+function heading(title: string, provenance: string): string {
+  return `\n${HR}\n  ${title}\n  ${provenance}\n${HR}`;
+}
+
+function render(r: {
+  scenario: string;
+  group: { id: string; name: string; folder: string; provider: string; source: string };
+  session: { id: string; thread_id: string | null; messaging_group_id: string | null };
+  batch: Array<Record<string, unknown>>;
+  mounts: Array<{ hostPath: string; containerPath: string; readonly: boolean }>;
+  settingsJson: string;
+  skills: string[];
+  claudeMd: { entry: string; parts: Array<{ import: string; source: string; content: string }>; local: string };
+  systemPrompt: { base: string; append: string };
+  sdkOptions: Record<string, unknown> | null;
+  mcpTools: Array<{ name: string; description?: string }>;
+  continuation: string | null;
+  prompt: string | null;
+  notes: string[];
+}, only?: string): void {
+  const want = (name: string) => !only || only === name;
+  const p = (s: string) => console.log(s);
+
+  if (want('scenario')) {
+    p(heading('SCENARIO', 'staged into a sandboxed session by scripts/context-preview.ts'));
+    p(`  ${r.scenario} — agent group "${r.group.name}" (${r.group.source}), provider ${r.group.provider}`);
+    p(`  session ${r.session.id}  thread=${r.session.thread_id ?? '-'}  messaging_group=${r.session.messaging_group_id ?? '- (system session)'}`);
+    p('');
+    p('  messages_in staged:');
+    for (const m of r.batch) {
+      p(`    seq=${m.seq} kind=${m.kind} trigger=${m.trigger} on_wake=${m.on_wake} status=${m.status} channel=${m.channel_type ?? '-'}`);
+    }
+  }
+
+  if (want('environment')) {
+    p(heading('CONTAINER ENVIRONMENT', 'src/container-runner.ts buildMounts() — exact mount table for this spawn'));
+    for (const m of r.mounts) {
+      p(`  ${m.containerPath}${m.readonly ? '  (ro)' : '  (rw)'}`);
+      p(`    ← ${m.hostPath}`);
+    }
+    p('');
+    p('  /home/node/.claude/settings.json (src/group-init.ts — SDK user settings; enables agent teams + PreCompact hook):');
+    p(indent(r.settingsJson, 4));
+    p('  /home/node/.claude/skills/ (src/container-runner.ts syncSkillSymlinks + template-stamped dirs):');
+    for (const s of r.skills) p(`    ${s}`);
+    if (r.skills.length === 0) p('    (none)');
+  }
+
+  if (want('claude-md')) {
+    p(heading('PROJECT DOC — /workspace/agent/CLAUDE.md', 'composed per spawn by src/claude-md-compose.ts; @-imports expanded by Claude Code in-container'));
+    p(indent(r.claudeMd.entry.trimEnd(), 2));
+    for (const part of r.claudeMd.parts) {
+      p(`\n  ┌─ ${part.import}`);
+      p(`  │  source: ${part.source}`);
+      p('  └─');
+      p(indent(part.content.trimEnd(), 4));
+    }
+    p('\n  ┌─ CLAUDE.local.md (per-group memory, settingSources "local", RW for the agent)');
+    p('  └─');
+    p(indent(r.claudeMd.local.trimEnd() || '(empty)', 4));
+  }
+
+  if (want('system-prompt')) {
+    p(heading('SYSTEM PROMPT', 'base: SDK preset; append: container/agent-runner/src/destinations.ts buildSystemPromptAddendum()'));
+    p(`  base: ${r.systemPrompt.base}`);
+    p('  append:');
+    p(indent(r.systemPrompt.append, 4));
+  }
+
+  if (want('sdk-options')) {
+    p(heading('SDK OPTIONS', 'container/agent-runner/src/providers/claude.ts buildQueryOptions() — exact options object'));
+    p(indent(JSON.stringify(r.sdkOptions, null, 2), 2));
+  }
+
+  if (want('mcp-tools')) {
+    p(heading('MCP TOOLS (mcp__nanoclaw__*)', 'container/agent-runner/src/mcp-tools/* — the registered tool surface'));
+    for (const t of r.mcpTools) {
+      p(`  ${t.name}`);
+      if (t.description) p(indent(t.description.split('\n')[0], 6));
+    }
+  }
+
+  if (want('prompt')) {
+    p(heading('PROMPT', 'the exact string the poll loop hands the provider — captured from the real runPollLoop'));
+    if (r.continuation) p(`  (SDK resume: ${r.continuation})\n`);
+    p(indent(r.prompt ?? '(no query captured — no wake-eligible messages staged)', 2));
+  }
+
+  if (want('notes') && r.notes.length > 0) {
+    p(heading('NOTES', 'scenario-specific caveats'));
+    for (const n of r.notes) p(`  • ${n}`);
+  }
+  p('');
+}
+
+function indent(s: string, n: number): string {
+  const pad = ' '.repeat(n);
+  return s
+    .split('\n')
+    .map((l) => pad + l)
+    .join('\n');
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(1);
+});

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -268,6 +268,23 @@ function taskId(args: Record<string, unknown>): string {
   return id;
 }
 
+/**
+ * The run-log directive appended to every task prompt. Exported so the
+ * context-preview tool (scripts/context-preview.ts) stages task fires with
+ * the exact content createTask writes.
+ */
+export function taskPromptWithLog(prompt: string, seriesId: string): string {
+  return (
+    `${prompt}\n\n` +
+    `[A task serves the user two separate ways — do whichever the task above asks for, and ALWAYS the run log:\n` +
+    `• MESSAGE (only if asked): if the task says to report/notify the user, send your result with an EXPLICIT destination — <message to="name">…</message> or send_message({ to: "name", … }). This run has no chat attached: an unaddressed reply is DISCARDED, so the explicit send is the ONLY thing the user receives.\n` +
+    `• RUN LOG (ALWAYS — even if you sent no message and did nothing else this run): after any sends, end the run with:\n` +
+    `    ncl tasks append-log --msg "<what you did, and why it mattered>"\n` +
+    `  Write it like a work-log entry a human keeps — concrete: what you did and WHY (a no-op run still gets a line saying why nothing was needed). If you wrote or modified files this run, name them in --msg. Not a greeting, not a copy of the message you sent. The host stamps the UTC time (do NOT add one), do NOT edit tasks/${seriesId}.md by hand, and this NEVER goes to the user.\n` +
+    `Need context from past runs? Read tasks/${seriesId}.md first.]`
+  );
+}
+
 function createTask(args: Record<string, unknown>, ctx: CallerContext) {
   const group = groupArg(args, ctx);
   if (!group) throw new Error('--group is required');
@@ -282,14 +299,7 @@ function createTask(args: Record<string, unknown>, ctx: CallerContext) {
   const originSessionId = ctx.caller === 'agent' ? ctx.sessionId : null;
   // Each series runs in its own isolated session; point the fire at its own log.
   const { session } = resolveTaskSession(group, id);
-  const promptWithLog =
-    `${prompt}\n\n` +
-    `[A task serves the user two separate ways — do whichever the task above asks for, and ALWAYS the run log:\n` +
-    `• MESSAGE (only if asked): if the task says to report/notify the user, send your result with an EXPLICIT destination — <message to="name">…</message> or send_message({ to: "name", … }). This run has no chat attached: an unaddressed reply is DISCARDED, so the explicit send is the ONLY thing the user receives.\n` +
-    `• RUN LOG (ALWAYS — even if you sent no message and did nothing else this run): after any sends, end the run with:\n` +
-    `    ncl tasks append-log --msg "<what you did, and why it mattered>"\n` +
-    `  Write it like a work-log entry a human keeps — concrete: what you did and WHY (a no-op run still gets a line saying why nothing was needed). If you wrote or modified files this run, name them in --msg. Not a greeting, not a copy of the message you sent. The host stamps the UTC time (do NOT add one), do NOT edit tasks/${id}.md by hand, and this NEVER goes to the user.\n` +
-    `Need context from past runs? Read tasks/${id}.md first.]`;
+  const promptWithLog = taskPromptWithLog(prompt, id);
 
   const created = withInbound(session, (db) => {
     insertTaskRow(db, {

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -33,10 +33,11 @@ export function insertTaskRow(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, timestamp, status, tries, process_after, recurrence, kind, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (@id, @seq, datetime('now'), @status, 0, @processAfter, @recurrence, 'task', NULL, NULL, NULL, @content, @seriesId)`,
+     VALUES (@id, @seq, @timestamp, @status, 0, @processAfter, @recurrence, 'task', NULL, NULL, NULL, @content, @seriesId)`,
   ).run({
     status: 'pending',
     ...row,
+    timestamp: new Date().toISOString(),
     seq: nextEvenSeq(db),
   });
 }


### PR DESCRIPTION
Adds `scripts/context-preview.ts` — simulate a scenario (first-message, followup, accumulate, task-fire, on-wake, a2a, subagent) and print exactly what the agent sees: expanded CLAUDE.md, system-prompt addendum, SDK options, MCP tools, mounts, and the exact prompt string. Imports the real code paths (host half sandboxed under tsx, container half drives the real `runPollLoop` under Bun), so changes to the composer/formatter/instructions are reflected immediately. `--group <folder>` previews a live group read-only. Docs: `docs/context-preview.md`.

Small seams exported to keep it duplication-free: `buildQueryOptions`, `formatMessagesWithCommands`, `taskPromptWithLog`, `listRegisteredTools`, `setTestConfig`.

Also fixes `insertTaskRow` to stamp ISO timestamps like every other `messages_in` writer — the `datetime('now')` stamp rendered `<task time>` hours off from adjacent chat timestamps (found with the tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2YZQDTw9TQrH3m8NBtVAW