### PR TITLE
fix(container): raise the agent SDK's 32000 output-token cap to the model's real ceiling

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -420,12 +420,37 @@ function selectedSkillNames(containerConfig: import('./container-config.js').Con
     : [];
 }
 
+/**
+ * Output-token ceiling for the Claude agent SDK.
+ *
+ * Left unset, the SDK caps a turn at 32000 output tokens and kills it with
+ * "Claude's response exceeded the 32000 output token maximum" — which killed real
+ * turns (a long CAD/OpenSCAD answer in rolling-bench). Every current model's real
+ * ceiling is far higher, so there's no reason to leave that headroom unused.
+ *
+ * Model-aware because the ceilings differ and overshooting is a 400:
+ *   Haiku 4.5                                    →  64K
+ *   Opus 4.6/4.7/4.8, Sonnet 4.6/5, Fable 5      → 128K
+ *
+ * Unknown/custom model strings fall back to 64K — the value every current model
+ * accepts. Override with NANOCLAW_MAX_OUTPUT_TOKENS. This is a ceiling, not a
+ * target: raising it costs nothing unless a turn actually needs the room.
+ */
+function maxOutputTokensFor(model: string | null | undefined): number {
+  const override = Number(process.env.NANOCLAW_MAX_OUTPUT_TOKENS);
+  if (Number.isFinite(override) && override > 0) return Math.floor(override);
+  const m = (model ?? '').toLowerCase();
+  if (m.includes('haiku')) return 64_000;
+  if (!m || m.includes('opus') || m.includes('sonnet') || m.includes('fable')) return 128_000;
+  return 64_000;
+}
+
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
-  _provider: string,
+  provider: string,
   providerContribution: ProviderContainerContribution,
   agentIdentifier?: string,
 ): Promise<string[]> {
@@ -441,6 +466,13 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Raise the SDK's 32000 output-token cap to the model's real ceiling. Claude
+  // provider only — the var is read by the Claude Agent SDK and means nothing to
+  // opencode/ollama, whose own limits are configured elsewhere.
+  if (provider === 'claude') {
+    args.push('-e', `CLAUDE_CODE_MAX_OUTPUT_TOKENS=${maxOutputTokensFor(containerConfig.model)}`);
+  }
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {


### PR DESCRIPTION
Fixes #3023.

Nothing in the tree ever sets `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, so every Claude agent runs at the Agent SDK's default cap of 32000 output tokens. A long turn then dies partway through with:

```
API Error: Claude's response exceeded the 32000 output token maximum.
To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.
```

The work is lost and the room gets the raw API error — the turn is destroyed rather than degraded. I hit this on an agent emitting a long OpenSCAD file.

That default is far below what any current model actually supports:

| Model | Real max output tokens |
|---|---|
| Opus 4.6 / 4.7 / 4.8, Sonnet 4.6 / 5, Fable 5 | 128K |
| Haiku 4.5 | 64K |

## What this does

Sets the variable at spawn time in `buildContainerArgs`, next to the existing `TZ` push, derived from the agent group's configured model.

It is **model-aware by necessity**: the ceilings differ and overshooting is a 400. Haiku 4.5 tops out at 64K, so a blanket 128K would break every Haiku-configured group.

- **Claude provider only** — the variable is read by the Claude Agent SDK and means nothing to opencode/ollama, whose limits are configured elsewhere. (This un-underscores the already-present `_provider` param.)
- **Unknown/custom model strings fall back to 64K** — the value every current model accepts — rather than guessing high and risking a 400.
- **Overridable** via `NANOCLAW_MAX_OUTPUT_TOKENS`, for anyone who wants a tighter cap to bound spend.
- **It is a ceiling, not a target.** Raising it changes nothing for ordinary turns; you only pay for tokens actually generated. The agent-runner streams, so a high ceiling does not introduce the HTTP-timeout problem a large non-streaming `max_tokens` would.

## Verification

Spawned real agent containers and inspected their environment: a default-model group now comes up with `CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000`, and a Haiku-configured group correctly gets `64000`. Typechecks clean.

## Alternative considered

The Models API now returns `max_tokens` per model (`GET /v1/models/{id}`), so the ceiling could be looked up instead of hardcoded, and would stay correct as models ship. That needs a network call at spawn and is a bigger change — happy to go that way instead if you'd prefer it.