### PR TITLE
feat(channels): add Dial channel adapter (SMS + AI voice calls)

### DIFF
--- a/container/skills/dial-cli/SKILL.md
+++ b/container/skills/dial-cli/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: dial-cli
+description: Reference for the `dial` CLI — gives an agent a real phone number to send SMS, place AI voice calls, and react to inbound texts and calls via the Dial platform (getdial.ai). Use when the user mentions phones, calls, texts, SMS, voice, OTP, 2FA, or verification codes; when they ask to text, call, ring, or wait for a code from someone; before running any `dial …` command for the first time in a session; or when investigating what the Dial platform can do. Load this skill before invoking the CLI — `dial --help` alone will not surface the workflows, the `--json` conventions, the onboarding/auth flow, or the docs-lookup pattern needed to use Dial correctly.
+---
+
+# Dial CLI
+
+`dial` is the official CLI for [Dial](https://getdial.ai) — a Communication Stack for AI Agents. It wraps the Dial REST API so you can sign up, provision phone numbers, send SMS, place voice calls handled by an AI voice agent, and stream account events, all without writing HTTP code.
+
+The first time the user asks you to "text someone," "call someone," "receive a code," or anything else phone-shaped, reach for `dial`.
+
+## When `dial` is missing
+
+If `dial` is not on the PATH (e.g. `command -v dial` returns nothing, or any `dial …` invocation errors with "command not found"), do **not** improvise an install. Fetch the bootstrap instructions and follow them:
+
+```bash
+curl -fsSL https://getdial.ai/skills.md
+```
+
+That document is the authoritative install + onboarding script. Read it, then execute the steps it specifies (install, `dial doctor`, signup, onboard, listen install).
+
+## Orient yourself before each new verb
+
+This skill **does not enumerate every flag**. The CLI is the source of truth — when you encounter a verb you have not used in this session, run its `--help` first:
+
+```bash
+dial --help                    # all top-level commands
+dial <command> --help          # flags + usage for a specific command
+dial <command> <sub> --help    # subcommand-level help
+```
+
+Examples worth running on first use: `dial doctor --help`, `dial message --help`, `dial call --help`, `dial call get --help`, `dial wait-for --help`, `dial local-target add url --help`.
+
+Every command supports `--json` for machine-readable output — prefer it when piping into `jq` or parsing the result programmatically.
+
+## Onboarding flow
+
+If `dial doctor --json` reports `nextStep` other than `ready`, the user is not yet set up. The full first-time flow is:
+
+```bash
+dial signup you@example.com           # email OTP
+dial onboard --code 123456 \          # verify, writes ~/.local/share/dial/auth.json
+  --inbound-instruction "You are my receptionist. Greet the caller and find out what they need."
+dial listen install                   # background daemon for inbound events
+```
+
+`--inbound-instruction` is **required when onboarding provisions your first number** (a new account) — it's the system prompt the AI voice agent uses on calls *to* your number. It's ignored when signing in to an existing account. Change it later with `dial number set <number> --inbound-instruction "..."`.
+
+`dial onboard` also installs a Dial skill into your agent's config (claude-code, cursor, codex, opencode, pi, openclaw, nanoclaw, hermes) when you pass `--agent <name>`.
+
+`dial listen install` needs a user service supervisor (launchd on macOS, systemd `--user` on Linux). In sandboxes / containers / CI without one it can't run — `dial onboard` detects this and says so. Inbound events still work without it: `dial wait-for` long-polls the API when the daemon isn't running.
+
+## Searching for what the CLI / API can do
+
+For anything beyond what `--help` shows on the local CLI, the canonical reference is the published docs. Two endpoints make this fast:
+
+### Capability search — `llms-full.txt`
+
+A single concatenated markdown file of the whole docs site. Grep it directly for the keyword you care about:
+
+```bash
+curl -fsSL https://docs.getdial.ai/llms-full.txt | grep -i -B2 -A8 'whatsapp'
+curl -fsSL https://docs.getdial.ai/llms-full.txt | grep -i -B1 -A5 'webhook'
+curl -fsSL https://docs.getdial.ai/llms-full.txt | grep -i -B1 -A5 'language'
+```
+
+Use this when you want to know *if* Dial supports something, or *which command / endpoint* covers it — without reading the whole site.
+
+### Deep dive — `sitemap.xml` + per-page `.md`
+
+When you need to read a page in detail (after grep found a hit, or because you need fuller context), use the sitemap to discover URLs, then fetch the **`.md` companion** of any page — it's the same content as the HTML page but in plain markdown, faster to read and friendlier to scan.
+
+```bash
+# 1. Discover available pages
+curl -fsSL https://docs.getdial.ai/sitemap.xml | grep -oE 'https://docs\.getdial\.ai/[^<]+'
+
+# 2. For any page like
+#    https://docs.getdial.ai/documentation/get-started/introduction
+#    fetch the .md companion:
+curl -fsSL https://docs.getdial.ai/documentation/get-started/introduction.md
+```
+
+The rule is **one-to-one**: every documentation page at `https://docs.getdial.ai/<path>` has a markdown twin at `https://docs.getdial.ai/<path>.md`. Use the `.md` version whenever you're reading docs from inside an agent.
+
+## Workflow shapes worth knowing
+
+These are the verbs you will most often compose. Read the relevant `.md` page for the full story; the one-liners below are just signposts.
+
+- **Send an SMS** — `dial message --to +14155550123 --body "..."` ([send-an-sms.md](https://docs.getdial.ai/documentation/capabilities/send-an-sms.md))
+- **Show a typing indicator while composing** — `dial typing start --to-number +14155550123`; sending a message clears it natively, so start again between messages, and `dial typing stop --to-number +14155550123` if you end up not sending. iMessage numbers display it; SMS numbers ignore it, so it's always safe to call ([commands.md](https://docs.getdial.ai/documentation/reference/commands.md))
+- **Place a voice call** — `dial call --to +14155550123 --outbound-instruction "..."` then `dial call get <id>` once it ends. Add `--voice-gender male|female` to choose the agent's voice (default: female) ([place-a-voice-call.md](https://docs.getdial.ai/documentation/capabilities/place-a-voice-call.md))
+- **Buy an additional number** — `dial number purchase --inbound-instruction "..." --explicit-programmatic-consent "<attestation>"`. `--explicit-programmatic-consent` is **required**: a short attestation that the account holder consented to provisioning programmatically. Add `--include-imessage` for an [iMessage number](https://docs.getdial.ai/documentation/capabilities/send-an-imessage.md) (pay-as-you-go only; provisioned asynchronously — poll `dial number list` until ready) ([manage-phone-numbers.md](https://docs.getdial.ai/documentation/capabilities/manage-phone-numbers.md))
+- **Set a number's inbound behavior or nickname** — `dial number set +14155550123 --inbound-instruction "..."` and/or `--inbound-language es-ES` and/or `--nickname "Support line"` (at least one flag; `--nickname ""` / `--inbound-language ""` clear). The inbound instruction is the system prompt the AI uses on calls *into* that number; set it at `dial onboard` / `dial number purchase` time and change it here. The inbound language pins inbound calls to one language — unset, the AI detects the caller's language from their country prefix (alongside en-US). The nickname is a human-readable label for telling numbers apart ([manage-phone-numbers.md](https://docs.getdial.ai/documentation/capabilities/manage-phone-numbers.md))
+- **Receive a verification code (2FA)** — `dial wait-for message.received -f channel=sms` and parse the body ([receive-inbound-sms.md](https://docs.getdial.ai/documentation/capabilities/receive-inbound-sms.md))
+- **React to a call ending** — `dial wait-for call.ended -f callId=<id>`. Fires however the call ends — completed, failed, **or cancelled** — carrying the terminal `status` and a `canceled` flag, so the wait always resolves ([stream-account-events.md](https://docs.getdial.ai/documentation/capabilities/stream-account-events.md))
+- **Fan inbound events to a local handler** — `dial local-target add cmd /path/to/handler` or `dial local-target add url http://127.0.0.1:8787/dial` ([local-url-target.md](https://docs.getdial.ai/documentation/integrations/local-url-target.md), [cli-command-target.md](https://docs.getdial.ai/documentation/integrations/cli-command-target.md))
+
+## Conventions
+
+- `--json` everywhere for parseable output.
+- `--from-number <id|E.164|nickname>` picks the number to act from flexibly; the legacy `--from-number-id <id>` takes an id only (use one or the other). Both default to the number Dial auto-provisioned during `dial onboard`. List others with `dial number list`.
+- Phone numbers are E.164 (`+14155550123`). Reject anything else before calling Dial.
+- Writes (`message`, `call`, `number purchase`) are **not idempotent** — on an ambiguous failure, list first to check before retrying.
+- The local API key lives at `~/.local/share/dial/auth.json` (mode 0600). The CLI reads it automatically; never echo it back to the user or paste it into responses.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@chat-adapter/whatsapp": "4.29.0",
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
+    "@getdial/sdk": "0.17.0",
     "@onecli-sh/sdk": "^0.3.1",
     "@resend/chat-sdk-adapter": "^0.1.1",
     "@types/qrcode": "^1.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,49 +10,52 @@ importers:
     dependencies:
       '@beeper/chat-adapter-matrix':
         specifier: ^0.2.0
-        version: 0.2.0(zod@4.3.6)
+        version: 0.2.0(zod@4.4.3)
       '@bitbasti/chat-adapter-webex':
         specifier: ^0.1.0
-        version: 0.1.0(chat@4.29.0(zod@4.3.6))
+        version: 0.1.0(chat@4.29.0(zod@4.4.3))
       '@chat-adapter/discord':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/gchat':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/github':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/linear':
         specifier: 4.29.0
-        version: 4.29.0(graphql@16.13.2)(zod@4.3.6)
+        version: 4.29.0(graphql@16.13.2)(zod@4.4.3)
       '@chat-adapter/slack':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/state-memory':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/teams':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@chat-adapter/whatsapp':
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       '@clack/core':
         specifier: ^1.2.0
         version: 1.2.0
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.2.0
+      '@getdial/sdk':
+        specifier: 0.17.0
+        version: 0.17.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))
       '@onecli-sh/sdk':
         specifier: ^0.3.1
         version: 0.3.1
       '@resend/chat-sdk-adapter':
         specifier: ^0.1.1
-        version: 0.1.1(@chat-adapter/shared@4.29.0(zod@4.3.6))(chat@4.29.0(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.1.1(@chat-adapter/shared@4.29.0(zod@4.4.3))(chat@4.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -64,10 +67,10 @@ importers:
         version: 11.10.0
       chat:
         specifier: 4.29.0
-        version: 4.29.0(zod@4.3.6)
+        version: 4.29.0(zod@4.4.3)
       chat-adapter-imessage:
         specifier: ^0.1.1
-        version: 0.1.1(chat@4.29.0(zod@4.3.6))(typescript@5.9.3)
+        version: 0.1.1(chat@4.29.0(zod@4.4.3))(typescript@5.9.3)
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
@@ -119,7 +122,7 @@ importers:
         version: 8.58.2(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -131,8 +134,75 @@ packages:
     resolution: {integrity: sha512-0Hz7Kx4hs70KZWep/Rd7aw/qOLUF92wUOhn7ZsOuB5xNR/06NL1E2RAI9+UKH1FtvN8nD6mFjH7UKSjv6vOWvQ==}
     engines: {node: '>=16'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@beeper/chat-adapter-matrix@0.2.0':
@@ -443,6 +513,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@getdial/sdk@0.17.0':
+    resolution: {integrity: sha512-pmduS63YbYs+Rl3jPIHAiji2fEF/ZPG53i5VLURmuKE/zgTOB5wSF95QwcIwVYANi7m+SEeZFWqUAd5w8XtdhA==}
+
   '@googleapis/chat@44.6.0':
     resolution: {integrity: sha512-Bnqzev/bSTXSbE0/N2WS4Stnleo8j9bJJ1LkCBk1fXQnehcArVMv7q543rzPYU6MJql4D34On6diNGAuYtI9xQ==}
     engines: {node: '>=12.0.0'}
@@ -631,8 +704,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/ttlcache@1.4.1':
+    resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
+    engines: {node: '>=12'}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@keyv/bigmap@1.3.1':
     resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
@@ -986,6 +1087,62 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-native/assets-registry@0.86.0':
+    resolution: {integrity: sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/codegen@0.86.0':
+    resolution: {integrity: sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/community-cli-plugin@0.86.0':
+    resolution: {integrity: sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@react-native-community/cli': '*'
+      '@react-native/metro-config': 0.86.0
+    peerDependenciesMeta:
+      '@react-native-community/cli':
+        optional: true
+      '@react-native/metro-config':
+        optional: true
+
+  '@react-native/debugger-frontend@0.86.0':
+    resolution: {integrity: sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/debugger-shell@0.86.0':
+    resolution: {integrity: sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/dev-middleware@0.86.0':
+    resolution: {integrity: sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/gradle-plugin@0.86.0':
+    resolution: {integrity: sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/js-polyfills@0.86.0':
+    resolution: {integrity: sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  '@react-native/normalize-colors@0.86.0':
+    resolution: {integrity: sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==}
+
+  '@react-native/virtualized-lists@0.86.0':
+    resolution: {integrity: sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    peerDependencies:
+      '@types/react': ^19.2.0
+      react: '*'
+      react-native: 0.86.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
     engines: {node: '>= 18.19.0'}
@@ -1146,6 +1303,9 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
   '@slack/logger@4.0.1':
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
@@ -1186,6 +1346,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1209,6 +1372,15 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1236,6 +1408,12 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -1363,6 +1541,10 @@ packages:
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1381,11 +1563,18 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agentkeepalive@3.5.3:
+    resolution: {integrity: sha512-yqXL+k5rr8+ZRpOAntkaaRgWgE5o8ESAj5DyRmVTCSoZxXmqemb9Dd7T4i5UzwuERdLAJUy6XzR9zFVuf0kzkw==}
+    engines: {node: '>= 4.0.0'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   another-json@0.2.0:
     resolution: {integrity: sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==}
+
+  anser@1.4.10:
+    resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1395,12 +1584,23 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
@@ -1425,6 +1625,9 @@ packages:
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    resolution: {integrity: sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1440,6 +1643,15 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -1482,14 +1694,32 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1513,6 +1743,19 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001805:
+    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
+
+  cbor-js@0.1.0:
+    resolution: {integrity: sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==}
+
+  cbor-sync@1.0.4:
+    resolution: {integrity: sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1557,8 +1800,27 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chrome-launcher@0.15.2:
+    resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
+  chromium-edge-launcher@0.3.0:
+    resolution: {integrity: sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==}
+
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -1581,8 +1843,19 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -1633,6 +1906,18 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1664,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1675,6 +1964,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1723,8 +2016,15 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1743,6 +2043,9 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1768,6 +2071,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -1778,6 +2085,11 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-plugin-no-catch-all@1.1.0:
     resolution: {integrity: sha512-VkP62jLTmccPrFGN/W6V7a3SEwdtTZm+Su2k4T3uyJirtkm0OMMm97h7qd8pRFAHus/jQg9FpUpLRc7sAylBEQ==}
@@ -1814,6 +2126,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1837,6 +2154,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -1854,6 +2175,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -1883,8 +2207,19 @@ packages:
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
 
+  fast-text-encoding@1.0.6:
+    resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
+
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
+  fb-dotslash@0.5.8:
+    resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1899,6 +2234,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1909,6 +2247,14 @@ packages:
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1929,6 +2275,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  flow-enums-runtime@0.0.6:
+    resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -1948,6 +2297,10 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -1973,6 +2326,10 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1987,6 +2344,10 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -2018,6 +2379,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
@@ -2053,6 +2417,21 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  hermes-compiler@250829098.0.14:
+    resolution: {integrity: sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==}
+
+  hermes-estree@0.35.0:
+    resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
+
+  hermes-estree@0.36.0:
+    resolution: {integrity: sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==}
+
+  hermes-parser@0.35.0:
+    resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
+
+  hermes-parser@0.36.0:
+    resolution: {integrity: sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==}
+
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
@@ -2073,9 +2452,16 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2097,6 +2483,11 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2111,9 +2502,21 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
@@ -2134,6 +2537,10 @@ packages:
     resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
 
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -2145,14 +2552,45 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsc-safe-url@0.2.4:
+    resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -2169,6 +2607,11 @@ packages:
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -2201,6 +2644,10 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2208,6 +2655,9 @@ packages:
   libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
     resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
     version: 6.0.0
+
+  lighthouse-logger@1.4.2:
+    resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2283,6 +2733,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lil-uuid@0.1.1:
+    resolution: {integrity: sha512-GhWI8f61tBlMeqULZ1QWhFiiyFIFdPlg//S8Udq1wjq1FJhpFKTfnbduSxAQjueofeUtpr7UvQ/lIK/sKUF8dg==}
+
   limiter@1.1.5:
     resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
 
@@ -2324,6 +2777,9 @@ packages:
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -2337,13 +2793,24 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
@@ -2358,6 +2825,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -2365,6 +2835,9 @@ packages:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
     hasBin: true
+
+  marky@1.3.0:
+    resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2420,9 +2893,73 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  metro-babel-transformer@0.84.4:
+    resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-cache-key@0.84.4:
+    resolution: {integrity: sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-cache@0.84.4:
+    resolution: {integrity: sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-config@0.84.4:
+    resolution: {integrity: sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-core@0.84.4:
+    resolution: {integrity: sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-file-map@0.84.4:
+    resolution: {integrity: sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-minify-terser@0.84.4:
+    resolution: {integrity: sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-resolver@0.84.4:
+    resolution: {integrity: sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-runtime@0.84.4:
+    resolution: {integrity: sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-source-map@0.84.4:
+    resolution: {integrity: sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-symbolicate@0.84.4:
+    resolution: {integrity: sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
+
+  metro-transform-plugins@0.84.4:
+    resolution: {integrity: sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro-transform-worker@0.84.4:
+    resolution: {integrity: sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+
+  metro@0.84.4:
+    resolution: {integrity: sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2508,6 +3045,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -2523,6 +3064,11 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -2541,8 +3087,16 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2566,6 +3120,10 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
@@ -2575,12 +3133,28 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   node-typedstream@1.4.1:
     resolution: {integrity: sha512-W9zcPlI3RRPOmwaDjwRyr7aYLoJFbvLIIHluFM3I+KZjAlbyhG4L3jSTEJlQmDqrMRQlFVTmivgJWgFlvWXx2Q==}
@@ -2591,6 +3165,13 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  ob1@0.84.4:
+    resolution: {integrity: sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2614,12 +3195,20 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2676,6 +3265,14 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2706,6 +3303,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -2747,12 +3348,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  promise@8.3.0:
+    resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -2765,9 +3373,19 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  pubnub@11.0.2:
+    resolution: {integrity: sha512-N0YQGn02hIkTQUVxQiDw/Fk9dQNDyJDcMDOluu7hy1s7j3nJ++XEn5nckbh8U6/FD+IuyQmh3mG4Or/CmuRZeQ==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2796,6 +3414,9 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -2811,10 +3432,39 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-devtools-core@6.1.5:
+    resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-native-url-polyfill@2.0.0:
+    resolution: {integrity: sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==}
+    peerDependencies:
+      react-native: '*'
+
+  react-native@0.86.0:
+    resolution: {integrity: sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==}
+    engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
+    hasBin: true
+    peerDependencies:
+      '@react-native/jest-preset': 0.86.0
+      '@types/react': ^19.1.1
+      react: ^19.2.3
+    peerDependenciesMeta:
+      '@react-native/jest-preset':
+        optional: true
+      '@types/react':
+        optional: true
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -2834,6 +3484,9 @@ packages:
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -2903,14 +3556,30 @@ packages:
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@2.1.0:
+    resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
+    engines: {node: '>=0.10.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -2933,6 +3602,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -2965,6 +3638,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   socket.io-client@4.8.3:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
@@ -2973,11 +3650,30 @@ packages:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
 
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
@@ -2990,8 +3686,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -3030,6 +3737,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   svix@1.84.1:
     resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
@@ -3043,8 +3754,16 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  throat@5.0.0:
+    resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3061,6 +3780,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
@@ -3072,6 +3798,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3102,6 +3831,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -3161,6 +3894,12 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3169,6 +3908,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -3277,13 +4020,36 @@ packages:
       jsdom:
         optional: true
 
+  vlq@1.0.1:
+    resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@5.0.0:
+    resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
+    engines: {node: '>=8'}
+
   wechat-ilink-client@0.1.0:
     resolution: {integrity: sha512-/gsWGEGEsWA7C5cgfKtguCL7QPdT95I1HfHHiRcHtwQppwVfgD8aDL4m4soANp1qQDl5RgiJ7q9gh9X5cXUfqA==}
     engines: {node: '>=20'}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-url-without-unicode@8.0.0-3:
+    resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
+    engines: {node: '>=10'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -3309,8 +4075,24 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -3343,16 +4125,36 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3360,6 +4162,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3374,13 +4179,113 @@ snapshots:
       jsonwebtoken: 9.0.3
       uuid: 8.3.2
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.2': {}
 
-  '@beeper/chat-adapter-matrix@0.2.0(zod@4.3.6)':
+  '@babel/template@7.29.7':
     dependencies:
-      '@chat-adapter/state-memory': 4.29.0(zod@4.3.6)
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@beeper/chat-adapter-matrix@0.2.0(zod@4.4.3)':
+    dependencies:
+      '@chat-adapter/state-memory': 4.29.0(zod@4.4.3)
       '@chat-adapter/state-redis': 4.26.0
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
       marked: 15.0.12
       matrix-js-sdk: 41.3.0
       node-html-parser: 7.1.0
@@ -3391,10 +4296,10 @@ snapshots:
       - supports-color
       - zod
 
-  '@bitbasti/chat-adapter-webex@0.1.0(chat@4.29.0(zod@4.3.6))':
+  '@bitbasti/chat-adapter-webex@0.1.0(chat@4.29.0(zod@4.4.3))':
     dependencies:
       '@chat-adapter/shared': 4.26.0
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3418,10 +4323,10 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@chat-adapter/discord@4.29.0(zod@4.3.6)':
+  '@chat-adapter/discord@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
-      chat: 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
+      chat: 4.29.0(zod@4.4.3)
       discord-api-types: 0.37.120
       discord-interactions: 4.4.0
       discord.js: 14.26.3
@@ -3432,33 +4337,33 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@chat-adapter/gchat@4.29.0(zod@4.3.6)':
+  '@chat-adapter/gchat@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@googleapis/chat': 44.6.0
       '@googleapis/workspaceevents': 9.1.0
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/github@4.29.0(zod@4.3.6)':
+  '@chat-adapter/github@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@octokit/auth-app': 8.2.0
       '@octokit/rest': 22.0.1
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/linear@4.29.0(graphql@16.13.2)(zod@4.3.6)':
+  '@chat-adapter/linear@4.29.0(graphql@16.13.2)(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@linear/sdk': 76.0.0(graphql@16.13.2)
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - graphql
@@ -3471,20 +4376,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chat-adapter/shared@4.29.0(zod@4.3.6)':
+  '@chat-adapter/shared@4.29.0(zod@4.4.3)':
     dependencies:
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.29.0(zod@4.3.6)':
+  '@chat-adapter/slack@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7
       '@slack/web-api': 7.15.1
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - bufferutil
@@ -3493,9 +4398,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@chat-adapter/state-memory@4.29.0(zod@4.3.6)':
+  '@chat-adapter/state-memory@4.29.0(zod@4.4.3)':
     dependencies:
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -3510,33 +4415,33 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
-  '@chat-adapter/teams@4.29.0(zod@4.3.6)':
+  '@chat-adapter/teams@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@microsoft/teams.api': 2.0.8
       '@microsoft/teams.apps': 2.0.8
       '@microsoft/teams.cards': 2.0.8
       '@microsoft/teams.graph-endpoints': 2.0.8
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - debug
       - supports-color
       - zod
 
-  '@chat-adapter/telegram@4.29.0(zod@4.3.6)':
+  '@chat-adapter/telegram@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
-      chat: 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/whatsapp@4.29.0(zod@4.3.6)':
+  '@chat-adapter/whatsapp@4.29.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
-      chat: 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -3746,6 +4651,15 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@getdial/sdk@0.17.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))':
+    dependencies:
+      pubnub: 11.0.2(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+      - supports-color
+
   '@googleapis/chat@44.6.0':
     dependencies:
       googleapis-common: 8.0.1
@@ -3875,7 +4789,44 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/ttlcache@1.4.1': {}
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.19.17
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -4223,6 +5174,74 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  '@react-native/assets-registry@0.86.0': {}
+
+  '@react-native/codegen@0.86.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      hermes-parser: 0.36.0
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.16
+      yargs: 17.7.3
+
+  '@react-native/community-cli-plugin@0.86.0':
+    dependencies:
+      '@react-native/dev-middleware': 0.86.0
+      debug: 4.4.3
+      invariant: 2.2.4
+      metro: 0.84.4
+      metro-config: 0.84.4
+      metro-core: 0.84.4
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/debugger-frontend@0.86.0': {}
+
+  '@react-native/debugger-shell@0.86.0':
+    dependencies:
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      fb-dotslash: 0.5.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/dev-middleware@0.86.0':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.86.0
+      '@react-native/debugger-shell': 0.86.0
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.3.0
+      connect: 3.7.0
+      debug: 4.4.3
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      open: 7.4.2
+      serve-static: 1.16.3
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/gradle-plugin@0.86.0': {}
+
+  '@react-native/js-polyfills@0.86.0': {}
+
+  '@react-native/normalize-colors@0.86.0': {}
+
+  '@react-native/virtualized-lists@0.86.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.2.5
+      react-native: 0.86.0(@babel/core@7.29.7)(react@19.2.5)
+
   '@redis/bloom@5.12.1(@redis/client@5.12.1)':
     dependencies:
       '@redis/client': 5.12.1
@@ -4243,12 +5262,12 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1
 
-  '@resend/chat-sdk-adapter@0.1.1(@chat-adapter/shared@4.29.0(zod@4.3.6))(chat@4.29.0(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@resend/chat-sdk-adapter@0.1.1(@chat-adapter/shared@4.29.0(zod@4.4.3))(chat@4.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
       '@react-email/components': 1.0.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@react-email/render': 2.0.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
       hast-util-to-html: 9.0.5
       mdast-util-to-hast: 13.2.1
       resend: 6.9.2(@react-email/render@2.0.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -4323,6 +5342,8 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@sinclair/typebox@0.27.10': {}
+
   '@slack/logger@4.0.1':
     dependencies:
       '@types/node': 22.19.17
@@ -4382,6 +5403,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4409,6 +5432,16 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
@@ -4438,6 +5471,12 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -4541,13 +5580,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -4620,6 +5659,10 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4633,6 +5676,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agentkeepalive@3.5.3:
+    dependencies:
+      humanize-ms: 1.2.1
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4642,15 +5689,25 @@ snapshots:
 
   another-json@0.2.0: {}
 
+  anser@1.4.10: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
 
   async-mutex@0.5.0:
     dependencies:
@@ -4686,6 +5743,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  babel-plugin-syntax-hermes-parser@0.36.0:
+    dependencies:
+      hermes-parser: 0.36.0
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -4695,6 +5756,10 @@ snapshots:
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.43: {}
+
+  basic-ftp@5.3.1: {}
 
   before-after-hook@4.0.0: {}
 
@@ -4752,13 +5817,36 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.6:
+    dependencies:
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
 
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-from@1.1.2: {}
+
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -4787,6 +5875,14 @@ snapshots:
 
   camelcase@5.3.1: {}
 
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001805: {}
+
+  cbor-js@0.1.0: {}
+
+  cbor-sync@1.0.4: {}
+
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
@@ -4802,12 +5898,12 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat-adapter-imessage@0.1.1(chat@4.29.0(zod@4.3.6))(typescript@5.9.3):
+  chat-adapter-imessage@0.1.1(chat@4.29.0(zod@4.4.3))(typescript@5.9.3):
     dependencies:
       '@chat-adapter/shared': 4.26.0
       '@photon-ai/advanced-imessage-kit': 1.14.3(typescript@5.9.3)
       '@photon-ai/imessage-kit': 2.1.2
-      chat: 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4827,7 +5923,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  chat@4.29.0(zod@4.3.6):
+  chat@4.29.0(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -4837,17 +5933,46 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   chownr@1.1.4: {}
+
+  chrome-launcher@0.15.2:
+    dependencies:
+      '@types/node': 22.19.17
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  chromium-edge-launcher@0.3.0:
+    dependencies:
+      '@types/node': 22.19.17
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.4.2
+      mkdirp: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  ci-info@2.0.0: {}
+
+  ci-info@3.9.0: {}
 
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cluster-key-slot@1.1.2: {}
 
@@ -4866,7 +5991,20 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@12.1.0: {}
+
+  commander@2.20.3: {}
+
   concat-map@0.0.1: {}
+
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   consola@3.4.2: {}
 
@@ -4909,6 +6047,12 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4929,11 +6073,19 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -4998,7 +6150,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.389: {}
+
   emoji-regex@8.0.0: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5021,6 +6177,10 @@ snapshots:
   engine.io-parser@5.2.3: {}
 
   entities@4.5.0: {}
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-define-property@1.0.1: {}
 
@@ -5068,11 +6228,21 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-plugin-no-catch-all@1.1.0(eslint@9.39.4):
     dependencies:
@@ -5134,6 +6304,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -5152,6 +6324,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
@@ -5161,6 +6335,8 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  exponential-backoff@3.1.3: {}
 
   express@5.2.1:
     dependencies:
@@ -5213,9 +6389,17 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
+  fast-text-encoding@1.0.6: {}
+
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
+
+  fb-dotslash@0.5.8: {}
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -5225,6 +6409,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5240,6 +6426,22 @@ snapshots:
       - supports-color
 
   file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@2.1.1:
     dependencies:
@@ -5269,6 +6471,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  flow-enums-runtime@0.0.6: {}
+
   follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
@@ -5284,6 +6488,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -5310,6 +6516,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -5333,6 +6541,14 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   github-from-package@0.0.0: {}
 
@@ -5368,6 +6584,8 @@ snapshots:
       - supports-color
 
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
 
@@ -5407,6 +6625,20 @@ snapshots:
 
   he@1.2.0: {}
 
+  hermes-compiler@250829098.0.14: {}
+
+  hermes-estree@0.35.0: {}
+
+  hermes-estree@0.36.0: {}
+
+  hermes-parser@0.35.0:
+    dependencies:
+      hermes-estree: 0.35.0
+
+  hermes-parser@0.36.0:
+    dependencies:
+      hermes-estree: 0.36.0
+
   hookified@1.15.1: {}
 
   hookified@2.1.1: {}
@@ -5436,12 +6668,23 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -5455,6 +6698,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5466,7 +6713,15 @@ snapshots:
 
   ini@1.3.8: {}
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
+  ip-address@10.2.0: {}
+
   ipaddr.js@1.9.1: {}
+
+  is-docker@2.2.1: {}
 
   is-electron@2.2.2: {}
 
@@ -5480,19 +6735,58 @@ snapshots:
 
   is-network-error@1.3.1: {}
 
+  is-number@7.0.0: {}
+
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   isexe@2.0.0: {}
 
+  jest-get-type@29.6.3: {}
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.17
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.2
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 22.19.17
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jose@4.15.9: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsc-safe-url@0.2.4: {}
+
+  jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -5505,6 +6799,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-with-bigint@3.5.8: {}
+
+  json5@2.2.3: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -5554,6 +6850,8 @@ snapshots:
 
   leac@0.6.0: {}
 
+  leven@3.1.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5563,6 +6861,13 @@ snapshots:
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 7.5.5
+
+  lighthouse-logger@1.4.2:
+    dependencies:
+      debug: 2.6.9
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5613,6 +6918,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lil-uuid@0.1.1: {}
+
   limiter@1.1.5: {}
 
   locate-path@5.0.0:
@@ -5643,6 +6950,8 @@ snapshots:
 
   lodash.snakecase@4.1.1: {}
 
+  lodash.throttle@4.1.1: {}
+
   lodash@4.18.1: {}
 
   loglevel@1.9.2: {}
@@ -5651,11 +6960,21 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@11.3.6: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lru-cache@7.18.3: {}
 
   lru-memoizer@2.3.0:
     dependencies:
@@ -5670,9 +6989,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
   markdown-table@3.0.4: {}
 
   marked@15.0.12: {}
+
+  marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -5816,7 +7141,185 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memoize-one@5.2.1: {}
+
   merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  metro-babel-transformer@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.35.0
+      metro-cache-key: 0.84.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-cache-key@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache@0.84.4:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.84.4
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-config@0.84.4:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.4
+      metro-cache: 0.84.4
+      metro-core: 0.84.4
+      metro-runtime: 0.84.4
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-core@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.84.4
+
+  metro-file-map@0.84.4:
+    dependencies:
+      debug: 4.4.3
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-minify-terser@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.49.0
+
+  metro-resolver@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.84.4:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      flow-enums-runtime: 0.0.6
+
+  metro-source-map@0.84.4:
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.84.4
+      nullthrows: 1.1.1
+      ob1: 0.84.4
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-symbolicate@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.84.4
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-worker@0.84.4:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      flow-enums-runtime: 0.0.6
+      metro: 0.84.4
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-minify-terser: 0.84.4
+      metro-source-map: 0.84.4
+      metro-transform-plugins: 0.84.4
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.84.4:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.84.4
+      metro-cache: 0.84.4
+      metro-cache-key: 0.84.4
+      metro-config: 0.84.4
+      metro-core: 0.84.4
+      metro-file-map: 0.84.4
+      metro-resolver: 0.84.4
+      metro-runtime: 0.84.4
+      metro-source-map: 0.84.4
+      metro-symbolicate: 0.84.4
+      metro-transform-plugins: 0.84.4
+      metro-transform-worker: 0.84.4
+      mime-types: 3.0.2
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.11
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -6009,6 +7512,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -6020,6 +7528,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@1.6.0: {}
 
   mimic-response@3.1.0: {}
 
@@ -6035,10 +7545,14 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mkdirp@1.0.4: {}
+
   mpg123-decoder@1.0.3:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -6065,11 +7579,17 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  netmask@2.1.1: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
 
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -6082,6 +7602,10 @@ snapshots:
       css-select: 5.2.2
       he: 1.2.0
 
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.51: {}
+
   node-typedstream@1.4.1:
     dependencies:
       bplist-parser: 0.3.2
@@ -6092,6 +7616,12 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nullthrows@1.1.1: {}
+
+  ob1@0.84.4:
+    dependencies:
+      flow-enums-runtime: 0.0.6
 
   object-assign@4.1.1: {}
 
@@ -6113,6 +7643,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6120,6 +7654,11 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -6180,6 +7719,24 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6202,6 +7759,8 @@ snapshots:
   peberminta@0.9.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -6254,9 +7813,19 @@ snapshots:
 
   prettier@3.8.2: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
+
+  promise@8.3.0:
+    dependencies:
+      asap: 2.0.6
 
   property-information@7.1.0: {}
 
@@ -6280,7 +7849,40 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   proxy-from-env@2.1.0: {}
+
+  pubnub@11.0.2(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5)):
+    dependencies:
+      agentkeepalive: 3.5.3
+      buffer: 6.0.3
+      cbor-js: 0.1.0
+      cbor-sync: 1.0.4
+      fast-text-encoding: 1.0.6
+      fflate: 0.8.3
+      form-data: 4.0.5
+      lil-uuid: 0.1.1
+      node-fetch: 2.7.0
+      proxy-agent: 6.5.0
+      react-native-url-polyfill: 2.0.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+      - supports-color
 
   pump@3.0.4:
     dependencies:
@@ -6311,6 +7913,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
+
   quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
@@ -6329,10 +7935,70 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-devtools-core@6.1.5:
+    dependencies:
+      shell-quote: 1.10.0
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-is@18.3.1: {}
+
+  react-native-url-polyfill@2.0.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5)):
+    dependencies:
+      react-native: 0.86.0(@babel/core@7.29.7)(react@19.2.5)
+      whatwg-url-without-unicode: 8.0.0-3
+
+  react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5):
+    dependencies:
+      '@react-native/assets-registry': 0.86.0
+      '@react-native/codegen': 0.86.0(@babel/core@7.29.7)
+      '@react-native/community-cli-plugin': 0.86.0
+      '@react-native/gradle-plugin': 0.86.0
+      '@react-native/js-polyfills': 0.86.0
+      '@react-native/normalize-colors': 0.86.0
+      '@react-native/virtualized-lists': 0.86.0(react-native@0.86.0(@babel/core@7.29.7)(react@19.2.5))(react@19.2.5)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-plugin-syntax-hermes-parser: 0.36.0
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      hermes-compiler: 250829098.0.14
+      invariant: 2.2.4
+      memoize-one: 5.2.1
+      metro-runtime: 0.84.4
+      metro-source-map: 0.84.4
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.2.5
+      react-devtools-core: 6.1.5
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.27.0
+      semver: 7.7.4
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.16
+      whatwg-fetch: 3.6.20
+      ws: 7.5.11
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@react-native/metro-config'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  react-refresh@0.14.2: {}
 
   react@19.2.5: {}
 
@@ -6356,6 +8022,8 @@ snapshots:
       - '@opentelemetry/api'
 
   reflect-metadata@0.2.2: {}
+
+  regenerator-runtime@0.13.11: {}
 
   remark-gfm@4.0.1:
     dependencies:
@@ -6447,7 +8115,27 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
+  semver@6.3.1: {}
+
   semver@7.7.4: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   send@1.2.1:
     dependencies:
@@ -6462,6 +8150,17 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serialize-error@2.1.0: {}
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6515,6 +8214,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -6558,6 +8259,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smart-buffer@4.2.0: {}
+
   socket.io-client@4.8.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -6576,11 +8279,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.5.7: {}
+
+  source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -6588,10 +8313,18 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackframe@1.3.4: {}
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
@@ -6628,6 +8361,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   svix@1.84.1:
     dependencies:
       standardwebhooks: 1.0.0
@@ -6650,9 +8387,18 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  terser@5.49.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  throat@5.0.0: {}
 
   tinybench@2.9.0: {}
 
@@ -6665,6 +8411,12 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tmpl@1.0.5: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
@@ -6674,6 +8426,8 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
 
@@ -6701,6 +8455,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.7.1: {}
 
   type-is@2.0.1:
     dependencies:
@@ -6768,6 +8524,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
+    dependencies:
+      browserslist: 4.28.6
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -6775,6 +8537,8 @@ snapshots:
   url-template@2.0.8: {}
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
 
@@ -6794,7 +8558,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6805,12 +8569,14 @@ snapshots:
       '@types/node': 22.19.17
       esbuild: 0.27.7
       fsevents: 2.3.3
+      terser: 5.49.0
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -6827,18 +8593,41 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
     transitivePeerDependencies:
       - msw
 
+  vlq@1.0.1: {}
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  webidl-conversions@5.0.0: {}
 
   wechat-ilink-client@0.1.0:
     optionalDependencies:
       qrcode-terminal: 0.12.0
+
+  whatwg-fetch@3.6.20: {}
+
+  whatwg-url-without-unicode@8.0.0-3:
+    dependencies:
+      buffer: 5.7.1
+      punycode: 2.3.1
+      webidl-conversions: 5.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-module@2.0.1: {}
 
@@ -6861,7 +8650,15 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
+
+  ws@7.5.11: {}
 
   ws@8.18.3: {}
 
@@ -6871,12 +8668,20 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
   yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+
+  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -6892,8 +8697,20 @@ snapshots:
       y18n: 4.0.3
       yargs-parser: 18.1.3
 
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/src/channels/dial-pairing.test.ts
+++ b/src/channels/dial-pairing.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the Dial pairing store — the code-mint / match / supersede
+ * logic that backs the wizard's pairing step and the adapter's interceptor.
+ * No DB or network: it's a JSON file under a temp path.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _resetForTest,
+  _setStorePathForTest,
+  createPairing,
+  extractCode,
+  tryConsume,
+  waitForPairing,
+} from './dial-pairing.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dial-pairing-'));
+  _setStorePathForTest(path.join(dir, 'dial-pairings.json'));
+});
+afterEach(() => {
+  _resetForTest();
+  _setStorePathForTest(null);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('extractCode', () => {
+  it('accepts a bare 4-digit body only', () => {
+    expect(extractCode('1234')).toBe('1234');
+    expect(extractCode('  4321 ')).toBe('4321');
+    expect(extractCode('my code is 1234')).toBeNull();
+    expect(extractCode('12345')).toBeNull();
+    expect(extractCode('hello')).toBeNull();
+  });
+});
+
+describe('createPairing / tryConsume', () => {
+  it('mints a 4-digit code and consumes it on an exact match', async () => {
+    const rec = await createPairing();
+    expect(rec.code).toMatch(/^\d{4}$/);
+    expect(rec.status).toBe('pending');
+
+    const consumed = await tryConsume({ text: rec.code, fromNumber: '+15551230000' });
+    expect(consumed?.status).toBe('consumed');
+    expect(consumed?.consumed?.fromNumber).toBe('+15551230000');
+  });
+
+  it('does not consume a non-matching body', async () => {
+    const rec = await createPairing();
+    expect(await tryConsume({ text: 'not a code', fromNumber: '+1555' })).toBeNull();
+    expect(await tryConsume({ text: '9999', fromNumber: '+1555' })).toBeNull(); // wrong 4 digits (assuming != rec.code)
+    // The real code still works afterward.
+    expect((await tryConsume({ text: rec.code, fromNumber: '+1555' }))?.status).toBe('consumed');
+  });
+
+  it('supersedes a prior pending code', async () => {
+    const first = await createPairing();
+    const second = await createPairing();
+    expect(second.code).not.toBe(first.code);
+    // The old code no longer matches (invalidated).
+    expect(await tryConsume({ text: first.code, fromNumber: '+1555' })).toBeNull();
+    expect((await tryConsume({ text: second.code, fromNumber: '+1555' }))?.status).toBe('consumed');
+  });
+});
+
+describe('waitForPairing', () => {
+  it('resolves once the code is consumed', async () => {
+    const rec = await createPairing();
+    const waiting = waitForPairing(rec.code, 20);
+    await tryConsume({ text: rec.code, fromNumber: '+15559998888' });
+    const resolved = await waiting;
+    expect(resolved.consumed?.fromNumber).toBe('+15559998888');
+  });
+});

--- a/src/channels/dial-pairing.ts
+++ b/src/channels/dial-pairing.ts
@@ -1,0 +1,203 @@
+/**
+ * Dial pairing — proves the operator controls a phone before it's registered.
+ *
+ * Setup mints a one-time 4-digit code; the operator texts exactly those 4
+ * digits to the Dial number from the phone they want registered. The inbound
+ * interceptor in dial.ts matches the code, records the sender's number, and
+ * (if no owner exists yet) promotes them to owner — all before the message
+ * reaches an agent. The message must be exactly the 4 digits; a text that
+ * merely contains a 4-digit number does NOT match.
+ *
+ * Storage is a JSON file at data/dial-pairings.json — single-process,
+ * read-modify-write under an in-process mutex. Mirrors telegram-pairing.ts.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from '../config.js';
+import { log } from '../log.js';
+
+export type PairingStatus = 'pending' | 'consumed' | 'invalidated' | 'unknown';
+
+export interface ConsumedDetails {
+  /** The phone number (E.164) that sent the code. */
+  fromNumber: string;
+  consumedAt: string;
+}
+
+export interface PairingRecord {
+  code: string;
+  createdAt: string;
+  status: Exclude<PairingStatus, 'unknown'>;
+  consumed?: ConsumedDetails;
+}
+
+interface Store {
+  pairings: PairingRecord[];
+}
+
+const FILE_NAME = 'dial-pairings.json';
+
+let storePathOverride: string | null = null;
+export function _setStorePathForTest(p: string | null): void {
+  storePathOverride = p;
+}
+
+function storePath(): string {
+  return storePathOverride ?? path.join(DATA_DIR, FILE_NAME);
+}
+
+let mutex: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T> | T): Promise<T> {
+  const next = mutex.then(() => fn());
+  mutex = next.catch(() => {});
+  return next;
+}
+
+function readStore(): Store {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath(), 'utf8')) as Store;
+    if (!Array.isArray(parsed.pairings)) return { pairings: [] };
+    return parsed;
+  } catch {
+    return { pairings: [] };
+  }
+}
+
+function writeStore(store: Store): void {
+  const p = storePath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2));
+  fs.renameSync(tmp, p);
+}
+
+/** Keep the store small — retain the most recent 50 records. */
+function sweep(store: Store): void {
+  if (store.pairings.length > 50) store.pairings = store.pairings.slice(-50);
+}
+
+function generateCode(active: Set<string>): string {
+  for (let i = 0; i < 50; i++) {
+    const code = Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(4, '0');
+    if (!active.has(code)) return code;
+  }
+  throw new Error('Could not allocate a free pairing code');
+}
+
+/** Mint a fresh pairing code, superseding any prior pending one. */
+export async function createPairing(): Promise<PairingRecord> {
+  return withLock(() => {
+    const store = readStore();
+    sweep(store);
+    for (const r of store.pairings) {
+      if (r.status === 'pending') r.status = 'invalidated';
+    }
+    const active = new Set(store.pairings.filter((r) => r.status === 'pending').map((r) => r.code));
+    const record: PairingRecord = {
+      code: generateCode(active),
+      createdAt: new Date().toISOString(),
+      status: 'pending',
+    };
+    store.pairings.push(record);
+    writeStore(store);
+    log.info('Dial pairing created', { code: record.code });
+    return record;
+  });
+}
+
+/** A 4-digit-only body is a code candidate; anything else is not. */
+export function extractCode(text: string): string | null {
+  const m = text.trim().match(/^(\d{4})$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Match an inbound SMS body against a pending pairing. On match, marks it
+ * consumed and returns the record; returns null on no match.
+ */
+export async function tryConsume(input: { text: string; fromNumber: string }): Promise<PairingRecord | null> {
+  const code = extractCode(input.text);
+  if (!code) return null;
+  return withLock(() => {
+    const store = readStore();
+    sweep(store);
+    const record = store.pairings.find((r) => r.code === code && r.status === 'pending');
+    if (!record) return null;
+    record.status = 'consumed';
+    record.consumed = { fromNumber: input.fromNumber, consumedAt: new Date().toISOString() };
+    writeStore(store);
+    log.info('Dial pairing consumed', { code, fromNumber: input.fromNumber });
+    return record;
+  });
+}
+
+export function getPairing(code: string): PairingRecord | null {
+  const store = readStore();
+  return store.pairings.find((p) => p.code === code) ?? null;
+}
+
+/**
+ * Resolve when the pairing is consumed; reject when it is superseded/invalidated.
+ * Waits indefinitely (codes don't expire) via fs.watch + a slow poll fallback.
+ */
+export async function waitForPairing(code: string, pollMs = 1000): Promise<PairingRecord> {
+  const initial = getPairing(code);
+  if (!initial) throw new Error(`Unknown pairing code: ${code}`);
+
+  return new Promise<PairingRecord>((resolve, reject) => {
+    let watcher: fs.FSWatcher | null = null;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let settled = false;
+
+    const cleanup = () => {
+      settled = true;
+      try {
+        watcher?.close();
+      } catch {
+        /* ignore */
+      }
+      if (interval) clearInterval(interval);
+    };
+
+    const check = () => {
+      if (settled) return;
+      const r = getPairing(code);
+      if (!r) {
+        cleanup();
+        reject(new Error(`Pairing ${code} disappeared`));
+        return;
+      }
+      if (r.status === 'consumed') {
+        cleanup();
+        resolve(r);
+      } else if (r.status === 'invalidated') {
+        cleanup();
+        reject(new Error(`Pairing ${code} was superseded`));
+      }
+    };
+
+    try {
+      const dir = path.dirname(storePath());
+      fs.mkdirSync(dir, { recursive: true });
+      watcher = fs.watch(dir, (_e, fname) => {
+        if (!fname || fname.toString().startsWith(path.basename(storePath()))) check();
+      });
+    } catch {
+      /* fs.watch unsupported — poll-only */
+    }
+    interval = setInterval(check, pollMs);
+    check();
+  });
+}
+
+/** Test helper — wipe the store. */
+export function _resetForTest(): void {
+  try {
+    fs.unlinkSync(storePath());
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/channels/dial-registration.test.ts
+++ b/src/channels/dial-registration.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Integration test for the dial channel's single reach-in: the self-registration
+ * import in the `src/channels/index.ts` barrel. Importing the barrel runs dial.ts's
+ * top-level `registerChannelAdapter('dial', …)`; without the import the channel is
+ * silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './dial.js';` line is deleted, or the barrel fails to evaluate for any
+ * reason (so the channel genuinely would not register), this goes red. A structural
+ * check of the import line would falsely pass in that second case.
+ *
+ * dial is a native adapter (no Chat SDK bridge): it uses the official `@getdial/sdk`
+ * for outbound and Dial's CLI command-target (a spooled-event handler) for inbound.
+ * Importing the barrel requires `@getdial/sdk` to be installed, which holds in a
+ * composed install: the skill's `pnpm install` step runs before this test — so this
+ * test also implicitly guards that dependency (an unmocked import throws if the
+ * package is missing). Registration is a pure top-level call, and dial.ts opens the
+ * spool watcher / shells out to the `dial` CLI only inside setup() (run at host
+ * startup), never at import.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('dial channel registration', () => {
+  it('registers dial via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('dial');
+  });
+});

--- a/src/channels/dial.ts
+++ b/src/channels/dial.ts
@@ -2,24 +2,20 @@
  * Dial channel adapter for NanoClaw v2.
  *
  * Dial (https://getdial.ai) gives an agent a real phone number — SMS and
- * AI-handled voice calls. This is a native adapter (no Chat SDK bridge):
+ * AI-handled voice calls. Native adapter (no Chat SDK bridge):
  *
- *   - Outbound uses the official `@getdial/sdk` (`DialClient.sendMessage`),
- *     sending as the account's auto-provisioned number.
- *   - Inbound uses the documented **CLI command-target** pattern
+ *   - Outbound SMS via the official `@getdial/sdk` (`DialClient.sendMessage`).
+ *   - Inbound via Dial's documented CLI command-target
  *     (docs.getdial.ai/integrations/agent-clients/nanoclaw). NanoClaw has no
- *     inbound HTTP webhook, so instead of a local server we register a small
- *     handler script with Dial's `listen` daemon. For every account event the
- *     daemon runs the handler with the event JSON as its final positional
- *     argument; the handler spools the event to a directory this adapter
- *     watches. Each `message.received` / `call.ended` becomes an InboundMessage
- *     routed through the normal entity model, so replies flow back out via
- *     `deliver()` → the SDK → SMS.
+ *     inbound HTTP webhook, so the adapter registers a small handler script
+ *     with Dial's `listen` daemon; the daemon runs it per event with the event
+ *     JSON as the final arg, the handler spools it to a directory the adapter
+ *     watches, and `message.received` / `call.ended` route through the normal
+ *     entity model so replies flow back out over SMS.
  *
- * Credentials come from Dial's own auth file (`~/.local/share/dial/auth.v1.json`,
- * written by `dial signup` + `dial onboard`), or from DIAL_API_KEY /
- * DIAL_FROM_NUMBER env overrides. If neither yields an API key the factory
- * returns null and the channel is skipped.
+ * The API key + from-number come from Dial's auth file (written by `dial
+ * onboard`). If there's no key the factory returns null and the channel is
+ * skipped.
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -34,64 +30,26 @@ import { DATA_DIR } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 
-const DEFAULT_BASE_URL = 'https://api.getdial.ai';
-
-/** Longest single SMS/MMS body we send in one shot; longer text is chunked. */
+/** Longest SMS body sent in one shot; longer text is chunked. */
 const MAX_CHUNK = 1500;
 
-/** How long a seen event id stays in the dedup window (the listen daemon
- *  retries a failed handler invocation once, which can double-deliver). */
+/** Dedup window — the listen daemon retries a failed handler invocation once. */
 const DEDUP_TTL_MS = 5 * 60_000;
 
-// ---------------------------------------------------------------------------
-// Dial listen-daemon event envelope (subset we consume). Mirrors the shapes
-// documented at docs.getdial.ai/documentation/cli/listen-service and the
-// @getdial/sdk `DialEvent` types.
-// ---------------------------------------------------------------------------
-
+/** Dial listen-daemon event envelope (the subset we consume). */
 interface DialEventEnvelope {
   id?: string;
-  object?: string;
   type?: string;
   createdAt?: string;
   data?: Record<string, unknown>;
 }
 
-// ---------------------------------------------------------------------------
-// Config resolution
-// ---------------------------------------------------------------------------
-
-interface DialAuth {
-  apiKey?: string;
-  phoneNumber?: string;
-}
-
-/** Path to Dial's auth file, honoring XDG_DATA_HOME then $HOME/.local/share. */
-function defaultAuthFilePath(): string {
-  const base = process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share');
-  return path.join(base, 'dial', 'auth.v1.json');
-}
-
-function readDialAuth(authFile: string): DialAuth {
-  try {
-    const raw = fs.readFileSync(authFile, 'utf8');
-    const parsed = JSON.parse(raw) as DialAuth;
-    return { apiKey: parsed.apiKey, phoneNumber: parsed.phoneNumber };
-  } catch {
-    return {};
-  }
-}
-
 interface DialConfig {
   apiKey: string;
-  baseUrl: string;
+  /** E.164 to send from; '' → let the server use the account's default number. */
   fromNumber: string;
   cliPath: string;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function chunkText(text: string, limit: number): string[] {
   const chunks: string[] = [];
@@ -109,39 +67,17 @@ function chunkText(text: string, limit: number): string[] {
   return chunks;
 }
 
-const CONTENT_TYPES: Record<string, string> = {
-  jpg: 'image/jpeg',
-  jpeg: 'image/jpeg',
-  png: 'image/png',
-  gif: 'image/gif',
-  webp: 'image/webp',
-  pdf: 'application/pdf',
-  mp3: 'audio/mpeg',
-  m4a: 'audio/mp4',
-  mp4: 'video/mp4',
-  txt: 'text/plain',
-};
-
-function inferContentType(filename: string): string {
-  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-  return CONTENT_TYPES[ext] ?? 'application/octet-stream';
-}
-
 /**
- * The handler script Dial's listen daemon runs per event. It spools the event
- * JSON (the daemon passes it as the final positional argument) into a directory
- * this adapter watches. Written atomically (temp + rename) so the watcher never
- * reads a partial file. Runs with a clean env (only PATH + HOME), so the spool
- * dir is baked in as an absolute path.
+ * The handler script Dial's listen daemon runs per event: it spools the event
+ * JSON (passed as the final positional argument) into a directory the adapter
+ * watches, written atomically (temp + rename) so the watcher never reads a
+ * partial file. Runs with a clean env (PATH + HOME only), so the spool dir is
+ * baked in as an absolute path.
  */
 function handlerScript(spoolDir: string): string {
   return `#!/usr/bin/env bash
 # Auto-generated by NanoClaw's Dial channel adapter (src/channels/dial.ts).
-# Registered as a Dial CLI command target — see:
-#   https://docs.getdial.ai/integrations/methods/cli-command-target
-# For each account event the listen daemon runs this with the event JSON as the
-# final positional argument. We spool it to a directory the adapter watches;
-# there is no local HTTP endpoint.
+# Dial CLI command target: https://docs.getdial.ai/integrations/methods/cli-command-target
 set -euo pipefail
 [ "$#" -eq 0 ] && exit 0
 spool=${JSON.stringify(spoolDir)}
@@ -154,17 +90,11 @@ exit 0
 `;
 }
 
-// ---------------------------------------------------------------------------
-// Adapter
-// ---------------------------------------------------------------------------
-
 /**
- * Dial models every conversation as a 1:1 exchange between the account's number
- * and a remote number — there are no group chats. So every inbound is a DM
- * (isGroup:false, isMention:true) and mentions are 'dm-only'. The group context
- * mirrors dm defaults purely so nothing is undefined; it never fires. Unknown
- * senders default to 'request_approval': anyone can text a phone number, so a
- * cold inbound (a stray SMS, a 2FA code from a service) asks before engaging.
+ * Dial has no group chats: every conversation is 1:1 between the account's
+ * number and a remote number, so every inbound is a DM (isMention:true,
+ * isGroup:false) and mentions are 'dm-only'. Unknown senders default to
+ * 'request_approval' — anyone can text a phone number.
  */
 const DIAL_DEFAULTS: ChannelDefaults = {
   dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
@@ -173,7 +103,7 @@ const DIAL_DEFAULTS: ChannelDefaults = {
 };
 
 export function createDialAdapter(config: DialConfig): ChannelAdapter {
-  const client = new DialClient({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  const client = new DialClient({ apiKey: config.apiKey });
   const spoolDir = path.join(DATA_DIR, 'dial', 'inbound');
   const handlerPath = path.join(DATA_DIR, 'dial', 'handle-dial-event.sh');
 
@@ -184,118 +114,54 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
   let draining = false;
   const seen = new Map<string, number>();
 
-  function markSeen(id: string): boolean {
+  /** True if this event id was already routed within the dedup window. */
+  function seenBefore(id: string): boolean {
     const now = Date.now();
-    for (const [k, ts] of seen) {
-      if (now - ts > DEDUP_TTL_MS) seen.delete(k);
-    }
-    if (seen.has(id)) return false;
+    for (const [k, ts] of seen) if (now - ts > DEDUP_TTL_MS) seen.delete(k);
+    if (seen.has(id)) return true;
     seen.set(id, now);
-    return true;
+    return false;
   }
 
-  // -- inbound: spool → route --------------------------------------------
-
-  function routeMessageReceived(env: DialEventEnvelope): void {
-    if (!setup) return;
-    const data = env.data ?? {};
-    if (data.source && data.source !== 'external') {
-      log.debug('Dial: skipping non-external message', { source: data.source });
-      return;
-    }
-    const from = typeof data.from === 'string' ? data.from : '';
-    if (!from) return;
-    const channel = typeof data.channel === 'string' ? data.channel : 'sms';
-
-    let text = typeof data.body === 'string' ? data.body : '';
-    const media = Array.isArray(data.media) ? (data.media as Array<Record<string, unknown>>) : [];
-    const attachmentRefs: Array<{ url: string; contentType: string }> = [];
-    for (const m of media) {
-      const url = typeof m.url === 'string' ? m.url : '';
-      if (!url) continue;
-      const contentType = typeof m.contentType === 'string' ? m.contentType : 'application/octet-stream';
-      const line = `[Media: ${url}]`;
-      text = text ? `${text}\n${line}` : line;
-      attachmentRefs.push({ url, contentType });
-    }
-    if (!text && attachmentRefs.length === 0) return;
-
-    const messageId = typeof data.messageId === 'string' ? data.messageId : env.id || String(Date.now());
-    const msg: InboundMessage = {
-      id: messageId,
-      kind: 'chat',
-      content: {
-        text,
-        sender: from,
-        senderId: `dial:${from}`,
-        senderName: from,
-        channel,
-        ...(attachmentRefs.length > 0 ? { attachments: attachmentRefs } : {}),
-      },
-      isMention: true,
-      isGroup: false,
-      timestamp: env.createdAt || new Date().toISOString(),
-    };
-    setup.onMetadata(from, from, false);
-    void Promise.resolve(setup.onInbound(from, null, msg)).catch((err) =>
-      log.error('Dial: onInbound failed', { from, err }),
-    );
-    log.info('Dial message received', { from, channel });
-  }
-
-  function routeCallEnded(env: DialEventEnvelope): void {
-    if (!setup) return;
-    const data = env.data ?? {};
-    const direction = data.direction === 'outbound' ? 'outbound' : 'inbound';
-    const peer = direction === 'inbound' ? data.from : data.to;
-    if (typeof peer !== 'string' || !peer) return;
-
-    const callId = typeof data.callId === 'string' ? data.callId : env.id || '';
-    const status = typeof data.status === 'string' ? data.status : 'ended';
-    const canceled = data.canceled === true;
-    const duration = typeof data.durationSeconds === 'number' ? data.durationSeconds : null;
-    const transcriptAvailable = data.transcriptAvailable === true;
-
-    const parts = [
-      `[Voice call ${direction} ${status}${canceled ? ' (canceled)' : ''}`,
-      duration != null ? `, ${duration}s` : '',
-      '.',
-      transcriptAvailable && callId ? ` Transcript available — run \`dial call get ${callId}\` to read it.` : '',
-      ']',
-    ];
-    const text = parts.join('');
-
-    const msg: InboundMessage = {
-      id: callId || String(Date.now()),
-      kind: 'chat',
-      content: { text, sender: peer, senderId: `dial:${peer}`, senderName: peer, channel: 'call' },
-      isMention: true,
-      isGroup: false,
-      timestamp: env.createdAt || new Date().toISOString(),
-    };
-    setup.onMetadata(peer, peer, false);
-    void Promise.resolve(setup.onInbound(peer, null, msg)).catch((err) =>
-      log.error('Dial: onInbound (call) failed', { peer, err }),
-    );
-    log.info('Dial call event received', { peer, direction, status });
-  }
-
+  /** Route one inbound event — SMS text and ended-call notifications only. */
   function routeEvent(env: DialEventEnvelope): void {
-    const id = env.id;
-    if (id && !markSeen(id)) {
-      log.debug('Dial: duplicate event dropped', { id });
+    if (!setup) return;
+    if (env.id && seenBefore(env.id)) return;
+    const data = env.data ?? {};
+
+    let peer = '';
+    let text = '';
+    if (env.type === 'message.received') {
+      if (data.source && data.source !== 'external') return; // ignore Dial-synthesized test SMS
+      peer = typeof data.from === 'string' ? data.from : '';
+      text = typeof data.body === 'string' ? data.body : '';
+    } else if (env.type === 'call.ended') {
+      const outbound = data.direction === 'outbound';
+      const other = outbound ? data.to : data.from;
+      peer = typeof other === 'string' ? other : '';
+      const dur = typeof data.durationSeconds === 'number' ? `, ${data.durationSeconds}s` : '';
+      const callId = typeof data.callId === 'string' ? data.callId : '';
+      const transcript =
+        data.transcriptAvailable && callId ? ` Run \`dial call get ${callId}\` for the transcript.` : '';
+      text = `[Voice call ${outbound ? 'outbound' : 'inbound'} ${data.status ?? 'ended'}${data.canceled ? ' (canceled)' : ''}${dur}.${transcript}]`;
+    } else {
       return;
     }
-    switch (env.type) {
-      case 'message.received':
-        routeMessageReceived(env);
-        break;
-      case 'call.ended':
-        routeCallEnded(env);
-        break;
-      default:
-        log.debug('Dial: ignoring event type', { type: env.type });
-    }
+    if (!peer || !text) return;
+
+    const id = [data.messageId, data.callId, env.id].find((v): v is string => typeof v === 'string' && !!v);
+    const msg: InboundMessage = {
+      id: id ?? peer,
+      kind: 'chat',
+      content: { text, sender: peer, senderId: `dial:${peer}`, senderName: peer },
+      isMention: true,
+      isGroup: false,
+      timestamp: env.createdAt || new Date().toISOString(),
+    };
+    void Promise.resolve(setup.onInbound(peer, null, msg)).catch((err) =>
+      log.error('Dial: onInbound failed', { peer, err }),
+    );
+    log.info('Dial inbound routed', { peer, type: env.type });
   }
 
   function processSpoolFile(file: string): void {
@@ -312,14 +178,11 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       /* best-effort */
     }
     if (!raw.trim()) return;
-    let env: DialEventEnvelope;
     try {
-      env = JSON.parse(raw) as DialEventEnvelope;
+      routeEvent(JSON.parse(raw) as DialEventEnvelope);
     } catch (err) {
       log.warn('Dial: unparseable spooled event', { file, err });
-      return;
     }
-    routeEvent(env);
   }
 
   /** Drain the spool directory once, in filename (roughly chronological) order. */
@@ -327,36 +190,23 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
     if (draining) return;
     draining = true;
     try {
-      const files = fs
+      for (const f of fs
         .readdirSync(spoolDir)
         .filter((f) => f.endsWith('.json'))
-        .sort();
-      for (const f of files) processSpoolFile(f);
-    } catch (err) {
-      // ENOENT is normal before the first event lands; anything else is worth a note.
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        log.debug('Dial: spool drain error', { err });
+        .sort()) {
+        processSpoolFile(f);
       }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') log.debug('Dial: spool drain error', { err });
     } finally {
       draining = false;
     }
   }
 
-  // -- command-target / listen-daemon wiring ------------------------------
-
-  function runDial(args: string[]): string {
-    return execFileSync(config.cliPath, args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 15_000,
-    });
-  }
-
   /**
-   * Best-effort: (re)write the handler script and register it as a Dial CLI
-   * command target, and warn if the listen daemon isn't running. All failures
-   * are logged, never thrown — the wizard/installer normally establishes this,
-   * and the adapter keeps watching the spool regardless.
+   * Best-effort: write the handler script and register it as a Dial CLI command
+   * target. Failures are logged, never thrown — the adapter keeps watching the
+   * spool regardless, and the wizard/skill can establish this out of band.
    */
   function ensureCommandTarget(): void {
     try {
@@ -368,39 +218,21 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       return;
     }
     try {
-      execFileSync('which', [config.cliPath], { stdio: 'ignore' });
-    } catch {
-      log.warn(
-        'Dial: `dial` CLI not found on PATH — inbound events will not be delivered until the listen daemon is set up',
-        {
-          cliPath: config.cliPath,
-        },
-      );
-      return;
-    }
-    try {
-      const doctor = JSON.parse(runDial(['doctor', '--json'])) as { listen?: { running?: boolean } };
-      if (!doctor.listen?.running) {
-        log.warn('Dial: listen daemon is not running — run `dial listen install` so inbound events reach NanoClaw');
-      }
-    } catch (err) {
-      log.debug('Dial: doctor check failed', { err });
-    }
-    try {
-      const listed = runDial(['local-target', 'list', '--json']);
+      const listed = execFileSync(config.cliPath, ['local-target', 'list', '--json'], {
+        encoding: 'utf8',
+        timeout: 15_000,
+      });
       if (!listed.includes(handlerPath)) {
-        runDial(['local-target', 'add', 'cmd', handlerPath]);
+        execFileSync(config.cliPath, ['local-target', 'add', 'cmd', handlerPath], { stdio: 'ignore', timeout: 15_000 });
         log.info('Dial: registered CLI command target', { handlerPath });
       }
     } catch (err) {
-      log.warn('Dial: could not register command target — set it up with `dial local-target add cmd <handler>`', {
-        handlerPath,
-        err,
-      });
+      log.warn(
+        'Dial: could not register command target — check `dial` is on PATH (DIAL_CLI_PATH) and `dial listen install` has run',
+        { err },
+      );
     }
   }
-
-  // -- adapter ------------------------------------------------------------
 
   const adapter: ChannelAdapter = {
     name: 'dial',
@@ -413,34 +245,24 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       fs.mkdirSync(spoolDir, { recursive: true });
       ensureCommandTarget();
 
-      // Drain anything spooled while we were down, then watch for new events.
-      drainSpool();
+      drainSpool(); // anything spooled while we were down
       try {
         watcher = fs.watch(spoolDir, () => drainSpool());
       } catch (err) {
         log.debug('Dial: fs.watch unavailable, relying on poll', { err });
       }
-      // Poll fallback — fs.watch misses events on some platforms/mounts.
-      pollTimer = setInterval(drainSpool, 2000);
+      pollTimer = setInterval(drainSpool, 2000); // fallback — fs.watch misses events on some mounts
 
       connected = true;
-      log.info('Dial channel connected', { fromNumber: config.fromNumber });
+      log.info('Dial channel connected', { fromNumber: config.fromNumber || '(account default)' });
     },
 
     async teardown(): Promise<void> {
       connected = false;
-      if (watcher) {
-        try {
-          watcher.close();
-        } catch {
-          /* ignore */
-        }
-        watcher = null;
-      }
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-      }
+      watcher?.close();
+      watcher = null;
+      if (pollTimer) clearInterval(pollTimer);
+      pollTimer = null;
       log.info('Dial channel disconnected');
     },
 
@@ -450,57 +272,28 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
 
     async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
       const content = message.content as Record<string, unknown> | string | undefined;
-      let text: string | null = null;
-      if (typeof content === 'string') {
-        text = content;
-      } else if (content && typeof content === 'object' && typeof content.text === 'string') {
-        text = content.text;
-      }
-      const files = message.files ?? [];
+      const text =
+        typeof content === 'string'
+          ? content
+          : content && typeof content === 'object' && typeof content.text === 'string'
+            ? content.text
+            : '';
+      if (!text) return undefined;
 
       let lastId: string | undefined;
-      if (text) {
-        const chunks = text.length <= MAX_CHUNK ? [text] : chunkText(text, MAX_CHUNK);
-        for (const chunk of chunks) {
-          try {
-            const sent = await client.sendMessage({ to: platformId, fromNumber: config.fromNumber, body: chunk });
-            lastId = sent?.id ?? lastId;
-          } catch (err) {
-            log.error('Dial: sendMessage failed', { platformId, err });
-          }
+      for (const chunk of text.length <= MAX_CHUNK ? [text] : chunkText(text, MAX_CHUNK)) {
+        try {
+          const sent = await client.sendMessage({
+            to: platformId,
+            body: chunk,
+            ...(config.fromNumber ? { fromNumber: config.fromNumber } : {}),
+          });
+          lastId = sent?.id ?? lastId;
+        } catch (err) {
+          log.error('Dial: sendMessage failed', { platformId, err });
         }
       }
-
-      if (files.length > 0) {
-        // Dial caps a send at 10 media items; batch accordingly.
-        for (let i = 0; i < files.length; i += 10) {
-          const batch = files.slice(i, i + 10);
-          try {
-            const sent = await client.sendMessage({
-              to: platformId,
-              fromNumber: config.fromNumber,
-              media: batch.map((f) => ({
-                data: new Uint8Array(f.data),
-                contentType: inferContentType(f.filename),
-                filename: f.filename,
-              })),
-            });
-            lastId = sent?.id ?? lastId;
-          } catch (err) {
-            log.error('Dial: media send failed', { platformId, count: batch.length, err });
-          }
-        }
-      }
-
       return lastId;
-    },
-
-    async setTyping(platformId: string, _threadId: string | null): Promise<void> {
-      try {
-        await client.startTyping({ toNumber: platformId, fromNumber: config.fromNumber });
-      } catch (err) {
-        log.debug('Dial: typing indicator failed', { platformId, err });
-      }
     },
   };
 
@@ -513,26 +306,29 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
 
 registerChannelAdapter('dial', {
   factory: () => {
-    const env = readEnvFile(['DIAL_API_KEY', 'DIAL_FROM_NUMBER', 'DIAL_BASE_URL', 'DIAL_AUTH_FILE', 'DIAL_CLI_PATH']);
-
-    const authFile = process.env.DIAL_AUTH_FILE || env.DIAL_AUTH_FILE || defaultAuthFilePath();
-    const auth = readDialAuth(authFile);
-
-    const apiKey = process.env.DIAL_API_KEY || env.DIAL_API_KEY || auth.apiKey || '';
+    // Credentials come from Dial's own auth file (written by `dial onboard`).
+    const authFile = path.join(
+      process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share'),
+      'dial',
+      'auth.v1.json',
+    );
+    let apiKey = '';
+    let fromNumber = '';
+    try {
+      const auth = JSON.parse(fs.readFileSync(authFile, 'utf8')) as { apiKey?: string; phoneNumber?: string };
+      apiKey = auth.apiKey ?? '';
+      fromNumber = auth.phoneNumber ?? '';
+    } catch {
+      /* no auth file — not signed in */
+    }
     if (!apiKey) {
-      log.debug('Dial: no API key (run `dial signup` + `dial onboard`, or set DIAL_API_KEY), skipping channel');
+      log.debug('Dial: not signed in (run `dial signup` + `dial onboard`), skipping channel');
       return null;
     }
 
-    const fromNumber = process.env.DIAL_FROM_NUMBER || env.DIAL_FROM_NUMBER || auth.phoneNumber || '';
-    if (!fromNumber) {
-      log.warn('Dial: no from-number resolved — set DIAL_FROM_NUMBER or run `dial onboard` to provision one');
-    }
-
-    const baseUrl = process.env.DIAL_BASE_URL || env.DIAL_BASE_URL || DEFAULT_BASE_URL;
+    const env = readEnvFile(['DIAL_CLI_PATH']);
     const cliPath = process.env.DIAL_CLI_PATH || env.DIAL_CLI_PATH || 'dial';
-
-    return createDialAdapter({ apiKey, baseUrl, fromNumber, cliPath });
+    return createDialAdapter({ apiKey, fromNumber, cliPath });
   },
   defaults: DIAL_DEFAULTS,
 });

--- a/src/channels/dial.ts
+++ b/src/channels/dial.ts
@@ -1,0 +1,538 @@
+/**
+ * Dial channel adapter for NanoClaw v2.
+ *
+ * Dial (https://getdial.ai) gives an agent a real phone number — SMS and
+ * AI-handled voice calls. This is a native adapter (no Chat SDK bridge):
+ *
+ *   - Outbound uses the official `@getdial/sdk` (`DialClient.sendMessage`),
+ *     sending as the account's auto-provisioned number.
+ *   - Inbound uses the documented **CLI command-target** pattern
+ *     (docs.getdial.ai/integrations/agent-clients/nanoclaw). NanoClaw has no
+ *     inbound HTTP webhook, so instead of a local server we register a small
+ *     handler script with Dial's `listen` daemon. For every account event the
+ *     daemon runs the handler with the event JSON as its final positional
+ *     argument; the handler spools the event to a directory this adapter
+ *     watches. Each `message.received` / `call.ended` becomes an InboundMessage
+ *     routed through the normal entity model, so replies flow back out via
+ *     `deliver()` → the SDK → SMS.
+ *
+ * Credentials come from Dial's own auth file (`~/.local/share/dial/auth.v1.json`,
+ * written by `dial signup` + `dial onboard`), or from DIAL_API_KEY /
+ * DIAL_FROM_NUMBER env overrides. If neither yields an API key the factory
+ * returns null and the channel is skipped.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { DialClient } from '@getdial/sdk';
+
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import { DATA_DIR } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+
+const DEFAULT_BASE_URL = 'https://api.getdial.ai';
+
+/** Longest single SMS/MMS body we send in one shot; longer text is chunked. */
+const MAX_CHUNK = 1500;
+
+/** How long a seen event id stays in the dedup window (the listen daemon
+ *  retries a failed handler invocation once, which can double-deliver). */
+const DEDUP_TTL_MS = 5 * 60_000;
+
+// ---------------------------------------------------------------------------
+// Dial listen-daemon event envelope (subset we consume). Mirrors the shapes
+// documented at docs.getdial.ai/documentation/cli/listen-service and the
+// @getdial/sdk `DialEvent` types.
+// ---------------------------------------------------------------------------
+
+interface DialEventEnvelope {
+  id?: string;
+  object?: string;
+  type?: string;
+  createdAt?: string;
+  data?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+interface DialAuth {
+  apiKey?: string;
+  phoneNumber?: string;
+}
+
+/** Path to Dial's auth file, honoring XDG_DATA_HOME then $HOME/.local/share. */
+function defaultAuthFilePath(): string {
+  const base = process.env.XDG_DATA_HOME || path.join(homedir(), '.local', 'share');
+  return path.join(base, 'dial', 'auth.v1.json');
+}
+
+function readDialAuth(authFile: string): DialAuth {
+  try {
+    const raw = fs.readFileSync(authFile, 'utf8');
+    const parsed = JSON.parse(raw) as DialAuth;
+    return { apiKey: parsed.apiKey, phoneNumber: parsed.phoneNumber };
+  } catch {
+    return {};
+  }
+}
+
+interface DialConfig {
+  apiKey: string;
+  baseUrl: string;
+  fromNumber: string;
+  cliPath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function chunkText(text: string, limit: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= limit) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitAt = remaining.lastIndexOf('\n', limit);
+    if (splitAt <= 0) splitAt = limit;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^\n/, '');
+  }
+  return chunks;
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  pdf: 'application/pdf',
+  mp3: 'audio/mpeg',
+  m4a: 'audio/mp4',
+  mp4: 'video/mp4',
+  txt: 'text/plain',
+};
+
+function inferContentType(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  return CONTENT_TYPES[ext] ?? 'application/octet-stream';
+}
+
+/**
+ * The handler script Dial's listen daemon runs per event. It spools the event
+ * JSON (the daemon passes it as the final positional argument) into a directory
+ * this adapter watches. Written atomically (temp + rename) so the watcher never
+ * reads a partial file. Runs with a clean env (only PATH + HOME), so the spool
+ * dir is baked in as an absolute path.
+ */
+function handlerScript(spoolDir: string): string {
+  return `#!/usr/bin/env bash
+# Auto-generated by NanoClaw's Dial channel adapter (src/channels/dial.ts).
+# Registered as a Dial CLI command target — see:
+#   https://docs.getdial.ai/integrations/methods/cli-command-target
+# For each account event the listen daemon runs this with the event JSON as the
+# final positional argument. We spool it to a directory the adapter watches;
+# there is no local HTTP endpoint.
+set -euo pipefail
+[ "$#" -eq 0 ] && exit 0
+spool=${JSON.stringify(spoolDir)}
+mkdir -p "$spool"
+event="\${!#}"   # value of the last positional parameter = the event JSON
+tmp="$spool/.tmp.$$.\${RANDOM}"
+printf '%s' "$event" > "$tmp"
+mv -f "$tmp" "$spool/$(date +%s).$$.\${RANDOM}.json"
+exit 0
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Dial models every conversation as a 1:1 exchange between the account's number
+ * and a remote number — there are no group chats. So every inbound is a DM
+ * (isGroup:false, isMention:true) and mentions are 'dm-only'. The group context
+ * mirrors dm defaults purely so nothing is undefined; it never fires. Unknown
+ * senders default to 'request_approval': anyone can text a phone number, so a
+ * cold inbound (a stray SMS, a 2FA code from a service) asks before engaging.
+ */
+const DIAL_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  group: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  mentions: 'dm-only',
+};
+
+export function createDialAdapter(config: DialConfig): ChannelAdapter {
+  const client = new DialClient({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  const spoolDir = path.join(DATA_DIR, 'dial', 'inbound');
+  const handlerPath = path.join(DATA_DIR, 'dial', 'handle-dial-event.sh');
+
+  let setup: ChannelSetup | null = null;
+  let connected = false;
+  let watcher: fs.FSWatcher | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let draining = false;
+  const seen = new Map<string, number>();
+
+  function markSeen(id: string): boolean {
+    const now = Date.now();
+    for (const [k, ts] of seen) {
+      if (now - ts > DEDUP_TTL_MS) seen.delete(k);
+    }
+    if (seen.has(id)) return false;
+    seen.set(id, now);
+    return true;
+  }
+
+  // -- inbound: spool → route --------------------------------------------
+
+  function routeMessageReceived(env: DialEventEnvelope): void {
+    if (!setup) return;
+    const data = env.data ?? {};
+    if (data.source && data.source !== 'external') {
+      log.debug('Dial: skipping non-external message', { source: data.source });
+      return;
+    }
+    const from = typeof data.from === 'string' ? data.from : '';
+    if (!from) return;
+    const channel = typeof data.channel === 'string' ? data.channel : 'sms';
+
+    let text = typeof data.body === 'string' ? data.body : '';
+    const media = Array.isArray(data.media) ? (data.media as Array<Record<string, unknown>>) : [];
+    const attachmentRefs: Array<{ url: string; contentType: string }> = [];
+    for (const m of media) {
+      const url = typeof m.url === 'string' ? m.url : '';
+      if (!url) continue;
+      const contentType = typeof m.contentType === 'string' ? m.contentType : 'application/octet-stream';
+      const line = `[Media: ${url}]`;
+      text = text ? `${text}\n${line}` : line;
+      attachmentRefs.push({ url, contentType });
+    }
+    if (!text && attachmentRefs.length === 0) return;
+
+    const messageId = typeof data.messageId === 'string' ? data.messageId : env.id || String(Date.now());
+    const msg: InboundMessage = {
+      id: messageId,
+      kind: 'chat',
+      content: {
+        text,
+        sender: from,
+        senderId: `dial:${from}`,
+        senderName: from,
+        channel,
+        ...(attachmentRefs.length > 0 ? { attachments: attachmentRefs } : {}),
+      },
+      isMention: true,
+      isGroup: false,
+      timestamp: env.createdAt || new Date().toISOString(),
+    };
+    setup.onMetadata(from, from, false);
+    void Promise.resolve(setup.onInbound(from, null, msg)).catch((err) =>
+      log.error('Dial: onInbound failed', { from, err }),
+    );
+    log.info('Dial message received', { from, channel });
+  }
+
+  function routeCallEnded(env: DialEventEnvelope): void {
+    if (!setup) return;
+    const data = env.data ?? {};
+    const direction = data.direction === 'outbound' ? 'outbound' : 'inbound';
+    const peer = direction === 'inbound' ? data.from : data.to;
+    if (typeof peer !== 'string' || !peer) return;
+
+    const callId = typeof data.callId === 'string' ? data.callId : env.id || '';
+    const status = typeof data.status === 'string' ? data.status : 'ended';
+    const canceled = data.canceled === true;
+    const duration = typeof data.durationSeconds === 'number' ? data.durationSeconds : null;
+    const transcriptAvailable = data.transcriptAvailable === true;
+
+    const parts = [
+      `[Voice call ${direction} ${status}${canceled ? ' (canceled)' : ''}`,
+      duration != null ? `, ${duration}s` : '',
+      '.',
+      transcriptAvailable && callId ? ` Transcript available — run \`dial call get ${callId}\` to read it.` : '',
+      ']',
+    ];
+    const text = parts.join('');
+
+    const msg: InboundMessage = {
+      id: callId || String(Date.now()),
+      kind: 'chat',
+      content: { text, sender: peer, senderId: `dial:${peer}`, senderName: peer, channel: 'call' },
+      isMention: true,
+      isGroup: false,
+      timestamp: env.createdAt || new Date().toISOString(),
+    };
+    setup.onMetadata(peer, peer, false);
+    void Promise.resolve(setup.onInbound(peer, null, msg)).catch((err) =>
+      log.error('Dial: onInbound (call) failed', { peer, err }),
+    );
+    log.info('Dial call event received', { peer, direction, status });
+  }
+
+  function routeEvent(env: DialEventEnvelope): void {
+    const id = env.id;
+    if (id && !markSeen(id)) {
+      log.debug('Dial: duplicate event dropped', { id });
+      return;
+    }
+    switch (env.type) {
+      case 'message.received':
+        routeMessageReceived(env);
+        break;
+      case 'call.ended':
+        routeCallEnded(env);
+        break;
+      default:
+        log.debug('Dial: ignoring event type', { type: env.type });
+    }
+  }
+
+  function processSpoolFile(file: string): void {
+    const full = path.join(spoolDir, file);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(full, 'utf8');
+    } catch {
+      return; // already consumed by a concurrent tick
+    }
+    try {
+      fs.unlinkSync(full);
+    } catch {
+      /* best-effort */
+    }
+    if (!raw.trim()) return;
+    let env: DialEventEnvelope;
+    try {
+      env = JSON.parse(raw) as DialEventEnvelope;
+    } catch (err) {
+      log.warn('Dial: unparseable spooled event', { file, err });
+      return;
+    }
+    routeEvent(env);
+  }
+
+  /** Drain the spool directory once, in filename (roughly chronological) order. */
+  function drainSpool(): void {
+    if (draining) return;
+    draining = true;
+    try {
+      const files = fs
+        .readdirSync(spoolDir)
+        .filter((f) => f.endsWith('.json'))
+        .sort();
+      for (const f of files) processSpoolFile(f);
+    } catch (err) {
+      // ENOENT is normal before the first event lands; anything else is worth a note.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        log.debug('Dial: spool drain error', { err });
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  // -- command-target / listen-daemon wiring ------------------------------
+
+  function runDial(args: string[]): string {
+    return execFileSync(config.cliPath, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+    });
+  }
+
+  /**
+   * Best-effort: (re)write the handler script and register it as a Dial CLI
+   * command target, and warn if the listen daemon isn't running. All failures
+   * are logged, never thrown — the wizard/installer normally establishes this,
+   * and the adapter keeps watching the spool regardless.
+   */
+  function ensureCommandTarget(): void {
+    try {
+      fs.mkdirSync(path.dirname(handlerPath), { recursive: true });
+      fs.writeFileSync(handlerPath, handlerScript(spoolDir), { mode: 0o755 });
+      fs.chmodSync(handlerPath, 0o755);
+    } catch (err) {
+      log.warn('Dial: could not write command-target handler', { handlerPath, err });
+      return;
+    }
+    try {
+      execFileSync('which', [config.cliPath], { stdio: 'ignore' });
+    } catch {
+      log.warn(
+        'Dial: `dial` CLI not found on PATH — inbound events will not be delivered until the listen daemon is set up',
+        {
+          cliPath: config.cliPath,
+        },
+      );
+      return;
+    }
+    try {
+      const doctor = JSON.parse(runDial(['doctor', '--json'])) as { listen?: { running?: boolean } };
+      if (!doctor.listen?.running) {
+        log.warn('Dial: listen daemon is not running — run `dial listen install` so inbound events reach NanoClaw');
+      }
+    } catch (err) {
+      log.debug('Dial: doctor check failed', { err });
+    }
+    try {
+      const listed = runDial(['local-target', 'list', '--json']);
+      if (!listed.includes(handlerPath)) {
+        runDial(['local-target', 'add', 'cmd', handlerPath]);
+        log.info('Dial: registered CLI command target', { handlerPath });
+      }
+    } catch (err) {
+      log.warn('Dial: could not register command target — set it up with `dial local-target add cmd <handler>`', {
+        handlerPath,
+        err,
+      });
+    }
+  }
+
+  // -- adapter ------------------------------------------------------------
+
+  const adapter: ChannelAdapter = {
+    name: 'dial',
+    channelType: 'dial',
+    supportsThreads: false,
+    defaults: DIAL_DEFAULTS,
+
+    async setup(cfg: ChannelSetup): Promise<void> {
+      setup = cfg;
+      fs.mkdirSync(spoolDir, { recursive: true });
+      ensureCommandTarget();
+
+      // Drain anything spooled while we were down, then watch for new events.
+      drainSpool();
+      try {
+        watcher = fs.watch(spoolDir, () => drainSpool());
+      } catch (err) {
+        log.debug('Dial: fs.watch unavailable, relying on poll', { err });
+      }
+      // Poll fallback — fs.watch misses events on some platforms/mounts.
+      pollTimer = setInterval(drainSpool, 2000);
+
+      connected = true;
+      log.info('Dial channel connected', { fromNumber: config.fromNumber });
+    },
+
+    async teardown(): Promise<void> {
+      connected = false;
+      if (watcher) {
+        try {
+          watcher.close();
+        } catch {
+          /* ignore */
+        }
+        watcher = null;
+      }
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+      log.info('Dial channel disconnected');
+    },
+
+    isConnected(): boolean {
+      return connected;
+    },
+
+    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+      const content = message.content as Record<string, unknown> | string | undefined;
+      let text: string | null = null;
+      if (typeof content === 'string') {
+        text = content;
+      } else if (content && typeof content === 'object' && typeof content.text === 'string') {
+        text = content.text;
+      }
+      const files = message.files ?? [];
+
+      let lastId: string | undefined;
+      if (text) {
+        const chunks = text.length <= MAX_CHUNK ? [text] : chunkText(text, MAX_CHUNK);
+        for (const chunk of chunks) {
+          try {
+            const sent = await client.sendMessage({ to: platformId, fromNumber: config.fromNumber, body: chunk });
+            lastId = sent?.id ?? lastId;
+          } catch (err) {
+            log.error('Dial: sendMessage failed', { platformId, err });
+          }
+        }
+      }
+
+      if (files.length > 0) {
+        // Dial caps a send at 10 media items; batch accordingly.
+        for (let i = 0; i < files.length; i += 10) {
+          const batch = files.slice(i, i + 10);
+          try {
+            const sent = await client.sendMessage({
+              to: platformId,
+              fromNumber: config.fromNumber,
+              media: batch.map((f) => ({
+                data: new Uint8Array(f.data),
+                contentType: inferContentType(f.filename),
+                filename: f.filename,
+              })),
+            });
+            lastId = sent?.id ?? lastId;
+          } catch (err) {
+            log.error('Dial: media send failed', { platformId, count: batch.length, err });
+          }
+        }
+      }
+
+      return lastId;
+    },
+
+    async setTyping(platformId: string, _threadId: string | null): Promise<void> {
+      try {
+        await client.startTyping({ toNumber: platformId, fromNumber: config.fromNumber });
+      } catch (err) {
+        log.debug('Dial: typing indicator failed', { platformId, err });
+      }
+    },
+  };
+
+  return adapter;
+}
+
+// ---------------------------------------------------------------------------
+// Self-registration
+// ---------------------------------------------------------------------------
+
+registerChannelAdapter('dial', {
+  factory: () => {
+    const env = readEnvFile(['DIAL_API_KEY', 'DIAL_FROM_NUMBER', 'DIAL_BASE_URL', 'DIAL_AUTH_FILE', 'DIAL_CLI_PATH']);
+
+    const authFile = process.env.DIAL_AUTH_FILE || env.DIAL_AUTH_FILE || defaultAuthFilePath();
+    const auth = readDialAuth(authFile);
+
+    const apiKey = process.env.DIAL_API_KEY || env.DIAL_API_KEY || auth.apiKey || '';
+    if (!apiKey) {
+      log.debug('Dial: no API key (run `dial signup` + `dial onboard`, or set DIAL_API_KEY), skipping channel');
+      return null;
+    }
+
+    const fromNumber = process.env.DIAL_FROM_NUMBER || env.DIAL_FROM_NUMBER || auth.phoneNumber || '';
+    if (!fromNumber) {
+      log.warn('Dial: no from-number resolved — set DIAL_FROM_NUMBER or run `dial onboard` to provision one');
+    }
+
+    const baseUrl = process.env.DIAL_BASE_URL || env.DIAL_BASE_URL || DEFAULT_BASE_URL;
+    const cliPath = process.env.DIAL_CLI_PATH || env.DIAL_CLI_PATH || 'dial';
+
+    return createDialAdapter({ apiKey, baseUrl, fromNumber, cliPath });
+  },
+  defaults: DIAL_DEFAULTS,
+});

--- a/src/channels/dial.ts
+++ b/src/channels/dial.ts
@@ -2,20 +2,25 @@
  * Dial channel adapter for NanoClaw v2.
  *
  * Dial (https://getdial.ai) gives an agent a real phone number — SMS and
- * AI-handled voice calls. Native adapter (no Chat SDK bridge):
+ * AI-handled voice calls. Native adapter (no Chat SDK bridge).
  *
  *   - Outbound SMS via the official `@getdial/sdk` (`DialClient.sendMessage`).
  *   - Inbound via Dial's documented CLI command-target
- *     (docs.getdial.ai/integrations/agent-clients/nanoclaw). NanoClaw has no
- *     inbound HTTP webhook, so the adapter registers a small handler script
- *     with Dial's `listen` daemon; the daemon runs it per event with the event
- *     JSON as the final arg, the handler spools it to a directory the adapter
- *     watches, and `message.received` / `call.ended` route through the normal
- *     entity model so replies flow back out over SMS.
+ *     (docs.getdial.ai/integrations/agent-clients/nanoclaw): the `dial listen`
+ *     daemon runs a spool handler per event; the adapter watches the spool
+ *     directory and routes each event.
  *
- * The API key + from-number come from Dial's auth file (written by `dial
- * onboard`). If there's no key the factory returns null and the channel is
- * skipped.
+ * PUBLIC-LINE MODEL. The Dial number is one shared conversation (a single
+ * messaging group whose platform_id is the number itself), and each remote
+ * correspondent is a THREAD inside it (threadId = their E.164). One wiring +
+ * `unknown_sender_policy: 'public'` therefore lets anyone text/call the number
+ * and reach the agent with no per-sender approval, while replies still route
+ * to the right person via their thread. Ownership is bootstrapped by a pairing
+ * code (see dial-pairing.ts): the operator texts a 4-digit code to the number,
+ * the interceptor records their number as owner before it reaches an agent.
+ *
+ * Credentials come from Dial's auth file (written by `dial onboard`). If
+ * there's no key the factory returns null and the channel is skipped.
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -26,9 +31,12 @@ import { DialClient } from '@getdial/sdk';
 
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { tryConsume } from './dial-pairing.js';
 import { DATA_DIR } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
+import { grantRole, hasAnyOwner } from '../modules/permissions/db/user-roles.js';
+import { upsertUser } from '../modules/permissions/db/users.js';
 
 /** Longest SMS body sent in one shot; longer text is chunked. */
 const MAX_CHUNK = 1500;
@@ -46,7 +54,7 @@ interface DialEventEnvelope {
 
 interface DialConfig {
   apiKey: string;
-  /** E.164 to send from; '' → let the server use the account's default number. */
+  /** The account's Dial number (E.164). Used as the shared line's platform_id. */
   fromNumber: string;
   cliPath: string;
 }
@@ -70,9 +78,8 @@ function chunkText(text: string, limit: number): string[] {
 /**
  * The handler script Dial's listen daemon runs per event: it spools the event
  * JSON (passed as the final positional argument) into a directory the adapter
- * watches, written atomically (temp + rename) so the watcher never reads a
- * partial file. Runs with a clean env (PATH + HOME only), so the spool dir is
- * baked in as an absolute path.
+ * watches, written atomically (temp + rename). Runs with a clean env (PATH +
+ * HOME only), so the spool dir is baked in as an absolute path.
  */
 function handlerScript(spoolDir: string): string {
   return `#!/usr/bin/env bash
@@ -91,14 +98,13 @@ exit 0
 }
 
 /**
- * Dial has no group chats: every conversation is 1:1 between the account's
- * number and a remote number, so every inbound is a DM (isMention:true,
- * isGroup:false) and mentions are 'dm-only'. Unknown senders default to
- * 'request_approval' — anyone can text a phone number.
+ * Public line: the number is one shared, threaded conversation. `public`
+ * admits every sender (no per-sender approval); `threads: true` gives each
+ * correspondent their own thread/session so replies route back correctly.
  */
 const DIAL_DEFAULTS: ChannelDefaults = {
-  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
-  group: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'public' },
+  group: { engageMode: 'pattern', engagePattern: '.', threads: true, unknownSenderPolicy: 'public' },
   mentions: 'dm-only',
 };
 
@@ -106,6 +112,9 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
   const client = new DialClient({ apiKey: config.apiKey });
   const spoolDir = path.join(DATA_DIR, 'dial', 'inbound');
   const handlerPath = path.join(DATA_DIR, 'dial', 'handle-dial-event.sh');
+  // The shared line's platform_id. Falls back to the sender if somehow unset
+  // (degrades to per-sender conversations rather than breaking).
+  const line = config.fromNumber;
 
   let setup: ChannelSetup | null = null;
   let connected = false;
@@ -114,7 +123,6 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
   let draining = false;
   const seen = new Map<string, number>();
 
-  /** True if this event id was already routed within the dedup window. */
   function seenBefore(id: string): boolean {
     const now = Date.now();
     for (const [k, ts] of seen) if (now - ts > DEDUP_TTL_MS) seen.delete(k);
@@ -123,8 +131,54 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
     return false;
   }
 
-  /** Route one inbound event — SMS text and ended-call notifications only. */
-  function routeEvent(env: DialEventEnvelope): void {
+  async function sendSms(to: string, body: string): Promise<string | undefined> {
+    let lastId: string | undefined;
+    for (const chunk of body.length <= MAX_CHUNK ? [body] : chunkText(body, MAX_CHUNK)) {
+      const sent = await client.sendMessage({
+        to,
+        body: chunk,
+        ...(config.fromNumber ? { fromNumber: config.fromNumber } : {}),
+      });
+      lastId = sent?.id ?? lastId;
+    }
+    return lastId;
+  }
+
+  /**
+   * Pairing interceptor: if an inbound SMS body is exactly a pending 4-digit
+   * code, consume it — record the sender's number, promote to owner if the
+   * install has none yet, confirm by SMS — and swallow the message so it never
+   * reaches an agent. Returns true when consumed.
+   */
+  async function consumePairing(fromNumber: string, text: string): Promise<boolean> {
+    let consumed;
+    try {
+      consumed = await tryConsume({ text, fromNumber });
+    } catch (err) {
+      log.warn('Dial: pairing consume failed', { err });
+      return false;
+    }
+    if (!consumed) return false;
+
+    const now = new Date().toISOString();
+    const userId = `dial:${fromNumber}`;
+    upsertUser({ id: userId, kind: 'dial', display_name: null, created_at: now });
+    let promoted = false;
+    if (!hasAnyOwner()) {
+      grantRole({ user_id: userId, role: 'owner', agent_group_id: null, granted_by: null, granted_at: now });
+      promoted = true;
+    }
+    log.info('Dial pairing accepted', { fromNumber, promotedToOwner: promoted });
+    try {
+      await sendSms(fromNumber, 'Paired ✅ — your NanoClaw assistant is set up. Text me anytime.');
+    } catch (err) {
+      log.warn('Dial: pairing confirmation SMS failed', { err });
+    }
+    return true;
+  }
+
+  /** Route one inbound event — SMS text and ended-call notifications. */
+  async function routeEvent(env: DialEventEnvelope): Promise<void> {
     if (!setup) return;
     if (env.id && seenBefore(env.id)) return;
     const data = env.data ?? {};
@@ -135,6 +189,8 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       if (data.source && data.source !== 'external') return; // ignore Dial-synthesized test SMS
       peer = typeof data.from === 'string' ? data.from : '';
       text = typeof data.body === 'string' ? data.body : '';
+      // Pairing codes are consumed before any agent sees them.
+      if (peer && (await consumePairing(peer, text))) return;
     } else if (env.type === 'call.ended') {
       const outbound = data.direction === 'outbound';
       const other = outbound ? data.to : data.from;
@@ -150,6 +206,11 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
     if (!peer || !text) return;
 
     const id = [data.messageId, data.callId, env.id].find((v): v is string => typeof v === 'string' && !!v);
+    // Public-line model: the number itself is the messaging group; the peer is
+    // the thread, so replies route back to them and every sender shares one
+    // (public) wiring.
+    const platformId = line || peer;
+    const threadId = line ? peer : null;
     const msg: InboundMessage = {
       id: id ?? peer,
       kind: 'chat',
@@ -158,7 +219,7 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       isGroup: false,
       timestamp: env.createdAt || new Date().toISOString(),
     };
-    void Promise.resolve(setup.onInbound(peer, null, msg)).catch((err) =>
+    void Promise.resolve(setup.onInbound(platformId, threadId, msg)).catch((err) =>
       log.error('Dial: onInbound failed', { peer, err }),
     );
     log.info('Dial inbound routed', { peer, type: env.type });
@@ -178,11 +239,14 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       /* best-effort */
     }
     if (!raw.trim()) return;
+    let env: DialEventEnvelope;
     try {
-      routeEvent(JSON.parse(raw) as DialEventEnvelope);
+      env = JSON.parse(raw) as DialEventEnvelope;
     } catch (err) {
       log.warn('Dial: unparseable spooled event', { file, err });
+      return;
     }
+    void routeEvent(env).catch((err) => log.error('Dial: routeEvent failed', { err }));
   }
 
   /** Drain the spool directory once, in filename (roughly chronological) order. */
@@ -206,7 +270,7 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
   /**
    * Best-effort: write the handler script and register it as a Dial CLI command
    * target. Failures are logged, never thrown — the adapter keeps watching the
-   * spool regardless, and the wizard/skill can establish this out of band.
+   * spool, and the wizard/skill can establish this out of band.
    */
   function ensureCommandTarget(): void {
     try {
@@ -237,7 +301,7 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
   const adapter: ChannelAdapter = {
     name: 'dial',
     channelType: 'dial',
-    supportsThreads: false,
+    supportsThreads: true,
     defaults: DIAL_DEFAULTS,
 
     async setup(cfg: ChannelSetup): Promise<void> {
@@ -254,7 +318,7 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       pollTimer = setInterval(drainSpool, 2000); // fallback — fs.watch misses events on some mounts
 
       connected = true;
-      log.info('Dial channel connected', { fromNumber: config.fromNumber || '(account default)' });
+      log.info('Dial channel connected', { line: config.fromNumber || '(account default)' });
     },
 
     async teardown(): Promise<void> {
@@ -270,7 +334,7 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
       return connected;
     },
 
-    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+    async deliver(platformId: string, threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
       const content = message.content as Record<string, unknown> | string | undefined;
       const text =
         typeof content === 'string'
@@ -280,20 +344,19 @@ export function createDialAdapter(config: DialConfig): ChannelAdapter {
             : '';
       if (!text) return undefined;
 
-      let lastId: string | undefined;
-      for (const chunk of text.length <= MAX_CHUNK ? [text] : chunkText(text, MAX_CHUNK)) {
-        try {
-          const sent = await client.sendMessage({
-            to: platformId,
-            body: chunk,
-            ...(config.fromNumber ? { fromNumber: config.fromNumber } : {}),
-          });
-          lastId = sent?.id ?? lastId;
-        } catch (err) {
-          log.error('Dial: sendMessage failed', { platformId, err });
-        }
+      // Public-line model: the correspondent is the thread. Reply to threadId;
+      // platformId is the shared line. Never text the line's own number.
+      const recipient = threadId || platformId;
+      if (!recipient || recipient === config.fromNumber) {
+        log.warn('Dial: no reply recipient (no thread) — dropping outbound', { platformId, threadId });
+        return undefined;
       }
-      return lastId;
+      try {
+        return await sendSms(recipient, text);
+      } catch (err) {
+        log.error('Dial: sendMessage failed', { recipient, err });
+        return undefined;
+      }
     },
   };
 

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -53,6 +53,9 @@ import './whatsapp.js';
 // signal (native, no Chat SDK — signal-cli TCP JSON-RPC daemon)
 // import './signal.js';
 
+// dial (native, no Chat SDK — @getdial/sdk outbound + CLI command-target inbound)
+import './dial.js';
+
 // emacs (native HTTP bridge, no Chat SDK)
 // import './emacs.js';
 


### PR DESCRIPTION
## What

Adds a native channel adapter for [Dial](https://getdial.ai) — a real phone number for SMS/MMS and AI-handled voice calls. No Chat SDK bridge.

- **Outbound** via the official `@getdial/sdk` (`DialClient.sendMessage`), sending as the account's auto-provisioned number. Long text is chunked; files go out as MMS media.
- **Inbound** via Dial's documented [CLI command-target](https://docs.getdial.ai/integrations/methods/cli-command-target) (per [docs.getdial.ai/integrations/agent-clients/nanoclaw](https://docs.getdial.ai/integrations/agent-clients/nanoclaw)) — **no local HTTP endpoint**. On startup the adapter writes a small handler script, registers it with `dial local-target add cmd`, and watches a spool directory. The `dial listen` daemon runs the handler per event; the adapter routes `message.received` (external only) and `call.ended` through the normal entity model, so replies flow back out over SMS.

Credentials resolve from Dial's own auth file (`~/.local/share/dial/auth.v1.json`, written by `dial onboard`) or `DIAL_*` env overrides; the factory returns `null` (channel skipped) when no API key is present.

## Files

- `src/channels/dial.ts` — the adapter
- `src/channels/dial-registration.test.ts` — barrel self-registration test
- `src/channels/index.ts` — `import './dial.js';`
- `package.json` — pinned `@getdial/sdk@0.17.0` (release-age-eligible under the 3-day gate; 0.18/0.19 were too new)

The user-facing wizard, `setup/add-dial.sh` installer, and `/add-dial` skill live in the trunk PR against `main` (matching where every other channel's setup surface lives).

## Testing

- `pnpm run build` clean (only the pre-existing `deltachat.ts` missing-dep error, unrelated).
- `pnpm exec vitest run src/channels/dial-registration.test.ts` passes.
- Exercised the inbound spool→`onInbound` path end-to-end (external SMS routed, `internal` filtered, duplicate event id deduped, spool drained, `call.ended` summary formatted).
- Verified the `dial local-target list/add/remove` contract and the SDK named-import + `sendMessage`/`startTyping` param shapes against the real CLI/SDK (v0.17.0).

**Note on `pnpm-lock.yaml`:** the ~1.9k-line churn is `@getdial/sdk` + its `pubnub`/`zod` deps plus zod peer re-resolution across existing `@chat-adapter/*` packages — zero resolution entries removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)