### PR TITLE
feat: support scheduled tasks in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See [docs/v1-to-v2-changes.md](docs/v1-to-v2-changes.md) for what's different an
 - **Multi-channel messaging** — WhatsApp, Telegram, Discord, Slack, Microsoft Teams, iMessage, Matrix, Google Chat, Webex, Linear, GitHub, WeChat, and email via Resend. Installed on demand with `/add-<channel>` skills. Run one or many at the same time.
 - **Flexible isolation** — connect each channel to its own agent for full privacy, share one agent across many channels for unified memory with separate conversations, or fold multiple channels into a single shared session so one conversation spans many surfaces. Pick per channel via `/manage-channels`. See [docs/isolation-model.md](docs/isolation-model.md).
 - **Per-agent workspace** — each agent group has its own `CLAUDE.md`, its own memory, its own container, and only the mounts you allow. Nothing crosses the boundary unless you wire it to.
-- **Scheduled tasks** — recurring jobs executed by the agent, which can message you the results
+- **Scheduled tasks**: recurring jobs executed by the agent, with optional [script gates](docs/scheduled-tasks.md) that avoid waking it when there is no work
 - **Web access** — search and fetch content from the web
 - **Container isolation** — agents are sandboxed in Docker containers (macOS/Linux/WSL2)
 - **Credential security** — agents never hold raw API keys. Outbound requests route through [OneCLI's Agent Vault](https://github.com/onecli/onecli), which injects credentials at request time and enforces per-agent policies and rate limits.

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -1,0 +1,167 @@
+# Scheduled Tasks
+
+Scheduled tasks run an agent prompt at a future time or on a recurring cron
+schedule. Each task belongs to an agent group and runs in its own system
+session, separate from normal chat sessions.
+
+Run `ncl tasks create --help` for the complete and current CLI reference.
+
+## Create a recurring task
+
+From the host, pass the agent group that should own the task:
+
+```bash
+ncl tasks create \
+  --group <agent-group-id> \
+  --name "weekday briefing" \
+  --recurrence "0 9 * * 1-5" \
+  --prompt "Prepare the weekday briefing and send it to telegram"
+```
+
+The first run is calculated from the cron schedule. Cron expressions use the
+NanoClaw installation timezone.
+
+Inside an agent container, `--group` is filled in automatically with that
+agent's group.
+
+## Create a one-time task
+
+One-time tasks use `--process-after` instead of `--recurrence`:
+
+```bash
+ncl tasks create \
+  --group <agent-group-id> \
+  --name "call reminder" \
+  --process-after "2026-07-14T18:00:00+03:00" \
+  --prompt "Remind me to call Dana"
+```
+
+`--process-after` accepts an ISO 8601 timestamp or a local time interpreted in
+the installation timezone.
+
+## Delivery and run logs
+
+A scheduled task has no chat attached to it. If its result should reach a
+user, the prompt must tell the agent where to send it. Use a destination name
+available to that agent, such as `telegram` or `team-slack`.
+
+NanoClaw also asks the agent to append a short work-log entry after each agent
+run. View run counts, failures, and recent log entries with:
+
+```bash
+ncl tasks get <task-id> --group <agent-group-id>
+```
+
+## Manage and test tasks
+
+```bash
+ncl tasks list --group <agent-group-id>
+ncl tasks update <task-id> --group <agent-group-id> --prompt "New prompt"
+ncl tasks pause <task-id> --group <agent-group-id>
+ncl tasks resume <task-id> --group <agent-group-id>
+ncl tasks cancel <task-id> --group <agent-group-id>
+ncl tasks delete <task-id> --group <agent-group-id>
+```
+
+`cancel` stops the live task but keeps its history. `delete` permanently removes
+the whole task series and its history.
+
+To test a task immediately without changing its schedule:
+
+```bash
+ncl tasks run <task-id> --group <agent-group-id>
+```
+
+`run` also works while a task is paused. It queues one extra run and does not
+resume the recurring schedule.
+
+## Script gates
+
+A task can run a Bash script before waking the agent. This is useful for
+frequent checks where most runs have nothing for the agent to do.
+
+The script's last line of standard output must be JSON:
+
+```json
+{ "wakeAgent": false }
+```
+
+or:
+
+```json
+{ "wakeAgent": true, "data": { "alerts": 2 } }
+```
+
+- `wakeAgent: false` completes the run without calling the model.
+- `wakeAgent: true` wakes the agent and adds `data` to its prompt.
+
+Scripts run with Bash, a 30-second timeout, and a 1 MB output limit. The JSON
+decision must be the final line written to standard output. Keep `data` small
+and include only what the agent needs.
+
+For example, save this as `check-marker.sh`:
+
+```bash
+marker=/workspace/agent/wake-next-task
+
+if [ -f "$marker" ]; then
+  rm -f "$marker"
+  echo '{"wakeAgent": true, "data": {"reason": "marker found"}}'
+else
+  echo '{"wakeAgent": false}'
+fi
+```
+
+Test it before scheduling, then pass its contents to `ncl`:
+
+```bash
+bash check-marker.sh
+
+ncl tasks create \
+  --group <agent-group-id> \
+  --name "marker check" \
+  --recurrence "*/15 * * * *" \
+  --prompt "Handle the condition reported by the script" \
+  --script "$(cat check-marker.sh)"
+```
+
+Store state that must survive between runs under `/workspace/agent`, the agent
+group workspace.
+
+Avoid putting secrets directly in task scripts. Prefer runtime credential
+injection through OneCLI so credentials are not stored in the task definition.
+
+## Frequency limit
+
+An ungated recurring task that would fire more than four times in the next 24
+hours is rejected. A task with a script gate is allowed to run more often
+because `wakeAgent: false` uses no model tokens.
+
+For an intentionally frequent task that has no script, see the explicit
+override in `ncl tasks create --help` and confirm the token and quota cost
+before using it.
+
+## Script failures
+
+A timeout, nonzero exit, missing decision, or invalid JSON counts as a failed
+run. Consecutive failures delay the next recurring run by 2, 4, 8, 16, 32,
+then 60 minutes. Further failures stay at the 60-minute delay.
+
+After eight consecutive failures, NanoClaw pauses the series and writes the
+reason to its run log. Fix the script, test it, then resume the task:
+
+```bash
+ncl tasks resume <task-id> --group <agent-group-id>
+```
+
+A valid `wakeAgent: false` decision is a successful run. It does not trigger
+failure backoff.
+
+## Template tasks
+
+Agent templates can include recurring tasks and optional script gates. Template
+tasks are created paused so installing a template never starts background work
+without approval. See [Agent Templates](templates.md#recurring-tasks).
+
+For implementation details, see
+[Pre-Agent Scripts](agent-runner-details.md#pre-agent-scripts-tasks).

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,8 +1,8 @@
 # Agent Templates
 
 A **template** is a reusable folder you stamp into a working agent group: it
-carries the agent's standing instructions, its MCP tool servers, and its skills,
-but **no secrets and no provider**. Point `ncl` at one and
+carries the agent's standing instructions, its MCP tool servers, its skills,
+and optional recurring tasks, but **no secrets and no provider**. Point `ncl` at one and
 you get a configured agent in seconds; you choose the runtime/provider
 separately.
 
@@ -55,6 +55,7 @@ is optional and defaults sensibly:
 │       └── *.md
 ├── .mcp.json             # optional: MCP servers (command + args), NO secrets
 ├── skills/<name>/        # optional: one folder per skill (SKILL.md + any references/), copied whole
+├── tasks/*.md             # optional: recurring tasks, created paused
 └── README.md             # recommended: per-template docs
 ```
 
@@ -64,6 +65,7 @@ is optional and defaults sensibly:
 | `context/**/*.md` (others) | Extra context, copied into the agent's workspace with the same layout relative to `instructions.md` | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers (written verbatim to container config) | No |
 | `skills/<name>/` | A skill, auto-triggered by its `description` | No |
+| `tasks/*.md` | Recurring scheduled tasks, created paused pending user activation | No |
 
 Notes:
 
@@ -75,6 +77,43 @@ Notes:
   persona gets truncated. Put bulk material in `skills/` or extra context files instead.
 - Skills are copied into the agent's own skills overlay, keyed to that group,
   never shared across groups.
+
+### Recurring tasks
+
+Each immediate Markdown file under `tasks/` defines one recurring task. The
+filename becomes its readable name, the frontmatter supplies its cron schedule,
+and the Markdown body is the prompt:
+
+```markdown
+---
+schedule: "0 9 * * 1-5"
+---
+
+Review the pipeline and prepare the weekday sales briefing.
+```
+
+The frontmatter accepts only `schedule`; unknown fields are rejected so typos
+cannot silently change behavior. Task files are template input, like
+`.mcp.json`: they are not copied into the agent workspace after stamping.
+
+Template tasks use the same creation path as `ncl tasks create`, including cron
+validation, the install timezone, first-run calculation, isolated task sessions,
+the run-log prompt, and the four-fires-per-day safety limit. Templates support
+recurring schedule + prompt only. One-shots, gate scripts, and the dangerous
+frequency override remain available through `ncl tasks create`, not template
+frontmatter.
+
+Tasks start **paused**, so stamping a template never starts background work
+without user consent. Until the setup welcome flow offers activation, inspect
+and enable them with the existing task CLI:
+
+```bash
+ncl tasks list --group <agent-group-id> --status paused
+ncl tasks resume <task-id>
+```
+
+Resuming preserves NanoClaw's normal pause/resume semantics: if the stored next
+run passed while paused, the task is eligible immediately.
 
 ### Referencing extra context files
 
@@ -167,5 +206,6 @@ repo, not this one. To add one: fork that repo, drop a folder at
 `<category>/<template>/` with at least `context/instructions.md`, test it end to
 end (copy it under `templates/` and run
 `ncl groups create --template <category>/<template> --name Test`), confirm
-no secrets are committed, and open a PR. The repo's README has the full anatomy,
+any predefined tasks appear under `ncl tasks list --status paused`, confirm no
+secrets are committed, and open a PR. The repo's README has the full anatomy,
 category conventions, and checklist.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -6,7 +6,7 @@ and optional recurring tasks, but **no secrets and no provider**. Point `ncl` at
 you get a configured agent in seconds; you choose the runtime/provider
 separately.
 
-Templates are purely additive: no DB migration, no new dependency. **Templates
+Templates are purely additive and require no DB migration. **Templates
 are resolved only from a local directory**: `templates/` at the
 project root by default (committed but shipped empty), or whatever
 `NANOCLAW_TEMPLATES_DIR` points at (a local path only). The public registry
@@ -82,26 +82,39 @@ Notes:
 
 Each immediate Markdown file under `tasks/` defines one recurring task. The
 filename becomes its readable name, the frontmatter supplies its cron schedule,
-and the Markdown body is the prompt:
+an optional script can decide whether to wake the agent, and the Markdown body
+is the prompt:
 
 ```markdown
 ---
-schedule: "0 9 * * 1-5"
+schedule: "*/15 * * * *"
+script: |
+  if [ -f /workspace/agent/wake-next-task ]; then
+    echo '{"wakeAgent": true}'
+  else
+    echo '{"wakeAgent": false}'
+  fi
 ---
 
-Review the pipeline and prepare the weekday sales briefing.
+Investigate the alerts reported by the script and notify me if they are serious.
 ```
 
-The frontmatter accepts only `schedule`; unknown fields are rejected so typos
-cannot silently change behavior. Task files are template input, like
-`.mcp.json`: they are not copied into the agent workspace after stamping.
+`schedule` is required. `script` is optional and may be a single-line or
+multiline YAML string. The frontmatter accepts no other fields, so typos cannot
+silently change behavior. Task files are template input, like `.mcp.json`: they
+are not copied into the agent workspace after stamping.
 
 Template tasks use the same creation path as `ncl tasks create`, including cron
 validation, the install timezone, first-run calculation, isolated task sessions,
-the run-log prompt, and the four-fires-per-day safety limit. Templates support
-recurring schedule + prompt only. One-shots, gate scripts, and the dangerous
-frequency override remain available through `ncl tasks create`, not template
-frontmatter.
+the run-log prompt, script behavior, and frequency limits. Ungated tasks are
+limited to four fires in the next 24 hours; tasks with a script gate may run more
+often. Templates do not expose the dangerous frequency override or one-time
+tasks.
+
+The script is passed unchanged to NanoClaw's normal task creation and execution
+path. See [Scheduled Tasks](scheduled-tasks.md#script-gates) for the script
+contract, testing workflow, frequency limit, and failure behavior. Avoid putting
+secrets directly in scripts; prefer runtime credential injection through OneCLI.
 
 Tasks start **paused**, so stamping a template never starts background work
 without user consent. Until the setup welcome flow offers activation, inspect

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "better-sqlite3": "11.10.0",
     "chat": "4.29.0",
     "cron-parser": "5.5.0",
-    "kleur": "^4.1.5"
+    "kleur": "^4.1.5",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.35.0
@@ -65,7 +68,7 @@ importers:
         version: 8.58.2(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -1493,6 +1496,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1867,13 +1875,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -2929,7 +2937,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2941,11 +2949,12 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -2962,7 +2971,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -2981,6 +2990,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -74,7 +74,7 @@ registerResource({
       description:
         'Create (or return the existing) agent group with its container config. Idempotent on --folder. ' +
         'With --template <ref>, stamp from a local template under templates/ (MCP servers + instructions ' +
-        '+ skills). Use --folder <slug> and --name <display name>.',
+        '+ skills + paused recurring tasks). Use --folder <slug> and --name <display name>.',
       handler: async (args) => {
         if (args.template) {
           return createAgentFromTemplate(String(args.template), {

--- a/src/cli/resources/tasks.test.ts
+++ b/src/cli/resources/tasks.test.ts
@@ -87,7 +87,8 @@ describe('tasks CLI resource', () => {
 
     expect(resp.ok).toBe(true);
     if (!resp.ok) return;
-    const created = resp.data as { series_id: string; session_id: string };
+    const created = resp.data as { series_id: string; session_id: string; status: string };
+    expect(created.status).toBe('pending');
     expect(created.session_id).not.toBe('chat-1');
 
     // The task lands in its own isolated per-series session, not the chat session.

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -1,10 +1,8 @@
-import { randomUUID } from 'crypto';
 import fs from 'fs';
 
 import type Database from 'better-sqlite3';
-import { CronExpressionParser } from 'cron-parser';
 
-import { GROUPS_DIR, TIMEZONE } from '../../config.js';
+import { GROUPS_DIR } from '../../config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import {
   findTaskSessions,
@@ -23,8 +21,17 @@ import {
   updateTask,
   type TaskUpdate,
 } from '../../modules/scheduling/db.js';
-import { inboundDbPath, resolveTaskSession, withInboundDb } from '../../session-manager.js';
-import { parseZonedToUtc } from '../../timezone.js';
+import {
+  createScheduledTask,
+  enforceRecurrenceLimit,
+  makeTaskId,
+  MAX_DAILY_FIRES,
+  parseProcessAfter,
+  prepareScheduledTask,
+  type ScheduledTaskRow,
+  validateRecurrence,
+} from '../../modules/scheduling/create.js';
+import { inboundDbPath, withInboundDb } from '../../session-manager.js';
 import { registerResource } from '../crud.js';
 import { appendRunLog } from '../../modules/scheduling/run-log.js';
 import { formatTasksTable } from '../format-tasks.js';
@@ -32,17 +39,7 @@ import type { CallerContext } from '../frame.js';
 
 type TaskStatus = 'pending' | 'paused';
 
-interface TaskRow {
-  row_id: string;
-  series_id: string | null;
-  status: string;
-  process_after: string | null;
-  recurrence: string | null;
-  content: string;
-  timestamp: string;
-  tries: number;
-  seq: number;
-}
+type TaskRow = ScheduledTaskRow;
 
 interface ScopedSession {
   id: string;
@@ -57,50 +54,6 @@ function bool(value: unknown): boolean {
   return value === true || value === 'true' || value === '1';
 }
 
-/**
- * Short, readable, filesystem/thread-safe task id. With a name → `<slug>-<4hex>`
- * (e.g. "Morning joke" → `morning-joke-a25c`); without → `t-<6hex>`. Always
- * matches /^[a-z0-9-]+$/ so it is safe as a thread suffix (`system:tasks:<id>`),
- * a filename (`tasks/<id>.md`), and a copy-pasteable --id.
- */
-function makeTaskId(name: unknown): string {
-  const hex = (n: number): string => randomUUID().replace(/-/g, '').slice(0, n);
-  const slug =
-    typeof name === 'string'
-      ? name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-+|-+$/g, '')
-          .slice(0, 24)
-          .replace(/-+$/g, '')
-      : '';
-  return slug ? `${slug}-${hex(4)}` : `t-${hex(6)}`;
-}
-
-function parseProcessAfter(value: unknown): string {
-  const raw = str(value);
-  if (!raw) throw new Error('--process-after is required');
-  const date = parseZonedToUtc(raw, TIMEZONE);
-  if (Number.isNaN(date.getTime())) throw new Error(`invalid --process-after: ${raw}`);
-  return date.toISOString();
-}
-
-/**
- * First-run timestamp for a new task. When a recurrence is given but no
- * --process-after, derive the first fire from the cron grid (in TIMEZONE) so the
- * common recurring case is a single flag — `--recurrence "0 9 * * 1-5"` — with no
- * redundant, easily-stale hand-picked instant. --process-after is still required
- * for one-shots (no recurrence to derive from) and still wins when supplied.
- */
-function firstRunIso(value: unknown, recurrence: string | null): string {
-  if (str(value) === undefined && recurrence) {
-    const next = CronExpressionParser.parse(recurrence, { tz: TIMEZONE }).next().toISOString();
-    if (!next) throw new Error(`--recurrence has no upcoming run: ${recurrence}`);
-    return next;
-  }
-  return parseProcessAfter(value);
-}
-
 function normalizeNullableString(value: unknown): string | null | undefined {
   if (value === undefined) return undefined;
   if (value === null) return null;
@@ -108,57 +61,6 @@ function normalizeNullableString(value: unknown): string | null | undefined {
   const trimmed = value.trim();
   if (trimmed === '' || trimmed === 'null' || trimmed === 'none') return null;
   return value;
-}
-
-function validateRecurrence(value: string | null | undefined): void {
-  if (!value) return;
-  try {
-    CronExpressionParser.parse(value, { tz: TIMEZONE });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`invalid --recurrence: ${msg}`, { cause: err });
-  }
-}
-
-/**
- * Frequency guard: refuse recurrences more frequent than 4 fires/day unless
- * the agent explicitly overrides. Frequent tasks burn the user's quota (or
- * get their account banned) — the sanctioned pattern is a slower cron plus a
- * pre-task gate script that checks an external condition and only wakes the
- * agent when something changed (`ncl tasks create --help`). Counted over the
- * next 24h from now in the instance timezone, so uneven crons are judged by
- * what they would actually do.
- */
-const MAX_DAILY_FIRES = 4;
-
-const RECURRENCE_LIMIT_WARNING =
-  'Warning: this task has not been scheduled. Frequent running tasks consume the ' +
-  "user's subscription quota or unnecessarily use tokens and can cause the user's " +
-  'account to be banned. Instead, use a pre-task run script that you write that can ' +
-  'check some kind of external condition, usually via one or more API calls. The ' +
-  'script returns a decision programmatically whether the task needs to be run now ' +
-  'or not. For example, an API call to GitHub to check if there are open PRs, and ' +
-  'only run when there are new open PRs.\n' +
-  'Run `ncl tasks create --help` to get full directions on how to write a script and test it.\n\n' +
-  'Note: if and only if you explicitly need to schedule a task more frequently and ' +
-  "you've verified with the user that they understand and that this is what they " +
-  'want and based on your judgment you agree that this is the right thing to do in ' +
-  'this situation, you can override this with --dangerously-override-recurrence-limit';
-
-function enforceRecurrenceLimit(recurrence: string | null, override: boolean, hasScript: boolean): void {
-  // A gate script IS the sanctioned mitigation the warning steers toward — a
-  // script-gated fire that finds nothing never wakes the agent, so scripted
-  // tasks may run at any cadence without the override.
-  if (!recurrence || override || hasScript) return;
-  const horizon = Date.now() + 24 * 60 * 60 * 1000;
-  const interval = CronExpressionParser.parse(recurrence, { tz: TIMEZONE });
-  let fires = 0;
-  while (fires <= MAX_DAILY_FIRES) {
-    const next = interval.next();
-    if (next.getTime() > horizon) break;
-    fires++;
-  }
-  if (fires > MAX_DAILY_FIRES) throw new Error(RECURRENCE_LIMIT_WARNING);
 }
 
 function statusFilter(args: Record<string, unknown>): TaskStatus | undefined {
@@ -275,28 +177,19 @@ function createTask(args: Record<string, unknown>, ctx: CallerContext) {
   const prompt = str(args.prompt);
   if (!prompt) throw new Error('--prompt is required');
   const recurrence = normalizeNullableString(args.recurrence) ?? null;
-  validateRecurrence(recurrence);
   const script = normalizeNullableString(args.script) ?? null;
-  enforceRecurrenceLimit(recurrence, bool(args.dangerously_override_recurrence_limit), script != null);
-  const processAfter = firstRunIso(args.process_after, recurrence);
-  const id = makeTaskId(args.name);
-  const originSessionId = ctx.caller === 'agent' ? ctx.sessionId : null;
-  // Each series runs in its own isolated session. Delivery and run-log
-  // instructions are injected by that session's runtime prompt rather than
-  // baked into persisted task content, so the contract can evolve in code.
-  const { session } = resolveTaskSession(group, id);
-  const created = withInbound(session, (db) => {
-    insertTaskRow(db, {
-      id,
-      seriesId: id,
-      processAfter,
-      recurrence,
-      content: JSON.stringify({ prompt, script, originSessionId }),
-    });
-    return selectTask(db, id);
+  const prepared = prepareScheduledTask({
+    name: str(args.name),
+    prompt,
+    recurrence,
+    processAfter: str(args.process_after),
+    script,
+    dangerouslyOverrideRecurrenceLimit: bool(args.dangerously_override_recurrence_limit),
   });
-  if (!created) throw new Error('task system session inbound.db not found');
-  return toOutput(session, created);
+  const { session, row } = createScheduledTask(group, prepared, {
+    originSessionId: ctx.caller === 'agent' ? ctx.sessionId : null,
+  });
+  return toOutput(session, row);
 }
 
 /**

--- a/src/modules/scheduling/create.ts
+++ b/src/modules/scheduling/create.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+
+import { CronExpressionParser } from 'cron-parser';
+
+import { TIMEZONE } from '../../config.js';
+import { inboundDbPath, resolveTaskSession, withInboundDb } from '../../session-manager.js';
+import { parseZonedToUtc } from '../../timezone.js';
+import { insertTaskRow } from './db.js';
+
+export const MAX_DAILY_FIRES = 4;
+
+const RECURRENCE_LIMIT_WARNING =
+  'Warning: this task has not been scheduled. Frequent running tasks consume the ' +
+  "user's subscription quota or unnecessarily use tokens and can cause the user's " +
+  'account to be banned. Instead, use a pre-task run script that you write that can ' +
+  'check some kind of external condition, usually via one or more API calls. The ' +
+  'script returns a decision programmatically whether the task needs to be run now ' +
+  'or not. For example, an API call to GitHub to check if there are open PRs, and ' +
+  'only run when there are new open PRs.\n' +
+  'Run `ncl tasks create --help` to get full directions on how to write a script and test it.\n\n' +
+  'Note: if and only if you explicitly need to schedule a task more frequently and ' +
+  "you've verified with the user that they understand and that this is what they " +
+  'want and based on your judgment you agree that this is the right thing to do in ' +
+  'this situation, you can override this with --dangerously-override-recurrence-limit';
+
+export interface PreparedScheduledTask {
+  name?: string;
+  prompt: string;
+  recurrence: string | null;
+  script: string | null;
+  processAfter: string;
+}
+
+export interface ScheduledTaskRow {
+  row_id: string;
+  series_id: string | null;
+  status: string;
+  process_after: string | null;
+  recurrence: string | null;
+  content: string;
+  timestamp: string;
+  tries: number;
+  seq: number;
+}
+
+/**
+ * Short, readable, filesystem/thread-safe task id. With a name → `<slug>-<4hex>`;
+ * without one → `t-<6hex>`. Always matches /^[a-z0-9-]+$/ so it is safe as a
+ * thread suffix, filename, and copy-pasteable CLI argument.
+ */
+export function makeTaskId(name: unknown): string {
+  const hex = (n: number): string => randomUUID().replace(/-/g, '').slice(0, n);
+  const slug =
+    typeof name === 'string'
+      ? name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '')
+          .slice(0, 24)
+          .replace(/-+$/g, '')
+      : '';
+  return slug ? `${slug}-${hex(4)}` : `t-${hex(6)}`;
+}
+
+export function parseProcessAfter(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error('--process-after is required');
+  const date = parseZonedToUtc(value, TIMEZONE);
+  if (Number.isNaN(date.getTime())) throw new Error(`invalid --process-after: ${value}`);
+  return date.toISOString();
+}
+
+export function validateRecurrence(value: string | null | undefined): void {
+  if (!value) return;
+  try {
+    CronExpressionParser.parse(value, { tz: TIMEZONE });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`invalid --recurrence: ${msg}`, { cause: err });
+  }
+}
+
+export function enforceRecurrenceLimit(recurrence: string | null, override: boolean, hasScript: boolean): void {
+  // A gate script is the sanctioned mitigation: a skipped fire costs no agent
+  // tokens, so scripted tasks may poll faster without the explicit override.
+  if (!recurrence || override || hasScript) return;
+  const horizon = Date.now() + 24 * 60 * 60 * 1000;
+  const interval = CronExpressionParser.parse(recurrence, { tz: TIMEZONE });
+  let fires = 0;
+  while (fires <= MAX_DAILY_FIRES) {
+    const next = interval.next();
+    if (next.getTime() > horizon) break;
+    fires++;
+  }
+  if (fires > MAX_DAILY_FIRES) throw new Error(RECURRENCE_LIMIT_WARNING);
+}
+
+/** Validate task semantics and derive its first run without writing anything. */
+export function prepareScheduledTask(input: {
+  name?: string;
+  prompt: string;
+  recurrence?: string | null;
+  processAfter?: string;
+  script?: string | null;
+  dangerouslyOverrideRecurrenceLimit?: boolean;
+}): PreparedScheduledTask {
+  if (!input.prompt) throw new Error('--prompt is required');
+  const recurrence = input.recurrence ?? null;
+  const script = input.script ?? null;
+  validateRecurrence(recurrence);
+  enforceRecurrenceLimit(recurrence, input.dangerouslyOverrideRecurrenceLimit === true, script !== null);
+
+  let processAfter: string;
+  if (input.processAfter === undefined && recurrence) {
+    const next = CronExpressionParser.parse(recurrence, { tz: TIMEZONE }).next().toISOString();
+    if (!next) throw new Error(`--recurrence has no upcoming run: ${recurrence}`);
+    processAfter = next;
+  } else {
+    processAfter = parseProcessAfter(input.processAfter);
+  }
+
+  return { name: input.name, prompt: input.prompt, recurrence, script, processAfter };
+}
+
+/** Persist a prepared task through NanoClaw's single task/session representation. */
+export function createScheduledTask(
+  agentGroupId: string,
+  task: PreparedScheduledTask,
+  options?: { status?: 'pending' | 'paused'; originSessionId?: string | null },
+): { session: { id: string; agent_group_id: string }; row: ScheduledTaskRow } {
+  const id = makeTaskId(task.name);
+  const { session } = resolveTaskSession(agentGroupId, id);
+
+  if (!fs.existsSync(inboundDbPath(agentGroupId, session.id))) {
+    throw new Error('task system session inbound.db not found');
+  }
+  const row = withInboundDb(agentGroupId, session.id, (db) => {
+    insertTaskRow(db, {
+      id,
+      seriesId: id,
+      processAfter: task.processAfter,
+      recurrence: task.recurrence,
+      content: JSON.stringify({
+        prompt: task.prompt,
+        script: task.script,
+        originSessionId: options?.originSessionId ?? null,
+      }),
+      status: options?.status ?? 'pending',
+    });
+    return db
+      .prepare(
+        `SELECT id AS row_id, series_id, status, process_after, recurrence, content, timestamp, tries, seq
+           FROM messages_in WHERE id = ?`,
+      )
+      .get(id) as ScheduledTaskRow;
+  });
+
+  return { session: { id: session.id, agent_group_id: session.agent_group_id }, row };
+}

--- a/src/templates/create-agent.test.ts
+++ b/src/templates/create-agent.test.ts
@@ -1,3 +1,4 @@
+import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,9 +19,11 @@ vi.mock('../log.js', () => ({
   log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn() },
 }));
 
-import { closeDb, initTestDb, runMigrations } from '../db/index.js';
+import { closeDb, getAllAgentGroups, initTestDb, runMigrations } from '../db/index.js';
 import { getContainerConfig } from '../db/container-configs.js';
+import { findTaskSessions } from '../db/sessions.js';
 import { PERSONA_PREPEND_FILE } from '../group-persona.js';
+import { inboundDbPath } from '../session-manager.js';
 import { createAgentFromTemplate } from './create-agent.js';
 
 function writeTemplate(): void {
@@ -36,6 +39,12 @@ function writeTemplate(): void {
   const skillDir = path.join(t, 'skills', 'widget');
   fs.mkdirSync(skillDir, { recursive: true });
   fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: widget\n---\n');
+}
+
+function writeTask(name: string, schedule: string, prompt: string): void {
+  const dir = path.join(TEMPLATES_DIR, 'sales', 'sdr', 'tasks');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${name}.md`), `---\nschedule: "${schedule}"\n---\n\n${prompt}\n`);
 }
 
 beforeEach(() => {
@@ -79,5 +88,40 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(path.join(groupDir, 'playbook.md'))).toBe(true);
     expect(fs.existsSync(path.join(groupDir, 'additional_context', 'faq.md'))).toBe(true);
     expect(fs.existsSync(path.join(groupDir, 'context'))).toBe(false);
+  });
+
+  it('creates template tasks paused through the normal isolated task-session path', () => {
+    writeTask('weekday-briefing', '0 9 * * 1-5', 'Send the weekday briefing.');
+
+    const g = createAgentFromTemplate('sales/sdr', { name: 'SDR Tasks' });
+    const sessions = findTaskSessions(g.id);
+    expect(sessions).toHaveLength(1);
+
+    const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
+    const row = db
+      .prepare("SELECT status, recurrence, process_after, content FROM messages_in WHERE kind = 'task'")
+      .get() as { status: string; recurrence: string; process_after: string; content: string };
+    db.close();
+
+    expect(row.status).toBe('paused');
+    expect(row.recurrence).toBe('0 9 * * 1-5');
+    expect(new Date(row.process_after).getTime()).toBeGreaterThan(Date.now());
+    expect(JSON.parse(row.content)).toMatchObject({
+      prompt: 'Send the weekday briefing.',
+      script: null,
+      originSessionId: null,
+    });
+    expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, 'tasks', 'weekday-briefing.md'))).toBe(false);
+  });
+
+  it.each([
+    ['invalid cron', 'not a cron', /invalid --recurrence/],
+    ['too-frequent cron', '* * * * *', /has not been scheduled/],
+  ])('rejects %s before creating the agent group', (_case, schedule, expected) => {
+    writeTask('broken', schedule, 'Never created.');
+
+    expect(() => createAgentFromTemplate('sales/sdr', { name: 'Broken Tasks' })).toThrow(expected);
+    expect(getAllAgentGroups()).toEqual([]);
+    expect(fs.existsSync(path.join(GROUPS_DIR, 'broken-tasks'))).toBe(false);
   });
 });

--- a/src/templates/create-agent.test.ts
+++ b/src/templates/create-agent.test.ts
@@ -41,10 +41,16 @@ function writeTemplate(): void {
   fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: widget\n---\n');
 }
 
-function writeTask(name: string, schedule: string, prompt: string): void {
+function writeTask(name: string, schedule: string, prompt: string, script?: string): void {
   const dir = path.join(TEMPLATES_DIR, 'sales', 'sdr', 'tasks');
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, `${name}.md`), `---\nschedule: "${schedule}"\n---\n\n${prompt}\n`);
+  const scriptBlock = script
+    ? `script: |\n${script
+        .split('\n')
+        .map((line) => `  ${line}`)
+        .join('\n')}\n`
+    : '';
+  fs.writeFileSync(path.join(dir, `${name}.md`), `---\nschedule: "${schedule}"\n${scriptBlock}---\n\n${prompt}\n`);
 }
 
 beforeEach(() => {
@@ -112,6 +118,30 @@ describe('createAgentFromTemplate', () => {
       originSessionId: null,
     });
     expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, 'tasks', 'weekday-briefing.md'))).toBe(false);
+  });
+
+  it('forwards multiline scripts unchanged through the shared task creation path', () => {
+    const script = 'count=2\necho \'{"wakeAgent": true, "data": {"count": 2}}\'';
+    writeTask('alert-watch', '*/15 * * * *', 'Investigate new alerts.', script);
+
+    const g = createAgentFromTemplate('sales/sdr', { name: 'Scripted Tasks' });
+    const sessions = findTaskSessions(g.id);
+    expect(sessions).toHaveLength(1);
+
+    const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
+    const row = db.prepare("SELECT status, recurrence, content FROM messages_in WHERE kind = 'task'").get() as {
+      status: string;
+      recurrence: string;
+      content: string;
+    };
+    db.close();
+
+    expect(row.status).toBe('paused');
+    expect(row.recurrence).toBe('*/15 * * * *');
+    expect(JSON.parse(row.content)).toMatchObject({
+      script: `${script}\n`,
+      originSessionId: null,
+    });
   });
 
   it.each([

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -8,6 +8,7 @@ import { ensureContainerConfig, updateContainerConfigJson } from '../db/containe
 import { assertValidGroupFolder, resolveGroupFolderPath } from '../group-folder.js';
 import { PERSONA_PREPEND_FILE } from '../group-persona.js';
 import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
+import { createScheduledTask, prepareScheduledTask } from '../modules/scheduling/create.js';
 import type { AgentGroup } from '../types.js';
 import { resolveLocalTemplate } from './local-dir.js';
 import { parseTemplate } from './parse.js';
@@ -19,8 +20,8 @@ export interface CreateAgentOptions {
 /**
  * Stamp a self-contained agent group from a LOCAL template ref under
  * TEMPLATES_DIR. The template carries MCP servers, instructions, optional
- * context extras, and optional skills — nothing else (no policy, no packages,
- * no provider).
+ * context extras, skills, and paused recurring tasks, but nothing else (no policy,
+ * packages, or provider).
  *
  * The template persona is written to the provider-neutral `instructions.prepend.md`
  * (see src/group-persona.ts). Each provider's project-doc composer inlines it at
@@ -34,6 +35,14 @@ export interface CreateAgentOptions {
 export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions): AgentGroup {
   const dir = resolveLocalTemplate(ref);
   const tpl = parseTemplate(dir);
+  const tasks = tpl.tasks.map((task) => {
+    try {
+      return prepareScheduledTask({ name: task.name, prompt: task.prompt, recurrence: task.schedule });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid template task ${task.source}: ${message}`, { cause: err });
+    }
+  });
 
   const id = randomUUID();
   const name = opts?.name ?? path.basename(dir);
@@ -73,6 +82,10 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   for (const { name: skill, srcDir } of tpl.skills) {
     fs.cpSync(srcDir, path.join(skillsDir, skill), { recursive: true });
   }
+
+  // Template tasks require explicit activation. The later welcome flow can
+  // present these exact paused tasks and resume only the ones the user accepts.
+  for (const task of tasks) createScheduledTask(id, task, { status: 'paused' });
 
   return group;
 }

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -37,7 +37,12 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   const tpl = parseTemplate(dir);
   const tasks = tpl.tasks.map((task) => {
     try {
-      return prepareScheduledTask({ name: task.name, prompt: task.prompt, recurrence: task.schedule });
+      return prepareScheduledTask({
+        name: task.name,
+        prompt: task.prompt,
+        recurrence: task.schedule,
+        script: task.script,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(`Invalid template task ${task.source}: ${message}`, { cause: err });

--- a/src/templates/parse.test.ts
+++ b/src/templates/parse.test.ts
@@ -27,7 +27,10 @@ describe('parseTemplate', () => {
     write('context/playbook.md', '# Playbook');
     write('context/additional_context/faq.md', '# FAQ');
     write('skills/research/SKILL.md', 'do research');
-    write('tasks/weekly-review.md', "---\nschedule: '0 9 * * 1'\n---\n\nReview the week.\n");
+    write(
+      'tasks/weekly-review.md',
+      '---\nschedule: \'0 9 * * 1\'\nscript: |\n  changed=$(git status --short)\n  echo "{\\"wakeAgent\\": $([ -n \\"$changed\\" ] && echo true || echo false)}"\n---\n\nReview the week.\n',
+    );
     write('tasks/daily-briefing.md', '---\nschedule: 0 8 * * *\n---\n\nSend the briefing.\n');
     fs.writeFileSync(path.join(dir, 'context', 'notes.txt'), 'ignored'); // non-.md is ignored
 
@@ -48,10 +51,19 @@ describe('parseTemplate', () => {
       {
         name: 'weekly-review',
         schedule: '0 9 * * 1',
+        script:
+          'changed=$(git status --short)\necho "{\\"wakeAgent\\": $([ -n \\"$changed\\" ] && echo true || echo false)}"\n',
         prompt: 'Review the week.',
         source: 'tasks/weekly-review.md',
       },
     ]);
+  });
+
+  it('accepts a single-line script string', () => {
+    write('context/instructions.md', 'Be helpful.');
+    write('tasks/check.md', '---\nschedule: "0 9 * * *"\nscript: echo wake\n---\nCheck it.\n');
+
+    expect(parseTemplate(dir).tasks[0].script).toBe('echo wake');
   });
 
   it('defaults the optionals when only instructions.md is present', () => {
@@ -65,9 +77,14 @@ describe('parseTemplate', () => {
 
   it.each([
     ['missing frontmatter', 'Run it.', /must start with ---/],
-    ['unknown field', '---\ncron: 0 9 * * *\n---\nRun it.', /only schedule/],
-    ['extra field', '---\nschedule: 0 9 * * *\nenabled: true\n---\nRun it.', /only schedule/],
-    ['mismatched quote', '---\nschedule: "0 9 * * *\n---\nRun it.', /mismatched quotes/],
+    ['unknown field', '---\ncron: 0 9 * * *\n---\nRun it.', /only schedule and script/],
+    ['extra field', '---\nschedule: 0 9 * * *\nenabled: true\n---\nRun it.', /only schedule and script/],
+    ['invalid YAML', '---\nschedule: "0 9 * * *\n---\nRun it.', /invalid YAML frontmatter/],
+    ['non-mapping frontmatter', '---\n- schedule\n---\nRun it.', /YAML mapping/],
+    ['non-string schedule', '---\nschedule: 9\n---\nRun it.', /schedule must be a nonempty string/],
+    ['empty schedule', '---\nschedule: "  "\n---\nRun it.', /schedule must be a nonempty string/],
+    ['non-string script', '---\nschedule: 0 9 * * *\nscript: 42\n---\nRun it.', /script must be a nonempty string/],
+    ['empty script', '---\nschedule: 0 9 * * *\nscript: "  "\n---\nRun it.', /script must be a nonempty string/],
     ['empty prompt', '---\nschedule: 0 9 * * *\n---\n', /prompt is required/],
   ])('rejects a task with %s', (_case, content, expected) => {
     write('context/instructions.md', 'Be helpful.');

--- a/src/templates/parse.test.ts
+++ b/src/templates/parse.test.ts
@@ -21,12 +21,14 @@ function write(rel: string, content: string): void {
 }
 
 describe('parseTemplate', () => {
-  it('parses mcpServers, instructions, context extras, and skills', () => {
+  it('parses mcpServers, instructions, context extras, skills, and tasks', () => {
     write('.mcp.json', JSON.stringify({ mcpServers: { fs: { command: 'mcp-fs', args: ['/data'] } } }));
     write('context/instructions.md', 'Be helpful.\n\n');
     write('context/playbook.md', '# Playbook');
     write('context/additional_context/faq.md', '# FAQ');
     write('skills/research/SKILL.md', 'do research');
+    write('tasks/weekly-review.md', "---\nschedule: '0 9 * * 1'\n---\n\nReview the week.\n");
+    write('tasks/daily-briefing.md', '---\nschedule: 0 8 * * *\n---\n\nSend the briefing.\n');
     fs.writeFileSync(path.join(dir, 'context', 'notes.txt'), 'ignored'); // non-.md is ignored
 
     const tpl = parseTemplate(dir);
@@ -36,6 +38,20 @@ describe('parseTemplate', () => {
     // Nested extras keep their context/-relative path as the name.
     expect(tpl.contextExtras.map((c) => c.name).sort()).toEqual(['additional_context/faq.md', 'playbook.md']);
     expect(tpl.skills.map((s) => s.name)).toEqual(['research']);
+    expect(tpl.tasks).toEqual([
+      {
+        name: 'daily-briefing',
+        schedule: '0 8 * * *',
+        prompt: 'Send the briefing.',
+        source: 'tasks/daily-briefing.md',
+      },
+      {
+        name: 'weekly-review',
+        schedule: '0 9 * * 1',
+        prompt: 'Review the week.',
+        source: 'tasks/weekly-review.md',
+      },
+    ]);
   });
 
   it('defaults the optionals when only instructions.md is present', () => {
@@ -44,6 +60,19 @@ describe('parseTemplate', () => {
     expect(tpl.mcpServers).toEqual({});
     expect(tpl.contextExtras).toEqual([]);
     expect(tpl.skills).toEqual([]);
+    expect(tpl.tasks).toEqual([]);
+  });
+
+  it.each([
+    ['missing frontmatter', 'Run it.', /must start with ---/],
+    ['unknown field', '---\ncron: 0 9 * * *\n---\nRun it.', /only schedule/],
+    ['extra field', '---\nschedule: 0 9 * * *\nenabled: true\n---\nRun it.', /only schedule/],
+    ['mismatched quote', '---\nschedule: "0 9 * * *\n---\nRun it.', /mismatched quotes/],
+    ['empty prompt', '---\nschedule: 0 9 * * *\n---\n', /prompt is required/],
+  ])('rejects a task with %s', (_case, content, expected) => {
+    write('context/instructions.md', 'Be helpful.');
+    write('tasks/broken.md', content);
+    expect(() => parseTemplate(dir)).toThrow(expected);
   });
 
   it('throws when context/instructions.md is missing', () => {

--- a/src/templates/parse.ts
+++ b/src/templates/parse.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { parse } from 'yaml';
 
 /** A parsed template folder. Pure data — no DB, no side effects. */
 export interface Template {
@@ -13,6 +14,7 @@ export interface Template {
 export interface TemplateTask {
   name: string;
   schedule: string;
+  script?: string;
   prompt: string;
   source: string;
 }
@@ -92,22 +94,42 @@ function parseTaskFile(tasksDir: string, file: string): TemplateTask {
   const closing = lines.indexOf('---', 1);
   if (closing === -1) throw new Error(`Template task ${source} is missing the closing ---`);
 
-  const metadata = lines.slice(1, closing).filter((line) => line.trim().length > 0);
-  if (metadata.length !== 1 || !metadata[0].startsWith('schedule:')) {
-    throw new Error(`Template task ${source} frontmatter must contain only schedule`);
+  let metadata: unknown;
+  try {
+    metadata = parse(lines.slice(1, closing).join('\n'));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Template task ${source} has invalid YAML frontmatter: ${message}`, { cause: err });
   }
-  let schedule = metadata[0].slice('schedule:'.length).trim();
-  if ((schedule.startsWith('"') && schedule.endsWith('"')) || (schedule.startsWith("'") && schedule.endsWith("'"))) {
-    schedule = schedule.slice(1, -1).trim();
-  } else if (/^["']|["']$/.test(schedule)) {
-    throw new Error(`Template task ${source} has mismatched quotes around schedule`);
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error(`Template task ${source} frontmatter must be a YAML mapping`);
   }
-  if (!schedule) throw new Error(`Template task ${source} schedule is required`);
+  const unknownFields = Object.keys(metadata).filter((key) => key !== 'schedule' && key !== 'script');
+  if (unknownFields.length > 0) {
+    throw new Error(`Template task ${source} frontmatter accepts only schedule and script`);
+  }
+
+  const scheduleValue = Reflect.get(metadata, 'schedule');
+  if (typeof scheduleValue !== 'string' || !scheduleValue.trim()) {
+    throw new Error(`Template task ${source} schedule must be a nonempty string`);
+  }
+  const schedule = scheduleValue.trim();
+
+  const scriptValue = Reflect.get(metadata, 'script');
+  if (scriptValue !== undefined && (typeof scriptValue !== 'string' || !scriptValue.trim())) {
+    throw new Error(`Template task ${source} script must be a nonempty string`);
+  }
 
   const prompt = lines
     .slice(closing + 1)
     .join('\n')
     .trim();
   if (!prompt) throw new Error(`Template task ${source} prompt is required`);
-  return { name, schedule, prompt, source };
+  return {
+    name,
+    schedule,
+    ...(typeof scriptValue === 'string' ? { script: scriptValue } : {}),
+    prompt,
+    source,
+  };
 }

--- a/src/templates/parse.ts
+++ b/src/templates/parse.ts
@@ -7,6 +7,14 @@ export interface Template {
   instructions: string; // context/instructions.md (required)
   contextExtras: { name: string; content: string }[]; // context/**/*.md except instructions.md; name relative to context/
   skills: { name: string; srcDir: string }[]; // skills/<name>/ real folders
+  tasks: TemplateTask[]; // tasks/*.md, recurring tasks created paused when stamped
+}
+
+export interface TemplateTask {
+  name: string;
+  schedule: string;
+  prompt: string;
+  source: string;
 }
 
 function readJson(file: string): unknown {
@@ -18,9 +26,9 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 /**
- * Read and lightly validate a template folder into a typed object. Throws only
- * if the folder is missing or `context/instructions.md` (the one required file)
- * is absent. `unknown`-in / parsed-out at the .mcp.json boundary.
+ * Read and validate a template folder into a typed object. The folder and
+ * context/instructions.md are required; optional task files are strict so a
+ * typo cannot silently stamp incomplete automation.
  */
 export function parseTemplate(dir: string): Template {
   if (!fs.existsSync(dir)) throw new Error(`Template folder not found: ${dir}`);
@@ -38,6 +46,7 @@ export function parseTemplate(dir: string): Template {
     instructions,
     contextExtras: readContextExtras(path.join(dir, 'context')),
     skills: readSkills(path.join(dir, 'skills')),
+    tasks: readTasks(path.join(dir, 'tasks')),
   };
 }
 
@@ -61,4 +70,44 @@ function readSkills(skillsDir: string): { name: string; srcDir: string }[] {
     .readdirSync(skillsDir)
     .map((name) => ({ name, srcDir: path.join(skillsDir, name) }))
     .filter(({ srcDir }) => fs.statSync(srcDir).isDirectory());
+}
+
+/** Immediate Markdown files under tasks/. Filename = task name, body = prompt. */
+function readTasks(tasksDir: string): TemplateTask[] {
+  if (!fs.existsSync(tasksDir)) return [];
+  return fs
+    .readdirSync(tasksDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => parseTaskFile(tasksDir, entry.name));
+}
+
+function parseTaskFile(tasksDir: string, file: string): TemplateTask {
+  const source = `tasks/${file}`;
+  const name = path.basename(file, '.md');
+  if (!name) throw new Error(`Template task ${source} has no task name`);
+
+  const lines = fs.readFileSync(path.join(tasksDir, file), 'utf-8').split(/\r?\n/);
+  if (lines[0] !== '---') throw new Error(`Template task ${source} must start with --- frontmatter`);
+  const closing = lines.indexOf('---', 1);
+  if (closing === -1) throw new Error(`Template task ${source} is missing the closing ---`);
+
+  const metadata = lines.slice(1, closing).filter((line) => line.trim().length > 0);
+  if (metadata.length !== 1 || !metadata[0].startsWith('schedule:')) {
+    throw new Error(`Template task ${source} frontmatter must contain only schedule`);
+  }
+  let schedule = metadata[0].slice('schedule:'.length).trim();
+  if ((schedule.startsWith('"') && schedule.endsWith('"')) || (schedule.startsWith("'") && schedule.endsWith("'"))) {
+    schedule = schedule.slice(1, -1).trim();
+  } else if (/^["']|["']$/.test(schedule)) {
+    throw new Error(`Template task ${source} has mismatched quotes around schedule`);
+  }
+  if (!schedule) throw new Error(`Template task ${source} schedule is required`);
+
+  const prompt = lines
+    .slice(closing + 1)
+    .join('\n')
+    .trim();
+  if (!prompt) throw new Error(`Template task ${source} prompt is required`);
+  return { name, schedule, prompt, source };
 }


### PR DESCRIPTION
## What

Templates can define recurring scheduled tasks in `tasks/*.md`. Each file contains a cron schedule, an optional script gate, and the agent prompt. Template tasks are created paused when the agent group is stamped.

This also adds a plain scheduled-tasks guide covering creation, schedules, script gates, testing, activation, and task management.

## Why

Template authors should be able to ship useful monitors and recurring workflows without asking users to recreate them manually. Tasks start paused so users can inspect them before activation.

Template tasks and `ncl tasks create` use the same preparation and persistence functions. Schedule validation, recurrence limits, script handling, task sessions, and stored content therefore change together instead of drifting into two implementations.

## How

- Parse immediate Markdown files under `tasks/` with YAML frontmatter.
- Require a nonempty `schedule`, accept an optional nonempty `script`, and reject unknown frontmatter fields.
- Use the Markdown body as the task prompt.
- Validate all template tasks before creating the agent group.
- Extract the existing scheduled-task preparation and creation path into a shared scheduling module.
- Call that shared path from both `ncl tasks create` and template stamping.
- Pass script text through unchanged to the existing scheduled-task runtime.
- Create template tasks as `paused`; normal CLI-created tasks remain `pending`.
- Document the template format and link it to the canonical scheduled-tasks and script-gate guide.

## How tested

- Full host suite: 93 files and 1,137 tests passed.
- `pnpm run build` passed.
- `pnpm run format:check` passed.
- ESLint passed for all touched TypeScript files, with one existing warning in `tasks.ts` and no errors.
- Container script-gate tests: 3 passed.
- `git diff --check` passed.
- Tested in a separate fresh-install worktree by stamping a sample template, confirming its task was created paused, running its real script gate, and confirming `wakeAgent: false` completed without starting a provider session.
