### PR TITLE
fix(delivery): drain outbound messages on container exit

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,6 +43,7 @@ import {
   type ProviderContainerContribution,
   type VolumeMount,
 } from './providers/provider-container-registry.js';
+import { deliverSessionMessages } from './delivery.js';
 import {
   heartbeatPath,
   markContainerRunning,
@@ -196,6 +197,13 @@ async function spawnContainer(session: Session): Promise<void> {
     activeContainers.delete(session.id);
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
+    // Drain any outbound messages written just before the container exited.
+    // Once container_status = 'stopped', the session is excluded from
+    // getRunningSessions() (active poll, 1 s) and won't be swept for up to
+    // 60 s — draining here closes that window.
+    void deliverSessionMessages(session).catch((err) =>
+      log.error('Post-exit delivery drain failed', { sessionId: session.id, err }),
+    );
     // code null = killed by signal (normal shutdown path), not a boot failure.
     if (code !== 0 && code !== null && stderrTail.length > 0) {
       log.warn('Container exited non-zero', { sessionId: session.id, code, containerName, stderrTail });


### PR DESCRIPTION
## Problem

When a container exits, its session is removed from `container_status=running/idle`, so the 1s active delivery poll stops seeing it. Any `<message>` blocks written to `outbound.db` just before exit are delayed up to 60s until the sweep poll picks them up.

## Fix

Call `deliverSessionMessages()` immediately in the container `close` event, so end-of-turn messages are flushed without waiting for the next sweep cycle.

Running in production on our instance since 2026-07-11 — end-of-turn messages that previously lagged up to a minute now deliver immediately.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
