### PR TITLE
fix(whatsapp): don't translate group participants to phone JIDs (LID-mode group sends stuck on "waiting")

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -460,19 +460,21 @@ registerChannelAdapter('whatsapp', {
       const cached = groupMetadataCache.get(jid);
       if (cached && cached.expiresAt > Date.now()) return cached.metadata;
 
+      // Return WhatsApp's native group metadata UNMODIFIED. Baileys uses this to
+      // distribute the group sender-key; it also reads `addressingMode` from it.
+      // For LID-addressed groups the participants must keep their native @lid ids
+      // so they match addressingMode='lid'. Translating them to phone JIDs
+      // (previous behavior) left addressingMode='lid' but pn-shaped participant
+      // ids — an inconsistency that desynced sender-key distribution, so member
+      // devices never received the key and group messages stuck on "waiting for
+      // this message". DMs and phone-addressed (small) groups were unaffected.
+      // The LID→phone translation for inbound sender routing happens separately.
       const metadata = await sock.groupMetadata(jid);
-      const participants = await Promise.all(
-        metadata.participants.map(async (p) => ({
-          ...p,
-          id: await translateJid(p.id),
-        })),
-      );
-      const normalized = { ...metadata, participants };
       groupMetadataCache.set(jid, {
-        metadata: normalized,
+        metadata,
         expiresAt: Date.now() + GROUP_METADATA_CACHE_TTL_MS,
       });
-      return normalized;
+      return metadata;
     }
 
     async function syncGroupMetadata(force = false): Promise<void> {


### PR DESCRIPTION
## Problem

In LID-addressed WhatsApp groups, the bot's replies **never render for members** — they stay on "waiting for this message" indefinitely. The host logs the send as delivered, but recipients never get the group sender-key. Crucially:

- **DMs work fine.**
- **Small / newly-created (phone-number-addressed) groups work fine.**
- Only **large / migrated (LID-addressed) groups** break.

That split is the tell, and it survives every session/key reset (host restart, clearing `store/auth` sessions, even a full device re-link — which just produces a `Bad MAC` storm that never settles).

## Root cause

`getNormalizedGroupMetadata` is the `cachedGroupMetadata` callback Baileys uses to distribute a group's sender-key. It preserved `addressingMode` (e.g. `'lid'`) from the metadata but rewrote every participant `id` from its native `@lid` to a phone JID via `translateJid`.

Baileys (`@whiskeysockets/baileys@7.0.0-rc.9`, `Socket/messages-send.js` ~508-547) reads `addressingMode` from that same metadata and distributes the sender-key to the participant devices derived from it. So for a LID group it produced a contradiction — `addressingMode: 'lid'` with **phone-JID-shaped participant ids** — and the sender-key went to devices that don't match the LID envelope. Member devices received the group message but never the key → permanent "waiting for this message". DMs and phone-addressed groups have no lid/pn contradiction, so they were unaffected.

## Fix

Return WhatsApp's native `sock.groupMetadata(jid)` unmodified so `addressingMode` and participant ids stay consistent. The function's only caller is `cachedGroupMetadata`; the LID→phone translation needed for **inbound** sender routing happens separately (`translateJid` on `msg.key` remoteJid/participant), so inbound is unchanged.

## Verification

Deployed to a live install: replies in a previously-stuck LID group immediately began rendering for all members instead of "waiting for this message." DMs and small groups continue to work. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)