### PR TITLE
feat(container): optional MCP tool allowlist

### DIFF
--- a/container/agent-runner/src/mcp-tools/server.ts
+++ b/container/agent-runner/src/mcp-tools/server.ts
@@ -21,6 +21,24 @@ function log(msg: string): void {
 const allTools: McpToolDefinition[] = [];
 const toolMap = new Map<string, McpToolDefinition>();
 
+/**
+ * Optional per-deployment allowlist. When `NANOCLAW_MCP_TOOL_ALLOWLIST` is set
+ * to a comma-separated list of tool names, only those tools are listed and
+ * invocable; every other registered tool is hidden. Unset (the default) exposes
+ * all registered tools — no behavior change.
+ */
+function enabledTools(): McpToolDefinition[] {
+  const configured = process.env.NANOCLAW_MCP_TOOL_ALLOWLIST;
+  if (!configured) return allTools;
+  const allowed = new Set(
+    configured
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
+  return allTools.filter((definition) => allowed.has(definition.tool.name));
+}
+
 export function registerTools(tools: McpToolDefinition[]): void {
   for (const t of tools) {
     if (toolMap.has(t.tool.name)) {
@@ -36,12 +54,14 @@ export async function startMcpServer(): Promise<void> {
   const server = new Server({ name: 'nanoclaw', version: '2.0.0' }, { capabilities: { tools: {} } });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: allTools.map((t) => t.tool),
+    tools: enabledTools().map((t) => t.tool),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
-    const tool = toolMap.get(name);
+    // Resolve against the allowlist so a disabled tool cannot be invoked even
+    // if the client already knew its name from a prior listing.
+    const tool = enabledTools().find((definition) => definition.tool.name === name);
     if (!tool) {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }] };
     }
@@ -50,5 +70,6 @@ export async function startMcpServer(): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  log(`MCP server started with ${allTools.length} tools: ${allTools.map((t) => t.tool.name).join(', ')}`);
+  const tools = enabledTools();
+  log(`MCP server started with ${tools.length} tools: ${tools.map((t) => t.tool.name).join(', ')}`);
 }


### PR DESCRIPTION
## What

Adds an optional `NANOCLAW_MCP_TOOL_ALLOWLIST` environment variable to the agent container. When set to a comma-separated list of tool names, only those tools are listed and invocable; every other registered MCP tool is hidden.

```
NANOCLAW_MCP_TOOL_ALLOWLIST=send_message,send_file
```

## Why

Deployments sometimes want to expose a narrower tool surface than the full registered set — e.g. restrict an agent to messaging only, or drop a tool that a particular integration must not use. Today the container always advertises every tool that self-registered at import time, with no per-deployment switch.

## Behavior

- **Unset (default):** all registered tools are exposed — no behavior change for existing installs.
- **Set:** the allowlist is enforced on both `tools/list` and `tools/call`, so a disabled tool cannot be invoked even if a client already learned its name from an earlier listing.

Single self-contained change in `container/agent-runner/src/mcp-tools/server.ts`; no interface or schema changes.

## Testing

- `tsc -p container/agent-runner/tsconfig.json --noEmit` passes.
- Container unit tests run under `bun:test`; not executed in my local environment (no bun on host). Logic is a pure env-parse + array filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)