### PR TITLE
Fix/channel adapter startup swallow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to NanoClaw will be documented in this file.
 - **Per-exchange archiving is provider-owned** — the `onExchangeComplete` hook; the markdown writer ships with the codex payload.
 - **Container boot failures now say why** — the last stderr lines are logged at `warn` on a non-zero exit instead of a silent crash loop.
 - **Slash commands now interrupt an in-flight turn.** A runner-handled command (`/clear`, `/compact`, `/cost`, …) arriving mid-turn aborts the active stream and runs immediately instead of waiting out the turn.
+- **A channel adapter that fails to start now restarts the host instead of running deaf.** When a configured channel's setup fails at boot — a non-network error, or a network error that outlives the retry budget — `initChannelAdapters` throws instead of only logging, so the process exits non-zero and the supervisor + circuit breaker retry it. Previously the host reported healthy while silently missing that channel until a manual restart (#3064).
 
 ## [2.1.0] - 2026-06-07
 

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -356,3 +356,91 @@ describe('channel + router integration', () => {
     expect((mockAdapter.delivered[0].content as { text: string }).text).toBe('Agent response');
   });
 });
+
+describe('channel registry — startup failure (#3064)', () => {
+  // Fresh module per test: registry + activeAdapters are module-level, and
+  // these arms register adapters whose setup throws.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    const { teardownChannelAdapters } = await import('./channel-registry.js');
+    await teardownChannelAdapters();
+    vi.resetModules();
+  });
+
+  const mockSetup = () => ({
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  });
+
+  it('throws ChannelAdapterStartupError when a configured adapter fails setup', async () => {
+    const reg = await import('./channel-registry.js');
+    const bad = createMockAdapter('telegram');
+    bad.setup = async () => {
+      throw new Error('bad token');
+    };
+    reg.registerChannelAdapter('telegram', { factory: () => bad });
+
+    await expect(reg.initChannelAdapters(mockSetup)).rejects.toBeInstanceOf(reg.ChannelAdapterStartupError);
+  });
+
+  it('starts healthy adapters and reports only the failed one', async () => {
+    const reg = await import('./channel-registry.js');
+    const healthy = createMockAdapter('slack');
+    const bad = createMockAdapter('telegram');
+    bad.setup = async () => {
+      throw new Error('bad token');
+    };
+    reg.registerChannelAdapter('slack', { factory: () => healthy });
+    reg.registerChannelAdapter('telegram', { factory: () => bad });
+
+    let caught: unknown;
+    try {
+      await reg.initChannelAdapters(mockSetup);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(reg.ChannelAdapterStartupError);
+    expect((caught as InstanceType<typeof reg.ChannelAdapterStartupError>).channels).toEqual(['telegram']);
+    // The healthy adapter still came up before the aggregate throw.
+    expect(reg.getChannelAdapter('slack')).toBe(healthy);
+  });
+
+  it('does not treat missing credentials (null factory) as a failure', async () => {
+    const reg = await import('./channel-registry.js');
+    reg.registerChannelAdapter('no-creds', { factory: () => null });
+
+    await expect(reg.initChannelAdapters(mockSetup)).resolves.toBeUndefined();
+  });
+
+  it('retries a NetworkError, then throws once the retry budget is spent', async () => {
+    vi.useFakeTimers();
+    const reg = await import('./channel-registry.js');
+    let attempts = 0;
+    const bad = createMockAdapter('telegram');
+    bad.setup = async () => {
+      attempts += 1;
+      const err = new Error('dns hiccup at boot');
+      err.name = 'NetworkError';
+      throw err;
+    };
+    reg.registerChannelAdapter('telegram', { factory: () => bad });
+
+    const settled = reg
+      .initChannelAdapters(mockSetup)
+      .then(() => 'resolved')
+      .catch((err: unknown) => err);
+    await vi.runAllTimersAsync();
+    const result = await settled;
+
+    expect(result).toBeInstanceOf(reg.ChannelAdapterStartupError);
+    // 1 initial attempt + 3 retries (SETUP_RETRY_DELAYS_MS has three entries).
+    expect(attempts).toBe(4);
+  });
+});

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -228,11 +228,32 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
   return registry.get(name)?.containerConfig;
 }
 
+/** Thrown by initChannelAdapters when one or more registered adapters fail to
+ *  finish setup — a non-network error, or a network error that outlived the
+ *  retry budget. Propagated to the startup path (`main().catch` → exit 1) so a
+ *  boot that can't bring a configured channel up restarts under the supervisor
+ *  and circuit breaker, instead of running deaf: healthy on the surface but
+ *  silently missing that channel until someone restarts by hand (#3064).
+ *  Adapters that return null (missing credentials) are skipped, not failures. */
+export class ChannelAdapterStartupError extends Error {
+  constructor(readonly channels: string[]) {
+    super(
+      `Channel adapter(s) failed to start: ${channels.join(', ')}. ` +
+        `Refusing to run without a configured channel — restarting. ` +
+        `See the startup log above for each adapter's error.`,
+    );
+    this.name = 'ChannelAdapterStartupError';
+  }
+}
+
 /**
- * Instantiate and set up all registered channel adapters.
- * Skips adapters that return null (missing credentials).
+ * Instantiate and set up all registered channel adapters. Skips adapters that
+ * return null (missing credentials); throws ChannelAdapterStartupError if any
+ * configured adapter fails to start, so the failure reaches the supervisor
+ * instead of being swallowed (#3064).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
+  const failed: string[] = [];
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
@@ -278,8 +299,16 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
       activeAdapters.set(key, adapter);
       log.info('Channel adapter started', { channel: name, type: adapter.channelType, instance: key });
     } catch (err) {
+      // Log each adapter's own error for diagnostics and record the name, but
+      // keep going so a single boot surfaces every broken channel at once. The
+      // aggregate throw below escalates to the crash-recovery path.
       log.error('Failed to start channel adapter', { channel: name, err });
+      failed.push(name);
     }
+  }
+
+  if (failed.length > 0) {
+    throw new ChannelAdapterStartupError(failed);
   }
 }
 


### PR DESCRIPTION
## What
`initChannelAdapters` now propagates a channel adapter's startup failure instead of catching and only logging it. If any configured adapter fails to finish setup, boot throws `ChannelAdapterStartupError` and the process exits non-zero.

## Why
A channel whose setup failed at boot — e.g. Telegram after a reboot with delayed network, once the network-retry budget was spent — was logged then skipped, so the host reported healthy while running deaf on that channel. Because the process stayed alive, the supervisor's KeepAlive/Restart never fired, leaving the channel dead until a manual restart.

## How it works
Per-adapter failures are logged and collected; after the loop, a single `ChannelAdapterStartupError` naming every failed channel is thrown. It rides the existing startup path (`main().catch` → `exit 1`), so the supervisor + circuit breaker retry the boot with backoff. Missing credentials (a null factory) stay a benign skip, and the network-retry loop is unchanged, so transient blips are still absorbed before escalating.

## How it was tested
`pnpm test` (full host suite) and `pnpm typecheck` pass. Added `channel-registry.test.ts` cases: a failed adapter setup rejects with `ChannelAdapterStartupError`; a healthy adapter still starts while only the failed channel is reported; missing credentials stay a benign skip; a `NetworkError` is retried across the full budget before it escalates.

Closes #3064