### PR TITLE
docs(pairing): align init-first-agent with current status blocks

### DIFF
--- a/.claude/skills/init-first-agent/SKILL.md
+++ b/.claude/skills/init-first-agent/SKILL.md
@@ -67,7 +67,7 @@ For Telegram only, there's an existing pair-code primitive. When you run this to
 npx tsx setup/index.ts --step pair-telegram -- --intent new-agent:dm-with-<folder>
 ```
 
-Parse the `PAIR_TELEGRAM_ISSUED` status block for `CODE` and follow the `REMINDER_TO_ASSISTANT` line in that block. Then wait for the `PAIR_TELEGRAM` block — read `PLATFORM_ID` and `PAIRED_USER_ID` from it. telegram.ts's interceptor has already upserted the user and granted owner if none existed yet. Use `PLATFORM_ID` and `PAIRED_USER_ID` directly in step 4.
+Read `CODE` from the initial `PAIR_TELEGRAM_CODE` status block (`REASON=initial`); the step also renders the same code in a user-facing card. If a wrong code invalidates it, use the replacement from the next `PAIR_TELEGRAM_CODE` block (`REASON=regenerated`). Then wait for the final `PAIR_TELEGRAM` block and read `PLATFORM_ID` and `PAIRED_USER_ID` from it. telegram.ts's interceptor has already upserted the user and granted owner if none existed yet. Use `PLATFORM_ID` and `PAIRED_USER_ID` directly in step 4.
 
 ## 4. Run the init script
 

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -10,7 +10,7 @@
  *   PAIR_TELEGRAM_CODE       { CODE, REASON=initial|regenerated }
  *   PAIR_TELEGRAM_ATTEMPT    { CANDIDATE }
  *   PAIR_TELEGRAM (final)    { STATUS=success, CODE, INTENT, PLATFORM_ID,
- *                              IS_GROUP, PAIRED_USER_ID }
+ *                              IS_GROUP, ADMIN_USER_ID, PAIRED_USER_ID }
  *                         or { STATUS=failed, CODE, ERROR }
  *
  * Depends on src/channels/telegram-pairing.js, which the /add-telegram skill


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** Updates init-first-agent to parse the Telegram pairing status blocks that setup/pair-telegram.ts actually emits, and corrects the emitter contract comment to include ADMIN_USER_ID.

**Why:** The skill still waited for PAIR_TELEGRAM_ISSUED and REMINDER_TO_ASSISTANT, neither of which exists. An assistant following it could stall instead of presenting the pairing code.

**How it works:** Read the initial or regenerated code from PAIR_TELEGRAM_CODE, then consume PLATFORM_ID and PAIRED_USER_ID from the final PAIR_TELEGRAM block.

**How tested:** Cross-checked every documented field and block name against the live emitStatus calls; git diff --check passes.