### PR TITLE
fix: avoid duplicate replies after send_message

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -142,3 +142,25 @@ export function getUndeliveredMessages(): MessageOutRow[] {
     )
     .all() as MessageOutRow[];
 }
+
+export function getMaxMessageOutSeq(): number {
+  const row = getOutboundDb().prepare('SELECT COALESCE(MAX(seq), 0) AS seq FROM messages_out').get() as { seq: number };
+  return row.seq;
+}
+
+export function hasChatReplySince(
+  seq: number,
+  platformId: string | null,
+  channelType: string | null,
+): boolean {
+  if (!platformId || !channelType) return false;
+  const row = getOutboundDb()
+    .prepare(
+      `SELECT 1 FROM messages_out
+       WHERE seq > $seq AND kind = 'chat'
+         AND platform_id = $platform_id AND channel_type = $channel_type
+       LIMIT 1`,
+    )
+    .get({ $seq: seq, $platform_id: platformId, $channel_type: channelType });
+  return row != null;
+}

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
-import { getUndeliveredMessages } from './db/messages-out.js';
+import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
 import { isCorruptionError, processQuery } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
@@ -435,6 +435,32 @@ describe('error result with no <message> envelope', () => {
     expect(getUndeliveredMessages()).toHaveLength(0);
     expect(pushes).toHaveLength(1);
     expect(pushes[0]).toContain('was not delivered');
+  });
+
+  it('does not nudge after send_message already replied to the triggering channel', async () => {
+    const pushes: string[] = [];
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-1' };
+      writeMessageOut({
+        id: 'tool-reply',
+        kind: 'chat',
+        platform_id: ERR_ROUTING.platformId,
+        channel_type: ERR_ROUTING.channelType,
+        content: JSON.stringify({ text: 'Reply sent by MCP' }),
+      });
+      yield { type: 'result', text: 'bare internal summary' };
+    }
+    const query: AgentQuery = {
+      push: (message) => pushes.push(message),
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    };
+
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(getUndeliveredMessages()).toHaveLength(1);
+    expect(pushes).toHaveLength(0);
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -6,7 +6,7 @@ import {
   markScriptSkipped,
   type MessageInRow,
 } from './db/messages-in.js';
-import { writeMessageOut } from './db/messages-out.js';
+import { getMaxMessageOutSeq, hasChatReplySince, writeMessageOut } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import {
   clearContinuation,
@@ -348,6 +348,7 @@ export async function processQuery(
   initialPrompt: string,
   initialContinuation: string | undefined,
 ): Promise<QueryResult> {
+  let messageOutSeqAtRoundStart = getMaxMessageOutSeq();
   let queryContinuation: string | undefined;
   let done = false;
   let unwrappedNudged = false;
@@ -438,6 +439,7 @@ export async function processQuery(
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;
         taskBlockNudged = false;
+        messageOutSeqAtRoundStart = getMaxMessageOutSeq();
         query.push(prompt);
         archivePrompts.push(prompt);
         markCompleted(keptIds);
@@ -524,7 +526,12 @@ export async function processQuery(
             });
             archivePrompts.shift();
           } else {
-            const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
+            const alreadyReplied = hasChatReplySince(
+              messageOutSeqAtRoundStart,
+              routing.platformId,
+              routing.channelType,
+            );
+            const willRetryWrapping = hasUnwrapped && !unwrappedNudged && !alreadyReplied;
             notifyExchangeComplete(onExchangeComplete, {
               prompt: archivePrompts[0] ?? initialPrompt,
               result: event.text,


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Capture the outbound message sequence at the start of each provider round. If `send_message` already wrote a chat reply to the triggering channel, a bare final summary no longer triggers the re-wrap nudge and a second model run.

Normal unwrapped results still receive the existing nudge when no reply was delivered.

Closes #3026

## Testing

- `bun test` — 118 passed
- `bun run typecheck`

## For Skills

Not applicable.