### PR TITLE
Warn before connecting a shared WhatsApp number

### DIFF
--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -7,6 +7,34 @@ description: Add WhatsApp channel via native Baileys adapter. Direct connection 
 
 Adds WhatsApp support via the native Baileys adapter (no Chat SDK bridge).
 
+## Number safety check (required)
+
+Complete this check before running any install or authentication command. If the user already said they want to use their **shared**, **personal**, **main**, **existing**, or **everyday** WhatsApp number, treat it as a shared number and show the warning immediately. Do not ask the number-type question again.
+
+Otherwise, use `AskUserQuestion`:
+
+**Which WhatsApp number will NanoClaw use?**
+
+- **Dedicated number (Recommended)** — a separate number used only for NanoClaw
+- **Shared / personal number** — the user's existing everyday WhatsApp number
+
+Remember the answer as `NUMBER_MODE` for the rest of this workflow.
+
+If `NUMBER_MODE=shared`, show this warning exactly:
+
+> ⚠️ **Risk to your WhatsApp account**
+>
+> Connecting your shared or personal number could cause WhatsApp to temporarily suspend or permanently ban that number. You could lose access to the WhatsApp account, chats, and groups you rely on.
+>
+> We strongly recommend using a separate, dedicated number for NanoClaw.
+
+Then use `AskUserQuestion`:
+
+- **Go back and use a dedicated number (Recommended)**
+- **I understand the risk — continue with my shared number**
+
+Do not continue with installation or authentication unless the user explicitly selects the second option. If they choose a dedicated number, set `NUMBER_MODE=dedicated` and continue without showing the warning again.
+
 ## Install
 
 NanoClaw doesn't ship channels in trunk. This skill copies the native WhatsApp (Baileys) adapter and its `whatsapp-auth` setup step in from the `channels` branch. No Chat SDK bridge.
@@ -92,7 +120,7 @@ WhatsApp uses linked-device authentication — no API key, just a one-time pairi
 
 ### Check current state
 
-Check if WhatsApp is already authenticated. If `store/auth/creds.json` exists, skip to "Dedicated vs personal number".
+Check if WhatsApp is already authenticated. The number safety check above is still required even when credentials already exist. If `store/auth/creds.json` exists, skip to "Dedicated vs personal number" after completing the safety check.
 
 ```bash
 test -f store/auth/creds.json && echo "WhatsApp auth exists" || echo "No WhatsApp auth"
@@ -209,9 +237,7 @@ The adapter behaves fundamentally differently depending on whether the linked nu
 - **Shared/personal number** (`ASSISTANT_HAS_OWN_NUMBER` unset or not `true`) — DMs to this number and group @-tags of it address the *human*, not the bot. The adapter never emits a mention signal (`mentions: 'never'` in its declared channel defaults), so: no stranger DM ever auto-creates a messaging group or raises an admin approval card; group wirings default to a name pattern (`\b<AgentName>\b`) instead of platform mentions; auto-created chats default to `unknown_sender_policy: 'strict'`; outbound messages are prefixed with the assistant's name.
 - **Dedicated number** (`ASSISTANT_HAS_OWN_NUMBER=true`) — everything sent to the number is for the bot. DMs and group mentions carry a real mention signal (`mentions: 'platform'`), unknown senders escalate via `request_approval` approval cards, and card-approved groups wire with `engage_mode: 'mention'`. No name prefix on outbound.
 
-AskUserQuestion: Is this a shared phone number (personal WhatsApp) or a dedicated number?
-- **Shared number** — your personal WhatsApp (bot prefixes messages with its name)
-- **Dedicated number** — a separate phone/SIM for the assistant
+Use the `NUMBER_MODE` selected in the required safety check. If information discovered later contradicts that selection, ask again before changing modes; switching to shared requires the same warning and explicit acknowledgement.
 
 Write the answer to `.env` **explicitly in both cases** (don't rely on the inference rule for new installs):
 
@@ -224,7 +250,7 @@ ASSISTANT_HAS_OWN_NUMBER=false
 
 ### Update path: existing install, flag unset
 
-If WhatsApp auth already exists (`store/auth/creds.json` present) but `.env` has no `ASSISTANT_HAS_OWN_NUMBER` line, the install predates the explicit switch. Ask the operator which mode applies and write it explicitly.
+If WhatsApp auth already exists (`store/auth/creds.json` present) but `.env` has no `ASSISTANT_HAS_OWN_NUMBER` line, the install predates the explicit switch. Use the mode established by the required safety check and write it explicitly.
 
 Suggest a default by comparing the authed number against the wired DM chat:
 

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  brightSelect: vi.fn(),
+  note: vi.fn(),
+  userInput: vi.fn(),
+}));
+
+vi.mock('../lib/bright-select.js', () => ({
+  brightSelect: mocks.brightSelect,
+}));
+
+vi.mock('../lib/theme.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/theme.js')>()),
+  note: mocks.note,
+}));
+
+vi.mock('../logs.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logs.js')>()),
+  userInput: mocks.userInput,
+}));
+
+import { BACK_TO_CHANNEL_SELECTION } from '../lib/back-nav.js';
+import { runWhatsAppChannel } from './whatsapp.js';
+
+describe('WhatsApp shared-number risk gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the warning and requires explicit acknowledgement for a shared number', async () => {
+    mocks.brightSelect.mockResolvedValueOnce('shared').mockResolvedValueOnce('continue').mockResolvedValueOnce('back');
+
+    const result = await runWhatsAppChannel('Daniel');
+
+    expect(result).toBe(BACK_TO_CHANNEL_SELECTION);
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining('temporarily suspend or permanently ban that number'),
+      '⚠️ Risk to your WhatsApp account',
+    );
+    expect(mocks.userInput).toHaveBeenCalledWith('whatsapp_shared_risk_acknowledged', 'true');
+  });
+
+  it('does not show the warning for a dedicated number', async () => {
+    mocks.brightSelect.mockResolvedValueOnce('dedicated').mockResolvedValueOnce('back');
+
+    const result = await runWhatsAppChannel('Daniel');
+
+    expect(result).toBe(BACK_TO_CHANNEL_SELECTION);
+    expect(mocks.note).not.toHaveBeenCalled();
+    expect(mocks.userInput).not.toHaveBeenCalledWith('whatsapp_shared_risk_acknowledged', expect.anything());
+  });
+
+  it('switches to dedicated mode when the user declines the shared-number risk', async () => {
+    mocks.brightSelect.mockResolvedValueOnce('shared').mockResolvedValueOnce('dedicated').mockResolvedValueOnce('back');
+
+    const result = await runWhatsAppChannel('Daniel');
+
+    expect(result).toBe(BACK_TO_CHANNEL_SELECTION);
+    expect(mocks.note).toHaveBeenCalledOnce();
+    expect(mocks.userInput).not.toHaveBeenCalledWith('whatsapp_shared_risk_acknowledged', expect.anything());
+  });
+});

--- a/setup/channels/whatsapp-flow.test.ts
+++ b/setup/channels/whatsapp-flow.test.ts
@@ -36,7 +36,7 @@ describe('WhatsApp shared-number risk gate', () => {
     expect(result).toBe(BACK_TO_CHANNEL_SELECTION);
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining('temporarily suspend or permanently ban that number'),
-      '⚠️ Risk to your WhatsApp account',
+      'Risk to your WhatsApp account',
     );
     expect(mocks.userInput).toHaveBeenCalledWith('whatsapp_shared_risk_acknowledged', 'true');
   });

--- a/setup/channels/whatsapp.ts
+++ b/setup/channels/whatsapp.ts
@@ -6,8 +6,8 @@
  *
  *   1. Ask whether the agent gets a dedicated number or shares the
  *      operator's personal one. Personal ⇒ interception screen that spells
- *      out self-chat-only mode and steers toward alternatives (default is
- *      back to channel selection)
+ *      out the account-ban risk and self-chat-only mode (default is switching
+ *      to a dedicated number)
  *   2. Ask how to authenticate (QR code in terminal, default, or pairing code)
  *   3. If pairing-code: collect the phone number
  *   4. Install the adapter + Baileys + QR + pino via setup/add-whatsapp.sh
@@ -68,7 +68,7 @@ export async function runWhatsAppChannel(displayName: string): Promise<ChannelFl
   let mode: 'dedicated' | 'shared' = ownership;
   if (mode === 'shared') {
     const proceed = await confirmSharedNumber();
-    if (proceed === 'back') return BACK_TO_CHANNEL_SELECTION;
+    if (proceed === 'dedicated') mode = 'dedicated';
   }
 
   const method = await askAuthMethod();
@@ -121,7 +121,7 @@ export async function runWhatsAppChannel(displayName: string): Promise<ChannelFl
       // Chatting from the bot's own number IS the shared-number setup —
       // route through the same interception screen as the up-front pick.
       const proceed = await confirmSharedNumber();
-      if (proceed === 'back') return BACK_TO_CHANNEL_SELECTION;
+      if (proceed === 'dedicated') return BACK_TO_CHANNEL_SELECTION;
       mode = 'shared';
     }
   }
@@ -221,13 +221,19 @@ async function askNumberOwnership(): Promise<'dedicated' | 'shared' | 'back'> {
 }
 
 /**
- * Interception screen for the shared-number path: make the self-chat-only
- * tradeoff explicit and steer toward alternatives before any install or
- * auth happens. Default is bailing back to channel selection.
+ * Interception screen for the shared-number path: make the account-ban risk
+ * and self-chat-only tradeoff explicit before any install or auth happens.
+ * Default is switching to a dedicated number.
  */
-async function confirmSharedNumber(): Promise<'continue' | 'back'> {
+async function confirmSharedNumber(): Promise<'continue' | 'dedicated'> {
   note(
     [
+      'Connecting your shared or personal number could cause WhatsApp to',
+      'temporarily suspend or permanently ban that number. You could lose access',
+      'to the WhatsApp account, chats, and groups you rely on.',
+      '',
+      'We strongly recommend using a separate, dedicated number for NanoClaw.',
+      '',
       'On your personal number, the agent lives only in your "You" / self-chat.',
       'Messages other people send you are ignored entirely — never read, never',
       'answered, never flagged for approval. Nobody else can talk to the agent.',
@@ -238,19 +244,29 @@ async function confirmSharedNumber(): Promise<'continue' | 'back'> {
       `  • ${brandBold('a dedicated WhatsApp number')} — spare SIM, eSIM, or old phone`,
       `  • ${brandBold('/add-whatsapp-cloud')} — the official Meta Business API`,
     ].join('\n'),
-    'Personal number = self-chat only',
+    '⚠️ Risk to your WhatsApp account',
   );
   const choice = ensureAnswer(
     await brightSelect({
       message: 'How would you like to proceed?',
       options: [
-        { value: 'back', label: '← Pick a different channel' },
-        { value: 'continue', label: 'Continue — self-chat only' },
+        {
+          value: 'dedicated',
+          label: 'Go back and use a dedicated number',
+          hint: 'recommended',
+        },
+        {
+          value: 'continue',
+          label: 'I understand the risk — continue with my shared number',
+        },
       ],
-      initialValue: 'back',
+      initialValue: 'dedicated',
     }),
-  ) as 'continue' | 'back';
+  ) as 'continue' | 'dedicated';
   setupLog.userInput('whatsapp_shared_confirm', choice);
+  if (choice === 'continue') {
+    setupLog.userInput('whatsapp_shared_risk_acknowledged', 'true');
+  }
   return choice;
 }
 

--- a/setup/channels/whatsapp.ts
+++ b/setup/channels/whatsapp.ts
@@ -244,7 +244,7 @@ async function confirmSharedNumber(): Promise<'continue' | 'dedicated'> {
       `  • ${brandBold('a dedicated WhatsApp number')} — spare SIM, eSIM, or old phone`,
       `  • ${brandBold('/add-whatsapp-cloud')} — the official Meta Business API`,
     ].join('\n'),
-    '⚠️ Risk to your WhatsApp account',
+    'Risk to your WhatsApp account',
   );
   const choice = ensureAnswer(
     await brightSelect({


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill**
- [ ] **Utility skill**
- [ ] **Operational/container skill**
- [x] **Fix**
- [ ] **Simplification**
- [ ] **Documentation**

## Description

### What changed

- Warn users that connecting a shared or personal WhatsApp number could result in temporary suspension or a permanent ban.
- Show the warning before authentication in both first-run setup and `/add-whatsapp`.
- Require explicit acknowledgement before continuing with a shared number.
- Keep dedicated-number setup free of the additional warning.
- Log shared-number risk acknowledgement during setup.

### Why

The existing flow explained the limitations of shared-number mode but did not explicitly communicate the risk to the user’s WhatsApp account. In `/add-whatsapp`, the shared-versus-dedicated decision also occurred after authentication, when the number had already been connected.

### Validation

- Added setup-flow coverage for shared, dedicated, and declined-risk paths.
- Focused WhatsApp tests: 10 passed.
- Full test suite: 747 passed.
- TypeScript build passed.
- Manually verified the warning in the first-run terminal setup.

## For Skills

- [x] SKILL.md contains instructions, not inline code.
- [x] SKILL.md is under 500 lines.
- [ ] I tested this skill on a fresh clone.