### PR TITLE
fix(add-slack): configure credentials before webhook URL verification + clarify tunnel proxy options

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -112,7 +112,12 @@ launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
 
 The Chat SDK bridge automatically starts a shared webhook server on port 3000 (configurable via `WEBHOOK_PORT` env var). The server handles `/webhook/slack` for Slack and other webhook-based adapters. This port must be publicly reachable from the internet for Slack to deliver events.
 
-If running locally, discuss options for exposing the server — e.g. ngrok (`ngrok http 3000`), Cloudflare Tunnel, or a reverse proxy on a VPS. The resulting public URL becomes the base for `https://your-domain/webhook/slack`.
+**Public server:** point Slack's Request URL directly at `https://your-domain/webhook/slack`.
+
+**Local install:** expose port 3000 with a tunnel proxy. The resulting public URL becomes the base for `https://your-domain/webhook/slack`. Options:
+
+- **ngrok** — `ngrok http 3000`. A [free ngrok account](https://ngrok.com) includes one static domain that survives restarts (`ngrok http --url=your-slug.ngrok-free.dev 3000`); without an account each restart gives a new URL you'd need to re-enter in Slack.
+- **Cloudflare Tunnel** — `cloudflared tunnel --url http://localhost:3000`. Quick tunnels are ephemeral; a [named tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) gives a stable URL that survives reboots.
 
 ## Next Steps
 

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -76,6 +76,23 @@ End-to-end message delivery against a real Slack workspace is verified manually 
 6. Go to **App Home** and enable the **Messages Tab**
 7. Check **"Allow users to send Slash commands and messages from the messages tab"**
 
+### Configure environment
+
+Add to `.env`:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+Sync to container and restart the service before continuing — the Slack adapter only starts when `SLACK_BOT_TOKEN` is present, so the webhook route won't register until the service is running with credentials loaded. Slack sends a verification challenge the moment you enter the Request URL; if the adapter isn't up, the challenge fails and the URL can't be saved.
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+# systemctl --user restart nanoclaw                 # Linux
+```
+
 ### Event Subscriptions
 
 8. Go to **Event Subscriptions** and toggle **Enable Events**
@@ -90,17 +107,6 @@ End-to-end message delivery against a real Slack workspace is verified manually 
 13. Set the **Request URL** to the same `https://your-domain/webhook/slack`
 14. Click **Save Changes**
 15. Slack will show a banner asking you to **reinstall the app** — click it to apply the new settings
-
-### Configure environment
-
-Add to `.env`:
-
-```bash
-SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_SIGNING_SECRET=your-signing-secret
-```
-
-Sync to container: `mkdir -p data/env && cp .env data/env/env`
 
 ### Webhook server
 

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -114,10 +114,10 @@ The Chat SDK bridge automatically starts a shared webhook server on port 3000 (c
 
 **Public server:** point Slack's Request URL directly at `https://your-domain/webhook/slack`.
 
-**Local install:** expose port 3000 with a tunnel proxy. The resulting public URL becomes the base for `https://your-domain/webhook/slack`. Options:
+**Local install:** expose port 3000 with any tunnel proxy that provides a public HTTPS URL — the resulting URL becomes the base for `https://your-domain/webhook/slack`. Whatever tool you use, prefer one that gives a **stable URL** (the same URL across restarts), otherwise you'd need to update the Request URL in the Slack app dashboard every time the tunnel restarts. Some common options:
 
-- **ngrok** — `ngrok http 3000`. A [free ngrok account](https://ngrok.com) includes one static domain that survives restarts (`ngrok http --url=your-slug.ngrok-free.dev 3000`); without an account each restart gives a new URL you'd need to re-enter in Slack.
-- **Cloudflare Tunnel** — `cloudflared tunnel --url http://localhost:3000`. Quick tunnels are ephemeral; a [named tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) gives a stable URL that survives reboots.
+- **ngrok** — `ngrok http 3000`. A [free ngrok account](https://ngrok.com) includes one static domain (`ngrok http --url=your-slug.ngrok-free.dev 3000`); without an account each restart generates a new URL.
+- **Cloudflare Tunnel** — `cloudflared tunnel --url http://localhost:3000`. Quick tunnels are ephemeral; a [named tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) gives a stable URL.
 
 ## Next Steps
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Two fixes to `.claude/skills/add-slack/SKILL.md` based on a real install walkthrough.

**Bug: credential ordering**

The skill puts "Configure environment" (adding tokens to `.env` and syncing) after "Event Subscriptions". This is backwards: the Slack adapter only starts when `SLACK_BOT_TOKEN` is present — if the service hasn't been restarted with credentials loaded, the webhook route is never registered. When the user enters the Request URL in Event Subscriptions, Slack immediately sends a verification challenge; with no adapter running, the challenge hits a dead endpoint and the URL can't be saved.

Fix: move "Configure environment" before "Event Subscriptions" and add an explicit restart step with a one-line explanation of why the order matters.

**Improvement: tunnel proxy guidance**

The previous "Webhook server" section mentioned ngrok and Cloudflare Tunnel in passing without enough context. Expand it to distinguish public server installs (point Slack directly at the server) from local installs (need a tunnel proxy), frame the two tools as examples among many, and surface the key criterion — a stable URL that survives restarts — so users understand what they're actually choosing between.

## Related

PR #2700 (`fix(skill/add-slack): switch to Socket Mode setup`) is open and addresses the larger question of switching the skill entirely to Socket Mode — a direction I agree with. This PR is additive and complementary: it fixes the credential ordering bug that exists regardless of which connection mode is used, and improves the webhook server section for installs that haven't adopted Socket Mode yet. Both PRs can coexist; if #2700 lands first, the ordering fix and tunnel proxy guidance should carry over to the Socket Mode version.

## Testing

Verified end-to-end on a local macOS install: followed the updated skill order, confirmed the adapter started before the Slack URL verification step, and confirmed the challenge passed on first attempt.