### PR TITLE
fix(container): relocate TMPDIR off /tmp so onecli CA can't be poisoned into a root-owned dir

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -5,6 +5,7 @@
  */
 import { ChildProcess, exec, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
 
@@ -53,6 +54,34 @@ import {
 import type { AgentGroup, Session } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
+
+// Filenames the onecli SDK writes under os.tmpdir() and bind-mounts into every
+// agent container. If Docker ever auto-creates one of these as a directory
+// (missing bind source), the SDK's writeFileSync hits EISDIR and no container
+// spawns. tmpdir-setup.ts points TMPDIR at an aburi-owned ext4 dir so we can
+// actually delete a stray dir here — self-healing the poisoned state instead of
+// needing a manual `sudo rmdir`.
+const ONECLI_CA_TMP_FILES = ['onecli-proxy-ca.pem', 'onecli-combined-ca.pem'];
+
+/**
+ * Remove any onecli CA path that exists as a directory before the SDK tries to
+ * write it as a file. No-op in the normal case. Best-effort: a failure here
+ * just surfaces later as the SDK's own EISDIR, so we log and continue.
+ */
+function clearStrayCaCertDirs(): void {
+  for (const name of ONECLI_CA_TMP_FILES) {
+    const p = path.join(os.tmpdir(), name);
+    try {
+      if (fs.statSync(p).isDirectory()) {
+        fs.rmSync(p, { recursive: true, force: true });
+        log.warn('Removed stray onecli CA directory before spawn', { path: p });
+      }
+    } catch {
+      // ENOENT (normal) or EACCES (still root-owned in a sticky dir) — nothing
+      // more we can do in-process; let the SDK report if it still fails.
+    }
+  }
+}
 
 /** Active containers tracked by session ID. */
 const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
@@ -487,6 +516,8 @@ async function buildContainerArgs(
   if (agentIdentifier) {
     await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
   }
+  // Self-heal a poisoned CA path (Docker-created root dir) before the SDK writes it.
+  clearStrayCaCertDirs();
   const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
   if (!onecliApplied) {
     throw new Error('OneCLI gateway not applied — refusing to spawn container without credentials');

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@
  * Thin orchestrator: init DB, run migrations, start channel adapters,
  * start delivery polls, start sweep, handle shutdown.
  */
+// Must run before any container spawn: relocates TMPDIR off volatile
+// root-sticky /tmp so the onecli proxy CA can't be poisoned into a root-owned
+// dir (EISDIR → no containers spawn → WhatsApp goes silent). See tmpdir-setup.ts.
+import './tmpdir-setup.js';
+
 import path from 'path';
 
 import { backfillContainerConfigs } from './backfill-container-configs.js';

--- a/src/tmpdir-setup.ts
+++ b/src/tmpdir-setup.ts
@@ -1,0 +1,26 @@
+/**
+ * Relocate the process temp dir off /tmp — must run before the first container spawn.
+ *
+ * The onecli SDK writes its proxy CA to `os.tmpdir()/onecli-proxy-ca.pem` and
+ * bind-mounts it into every agent container. Under Docker Desktop/WSL2, /tmp is
+ * volatile (wiped on WSL remount / Docker restart) AND sticky + root-owned, so
+ * when the file vanishes mid-spawn the Docker daemon auto-creates the missing
+ * bind source as a root-owned *directory* that our aburi-owned process can never
+ * delete. Every later `writeFileSync` then hits EISDIR and no container spawns —
+ * WhatsApp routes messages but nothing answers (the recurring "stuck" state).
+ *
+ * Pointing TMPDIR at a stable, aburi-owned ext4 dir removes the volatility and
+ * lets the spawn-time guard in container-runner.ts self-heal any stray dir
+ * (possible now because the parent is owned by us and non-sticky). os.tmpdir()
+ * reads TMPDIR fresh on every call, so setting it here is sufficient. Kept on
+ * ext4 (home dir), NOT drvfs, so Unix sockets under tmpdir keep working
+ * (they fail with ENOTSUP on drvfs).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const NANOCLAW_TMPDIR = path.join(os.homedir(), '.cache', 'nanoclaw', 'tmp');
+
+fs.mkdirSync(NANOCLAW_TMPDIR, { recursive: true });
+process.env.TMPDIR = NANOCLAW_TMPDIR;


### PR DESCRIPTION
## Problem

Agents intermittently go silent — the host routes inbound messages but no container ever spawns, so channels (e.g. WhatsApp) stop replying. The host log fills with:

```
wakeContainer failed — EISDIR: illegal operation on a directory, open '/tmp/onecli-proxy-ca.pem'
    at writeCaCertificate (@onecli-sh/sdk/lib/index.mjs)
    at ContainerClient.applyContainerConfig
    at buildContainerArgs (src/container-runner.ts)
```

**Root cause:** the onecli SDK writes its proxy CA to `os.tmpdir()/onecli-proxy-ca.pem` and bind-mounts it into every agent container. Under Docker Desktop / WSL2, `/tmp` is both **volatile** (wiped on WSL remount / Docker restart) and **sticky + root-owned**. When the file vanishes mid-spawn, the Docker daemon auto-creates the missing bind source as a **root-owned directory** — which the host process (running as a normal user) can never delete from sticky `/tmp`. Every subsequent `writeFileSync` then throws `EISDIR`, and no container spawns until the directory is manually removed with `sudo`.

## Fix

Two complementary changes:

1. **`src/tmpdir-setup.ts`** (new, imported first in `src/index.ts`) — sets `TMPDIR` to a stable, user-owned dir (`~/.cache/nanoclaw/tmp`) before the first spawn. `os.tmpdir()` reads `TMPDIR` fresh on each call, so the SDK writes the CA there instead of volatile `/tmp`. Kept off drvfs (on the home ext4 dir) so Unix sockets under tmpdir keep working.
2. **`clearStrayCaCertDirs()`** in `src/container-runner.ts` — runs just before `applyContainerConfig`; if a CA path is ever a stray directory, removes it in-process. This now works because the new parent dir is user-owned and non-sticky (impossible in root-sticky `/tmp`), so it self-heals at spawn time.

## Verification

Rebuilt, restarted the host service, and confirmed an organic spawn wrote the CA as a **regular file** at the new path with no `EISDIR` and a clean `OneCLI gateway applied` → `Spawning container`. `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)