### PR TITLE
fix: exchange archives stamp local time

### DIFF
--- a/container/agent-runner/src/providers/exchange-archive.ts
+++ b/container/agent-runner/src/providers/exchange-archive.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import { TIMEZONE, formatLocalStamp } from '../timezone.js';
+
 /**
  * Per-thread conversation archive for providers with no on-disk transcript —
  * payload code, shipped with the provider that needs it. The provider's
@@ -62,7 +64,7 @@ export function archiveProviderExchange(options: ProviderExchangeArchiveOptions)
     '',
     '---',
     '',
-    `Archived: ${timestamp.toISOString()} · Status: ${options.status}`,
+    `Archived: ${formatLocalStamp(timestamp, TIMEZONE)} · Status: ${options.status}`,
     '',
     `**User**: ${truncate(options.prompt)}`,
     '',
@@ -86,7 +88,10 @@ function threadArchiveFilename(
   const dated = /^\d{4}-\d{2}-\d{2}-/;
   const existing = fs.readdirSync(dir).find((f) => dated.test(f) && f.replace(dated, '') === suffix);
   if (existing) return existing;
-  return `${timestamp.toISOString().split('T')[0]}-${suffix}`;
+  // Local calendar day — the agent navigates conversations/ by these
+  // date-sortable names, and evening sessions west of UTC would otherwise
+  // land under tomorrow's date.
+  return `${formatLocalStamp(timestamp, TIMEZONE).slice(0, 10)}-${suffix}`;
 }
 
 function sanitizeSlug(value: string): string {

--- a/container/agent-runner/src/timezone.ts
+++ b/container/agent-runner/src/timezone.ts
@@ -48,6 +48,22 @@ export function formatLocalTime(utcIso: string, timezone: string): string {
   });
 }
 
+/**
+ * Compact sortable local stamp for log lines: "YYYY-MM-DD HH:mm" in `timezone`.
+ * (sv-SE is the one locale whose default rendering is this exact shape.)
+ */
+export function formatLocalStamp(date: Date, timezone: string): string {
+  return date.toLocaleString('sv-SE', {
+    timeZone: resolveTimezone(timezone),
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
 function resolveContainerTimezone(): string {
   const candidates = [process.env.TZ, Intl.DateTimeFormat().resolvedOptions().timeZone];
   for (const tz of candidates) {


### PR DESCRIPTION
Providers-branch half of the timestamp convention fix (companion to the trunk PR): Codex/OpenCode exchange archives — the agent-readable `conversations/*.md` substitute for a transcript — now stamp `Archived:` lines and filename dates in the install timezone instead of raw UTC ISO, so evening sessions west of UTC no longer archive under tomorrow's date. Adds `formatLocalStamp` to this branch's container `timezone.ts` (same helper as trunk, mirror kept aligned).

The branch's two pre-existing typecheck errors and one test error (`codex.ts` 'file' event / `effort`) are untouched — they exist on `origin/providers` and one already has `fix/codex-file-event` pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2YZQDTw9TQrH3m8NBtVAW