### PR TITLE
fix(skills): switch Telegram deep-link from t.me to telegram.me

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -129,7 +129,7 @@ matches them. Open the bot first so you're on the right screen when the code
 appears. Tell the user:
 
 ```nc:operator
-Open @{{bot_username}} (https://t.me/{{bot_username}}) in Telegram now and keep it on screen — a 4-digit pairing code is about to appear in this terminal. When it does, send just those 4 digits to the bot as a message (in a group chat with Group Privacy on, prefix them with @{{bot_username}}). A wrong guess is rejected and a fresh code is issued automatically.
+Open @{{bot_username}} (https://telegram.me/{{bot_username}}) in Telegram now and keep it on screen — a 4-digit pairing code is about to appear in this terminal. When it does, send just those 4 digits to the bot as a message (in a group chat with Group Privacy on, prefix them with @{{bot_username}}). A wrong guess is rejected and a fresh code is issued automatically.
 ```
 
 Run the pairing handshake. It prints the code, streams "waiting…" and wrong-code


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

(Ticked Fix, though the fixed line is skill prose rather than source: it is the live URL the setup driver extracts and offers to open during Telegram pairing.)

## Description

**Problem.** During Telegram setup, the pairing step deep-links the operator to the bot chat. Since 2026-07-13 that open dead-ends on `DNS_PROBE_FINISHED_NXDOMAIN` in the browser.

**Root cause.** Not local DNS and not a nanoclaw regression: the .me registry placed `t.me` on `serverHold` on 2026-07-13, which drops the name from the TLD zone, so every resolver worldwide returns NXDOMAIN ([Domain Name Wire](https://domainnamewire.com/2026/07/13/telegrams-t-me-domain-suspended-leading-to-outages/), [Domain Incite](https://domainincite.com/31803-cybercrime-link-as-t-me-gets-taken-down)). Verified independently of any local resolver via DoH:

```
$ curl -s "https://dns.google/resolve?name=t.me&type=A"
{"Status":3, ... "Comment":"Response from 199.249.127.1."}   # NXDOMAIN from the .me TLD server

$ whois t.me | grep -i hold
Domain Status: serverHold https://icann.org/epp#serverHold   # Updated Date: 2026-07-13T19:24:55Z
```

**Change.** One line in `.claude/skills/add-telegram/SKILL.md`: the pairing-step operator block now links `https://telegram.me/{{bot_username}}` instead of `https://t.me/{{bot_username}}`. `telegram.me` is Telegram's original official alias and serves the identical bot profile page:

```
$ curl -sI https://telegram.me/<bot_username> | head -1
HTTP/2 200
```

**Why safe / alternatives.** `tg://resolve?domain=` would bypass DNS for the web page but silently fails when the scheme has no handler (the reason the flow standardized on an https link originally). If the registry lifts the hold, `telegram.me` keeps working regardless, so there is nothing to revert.

**Scope.** `git diff --name-only upstream/main...HEAD` shows exactly one file, `.claude/skills/add-telegram/SKILL.md`. Intentionally untouched:

- `scripts/skill-policy.test.ts:177-178` uses `t.me` as arbitrary fixture URLs for `extractOfferUrl`; they test URL extraction, not reachability.
- `docs/skill-engine-seam.md:194` quotes the old URL as part of a historical migration record.
- The `channels`/`providers` registry branches: swept both tips, the telegram payload (`src/channels/telegram*.ts`) contains no `t.me` reference; the only other occurrence is the stale `docs/docker-sandboxes.md` snapshot on `channels`, which no install materializes.

**Verification.**

```
$ pnpm exec tsx scripts/skill-directives.ts .claude/skills/add-telegram
"problems": [], "warnings": []      # operator directive at :131 now carries the telegram.me URL

$ pnpm test
Test Files  93 passed (93)
Tests  1137 passed (1137)
```

Declared gap: no new test added, the change is a hostname inside skill prose with no logic to assert; a fresh-clone Telegram install was not re-run for this one-line swap (the target URL is verified reachable above, and the skill lint plus the full suite pass).

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

(Not a new skill: a one-line URL swap in existing skill text. Attestations left unticked rather than claimed; fresh-clone status is declared above.)
