### PR TITLE
fix(channels): download inbound attachments that lost fetchData (#2888)

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, splitForLimit, enrichInboundAttachment } from './chat-sdk-bridge.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -419,5 +419,57 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(calls).toHaveLength(1);
     const msg = calls[0].message as { markdown?: string };
     expect(msg.markdown).toBe('plain hello');
+  });
+});
+
+describe('enrichInboundAttachment', () => {
+  it('downloads bytes via fetchData when present', async () => {
+    const att = {
+      type: 'audio',
+      mimeType: 'audio/ogg',
+      size: 3,
+      fetchData: async () => Buffer.from('abc'),
+    };
+    const entry = await enrichInboundAttachment(att, {});
+    expect(entry.data).toBe(Buffer.from('abc').toString('base64'));
+  });
+
+  it('recovers via adapter.rehydrateAttachment when fetchData is absent (#2888 — Telegram voice)', async () => {
+    // Post-serialize shape: no fetchData, but fetchMetadata.fileId survives.
+    const att = { type: 'audio', mimeType: 'audio/ogg', size: 3, fetchMetadata: { fileId: 'f1' } };
+    const adapter = {
+      rehydrateAttachment: (a: Record<string, unknown>) => ({ ...a, fetchData: async () => Buffer.from('ogg') }),
+    };
+    const entry = await enrichInboundAttachment(att, adapter);
+    expect(entry.data).toBe(Buffer.from('ogg').toString('base64'));
+  });
+
+  it('does not throw when rehydrateAttachment throws (adapter robustness)', async () => {
+    const att = { type: 'audio', mimeType: 'audio/ogg', size: 3, fetchMetadata: { fileId: 'f1' } };
+    const adapter = {
+      rehydrateAttachment: () => {
+        throw new Error('boom');
+      },
+    };
+    const entry = await enrichInboundAttachment(att, adapter);
+    expect(entry.data).toBeUndefined();
+  });
+
+  it('falls back to fetching att.url for url-only adapters (#2888 — Discord)', async () => {
+    const att = { type: 'image', mimeType: 'image/png', size: 3, url: 'https://example/y.png' };
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new TextEncoder().encode('png').buffer,
+    } as unknown as Response);
+    const entry = await enrichInboundAttachment(att, {});
+    expect(entry.data).toBe(Buffer.from('png').toString('base64'));
+    expect(spy).toHaveBeenCalledWith('https://example/y.png');
+    spy.mockRestore();
+  });
+
+  it('leaves data unset without throwing when nothing can download', async () => {
+    const att = { type: 'audio', mimeType: 'audio/ogg', size: 3 };
+    const entry = await enrichInboundAttachment(att, {});
+    expect(entry.data).toBeUndefined();
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -134,6 +134,66 @@ export function splitForLimit(text: string, limit: number): string[] {
   return chunks;
 }
 
+/**
+ * Build the serialized inbox entry for one inbound attachment, downloading its
+ * bytes into `entry.data` (base64) so the host can stage a real file.
+ *
+ * The chat-sdk core strips `data`/`fetchData` when it serializes a message but
+ * keeps `fetchMetadata`; adapters restore the downloader via
+ * `rehydrateAttachment`. url-only adapters (e.g. Discord) expose `url` instead.
+ * Recovering here fixes inbound attachments (incl. Telegram voice/audio) that
+ * reach this point without a live `fetchData`. See nanoclaw#2888.
+ */
+export async function enrichInboundAttachment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  att: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  adapter: any,
+): Promise<Record<string, unknown>> {
+  const entry: Record<string, unknown> = {
+    type: att.type,
+    name: att.name,
+    mimeType: att.mimeType,
+    size: att.size,
+    width: att.width,
+    height: att.height,
+  };
+
+  let fetchData: (() => Promise<Buffer>) | undefined = att.fetchData;
+  if (!fetchData && typeof adapter?.rehydrateAttachment === 'function') {
+    try {
+      fetchData = adapter.rehydrateAttachment(att)?.fetchData;
+    } catch (err) {
+      log.warn('Failed to rehydrate attachment downloader', { type: att.type, err });
+    }
+  }
+
+  if (fetchData) {
+    try {
+      const buffer = await fetchData();
+      entry.data = buffer.toString('base64');
+    } catch (err) {
+      log.warn('Failed to download attachment', { type: att.type, err });
+    }
+  } else if (typeof att.url === 'string' && att.url) {
+    try {
+      const res = await fetch(att.url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buffer = Buffer.from(await res.arrayBuffer());
+      const MAX_BYTES = 25 * 1024 * 1024;
+      if (buffer.length > MAX_BYTES) {
+        throw new Error(`attachment exceeds ${MAX_BYTES} bytes (${buffer.length})`);
+      }
+      entry.data = buffer.toString('base64');
+      entry.url = att.url;
+    } catch (err) {
+      log.warn('Failed to download attachment via url', { type: att.type, err });
+    }
+  }
+
+  return entry;
+}
+
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
   // The instance name becomes a webhook route segment (the route regex is
@@ -163,28 +223,12 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serialized = message.toJSON() as Record<string, any>;
 
-    // Download attachment data before serialization loses fetchData()
+    // Download attachment data before serialization loses fetchData(); recover
+    // a lost downloader via the adapter or a url fallback (see nanoclaw#2888).
     if (message.attachments && message.attachments.length > 0) {
       const enriched = [];
       for (const att of message.attachments) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entry: Record<string, any> = {
-          type: att.type,
-          name: att.name,
-          mimeType: att.mimeType,
-          size: att.size,
-          width: (att as unknown as Record<string, unknown>).width,
-          height: (att as unknown as Record<string, unknown>).height,
-        };
-        if (att.fetchData) {
-          try {
-            const buffer = await att.fetchData();
-            entry.data = buffer.toString('base64');
-          } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
-          }
-        }
-        enriched.push(entry);
+        enriched.push(await enrichInboundAttachment(att, adapter));
       }
       serialized.attachments = enriched;
     }


### PR DESCRIPTION
## What & why

Fixes #2888. Inbound attachments that reach the chat-sdk bridge **without** a live
`fetchData()` are silently dropped: the agent only sees a filename/placeholder, no
bytes. This affects Telegram **voice/audio notes** (empty-text message + an
`audio/ogg` attachment whose bytes never download) and url-only adapters like
Discord.

## Root cause

`messageToInbound` in `src/channels/chat-sdk-bridge.ts` downloaded bytes only inside
`if (att.fetchData)`. The chat-sdk core strips `data`/`fetchData` when serializing a
message but keeps `fetchMetadata`; adapters expose `rehydrateAttachment()` to rebuild
the downloader from it (Telegram: `fetchMetadata.fileId`). That recovery was never
applied on the inbound path, so `entry.data` stayed unset and `extractAttachmentFiles`
(`session-manager.ts`) skipped staging the file. No error was logged — the download
branch was simply skipped.

## Change

Extract a small, unit-tested `enrichInboundAttachment(att, adapter)` helper. When
`fetchData` is absent it: (1) calls `adapter.rehydrateAttachment(att)` and uses the
restored `fetchData`; (2) otherwise falls back to `fetch(att.url)` (25 MB cap, fails
loud). Behavior for attachments that already have `fetchData` is unchanged. The
`rehydrateAttachment` call is guarded so a throwing adapter can never drop the whole
inbound message.

One source file + its test. No dependency or interface changes.

## Tests

Adds `enrichInboundAttachment` unit tests: fetchData path, rehydrate recovery (#2888
Telegram voice), url fallback (#2888 Discord), the no-op/no-throw case, and a
throwing-`rehydrateAttachment` robustness case.

## Note

The deeper cause is upstream in the `chat` core (it does not rehydrate before handler
delivery). This bridge-level recovery is the minimal, self-contained fix; an upstream
core fix would let this become a no-op.
