### PR TITLE
fix: stamp task rows with ISO timestamps

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
 import { getPendingMessages } from './db/messages-in.js';
 import { formatMessages, stripInternalTags } from './formatter.js';
-import { TIMEZONE } from './timezone.js';
+import { TIMEZONE, formatLocalTime } from './timezone.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -106,6 +106,14 @@ describe('timestamp formatting', () => {
     insertMessage('m1', 'chat', { sender: 'Alice', text: 'hi' }, { timestamp: '2026-06-15T15:30:00.000Z' });
     const result = formatMessages(getPendingMessages());
     expect(result).toMatch(/(AM|PM)/);
+  });
+});
+
+describe('task timestamps', () => {
+  it('renders task time in the user TZ, same as chat rows', () => {
+    insertMessage('t1', 'task', { prompt: 'do the thing' }, { timestamp: '2026-01-05T12:00:00.000Z' });
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain(`time="${formatLocalTime('2026-01-05T12:00:00.000Z', TIMEZONE)}"`);
   });
 });
 

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -33,10 +33,11 @@ export function insertTaskRow(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, timestamp, status, tries, process_after, recurrence, kind, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (@id, @seq, datetime('now'), @status, 0, @processAfter, @recurrence, 'task', NULL, NULL, NULL, @content, @seriesId)`,
+     VALUES (@id, @seq, @timestamp, @status, 0, @processAfter, @recurrence, 'task', NULL, NULL, NULL, @content, @seriesId)`,
   ).run({
     status: 'pending',
     ...row,
+    timestamp: new Date().toISOString(),
     seq: nextEvenSeq(db),
   });
 }


### PR DESCRIPTION
`insertTaskRow` stamped `datetime('now')` (naive UTC), which the container formatter parses as local time — so `<task time>` rendered hours off from the ISO-Z chat timestamps beside it. Stamp ISO like every other `messages_in` writer. Adds a formatter regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)