### PR TITLE
fix(signal): send read receipts so senders see messages marked read

### DIFF
--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -33,6 +33,9 @@ function spawnSignalDaemon(cliPath: string, account: string, host: string, port:
   if (account) args.push('-a', account);
   args.push('daemon', '--tcp', `${host}:${port}`, '--no-receive-stdout');
   args.push('--receive-mode', 'on-start');
+  // Send read receipts (in addition to signal-cli's default delivery receipts)
+  // so senders see their messages marked read once the daemon receives them.
+  args.push('--send-read-receipts');
 
   const child = spawn(cliPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
   let exited = false;


### PR DESCRIPTION
**What** — Add `--send-read-receipts` to the signal-cli daemon args so NanoClaw emits read receipts, not only signal-cli's default delivery receipts.

**Why** — signal-cli defaults to delivery receipts only. On the sender's side that shows as delivered-but-unread (the hollow double-check on Signal) even after the agent has received and acted on the message — misleading for an assistant that did in fact read it. `--send-read-receipts` makes signal-cli send read receipts as messages arrive in `on-start` receive mode.

**Scope** — One line in `spawnSignalDaemon` (`src/channels/signal.ts`), alongside the existing daemon flags. No new dependencies; no behavior change beyond the receipt signal.

**Testing** — Running on a live v2 Signal install; after adding the flag, sent messages flip from delivered to read once the daemon receives them.

Checked open PRs/issues first — no existing work on read receipts.
