### PR TITLE
fix(delivery): don't permanently drop transient send failures after 3 fast retries

### DIFF
--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -36,7 +36,7 @@ import {
 } from './db/index.js';
 import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
-import { deliverSessionMessages, setDeliveryAdapter } from './delivery.js';
+import { deliverSessionMessages, setDeliveryAdapter, isTransientDeliveryError } from './delivery.js';
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
 
 function now(): string {
@@ -157,40 +157,89 @@ describe('deliverSessionMessages — concurrent invocations', () => {
 });
 
 describe('deliverSessionMessages — retry and permanent failure', () => {
-  it('retries on adapter failure and marks failed after MAX_DELIVERY_ATTEMPTS (3)', async () => {
+  it('keeps retrying a transient (network) failure past the old 3-attempt cap', async () => {
+    // Regression for silent drops on flaky links: a brief connectivity gap
+    // used to permanently drop the reply after 3 fast retries. Transient
+    // failures must now keep retrying (with backoff) within the horizon.
+    vi.useFakeTimers();
+    try {
+      seedAgentAndChannel();
+      const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+      insertOutbound('ag-1', session.id, 'out-net');
+
+      let callCount = 0;
+      setDeliveryAdapter({
+        async deliver() {
+          callCount++;
+          throw Object.assign(new Error('Network error calling Telegram sendMessage'), { type: 'NetworkError' });
+        },
+      });
+
+      // Drive several poll cycles, advancing past the (capped) backoff each time.
+      for (let i = 0; i < 6; i++) {
+        await deliverSessionMessages(session);
+        vi.advanceTimersByTime(60_000);
+      }
+
+      expect(callCount).toBeGreaterThan(3);
+      const inDb = openInboundDb('ag-1', session.id);
+      const failed = getDeliveredIds(inDb).has('out-net');
+      inDb.close();
+      expect(failed).toBe(false); // not permanently dropped within the horizon
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives up on a transient failure once the retry horizon elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      seedAgentAndChannel();
+      const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+      insertOutbound('ag-1', session.id, 'out-net-long');
+
+      setDeliveryAdapter({
+        async deliver() {
+          throw Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+        },
+      });
+
+      await deliverSessionMessages(session); // stamps firstFailedAt
+      vi.advanceTimersByTime(31 * 60_000); // past the 30-min horizon
+      await deliverSessionMessages(session); // this cycle gives up
+
+      const inDb = openInboundDb('ag-1', session.id);
+      const failed = getDeliveredIds(inDb).has('out-net-long');
+      inDb.close();
+      expect(failed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('marks a permanent (validation) failure failed after MAX_PERMANENT_ATTEMPTS (3)', async () => {
     seedAgentAndChannel();
     const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
-    insertOutbound('ag-1', session.id, 'out-flaky');
+    insertOutbound('ag-1', session.id, 'out-bad');
 
     let callCount = 0;
     setDeliveryAdapter({
       async deliver() {
         callCount++;
-        throw new Error('network timeout');
+        throw Object.assign(new Error("Bad Request: can't parse entities"), { type: 'ValidationError' });
       },
     });
 
-    // Attempt 1
     await deliverSessionMessages(session);
-    expect(callCount).toBe(1);
+    await deliverSessionMessages(session);
+    await deliverSessionMessages(session); // 3rd attempt → permanent failure
+    await deliverSessionMessages(session); // no-op, already marked failed
 
-    // Attempt 2
-    await deliverSessionMessages(session);
-    expect(callCount).toBe(2);
-
-    // Attempt 3 — should mark as permanently failed
-    await deliverSessionMessages(session);
     expect(callCount).toBe(3);
-
-    // Attempt 4 — message is now in delivered (as failed), adapter not called
-    await deliverSessionMessages(session);
-    expect(callCount).toBe(3);
-
-    // Verify the message is in the delivered table with 'failed' status
     const inDb = openInboundDb('ag-1', session.id);
-    const delivered = getDeliveredIds(inDb);
+    const failed = getDeliveredIds(inDb).has('out-bad');
     inDb.close();
-    expect(delivered.has('out-flaky')).toBe(true);
+    expect(failed).toBe(true);
   });
 
   it('does not acknowledge a message when no channel adapter is registered (#2995)', async () => {
@@ -252,6 +301,34 @@ describe('deliverSessionMessages — retry and permanent failure', () => {
     // Attempt 3 — not called, message already delivered
     await deliverSessionMessages(session);
     expect(callCount).toBe(2);
+  });
+});
+
+describe('isTransientDeliveryError', () => {
+  it('classifies network/timeout/5xx/429 failures as transient', () => {
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { type: 'NetworkError' }))).toBe(true);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { code: 'ETIMEDOUT' }))).toBe(true);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { code: 'ECONNRESET' }))).toBe(true);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { code: 'EAI_AGAIN' }))).toBe(true);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { status: 503 }))).toBe(true);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { status: 429 }))).toBe(true);
+    expect(isTransientDeliveryError(new Error('socket hang up'))).toBe(true);
+    expect(isTransientDeliveryError(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('classifies validation / permission / unknown failures as permanent', () => {
+    expect(
+      isTransientDeliveryError(
+        Object.assign(new Error("Bad Request: can't parse entities"), { type: 'ValidationError' }),
+      ),
+    ).toBe(false);
+    expect(isTransientDeliveryError(new Error('unauthorized channel destination: ag-1 cannot send to ...'))).toBe(
+      false,
+    );
+    expect(isTransientDeliveryError(new Error('unknown messaging group for telegram/telegram:1'))).toBe(false);
+    expect(isTransientDeliveryError(Object.assign(new Error('x'), { status: 400 }))).toBe(false);
+    expect(isTransientDeliveryError(null)).toBe(false);
+    expect(isTransientDeliveryError('boom')).toBe(false);
   });
 });
 

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -38,10 +38,88 @@ import type { PendingApproval, Session } from './types.js';
 
 const ACTIVE_POLL_MS = 1000;
 const SWEEP_POLL_MS = 60_000;
-const MAX_DELIVERY_ATTEMPTS = 3;
 
-/** Track delivery attempt counts. Resets on process restart (gives failed messages a fresh chance). */
-const deliveryAttempts = new Map<string, number>();
+// Delivery retry policy.
+//
+// A failed send is retried on subsequent polls. How long we keep retrying
+// depends on whether the failure looks transient:
+//
+//   - Permanent (validation / oversize / content-filtered / unauthorized
+//     destination): retrying can't help, so give up after
+//     MAX_PERMANENT_ATTEMPTS and mark the message failed.
+//   - Transient (network blip, timeout, connection reset, 5xx, 429): a brief
+//     connectivity gap must not permanently drop an agent's reply, so retry
+//     with exponential backoff until TRANSIENT_RETRY_HORIZON_MS has elapsed
+//     since the first failure. On a flaky uplink this is the difference
+//     between a delayed reply and a silently lost one (see #2423).
+//
+// Unrecognized errors are treated as permanent: we only extend the retry
+// horizon when we're confident a failure is transient, so an unknown
+// deterministic error can never wedge the queue in an unbounded retry loop.
+const MAX_PERMANENT_ATTEMPTS = 3;
+const TRANSIENT_RETRY_HORIZON_MS = 30 * 60_000;
+const RETRY_BACKOFF_BASE_MS = 1000;
+const RETRY_BACKOFF_CAP_MS = 60_000;
+
+interface DeliveryAttemptState {
+  attempts: number;
+  /** Epoch ms of the first failure — bounds the transient retry horizon. */
+  firstFailedAt: number;
+  /** Epoch ms before which the message should not be retried (backoff). */
+  nextRetryAt: number;
+}
+
+/** Per-message delivery attempt state. Cleared on success, permanent failure,
+ *  or process restart (a restart gives failed messages a fresh chance). */
+const deliveryAttempts = new Map<string, DeliveryAttemptState>();
+
+/** Exponential backoff (ms) for retry attempt N (1-based), capped. */
+function retryBackoffMs(attempts: number): number {
+  return Math.min(RETRY_BACKOFF_BASE_MS * 2 ** (attempts - 1), RETRY_BACKOFF_CAP_MS);
+}
+
+/**
+ * Classify a delivery error as transient (worth retrying past the permanent
+ * cap, with backoff) or permanent (give up quickly). Network-level failures,
+ * timeouts, and 429/5xx responses are transient; everything else — including
+ * unrecognized errors — is treated as permanent so the retry loop stays
+ * bounded. Exported for unit testing.
+ */
+export function isTransientDeliveryError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as {
+    name?: unknown;
+    type?: unknown;
+    code?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+    message?: unknown;
+  };
+  const tag = `${String(e.type ?? '')} ${String(e.name ?? '')}`.toLowerCase();
+  // Telegram 400 "can't parse entities", oversize, content filter, etc.
+  if (tag.includes('validation')) return false;
+  if (tag.includes('network') || tag.includes('timeout')) return true;
+  const code = String(e.code ?? '').toUpperCase();
+  if (
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ENETUNREACH' ||
+    code === 'ENETDOWN' ||
+    code === 'EAI_AGAIN' ||
+    code === 'EPIPE' ||
+    code === 'ECONNABORTED' ||
+    code.startsWith('UND_ERR')
+  ) {
+    return true;
+  }
+  const status = typeof e.status === 'number' ? e.status : typeof e.statusCode === 'number' ? e.statusCode : undefined;
+  if (status !== undefined && (status === 408 || status === 429 || status >= 500)) return true;
+  const msg = String(e.message ?? '').toLowerCase();
+  return /\b(network|timed?\s?out|timeout|socket hang up|fetch failed|connection (?:reset|refused|closed|timed out)|econnreset|etimedout|enetunreach|eai_again|temporarily|rate limit|too many requests)\b/.test(
+    msg,
+  );
+}
 
 /**
  * Sessions whose outbound queue is currently being drained.
@@ -200,6 +278,11 @@ async function drainSession(session: Session): Promise<void> {
     migrateDeliveredTable(inDb);
 
     for (const msg of undelivered) {
+      // Honor per-message backoff: a message that just failed a transient
+      // send is not retried until its backoff window has elapsed.
+      const backoffState = deliveryAttempts.get(msg.id);
+      if (backoffState && backoffState.nextRetryAt > Date.now()) continue;
+
       try {
         const platformMsgId = await deliverMessage(msg, session, inDb);
         markDelivered(inDb, msg.id, platformMsgId ?? null);
@@ -215,23 +298,36 @@ async function drainSession(session: Session): Promise<void> {
           pauseTypingRefreshAfterDelivery(session.id);
         }
       } catch (err) {
-        const attempts = (deliveryAttempts.get(msg.id) ?? 0) + 1;
-        deliveryAttempts.set(msg.id, attempts);
-        if (attempts >= MAX_DELIVERY_ATTEMPTS) {
+        const prev = deliveryAttempts.get(msg.id);
+        const now = Date.now();
+        const attempts = (prev?.attempts ?? 0) + 1;
+        const firstFailedAt = prev?.firstFailedAt ?? now;
+        const transient = isTransientDeliveryError(err);
+        // Transient failures retry until the time horizon elapses; permanent
+        // failures give up after a small fixed cap. Either way, once we give
+        // up the message is marked failed and never retried again.
+        const giveUp = transient
+          ? now - firstFailedAt >= TRANSIENT_RETRY_HORIZON_MS
+          : attempts >= MAX_PERMANENT_ATTEMPTS;
+        if (giveUp) {
           log.error('Message delivery failed permanently, giving up', {
             messageId: msg.id,
             sessionId: session.id,
             attempts,
+            transient,
             err,
           });
           markDeliveryFailed(inDb, msg.id);
           deliveryAttempts.delete(msg.id);
         } else {
+          const retryInMs = transient ? retryBackoffMs(attempts) : 0;
+          deliveryAttempts.set(msg.id, { attempts, firstFailedAt, nextRetryAt: now + retryInMs });
           log.warn('Message delivery failed, will retry', {
             messageId: msg.id,
             sessionId: session.id,
             attempt: attempts,
-            maxAttempts: MAX_DELIVERY_ATTEMPTS,
+            transient,
+            retryInMs,
             err,
           });
         }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What** — Distinguish transient from permanent outbound-delivery failures so a brief network blip no longer permanently drops an agent's reply.

**Why** — `deliverSessionMessages` retried *any* failure 3 times (~1s apart) and then called `markDeliveryFailed()` forever, with no distinction between a transient network error and a permanent one. On a flaky uplink this silently dropped fully-deliverable replies (the failing payloads delivered fine once the connection recovered — they were just never retried). Closes #3058; related to #2423.

**How it works**
- `isTransientDeliveryError()` classifies the caught error: network codes (`ETIMEDOUT`/`ECONNRESET`/`ENETUNREACH`/`EAI_AGAIN`/…), `NetworkError`/timeout tags, and `408`/`429`/`5xx` are transient; validation / oversize / unauthorized-destination and anything unrecognized are permanent — so an unknown deterministic error can't wedge the queue in an unbounded retry loop.
- Transient failures retry with exponential backoff (1s → 60s cap) until a 30-minute horizon; permanent failures give up after the existing 3-attempt cap. Backoff is honored via a per-message `nextRetryAt`.
- No behavior change on the permanent paths — validation errors, unauthorized destinations, and the missing-adapter case (#2995) still fail after 3.

**How it was tested**
- `pnpm exec vitest run src/delivery.test.ts` — 14 passed. New cases: transient failure keeps retrying past the old 3-cap; transient gives up after the horizon; permanent (validation) fails after 3; unit tests for the classifier.
- Full host suite: **1155 passed**. `tsc --noEmit` clean.
