### PR TITLE
fix(whatsapp): remove cachedGroupMetadata that breaks SKDM in LID groups

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -532,7 +532,15 @@ registerChannelAdapter('whatsapp', {
         printQRInTerminal: false,
         logger: baileysLogger,
         browser: Browsers.macOS('Chrome'),
-        cachedGroupMetadata: async (jid: string) => getNormalizedGroupMetadata(jid),
+        // Do NOT pass cachedGroupMetadata here. getNormalizedGroupMetadata
+        // translates participant LID JIDs to PN JIDs for adapter routing,
+        // but Baileys needs the original LID JIDs when building sender-key
+        // distribution stanzas for LID-mode groups. Feeding PN JIDs makes
+        // the server silently drop the SKDM (error 421), leaving every
+        // recipient stuck on "Waiting for this message". Baileys' own
+        // groupMetadata() call is correct and only fires on
+        // sender-key-memory miss — cheap enough. See commit 42583ff for
+        // the original guard.
         getMessage: async (key: WAMessageKey) => {
           // Check in-memory cache first (recently sent messages)
           const cached = sentMessageCache.get(key.id || '');


### PR DESCRIPTION
## Summary
Passing `getNormalizedGroupMetadata` as `cachedGroupMetadata` to `makeWASocket` feeds Baileys group metadata with participant JIDs already translated to phone (`@s.whatsapp.net`) form. LID-mode groups require LID addressing in sender-key distribution stanzas — feeding PN JIDs makes the WhatsApp server silently drop the SKDM (error 421), so every recipient stays stuck on "Waiting for this message. This may take a while." indefinitely and cannot decrypt any of the bot's outbound group messages.

This was the original guard removed by commit `42583ff` and reintroduced inadvertently in a later refactor. Restoring the guard and its explanatory comment fixes the regression. Baileys' own `groupMetadata()` call is correct and only fires on sender-key-memory miss, which is rare, so the cache isn't worth the correctness cost.

## Repro (confirmed on a production install)
1. Bot sends a message to a LID-mode WhatsApp group
2. All participants show "Waiting for this message. This may take a while." indefinitely on every message from the bot
3. Deleting the bot's own sender-key file (`store/auth/sender-key-<group>--<lid-user>_1--<device>.json`) makes Baileys regenerate the key on next send, but recipients **still** can't decrypt because the SKDM is addressed to non-existent PN sessions
4. Removing this line and re-triggering the send fixes it — SKDMs land on the LID sessions that participants actually have, and everyone decrypts on the first message

## Test plan
- [ ] Rebuild host (`pnpm run build`)
- [ ] Restart nanoclaw
- [ ] Delete the bot's sender-key file for a stuck LID group
- [ ] Have the bot post a message; verify all participants decrypt it on first try