### PR TITLE
fix(discord): drop system messages (THREAD_CREATED etc.) before routing

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -647,6 +647,21 @@ async function handleForwardedEvent(
     return;
   }
 
+  // Drop Discord SYSTEM messages before they reach the adapter. When a user
+  // creates a thread, Discord posts a type-18 THREAD_CREATED system message
+  // in the PARENT channel whose `content` is the thread name.
+  // @chat-adapter/discord's handleForwardedMessage never checks `type`, so
+  // that system message routes as a normal user message in the parent
+  // channel and the agent replies to the thread *title* in the main channel.
+  // Keep only real user content: 0 DEFAULT, 19 REPLY.
+  if (event.type === 'GATEWAY_MESSAGE_CREATE' && event.data) {
+    const msgType = (event.data as { type?: unknown }).type;
+    if (typeof msgType === 'number' && msgType !== 0 && msgType !== 19) {
+      log.info('Dropping Discord system message', { messageType: msgType });
+      return;
+    }
+  }
+
   // Handle interaction events (button clicks) — not handled by adapter's handleForwardedGatewayEvent
   if (event.type === 'GATEWAY_INTERACTION_CREATE' && event.data) {
     const interaction = event.data;


### PR DESCRIPTION
## Problem

When a user creates a thread on Discord, the platform posts a **THREAD_CREATED (type 18) system message in the parent channel** whose `content` is the thread name. The gateway listener forwards it like any `MESSAGE_CREATE`, and the Discord adapter's `handleForwardedMessage` never checks the message `type` — so the bridge routes the thread title as if the user had typed it in the parent channel.

**Symptom:** open a thread, say something inside it → the agent answers inside the thread, **and also replies to the thread *title* in the main channel** as a ghost turn. Any bot wired with `engage_mode: mention-sticky` or pattern engagement in a channel hits this every time someone opens a thread. Other system messages (pins, boosts, member joins, forwards/type 21) leak the same way as phantom chatter.

## Fix

Filter forwarded `GATEWAY_MESSAGE_CREATE` events in the bridge's forwarded-event handler to real user content types only — `0` (DEFAULT) and `19` (REPLY) — before handing the event to the adapter, mirroring what the Discord docs classify as user-authored message types. Unknown/absent `type` fields pass through unchanged, so nothing breaks if the adapter ever pre-filters.

15 lines, no behavior change for normal messages, replies, threads, DMs.

## Verification

Live on a running install:
- created a thread in a wired channel → log shows `Dropping Discord system message messageType=18` (and `21` for a forward), **no ghost reply in the parent channel**
- normal channel messages, replies, and in-thread conversations route exactly as before
- `tsc --noEmit` clean, `vitest` channel suite green (57 tests)