### PR TITLE
RFC: temporal (incognito) sessions — throwaway, memory-free DM sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Each session has **two** SQLite files under `data/v2-sessions/<session_id>/`:
 
 Exactly one writer per file — no cross-mount lock contention. Heartbeat is a file touch at `/workspace/.heartbeat`, not a DB update. Host uses even `seq` numbers, container uses odd.
 
+## Temporal ("Incognito") Sessions
+
+`/incognito` (DMs only) starts a throwaway, memory-free session: a distinct row disambiguated from the normal session by `sessions.temporal = 1` (migration 020), storing the **real** `thread_id` + `messaging_group_id` so replies still route back. Its container gets a fresh, empty `/workspace/agent` (composed operating instructions only — no `CLAUDE.local.md`, `memory/`, `conversations/`, or ad-hoc files) plus an isolated `/home/node/.claude`, both under the session folder and `rm -rf`'d on teardown. `NANOCLAW_TEMPORAL=1` adds a "nothing persists" system-prompt note. `/incognito end` (or `/exit`, or ~30 min idle via the sweep) tears it down. All `temporal=0` lookups (`findSessionForAgent`, etc.) exclude temporal rows; `findTemporalSession` matches them. Key files: `src/incognito.ts`, `src/temporal-session.ts`, temporal branch in `src/container-runner.ts` (`buildMounts`). See [docs/temporal-session/](docs/temporal-session/).
+
 ## Central DB
 
 `data/v2.db` holds everything that isn't per-session: users, user_roles, agent_groups, messaging_groups, wiring, pending_approvals, user_dms, chat_sdk_* (for the Chat SDK bridge), schema_version. Migrations live at `src/db/migrations/`.
@@ -64,6 +68,8 @@ For ad-hoc queries from skills or scripts, use the in-tree wrapper rather than t
 | `src/delivery.ts` | Polls `outbound.db`, delivers via adapter, handles system actions (schedule, approvals, etc.) |
 | `src/host-sweep.ts` | 60s sweep: `processing_ack` sync, stale detection, due-message wake, recurrence |
 | `src/session-manager.ts` | Resolves sessions; opens `inbound.db` / `outbound.db`; manages heartbeat path |
+| `src/incognito.ts` | Parses the `/incognito` chat command (start / end); router-side, before the command gate |
+| `src/temporal-session.ts` | Temporal ("incognito") session lifecycle — `resolveTemporalSession` / `destroyTemporalSession` (see below) |
 | `src/container-runner.ts` | Spawns per-agent-group Docker containers with session DB + outbox mounts, OneCLI `ensureAgent` |
 | `src/container-runtime.ts` | Docker CLI wrapper (runtime binary, host-gateway args, mount args), orphan cleanup |
 | `src/modules/permissions/access.ts` | `canAccessAgentGroup` — owner / global admin / scoped admin / member resolution against `user_roles` + `agent_group_members` |

--- a/container/agent-runner/src/destinations.test.ts
+++ b/container/agent-runner/src/destinations.test.ts
@@ -61,3 +61,21 @@ describe('buildSystemPromptAddendum — multi-destination routing guidance', () 
     expect(prompt).toContain('`casa`');
   });
 });
+
+describe('buildSystemPromptAddendum — temporal (incognito) note', () => {
+  afterEach(() => {
+    delete process.env.NANOCLAW_TEMPORAL;
+  });
+
+  it('includes the incognito note when NANOCLAW_TEMPORAL=1', () => {
+    process.env.NANOCLAW_TEMPORAL = '1';
+    const prompt = buildSystemPromptAddendum('Casa');
+    expect(prompt).toContain('Temporary (incognito) session');
+    expect(prompt).toContain('nothing here persists');
+  });
+
+  it('omits the incognito note when NANOCLAW_TEMPORAL is unset', () => {
+    const prompt = buildSystemPromptAddendum('Casa');
+    expect(prompt).not.toContain('incognito');
+  });
+});

--- a/container/agent-runner/src/destinations.ts
+++ b/container/agent-runner/src/destinations.ts
@@ -63,9 +63,9 @@ export function findByRouting(
   const db = getInboundDb();
   const row =
     channelType === 'agent'
-      ? (db
-          .prepare("SELECT * FROM destinations WHERE type = 'agent' AND agent_group_id = ?")
-          .get(platformId) as DestRow | undefined)
+      ? (db.prepare("SELECT * FROM destinations WHERE type = 'agent' AND agent_group_id = ?").get(platformId) as
+          | DestRow
+          | undefined)
       : (db
           .prepare("SELECT * FROM destinations WHERE type = 'channel' AND channel_type = ? AND platform_id = ?")
           .get(channelType, platformId) as DestRow | undefined);
@@ -83,7 +83,23 @@ export function buildSystemPromptAddendum(assistantName?: string): string {
   const sections: string[] = [];
 
   if (assistantName) {
-    sections.push(['# You are ' + assistantName, '', `Your name is **${assistantName}**. Use it when the channel asks who you are, when introducing yourself, and when signing any message that explicitly calls for a signature.`].join('\n'));
+    sections.push(
+      [
+        '# You are ' + assistantName,
+        '',
+        `Your name is **${assistantName}**. Use it when the channel asks who you are, when introducing yourself, and when signing any message that explicitly calls for a signature.`,
+      ].join('\n'),
+    );
+  }
+
+  if (process.env.NANOCLAW_TEMPORAL === '1') {
+    sections.push(
+      [
+        '# Temporary (incognito) session',
+        '',
+        'This is a temporary, incognito conversation. It starts from a clean slate — none of your long-term memory is loaded — and nothing here persists: this workspace and anything you write in it is discarded when the session ends. Do not claim to have saved anything or that you will remember this conversation later.',
+      ].join('\n'),
+    );
   }
 
   sections.push(buildDestinationsSection());

--- a/docs/temporal-session/temporal-session-11-07-2026-design.md
+++ b/docs/temporal-session/temporal-session-11-07-2026-design.md
@@ -2,8 +2,22 @@
 
 **Date:** 2026-07-11
 **Branch:** `feature/temporal-session`
-**Status:** Draft — pending review
+**Status:** Implemented (see `temporal-session-11-07-2026-plan.md`)
 **Type:** Design / spec
+
+## Usage
+
+In a **direct message** with the agent:
+
+- `/incognito [message]` — start a fresh, memory-free session. The agent starts
+  with a clean slate (no long-term memory loaded) and nothing said or written
+  persists. Any text after the command becomes the first turn.
+- Follow-up messages continue the incognito conversation (multi-turn).
+- `/incognito end` (or `/exit`, `/endincognito`) — leave incognito; the normal
+  session (with its memory) resumes. Incognito also ends automatically after
+  ~30 minutes idle.
+
+Incognito is **DM-only**; in a group chat the command is refused with a note.
 
 ## 1. Goal
 

--- a/docs/temporal-session/temporal-session-11-07-2026-design.md
+++ b/docs/temporal-session/temporal-session-11-07-2026-design.md
@@ -1,0 +1,188 @@
+# Temporal ("Incognito") Sessions — Design
+
+**Date:** 2026-07-11
+**Branch:** `feature/temporal-session`
+**Status:** Draft — pending review
+**Type:** Design / spec
+
+## 1. Goal
+
+Add the ability to start a **temporal session**: a throwaway conversation that does **not** load the agent group's stored long-term memory, and whose own activity **never persists** to that memory. Think "incognito mode" for a NanoClaw agent.
+
+Today every session for an agent group runs in the same shared group workspace and therefore always sees (and writes to) the group's accumulated long-term memory. There is no way to say "just this once, talk to me with a clean slate and forget it afterward."
+
+## 2. Locked decisions
+
+Confirmed with the requester before design:
+
+| Axis | Decision |
+|------|----------|
+| **Trigger** | Chat command / prefix (e.g. `/incognito …`). Not an admin-only / ncl-only knob, not a permanent per-wiring setting. |
+| **Isolation strength** | **Full incognito** — the agent cannot *read* prior long-term memory, **and** nothing it *writes* during the session persists. |
+| **Continuity** | A **distinct throwaway session** with its own id + transcript. It maintains multi-turn continuity *within itself*, starts clean, and is discarded when it ends. The normal thread session is untouched. |
+| **Scope** | **DMs only** (`is_group=0`). In a group chat the command is refused with a one-line note (see §5.3). Rationale in §5.3 / §9. |
+
+## 3. Background — how long-term memory loads today (discovery)
+
+All long-term memory lives in the **group dir** (`groups/<folder>/`), which is mounted **RW at `/workspace/agent`** and is **shared across every session** of that agent group. There is no per-session workspace isolation.
+
+Memory reaches the agent through several surfaces:
+
+| Surface | What it is | Entry into context | Reference |
+|---|---|---|---|
+| `CLAUDE.local.md` | Primary per-group memory | **Auto-loaded** by the Claude SDK via `settingSources: ['project','user','local']` — the `local` source is this file | `container/agent-runner/src/providers/claude.ts:421` |
+| Ad-hoc workspace files | `customers.md`, `people.md`, project notes, etc. — the agent is *instructed* to create these in the workspace root and index them from `CLAUDE.local.md` | Read on demand by the agent; discoverable via `Glob`/`Read` | `container/CLAUDE.md` ("Memory" / "Workspace" sections) |
+| `memory/` tree | Structured scaffold (`index.md`, `system/`, `memories/`, `data/`) for providers with `usesMemoryScaffold` | Scaffolded at boot; read on demand | `container/agent-runner/src/memory-scaffold.ts`, `index.ts:103` |
+| `conversations/` | Archived past-session transcripts | Written by the PreCompact/rotation path; read on demand. Write path already env-overridable via `NANOCLAW_CONVERSATIONS_DIR` | `container/agent-runner/src/providers/claude.ts:225` |
+| SDK transcript `.jsonl` | Within-session resume history (short-term, but stored per-**group**) | Loaded via `resume: input.continuation`. Lives under `/home/node/.claude`, which is mounted from the **per-group** `data/v2-sessions/<group>/.claude-shared` | `container-runner.ts:281,334` |
+
+**Design-critical takeaway:** because the agent stores memory as *arbitrary files in the workspace root* (not just three well-known paths), "read isolation" cannot be achieved by hiding a fixed list of files. It requires giving the temporal session a **fresh, empty workspace** that contains only the operating instructions (persona, skills, shared base) and none of the accumulated memory.
+
+There is currently **no** temporal / ephemeral / no-memory flag anywhere in the session, wiring, or container-config models.
+
+## 4. Design overview
+
+Two cooperating pieces:
+
+1. **Host routing + lifecycle** — a `/incognito` command starts a distinct temporal session for the current thread; subsequent messages continue in it; `/incognito end` (or an idle timeout) tears it down and discards all its data. The normal thread session is never touched.
+2. **Host spawn — ephemeral workspace ("M2")** — a temporal session's container is given a *fresh per-session workspace* at `/workspace/agent` (operating instructions only, no memory) and an isolated `/home/node/.claude`. All writes land in per-session ephemeral dirs that are deleted on teardown.
+
+The container/agent-runner code needs **essentially no change** — because the temporal container simply sees a workspace with no memory in it, and all its writes go to ephemeral locations. (One optional addition: a one-line system-prompt note so the agent knows it's in a temporal session and won't promise to "remember" anything.)
+
+```
+Normal thread session ───────────────► group dir /workspace/agent (shared, persistent)
+                                        + group /home/node/.claude (shared)
+
+/incognito  ──► Temporal session ─────► fresh ephemeral /workspace/agent (instructions only)
+              (own id, temporal=1)      + fresh ephemeral /home/node/.claude
+                                        → both deleted on /incognito end or idle sweep
+```
+
+## 5. Trigger & routing
+
+### 5.1 Commands (defaults; wording configurable)
+
+| Command | Effect |
+|---|---|
+| `/incognito [first message]` | Start a fresh temporal session for this thread. Any text after the command becomes the first turn. If a temporal session is already active for the thread, it is discarded and a new one starts. |
+| `/incognito end` (aliases `/endincognito`, `/exit`) | Close and **discard** the active temporal session; a short confirmation is delivered; routing reverts to the normal session. No-op (with a gentle note) if not in incognito. |
+| _idle timeout_ | The host sweep auto-ends an idle temporal session (reuses the existing idle ceiling; see §8). |
+
+Detection happens in the router **before** `gateCommand` and **before** session resolution, because the command changes *which session* the message routes to. The existing command gate (`command-gate.ts`) is unchanged — `/incognito` is consumed upstream and never reaches it or the container.
+
+### 5.2 Routing rule (per inbound message, inside the fan-out)
+
+For a message directed at `(agent, messagingGroup, thread)`:
+
+0. **Group chat (`mg.is_group !== 0`)?** → incognito is not available. If the message is a `/incognito` command, reply with the DM-only note (§5.3) and do not route further; otherwise fall straight through to the normal path. Steps 1–3 below apply only in DMs.
+1. **Start command?** → `destroyTemporalSession(...)` if one exists, then `resolveTemporalSession(...)` to create a fresh one; deliver the stripped remainder (if any) as the first turn; wake.
+2. **End command?** → `destroyTemporalSession(...)`; deliver a confirmation to the real thread; do not route further.
+3. **Active temporal session exists for this thread?** → route this message to it (multi-turn continuity).
+4. **Otherwise** → existing normal `resolveSession(...)` path, unchanged.
+
+"Incognito is active for this thread" is derived from the DB: an `active`, `temporal=1` session for `(agentGroupId, messagingGroupId, thread)`. This is durable — it survives a host restart, and the normal session is always recoverable.
+
+### 5.3 Engagement & scope
+
+- **DMs only.** Incognito is available only in direct messages (`mg.is_group === 0`). In a group chat, `/incognito` is refused with a one-line note (`🕶️ Incognito is only available in direct messages.`) delivered to the thread, and never creates a temporal session. Rationale: "incognito" implies a private, personal, throwaway chat, but a NanoClaw session is scoped to the *thread*, not the individual — so in a shared thread one member's `/incognito` would silently flip the agent into memory-free mode for *everyone*, appearing to "forget" shared context mid-conversation. Per-user incognito inside a shared thread would require user-scoped sessions (a much larger change NanoClaw doesn't model today) — out of scope. See §9.
+- In a DM, a `/incognito` command **forces engagement** for the wired agent (it is a direct instruction), mirroring how a mention engages.
+- No new privilege gate: incognito only *reduces* what the agent sees and never mutates persistent memory, so any sender already allowed to DM the agent may use it.
+
+## 6. Session model & schema
+
+### 6.1 `temporal` flag on sessions
+
+Add a column so the normal and temporal sessions for the same `(group, mg, thread)` can **coexist** (the normal one holding history for when the user returns):
+
+- `sessions.temporal INTEGER NOT NULL DEFAULT 0` — migration `src/db/migrations/0NN-temporal-sessions.ts` + `src/db/schema.ts`.
+- `Session.temporal: 0 | 1` in `src/types.ts`.
+- Any uniqueness/index on `(agent_group_id, messaging_group_id, thread_id)` must include `temporal` so both rows are legal.
+
+### 6.2 Real `thread_id`, not synthetic — for correct delivery
+
+`writeSessionRouting` (`session-manager.ts:173`) derives the reply address from `session.thread_id`. Therefore a temporal session must store the **real** `thread_id` (so replies land back in the user's chat) and be disambiguated from the normal session **only** by `temporal=1`. (A synthetic `system:incognito:…` thread — the pattern task sessions use — would break reply delivery, so it is explicitly rejected here.)
+
+### 6.3 New session-manager surface
+
+- `resolveTemporalSession(agentGroupId, messagingGroupId, threadId)` → finds/creates the `temporal=1` session for the real thread (mirrors `resolveSession`, sets `temporal=1`).
+- `destroyTemporalSession(agentGroupId, messagingGroupId, threadId)` → closes the session, kills its container, and deletes its session folder + ephemeral workspace + ephemeral `.claude`.
+- Normal lookups (`findSessionForAgent`, `findSessionByAgentGroup`) filter to `temporal=0` so routing, sweeps, and delivery of normal traffic never pick up a temporal session by accident.
+
+## 7. Container spawn — ephemeral workspace (approach "M2")
+
+When `session.temporal === 1`, `buildMounts` / `spawnContainer` (`src/container-runner.ts`) diverge from the normal path:
+
+1. **Fresh workspace base.** Instead of mounting the group dir at `/workspace/agent`, mount a per-session ephemeral dir (e.g. `data/v2-sessions/<group>/<session>/agent-ephemeral/`) RW at `/workspace/agent`.
+2. **Operating instructions only.** Compose the group's CLAUDE.md **into the ephemeral base** (parameterize `composeGroupClaudeMd(group, targetDir?)` to accept an output dir; it still reads persona/skills/MCP config from the real group). Result: the ephemeral workspace has `CLAUDE.md`, `.claude-shared.md` (symlink → `/app/CLAUDE.md`, valid in-container), `.claude-fragments/`, and `container.json` — and **nothing else** (no `CLAUDE.local.md`, no `memory/`, no `conversations/`, no ad-hoc files).
+   - This sidesteps the dangling-symlink problem of nested-mounting individual instruction files: because the host owns the ephemeral dir, it recreates the same container-path symlinks the group dir uses.
+3. **Isolated SDK state.** Give the temporal container a fresh per-session `/home/node/.claude` (seeded with the same skill symlinks + `settings.json` the shared `.claude-shared` gets) — or, minimally, delete the temporal session's `.jsonl` on teardown. Recommended: fully isolate it so the incognito transcript never lands in the group's shared `.claude`.
+4. **Env marker.** Pass `NANOCLAW_TEMPORAL=1` so (optionally) the runner can append a system-prompt note, and so the spawn is self-describing in logs.
+5. **Additional mounts** declared in container config (explicit external resource dirs) are **kept** — they are declared resources, not accumulated agent memory. Only the group *workspace memory* is isolated.
+
+Because everything memory-related (scaffold, `conversations/`, transcript, any file the agent writes) now resolves inside ephemeral dirs, **no agent-runner code change is required** for isolation. The only optional container change is the system-prompt note.
+
+## 8. Teardown & cleanup
+
+A temporal session is discarded when:
+
+- The user sends `/incognito end` (or alias) → `destroyTemporalSession(...)` runs immediately.
+- The host sweep detects it idle → same teardown. Reuse the existing idle machinery in `src/host-sweep.ts` (which already auto-closes "spent" system/task sessions, `host-sweep.ts:170`, `updateSession(..., {status:'closed'})`). A temporal session with no running container past the idle ceiling (`ABSOLUTE_CEILING_MS`, or a shorter temporal-specific TTL) is closed and deleted.
+
+`destroyTemporalSession` must:
+1. `killContainer(session.id, 'temporal-end')` if running.
+2. `updateSession(session.id, {status:'closed'})` then `deleteSession(session.id)`.
+3. `rm -rf` the session folder (`data/v2-sessions/<group>/<session>/`), which contains the ephemeral workspace, ephemeral `.claude`, and both session DBs.
+
+Result: no residue in `groups/<folder>/`, no transcript in the group's `.claude`, nothing to leak into a future session.
+
+## 9. Rejected alternatives
+
+- **M1 — shadow specific paths.** Keep the group dir mounted; nested-mount empty dirs/files over `CLAUDE.local.md`, `memory/`, `conversations/`. *Rejected:* it still leaks the agent's ad-hoc workspace files (`customers.md`, `people.md`, project notes) that are also long-term memory. Does not deliver the "full incognito" isolation that was chosen.
+- **Soft read-only suppression.** Only drop the `local` settingSource + a system-prompt "don't touch memory" instruction. *Rejected:* smallest change (~10 lines), but relies on the agent obeying, and writes can still land in the group dir. Fails the "nothing persists" requirement.
+- **Synthetic `system:incognito:` thread id.** *Rejected:* breaks `writeSessionRouting` reply delivery (§6.2).
+- **Per-wiring / ncl-only trigger.** *Rejected by product decision:* the chat-command trigger was chosen for on-demand, per-conversation use.
+- **Supporting incognito in group chats.** *Rejected:* a session is thread-scoped, not user-scoped, so one member's `/incognito` would flip the shared thread to memory-free mode for everyone — a footgun, and "incognito" has no private meaning in a public thread anyway. True per-user incognito would need user-scoped sessions, a much larger change. DMs only (§5.3).
+
+## 10. Integration points (file-by-file)
+
+**Host — new:**
+- `src/incognito.ts` (new) — command parsing (`parseIncognitoCommand(text)` → `start | end | none`, stripped body) + the routing decision helper.
+
+**Host — changed:**
+- `src/router.ts` — call the incognito helper early in the fan-out; route to `resolveTemporalSession` / trigger `destroyTemporalSession`; force engagement on the start command; strip the command prefix from the delivered body.
+- `src/session-manager.ts` — `resolveTemporalSession`, `destroyTemporalSession`; temporal-aware routing writes.
+- `src/db/sessions.ts` — `temporal` column reads/writes; `findSessionForAgent` / `findSessionByAgentGroup` exclude `temporal=1`; a `findTemporalSession(...)` lookup.
+- `src/db/schema.ts` + `src/db/migrations/0NN-temporal-sessions.ts` — add the column + index.
+- `src/types.ts` — `Session.temporal`.
+- `src/container-runner.ts` — temporal branch in `buildMounts`/spawn (ephemeral workspace + `.claude`, `NANOCLAW_TEMPORAL=1`).
+- `src/claude-md-compose.ts` — accept an optional output dir so composition can target the ephemeral workspace.
+- `src/host-sweep.ts` — idle auto-teardown for temporal sessions.
+
+**Container — optional:**
+- `container/agent-runner/src/index.ts` (or `destinations.ts` addendum builder) — if `NANOCLAW_TEMPORAL=1`, append a short "this is a temporal session; nothing here persists" note to the system prompt.
+
+## 11. Testing
+
+**Host (vitest):**
+- Command parsing: `/incognito`, `/incognito hello`, `/incognito end`, aliases, non-commands.
+- Routing: start creates a `temporal=1` session with the **real** thread_id; follow-ups continue in it; `end` closes+deletes it and reverts; the normal session is never selected while incognito, and is intact afterward.
+- DM-only guard: `/incognito` in a group chat (`is_group=1`) does **not** create a temporal session and returns the DM-only note; a non-command message in a group is unaffected and routes normally.
+- Mount set: temporal spawn mounts the ephemeral workspace (not the group dir), contains only instruction artifacts, sets `NANOCLAW_TEMPORAL=1`, and isolates `/home/node/.claude`.
+- Teardown: `destroyTemporalSession` kills the container, closes+deletes the session, and removes the session folder; idle sweep triggers the same.
+- Delivery: a temporal session's reply routing resolves to the real `(channel, platform, thread)`.
+
+**Container (bun:test):**
+- If the system-prompt note is added: addendum reflects temporal mode when `NANOCLAW_TEMPORAL=1`, and is absent otherwise.
+
+## 12. Risks & open questions
+
+- **`/home/node/.claude` isolation cost.** Fully isolating SDK state per temporal session means seeding skill symlinks + `settings.json` into a fresh dir at spawn. If that proves heavy, the fallback is: keep the shared `.claude` mount but delete the temporal session's `.jsonl` on teardown. Decision can be made during implementation; both satisfy "nothing persists," the fresh-dir option is cleaner.
+- **Command wording.** `/incognito` vs `/private` vs `/fresh`; `end`/`/exit`/`/endincognito`. Defaults above; easy to change before implementation.
+- **Non-Claude providers.** M2 is provider-agnostic (the workspace is simply empty of memory). `usesMemoryScaffold` providers will scaffold into the ephemeral workspace — correct, and discarded on teardown. No special-casing needed.
+
+## 13. Out of scope
+
+- Persisting or "promoting" anything learned during a temporal session back into long-term memory.
+- A per-wiring "always incognito" channel setting (possible future add; the `temporal` flag + spawn path would be reused).
+- Group-chat incognito, in any form — whole-thread or per-user (§9). Would require user-scoped sessions if ever revisited.
+- Changing how normal sessions store or load memory.

--- a/docs/temporal-session/temporal-session-11-07-2026-plan.md
+++ b/docs/temporal-session/temporal-session-11-07-2026-plan.md
@@ -1,5 +1,37 @@
 # Plan: Temporal ("Incognito") Sessions
 
+## Status — closed out 2026-07-11
+
+All milestones **[DONE]** on `feature/temporal-session` (one commit each, sequential).
+
+| Milestone | Status | Commit |
+|---|---|---|
+| M1 — schema + temporal flag | [DONE] | `feat(sessions): add temporal flag + temporal-aware lookups` |
+| M2 — lifecycle helpers | [DONE] | `feat(sessions): temporal session lifecycle helpers` |
+| M3 — memory-free spawn | [DONE] | `feat(container): memory-free spawn for temporal sessions` |
+| M4 — /incognito routing | [DONE] | `feat(router): /incognito DM command routing` |
+| M5 — idle teardown + runner note | [DONE] | `feat(sweep): idle temporal teardown + agent-runner incognito note` |
+| M6 — integration tests + docs | [DONE] | `test(incognito): end-to-end routeInbound integration + docs` |
+
+**Verification:** host `tsc --noEmit` clean; `vitest run` = 774 passed. The only failing
+tests are 7 pre-existing `scripts/q.test.ts` cases that `spawnSync('pnpm', …)` — `pnpm` is
+absent from this shell's PATH (only `corepack pnpm` works), unrelated to this change.
+
+**Key decisions / deviations from the plan:**
+- `Session.temporal` is **optional** (`temporal?: number`), not required — the DB column
+  defaults to 0 and is always present on rows read back; `createSession` coalesces a missing
+  value to 0. Avoided churning ~20 pre-existing test `Session` literals (surgical-changes rule).
+- Lifecycle helpers live in a **new `src/temporal-session.ts`** (not `session-manager.ts`) to
+  avoid an import cycle (container-runner already imports `sessionDir` from session-manager).
+- `destroyTemporalSession` closes the row **synchronously**, deferring only the container kill
+  + folder `rm -rf` to the container's exit — so a re-`/incognito` can't reuse a dying session.
+- Incognito control notes (start/end/DM-only) deliver **immediately** via `deliverSessionMessages`
+  (idempotent, re-entry-guarded) rather than waiting up to 60s for the sweep.
+- **Not run in this environment:** container `bun test` + `tsc` for the one agent-runner change
+  (a guarded system-prompt note) — `bun` isn't installed here. Change mirrors the existing
+  `destinations.test.ts` pattern; unit tests added.
+- **Not done (per user request):** the PR was not opened; the branch is left ready.
+
 ## Context
 
 NanoClaw agents always run in their group's shared workspace (`/workspace/agent`, the

--- a/docs/temporal-session/temporal-session-11-07-2026-plan.md
+++ b/docs/temporal-session/temporal-session-11-07-2026-plan.md
@@ -13,9 +13,16 @@ All milestones **[DONE]** on `feature/temporal-session` (one commit each, sequen
 | M5 — idle teardown + runner note | [DONE] | `feat(sweep): idle temporal teardown + agent-runner incognito note` |
 | M6 — integration tests + docs | [DONE] | `test(incognito): end-to-end routeInbound integration + docs` |
 
-**Verification:** host `tsc --noEmit` clean; `vitest run` = 774 passed. The only failing
+**Verification:** host `tsc --noEmit` clean; `vitest run` = 775 passed. The only failing
 tests are 7 pre-existing `scripts/q.test.ts` cases that `spawnSync('pnpm', …)` — `pnpm` is
 absent from this shell's PATH (only `corepack pnpm` works), unrelated to this change.
+
+**Gate B (holistic adversarial review):** run over the whole diff. Lifecycle, path isolation,
+DM guard, and the parser verified sound. Two findings fixed (commit `fix(incognito): close
+review findings`): (1) `buildTemporalMounts` now drops provider-contributed mounts rooted under
+the real group dir (a `providesAgentSurfaces` provider could otherwise leak per-group memory —
+not exploitable with any shipped provider, closed structurally); (2) `/incognito end` now drains
+the temporal `outbound.db` before teardown so a just-written, not-yet-polled reply isn't lost.
 
 **Key decisions / deviations from the plan:**
 - `Session.temporal` is **optional** (`temporal?: number`), not required — the DB column

--- a/docs/temporal-session/temporal-session-11-07-2026-plan.md
+++ b/docs/temporal-session/temporal-session-11-07-2026-plan.md
@@ -1,0 +1,219 @@
+# Plan: Temporal ("Incognito") Sessions
+
+## Context
+
+NanoClaw agents always run in their group's shared workspace (`/workspace/agent`, the
+`groups/<folder>/` dir), so every session reads and writes the group's accumulated
+**long-term memory** — `CLAUDE.local.md`, ad-hoc files the agent creates in the workspace
+root (`customers.md`, `people.md`, …), the `memory/` scaffold, `conversations/` archives,
+and the SDK transcript. There is no way to have a throwaway conversation that ignores that
+memory and leaves no trace.
+
+This adds an **incognito mode**: a `/incognito` chat command (DMs only) starts a distinct,
+memory-free session that keeps its own multi-turn continuity, then is discarded on
+`/incognito end` or after idle. The normal session is never touched.
+
+The full design (decisions, rejected alternatives, rationale) lives in
+`docs/temporal-session/temporal-session-11-07-2026-design.md`.
+
+**Locked decisions:** trigger = `/incognito` chat command (stop: `/incognito end`, aliases
+`/exit`, `/endincognito`); isolation = full read+write incognito; continuity = distinct
+throwaway session; scope = **DMs only**; SDK transcript = fully isolated per session.
+
+**Key architectural choice:** the temporal session stores the **real** `thread_id` + real
+`messaging_group_id`, disambiguated from the normal session by a new `temporal=1` flag — NOT
+a synthetic `system:incognito:` thread. Required because `writeSessionRouting`
+(`src/session-manager.ts:173`) derives the reply address from `session.thread_id` +
+`session.messaging_group_id`; a synthetic thread would break delivery back to the chat.
+No unique constraint exists on `(agent_group_id, messaging_group_id, thread_id)`
+(`src/db/migrations/001-initial.ts`), so `temporal=0` and `temporal=1` rows coexist legally.
+
+**Isolation approach ("fresh workspace"):** rather than hiding a fixed set of memory paths
+(which leaks the ad-hoc files the agent creates in the workspace root), a temporal container
+gets a *fresh, empty* `/workspace/agent` containing only operating instructions
+(persona/skills/shared base) — no memory of any kind — plus its own fresh `/home/node/.claude`.
+Both live under the session folder and are `rm -rf`'d on teardown. Because the workspace is
+empty of memory and all writes fall into ephemeral dirs, the container/agent-runner needs only
+one tiny optional change (a system-prompt note).
+
+---
+
+## Branching & workflow (plan-guidelines)
+
+- **Strategy: A/B — one branch, one PR.** All milestones commit sequentially onto the existing
+  `feature/temporal-session` branch (already cut from `main`); a single PR opens at the end via
+  the `pr-mr-prepare` skill. Milestones are dependent and share state (sessions → session-manager
+  → container-runner → router → sweep), so they run **sequentially** — no parallel worktrees.
+- **Per milestone:** implement steps → write/run **unit tests** alongside (`testing-standards`)
+  → run the **`code-quality-pipeline`** skill → commit. Ask before opening the PR.
+- **Test levels:** host is **backend-only (no UI) → e2e/Playwright is skipped**. Unit tests carry
+  breadth (every branch/edge); one **integration** milestone covers the routing wiring end-to-end
+  on a real test DB (`initTestDb` + `runMigrations`, the `src/host-core.test.ts` pattern). All test
+  entities use **random IDs** (`crypto.randomUUID()` / `Date.now()` suffix).
+
+## Pre-implementation (first actions, once out of plan mode)
+
+1. **Save this plan** to `docs/temporal-session/temporal-session-11-07-2026-plan.md` (plan-guidelines
+   cardinal rule — plan on disk before any code). It's currently only in the plan-mode scratch file.
+2. **Commit the design doc** `docs/temporal-session/temporal-session-11-07-2026-design.md` (written
+   during brainstorming, not yet committed) to `feature/temporal-session`.
+
+---
+
+## Milestone 1 — Session schema + temporal flag
+
+Add the `temporal` column and make normal routing/lookups ignore temporal rows.
+
+- **`src/db/migrations/020-sessions-temporal.ts`** (new): `ALTER TABLE sessions ADD COLUMN
+  temporal INTEGER DEFAULT 0;` (mirror `018-approvals-approver-user-id.ts`). Register in
+  `src/db/migrations/index.ts` (import + append to `migrations`).
+- **`src/db/schema.ts`**: add `temporal INTEGER DEFAULT 0` to the `sessions` CREATE TABLE (keep
+  the reference schema in sync).
+- **`src/types.ts`**: add `temporal: number; // 0 | 1` to `Session` (raw-row cast → no mapper change).
+- **`src/db/sessions.ts`**:
+  - `createSession` — add `temporal` to the INSERT columns + `@temporal` value.
+  - Add `AND temporal = 0` to `findSession`, `findSessionForAgent`, `findSessionByAgentGroup`,
+    `findSystemSession`, `findTaskSessions`.
+  - Add `findTemporalSession(agentGroupId, messagingGroupId, threadId)` — `findSessionForAgent`
+    shape but `AND temporal = 1` (handle the `thread_id IS NULL` branch).
+  - Leave unchanged (must see temporal rows): `getActiveSessions`, `getRunningSessions`,
+    `getSession`/`updateSession`/`deleteSession`.
+- **`src/session-manager.ts`**: set `temporal: 0` on the `Session` literals in `resolveSession`
+  and `resolveTaskSession`.
+
+**Unit tests (`src/db/sessions.test.ts` or similar):** with random ids, insert a `temporal=1`
+and a `temporal=0` session for the same `(group, mg, thread)`; assert `findSessionForAgent`
+returns only the normal one and `findTemporalSession` only the temporal one; assert the other
+filtered lookups exclude `temporal=1`; assert `getActiveSessions` returns both.
+**Code-quality-pipeline:** run the `code-quality-pipeline` skill on the milestone diff before done.
+**Verify:** `pnpm run build`; `pnpm test`.
+
+## Milestone 2 — Temporal session lifecycle helpers
+
+- **`src/session-manager.ts`**:
+  - `resolveTemporalSession(agentGroupId, messagingGroupId, threadId, sessionMode)` — mirrors
+    `resolveSession` (same `lookupThreadId` rule) but `temporal: 1`; reuse `findTemporalSession`,
+    `createSession`, `initSessionFolder`.
+  - `destroyTemporalSession(session: Session)` — if running,
+    `killContainer(session.id, 'temporal-end', onExit)` (`src/container-runner.ts` supports
+    `onExit`); in the callback (or immediately if not running): `updateSession(status:'closed')`,
+    `deleteSession(id)`, `fs.rmSync(sessionDir(agentGroupId, id), { recursive:true, force:true })`.
+
+**Unit tests:** `resolveTemporalSession` creates a `temporal=1` row + folder and is idempotent
+(second call reuses); `destroyTemporalSession` closes+deletes the row and removes the folder;
+not-running vs running paths. Follow the mock-`DATA_DIR` + `initSessionFolder` pattern in
+`src/session-manager.test.ts`; random ids.
+**Code-quality-pipeline:** run before done. **Verify:** `pnpm test`.
+
+## Milestone 3 — Temporal container spawn (fresh workspace + isolated .claude)
+
+Branch the spawn on `session.temporal === 1` in **`src/container-runner.ts`**.
+
+- **Parameterize `composeGroupClaudeMd`** (`src/claude-md-compose.ts`) with an optional output dir:
+  writes (`CLAUDE.md`, `.claude-shared.md` symlink, `.claude-fragments/`, `CLAUDE.local.md`) go to
+  the target dir; persona (`readGroupPersona`) + container config (`getContainerConfig`) still read
+  from the real group. Default target = group dir (unchanged behavior).
+- **`buildMounts`** temporal branch:
+  - Ephemeral workspace at `sessionDir/agent-ephemeral/`: compose instructions into it, copy
+    `container.json`; mount RW at `/workspace/agent` **instead of** the group dir; no group-memory
+    mounts (no `CLAUDE.local.md`, `memory/`, `conversations/`, ad-hoc files).
+  - Ephemeral `/home/node/.claude` at `sessionDir/claude-ephemeral/`: write `DEFAULT_SETTINGS_JSON`
+    (reuse from `src/group-init.ts`), `mkdir skills/`, `syncSkillSymlinks(...)`; mount RW at
+    `/home/node/.claude` instead of the shared `.claude-shared`.
+  - Everything else identical (session DBs, `/app/src`, `/app/skills`, `/app/CLAUDE.md`, additional
+    + provider mounts). Ephemeral dirs sit under the session folder so they persist across turns and
+    are removed by `destroyTemporalSession`.
+- **`buildContainerArgs`**: when `session.temporal`, push `-e NANOCLAW_TEMPORAL=1` (after `TZ`, ~L443).
+
+**Unit tests:** `buildMounts` for a temporal session yields the `agent-ephemeral` + `claude-ephemeral`
+host paths (not group dir / shared `.claude-shared`) and args include `NANOCLAW_TEMPORAL=1`; a normal
+session is byte-for-byte unchanged; `composeGroupClaudeMd(group, tmpDir)` writes instructions into
+`tmpDir` and not the group dir.
+**Code-quality-pipeline:** run before done. **Verify:** `pnpm test`; manual spawn → container sees an
+empty workspace (no `CLAUDE.local.md`).
+
+## Milestone 4 — `/incognito` command routing (DM-only)
+
+- **`src/incognito.ts`** (new): `parseIncognitoCommand(content): { kind:'start'|'end'|'none';
+  body:string }` — parse via the JSON `.text` shape `safeParseContent` uses; recognize `/incognito`,
+  `/incognito end`, `/exit`, `/endincognito`; return the prefix-stripped `body`.
+- **`src/router.ts` — inside `deliverToAgent`, before `resolveSession` (line 470)** for `chat`/`chat-sdk`:
+  - Incognito command **and `mg.is_group !== 0`** → `writeOutboundDirect` the DM-only note (to the
+    normal session, resolved for delivery); `return`.
+  - `mg.is_group === 0`:
+    - `start` → `destroyTemporalSession` any existing, `resolveTemporalSession`; non-empty `body` →
+      `writeSessionMessage` the stripped body (rewrite content JSON `.text`) `trigger:1` + wake
+      (reuse the existing `startTypingRefresh` + `wakeContainer` block); empty → `writeOutboundDirect`
+      a "🕶️ Incognito on" note to the temporal session. `return`.
+    - `end` → resolve the normal session, `writeOutboundDirect` an "Incognito off" note to it, then
+      `destroyTemporalSession`. `return`.
+    - plain message → if `findTemporalSession` returns an active one, route THIS message to it; else
+      fall through to the normal path unchanged.
+
+Reuse: `safeParseContent`, `writeOutboundDirect`, `writeSessionMessage`, `writeSessionRouting`, the
+deliver-address block, the typing/`wakeContainer` block (all already in `deliverToAgent`).
+
+**Unit tests:** `parseIncognitoCommand` permutations (`/incognito`, `/incognito hi`, `/incognito end`,
+`/exit`, `/endincognito`, non-commands, leading whitespace, casing).
+**Code-quality-pipeline:** run before done. **Verify:** `pnpm test`.
+
+## Milestone 5 — Idle auto-teardown + agent-runner note
+
+- **`src/host-sweep.ts`**: per-session sweep — for `session.temporal === 1`, if
+  `!isContainerRunning(session.id)` and idle beyond `TEMPORAL_IDLE_MS` (default `ABSOLUTE_CEILING_MS`,
+  from `last_active ?? created_at`), call `destroyTemporalSession(session)`. `getActiveSessions`
+  already returns temporal sessions.
+- **`container/agent-runner/src/`** (optional, small): when `process.env.NANOCLAW_TEMPORAL === '1'`,
+  append a one-line note to the system-prompt addendum (`buildSystemPromptAddendum` in
+  `destinations.ts`, called from `index.ts`): *"This is a temporal/incognito session — nothing here
+  persists; do not claim to remember it later."*
+
+**Unit tests:** host — an idle, not-running temporal session is torn down by the sweep decision; a
+fresh or running one is not (extend `src/host-sweep.test.ts` decision-logic pattern, random ids).
+Container — `bun test`: addendum includes the note iff `NANOCLAW_TEMPORAL=1`.
+**Code-quality-pipeline:** run before done. **Verify:** `pnpm test`; `bun test` +
+`pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`.
+
+## Milestone 6 — Integration tests + docs
+
+- **Integration tests (`src/*.test.ts`, `initTestDb` + `runMigrations`, `host-core.test.ts` pattern,
+  random ids, mocked `container-runner`):** drive `routeInbound` for a DM:
+  - `/incognito` → a `temporal=1` session exists with the real thread_id, normal session untouched,
+    a wake/confirmation lands in the temporal session's `messages_out`.
+  - follow-up plain message → routed to the temporal session (not the normal one).
+  - `/incognito end` → temporal row + folder gone, "Incognito off" note in the normal session's
+    `messages_out`, normal session intact.
+  - `/incognito` in a group (`is_group=1`) → no temporal session created, DM-only note emitted.
+- **Docs:** flip the design doc "Status" to implemented; add a short `/incognito` usage blurb where
+  user-facing commands are documented.
+
+**Code-quality-pipeline:** run the final holistic pass over the whole diff before the PR.
+**Verify:** `pnpm run build`; full `pnpm test` + `bun test` green.
+
+---
+
+## Phase 3 — Close-out
+
+- Mark each milestone/step `[DONE]`/`[SKIPPED]`/`[DEFERRED]` in the `docs/` plan file with reasons;
+  record key decisions + verification results.
+- Update the root `CLAUDE.md` (keep < 100 lines): note the `/incognito` DM command, the `sessions.temporal`
+  flag, and the temporal-spawn path — pointing to the design doc for detail. Then run the
+  `claude-md-management:claude-md-improver` skill to validate (or do it manually + note the skip if the
+  plugin isn't installed).
+
+## Phase 4 — QA handover
+
+Backend-only, so this is the sole live pass. After merge/assembly, hand to the **`qa-engineer`** skill —
+adapted to NanoClaw (no HTTP API): drive real DM traffic through a channel and inspect session DBs +
+delivered replies rather than curl. Handoff bundle: this plan, the `/incognito` behavior + DM-only scope,
+how to run the host + reach a DM channel, and two identities (to confirm group-chat rejection + that one
+user's incognito is thread-scoped). Green-path: start → multi-turn → end, memory-isolation
+(no group memory referenced; `groups/<folder>/` untouched; temporal session folder gone). Break-it:
+`/incognito` in a group, `/exit` with no active session, rapid start/end, idle teardown. Gate on the
+verdict; convert confirmed findings into committed unit/integration tests per `testing-standards`; record
+the verdict in the plan file.
+
+## Out of scope
+
+Promoting anything learned in incognito back into memory; a per-wiring "always incognito" setting; any
+group-chat incognito (would need user-scoped sessions); changes to how normal sessions load memory.

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -44,16 +44,21 @@ const COMPOSED_HEADER = '<!-- Composed at spawn — do not edit. Edit CLAUDE.loc
  * fragments, and MCP server fragments declared in `container.json`. Creates
  * an empty `CLAUDE.local.md` if missing.
  */
-export function composeGroupClaudeMd(group: AgentGroup): void {
-  const groupDir = path.resolve(GROUPS_DIR, group.folder);
-  if (!fs.existsSync(groupDir)) {
-    fs.mkdirSync(groupDir, { recursive: true });
+export function composeGroupClaudeMd(group: AgentGroup, outputDir?: string): void {
+  const sourceGroupDir = path.resolve(GROUPS_DIR, group.folder);
+  // Writes go to `outputDir` when provided — temporal (incognito) sessions
+  // compose into a fresh ephemeral workspace so the agent gets operating
+  // instructions with no memory. Persona/config are always read from the real
+  // group. Defaults to the group dir, i.e. unchanged behavior.
+  const targetDir = outputDir ?? sourceGroupDir;
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true });
   }
 
-  const sharedLink = path.join(groupDir, '.claude-shared.md');
+  const sharedLink = path.join(targetDir, '.claude-shared.md');
   syncSymlink(sharedLink, SHARED_CLAUDE_MD_CONTAINER_PATH);
 
-  const fragmentsDir = path.join(groupDir, '.claude-fragments');
+  const fragmentsDir = path.join(targetDir, '.claude-fragments');
   if (!fs.existsSync(fragmentsDir)) {
     fs.mkdirSync(fragmentsDir, { recursive: true });
   }
@@ -114,7 +119,7 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
 
   // Template persona (if any) — inline so it survives the prune below; imported
   // first (see the imports assembly) so it prepends the composed system prompt.
-  const persona = readGroupPersona(groupDir);
+  const persona = readGroupPersona(sourceGroupDir);
   if (persona) {
     desired.set(PERSONA_FRAGMENT, { type: 'inline', content: persona });
   }
@@ -145,9 +150,9 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
     imports.push(`@./.claude-fragments/${name}`);
   }
   const body = [COMPOSED_HEADER, ...imports, ''].join('\n');
-  writeAtomic(path.join(groupDir, 'CLAUDE.md'), body);
+  writeAtomic(path.join(targetDir, 'CLAUDE.md'), body);
 
-  const localFile = path.join(groupDir, 'CLAUDE.local.md');
+  const localFile = path.join(targetDir, 'CLAUDE.local.md');
   if (!fs.existsSync(localFile)) {
     fs.writeFileSync(localFile, '');
   }

--- a/src/container-runner.temporal.test.ts
+++ b/src/container-runner.temporal.test.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { ROOT, GROUPS_DIR, DATA_DIR } = vi.hoisted(() => {
+  const root = '/tmp/nanoclaw-test-cr-temporal';
+  return { ROOT: root, GROUPS_DIR: `${root}/groups`, DATA_DIR: `${root}/data` };
+});
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, GROUPS_DIR, DATA_DIR };
+});
+
+import { composeGroupClaudeMd } from './claude-md-compose.js';
+import { buildMounts } from './container-runner.js';
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index.js';
+import type { ContainerConfig } from './container-config.js';
+import type { AgentGroup, Session } from './types.js';
+
+function now() {
+  return new Date().toISOString();
+}
+
+const folder = 'incognito-group';
+const ag = `ag-${randomUUID()}`;
+const agentGroup: AgentGroup = { id: ag, name: 'Agent', folder, agent_provider: null, created_at: now() };
+
+const cfg: ContainerConfig = {
+  mcpServers: {},
+  packages: { apt: [], npm: [] },
+  additionalMounts: [],
+  skills: 'all',
+};
+
+function session(temporal: 0 | 1): Session {
+  return {
+    id: `sess-${randomUUID()}`,
+    agent_group_id: ag,
+    messaging_group_id: `mg-${randomUUID()}`,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: now(),
+    temporal,
+  };
+}
+
+describe('temporal container mounts', () => {
+  beforeEach(() => {
+    fs.rmSync(ROOT, { recursive: true, force: true });
+    fs.mkdirSync(path.join(GROUPS_DIR, folder), { recursive: true });
+    const db = initTestDb();
+    runMigrations(db);
+    createAgentGroup({ id: ag, name: 'Agent', folder, agent_provider: null, created_at: now() });
+  });
+
+  afterEach(() => {
+    closeDb();
+    fs.rmSync(ROOT, { recursive: true, force: true });
+  });
+
+  it('temporal session mounts a fresh ephemeral workspace + isolated .claude, not the group', () => {
+    const sess = session(1);
+    const mounts = buildMounts(agentGroup, sess, cfg, 'claude', {});
+
+    const sessDir = path.join(DATA_DIR, 'v2-sessions', ag, sess.id);
+    const agentMount = mounts.find((m) => m.containerPath === '/workspace/agent');
+    const claudeMount = mounts.find((m) => m.containerPath === '/home/node/.claude');
+
+    expect(agentMount?.hostPath).toBe(path.join(sessDir, 'agent-ephemeral'));
+    expect(claudeMount?.hostPath).toBe(path.join(sessDir, 'claude-ephemeral'));
+
+    // The group dir and the shared .claude-shared must NEVER be mounted.
+    expect(mounts.some((m) => m.hostPath === path.join(GROUPS_DIR, folder))).toBe(false);
+    expect(mounts.some((m) => m.hostPath.includes('.claude-shared'))).toBe(false);
+
+    // Operating instructions composed into the ephemeral workspace, memory empty.
+    expect(fs.existsSync(path.join(agentMount!.hostPath, 'CLAUDE.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(agentMount!.hostPath, 'CLAUDE.local.md'), 'utf-8')).toBe('');
+  });
+
+  it('normal session still mounts the group dir + shared .claude-shared', () => {
+    const sess = session(0);
+    const mounts = buildMounts(agentGroup, sess, cfg, 'claude', {});
+
+    const agentMount = mounts.find((m) => m.containerPath === '/workspace/agent');
+    const claudeMount = mounts.find((m) => m.containerPath === '/home/node/.claude');
+
+    expect(agentMount?.hostPath).toBe(path.join(GROUPS_DIR, folder));
+    expect(claudeMount?.hostPath).toBe(path.join(DATA_DIR, 'v2-sessions', ag, '.claude-shared'));
+  });
+
+  it('composeGroupClaudeMd(group, outputDir) writes to outputDir, not the group dir', () => {
+    const outDir = path.join(ROOT, 'compose-out');
+    composeGroupClaudeMd(agentGroup, outDir);
+
+    expect(fs.existsSync(path.join(outDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'CLAUDE.local.md'))).toBe(true);
+    // The real group dir is left untouched.
+    expect(fs.existsSync(path.join(GROUPS_DIR, folder, 'CLAUDE.md'))).toBe(false);
+  });
+});

--- a/src/container-runner.temporal.test.ts
+++ b/src/container-runner.temporal.test.ts
@@ -95,6 +95,25 @@ describe('temporal container mounts', () => {
     expect(claudeMount?.hostPath).toBe(path.join(DATA_DIR, 'v2-sessions', ag, '.claude-shared'));
   });
 
+  it('drops a provider mount rooted under the group dir but keeps out-of-group mounts', () => {
+    const sess = session(1);
+    const groupLeak = {
+      hostPath: path.join(GROUPS_DIR, folder, 'secret-memory'),
+      containerPath: '/workspace/agent/leak',
+      readonly: false,
+    };
+    const sessionScoped = {
+      hostPath: path.join(DATA_DIR, 'v2-sessions', ag, sess.id, 'xdg'),
+      containerPath: '/home/node/.xdg',
+      readonly: false,
+    };
+
+    const mounts = buildMounts(agentGroup, sess, cfg, 'claude', { mounts: [groupLeak, sessionScoped] });
+
+    expect(mounts.some((m) => m.hostPath === groupLeak.hostPath)).toBe(false);
+    expect(mounts.some((m) => m.hostPath === sessionScoped.hostPath)).toBe(true);
+  });
+
   it('composeGroupClaudeMd(group, outputDir) writes to outputDir, not the group dir', () => {
     const outDir = path.join(ROOT, 'compose-out');
     composeGroupClaudeMd(agentGroup, outDir);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -156,6 +156,7 @@ async function spawnContainer(session: Session): Promise<void> {
     provider,
     contribution,
     agentIdentifier,
+    session.temporal === 1,
   );
 
   log.info('Spawning container', { sessionId: session.id, agentGroup: agentGroup.name, containerName });
@@ -271,6 +272,14 @@ export function buildMounts(
   provider: string,
   providerContribution: ProviderContainerContribution,
 ): VolumeMount[] {
+  // Temporal (incognito) session: a fresh, memory-free workspace + isolated
+  // .claude, both under the session folder (discarded on teardown). Never
+  // mounts the group dir or the shared .claude-shared, so no long-term memory
+  // or prior transcript can leak in.
+  if (session.temporal === 1) {
+    return buildTemporalMounts(agentGroup, session, containerConfig, provider, providerContribution);
+  }
+
   const projectRoot = process.cwd();
 
   // Default agent surfaces (composed project doc, skill links, provider state
@@ -359,6 +368,98 @@ export function buildMounts(
 }
 
 /**
+ * Mounts for a temporal (incognito) session: a fresh, memory-free workspace and
+ * an isolated Claude state dir, both under the session folder so
+ * `destroyTemporalSession` removes them wholesale. The group dir and the shared
+ * `.claude-shared` are never mounted, so no long-term memory (CLAUDE.local.md,
+ * memory/, conversations/, ad-hoc workspace files) or prior SDK transcript can
+ * leak in. All writes land in the ephemeral dirs and are discarded on teardown.
+ */
+function buildTemporalMounts(
+  agentGroup: AgentGroup,
+  session: Session,
+  containerConfig: import('./container-config.js').ContainerConfig,
+  provider: string,
+  providerContribution: ProviderContainerContribution,
+): VolumeMount[] {
+  const projectRoot = process.cwd();
+  const defaultSurfaces = !providerProvidesAgentSurfaces(provider);
+  const sessDir = sessionDir(agentGroup.id, session.id);
+  const groupDir = path.resolve(GROUPS_DIR, agentGroup.folder);
+  const agentDir = path.join(sessDir, 'agent-ephemeral');
+  const claudeStateDir = path.join(sessDir, 'claude-ephemeral');
+
+  fs.mkdirSync(agentDir, { recursive: true });
+
+  if (defaultSurfaces) {
+    // Compose operating instructions (persona/skills/shared base) INTO the
+    // ephemeral workspace — an empty CLAUDE.local.md, no memory/, no
+    // conversations/, no ad-hoc files. Reads persona/config from the real group.
+    composeGroupClaudeMd(agentGroup, agentDir);
+
+    // container.json so the runner's loadConfig finds it.
+    const srcCfg = path.join(groupDir, 'container.json');
+    if (fs.existsSync(srcCfg)) {
+      fs.copyFileSync(srcCfg, path.join(agentDir, 'container.json'));
+    }
+
+    // Isolated Claude state (settings + skill symlinks), so the incognito
+    // transcript never lands in the group's shared .claude-shared.
+    seedEphemeralClaudeDir(agentGroup.id, claudeStateDir, containerConfig);
+  }
+
+  const mounts: VolumeMount[] = [];
+  mounts.push({ hostPath: sessDir, containerPath: '/workspace', readonly: false });
+  mounts.push({ hostPath: agentDir, containerPath: '/workspace/agent', readonly: false });
+
+  // Shared base doc — imported by the composed entry via `.claude-shared.md`.
+  const sharedClaudeMd = path.join(projectRoot, 'container', 'CLAUDE.md');
+  if (defaultSurfaces && fs.existsSync(sharedClaudeMd)) {
+    mounts.push({ hostPath: sharedClaudeMd, containerPath: '/app/CLAUDE.md', readonly: true });
+  }
+  if (defaultSurfaces) {
+    mounts.push({ hostPath: claudeStateDir, containerPath: '/home/node/.claude', readonly: false });
+  }
+
+  const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
+  mounts.push({ hostPath: agentRunnerSrc, containerPath: '/app/src', readonly: true });
+
+  const skillsSrc = path.join(projectRoot, 'container', 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    mounts.push({ hostPath: skillsSrc, containerPath: '/app/skills', readonly: true });
+  }
+
+  if (containerConfig.additionalMounts && containerConfig.additionalMounts.length > 0) {
+    mounts.push(...validateAdditionalMounts(containerConfig.additionalMounts, agentGroup.name));
+  }
+  if (providerContribution.mounts) {
+    mounts.push(...providerContribution.mounts);
+  }
+
+  return mounts;
+}
+
+/**
+ * Seed an isolated /home/node/.claude for a temporal session: copy the group's
+ * settings.json (PreCompact hook + env) and create the skill symlinks fresh.
+ * `initGroupFilesystem` seeded the group's `.claude-shared` before buildMounts
+ * ran, so the source settings.json exists.
+ */
+function seedEphemeralClaudeDir(
+  agentGroupId: string,
+  claudeStateDir: string,
+  containerConfig: import('./container-config.js').ContainerConfig,
+): void {
+  fs.mkdirSync(claudeStateDir, { recursive: true });
+  const srcSettings = path.join(DATA_DIR, 'v2-sessions', agentGroupId, '.claude-shared', 'settings.json');
+  if (fs.existsSync(srcSettings)) {
+    fs.copyFileSync(srcSettings, path.join(claudeStateDir, 'settings.json'));
+  }
+  fs.mkdirSync(path.join(claudeStateDir, 'skills'), { recursive: true });
+  syncSkillSymlinks(claudeStateDir, containerConfig);
+}
+
+/**
  * Sync skill symlinks in .claude-shared/skills/ to match the container.json
  * selection. Each symlink points to a container path (/app/skills/<name>)
  * so it's dangling on the host but valid inside the container.
@@ -428,6 +529,7 @@ async function buildContainerArgs(
   _provider: string,
   providerContribution: ProviderContainerContribution,
   agentIdentifier?: string,
+  temporal = false,
 ): Promise<string[]> {
   const args: string[] = ['run', '--rm', '--name', containerName, '--label', CONTAINER_INSTALL_LABEL];
 
@@ -441,6 +543,10 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Temporal (incognito) marker — lets the runner append a "nothing persists"
+  // note to the system prompt. Isolation itself comes from the mount set.
+  if (temporal) args.push('-e', 'NANOCLAW_TEMPORAL=1');
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -432,11 +432,31 @@ function buildTemporalMounts(
   if (containerConfig.additionalMounts && containerConfig.additionalMounts.length > 0) {
     mounts.push(...validateAdditionalMounts(containerConfig.additionalMounts, agentGroup.name));
   }
+  // Provider-contributed mounts — but drop any rooted under the real group dir.
+  // A `providesAgentSurfaces` provider is documented to mount its per-group
+  // memory/state from ctx.groupDir (provider-container-registry.ts); that must
+  // never enter a memory-free temporal container. Session-scoped and other
+  // out-of-group mounts (e.g. opencode-xdg on sessionDir) are kept.
   if (providerContribution.mounts) {
-    mounts.push(...providerContribution.mounts);
+    for (const m of providerContribution.mounts) {
+      if (isPathUnder(m.hostPath, groupDir)) {
+        log.warn('Dropping group-dir provider mount from temporal session', {
+          hostPath: m.hostPath,
+          sessionId: session.id,
+        });
+        continue;
+      }
+      mounts.push(m);
+    }
   }
 
   return mounts;
+}
+
+/** True when `child` is `parent` or nested inside it. */
+function isPathUnder(child: string, parent: string): boolean {
+  const rel = path.relative(parent, path.resolve(child));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
 /**

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -27,6 +27,7 @@ export {
   createSession,
   getSession,
   findSession,
+  findTemporalSession,
   findSessionByAgentGroup,
   getSessionsByAgentGroup,
   getActiveSessions,

--- a/src/db/migrations/020-sessions-temporal.ts
+++ b/src/db/migrations/020-sessions-temporal.ts
@@ -1,0 +1,17 @@
+import type { Migration } from './index.js';
+
+/**
+ * `temporal` flag on `sessions`: marks an incognito/ephemeral session (the
+ * `/incognito` DM command). When temporal=1 the session is excluded from all
+ * normal routing/lifecycle lookups (findSessionForAgent, findSession, etc.) so
+ * it coexists alongside the normal session for the same (group, mg, thread)
+ * without colliding — there is no UNIQUE constraint on that triple. Its
+ * container gets a fresh, memory-free workspace and is discarded on teardown.
+ */
+export const migration020: Migration = {
+  version: 20,
+  name: 'sessions-temporal',
+  up(db) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN temporal INTEGER DEFAULT 0;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -18,6 +18,7 @@ import { moduleApprovalsPendingApprovals } from './module-approvals-pending-appr
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
+import { migration020 } from './020-sessions-temporal.js';
 
 export interface Migration {
   version: number;
@@ -52,6 +53,7 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration019,
+  migration020,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -118,7 +118,8 @@ CREATE TABLE sessions (
   status             TEXT DEFAULT 'active',
   container_status   TEXT DEFAULT 'stopped',
   last_active        TEXT,
-  created_at         TEXT NOT NULL
+  created_at         TEXT NOT NULL,
+  temporal           INTEGER DEFAULT 0
 );
 CREATE INDEX idx_sessions_agent_group ON sessions(agent_group_id);
 CREATE INDEX idx_sessions_lookup ON sessions(messaging_group_id, thread_id);

--- a/src/db/sessions-temporal.test.ts
+++ b/src/db/sessions-temporal.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  closeDb,
+  createAgentGroup,
+  createMessagingGroup,
+  createSession,
+  findSession,
+  findSessionByAgentGroup,
+  findTemporalSession,
+  getActiveSessions,
+  initTestDb,
+  runMigrations,
+} from './index.js';
+import { findSessionForAgent } from './sessions.js';
+
+function now() {
+  return new Date().toISOString();
+}
+
+describe('temporal sessions', () => {
+  const ag = `ag-${randomUUID()}`;
+  const mg = `mg-${randomUUID()}`;
+
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+    createAgentGroup({
+      id: ag,
+      name: 'Agent',
+      folder: `folder-${randomUUID()}`,
+      agent_provider: null,
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: mg,
+      channel_type: 'discord',
+      platform_id: `chan-${randomUUID()}`,
+      name: 'DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  const baseSess = () => ({
+    agent_group_id: ag,
+    messaging_group_id: mg,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active' as const,
+    container_status: 'stopped' as const,
+    last_active: null,
+    created_at: now(),
+  });
+
+  it('normal and temporal sessions coexist for the same (group, mg, thread)', () => {
+    const normalId = `sess-${randomUUID()}`;
+    const tempId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: normalId, temporal: 0 });
+    createSession({ ...baseSess(), id: tempId, temporal: 1 });
+
+    expect(getActiveSessions()).toHaveLength(2);
+  });
+
+  it('findSessionForAgent returns only the normal session', () => {
+    const normalId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: normalId, temporal: 0 });
+    createSession({ ...baseSess(), id: `sess-${randomUUID()}`, temporal: 1 });
+
+    const found = findSessionForAgent(ag, mg, null);
+    expect(found?.id).toBe(normalId);
+    expect(found?.temporal).toBe(0);
+  });
+
+  it('findTemporalSession returns only the temporal session', () => {
+    const tempId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: `sess-${randomUUID()}`, temporal: 0 });
+    createSession({ ...baseSess(), id: tempId, temporal: 1 });
+
+    const found = findTemporalSession(ag, mg, null);
+    expect(found?.id).toBe(tempId);
+    expect(found?.temporal).toBe(1);
+  });
+
+  it('temporal + normal coexist on a real thread id (not just DM null)', () => {
+    const thread = `thread-${randomUUID()}`;
+    const normalId = `sess-${randomUUID()}`;
+    const tempId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: normalId, thread_id: thread, temporal: 0 });
+    createSession({ ...baseSess(), id: tempId, thread_id: thread, temporal: 1 });
+
+    expect(findSessionForAgent(ag, mg, thread)?.id).toBe(normalId);
+    expect(findTemporalSession(ag, mg, thread)?.id).toBe(tempId);
+  });
+
+  it('findSession (messaging-group scoped) excludes temporal sessions', () => {
+    createSession({ ...baseSess(), id: `sess-${randomUUID()}`, temporal: 1 });
+    expect(findSession(mg, null)).toBeUndefined();
+
+    const normalId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: normalId, temporal: 0 });
+    expect(findSession(mg, null)?.id).toBe(normalId);
+  });
+
+  it('findSessionByAgentGroup excludes temporal sessions', () => {
+    createSession({ ...baseSess(), id: `sess-${randomUUID()}`, temporal: 1 });
+    expect(findSessionByAgentGroup(ag)).toBeUndefined();
+
+    const normalId = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id: normalId, temporal: 0 });
+    expect(findSessionByAgentGroup(ag)?.id).toBe(normalId);
+  });
+
+  it('createSession defaults temporal to 0 when omitted', () => {
+    const id = `sess-${randomUUID()}`;
+    createSession({ ...baseSess(), id });
+    expect(findSessionForAgent(ag, mg, null)?.id).toBe(id);
+    expect(findTemporalSession(ag, mg, null)).toBeUndefined();
+  });
+});

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -8,10 +8,10 @@ export const TASKS_SYSTEM_THREAD_ID = 'system:tasks';
 export function createSession(session: Session): void {
   getDb()
     .prepare(
-      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
-       VALUES (@id, @agent_group_id, @messaging_group_id, @thread_id, @agent_provider, @status, @container_status, @last_active, @created_at)`,
+      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at, temporal)
+       VALUES (@id, @agent_group_id, @messaging_group_id, @thread_id, @agent_provider, @status, @container_status, @last_active, @created_at, @temporal)`,
     )
-    .run(session);
+    .run({ ...session, temporal: session.temporal ?? 0 });
 }
 
 export function getSession(id: string): Session | undefined {
@@ -21,11 +21,13 @@ export function getSession(id: string): Session | undefined {
 export function findSession(messagingGroupId: string, threadId: string | null): Session | undefined {
   if (threadId) {
     return getDb()
-      .prepare('SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id = ? AND status = ?')
+      .prepare('SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id = ? AND status = ? AND temporal = 0')
       .get(messagingGroupId, threadId, 'active') as Session | undefined;
   }
   return getDb()
-    .prepare('SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id IS NULL AND status = ?')
+    .prepare(
+      'SELECT * FROM sessions WHERE messaging_group_id = ? AND thread_id IS NULL AND status = ? AND temporal = 0',
+    )
     .get(messagingGroupId, 'active') as Session | undefined;
 }
 
@@ -43,13 +45,37 @@ export function findSessionForAgent(
   if (threadId) {
     return getDb()
       .prepare(
-        "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id = ? AND status = 'active'",
+        "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id = ? AND status = 'active' AND temporal = 0",
       )
       .get(agentGroupId, messagingGroupId, threadId) as Session | undefined;
   }
   return getDb()
     .prepare(
-      "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id IS NULL AND status = 'active'",
+      "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id IS NULL AND status = 'active' AND temporal = 0",
+    )
+    .get(agentGroupId, messagingGroupId) as Session | undefined;
+}
+
+/**
+ * Find the active temporal (incognito) session for a DM. Mirrors
+ * `findSessionForAgent` but matches `temporal = 1` — the routing side uses it
+ * to detect that a thread is currently in incognito mode.
+ */
+export function findTemporalSession(
+  agentGroupId: string,
+  messagingGroupId: string,
+  threadId: string | null,
+): Session | undefined {
+  if (threadId) {
+    return getDb()
+      .prepare(
+        "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id = ? AND status = 'active' AND temporal = 1",
+      )
+      .get(agentGroupId, messagingGroupId, threadId) as Session | undefined;
+  }
+  return getDb()
+    .prepare(
+      "SELECT * FROM sessions WHERE agent_group_id = ? AND messaging_group_id = ? AND thread_id IS NULL AND status = 'active' AND temporal = 1",
     )
     .get(agentGroupId, messagingGroupId) as Session | undefined;
 }
@@ -61,6 +87,7 @@ export function findSessionByAgentGroup(agentGroupId: string): Session | undefin
       `SELECT * FROM sessions
        WHERE agent_group_id = ?
          AND status = 'active'
+         AND temporal = 0
          AND NOT (messaging_group_id IS NULL AND thread_id IS NOT NULL AND thread_id LIKE 'system:%')
        ORDER BY created_at DESC
        LIMIT 1`,
@@ -80,6 +107,7 @@ export function findSystemSession(agentGroupId: string, threadId: string): Sessi
          AND messaging_group_id IS NULL
          AND thread_id = ?
          AND status = 'active'
+         AND temporal = 0
        ORDER BY created_at DESC
        LIMIT 1`,
     )
@@ -104,6 +132,7 @@ export function findTaskSessions(agentGroupId: string): Session[] {
        WHERE agent_group_id = ?
          AND messaging_group_id IS NULL
          AND status = 'active'
+         AND temporal = 0
          AND (thread_id = ? OR thread_id LIKE ?)
        ORDER BY created_at DESC`,
     )

--- a/src/host-sweep.temporal.test.ts
+++ b/src/host-sweep.temporal.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { TEMPORAL_IDLE_MS, shouldDestroyTemporalSession } from './host-sweep.js';
+import type { Session } from './types.js';
+
+const NOW = Date.parse('2026-04-20T12:00:00.000Z');
+
+function sess(overrides: Partial<Session>): Session {
+  return {
+    id: 'sess-x',
+    agent_group_id: 'ag',
+    messaging_group_id: 'mg',
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: new Date(NOW).toISOString(),
+    created_at: new Date(NOW).toISOString(),
+    temporal: 1,
+    ...overrides,
+  };
+}
+
+describe('shouldDestroyTemporalSession', () => {
+  const idle = new Date(NOW - TEMPORAL_IDLE_MS - 1000).toISOString();
+  const fresh = new Date(NOW - 1000).toISOString();
+
+  it('tears down an idle, not-running temporal session', () => {
+    expect(shouldDestroyTemporalSession(sess({ last_active: idle }), false, NOW)).toBe(true);
+  });
+
+  it('keeps a temporal session whose container is running', () => {
+    expect(shouldDestroyTemporalSession(sess({ last_active: idle }), true, NOW)).toBe(false);
+  });
+
+  it('keeps a freshly-active temporal session', () => {
+    expect(shouldDestroyTemporalSession(sess({ last_active: fresh }), false, NOW)).toBe(false);
+  });
+
+  it('never tears down a normal (temporal=0) session', () => {
+    expect(shouldDestroyTemporalSession(sess({ temporal: 0, last_active: idle }), false, NOW)).toBe(false);
+  });
+
+  it('falls back to created_at when last_active is null', () => {
+    expect(shouldDestroyTemporalSession(sess({ last_active: null, created_at: idle }), false, NOW)).toBe(true);
+    expect(shouldDestroyTemporalSession(sess({ last_active: null, created_at: fresh }), false, NOW)).toBe(false);
+  });
+});

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -46,6 +46,7 @@ import {
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbeatPath } from './session-manager.js';
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { destroyTemporalSession } from './temporal-session.js';
 import type { Session } from './types.js';
 
 /**
@@ -67,6 +68,9 @@ export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
 // Stuck tolerance window applied per 'processing' claim — "did we see any
 // signs of life since this message was claimed?"
 export const CLAIM_STUCK_MS = 60 * 1000;
+// Idle window before an abandoned temporal (incognito) session is torn down.
+// Reuses the running-container ceiling; tunable independently if needed.
+export const TEMPORAL_IDLE_MS = ABSOLUTE_CEILING_MS;
 const MAX_TRIES = 5;
 const BACKOFF_BASE_MS = 5000;
 
@@ -176,6 +180,19 @@ export function shouldCloseTaskSession(
   return isTaskThread(threadId) && !containerRunning && liveTaskCount === 0;
 }
 
+/**
+ * An idle temporal (incognito) session — not running and untouched past the
+ * idle ceiling — is abandoned and should be torn down (its ephemeral workspace
+ * discarded). Measured from last_active, falling back to created_at.
+ */
+export function shouldDestroyTemporalSession(session: Session, containerRunning: boolean, now: number): boolean {
+  if (session.temporal !== 1 || containerRunning) return false;
+  const ref = session.last_active ?? session.created_at;
+  const refMs = parseSqliteUtc(ref);
+  if (Number.isNaN(refMs)) return false;
+  return now - refMs > TEMPORAL_IDLE_MS;
+}
+
 async function sweepSession(session: Session): Promise<void> {
   const agentGroup = getAgentGroup(session.agent_group_id);
   if (!agentGroup) return;
@@ -197,6 +214,7 @@ async function sweepSession(session: Session): Promise<void> {
     // outbound.db might not exist yet (container hasn't started)
   }
 
+  let tearDownTemporal = false;
   try {
     // 1. Sync processing_ack → messages_in status
     if (outDb) {
@@ -261,9 +279,19 @@ async function sweepSession(session: Session): Promise<void> {
         log.info('Closed spent task session', { sessionId: session.id, threadId: session.thread_id });
       }
     }
+
+    // 7. Idle temporal (incognito) session teardown. Decided here (DBs still
+    // open) but executed after the finally — destroyTemporalSession rm -rf's
+    // the session folder, so it must run once the DB handles are closed.
+    tearDownTemporal = shouldDestroyTemporalSession(session, isContainerRunning(session.id), Date.now());
   } finally {
     inDb.close();
     outDb?.close();
+  }
+
+  if (tearDownTemporal) {
+    destroyTemporalSession(session);
+    log.info('Tore down idle temporal session', { sessionId: session.id });
   }
 }
 

--- a/src/incognito.integration.test.ts
+++ b/src/incognito.integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration tests for the /incognito routing flow through routeInbound.
+ * Container spawning + delivery are mocked; assertions read the session DBs.
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_DIR = vi.hoisted(() => '/tmp/nanoclaw-test-incognito-int');
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn().mockResolvedValue(true),
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  getActiveContainerCount: vi.fn().mockReturnValue(0),
+  killContainer: vi.fn(),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: TEST_DIR };
+});
+
+vi.mock('./delivery.js', async () => {
+  const actual = await vi.importActual<typeof import('./delivery.js')>('./delivery.js');
+  return { ...actual, deliverSessionMessages: vi.fn().mockResolvedValue(undefined) };
+});
+
+import {
+  createAgentGroup,
+  createMessagingGroup,
+  createMessagingGroupAgent,
+  initTestDb,
+  runMigrations,
+  closeDb,
+} from './db/index.js';
+import { findSessionForAgent, findTemporalSession, getSession } from './db/sessions.js';
+import { outboundDbPath, inboundDbPath, sessionDir } from './session-manager.js';
+import type { InboundEvent } from './channels/adapter.js';
+
+function now() {
+  return new Date().toISOString();
+}
+
+const ag = `ag-${randomUUID()}`;
+const dm = `mg-dm-${randomUUID()}`;
+const group = `mg-grp-${randomUUID()}`;
+
+function messagesIn(sessionId: string): Array<{ id: string; content: string }> {
+  const db = new Database(inboundDbPath(ag, sessionId), { readonly: true });
+  try {
+    return db.prepare('SELECT id, content FROM messages_in ORDER BY timestamp').all() as Array<{
+      id: string;
+      content: string;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+function messagesOutText(sessionId: string): string[] {
+  const db = new Database(outboundDbPath(ag, sessionId), { readonly: true });
+  try {
+    const rows = db.prepare('SELECT content FROM messages_out ORDER BY seq').all() as Array<{ content: string }>;
+    return rows.map((r) => JSON.parse(r.content).text as string);
+  } finally {
+    db.close();
+  }
+}
+
+function dmEvent(text: string, id = `msg-${randomUUID()}`): InboundEvent {
+  return {
+    channelType: 'discord',
+    platformId: 'dm-chan',
+    threadId: null,
+    message: { id, kind: 'chat', content: JSON.stringify({ sender: 'User', text }), timestamp: now() },
+  };
+}
+
+describe('/incognito routing (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks(); // reset call history (keeps mockResolvedValue impls) — mocks are module-shared across tests
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const db = initTestDb();
+    runMigrations(db);
+
+    createAgentGroup({
+      id: ag,
+      name: 'Agent',
+      folder: `folder-${randomUUID()}`,
+      agent_provider: null,
+      created_at: now(),
+    });
+
+    // A DM (is_group=0) and a group chat (is_group=1), both wired to the agent.
+    for (const [id, isGroup, platform] of [
+      [dm, 0, 'dm-chan'],
+      [group, 1, 'grp-chan'],
+    ] as const) {
+      createMessagingGroup({
+        id,
+        channel_type: 'discord',
+        platform_id: platform,
+        name: 'chat',
+        is_group: isGroup,
+        unknown_sender_policy: 'public',
+        created_at: now(),
+      });
+      createMessagingGroupAgent({
+        id: `mga-${randomUUID()}`,
+        messaging_group_id: id,
+        agent_group_id: ag,
+        engage_mode: 'pattern',
+        engage_pattern: '.',
+        sender_scope: 'all',
+        ignored_message_policy: 'drop',
+        session_mode: 'shared',
+        priority: 0,
+        created_at: now(),
+      });
+    }
+  });
+
+  afterEach(() => {
+    closeDb();
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('/incognito <msg> starts a temporal session and leaves the normal session untouched', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { wakeContainer } = await import('./container-runner.js');
+
+    await routeInbound(dmEvent('/incognito what is 2+2'));
+
+    const temporal = findTemporalSession(ag, dm, null);
+    expect(temporal).toBeDefined();
+    expect(temporal!.temporal).toBe(1);
+    // No normal session created yet.
+    expect(findSessionForAgent(ag, dm, null)).toBeUndefined();
+
+    // The prefix-stripped first turn is delivered to the temporal session.
+    const rows = messagesIn(temporal!.id);
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0].content).text).toBe('what is 2+2');
+    expect(wakeContainer).toHaveBeenCalled();
+  });
+
+  it('bare /incognito emits an "Incognito on" note without waking a container', async () => {
+    const { routeInbound } = await import('./router.js');
+    const { wakeContainer } = await import('./container-runner.js');
+
+    await routeInbound(dmEvent('/incognito'));
+
+    const temporal = findTemporalSession(ag, dm, null);
+    expect(temporal).toBeDefined();
+    expect(messagesOutText(temporal!.id).join('\n')).toContain('Incognito on');
+    expect(wakeContainer).not.toHaveBeenCalled();
+  });
+
+  it('a follow-up message continues in the active temporal session', async () => {
+    const { routeInbound } = await import('./router.js');
+    await routeInbound(dmEvent('/incognito first'));
+    const temporal = findTemporalSession(ag, dm, null)!;
+
+    await routeInbound(dmEvent('second'));
+
+    // Same temporal session, two turns; still no normal session.
+    expect(findTemporalSession(ag, dm, null)!.id).toBe(temporal.id);
+    expect(messagesIn(temporal.id)).toHaveLength(2);
+    expect(findSessionForAgent(ag, dm, null)).toBeUndefined();
+  });
+
+  it('/incognito end tears down the temporal session and confirms via the normal session', async () => {
+    const { routeInbound } = await import('./router.js');
+    await routeInbound(dmEvent('/incognito hi'));
+    const temporal = findTemporalSession(ag, dm, null)!;
+    const tempDir = sessionDir(ag, temporal.id);
+    expect(fs.existsSync(tempDir)).toBe(true);
+
+    await routeInbound(dmEvent('/incognito end'));
+
+    // Temporal session + folder gone.
+    expect(findTemporalSession(ag, dm, null)).toBeUndefined();
+    expect(getSession(temporal.id)).toBeUndefined();
+    expect(fs.existsSync(tempDir)).toBe(false);
+
+    // Confirmation delivered via the (now-existing) normal session.
+    const normal = findSessionForAgent(ag, dm, null);
+    expect(normal).toBeDefined();
+    expect(messagesOutText(normal!.id).join('\n')).toContain('Incognito off');
+  });
+
+  it('/incognito in a group chat is refused and creates no temporal session', async () => {
+    const { routeInbound } = await import('./router.js');
+
+    await routeInbound({
+      channelType: 'discord',
+      platformId: 'grp-chan',
+      threadId: null,
+      message: {
+        id: `msg-${randomUUID()}`,
+        kind: 'chat',
+        content: JSON.stringify({ sender: 'User', text: '/incognito secret' }),
+        timestamp: now(),
+      },
+    });
+
+    expect(findTemporalSession(ag, group, null)).toBeUndefined();
+    const normal = findSessionForAgent(ag, group, null);
+    expect(normal).toBeDefined();
+    expect(messagesOutText(normal!.id).join('\n')).toContain('only available in direct messages');
+  });
+});

--- a/src/incognito.integration.test.ts
+++ b/src/incognito.integration.test.ts
@@ -181,6 +181,10 @@ describe('/incognito routing (integration)', () => {
 
     await routeInbound(dmEvent('/incognito end'));
 
+    // The temporal session is drained before teardown (in-flight reply safety).
+    const { deliverSessionMessages } = await import('./delivery.js');
+    expect(deliverSessionMessages).toHaveBeenCalledWith(expect.objectContaining({ id: temporal.id }));
+
     // Temporal session + folder gone.
     expect(findTemporalSession(ag, dm, null)).toBeUndefined();
     expect(getSession(temporal.id)).toBeUndefined();

--- a/src/incognito.test.ts
+++ b/src/incognito.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseIncognitoCommand, rewriteContentText } from './incognito.js';
+
+/** Build a channel content blob the way adapters do. */
+function content(text: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ text, ...extra });
+}
+
+describe('parseIncognitoCommand', () => {
+  it('bare /incognito starts with empty body', () => {
+    expect(parseIncognitoCommand(content('/incognito'))).toEqual({ kind: 'start', body: '' });
+  });
+
+  it('/incognito <message> starts with the stripped body', () => {
+    expect(parseIncognitoCommand(content('/incognito what is the capital of France'))).toEqual({
+      kind: 'start',
+      body: 'what is the capital of France',
+    });
+  });
+
+  it('/incognito end ends', () => {
+    expect(parseIncognitoCommand(content('/incognito end'))).toEqual({ kind: 'end', body: '' });
+  });
+
+  it('/exit and /endincognito are end aliases', () => {
+    expect(parseIncognitoCommand(content('/exit')).kind).toBe('end');
+    expect(parseIncognitoCommand(content('/endincognito')).kind).toBe('end');
+  });
+
+  it('is case-insensitive on the command token', () => {
+    expect(parseIncognitoCommand(content('/INCOGNITO Hi'))).toEqual({ kind: 'start', body: 'Hi' });
+    expect(parseIncognitoCommand(content('/Exit')).kind).toBe('end');
+  });
+
+  it('trims leading/surrounding whitespace', () => {
+    expect(parseIncognitoCommand(content('   /incognito   spaced   '))).toEqual({ kind: 'start', body: 'spaced' });
+  });
+
+  it('only exact "end" after /incognito is an end; anything else is a start body', () => {
+    expect(parseIncognitoCommand(content('/incognito end the meeting'))).toEqual({
+      kind: 'start',
+      body: 'end the meeting',
+    });
+  });
+
+  it('does not match a prefixed word like /incognitofoo', () => {
+    expect(parseIncognitoCommand(content('/incognitofoo')).kind).toBe('none');
+  });
+
+  it('plain text and other slash commands are none', () => {
+    expect(parseIncognitoCommand(content('hello there')).kind).toBe('none');
+    expect(parseIncognitoCommand(content('/help')).kind).toBe('none');
+  });
+
+  it('handles non-JSON content by treating it as raw text', () => {
+    expect(parseIncognitoCommand('/incognito raw')).toEqual({ kind: 'start', body: 'raw' });
+  });
+
+  it('empty text is none', () => {
+    expect(parseIncognitoCommand(content('')).kind).toBe('none');
+  });
+});
+
+describe('rewriteContentText', () => {
+  it('replaces .text and preserves other fields', () => {
+    const original = content('/incognito hello', { sender: 'Ann', senderId: 'u:1' });
+    const rewritten = JSON.parse(rewriteContentText(original, 'hello'));
+    expect(rewritten).toEqual({ text: 'hello', sender: 'Ann', senderId: 'u:1' });
+  });
+
+  it('falls back to a bare {text} blob for non-JSON input', () => {
+    expect(JSON.parse(rewriteContentText('not json', 'hi'))).toEqual({ text: 'hi' });
+  });
+});

--- a/src/incognito.ts
+++ b/src/incognito.ts
@@ -1,0 +1,67 @@
+/**
+ * `/incognito` command parsing for temporal (incognito) sessions.
+ *
+ * Detected in the router before the command gate and before session
+ * resolution, so the command never reaches the container and can redirect
+ * routing to a distinct, memory-free temporal session (DMs only).
+ */
+
+export type IncognitoKind = 'start' | 'end' | 'none';
+
+export interface IncognitoCommand {
+  kind: IncognitoKind;
+  /** For `start`, the message text after the command prefix (may be empty). */
+  body: string;
+}
+
+const START_COMMAND = '/incognito';
+const END_ALIASES = new Set(['/exit', '/endincognito']);
+
+/** Extract the `.text` field from a channel message content blob. */
+function extractText(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as { text?: string };
+    return (parsed.text ?? '').trim();
+  } catch {
+    return content.trim();
+  }
+}
+
+/**
+ * Classify a message as an incognito command.
+ *
+ *   `/incognito [message]` → start (message becomes the first turn)
+ *   `/incognito end` | `/exit` | `/endincognito` → end
+ *   anything else → none
+ */
+export function parseIncognitoCommand(content: string): IncognitoCommand {
+  const text = extractText(content);
+  if (!text) return { kind: 'none', body: '' };
+
+  const firstToken = text.split(/\s+/)[0].toLowerCase();
+
+  if (firstToken === START_COMMAND) {
+    const rest = text.slice(START_COMMAND.length).trim();
+    if (rest.toLowerCase() === 'end') return { kind: 'end', body: '' };
+    return { kind: 'start', body: rest };
+  }
+
+  if (END_ALIASES.has(firstToken)) return { kind: 'end', body: '' };
+
+  return { kind: 'none', body: text };
+}
+
+/**
+ * Rewrite a message content blob's `.text` field (used to deliver the
+ * prefix-stripped first turn of a `/incognito <message>` command while
+ * preserving sender metadata). Falls back to a bare `{ text }` blob if the
+ * original content isn't JSON.
+ */
+export function rewriteContentText(content: string, newText: string): string {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return JSON.stringify({ ...parsed, text: newText });
+  } catch {
+    return JSON.stringify({ text: newText });
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -697,6 +697,11 @@ async function endIncognito(
     return;
   }
 
+  // Drain any reply the incognito turn already wrote to outbound.db but that the
+  // 1s delivery poll hasn't picked up yet — otherwise destroyTemporalSession's
+  // rm -rf would drop it. (Idempotent + re-entry-guarded.)
+  await deliverSessionMessages(existing);
+
   await sendControlNote(normal, addr, '🕶️ Incognito off — back to normal. That conversation was not saved.');
   destroyTemporalSession(existing);
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -27,13 +27,16 @@ import {
   getMessagingGroupAgents,
   getMessagingGroupWithAgentCount,
 } from './db/messaging-groups.js';
-import { findSessionForAgent } from './db/sessions.js';
+import { findSessionForAgent, findTemporalSession } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import { resolveTemporalSession, destroyTemporalSession } from './temporal-session.js';
+import { parseIncognitoCommand, rewriteContentText } from './incognito.js';
+import { deliverSessionMessages } from './delivery.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
-import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
+import type { AgentGroup, MessagingGroup, MessagingGroupAgent, Session } from './types.js';
 import type { InboundEvent } from './channels/adapter.js';
 
 function generateId(): string {
@@ -467,7 +470,43 @@ async function deliverToAgent(
     effectiveSessionMode = 'per-thread';
   }
 
-  const { session, created } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
+  // Incognito (`/incognito`) handling — DM-only, before the command gate and
+  // session resolution so the command never reaches the container and routing
+  // can target a distinct, memory-free temporal session.
+  const isChat = event.message.kind === 'chat' || event.message.kind === 'chat-sdk';
+  const lookupThreadId = effectiveSessionMode === 'per-thread' ? effectiveThreadId : null;
+  if (isChat) {
+    const incog = parseIncognitoCommand(event.message.content);
+    if (incog.kind !== 'none' && mg.is_group !== 0) {
+      // Incognito is DM-only; refuse in group chats (a session is thread-scoped,
+      // so one member's /incognito would flip the whole thread — see design doc).
+      await sendIncognitoNote(
+        agent,
+        mg,
+        event,
+        effectiveThreadId,
+        effectiveSessionMode,
+        '🕶️ Incognito is only available in direct messages.',
+      );
+      return;
+    }
+    if (mg.is_group === 0 && incog.kind === 'start') {
+      await startIncognito(agent, mg, event, effectiveThreadId, effectiveSessionMode, lookupThreadId, incog.body);
+      return;
+    }
+    if (mg.is_group === 0 && incog.kind === 'end') {
+      await endIncognito(agent, mg, event, effectiveThreadId, effectiveSessionMode, lookupThreadId);
+      return;
+    }
+  }
+
+  // Route a follow-up message to an active incognito session when one exists
+  // (DM continuation); otherwise resolve the normal session.
+  const activeTemporal =
+    isChat && mg.is_group === 0 ? findTemporalSession(agent.agent_group_id, mg.id, lookupThreadId) : undefined;
+  const { session, created } = activeTemporal
+    ? { session: activeTemporal, created: false }
+    : resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
 
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source
@@ -547,6 +586,119 @@ async function deliverToAgent(
       if (!woke) stopTypingRefresh(freshSession.id);
     }
   }
+}
+
+// ── Incognito (`/incognito`) helpers ──
+
+type SessionMode = 'shared' | 'per-thread' | 'agent-shared';
+interface ReplyAddr {
+  channelType: string;
+  platformId: string;
+  threadId: string | null;
+}
+
+/** Reply/note address for a DM incognito interaction. */
+function incognitoAddr(event: InboundEvent, effectiveThreadId: string | null): ReplyAddr {
+  return event.replyTo ?? { channelType: event.channelType, platformId: event.platformId, threadId: effectiveThreadId };
+}
+
+/** Write a control note to a session's outbound DB and deliver it immediately. */
+async function sendControlNote(session: Session, addr: ReplyAddr, text: string): Promise<void> {
+  writeOutboundDirect(session.agent_group_id, session.id, {
+    id: `incognito-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    kind: 'chat',
+    platformId: addr.platformId,
+    channelType: addr.channelType,
+    threadId: addr.threadId,
+    content: JSON.stringify({ text }),
+  });
+  await deliverSessionMessages(session);
+}
+
+/** Deliver an incognito control note via the (normal) session for this DM. */
+async function sendIncognitoNote(
+  agent: MessagingGroupAgent,
+  mg: MessagingGroup,
+  event: InboundEvent,
+  effectiveThreadId: string | null,
+  effectiveSessionMode: SessionMode,
+  text: string,
+): Promise<void> {
+  const { session } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
+  await sendControlNote(session, incognitoAddr(event, effectiveThreadId), text);
+}
+
+/** Start (or restart) a temporal session for a DM and route the first turn. */
+async function startIncognito(
+  agent: MessagingGroupAgent,
+  mg: MessagingGroup,
+  event: InboundEvent,
+  effectiveThreadId: string | null,
+  effectiveSessionMode: SessionMode,
+  lookupThreadId: string | null,
+  body: string,
+): Promise<void> {
+  const existing = findTemporalSession(agent.agent_group_id, mg.id, lookupThreadId);
+  if (existing) destroyTemporalSession(existing);
+
+  const { session } = resolveTemporalSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
+  const addr = incognitoAddr(event, effectiveThreadId);
+
+  if (body) {
+    // Deliver the prefix-stripped first turn and wake the temporal container.
+    writeSessionMessage(session.agent_group_id, session.id, {
+      id: messageIdForAgent(event.message.id, agent.agent_group_id),
+      kind: event.message.kind,
+      timestamp: event.message.timestamp,
+      platformId: addr.platformId,
+      channelType: addr.channelType,
+      threadId: addr.threadId,
+      content: rewriteContentText(event.message.content, body),
+      trigger: 1,
+    });
+    startTypingRefresh(
+      session.id,
+      session.agent_group_id,
+      event.channelType,
+      event.platformId,
+      effectiveThreadId,
+      mg.instance,
+    );
+    const fresh = getSession(session.id);
+    if (fresh) {
+      const woke = await wakeContainer(fresh);
+      if (!woke) stopTypingRefresh(fresh.id);
+    }
+  } else {
+    await sendControlNote(
+      session,
+      addr,
+      '🕶️ Incognito on — clean slate, nothing here is saved. Send /incognito end to exit.',
+    );
+  }
+}
+
+/** End an active temporal session for a DM (or note that none is active). */
+async function endIncognito(
+  agent: MessagingGroupAgent,
+  mg: MessagingGroup,
+  event: InboundEvent,
+  effectiveThreadId: string | null,
+  effectiveSessionMode: SessionMode,
+  lookupThreadId: string | null,
+): Promise<void> {
+  const existing = findTemporalSession(agent.agent_group_id, mg.id, lookupThreadId);
+  // Confirm via the normal session, which survives the temporal teardown.
+  const { session: normal } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
+  const addr = incognitoAddr(event, effectiveThreadId);
+
+  if (!existing) {
+    await sendControlNote(normal, addr, "You're not in an incognito session.");
+    return;
+  }
+
+  await sendControlNote(normal, addr, '🕶️ Incognito off — back to normal. That conversation was not saved.');
+  destroyTemporalSession(existing);
 }
 
 /**

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -113,6 +113,7 @@ export function resolveSession(
     container_status: 'stopped',
     last_active: null,
     created_at: new Date().toISOString(),
+    temporal: 0,
   };
 
   createSession(session);
@@ -140,6 +141,7 @@ export function resolveTaskSession(agentGroupId: string, seriesId: string): { se
     container_status: 'stopped',
     last_active: null,
     created_at: new Date().toISOString(),
+    temporal: 0,
   };
 
   createSession(session);

--- a/src/temporal-session.test.ts
+++ b/src/temporal-session.test.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TEST_DIR = vi.hoisted(() => '/tmp/nanoclaw-test-temporal-lifecycle');
+
+vi.mock('./container-runner.js', () => ({
+  isContainerRunning: vi.fn().mockReturnValue(false),
+  killContainer: vi.fn(),
+}));
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js');
+  return { ...actual, DATA_DIR: TEST_DIR };
+});
+
+import { isContainerRunning, killContainer } from './container-runner.js';
+import { closeDb, createAgentGroup, createMessagingGroup, getSession, initTestDb, runMigrations } from './db/index.js';
+import { findTemporalSession } from './db/sessions.js';
+import { sessionDir } from './session-manager.js';
+import { destroyTemporalSession, resolveTemporalSession } from './temporal-session.js';
+
+function now() {
+  return new Date().toISOString();
+}
+
+describe('temporal-session lifecycle', () => {
+  const ag = `ag-${randomUUID()}`;
+  const mg = `mg-${randomUUID()}`;
+
+  beforeEach(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const db = initTestDb();
+    runMigrations(db);
+    createAgentGroup({
+      id: ag,
+      name: 'Agent',
+      folder: `folder-${randomUUID()}`,
+      agent_provider: null,
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: mg,
+      channel_type: 'discord',
+      platform_id: `chan-${randomUUID()}`,
+      name: 'DM',
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    vi.mocked(isContainerRunning).mockReturnValue(false);
+    vi.mocked(killContainer).mockReset();
+  });
+
+  afterEach(() => {
+    closeDb();
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('creates a temporal=1 session with a folder', () => {
+    const { session, created } = resolveTemporalSession(ag, mg, null, 'shared');
+    expect(created).toBe(true);
+    expect(session.temporal).toBe(1);
+    expect(session.messaging_group_id).toBe(mg);
+    expect(session.thread_id).toBeNull();
+    expect(fs.existsSync(sessionDir(ag, session.id))).toBe(true);
+    expect(findTemporalSession(ag, mg, null)?.id).toBe(session.id);
+  });
+
+  it('is idempotent — a second resolve reuses the same session', () => {
+    const first = resolveTemporalSession(ag, mg, null, 'shared');
+    const second = resolveTemporalSession(ag, mg, null, 'shared');
+    expect(second.created).toBe(false);
+    expect(second.session.id).toBe(first.session.id);
+  });
+
+  it('destroy (no running container) closes+deletes the row and removes the folder', () => {
+    const { session } = resolveTemporalSession(ag, mg, null, 'shared');
+    const dir = sessionDir(ag, session.id);
+    expect(fs.existsSync(dir)).toBe(true);
+
+    destroyTemporalSession(session);
+
+    expect(killContainer).not.toHaveBeenCalled();
+    expect(getSession(session.id)).toBeUndefined();
+    expect(findTemporalSession(ag, mg, null)).toBeUndefined();
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('destroy (running container) defers cleanup to container exit', () => {
+    const { session } = resolveTemporalSession(ag, mg, null, 'shared');
+    const dir = sessionDir(ag, session.id);
+
+    vi.mocked(isContainerRunning).mockReturnValue(true);
+    let onExit: (() => void) | undefined;
+    vi.mocked(killContainer).mockImplementation((_id, _reason, cb) => {
+      onExit = cb;
+    });
+
+    destroyTemporalSession(session);
+
+    // Cleanup deferred — row + folder still present until the container exits.
+    expect(killContainer).toHaveBeenCalledWith(session.id, 'temporal-end', expect.any(Function));
+    expect(getSession(session.id)).toBeDefined();
+    expect(fs.existsSync(dir)).toBe(true);
+
+    // Simulate the container process closing.
+    onExit?.();
+    expect(getSession(session.id)).toBeUndefined();
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+});

--- a/src/temporal-session.ts
+++ b/src/temporal-session.ts
@@ -1,0 +1,88 @@
+/**
+ * Temporal ("incognito") session lifecycle.
+ *
+ * A temporal session is a distinct, memory-free throwaway session started by
+ * the `/incognito` DM command. It stores the REAL thread_id + messaging_group_id
+ * (so replies route back to the chat) and is disambiguated from the normal
+ * session only by `temporal = 1`. Its container gets a fresh, empty workspace
+ * (see container-runner's temporal spawn branch) and everything it writes lives
+ * under the session folder, discarded wholesale on teardown.
+ *
+ * Lives in its own module (not session-manager) to avoid an import cycle:
+ * container-runner already imports `sessionDir` from session-manager, and
+ * `destroyTemporalSession` needs `killContainer` from container-runner.
+ */
+import fs from 'fs';
+
+import { isContainerRunning, killContainer } from './container-runner.js';
+import { createSession, deleteSession, findTemporalSession, updateSession } from './db/sessions.js';
+import { log } from './log.js';
+import { initSessionFolder, sessionDir } from './session-manager.js';
+import type { Session } from './types.js';
+
+function newSessionId(): string {
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Find or create the active temporal session for a DM. Mirrors `resolveSession`
+ * (same lookup-thread rule) but sets `temporal = 1`. DMs resolve to a null
+ * thread, so the temporal session coexists with the normal (null-thread)
+ * session for the same (group, mg).
+ */
+export function resolveTemporalSession(
+  agentGroupId: string,
+  messagingGroupId: string,
+  threadId: string | null,
+  sessionMode: 'shared' | 'per-thread' | 'agent-shared',
+): { session: Session; created: boolean } {
+  const lookupThreadId = sessionMode === 'per-thread' ? threadId : null;
+
+  const existing = findTemporalSession(agentGroupId, messagingGroupId, lookupThreadId);
+  if (existing) return { session: existing, created: false };
+
+  const id = newSessionId();
+  const session: Session = {
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: messagingGroupId,
+    thread_id: lookupThreadId,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: new Date().toISOString(),
+    temporal: 1,
+  };
+
+  createSession(session);
+  initSessionFolder(agentGroupId, id);
+  log.info('Temporal session created', { id, agentGroupId, messagingGroupId, threadId: lookupThreadId });
+
+  return { session, created: true };
+}
+
+/**
+ * Tear down a temporal session: kill its container (if running), close + delete
+ * the row, and remove its session folder (ephemeral workspace + isolated
+ * `.claude` + both session DBs) so nothing persists.
+ *
+ * When a container is running, cleanup is deferred to the container's exit so we
+ * never pull the session folder out from under a live process. `killContainer`
+ * only fires `onExit` when an active container exists, so the not-running path
+ * cleans up immediately.
+ */
+export function destroyTemporalSession(session: Session): void {
+  const cleanup = (): void => {
+    updateSession(session.id, { status: 'closed' });
+    deleteSession(session.id);
+    fs.rmSync(sessionDir(session.agent_group_id, session.id), { recursive: true, force: true });
+    log.info('Temporal session destroyed', { id: session.id, agentGroupId: session.agent_group_id });
+  };
+
+  if (isContainerRunning(session.id)) {
+    killContainer(session.id, 'temporal-end', cleanup);
+  } else {
+    cleanup();
+  }
+}

--- a/src/temporal-session.ts
+++ b/src/temporal-session.ts
@@ -73,8 +73,13 @@ export function resolveTemporalSession(
  * cleans up immediately.
  */
 export function destroyTemporalSession(session: Session): void {
+  // Close synchronously so the row is immediately excluded from lookups and
+  // sweeps (findTemporalSession filters status='active') even when the
+  // container kill + folder removal is deferred to the container's exit. This
+  // prevents a re-`/incognito` from reusing a session that's being torn down.
+  updateSession(session.id, { status: 'closed' });
+
   const cleanup = (): void => {
-    updateSession(session.id, { status: 'closed' });
     deleteSession(session.id);
     fs.rmSync(sessionDir(session.agent_group_id, session.id), { recursive: true, force: true });
     log.info('Temporal session destroyed', { id: session.id, agentGroupId: session.agent_group_id });

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,12 @@ export interface Session {
   container_status: 'running' | 'idle' | 'stopped';
   last_active: string | null;
   created_at: string;
+  /**
+   * 1 = incognito/ephemeral session (excluded from normal routing); 0 = normal.
+   * Optional on construction (DB column defaults to 0 and is always present on
+   * rows read back); `createSession` coalesces a missing value to 0.
+   */
+  temporal?: number;
 }
 
 // ── Session DB entities ──


### PR DESCRIPTION
## Type of Change

This is really an **RFC / vision share**, not a merge-ready feature. Per `CONTRIBUTING.md`, source-code *features* aren't accepted on `main` (they should be skills) — I'm opening this to share the design and get a read on whether the direction is interesting, and if so, how you'd want it shaped (skill vs. core).

## Description

**Temporal ("incognito") sessions** — a throwaway, memory-free DM session you start with `/incognito`.

- A distinct `sessions` row disambiguated by `sessions.temporal = 1` (migration `020`), storing the **real** `thread_id` + `messaging_group_id` so replies still route back to the same chat.
- Its container gets a fresh, empty `/workspace/agent` (composed operating instructions only — no `CLAUDE.local.md`, `memory/`, `conversations/`, or ad-hoc files) plus an isolated `/home/node/.claude`, both under the session folder and `rm -rf`'d on teardown.
- `NANOCLAW_TEMPORAL=1` adds a "nothing persists" system-prompt note.
- Ends via `/incognito end`, `/exit`, or ~30 min idle (host sweep tears it down).
- All `temporal=0` lookups (`findSessionForAgent`, etc.) exclude temporal rows; `findTemporalSession` matches them.

Key files: `src/incognito.ts`, `src/temporal-session.ts`, the temporal branch in `src/container-runner.ts` (`buildMounts`), migration `020`, plus router/sweep wiring. Design + plan under `docs/temporal-session/`.

## Honesty box 📦

- **Not tested live** — I don't have an API key, so this has never actually spun up a real container against the Anthropic API. Treat runtime behavior as unverified.
- It *was* developed test-first at dev time: unit + integration tests across sessions, router, sweep, container-runner, and an end-to-end `routeInbound` integration test, plus a self-review pass. So the logic is exercised — just never live.
- But at least we got the vision. 🙂

Happy to rework this as a skill, split it up, or close it — whatever fits the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
