### PR TITLE
feat(setup): offer Dial in the channel picker + wizard/installer/skill

### DIFF
--- a/.claude/skills/add-dial/REMOVE.md
+++ b/.claude/skills/add-dial/REMOVE.md
@@ -1,0 +1,11 @@
+# Remove Dial
+
+1. Remove `import './dial.js';` from `src/channels/index.ts`
+2. Delete `src/channels/dial.ts` and `src/channels/dial-registration.test.ts`
+3. Unregister the inbound command target (optional): `dial local-target remove "$PWD/data/dial/handle-dial-event.sh"`
+4. Remove the spool/handler artifacts (optional): `rm -rf data/dial`
+5. Remove any `DIAL_*` overrides from `.env` (and `data/env/env`)
+6. `pnpm uninstall @getdial/sdk`
+7. Rebuild and restart
+
+The Dial account itself, its number, and the `dial listen` daemon are managed by the `dial` CLI, not NanoClaw — remove them separately with `dial listen uninstall` etc. if you no longer want them.

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -52,6 +52,7 @@ This is what runs the command-target handler per event. In sandboxes/CI without 
 Skip to **Credentials** if all of these are already in place:
 
 - `src/channels/dial.ts` exists
+- `src/channels/dial-pairing.ts` exists (the SMS pairing store)
 - `src/channels/dial-registration.test.ts` exists
 - `container/skills/dial-cli/SKILL.md` exists (the bundled outbound-tool skill)
 - `src/channels/index.ts` contains `import './dial.js';`
@@ -71,6 +72,8 @@ The `dial-cli` container skill is part of the channel payload (the WhatsApp/Slac
 
 ```bash
 git show origin/channels:src/channels/dial.ts                    > src/channels/dial.ts
+git show origin/channels:src/channels/dial-pairing.ts            > src/channels/dial-pairing.ts
+git show origin/channels:src/channels/dial-pairing.test.ts       > src/channels/dial-pairing.test.ts
 git show origin/channels:src/channels/dial-registration.test.ts  > src/channels/dial-registration.test.ts
 mkdir -p container/skills/dial-cli
 git show origin/channels:container/skills/dial-cli/SKILL.md       > container/skills/dial-cli/SKILL.md

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -5,7 +5,7 @@ description: Add Dial channel integration — a real phone number for SMS and AI
 
 # Add Dial Channel
 
-Adds a real phone number to NanoClaw via a native adapter for [Dial](https://getdial.ai). Outbound (SMS/MMS) goes through the official `@getdial/sdk`; inbound (texts, ended calls) arrives via Dial's documented **CLI command-target** — no local HTTP endpoint. Inbound voice calls are answered by Dial's AI receptionist; the adapter surfaces the `call.ended` event so the agent can follow up.
+Adds a real phone number to NanoClaw via a native adapter for [Dial](https://getdial.ai). Outbound SMS goes through the official `@getdial/sdk`; inbound (texts, ended calls) arrives via Dial's documented **CLI command-target** — no local HTTP endpoint. Inbound voice calls are answered by Dial's AI receptionist; the adapter surfaces the `call.ended` event so the agent can follow up.
 
 Unlike a bot API, Dial gives the account its own phone number, auto-provisioned at signup. The operator owns it through their Dial account — there is no pairing handshake.
 
@@ -100,26 +100,16 @@ No `.env` entry is required — the adapter reads Dial's own auth file
 (`~/.local/share/dial/auth.v1.json`) written by `dial onboard`. If no API key
 is found there, the channel is skipped at startup.
 
-### Optional env overrides
+### Optional env override
 
 ```bash
-# Use an explicit API key instead of the auth file (e.g. a non-default install)
-DIAL_API_KEY=sk_...
-
-# Number to send from, E.164. Defaults to the auth file's provisioned number.
-DIAL_FROM_NUMBER=+14155550123
-
-# Auth file path (default: $XDG_DATA_HOME/dial/auth.v1.json or ~/.local/share/dial/auth.v1.json)
-DIAL_AUTH_FILE=/path/to/auth.v1.json
-
-# Dial API base URL (default: https://api.getdial.ai)
-DIAL_BASE_URL=https://api.getdial.ai
-
-# Path to the dial CLI (default: resolved on PATH). Used to register the command target.
+# Path to the dial CLI (default: resolved on PATH). Set this if the service
+# can't find `dial` (launchd/systemd run with a limited PATH). Used to
+# register the inbound command target.
 DIAL_CLI_PATH=/usr/local/bin/dial
 ```
 
-If you set any of these, sync to the container: `mkdir -p data/env && cp .env data/env/env`
+If you set it, sync to the container: `mkdir -p data/env && cp .env data/env/env`
 
 ### Restart
 
@@ -179,7 +169,7 @@ Otherwise, run `/init-first-agent` to create an agent and wire it to your Dial D
 ## Channel Info
 
 - **type**: `dial`
-- **terminology**: Dial has phone numbers, SMS/MMS messages, and AI voice calls. There are **no group chats** — every conversation is 1:1 between the account's number and a remote number.
+- **terminology**: Dial has phone numbers, SMS messages, and AI voice calls. There are **no group chats** — every conversation is 1:1 between the account's number and a remote number.
 - **supports-threads**: no
 - **platform-id-format**: the remote party's phone number in E.164 (`+14155550123`) — sent as-is, no channel prefix.
 - **how-to-find-id**: Text the Dial number, then query `messaging_groups` as shown above. The `platform_id` is the sender's E.164 number.
@@ -189,9 +179,7 @@ Otherwise, run `/init-first-agent` to create an agent and wire it to your Dial D
 ### Features
 
 - SMS send/receive; long replies are chunked (~1500 chars/segment).
-- MMS — outbound file attachments are sent as media; inbound media surface as `[Media: <url>]` lines plus a structured `attachments` array.
 - AI voice calls — inbound calls are answered by Dial's receptionist (configured via the number's inbound instruction); `call.ended` is surfaced to the agent with a hint to run `dial call get <id>` for the transcript. The agent places outbound calls via the `dial` CLI (see the `dial-cli` skill).
-- Typing indicators — sent via the SDK (iMessage numbers show them; SMS ignores them, always safe).
 - Event dedup — the listen daemon retries a failed handler once; the adapter drops duplicate event ids within a 5-minute window.
 
 ## Troubleshooting
@@ -202,7 +190,7 @@ Otherwise, run `/init-first-agent` to create an agent and wire it to your Dial D
 grep -i dial logs/nanoclaw.log | tail
 ```
 
-`Dial: no API key … skipping channel` means `dial onboard` hasn't run (no `~/.local/share/dial/auth.v1.json`), or set `DIAL_API_KEY`. Confirm with `dial doctor --json` (`auth.signedIn: true`).
+`Dial: not signed in … skipping channel` means `dial onboard` hasn't run (no `~/.local/share/dial/auth.v1.json`). Confirm with `dial doctor --json` (`auth.signedIn: true`).
 
 ### Inbound texts never arrive
 
@@ -213,7 +201,7 @@ grep -i dial logs/nanoclaw.log | tail
 
 ### Outbound send fails with 401
 
-The API key in the auth file is stale or the OneCLI/selective-secret model isn't the issue here (Dial creds are host-side, not vault-injected). Re-run `dial onboard` or refresh `dial doctor`, then restart.
+The API key in the auth file is stale. Re-run `dial onboard` (or check `dial doctor`), then restart NanoClaw.
 
 ### `dial` not on PATH under the service
 

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -53,6 +53,7 @@ Skip to **Credentials** if all of these are already in place:
 
 - `src/channels/dial.ts` exists
 - `src/channels/dial-registration.test.ts` exists
+- `container/skills/dial-cli/SKILL.md` exists (the bundled outbound-tool skill)
 - `src/channels/index.ts` contains `import './dial.js';`
 - `@getdial/sdk` is listed in `package.json` dependencies
 
@@ -64,11 +65,15 @@ Otherwise continue. Every step below is safe to re-run.
 git fetch origin channels
 ```
 
-### 2. Copy the adapter and test
+### 2. Copy the adapter, test, and the dial-cli container skill
+
+The `dial-cli` container skill is part of the channel payload (the WhatsApp/Slack pattern): it teaches the agent to drive the `dial` CLI for **outbound** — send SMS, place AI voice calls, reconfigure the number — from any channel it's on.
 
 ```bash
 git show origin/channels:src/channels/dial.ts                    > src/channels/dial.ts
 git show origin/channels:src/channels/dial-registration.test.ts  > src/channels/dial-registration.test.ts
+mkdir -p container/skills/dial-cli
+git show origin/channels:container/skills/dial-cli/SKILL.md       > container/skills/dial-cli/SKILL.md
 ```
 
 ### 3. Append the self-registration import

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: add-dial
+description: Add Dial channel integration — a real phone number for SMS and AI voice calls via the Dial platform (getdial.ai). Native adapter — no Chat SDK bridge.
+---
+
+# Add Dial Channel
+
+Adds a real phone number to NanoClaw via a native adapter for [Dial](https://getdial.ai). Outbound (SMS/MMS) goes through the official `@getdial/sdk`; inbound (texts, ended calls) arrives via Dial's documented **CLI command-target** — no local HTTP endpoint. Inbound voice calls are answered by Dial's AI receptionist; the adapter surfaces the `call.ended` event so the agent can follow up.
+
+Unlike a bot API, Dial gives the account its own phone number, auto-provisioned at signup. The operator owns it through their Dial account — there is no pairing handshake.
+
+## Prerequisites
+
+### The `dial` CLI
+
+```bash
+command -v dial || curl -fsSL https://getdial.ai/install | bash
+dial --version
+```
+
+For the full onboarding/auth reference, see the `dial-cli` skill or `curl -fsSL https://getdial.ai/skills.md`.
+
+### Sign in / provision a number
+
+```bash
+dial doctor --json         # nextStep: "ready" means you're already set up
+```
+
+If not signed in:
+
+```bash
+dial signup you@example.com                 # emails a 6-digit OTP
+dial onboard --code 123456 \                # verifies + provisions your first US number
+  --inbound-instruction "You are my receptionist. Greet the caller and find out what they need." \
+  --agent nanoclaw                          # also installs the Dial skill for the container agent
+```
+
+`--inbound-instruction` is required only when onboarding provisions a new account's first number; it's ignored when signing in to an existing account. `dial onboard` writes `~/.local/share/dial/auth.v1.json` (mode 0600) — the adapter reads its `apiKey` and `phoneNumber` from there.
+
+### Inbound event daemon
+
+```bash
+dial listen install        # user service (launchd/systemd) that fans out account events
+```
+
+This is what runs the command-target handler per event. In sandboxes/CI without a user service supervisor it can't run — outbound still works; inbound needs the daemon. See `dial listen --help`.
+
+## Install
+
+### Pre-flight (idempotent)
+
+Skip to **Credentials** if all of these are already in place:
+
+- `src/channels/dial.ts` exists
+- `src/channels/dial-registration.test.ts` exists
+- `src/channels/index.ts` contains `import './dial.js';`
+- `@getdial/sdk` is listed in `package.json` dependencies
+
+Otherwise continue. Every step below is safe to re-run.
+
+### 1. Fetch the channels branch
+
+```bash
+git fetch origin channels
+```
+
+### 2. Copy the adapter and test
+
+```bash
+git show origin/channels:src/channels/dial.ts                    > src/channels/dial.ts
+git show origin/channels:src/channels/dial-registration.test.ts  > src/channels/dial-registration.test.ts
+```
+
+### 3. Append the self-registration import
+
+Append to `src/channels/index.ts` (skip if the line is already present):
+
+```typescript
+import './dial.js';
+```
+
+### 4. Install the SDK (pinned)
+
+```bash
+pnpm install @getdial/sdk@0.17.0
+```
+
+### 5. Build and validate
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/dial-registration.test.ts
+```
+
+Both must be clean before proceeding. `dial-registration.test.ts` is the one integration test: it imports the real channel barrel and asserts the registry contains `dial`. It goes red if the `import './dial.js';` line is deleted or drifts, if the barrel fails to evaluate, or if `@getdial/sdk` is missing (an unmocked import throws). The adapter's typed SDK consumption is guarded by `pnpm run build`.
+
+## Credentials
+
+No `.env` entry is required — the adapter reads Dial's own auth file
+(`~/.local/share/dial/auth.v1.json`) written by `dial onboard`. If no API key
+is found there, the channel is skipped at startup.
+
+### Optional env overrides
+
+```bash
+# Use an explicit API key instead of the auth file (e.g. a non-default install)
+DIAL_API_KEY=sk_...
+
+# Number to send from, E.164. Defaults to the auth file's provisioned number.
+DIAL_FROM_NUMBER=+14155550123
+
+# Auth file path (default: $XDG_DATA_HOME/dial/auth.v1.json or ~/.local/share/dial/auth.v1.json)
+DIAL_AUTH_FILE=/path/to/auth.v1.json
+
+# Dial API base URL (default: https://api.getdial.ai)
+DIAL_BASE_URL=https://api.getdial.ai
+
+# Path to the dial CLI (default: resolved on PATH). Used to register the command target.
+DIAL_CLI_PATH=/usr/local/bin/dial
+```
+
+If you set any of these, sync to the container: `mkdir -p data/env && cp .env data/env/env`
+
+### Restart
+
+Run from your NanoClaw project root:
+
+```bash
+source setup/lib/install-slug.sh
+
+# macOS
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)
+
+# Linux
+systemctl --user restart $(systemd_unit)
+```
+
+## How inbound works (CLI command-target)
+
+There is no inbound HTTP webhook. On startup the adapter:
+
+1. Writes a small handler script to `data/dial/handle-dial-event.sh`.
+2. Registers it with Dial as a command target: `dial local-target add cmd <handler>` (idempotent — skipped if already registered).
+3. Watches `data/dial/inbound/` for spooled events.
+
+For every account event the `dial listen` daemon runs the handler with the event JSON as its final positional argument; the handler spools the event to the watched directory, and the adapter routes `message.received` (external only) and `call.ended` through the normal entity model. Replies flow back out via the SDK as SMS.
+
+If the `dial` CLI isn't on PATH at startup, or the listen daemon isn't running, the adapter logs a warning and keeps watching — set them up (`dial listen install`) and restart. Outbound is unaffected either way.
+
+## Wiring
+
+### DMs
+
+After the service starts, text the Dial number from your phone. The router auto-creates a `messaging_groups` row keyed by your number (E.164). Then:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db \
+  "SELECT id, platform_id FROM messaging_groups WHERE channel_type='dial' ORDER BY created_at DESC LIMIT 5"
+```
+
+Pass the `id` to `/init-first-agent` or `/manage-channels` to wire it to an agent group.
+
+### Grant user access
+
+New Dial senders are dropped until granted access (default unknown-sender policy is `request_approval`). After the sender's number appears in `messaging_groups` (host service running):
+
+```bash
+ncl users create --id "dial:+1YOURNUMBER" --kind dial --display-name "<name>"
+ncl roles grant --user "dial:+1YOURNUMBER" --role owner
+ncl members add --user "dial:+1YOURNUMBER" --group ag-AGENTID
+```
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now.
+
+Otherwise, run `/init-first-agent` to create an agent and wire it to your Dial DM, or `/manage-channels` to wire this channel to an existing agent group.
+
+## Channel Info
+
+- **type**: `dial`
+- **terminology**: Dial has phone numbers, SMS/MMS messages, and AI voice calls. There are **no group chats** — every conversation is 1:1 between the account's number and a remote number.
+- **supports-threads**: no
+- **platform-id-format**: the remote party's phone number in E.164 (`+14155550123`) — sent as-is, no channel prefix.
+- **how-to-find-id**: Text the Dial number, then query `messaging_groups` as shown above. The `platform_id` is the sender's E.164 number.
+- **typical-use**: Personal assistant reachable by text; sends SMS, places AI voice calls, and receives 2FA codes and replies.
+- **default-isolation**: One agent per Dial number. Multiple people texting the same number share the number but each gets their own session (default `shared` session mode).
+
+### Features
+
+- SMS send/receive; long replies are chunked (~1500 chars/segment).
+- MMS — outbound file attachments are sent as media; inbound media surface as `[Media: <url>]` lines plus a structured `attachments` array.
+- AI voice calls — inbound calls are answered by Dial's receptionist (configured via the number's inbound instruction); `call.ended` is surfaced to the agent with a hint to run `dial call get <id>` for the transcript. The agent places outbound calls via the `dial` CLI (see the `dial-cli` skill).
+- Typing indicators — sent via the SDK (iMessage numbers show them; SMS ignores them, always safe).
+- Event dedup — the listen daemon retries a failed handler once; the adapter drops duplicate event ids within a 5-minute window.
+
+## Troubleshooting
+
+### Channel skipped at startup
+
+```bash
+grep -i dial logs/nanoclaw.log | tail
+```
+
+`Dial: no API key … skipping channel` means `dial onboard` hasn't run (no `~/.local/share/dial/auth.v1.json`), or set `DIAL_API_KEY`. Confirm with `dial doctor --json` (`auth.signedIn: true`).
+
+### Inbound texts never arrive
+
+1. Listen daemon running? `dial doctor --json` → `listen.running: true`. If not: `dial listen install`.
+2. Command target registered? `dial local-target list --json` should include `data/dial/handle-dial-event.sh`. The adapter registers it on boot; if `dial` wasn't on PATH then, set `DIAL_CLI_PATH` and restart, or register manually: `dial local-target add cmd "$PWD/data/dial/handle-dial-event.sh"`.
+3. Spooled but not routed? Look for files piling up in `data/dial/inbound/` — a parse or routing error is logged in `logs/nanoclaw.log`.
+4. Internal test messages (`source: "internal"`, e.g. dashboard test tools) are intentionally ignored — only real carrier traffic (`source: "external"`) is routed.
+
+### Outbound send fails with 401
+
+The API key in the auth file is stale or the OneCLI/selective-secret model isn't the issue here (Dial creds are host-side, not vault-injected). Re-run `dial onboard` or refresh `dial doctor`, then restart.
+
+### `dial` not on PATH under the service
+
+launchd/systemd start NanoClaw with a limited PATH. If startup logs `dial CLI not found`, set `DIAL_CLI_PATH=/absolute/path/to/dial` in `.env`, sync to `data/env/env`, and restart.

--- a/.claude/skills/add-dial/SKILL.md
+++ b/.claude/skills/add-dial/SKILL.md
@@ -7,7 +7,7 @@ description: Add Dial channel integration — a real phone number for SMS and AI
 
 Adds a real phone number to NanoClaw via a native adapter for [Dial](https://getdial.ai). Outbound SMS goes through the official `@getdial/sdk`; inbound (texts, ended calls) arrives via Dial's documented **CLI command-target** — no local HTTP endpoint. Inbound voice calls are answered by Dial's AI receptionist; the adapter surfaces the `call.ended` event so the agent can follow up.
 
-Unlike a bot API, Dial gives the account its own phone number, auto-provisioned at signup. The operator owns it through their Dial account — there is no pairing handshake.
+Unlike a bot API, Dial gives the account its own phone number, auto-provisioned at signup. That number is modelled as a single **public, threaded line**: one messaging group whose `platform_id` is the Dial number itself, and each remote correspondent is a thread inside it (thread id = their E.164). One wiring with `unknown_sender_policy: 'public'` therefore lets anyone text or call the number and reach the agent with no per-sender approval, while replies still route back to the right person via their thread. Operator ownership is bootstrapped by a one-time **pairing** handshake: the operator texts a 4-digit code to the number, and the adapter records their number as owner before the message reaches an agent.
 
 ## Prerequisites
 
@@ -147,26 +147,35 @@ If the `dial` CLI isn't on PATH at startup, or the listen daemon isn't running, 
 
 ## Wiring
 
-### DMs
+The Dial line is wired **once**, as a single public messaging group whose
+`platform_id` is the Dial number itself. Every remote number that texts or
+calls it lands in that one group as its own thread — new senders do **not**
+create new messaging groups, and there is no per-sender approval to grant
+(`unknown_sender_policy` is `public`).
 
-After the service starts, text the Dial number from your phone. The router auto-creates a `messaging_groups` row keyed by your number (E.164). Then:
+The normal path is the setup wizard (`/setup` → connect Dial, or re-run the
+Dial channel flow), which provisions the number, runs the pairing handshake,
+and wires the public line for you. During pairing the operator texts a 4-digit
+code to the Dial number; the running adapter consumes it, records that number
+as a `dial:<E.164>` user, and grants it the `owner` role if the install has no
+owner yet — all before the message reaches an agent.
+
+### Inspecting the wired line
 
 ```bash
 pnpm exec tsx scripts/q.ts data/v2.db \
-  "SELECT id, platform_id FROM messaging_groups WHERE channel_type='dial' ORDER BY created_at DESC LIMIT 5"
+  "SELECT id, platform_id, unknown_sender_policy FROM messaging_groups WHERE channel_type='dial'"
 ```
 
-Pass the `id` to `/init-first-agent` or `/manage-channels` to wire it to an agent group.
+The `platform_id` is the **Dial line number** (the agent's provisioned number),
+not any sender's number, and `unknown_sender_policy` should read `public`.
 
-### Grant user access
+### Manual wiring (only if not using the wizard)
 
-New Dial senders are dropped until granted access (default unknown-sender policy is `request_approval`). After the sender's number appears in `messaging_groups` (host service running):
-
-```bash
-ncl users create --id "dial:+1YOURNUMBER" --kind dial --display-name "<name>"
-ncl roles grant --user "dial:+1YOURNUMBER" --role owner
-ncl members add --user "dial:+1YOURNUMBER" --group ag-AGENTID
-```
+Pass the messaging group `id` above to `/init-first-agent` or
+`/manage-channels` to wire it to an agent group. `public` only takes effect
+once the line is actually wired to an agent — an unwired line still holds
+unknown senders for approval.
 
 ## Next Steps
 
@@ -177,12 +186,12 @@ Otherwise, run `/init-first-agent` to create an agent and wire it to your Dial D
 ## Channel Info
 
 - **type**: `dial`
-- **terminology**: Dial has phone numbers, SMS messages, and AI voice calls. There are **no group chats** — every conversation is 1:1 between the account's number and a remote number.
-- **supports-threads**: no
-- **platform-id-format**: the remote party's phone number in E.164 (`+14155550123`) — sent as-is, no channel prefix.
-- **how-to-find-id**: Text the Dial number, then query `messaging_groups` as shown above. The `platform_id` is the sender's E.164 number.
+- **terminology**: Dial has phone numbers, SMS messages, and AI voice calls. The Dial number is a single public, threaded line — one messaging group with each remote correspondent as a thread — not a set of separate 1:1 chats.
+- **supports-threads**: yes — each correspondent is a thread (thread id = their E.164) within the one messaging group.
+- **platform-id-format**: the **Dial line number** in E.164 (`+14155550123`), sent as-is with no channel prefix. This is the messaging group's `platform_id`; each sender's own number is the thread id, not the `platform_id`.
+- **how-to-find-id**: Query `messaging_groups` as shown above (`WHERE channel_type='dial'`). The `platform_id` is the Dial line number.
 - **typical-use**: Personal assistant reachable by text; sends SMS, places AI voice calls, and receives 2FA codes and replies.
-- **default-isolation**: One agent per Dial number. Multiple people texting the same number share the number but each gets their own session (default `shared` session mode).
+- **default-isolation**: One agent on one public Dial line. Anyone can reach it (`unknown_sender_policy: 'public'`), and each correspondent gets their own thread and session.
 
 ### Features
 

--- a/setup/add-dial.sh
+++ b/setup/add-dial.sh
@@ -95,6 +95,16 @@ pnpm install "${SDK_VERSION}" >&2 2>/dev/null || {
   exit 1
 }
 
+# qrcode renders the pairing QR (an SMSTO: link) as terminal art in the wizard.
+# Idempotent — a no-op if a prior channel (Signal/WhatsApp) already installed it.
+if ! node -e "require.resolve('qrcode')" >/dev/null 2>&1; then
+  log "Installing qrcode@1.5.4…"
+  pnpm install qrcode@1.5.4 @types/qrcode@1.5.6 >&2 2>/dev/null || {
+    emit_status failed "pnpm install qrcode failed"
+    exit 1
+  }
+fi
+
 log "Building…"
 pnpm run build >&2 2>/dev/null || {
   emit_status failed "pnpm run build failed"

--- a/setup/add-dial.sh
+++ b/setup/add-dial.sh
@@ -5,8 +5,8 @@
 # confirmation, and service restart live in setup/channels/dial.ts. This
 # script only:
 #
-#   1. Fetches src/channels/dial.ts + dial-registration.test.ts from the
-#      channels branch.
+#   1. Fetches src/channels/dial.ts + dial-registration.test.ts and the
+#      dial-cli container skill from the channels branch.
 #   2. Appends the self-registration import to src/channels/index.ts.
 #   3. Installs @getdial/sdk (pinned).
 #   4. Builds.
@@ -71,6 +71,16 @@ if need_install; then
       exit 1
     }
   done
+
+  # Bundle the dial-cli container skill (outbound tool: drive the `dial` CLI
+  # to send SMS, place calls, reconfigure the number) — the WhatsApp/Slack
+  # pattern of shipping a channel's container skill with the channel.
+  log "Copying the dial-cli container skill…"
+  mkdir -p container/skills/dial-cli
+  git show "${CHANNELS_BRANCH}:container/skills/dial-cli/SKILL.md" > container/skills/dial-cli/SKILL.md || {
+    emit_status failed "git show ${CHANNELS_BRANCH}:container/skills/dial-cli/SKILL.md failed"
+    exit 1
+  }
 
   if ! grep -q "^import './dial.js';" src/channels/index.ts; then
     echo "import './dial.js';" >> src/channels/index.ts

--- a/setup/add-dial.sh
+++ b/setup/add-dial.sh
@@ -64,6 +64,8 @@ if need_install; then
   log "Copying adapter files from ${CHANNELS_BRANCH}…"
   for f in \
     src/channels/dial.ts \
+    src/channels/dial-pairing.ts \
+    src/channels/dial-pairing.test.ts \
     src/channels/dial-registration.test.ts
   do
     git show "${CHANNELS_BRANCH}:$f" > "$f" || {

--- a/setup/add-dial.sh
+++ b/setup/add-dial.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Install the Dial adapter in an already-running NanoClaw checkout.
+# Non-interactive — the operator-facing `dial` signup/onboard, number
+# confirmation, and service restart live in setup/channels/dial.ts. This
+# script only:
+#
+#   1. Fetches src/channels/dial.ts + dial-registration.test.ts from the
+#      channels branch.
+#   2. Appends the self-registration import to src/channels/index.ts.
+#   3. Installs @getdial/sdk (pinned).
+#   4. Builds.
+#
+# Dial credentials are NOT persisted here — the adapter reads them from Dial's
+# own auth file (~/.local/share/dial/auth.v1.json, written by `dial onboard`),
+# or from DIAL_API_KEY / DIAL_FROM_NUMBER env overrides. That keeps this script
+# idempotent and re-runnable without re-auth. Restart is the caller's job (the
+# wizard restarts the service; standalone /add-dial installs instruct it).
+#
+# Emits exactly one status block on stdout (ADD_DIAL) at the end. All chatty
+# progress goes to stderr so setup:auto's raw-log capture sees the full story
+# without cluttering the final block for the parser.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Keep in sync with .claude/skills/add-dial/SKILL.md.
+SDK_VERSION="@getdial/sdk@0.17.0"
+
+# shellcheck source=setup/lib/channels-remote.sh
+source "$PROJECT_ROOT/setup/lib/channels-remote.sh"
+CHANNELS_REMOTE=$(resolve_channels_remote)
+CHANNELS_BRANCH="${CHANNELS_REMOTE}/channels"
+
+emit_status() {
+  local status=$1 error=${2:-}
+  local already=${ADAPTER_ALREADY_INSTALLED:-false}
+  echo "=== NANOCLAW SETUP: ADD_DIAL ==="
+  echo "STATUS: ${status}"
+  echo "SDK_VERSION: ${SDK_VERSION}"
+  echo "ADAPTER_ALREADY_INSTALLED: ${already}"
+  [ -n "$error" ] && echo "ERROR: ${error}"
+  echo "=== END ==="
+}
+
+log() { echo "[add-dial] $*" >&2; }
+
+need_install() {
+  [ ! -f src/channels/dial.ts ] && return 0
+  ! grep -q "^import './dial.js';" src/channels/index.ts 2>/dev/null && return 0
+  return 1
+}
+
+ADAPTER_ALREADY_INSTALLED=true
+if need_install; then
+  ADAPTER_ALREADY_INSTALLED=false
+  log "Fetching channels branch…"
+  git fetch "$CHANNELS_REMOTE" channels >&2 2>/dev/null || {
+    emit_status failed "git fetch ${CHANNELS_REMOTE} channels failed"
+    exit 1
+  }
+
+  log "Copying adapter files from ${CHANNELS_BRANCH}…"
+  for f in \
+    src/channels/dial.ts \
+    src/channels/dial-registration.test.ts
+  do
+    git show "${CHANNELS_BRANCH}:$f" > "$f" || {
+      emit_status failed "git show ${CHANNELS_BRANCH}:$f failed"
+      exit 1
+    }
+  done
+
+  if ! grep -q "^import './dial.js';" src/channels/index.ts; then
+    echo "import './dial.js';" >> src/channels/index.ts
+  fi
+fi
+
+log "Installing ${SDK_VERSION}…"
+pnpm install "${SDK_VERSION}" >&2 2>/dev/null || {
+  emit_status failed "pnpm install ${SDK_VERSION} failed"
+  exit 1
+}
+
+log "Building…"
+pnpm run build >&2 2>/dev/null || {
+  emit_status failed "pnpm run build failed"
+  exit 1
+}
+
+emit_status success

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1252,7 +1252,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
-        { value: 'dial', label: 'Yes, connect Dial', hint: 'real phone number: SMS + AI voice calls' },
+        { value: 'dial', label: 'Yes, connect Dial', hint: 'voice calls, iMessage & SMS — worldwide' },
         {
           value: 'signal',
           label: 'Yes, connect Signal',

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -34,6 +34,7 @@ import k from 'kleur';
 import { BACK_TO_CHANNEL_SELECTION } from './lib/back-nav.js';
 import { runDiscordChannel } from './channels/discord.js';
 import { runIMessageChannel } from './channels/imessage.js';
+import { runDialChannel } from './channels/dial.js';
 import { runSignalChannel } from './channels/signal.js';
 import { runSlackChannel } from './channels/slack.js';
 import { runTeamsChannel } from './channels/teams.js';
@@ -69,7 +70,17 @@ import { isValidTimezone } from '../src/timezone.js';
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
 
-type ChannelChoice = 'telegram' | 'discord' | 'whatsapp' | 'signal' | 'teams' | 'slack' | 'imessage' | 'other' | 'skip';
+type ChannelChoice =
+  | 'telegram'
+  | 'discord'
+  | 'whatsapp'
+  | 'dial'
+  | 'signal'
+  | 'teams'
+  | 'slack'
+  | 'imessage'
+  | 'other'
+  | 'skip';
 
 async function main(): Promise<void> {
   // Make sure ~/.local/bin is on PATH for every child process we spawn.
@@ -555,6 +566,8 @@ async function main(): Promise<void> {
         result = await runDiscordChannel(displayName!);
       } else if (channelChoice === 'whatsapp') {
         result = await runWhatsAppChannel(displayName!);
+      } else if (channelChoice === 'dial') {
+        result = await runDialChannel(displayName!);
       } else if (channelChoice === 'signal') {
         result = await runSignalChannel(displayName!);
       } else if (channelChoice === 'teams') {
@@ -678,6 +691,8 @@ function channelDmLabel(choice: ChannelChoice): string | null {
       return 'Discord DMs';
     case 'whatsapp':
       return 'WhatsApp';
+    case 'dial':
+      return 'phone';
     case 'signal':
       return 'Signal';
     case 'teams':
@@ -1237,6 +1252,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
+        { value: 'dial', label: 'Yes, connect Dial', hint: 'real phone number: SMS + AI voice calls' },
         {
           value: 'signal',
           label: 'Yes, connect Signal',

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -1252,7 +1252,7 @@ async function askChannelChoice(): Promise<ChannelChoice> {
         { value: 'telegram', label: 'Yes, connect Telegram', hint: 'recommended' },
         { value: 'discord', label: 'Yes, connect Discord' },
         { value: 'whatsapp', label: 'Yes, connect WhatsApp', hint: 'best with a dedicated number' },
-        { value: 'dial', label: 'Yes, connect Dial', hint: 'voice calls, iMessage & SMS — worldwide' },
+        { value: 'dial', label: 'Yes, connect Dial', hint: 'a dedicated phone number for your agent — place calls, iMessage, SMS — worldwide' },
         {
           value: 'signal',
           label: 'Yes, connect Signal',

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -53,26 +53,10 @@ export async function runDialChannel(displayName: string): Promise<void> {
   ensureListenDaemon(cliPath);
   await restartService();
 
-  // Optional: wire the operator's own number as a first DM. Skipping is fine —
-  // Dial is a public line, so new senders get a one-tap "Connect to Nano?" on
-  // first contact (or you wire via /manage-channels). Providing a number just
-  // pre-wires your own DM so your texts work instantly + you get a welcome SMS.
-  const operatorPhone = await askOperatorPhone();
-  if (!operatorPhone) {
-    p.note(
-      [
-        'Dial is connected. Nothing is wired to an agent yet — the first time a number',
-        'texts or calls your line, the owner gets a one-tap "Connect to Nano?" to link it',
-        '(or wire it anytime with /manage-channels).',
-      ].join('\n'),
-      'Dial connected',
-    );
-    setupLog.step('dial-wire', 'skipped', 0, {});
-    return;
-  }
-
   const role = await askOperatorRole('Dial');
   setupLog.userInput('dial_role', role);
+
+  const operatorPhone = await askOperatorPhone();
   const agentName = await resolveAgentName();
 
   const init = await runQuietChild(
@@ -336,33 +320,31 @@ async function restartService(): Promise<void> {
   }
 }
 
-async function askOperatorPhone(): Promise<string | null> {
+async function askOperatorPhone(): Promise<string> {
   p.note(
     [
-      'Optional — the phone you personally text the assistant from.',
+      'What phone number will you text your assistant from?',
       '',
-      '  • Enter it to pre-wire your own DM now (instant, plus a welcome text).',
-      '  • Leave blank to skip — new senders get a one-tap connect instead.',
+      '  • Use full international format, starting with +',
       '',
-      k.dim('Full international format, e.g. +14155551234'),
+      k.dim('Example: +14155551234'),
     ].join('\n'),
-    'Your phone number (optional)',
+    'Your phone number',
   );
   const answer = ensureAnswer(
     await p.text({
-      message: 'Your phone number (Enter to skip)',
-      placeholder: '+14155551234',
+      message: 'Your phone number',
       validate: (v) => {
         const t = (v ?? '').trim();
-        if (!t) return undefined; // blank = skip
+        if (!t) return 'Phone number is required';
         if (!/^\+[1-9]\d{6,14}$/.test(t)) return 'Use E.164 format, e.g. +14155551234';
         return undefined;
       },
     }),
   ) as string;
-  const phone = (answer ?? '').trim();
-  setupLog.userInput('dial_operator_phone', phone || '(skipped)');
-  return phone || null;
+  const phone = answer.trim();
+  setupLog.userInput('dial_operator_phone', phone);
+  return phone;
 }
 
 async function resolveAgentName(): Promise<string> {

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -1,38 +1,15 @@
 /**
  * Dial channel flow for setup:auto.
  *
- * `runDialChannel(displayName)` owns the full branch from the `dial` CLI
- * presence check through the welcome SMS:
+ * `runDialChannel(displayName)`: probe the `dial` CLI → reuse the signed-in
+ * account or run signup(email+OTP)+onboard → confirm the auto-provisioned
+ * number → install the adapter (setup/add-dial.sh) → ensure the `dial listen`
+ * daemon (the adapter registers the command target itself on the next boot) →
+ * restart the service → wire the first agent to the operator's phone.
  *
- *   1. Probe the `dial` CLI on PATH. If missing, print the one-line installer
- *      (curl https://getdial.ai/install | bash) and bail with an actionable
- *      error.
- *   2. `dial doctor --json` — if already signed in, offer to reuse that
- *      account (no email/OTP re-prompt); otherwise collect email → `dial
- *      signup` → OTP → `dial onboard` (which also provisions the first US
- *      number and installs the nanoclaw Dial skill).
- *   3. Confirm the account's auto-provisioned number (`dial number list`).
- *      Provisioning is Dial's own concern — we never ask the operator to pick
- *      or buy a number.
- *   4. Install the adapter via setup/add-dial.sh (idempotent).
- *   5. Wire the CLI command-target handler: ensure the `dial listen` daemon is
- *      installed. The adapter registers the actual command target on its next
- *      boot, so the service restart in step 6 completes the wiring.
- *   6. Kick the service so the adapter picks up the Dial credentials and
- *      registers its command target.
- *   7. Ask operator role, the phone they'll text from, and the agent name.
- *   8. Wire the agent via scripts/init-first-agent.ts; the existing welcome
- *      path delivers the greeting through the adapter (an SMS to their phone).
- *
- * Dial has no group chats: every conversation is a 1:1 exchange between the
- * account's number and a remote number, so the operator's own phone is both
- * the user handle and the DM platform id. Ownership is established by the Dial
- * account auth (they signed up / signed in), so — unlike Telegram — there is
- * no pairing handshake.
- *
- * Output obeys the three-level contract: clack UI for the user, structured
- * entries in logs/setup.log, full raw output in per-step files under
- * logs/setup-steps/. See docs/setup-flow.md.
+ * Dial has no group chats — every conversation is 1:1 with a remote number, so
+ * the operator's own phone is both the user handle and the DM platform id, and
+ * ownership comes from the Dial account auth (no pairing handshake).
  */
 import { spawnSync } from 'child_process';
 
@@ -51,8 +28,7 @@ const DEFAULT_INBOUND_INSTRUCTION =
 
 interface DoctorReport {
   auth?: { signedIn?: boolean; email?: string };
-  listen?: { installed?: boolean; running?: boolean };
-  nextStep?: string;
+  listen?: { running?: boolean };
 }
 
 export async function runDialChannel(displayName: string): Promise<void> {
@@ -268,27 +244,15 @@ async function signUpFlow(cliPath: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 interface NumberListResponse {
-  numbers?: Array<{ number?: string; nickname?: string | null }>;
+  numbers?: Array<{ number?: string }>;
 }
 
 function confirmProvisionedNumber(cliPath: string): void {
   const list = dialJson<NumberListResponse>(cliPath, ['number', 'list']);
   const numbers = list?.numbers?.map((n) => n.number).filter((n): n is string => !!n) ?? [];
-  if (numbers.length === 0) {
-    p.note(
-      "Dial usually provisions a US number automatically at signup. Couldn't read one back just now — the adapter will still use whatever number your account has. You can check with `dial number list`.",
-      'Your Dial number',
-    );
-    return;
-  }
+  if (numbers.length === 0) return; // couldn't read one back; the adapter uses whatever the account has
   p.note(
-    [
-      'Your agent will send and receive from:',
-      '',
-      ...numbers.map((n) => `  ${accentGreen(n)}`),
-      '',
-      k.dim('Provisioned by Dial at signup — nothing to configure here.'),
-    ].join('\n'),
+    [`Your agent sends and receives from:`, '', ...numbers.map((n) => `  ${accentGreen(n)}`)].join('\n'),
     'Your Dial number',
   );
   setupLog.step('dial-number', 'success', 0, { NUMBERS: numbers.join(',') });

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -3,13 +3,14 @@
  *
  * `runDialChannel(displayName)`: probe the `dial` CLI → reuse the signed-in
  * account or run signup(email+OTP)+onboard → confirm the auto-provisioned
- * number → install the adapter (setup/add-dial.sh) → ensure the `dial listen`
- * daemon (the adapter registers the command target itself on the next boot) →
- * restart the service → wire the first agent to the operator's phone.
+ * number → install the adapter + dial-cli skill (setup/add-dial.sh) → ensure
+ * the `dial listen` daemon → restart the service → PAIR (show a 4-digit code
+ * the operator texts to the Dial number; the running adapter consumes it and
+ * records the sender as owner) → role prompt → wire the public line.
  *
- * Dial has no group chats — every conversation is 1:1 with a remote number, so
- * the operator's own phone is both the user handle and the DM platform id, and
- * ownership comes from the Dial account auth (no pairing handshake).
+ * The Dial number is a single PUBLIC, threaded line: one messaging group
+ * (platform_id = the number) with each texter as a thread, wired once with
+ * unknown_sender_policy 'public' so anyone can reach the agent.
  */
 import { spawnSync } from 'child_process';
 
@@ -35,7 +36,7 @@ export async function runDialChannel(displayName: string): Promise<void> {
   const cliPath = await ensureDialCli();
 
   await ensureSignedIn(cliPath);
-  confirmProvisionedNumber(cliPath);
+  const lineNumber = confirmProvisionedNumber(cliPath);
 
   const install = await runQuietChild('dial-install', 'bash', ['setup/add-dial.sh'], {
     running: 'Installing the Dial adapter…',
@@ -53,12 +54,20 @@ export async function runDialChannel(displayName: string): Promise<void> {
   ensureListenDaemon(cliPath);
   await restartService();
 
+  // WIRING via pairing: show a 4-digit code; the operator texts it to the Dial
+  // number from any phone. The running adapter consumes it (recording the
+  // sender as owner) before it reaches an agent. This proves control of the
+  // sending number without asking them to type it.
+  const pairedNumber = await runPairing(lineNumber);
+
   const role = await askOperatorRole('Dial');
   setupLog.userInput('dial_role', role);
-
-  const operatorPhone = await askOperatorPhone();
   const agentName = await resolveAgentName();
 
+  // Wire the PUBLIC line: the messaging group's platform_id is the Dial number
+  // itself; each texter becomes a thread. The adapter's declared defaults set
+  // unknown_sender_policy 'public', so init-first-agent stamps the mg public —
+  // everyone can reach the agent, no per-sender approval.
   const init = await runQuietChild(
     'init-first-agent',
     'pnpm',
@@ -69,9 +78,9 @@ export async function runDialChannel(displayName: string): Promise<void> {
       '--channel',
       'dial',
       '--user-id',
-      operatorPhone,
+      pairedNumber,
       '--platform-id',
-      operatorPhone,
+      lineNumber || pairedNumber,
       '--display-name',
       displayName,
       '--agent-name',
@@ -80,11 +89,11 @@ export async function runDialChannel(displayName: string): Promise<void> {
       role,
     ],
     {
-      running: `Connecting ${agentName} to Dial…`,
-      done: `${agentName} is ready. Check your phone for a welcome text.`,
+      running: `Connecting ${agentName} to your Dial line…`,
+      done: `${agentName} is live on ${lineNumber || 'your Dial number'}.`,
     },
     {
-      extraFields: { CHANNEL: 'dial', AGENT_NAME: agentName, PLATFORM_ID: operatorPhone, ROLE: role },
+      extraFields: { CHANNEL: 'dial', AGENT_NAME: agentName, PLATFORM_ID: lineNumber || pairedNumber, ROLE: role },
     },
   );
   if (!init.ok) {
@@ -92,6 +101,55 @@ export async function runDialChannel(displayName: string): Promise<void> {
       'init-first-agent',
       `Couldn't finish connecting ${agentName}.`,
       'You can retry later with `/manage-channels`.',
+    );
+  }
+}
+
+/**
+ * Pairing step: mint a 4-digit code, ask the operator to text it to the Dial
+ * number, and wait for the running adapter to consume it (shared JSON file
+ * under data/). Returns the paired sender's E.164. Uses a dynamic import
+ * because the pairing module ships with the channel (installed by
+ * setup/add-dial.sh above), so it doesn't exist at setup-module load time.
+ */
+async function runPairing(lineNumber: string | null): Promise<string> {
+  const { createPairing, waitForPairing } = await import('../../src/channels/dial-pairing.js');
+  const rec = await createPairing();
+  const target = lineNumber ?? 'your Dial number';
+  p.note(
+    [
+      `   ${accentGreen(rec.code.split('').join('  '))}`,
+      '',
+      `From the phone you want to use, text ${k.bold('only these 4 digits')} to ${k.bold(target)}.`,
+      k.dim('This proves the number is yours; you become the owner.'),
+    ].join('\n'),
+    'Pairing code',
+  );
+  setupLog.userInput('dial_pairing_code_issued', rec.code);
+
+  const s = p.spinner();
+  const start = Date.now();
+  s.start('Waiting for your text…');
+  try {
+    // Cap the wait so setup can't hang forever; the operator can re-run.
+    const consumed = await Promise.race([
+      waitForPairing(rec.code),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5 * 60_000)),
+    ]);
+    const from = consumed.consumed?.fromNumber;
+    if (!from) throw new Error('paired but no number recorded');
+    s.stop(`Paired with ${accentGreen(from)}. ${k.dim(`(${fmtDuration(Date.now() - start)})`)}`);
+    setupLog.step('dial-pair', 'success', Date.now() - start, { PAIRED_NUMBER: from });
+    return from;
+  } catch (err) {
+    const reason = err instanceof Error && err.message === 'timeout' ? 'no code received in time' : String(err);
+    s.stop('Pairing didn’t complete.', 1);
+    setupLog.step('dial-pair', 'failed', Date.now() - start, { ERROR: reason.slice(0, 120) });
+    // fail() returns Promise<never> — control never returns past here.
+    return await fail(
+      'dial-pair',
+      "Didn't receive the pairing code.",
+      'Make sure you texted exactly the 4 digits to the Dial number, then re-run setup.',
     );
   }
 }
@@ -247,15 +305,17 @@ interface NumberListResponse {
   numbers?: Array<{ number?: string }>;
 }
 
-function confirmProvisionedNumber(cliPath: string): void {
+/** Show + return the account's Dial number (the public line). Null if unreadable. */
+function confirmProvisionedNumber(cliPath: string): string | null {
   const list = dialJson<NumberListResponse>(cliPath, ['number', 'list']);
   const numbers = list?.numbers?.map((n) => n.number).filter((n): n is string => !!n) ?? [];
-  if (numbers.length === 0) return; // couldn't read one back; the adapter uses whatever the account has
+  if (numbers.length === 0) return null; // couldn't read one back; adapter uses the account default
   p.note(
-    [`Your agent sends and receives from:`, '', ...numbers.map((n) => `  ${accentGreen(n)}`)].join('\n'),
+    [`Your agent's public line:`, '', ...numbers.map((n) => `  ${accentGreen(n)}`)].join('\n'),
     'Your Dial number',
   );
   setupLog.step('dial-number', 'success', 0, { NUMBERS: numbers.join(',') });
+  return numbers[0];
 }
 
 function ensureListenDaemon(cliPath: string): void {
@@ -318,33 +378,6 @@ async function restartService(): Promise<void> {
     setupLog.step('dial-restart', 'failed', Date.now() - start, { ERROR: message });
     // Non-fatal — the user can restart manually if init-first-agent fails.
   }
-}
-
-async function askOperatorPhone(): Promise<string> {
-  p.note(
-    [
-      'What phone number will you text your assistant from?',
-      '',
-      '  • Use full international format, starting with +',
-      '',
-      k.dim('Example: +14155551234'),
-    ].join('\n'),
-    'Your phone number',
-  );
-  const answer = ensureAnswer(
-    await p.text({
-      message: 'Your phone number',
-      validate: (v) => {
-        const t = (v ?? '').trim();
-        if (!t) return 'Phone number is required';
-        if (!/^\+[1-9]\d{6,14}$/.test(t)) return 'Use E.164 format, e.g. +14155551234';
-        return undefined;
-      },
-    }),
-  ) as string;
-  const phone = answer.trim();
-  setupLog.userInput('dial_operator_phone', phone);
-  return phone;
 }
 
 async function resolveAgentName(): Promise<string> {

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -1,0 +1,402 @@
+/**
+ * Dial channel flow for setup:auto.
+ *
+ * `runDialChannel(displayName)` owns the full branch from the `dial` CLI
+ * presence check through the welcome SMS:
+ *
+ *   1. Probe the `dial` CLI on PATH. If missing, print the one-line installer
+ *      (curl https://getdial.ai/install | bash) and bail with an actionable
+ *      error.
+ *   2. `dial doctor --json` — if already signed in, offer to reuse that
+ *      account (no email/OTP re-prompt); otherwise collect email → `dial
+ *      signup` → OTP → `dial onboard` (which also provisions the first US
+ *      number and installs the nanoclaw Dial skill).
+ *   3. Confirm the account's auto-provisioned number (`dial number list`).
+ *      Provisioning is Dial's own concern — we never ask the operator to pick
+ *      or buy a number.
+ *   4. Install the adapter via setup/add-dial.sh (idempotent).
+ *   5. Wire the CLI command-target handler: ensure the `dial listen` daemon is
+ *      installed. The adapter registers the actual command target on its next
+ *      boot, so the service restart in step 6 completes the wiring.
+ *   6. Kick the service so the adapter picks up the Dial credentials and
+ *      registers its command target.
+ *   7. Ask operator role, the phone they'll text from, and the agent name.
+ *   8. Wire the agent via scripts/init-first-agent.ts; the existing welcome
+ *      path delivers the greeting through the adapter (an SMS to their phone).
+ *
+ * Dial has no group chats: every conversation is a 1:1 exchange between the
+ * account's number and a remote number, so the operator's own phone is both
+ * the user handle and the DM platform id. Ownership is established by the Dial
+ * account auth (they signed up / signed in), so — unlike Telegram — there is
+ * no pairing handshake.
+ *
+ * Output obeys the three-level contract: clack UI for the user, structured
+ * entries in logs/setup.log, full raw output in per-step files under
+ * logs/setup-steps/. See docs/setup-flow.md.
+ */
+import { spawnSync } from 'child_process';
+
+import * as p from '@clack/prompts';
+import k from 'kleur';
+
+import * as setupLog from '../logs.js';
+import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
+import { ensureAnswer, fail, runQuietChild } from '../lib/runner.js';
+import { askOperatorRole } from '../lib/role-prompt.js';
+import { accentGreen, fmtDuration } from '../lib/theme.js';
+
+const DEFAULT_AGENT_NAME = 'Nano';
+const DEFAULT_INBOUND_INSTRUCTION =
+  'You are a friendly AI receptionist answering calls to this number. Greet the caller, ask how you can help, and take a clear message — their name, number, and reason for calling — if you cannot help directly.';
+
+interface DoctorReport {
+  auth?: { signedIn?: boolean; email?: string };
+  listen?: { installed?: boolean; running?: boolean };
+  nextStep?: string;
+}
+
+export async function runDialChannel(displayName: string): Promise<void> {
+  const cliPath = await ensureDialCli();
+
+  await ensureSignedIn(cliPath);
+  confirmProvisionedNumber(cliPath);
+
+  const install = await runQuietChild('dial-install', 'bash', ['setup/add-dial.sh'], {
+    running: 'Installing the Dial adapter…',
+    done: 'Dial adapter installed.',
+    skipped: 'Dial adapter already installed.',
+  });
+  if (!install.ok) {
+    await fail(
+      'dial-install',
+      "Couldn't install the Dial adapter.",
+      'See logs/setup-steps/ for details, then retry setup.',
+    );
+  }
+
+  ensureListenDaemon(cliPath);
+  await restartService();
+
+  const role = await askOperatorRole('Dial');
+  setupLog.userInput('dial_role', role);
+
+  const operatorPhone = await askOperatorPhone();
+  const agentName = await resolveAgentName();
+
+  const init = await runQuietChild(
+    'init-first-agent',
+    'pnpm',
+    [
+      'exec',
+      'tsx',
+      'scripts/init-first-agent.ts',
+      '--channel',
+      'dial',
+      '--user-id',
+      operatorPhone,
+      '--platform-id',
+      operatorPhone,
+      '--display-name',
+      displayName,
+      '--agent-name',
+      agentName,
+      '--role',
+      role,
+    ],
+    {
+      running: `Connecting ${agentName} to Dial…`,
+      done: `${agentName} is ready. Check your phone for a welcome text.`,
+    },
+    {
+      extraFields: { CHANNEL: 'dial', AGENT_NAME: agentName, PLATFORM_ID: operatorPhone, ROLE: role },
+    },
+  );
+  if (!init.ok) {
+    await fail(
+      'init-first-agent',
+      `Couldn't finish connecting ${agentName}.`,
+      'You can retry later with `/manage-channels`.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dial CLI helpers
+// ---------------------------------------------------------------------------
+
+function dialCliPath(): string {
+  return process.env.DIAL_CLI_PATH || 'dial';
+}
+
+/** Run a `dial` command, capturing output. Never throws. */
+function runDial(cliPath: string, args: string[]): { ok: boolean; stdout: string; stderr: string } {
+  const res = spawnSync(cliPath, args, { encoding: 'utf8' });
+  return {
+    ok: !res.error && res.status === 0,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  };
+}
+
+/** Run a `dial … --json` command and parse the first JSON object in stdout. */
+function dialJson<T>(cliPath: string, args: string[]): T | null {
+  const res = runDial(cliPath, [...args, '--json']);
+  if (!res.stdout.trim()) return null;
+  try {
+    return JSON.parse(res.stdout) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureDialCli(): Promise<string> {
+  const cliPath = dialCliPath();
+  const probe = spawnSync(cliPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (!probe.error && probe.status === 0) return cliPath;
+
+  p.note(
+    [
+      "NanoClaw talks to Dial through the `dial` CLI, which isn't installed yet.",
+      '',
+      'Install it in another terminal:',
+      '',
+      k.cyan('  curl -fsSL https://getdial.ai/install | bash'),
+      '',
+      'Then re-run setup.',
+    ].join('\n'),
+    'dial CLI not found',
+  );
+  // fail() returns Promise<never> — control never returns past here.
+  await fail('dial-install', 'The `dial` CLI is required but not installed.', 'Install it and re-run setup.');
+  throw new Error('unreachable');
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+async function ensureSignedIn(cliPath: string): Promise<void> {
+  const doctor = dialJson<DoctorReport>(cliPath, ['doctor']);
+  if (doctor?.auth?.signedIn) {
+    const email = doctor.auth.email ?? 'this account';
+    const reuse = ensureAnswer(
+      await p.confirm({
+        message: `You're already signed in to Dial as ${accentGreen(email)}. Reuse this account?`,
+        initialValue: true,
+      }),
+    ) as boolean;
+    setupLog.userInput('dial_reuse_account', String(reuse));
+    if (reuse) {
+      // Signed in already — no verification needed; onboard just (re)installs
+      // the nanoclaw Dial skill so the agent can drive the CLI.
+      runDial(cliPath, ['onboard', '--agent', 'nanoclaw']);
+      return;
+    }
+  }
+
+  await signUpFlow(cliPath);
+}
+
+async function signUpFlow(cliPath: string): Promise<void> {
+  const email = ensureAnswer(
+    await p.text({
+      message: "What's your email? Dial sends a one-time code to verify it.",
+      validate: (v) => {
+        const t = (v ?? '').trim();
+        if (!t) return 'Email is required';
+        if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(t)) return "That doesn't look like an email address";
+        return undefined;
+      },
+    }),
+  ) as string;
+  const trimmedEmail = email.trim();
+  setupLog.userInput('dial_email', trimmedEmail);
+
+  const s = p.spinner();
+  s.start('Sending your verification code…');
+  const signup = runDial(cliPath, ['signup', trimmedEmail, '--force']);
+  if (!signup.ok) {
+    s.stop("Couldn't request a code.", 1);
+    await fail(
+      'dial-signup',
+      "Dial wouldn't send a verification code.",
+      (signup.stderr || 'Check the address and try setup again.').trim(),
+    );
+  }
+  s.stop(`Code sent to ${accentGreen(trimmedEmail)}. Check your inbox.`);
+
+  const code = ensureAnswer(
+    await p.text({
+      message: 'Enter the 6-digit code from your email',
+      validate: (v) => {
+        const t = (v ?? '').trim();
+        if (!/^\d{6}$/.test(t)) return 'The code is 6 digits';
+        return undefined;
+      },
+    }),
+  ) as string;
+
+  const s2 = p.spinner();
+  const start = Date.now();
+  s2.start('Verifying and provisioning your number…');
+  const onboard = runDial(cliPath, [
+    'onboard',
+    '--code',
+    code.trim(),
+    '--inbound-instruction',
+    DEFAULT_INBOUND_INSTRUCTION,
+    '--agent',
+    'nanoclaw',
+  ]);
+  if (!onboard.ok) {
+    s2.stop('Verification failed.', 1);
+    setupLog.step('dial-onboard', 'failed', Date.now() - start, {
+      ERROR: (onboard.stderr || 'onboard failed').slice(0, 200),
+    });
+    await fail(
+      'dial-onboard',
+      "Dial couldn't verify that code.",
+      'The code may have expired. Re-run setup to get a fresh one.',
+    );
+  }
+  s2.stop(`Signed in and ready. ${k.dim(`(${fmtDuration(Date.now() - start)})`)}`);
+  setupLog.step('dial-onboard', 'success', Date.now() - start, {});
+}
+
+// ---------------------------------------------------------------------------
+// Number + listen daemon
+// ---------------------------------------------------------------------------
+
+interface NumberListResponse {
+  numbers?: Array<{ number?: string; nickname?: string | null }>;
+}
+
+function confirmProvisionedNumber(cliPath: string): void {
+  const list = dialJson<NumberListResponse>(cliPath, ['number', 'list']);
+  const numbers = list?.numbers?.map((n) => n.number).filter((n): n is string => !!n) ?? [];
+  if (numbers.length === 0) {
+    p.note(
+      "Dial usually provisions a US number automatically at signup. Couldn't read one back just now — the adapter will still use whatever number your account has. You can check with `dial number list`.",
+      'Your Dial number',
+    );
+    return;
+  }
+  p.note(
+    [
+      'Your agent will send and receive from:',
+      '',
+      ...numbers.map((n) => `  ${accentGreen(n)}`),
+      '',
+      k.dim('Provisioned by Dial at signup — nothing to configure here.'),
+    ].join('\n'),
+    'Your Dial number',
+  );
+  setupLog.step('dial-number', 'success', 0, { NUMBERS: numbers.join(',') });
+}
+
+function ensureListenDaemon(cliPath: string): void {
+  const doctor = dialJson<DoctorReport>(cliPath, ['doctor']);
+  if (doctor?.listen?.running) return;
+
+  const s = p.spinner();
+  s.start('Setting up inbound event delivery…');
+  const res = runDial(cliPath, ['listen', 'install']);
+  if (res.ok) {
+    s.stop('Inbound events wired up.');
+    setupLog.step('dial-listen', 'success', 0, {});
+  } else {
+    // Non-fatal: some sandboxes/CI have no user service supervisor. Inbound
+    // still works once the daemon is started manually; outbound is unaffected.
+    s.stop('Inbound daemon not started automatically.', 1);
+    p.note(
+      [
+        "Couldn't start the Dial listen daemon automatically (this needs a user",
+        'service supervisor — launchd/systemd). Outbound texts and calls work',
+        'regardless. To receive inbound texts, run this once, then restart NanoClaw:',
+        '',
+        k.cyan('  dial listen install'),
+      ].join('\n'),
+      'Heads up',
+    );
+    setupLog.step('dial-listen', 'failed', 0, { ERROR: (res.stderr || 'listen install failed').slice(0, 200) });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service restart + prompts
+// ---------------------------------------------------------------------------
+
+async function restartService(): Promise<void> {
+  const s = p.spinner();
+  s.start('Restarting NanoClaw so it sees your Dial credentials…');
+  const start = Date.now();
+  const platform = process.platform;
+  try {
+    if (platform === 'darwin') {
+      spawnSync('launchctl', ['kickstart', '-k', `gui/${process.getuid?.() ?? 501}/${getLaunchdLabel()}`], {
+        stdio: 'ignore',
+      });
+    } else if (platform === 'linux') {
+      const unit = getSystemdUnit();
+      const user = spawnSync('systemctl', ['--user', 'restart', unit], { stdio: 'ignore' });
+      if (user.status !== 0) {
+        spawnSync('sudo', ['systemctl', 'restart', unit], { stdio: 'ignore' });
+      }
+    }
+    // Give the adapter a moment to reconnect and register its command target
+    // before init-first-agent's welcome SMS hits the delivery path.
+    await new Promise((r) => setTimeout(r, 5000));
+    s.stop(`NanoClaw restarted. ${k.dim(`(${fmtDuration(Date.now() - start)})`)}`);
+    setupLog.step('dial-restart', 'success', Date.now() - start, { PLATFORM: platform });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    s.stop(`Restart may have failed: ${message}`, 1);
+    setupLog.step('dial-restart', 'failed', Date.now() - start, { ERROR: message });
+    // Non-fatal — the user can restart manually if init-first-agent fails.
+  }
+}
+
+async function askOperatorPhone(): Promise<string> {
+  p.note(
+    [
+      'What phone number will you text your assistant from?',
+      '',
+      '  • Use full international format, starting with +',
+      '',
+      k.dim('Example: +14155551234'),
+    ].join('\n'),
+    'Your phone number',
+  );
+  const answer = ensureAnswer(
+    await p.text({
+      message: 'Your phone number',
+      validate: (v) => {
+        const t = (v ?? '').trim();
+        if (!t) return 'Phone number is required';
+        if (!/^\+[1-9]\d{6,14}$/.test(t)) return 'Use E.164 format, e.g. +14155551234';
+        return undefined;
+      },
+    }),
+  ) as string;
+  const phone = answer.trim();
+  setupLog.userInput('dial_operator_phone', phone);
+  return phone;
+}
+
+async function resolveAgentName(): Promise<string> {
+  const preset = process.env.NANOCLAW_AGENT_NAME?.trim();
+  if (preset) {
+    setupLog.userInput('agent_name', preset);
+    return preset;
+  }
+  const answer = ensureAnswer(
+    await p.text({
+      message: `What should your ${accentGreen('assistant')} be called?`,
+      placeholder: DEFAULT_AGENT_NAME,
+      defaultValue: DEFAULT_AGENT_NAME,
+    }),
+  ) as string;
+  const value = answer.trim() || DEFAULT_AGENT_NAME;
+  setupLog.userInput('agent_name', value);
+  return value;
+}

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -112,6 +112,21 @@ export async function runDialChannel(displayName: string): Promise<void> {
 }
 
 /**
+ * Render an SMSTO: URI as terminal-art QR lines. `qrcode` is installed by
+ * setup/add-dial.sh (dynamic import so setup-module load doesn't need it).
+ * Returns [] on any failure so the caller falls back to the plain code.
+ */
+async function renderSmsQr(uri: string): Promise<string[]> {
+  try {
+    const QRCode = await import('qrcode');
+    const art = await QRCode.toString(uri, { type: 'terminal', small: true });
+    return art.trimEnd().split('\n');
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Pairing step: mint a 4-digit code, ask the operator to text it to the Dial
  * number, and wait for the running adapter to consume it (shared JSON file
  * under data/). Returns the paired sender's E.164. Uses a dynamic import
@@ -122,15 +137,33 @@ async function runPairing(lineNumber: string | null): Promise<string> {
   const { createPairing, waitForPairing } = await import('../../src/channels/dial-pairing.js');
   const rec = await createPairing();
   const target = lineNumber ?? 'your Dial number';
-  p.note(
-    [
-      `   ${accentGreen(rec.code.split('').join('  '))}`,
-      '',
-      `From the phone you want to use, text ${k.bold('only these 4 digits')} to ${k.bold(target)}.`,
-      k.dim('This proves the number is yours; you become the owner.'),
-    ].join('\n'),
-    'Pairing code',
-  );
+
+  // Prefer a scannable QR: it encodes an SMSTO: link so the phone camera opens
+  // Messages pre-filled with the code + recipient — the operator just taps Send.
+  // Falls back to the plain code if there's no number or QR rendering fails.
+  const qrLines = lineNumber ? await renderSmsQr(`SMSTO:${lineNumber}:${rec.code}`) : [];
+  if (qrLines.length > 0) {
+    p.note(
+      [
+        ...qrLines,
+        '',
+        `Scan with your phone camera — it opens Messages pre-filled to ${k.bold(target)}.`,
+        `Just press ${k.bold('Send')}. (The message is the code ${accentGreen(rec.code)}.)`,
+        k.dim(`Can't scan? Text ${rec.code} to ${target} yourself.`),
+      ].join('\n'),
+      'Scan to pair',
+    );
+  } else {
+    p.note(
+      [
+        `   ${accentGreen(rec.code.split('').join('  '))}`,
+        '',
+        `From the phone you want to use, text ${k.bold('only these 4 digits')} to ${k.bold(target)}.`,
+        k.dim('This proves the number is yours; you become the owner.'),
+      ].join('\n'),
+      'Pairing code',
+    );
+  }
   setupLog.userInput('dial_pairing_code_issued', rec.code);
 
   const s = p.spinner();

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -13,6 +13,7 @@
  * unknown_sender_policy 'public' so anyone can reach the agent.
  */
 import { spawnSync } from 'child_process';
+import path from 'path';
 
 import * as p from '@clack/prompts';
 import k from 'kleur';
@@ -53,6 +54,11 @@ export async function runDialChannel(displayName: string): Promise<void> {
 
   ensureListenDaemon(cliPath);
   await restartService();
+  // Register the inbound command target from HERE, not the adapter: the host
+  // service runs under launchd/systemd with a limited PATH that often can't
+  // find `dial`, so its self-registration fails silently. The wizard has the
+  // CLI on PATH — register the handler the adapter just wrote at boot.
+  registerCommandTarget(cliPath);
 
   // WIRING via pairing: show a 4-digit code; the operator texts it to the Dial
   // number from any phone. The running adapter consumes it (recording the
@@ -170,6 +176,25 @@ function runDial(cliPath: string, args: string[]): { ok: boolean; stdout: string
     stdout: res.stdout ?? '',
     stderr: res.stderr ?? '',
   };
+}
+
+/**
+ * Register the adapter's inbound command target from the wizard. The host
+ * service's PATH (launchd/systemd) usually can't find `dial`, so the adapter's
+ * own boot-time registration fails silently — the wizard has the CLI on PATH,
+ * so it registers the handler the adapter wrote at boot. Idempotent.
+ */
+function registerCommandTarget(cliPath: string): void {
+  const handler = path.join(process.cwd(), 'data', 'dial', 'handle-dial-event.sh');
+  const listed = runDial(cliPath, ['local-target', 'list', '--json']);
+  if (listed.ok && listed.stdout.includes(handler)) return; // already registered
+  const res = runDial(cliPath, ['local-target', 'add', 'cmd', handler]);
+  setupLog.step(
+    'dial-command-target',
+    res.ok ? 'success' : 'failed',
+    0,
+    res.ok ? { HANDLER: handler } : { ERROR: (res.stderr || 'add failed').slice(0, 120) },
+  );
 }
 
 /** Run a `dial … --json` command and parse the first JSON object in stdout. */

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -53,10 +53,26 @@ export async function runDialChannel(displayName: string): Promise<void> {
   ensureListenDaemon(cliPath);
   await restartService();
 
+  // Optional: wire the operator's own number as a first DM. Skipping is fine —
+  // Dial is a public line, so new senders get a one-tap "Connect to Nano?" on
+  // first contact (or you wire via /manage-channels). Providing a number just
+  // pre-wires your own DM so your texts work instantly + you get a welcome SMS.
+  const operatorPhone = await askOperatorPhone();
+  if (!operatorPhone) {
+    p.note(
+      [
+        'Dial is connected. Nothing is wired to an agent yet — the first time a number',
+        'texts or calls your line, the owner gets a one-tap "Connect to Nano?" to link it',
+        '(or wire it anytime with /manage-channels).',
+      ].join('\n'),
+      'Dial connected',
+    );
+    setupLog.step('dial-wire', 'skipped', 0, {});
+    return;
+  }
+
   const role = await askOperatorRole('Dial');
   setupLog.userInput('dial_role', role);
-
-  const operatorPhone = await askOperatorPhone();
   const agentName = await resolveAgentName();
 
   const init = await runQuietChild(
@@ -320,31 +336,33 @@ async function restartService(): Promise<void> {
   }
 }
 
-async function askOperatorPhone(): Promise<string> {
+async function askOperatorPhone(): Promise<string | null> {
   p.note(
     [
-      'What phone number will you text your assistant from?',
+      'Optional — the phone you personally text the assistant from.',
       '',
-      '  • Use full international format, starting with +',
+      '  • Enter it to pre-wire your own DM now (instant, plus a welcome text).',
+      '  • Leave blank to skip — new senders get a one-tap connect instead.',
       '',
-      k.dim('Example: +14155551234'),
+      k.dim('Full international format, e.g. +14155551234'),
     ].join('\n'),
-    'Your phone number',
+    'Your phone number (optional)',
   );
   const answer = ensureAnswer(
     await p.text({
-      message: 'Your phone number',
+      message: 'Your phone number (Enter to skip)',
+      placeholder: '+14155551234',
       validate: (v) => {
         const t = (v ?? '').trim();
-        if (!t) return 'Phone number is required';
+        if (!t) return undefined; // blank = skip
         if (!/^\+[1-9]\d{6,14}$/.test(t)) return 'Use E.164 format, e.g. +14155551234';
         return undefined;
       },
     }),
   ) as string;
-  const phone = answer.trim();
-  setupLog.userInput('dial_operator_phone', phone);
-  return phone;
+  const phone = (answer ?? '').trim();
+  setupLog.userInput('dial_operator_phone', phone || '(skipped)');
+  return phone || null;
 }
 
 async function resolveAgentName(): Promise<string> {

--- a/setup/channels/dial.ts
+++ b/setup/channels/dial.ts
@@ -171,9 +171,13 @@ async function runPairing(lineNumber: string | null): Promise<string> {
   s.start('Waiting for your text…');
   try {
     // Cap the wait so setup can't hang forever; the operator can re-run.
+    // .unref() so the pending timer never keeps the process alive after a
+    // successful pair (otherwise setup hangs at the end until it fires).
     const consumed = await Promise.race([
       waitForPairing(rec.code),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5 * 60_000)),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('timeout')), 5 * 60_000).unref();
+      }),
     ]);
     const from = consumed.consumed?.fromNumber;
     if (!from) throw new Error('paired but no number recorded');


### PR DESCRIPTION
## What

Makes [Dial](https://getdial.ai) (a real phone number for SMS + AI voice calls) a first-class choice in `pnpm run setup:auto`, and ships its `/add-dial` install skill.

- **`setup/auto.ts`** — adds the `dial` picker option (between WhatsApp and Signal), the dispatcher case routing to `runDialChannel()`, the `ChannelChoice` union member, and the DM-label case.
- **`setup/channels/dial.ts`** — interactive wizard: probe the `dial` CLI → `dial doctor` reuse-or-signup(email+OTP)+onboard → confirm the account's auto-provisioned number → install the adapter → wire the `dial listen` command-target daemon → restart → wire the first agent to the operator's phone. No pairing handshake: the Dial account auth already establishes ownership (unlike Telegram's bot-token model), so the wizard just asks which number the operator will text from (WhatsApp-style).
- **`setup/add-dial.sh`** — idempotent installer: fetch the adapter from the `channels` branch, append the barrel import, `pnpm install @getdial/sdk@0.17.0`, build.
- **`.claude/skills/add-dial/`** — `/add-dial` skill + `REMOVE.md`, mirroring `/add-signal`.

The adapter itself is on the [`channels` branch PR](https://github.com/nanocoai/nanoclaw/pull/3032); this trunk change only makes it offerable and installable.

## Design notes

- Auto-provisioning is Dial's concern (signup grants one US number) — the wizard confirms the number but never asks the operator to pick or buy one.
- Inbound uses the CLI command-target pattern (no local HTTP endpoint), per docs.getdial.ai/integrations/agent-clients/nanoclaw.

## Testing

- `pnpm run build` clean.
- `pnpm exec vitest run setup/` — 141 tests pass.
- `setup/auto.ts` diff is minimal (only the 5 functional edits; the file has pre-existing prettier drift on `main` that I deliberately left untouched).
- Validated the wizard's `dial doctor` / `dial number list` JSON parsing against real CLI output (v0.32.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)