### PR TITLE
fix(agent): inject current_time into context header + weekday in local timestamps

### DIFF
--- a/container/agent-runner/src/formatter.test.ts
+++ b/container/agent-runner/src/formatter.test.ts
@@ -51,6 +51,11 @@ describe('context timezone header', () => {
     expect(result).toContain(`<context timezone="${TIMEZONE}"`);
   });
 
+  it('includes a current_time attribute so task turns (no message timestamp) still know the day/hour', () => {
+    const result = formatMessages([]);
+    expect(result).toMatch(/<context timezone="[^"]*" current_time="[^"]+" \/>/);
+  });
+
   it('header comes before the first <message> block when multiple are present', () => {
     insertMessage('m1', 'chat', { sender: 'Alice', text: 'one' });
     insertMessage('m2', 'chat', { sender: 'Bob', text: 'two' });

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -1,6 +1,6 @@
 import { findByRouting } from './destinations.js';
 import type { MessageInRow } from './db/messages-in.js';
-import { TIMEZONE, formatLocalTime } from './timezone.js';
+import { TIMEZONE, formatLocalTime, nowInZone } from './timezone.js';
 
 /**
  * Command categories for messages starting with '/'.
@@ -123,17 +123,22 @@ export function extractRouting(messages: MessageInRow[]): RoutingContext {
 /**
  * Format a batch of messages_in rows into a prompt string.
  *
- * Prepends a `<context timezone="<IANA>" />` header so the agent always knows
- * what timezone it's in — every timestamp it sees in message bodies is the
- * user's local time, and every time it produces (schedules, suggests) should
- * be interpreted as local time in that same zone. This header is v1 behavior
- * (src/v1/router.ts:20-22); dropping it led to misinterpretations where the
- * agent scheduled tasks for the wrong hour.
+ * Prepends a `<context timezone="<IANA>" current_time="<local now>" />` header so
+ * the agent always knows what timezone it's in AND the current day/hour — every
+ * timestamp it sees in message bodies is the user's local time, and every time it
+ * produces (schedules, suggests) should be interpreted as local time in that same
+ * zone. The timezone attribute is v1 behavior (src/v1/router.ts:20-22); dropping
+ * it led to misinterpretations where the agent scheduled tasks for the wrong hour.
+ *
+ * `current_time` (with weekday) is injected fresh each turn because the per-message
+ * `time="..."` timestamps only anchor chat turns — scheduled-task turns carry no
+ * incoming message, so without a current-time anchor the agent confuses days and
+ * hours on those turns.
  *
  * Strips routing fields — the agent never sees platform_id, channel_type, thread_id.
  */
 export function formatMessages(messages: MessageInRow[]): string {
-  const header = `<context timezone="${escapeXml(TIMEZONE)}" />\n`;
+  const header = `<context timezone="${escapeXml(TIMEZONE)}" current_time="${escapeXml(nowInZone(TIMEZONE))}" />\n`;
   if (messages.length === 0) return header;
 
   // Group by kind

--- a/container/agent-runner/src/timezone.test.ts
+++ b/container/agent-runner/src/timezone.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 
-import { formatLocalTime, isValidTimezone, parseZonedToUtc, resolveTimezone } from './timezone.js';
+import { formatLocalTime, isValidTimezone, nowInZone, parseZonedToUtc, resolveTimezone } from './timezone.js';
 
 // --- formatLocalTime ---
 
@@ -12,6 +12,12 @@ describe('formatLocalTime', () => {
     expect(result).toContain('PM');
     expect(result).toContain('Feb');
     expect(result).toContain('2026');
+  });
+
+  it('includes the weekday so the agent does not have to infer day-of-week from the date', () => {
+    // 2026-02-04 is a Wednesday
+    const result = formatLocalTime('2026-02-04T18:30:00.000Z', 'America/New_York');
+    expect(result).toContain('Wednesday');
   });
 
   it('handles different timezones', () => {
@@ -30,6 +36,21 @@ describe('formatLocalTime', () => {
     // Should format as UTC (noon UTC = 12:00 PM)
     expect(result).toContain('12:00');
     expect(result).toContain('PM');
+  });
+});
+
+// --- nowInZone ---
+
+describe('nowInZone', () => {
+  it('renders the current time in the given zone with a weekday', () => {
+    const result = nowInZone('America/New_York');
+    // weekday, month, year and a 12h clock marker are always present
+    expect(result).toMatch(/^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),/);
+    expect(result).toMatch(/\b(AM|PM)\b/);
+  });
+
+  it('falls back to UTC on an invalid timezone without throwing', () => {
+    expect(() => nowInZone('Not/AZone')).not.toThrow();
   });
 });
 

--- a/container/agent-runner/src/timezone.ts
+++ b/container/agent-runner/src/timezone.ts
@@ -39,6 +39,7 @@ export function formatLocalTime(utcIso: string, timezone: string): string {
   const date = new Date(utcIso);
   return date.toLocaleString('en-US', {
     timeZone: resolveTimezone(timezone),
+    weekday: 'long',
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -61,6 +62,30 @@ export function formatLocalStamp(date: Date, timezone: string): string {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
+  });
+}
+
+/**
+ * Current wall-clock time in the given zone, including weekday. Injected fresh
+ * into the per-turn context header so the agent always knows the current day AND
+ * hour — not just the timezone name.
+ *
+ * The existing per-message `time="..."` timestamps only anchor the agent on
+ * *chat* turns (turns triggered by an incoming message). Scheduled-task turns
+ * have no incoming message to stamp, so without this the agent runs them with no
+ * notion of the current day/time and confuses days and hours. This header covers
+ * every turn type.
+ */
+export function nowInZone(timezone: string): string {
+  return new Date().toLocaleString('en-US', {
+    timeZone: resolveTimezone(timezone),
+    weekday: 'long',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
   });
 }
 


### PR DESCRIPTION
## Problem

The agent frequently confuses the **day-of-week** and **hour**, most visibly on **scheduled-task turns** (recurring/cron messages). Two gaps combine to cause it:

1. **The `<context>` header carries only the timezone *name*, never the current time.** On a scheduled-task turn there is no incoming user message, so the per-message `time="..."` timestamps — the only other time anchor the agent gets — are absent entirely. The agent runs those turns with no notion of the current day or hour and guesses, often wrongly. This is the gap the existing message-timestamp approach can't cover, because a task turn has no message to stamp.
2. **`formatLocalTime` omits the weekday**, so even on chat turns the agent has to infer day-of-week from the date arithmetically — something LLMs do unreliably. (This is exactly what #1097 proposes to fix.)

Related prior reports: #526 (closed via the timezone-context header), #386 / #483 (TZ plumbing to containers).

## Fix

- Add `current_time="<weekday, date, time>"` to the context header, computed fresh each turn in the configured timezone via a new `nowInZone()` helper. This anchors **every** turn type — including task turns that have no message timestamp.
- Add `weekday: 'long'` to `formatLocalTime` so per-message timestamps also carry the day name. **Closes #1097.**

Both use the existing global `TIMEZONE` (resolved from `TZ`). `nowInZone(timezone)` takes the zone as an argument, so a future per-group timezone can pass it through with no rework.

### Example header
Before:
```
<context timezone="Asia/Jerusalem" />
```
After:
```
<context timezone="Asia/Jerusalem" current_time="Sunday, Jul 12, 2026, 7:08 PM" />
```

## Tests

Added coverage in `timezone.test.ts` (weekday in `formatLocalTime`; `nowInZone` output + invalid-zone fallback) and `formatter.test.ts` (the `current_time` attribute is present on the header). Full container suite passes:

```
36 pass, 0 fail  (timezone.test.ts + formatter.test.ts)
tsc -p container/agent-runner/tsconfig.json --noEmit  → clean
```

## Notes / scope

- Purely additive to the header shape; the existing `timezone` attribute and message formatting are unchanged.
- Verified in a live deployment: after this change the agent reports the correct current day/time purely from context (no shell/date call), including on scheduled-task turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PfQZBFoNdBvPgNLkvLckG