### PR TITLE
feat: host-orchestrated fallback to a backup LLM provider on usage limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspac
 | [docs/skill-directives.md](docs/skill-directives.md) | `nc:` directive reference: fence grammar, the eight kinds, effects, guards, lint |
 | [docs/skill-engine-seam.md](docs/skill-engine-seam.md) | Skill-engine consumer contract (wizard / pipeline / agent-relay) + boundary-rule rationale |
 | [docs/templates.md](docs/templates.md) | Agent templates: what they are, stamping via `ncl groups create --template` + the setup wizard, the OneCLI/MCP-credential model, supported providers, and how to contribute one |
+| [docs/fallback.md](docs/fallback.md) | Automatic install-wide failover to a backup LLM provider (detection, switch, return probe, response guarantee, operator surface) |
 
 ## Container Build Cache
 

--- a/container/agent-runner/src/fallback-report.ts
+++ b/container/agent-runner/src/fallback-report.ts
@@ -1,0 +1,45 @@
+import { writeMessageOut } from './db/messages-out.js';
+import type { LimitClassification } from './limit-detect.js';
+
+function generateId(): string {
+  return `sys-fallback-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Thrown from processQuery when a provider signals a real usage limit
+ * (quota/billing/overload — not a transient per-minute rate limit). Caught
+ * by runPollLoop, which reports it to the host instead of surfacing a plain
+ * `Error:` chat message.
+ */
+export class ProviderLimitError extends Error {
+  constructor(
+    public readonly signal: { classification: LimitClassification; resetAt: number | null; message: string },
+    public readonly provider: string,
+  ) {
+    super(signal.message);
+    this.name = 'ProviderLimitError';
+  }
+}
+
+export interface FallbackReport {
+  classification: LimitClassification;
+  resetAt: number | null;
+  message: string;
+  provider: string;
+  /** Ids of the messages that were in flight when the limit hit — left `processing` for the host to re-present. */
+  messageIds: string[];
+}
+
+/**
+ * Reports a hit limit to the host via a `kind:'system'` outbound row (the
+ * `registerDeliveryAction` pattern — see src/delivery.ts and
+ * src/modules/fallback/index.ts, which registers the `fallback_report`
+ * handler).
+ */
+export function writeFallbackReport(report: FallbackReport): void {
+  writeMessageOut({
+    id: generateId(),
+    kind: 'system',
+    content: JSON.stringify({ action: 'fallback_report', ...report }),
+  });
+}

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -418,9 +418,19 @@ describe('poll loop — provider error recovery', () => {
     controller.abort();
 
     const out = getUndeliveredMessages();
-    expect(out).toHaveLength(1);
-    expect(JSON.parse(out[0].content).text).toContain('Error:');
-    expect(JSON.parse(out[0].content).text).toContain('API rate limit exceeded');
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    const chatMsg = out.find((m) => {
+      try { return 'text' in JSON.parse(m.content); } catch { return false; }
+    });
+    expect(chatMsg).toBeDefined();
+    expect(JSON.parse(chatMsg!.content).text).toContain('Error:');
+    expect(JSON.parse(chatMsg!.content).text).toContain('API rate limit exceeded');
+
+    // Also has a provider_error system action
+    const sysMsg = out.find((m) => {
+      try { return JSON.parse(m.content).action === 'provider_error'; } catch { return false; }
+    });
+    expect(sysMsg).toBeDefined();
 
     // Input message should be marked completed despite the error
     const pending = getPendingMessages();
@@ -447,8 +457,18 @@ describe('poll loop — stale session recovery', () => {
 
     // Error was written to outbound
     const out = getUndeliveredMessages();
-    expect(out).toHaveLength(1);
-    expect(JSON.parse(out[0].content).text).toContain('Error:');
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    const chatMsg = out.find((m) => {
+      try { return 'text' in JSON.parse(m.content); } catch { return false; }
+    });
+    expect(chatMsg).toBeDefined();
+    expect(JSON.parse(chatMsg!.content).text).toContain('Error:');
+
+    // Also has a provider_error system action
+    const sysMsg = out.find((m) => {
+      try { return JSON.parse(m.content).action === 'provider_error'; } catch { return false; }
+    });
+    expect(sysMsg).toBeDefined();
 
     // Continuation was cleared (isSessionInvalid returned true)
     expect(getContinuation('mock')).toBeUndefined();
@@ -551,7 +571,7 @@ describe('poll loop — slash command during active query', () => {
 
     const provider = new BlockingProvider();
     const controller = new AbortController();
-    const loopPromise = runPollLoopWithTimeout(provider as unknown as MockProvider, controller.signal, 3000);
+    const loopPromise = runPollLoopWithTimeout(provider as unknown as MockProvider, controller.signal, 8000);
 
     await waitFor(() => provider.queries === 1, 2000);
     insertMessage('m-clear-active', { sender: 'Alice', text: '/clear' }, { platformId: 'chan-1', channelType: 'discord' });
@@ -559,7 +579,7 @@ describe('poll loop — slash command during active query', () => {
     await waitFor(() => provider.aborts === 1, 2000);
     await waitFor(
       () => getUndeliveredMessages().some((msg) => JSON.parse(msg.content).text === 'Session cleared.'),
-      2000,
+      5000,
     );
     controller.abort();
 
@@ -570,6 +590,211 @@ describe('poll loop — slash command during active query', () => {
     await loopPromise.catch(() => {});
   });
 });
+
+/**
+ * Run poll-loop with a non-mock provider name so that ProviderLimitError
+ * triggers the real fallback path (the limit branch requires
+ * config.providerName === 'claude').
+ */
+function runLimitLoop(provider: unknown, signal: AbortSignal, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    runPollLoop({
+      provider: provider as MockProvider,
+      providerName: 'claude',
+      cwd: '/tmp',
+      signal,
+    }),
+    rejectOnAbort(signal),
+    rejectOnTimeout(timeoutMs),
+  ]);
+}
+
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    signal.addEventListener('abort', () => reject(new Error('aborted')));
+  });
+}
+
+function rejectOnTimeout(timeoutMs: number): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error('timeout')), timeoutMs);
+  });
+}
+
+describe('poll loop — provider limit fallback', () => {
+  it('writes fallback_report and keeps messages processing on quota limit', async () => {
+    insertMessage('m1', { sender: 'Alice', text: 'check limit' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new LimitEventProvider('quota');
+    const controller = new AbortController();
+    const loopPromise = runLimitLoop(provider, controller.signal, 5000);
+
+    await waitFor(() => {
+      return getUndeliveredMessages().some(
+        (msg) => JSON.parse(msg.content).action === 'fallback_report',
+      );
+    }, 5000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    const report = out.find((msg) => {
+      const c = JSON.parse(msg.content);
+      return c.action === 'fallback_report';
+    });
+    expect(report).toBeDefined();
+    const content = JSON.parse(report!.content);
+    expect(content.classification).toBe('quota');
+    expect(Array.isArray(content.messageIds)).toBe(true);
+    expect(content.messageIds).toContain('m1');
+
+    // No chat "Error:" message — the limit branch doesn't write one
+    const chatMessages = out.filter((msg) => {
+      try { return 'text' in JSON.parse(msg.content); } catch { return false; }
+    });
+    expect(chatMessages.length).toBe(0);
+
+    // Input message stays marked as 'processing' in ack (not completed)
+    // getPendingMessages won't find it because markProcessing() already
+    // created the ack row — check the ack table directly.
+    const ackRow = getOutboundDb()
+      .prepare('SELECT status FROM processing_ack WHERE message_id = ?')
+      .get('m1') as { status: string } | undefined;
+    expect(ackRow).toBeDefined();
+    expect(ackRow!.status).toBe('processing');
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('writes fallback_report on billing result path', async () => {
+    insertMessage('m1', { sender: 'Alice', text: 'check limit' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new BillingResultProvider();
+    const controller = new AbortController();
+    const loopPromise = runLimitLoop(provider, controller.signal, 5000);
+
+    await waitFor(() => {
+      return getUndeliveredMessages().some(
+        (msg) => JSON.parse(msg.content).action === 'fallback_report',
+      );
+    }, 5000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    const report = out.find((msg) => {
+      const c = JSON.parse(msg.content);
+      return c.action === 'fallback_report';
+    });
+    expect(report).toBeDefined();
+    const content = JSON.parse(report!.content);
+    expect(content.classification).toBe('billing');
+
+    const ackRow = getOutboundDb()
+      .prepare('SELECT status FROM processing_ack WHERE message_id = ?')
+      .get('m1') as { status: string } | undefined;
+    expect(ackRow).toBeDefined();
+    expect(ackRow!.status).toBe('processing');
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('writes provider_error action on generic (non-limit) errors', async () => {
+    insertMessage('m1', { sender: 'Alice', text: 'trigger error' }, { platformId: 'chan-1', channelType: 'discord' });
+
+    const provider = new ThrowingProvider('something crashed');
+    const controller = new AbortController();
+    const loopPromise = runLimitLoop(provider, controller.signal, 5000);
+
+    await waitFor(() => {
+      return getUndeliveredMessages().some(
+        (msg) => {
+          try { return JSON.parse(msg.content).action === 'provider_error'; } catch { return false; }
+        },
+      );
+    }, 5000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    const providerError = out.find((msg) => {
+      try { return JSON.parse(msg.content).action === 'provider_error'; } catch { return false; }
+    });
+    expect(providerError).toBeDefined();
+    const errContent = JSON.parse(providerError!.content);
+    expect(errContent.provider).toBe('claude');
+
+    // Also has a chat error message
+    const chatMsg = out.find((msg) => {
+      try { return 'text' in JSON.parse(msg.content); } catch { return false; }
+    });
+    expect(chatMsg).toBeDefined();
+    expect(JSON.parse(chatMsg!.content).text).toContain('something crashed');
+
+    // Generic error: message is completed (the notice closes the turn)
+    const pending = getPendingMessages();
+    expect(pending).toHaveLength(0);
+
+    await loopPromise.catch(() => {});
+  });
+});
+
+/**
+ * Provider that emits a limit error event, simulating Claude hitting a real
+ * usage limit (quota/billing/overload). Used to test the poll-loop's fallback
+ * report path.
+ */
+class LimitEventProvider {
+  readonly supportsNativeSlashCommands = false;
+  private event: { type: string; message: string; retryable: boolean; classification: string; resetAt?: number | null };
+
+  constructor(classification: string, message?: string) {
+    this.event = {
+      type: 'error',
+      message: message ?? `Limit reached: ${classification}`,
+      retryable: false,
+      classification,
+    };
+  }
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query() {
+    const ev = this.event;
+    return {
+      push() {},
+      end() {},
+      abort() {},
+      events: (async function* () {
+        yield { type: 'init' as const, continuation: 'limit-session' };
+        yield ev;
+      })(),
+    };
+  }
+}
+
+/**
+ * Provider that emits a result with isError: true and billing-pattern text,
+ * simulating the billing error path in claude.ts.
+ */
+class BillingResultProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  isSessionInvalid(): boolean {
+    return false;
+  }
+
+  query() {
+    return {
+      push() {},
+      end() {},
+      abort() {},
+      events: (async function* () {
+        yield { type: 'init' as const, continuation: 'billing-session' };
+        yield { type: 'result' as const, text: 'Your credit balance is too low to continue.', isError: true };
+      })(),
+    };
+  }
+}
 
 /**
  * Provider whose query never completes until ended/aborted — for testing how

--- a/container/agent-runner/src/limit-detect.test.ts
+++ b/container/agent-runner/src/limit-detect.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test';
+
+import { classifyErrorResultText, classifyRateLimitEvent, classifyRetryStreak } from './limit-detect.js';
+
+describe('classifyRateLimitEvent', () => {
+  it('returns null for non-object input', () => {
+    expect(classifyRateLimitEvent(null)).toBeNull();
+    expect(classifyRateLimitEvent(undefined)).toBeNull();
+    expect(classifyRateLimitEvent('rejected')).toBeNull();
+  });
+
+  it('returns null for an allowed or allowed_warning status (spec rule 2 — stays on the retry path)', () => {
+    expect(classifyRateLimitEvent({ status: 'allowed' })).toBeNull();
+    expect(classifyRateLimitEvent({ status: 'allowed_warning' })).toBeNull();
+  });
+
+  it('returns null for an unknown or missing status', () => {
+    expect(classifyRateLimitEvent({})).toBeNull();
+    expect(classifyRateLimitEvent({ status: 'ok' })).toBeNull();
+  });
+
+  it('classifies a rejected status as quota with no resetAt when absent', () => {
+    const signal = classifyRateLimitEvent({ status: 'rejected' });
+    expect(signal).not.toBeNull();
+    expect(signal?.classification).toBe('quota');
+    expect(signal?.resetAt).toBeNull();
+  });
+
+  it('classifies a rejected status as quota and converts resetsAt seconds to ms', () => {
+    const signal = classifyRateLimitEvent({ status: 'rejected', resetsAt: 1_700_000_000 });
+    expect(signal?.classification).toBe('quota');
+    expect(signal?.resetAt).toBe(1_700_000_000 * 1000);
+  });
+
+  it('accepts snake_case and camelCase reset field aliases', () => {
+    expect(classifyRateLimitEvent({ status: 'rejected', reset_at: 100 })?.resetAt).toBe(100_000);
+    expect(classifyRateLimitEvent({ status: 'rejected', resetAt: 200 })?.resetAt).toBe(200_000);
+  });
+
+  it('is case-insensitive on status', () => {
+    expect(classifyRateLimitEvent({ status: 'REJECTED' })?.classification).toBe('quota');
+  });
+
+  it('falls back to a generated message when none is provided', () => {
+    const signal = classifyRateLimitEvent({ status: 'rejected' });
+    expect(signal?.message).toContain('rejected');
+  });
+
+  it('uses the provided message when present', () => {
+    const signal = classifyRateLimitEvent({ status: 'rejected', message: 'custom text' });
+    expect(signal?.message).toBe('custom text');
+  });
+});
+
+describe('classifyErrorResultText', () => {
+  it('returns null for empty text', () => {
+    expect(classifyErrorResultText('')).toBeNull();
+  });
+
+  it('returns null for text with no billing signal', () => {
+    expect(classifyErrorResultText('some unrelated error')).toBeNull();
+  });
+
+  it('classifies billing-pattern text as billing with no resetAt', () => {
+    const signal = classifyErrorResultText('Your credit balance is too low');
+    expect(signal).not.toBeNull();
+    expect(signal?.classification).toBe('billing');
+    expect(signal?.resetAt).toBeNull();
+    expect(signal?.message).toBe('Your credit balance is too low');
+  });
+
+  it('matches on insufficient credit and payment phrasing too', () => {
+    expect(classifyErrorResultText('insufficient credit to continue')?.classification).toBe('billing');
+    expect(classifyErrorResultText('payment required')?.classification).toBe('billing');
+  });
+
+  it('is case-insensitive', () => {
+    expect(classifyErrorResultText('BILLING ISSUE')?.classification).toBe('billing');
+  });
+});
+
+describe('classifyRetryStreak', () => {
+  it('returns null below both the streak-count and elapsed-time thresholds', () => {
+    const now = 1_000_000;
+    expect(classifyRetryStreak(3, now, now + 60_000)).toBeNull();
+  });
+
+  it('classifies as overload once the streak reaches 6', () => {
+    const now = 1_000_000;
+    const signal = classifyRetryStreak(6, now, now + 10_000);
+    expect(signal?.classification).toBe('overload');
+    expect(signal?.resetAt).toBeNull();
+  });
+
+  it('classifies as overload once 5 minutes have elapsed, regardless of streak count', () => {
+    const now = 1_000_000;
+    const signal = classifyRetryStreak(2, now, now + 5 * 60_000 + 1);
+    expect(signal?.classification).toBe('overload');
+  });
+
+  it('does not fire at exactly 5 minutes elapsed (strict greater-than)', () => {
+    const now = 1_000_000;
+    expect(classifyRetryStreak(2, now, now + 5 * 60_000)).toBeNull();
+  });
+
+  it('includes the streak count and elapsed seconds in the message', () => {
+    const now = 1_000_000;
+    const signal = classifyRetryStreak(6, now, now + 12_000);
+    expect(signal?.message).toContain('6');
+    expect(signal?.message).toContain('12s');
+  });
+});

--- a/container/agent-runner/src/limit-detect.ts
+++ b/container/agent-runner/src/limit-detect.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure classification of provider signals that mean "Claude has hit a real
+ * usage limit" (as opposed to a transient per-minute rate limit the SDK
+ * already retries on its own). Used by providers/claude.ts to decide when
+ * to surface a non-retryable limit error instead of a plain retryable one.
+ */
+export type LimitClassification = 'quota' | 'billing' | 'overload';
+
+export interface LimitSignal {
+  classification: LimitClassification;
+  /** Epoch ms the limit is expected to reset, if known. */
+  resetAt: number | null;
+  message: string;
+}
+
+// Only 'rejected' means the request was actually blocked. SDK status is
+// 'allowed' | 'allowed_warning' | 'rejected' — the first two mean the
+// request went through and are not a fallback trigger (spec rule 2).
+const BLOCKING_STATUSES = new Set(['rejected']);
+
+/**
+ * Classifies a `rate_limit_event`.rate_limit_info payload. Returns null
+ * for anything that isn't an actual block (unknown/missing status, or
+ * 'allowed'/'allowed_warning').
+ */
+export function classifyRateLimitEvent(raw: unknown): LimitSignal | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  const status = typeof obj.status === 'string' ? obj.status.toLowerCase() : '';
+  if (!BLOCKING_STATUSES.has(status)) return null;
+
+  const resetsAtRaw = obj.resetsAt ?? obj.reset_at ?? obj.resetAt;
+  const resetAt = typeof resetsAtRaw === 'number' && Number.isFinite(resetsAtRaw) ? resetsAtRaw * 1000 : null;
+
+  const message = typeof obj.message === 'string' ? obj.message : `rate limit event: ${status}`;
+  return { classification: 'quota', resetAt, message };
+}
+
+const BILLING_PATTERN = /billing|credit balance|insufficient credit|payment/i;
+
+/** Classifies a `result` event's error text — billing/credit exhaustion doesn't resolve on its own. */
+export function classifyErrorResultText(text: string): LimitSignal | null {
+  if (!text) return null;
+  if (BILLING_PATTERN.test(text)) {
+    return { classification: 'billing', resetAt: null, message: text };
+  }
+  return null;
+}
+
+/**
+ * A streak of consecutive `api_retry` system events with no successful
+ * progress in between usually means the service is persistently overloaded
+ * (the SDK's own retry loop can't get through). This is the primary
+ * anti-block defense — it fires well before the 10-minute host backstop.
+ */
+export function classifyRetryStreak(streak: number, firstAtMs: number, nowMs: number): LimitSignal | null {
+  const elapsedMs = nowMs - firstAtMs;
+  if (streak >= 6 || elapsedMs > 5 * 60_000) {
+    return {
+      classification: 'overload',
+      resetAt: null,
+      message: `${streak} consecutive API retries over ${Math.round(elapsedMs / 1000)}s`,
+    };
+  }
+  return null;
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -26,6 +26,10 @@ import {
 } from './formatter.js';
 import { isUploadTraceCommand, uploadTrace } from './upload-trace.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderExchange } from './providers/types.js';
+import { ProviderLimitError, writeFallbackReport } from './fallback-report.js';
+import { classifyErrorResultText, type LimitClassification } from './limit-detect.js';
+
+const LIMIT_CLASSIFICATIONS = new Set<string>(['quota', 'billing', 'overload'] satisfies LimitClassification[]);
 
 const POLL_INTERVAL_MS = 1000;
 const ACTIVE_POLL_INTERVAL_MS = 500;
@@ -249,6 +253,7 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
     // Publish the batch's in_reply_to so MCP tools (send_message, send_file)
     // can stamp it on outbound rows — needed for a2a return-path routing.
     setCurrentInReplyTo(routing.inReplyTo);
+    let limitAbort = false;
     try {
       const result = await processQuery(
         query,
@@ -276,27 +281,59 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         clearContinuation(config.providerName);
       }
 
-      // Write error response so the user knows something went wrong
-      writeMessageOut({
-        id: generateId(),
-        kind: 'chat',
-        platform_id: routing.platformId,
-        channel_type: routing.channelType,
-        thread_id: routing.threadId,
-        content: JSON.stringify({ text: `Error: ${errMsg}` }),
-      });
+      if (err instanceof ProviderLimitError && (config.providerName === 'claude' || config.providerName === 'mock')) {
+        // Real usage limit on the native provider: no chat "Error:" message
+        // (the switch notice, delivered host-side, replaces it), skip the
+        // final markCompleted below so these rows stay 'processing' — the
+        // host re-presents them to the backup provider without bumping
+        // `tries` — then drain until the host kills this container.
+        limitAbort = true;
+        log(`Provider limit hit (${err.signal.classification}) — reporting to host`);
+        writeFallbackReport({
+          classification: err.signal.classification,
+          resetAt: err.signal.resetAt,
+          message: err.signal.message,
+          provider: config.providerName,
+          messageIds: processingIds,
+        });
+        while (!config.signal?.aborted) {
+          await sleep(1000);
+        }
+      } else {
+        // Write error response so the user knows something went wrong.
+        // Also fire a `provider_error` system action alongside it — the
+        // fallback module uses it to detect a failed return probe or a
+        // double-fault (backup provider also failing) without a second
+        // chat message (this one already closes the turn out).
+        writeMessageOut({
+          id: generateId(),
+          kind: 'chat',
+          platform_id: routing.platformId,
+          channel_type: routing.channelType,
+          thread_id: routing.threadId,
+          content: JSON.stringify({ text: `Error: ${errMsg}` }),
+        });
+        writeMessageOut({
+          id: generateId(),
+          kind: 'system',
+          content: JSON.stringify({ action: 'provider_error', provider: config.providerName, message: errMsg }),
+        });
 
-      // The batch is still acked completed below (no redelivery). Without
-      // this line the only log trace of the errored turn is "Query error"
-      // followed by a "Completed" line that reads like success.
-      log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
+        // The batch is still acked completed below (no redelivery). Without
+        // this line the only log trace of the errored turn is "Query error"
+        // followed by a "Completed" line that reads like success.
+        log(`Errored batch will be acked completed — ${processingIds.length} message(s), no redelivery`);
+      }
     } finally {
       clearCurrentInReplyTo();
     }
 
     // Ensure completed even if processQuery ended without a result event
-    // (e.g. stream closed unexpectedly).
-    markCompleted(processingIds);
+    // (e.g. stream closed unexpectedly). Skipped on a limit-abort — those
+    // rows must stay 'processing' for the host to re-present them.
+    if (!limitAbort) {
+      markCompleted(processingIds);
+    }
     log(`Completed ${ids.length} message(s)`);
   }
 }
@@ -493,7 +530,31 @@ export async function processQuery(
         // effectively orphaned and the next message started a blank
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
+      } else if (
+        event.type === 'error' &&
+        !event.retryable &&
+        event.classification &&
+        LIMIT_CLASSIFICATIONS.has(event.classification)
+      ) {
+        // A real usage limit (quota/billing/overload), not a transient
+        // per-minute rate limit — abort the stream and let the outer catch
+        // report it to the host instead of retrying forever.
+        query.abort();
+        throw new ProviderLimitError(
+          {
+            classification: event.classification as LimitClassification,
+            resetAt: event.resetAt ?? null,
+            message: event.message,
+          },
+          providerName,
+        );
       } else if (event.type === 'result') {
+        if (event.isError === true && event.text) {
+          const billingSignal = classifyErrorResultText(event.text);
+          if (billingSignal) {
+            throw new ProviderLimitError(billingSignal, providerName);
+          }
+        }
         // A result — with or without text — means the turn is done. Mark
         // the initial batch completed now so the host sweep doesn't see
         // stale 'processing' claims while the query stays open for

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
 import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { classifyRateLimitEvent, classifyRetryStreak } from '../limit-detect.js';
 import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
 import { TIMEZONE, formatLocalStamp } from '../timezone.js';
 import { registerProvider } from './provider-registry.js';
@@ -519,12 +520,22 @@ export class ClaudeProvider implements AgentProvider {
 
     async function* translateEvents(): AsyncGenerator<ProviderEvent> {
       let messageCount = 0;
+      // Tracks consecutive api_retry system events with no intervening
+      // progress — a long streak means the SDK's own retry loop can't get
+      // through (persistent overload), not a transient blip.
+      let retryStreak = 0;
+      let retryStreakFirstAt = 0;
       for await (const message of sdkResult) {
         if (aborted) return;
         messageCount++;
 
         // Yield activity for every SDK event so the poll loop knows the agent is working
         yield { type: 'activity' };
+
+        const subtype = message.type === 'system' ? (message as { subtype?: string }).subtype : undefined;
+        if (subtype !== 'api_retry') {
+          retryStreak = 0;
+        }
 
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
@@ -536,10 +547,35 @@ export class ClaudeProvider implements AgentProvider {
           const m = message as { result?: string; is_error?: boolean; errors?: string[] };
           const text = m.result ?? (m.errors && m.errors.length > 0 ? m.errors.join('\n') : null);
           yield { type: 'result', text, isError: m.is_error === true };
-        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
-          yield { type: 'error', message: 'API retry', retryable: true };
+        } else if (subtype === 'api_retry') {
+          if (retryStreak === 0) retryStreakFirstAt = Date.now();
+          retryStreak++;
+          const overload = classifyRetryStreak(retryStreak, retryStreakFirstAt, Date.now());
+          if (overload) {
+            yield {
+              type: 'error',
+              message: overload.message,
+              retryable: false,
+              classification: overload.classification,
+              resetAt: overload.resetAt,
+            };
+          } else {
+            yield { type: 'error', message: 'API retry', retryable: true };
+          }
         } else if (message.type === 'rate_limit_event') {
-          yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
+          const rateInfo = (message as { rate_limit_info?: unknown }).rate_limit_info;
+          if (rateInfo && typeof rateInfo === 'object') {
+            const signal = classifyRateLimitEvent(rateInfo);
+            if (signal) {
+              yield {
+                type: 'error',
+                message: signal.message,
+                retryable: false,
+                classification: signal.classification,
+                resetAt: signal.resetAt,
+              };
+            }
+          }
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
           const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -3,3 +3,5 @@
 // level. Skills add a new provider by appending one import line below.
 
 import './claude.js';
+import './mock.js';
+import './ollama.js';

--- a/container/agent-runner/src/providers/mock.test.ts
+++ b/container/agent-runner/src/providers/mock.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test';
+
+import { MockProvider } from './mock.js';
+import type { MockFailMode } from './mock.js';
+import type { ProviderEvent } from './types.js';
+
+/**
+ * Collect only the initial events from a MockProvider query (before the
+ * wait-for-push loop).  After the first error or result event we call
+ * query.end() so the while-loop exits.
+ */
+async function collectInitialEvents(query: ReturnType<MockProvider['query']>): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const ev of query.events) {
+    events.push(ev);
+    if (ev.type === 'result' || ev.type === 'error') {
+      query.end();
+    }
+  }
+  return events;
+}
+
+describe('MockProvider — fail simulation', () => {
+  it('emits normal result when no failMode is set', async () => {
+    const provider = new MockProvider({}, undefined, null);
+    const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+    const events = await collectInitialEvents(query);
+
+    const results = events.filter((e) => e.type === 'result');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].isError).toBeUndefined();
+  });
+
+  it('emits quota error event when failMode=quota', async () => {
+    const provider = new MockProvider({}, undefined, 'quota');
+    const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+    const events = await collectInitialEvents(query);
+
+    const errors = events.filter((e) => e.type === 'error');
+    expect(errors.length).toBe(1);
+    expect(errors[0].classification).toBe('quota');
+    expect(errors[0].retryable).toBe(false);
+    expect(errors[0].message).toContain('limit');
+
+    const results = events.filter((e) => e.type === 'result' && !e.isError);
+    expect(results.length).toBe(0);
+  });
+
+  it('emits billing result when failMode=billing', async () => {
+    const provider = new MockProvider({}, undefined, 'billing');
+    const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+    const events = await collectInitialEvents(query);
+
+    const results = events.filter((e) => e.type === 'result' && e.isError === true);
+    expect(results.length).toBe(1);
+    expect(results[0].text).toContain('credit balance');
+  });
+
+  it('emits overload error event when failMode=overload', async () => {
+    const provider = new MockProvider({}, undefined, 'overload');
+    const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+    const events = await collectInitialEvents(query);
+
+    const errors = events.filter((e) => e.type === 'error');
+    expect(errors.length).toBe(1);
+    expect(errors[0].classification).toBe('overload');
+    expect(errors[0].message).toContain('overload');
+  });
+
+  it('includes resetAt when MOCK_RESET_AT env is set with failMode=quota', async () => {
+    process.env.MOCK_RESET_AT = '1700000000';
+    try {
+      const provider = new MockProvider({}, undefined, 'quota');
+      const query = provider.query({ prompt: 'hello', cwd: '/tmp' });
+      const events = await collectInitialEvents(query);
+
+      const errors = events.filter((e) => e.type === 'error');
+      expect(errors[0].resetAt).toBe(1_700_000_000 * 1000);
+      expect(errors[0].message).toContain('2023');
+    } finally {
+      delete process.env.MOCK_RESET_AT;
+    }
+  });
+
+  it('reverts to normal response on second query (fail only first turn)', async () => {
+    const provider = new MockProvider({}, undefined, 'quota');
+
+    const q1 = provider.query({ prompt: 'first', cwd: '/tmp' });
+    const e1 = await collectInitialEvents(q1);
+    expect(e1.filter((e) => e.type === 'error').length).toBe(1);
+
+    const q2 = provider.query({ prompt: 'second', cwd: '/tmp' });
+    const e2 = await collectInitialEvents(q2);
+    const results = e2.filter((e) => e.type === 'result' && !e.isError);
+    expect(results.length).toBe(1);
+    expect(results[0].text).toContain('second');
+  });
+});

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -2,17 +2,64 @@ import { registerProvider } from './provider-registry.js';
 import type { MemorySessionHookRegistration } from '../memory/session-hook.js';
 import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
+export type MockFailMode = 'quota' | 'billing' | 'overload';
+
+function parseFailMode(): MockFailMode | null {
+  const raw = process.env.MOCK_PROVIDER_FAIL?.trim().toLowerCase();
+  if (raw === 'quota' || raw === 'billing' || raw === 'overload') return raw;
+  return null;
+}
+
+function parseResetAt(): number | null {
+  const raw = process.env.MOCK_RESET_AT;
+  if (raw === undefined || raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function failEvents(mode: MockFailMode): ProviderEvent[] {
+  const resetAt = parseResetAt();
+  const ts = resetAt ? new Date(resetAt * 1000).toISOString() : 'unknown';
+
+  if (mode === 'billing') {
+    return [
+      { type: 'result', text: `Your credit balance is too low to continue. Please top up to resume.`, isError: true } as ProviderEvent,
+    ];
+  }
+
+  return [
+    {
+      type: 'error',
+      message: mode === 'quota'
+        ? `Usage limit reached — resets at ${ts}`
+        : `API overload: 6 consecutive retries over 300s`,
+      retryable: false,
+      classification: mode,
+      resetAt: resetAt ? resetAt * 1000 : null,
+    } as ProviderEvent,
+  ];
+}
+
 /**
  * Mock provider for testing. Returns canned responses.
- * Supports push() — queued messages produce additional results.
+ *
+ * When `MOCK_PROVIDER_FAIL=quota|billing|overload`, simulates a provider
+ * limit error that triggers the fallback flow (spec A10). `MOCK_RESET_AT`
+ * (unix seconds) sets the limit reset time.
+ *
+ * In tests, pass failMode directly to the constructor to avoid env-var
+ * cross-contamination between test cases.
  */
 export class MockProvider implements AgentProvider {
   readonly supportsNativeSlashCommands = false;
 
   private responseFactory: (prompt: string) => string;
+  private failMode: MockFailMode | null;
+  private failConsumed = false;
 
-  constructor(_options: ProviderOptions = {}, responseFactory?: (prompt: string) => string) {
+  constructor(_options: ProviderOptions = {}, responseFactory?: (prompt: string) => string, failMode?: MockFailMode | null) {
     this.responseFactory = responseFactory ?? ((prompt) => `Mock response to: ${prompt.slice(0, 100)}`);
+    this.failMode = failMode !== undefined ? failMode : parseFailMode();
   }
 
   registerMemorySessionHook(_hook: MemorySessionHookRegistration): void {}
@@ -27,31 +74,37 @@ export class MockProvider implements AgentProvider {
     let ended = false;
     let aborted = false;
     const responseFactory = this.responseFactory;
+    const shouldFail = this.failMode && !this.failConsumed;
+    const failMode = this.failMode;
+    this.failConsumed = true;
 
     const events: AsyncIterable<ProviderEvent> = {
       async *[Symbol.asyncIterator]() {
         yield { type: 'activity' };
         yield { type: 'init', continuation: `mock-session-${Date.now()}` };
 
-        // Process initial prompt
-        yield { type: 'activity' };
-        yield { type: 'result', text: responseFactory(input.prompt) };
+        if (shouldFail) {
+          yield { type: 'activity' };
+          for (const ev of failEvents(failMode!)) {
+            yield ev;
+          }
+        } else {
+          yield { type: 'activity' };
+          yield { type: 'result', text: responseFactory(input.prompt) };
+        }
 
-        // Process any pushed follow-ups
         while (!ended && !aborted) {
           if (pending.length > 0) {
             const msg = pending.shift()!;
             yield { type: 'result', text: responseFactory(msg) };
             continue;
           }
-          // Wait for push() or end()
           await new Promise<void>((resolve) => {
             waiting = resolve;
           });
           waiting = null;
         }
 
-        // Drain remaining
         while (pending.length > 0) {
           const msg = pending.shift()!;
           yield { type: 'result', text: responseFactory(msg) };

--- a/container/agent-runner/src/providers/ollama.ts
+++ b/container/agent-runner/src/providers/ollama.ts
@@ -1,0 +1,39 @@
+import { ClaudeProvider } from './claude.js';
+import { registerProvider } from './provider-registry.js';
+import type { ProviderOptions } from './types.js';
+
+function mergeNoProxy(current: string | undefined, additions: string): string {
+  if (!current?.trim()) return additions;
+  const parts = new Set(
+    current
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  for (const addition of additions.split(',')) {
+    const trimmed = addition.trim();
+    if (trimmed) parts.add(trimmed);
+  }
+  return [...parts].join(',');
+}
+
+class OllamaProvider extends ClaudeProvider {
+  constructor(options: ProviderOptions = {}) {
+    const baseUrl = process.env.OLLAMA_BASE_URL || 'http://host.docker.internal:11434';
+    const ollamaModel = process.env.OLLAMA_MODEL || '';
+
+    super({
+      ...options,
+      model: ollamaModel || options.model,
+      env: {
+        ...(options.env ?? {}),
+        ANTHROPIC_BASE_URL: baseUrl,
+        ANTHROPIC_API_KEY: 'ollama',
+        NO_PROXY: mergeNoProxy(options.env?.NO_PROXY, 'host.docker.internal'),
+        no_proxy: mergeNoProxy(options.env?.no_proxy, 'host.docker.internal'),
+      },
+    });
+  }
+}
+
+registerProvider('ollama', (opts) => new OllamaProvider(opts));

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -129,7 +129,7 @@ export type ProviderEvent =
    * dropping it as un-wrapped scratchpad, and to skip the re-wrap nudge.
    */
   | { type: 'result'; text: string | null; isError?: boolean }
-  | { type: 'error'; message: string; retryable: boolean; classification?: string }
+  | { type: 'error'; message: string; retryable: boolean; classification?: string; resetAt?: number | null }
   | { type: 'progress'; message: string }
   /**
    * Liveness signal. Providers MUST yield this on every underlying SDK

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -1,0 +1,99 @@
+# Provider Fallback
+
+Automatic install-wide failover to a backup LLM provider when the native
+provider (Claude) hits a real usage limit — quota exhausted, billing failure,
+or persistent API overload. Transient per-minute rate limits do **not**
+trigger a switch.
+
+## How it works
+
+The mechanism is host-orchestrated with container-side detection:
+
+1. **Detection (container).** The agent-runner classifies provider stream
+   events (`container/agent-runner/src/limit-detect.ts`):
+   - `rate_limit_event` with status `rejected` → `quota`
+   - a streak of ≥6 consecutive `api_retry` events (or >5 minutes with no
+     progress) → `overload`
+   - an error result matching billing text (`billing`, `credit balance`,
+     `insufficient credit`, `payment`) → `billing`
+
+   On a hit, `processQuery` throws `ProviderLimitError`; the poll loop writes
+   a `fallback_report` system action to `outbound.db`, leaves the claimed
+   messages in `processing`, and drains until the host kills the container.
+
+2. **Switch (host).** `handleFallbackReport` (`src/modules/fallback/controller.ts`)
+   enters fallback: persists the state in the `fallback_state` table (single
+   row, id=1), re-presents the stuck messages (back to `pending`, no `tries`
+   bump), writes a degradation fragment into every group's `.claude-fragments/`,
+   queues a switch notice for the origin conversation, and restarts all
+   containers. On respawn, `applyProviderOverride` (`src/provider-override.ts`)
+   substitutes the backup provider for the native one.
+
+3. **Return (host sweep).** Every 60s, `sweepFallbackReturn` drives a probe
+   state machine: when the retry time arrives, the origin session is restarted
+   on the native provider for one turn. A clean turn exits fallback everywhere;
+   a failed or timed-out probe re-schedules with backoff (5, 10, 20, 40, 60
+   minutes).
+
+4. **Safety net (host sweep).** `sweepFallbackSession` enforces a response
+   guarantee: any trigger message stuck `pending`/`processing` for more than
+   10 minutes forces fallback entry even if the container never reported —
+   covering wedged or crashed containers.
+
+## Configuration
+
+Set in `.env`:
+
+```bash
+FALLBACK_PROVIDER=ollama        # or: opencode
+OLLAMA_MODEL=qwen3:14b          # required for ollama
+OLLAMA_BASE_URL=http://host.docker.internal:11434   # optional, this is the default
+# OPENCODE_MODEL=...            # required when FALLBACK_PROVIDER=opencode
+```
+
+With no `FALLBACK_PROVIDER` configured, limit events produce an owner notice
+explaining that no backup is available; nothing else changes.
+
+The `ollama` provider ships with this module (`src/providers/ollama.ts`,
+`container/agent-runner/src/providers/ollama.ts`): Ollama speaks the Anthropic
+API natively, so the provider is the Claude provider pointed at the local
+endpoint via `ANTHROPIC_BASE_URL`. A local model keeps the fallback path
+working even when the outage is network- or billing-wide.
+
+## Operator surface
+
+- **Chat (owner-only):** `/fallback` or `/fallback status`, `/fallback force`,
+  `/fallback return`. Handled entirely host-side (`src/modules/fallback/commands.ts`)
+  so they work while the native provider is down.
+- **CLI:** `ncl fallback status|force|return` (`src/modules/fallback/cli.ts`).
+- **Notices:** the owner gets a message on switch, on return, and on
+  double-fault (backup also failing). The switch notice for the origin
+  conversation is prepended to the first real response (`fallback_pending_notices`
+  table) rather than sent as a standalone message.
+- **Audit:** every transition is logged to the `fallback_events` table.
+
+## Context continuity
+
+On switch, the module builds a short summary of the recent conversation
+(`src/modules/fallback/summary.ts`) and delivers it to the backup provider as
+an on-wake briefing, so the first fallback turn doesn't start blind. A
+degradation fragment (`.claude-fragments/zz-fallback.md`) tells the agent it
+is running on the backup model and to answer identity questions truthfully.
+
+## State
+
+- `fallback_state` (central DB, single row): active flag, mode (auto/forced),
+  classification, backup provider/model, probe bookkeeping, retry schedule.
+- `fallback_events` (central DB): append-only transition log.
+- `fallback_pending_notices` (per-session `inbound.db`): switch notice awaiting
+  prepend-on-delivery.
+
+## Testing
+
+- Unit: `src/modules/fallback/*.test.ts` (state machine, decision logic,
+  notices, commands, override), `container/agent-runner/src/limit-detect.test.ts`.
+- Integration: `container/agent-runner/src/integration.test.ts` (poll-loop
+  limit paths), `container/agent-runner/src/providers/mock.test.ts`.
+- End-to-end: the mock provider simulates limits via `MOCK_PROVIDER_FAIL=quota|billing|overload`
+  and `MOCK_RESET_AT` (unix seconds), forwarded to containers only when
+  `NODE_ENV !== 'production'`.

--- a/docs/fallback.md
+++ b/docs/fallback.md
@@ -45,14 +45,25 @@ The mechanism is host-orchestrated with container-side detection:
 Set in `.env`:
 
 ```bash
-FALLBACK_PROVIDER=ollama        # or: opencode
+# Local backup (ships with this module):
+FALLBACK_PROVIDER=ollama
 OLLAMA_MODEL=qwen3:14b          # required for ollama
 OLLAMA_BASE_URL=http://host.docker.internal:11434   # optional, this is the default
-# OPENCODE_MODEL=...            # required when FALLBACK_PROVIDER=opencode
+
+# Or a cloud backup through OpenCode (requires /add-opencode):
+# FALLBACK_PROVIDER=opencode
+# OPENCODE_MODEL=openrouter/deepseek/deepseek-v4-pro   # any model OpenCode can route
 ```
 
 With no `FALLBACK_PROVIDER` configured, limit events produce an owner notice
 explaining that no backup is available; nothing else changes.
+
+The `opencode` backup works with any provider OpenCode itself supports —
+OpenRouter, OpenAI, Google, DeepSeek, a direct provider API key, etc. — the
+`OPENCODE_MODEL` value is just OpenCode's `provider/model` reference, and
+credentials follow the normal OpenCode configuration (OneCLI vault / env).
+No OpenRouter account is required if you point OpenCode at a provider
+directly.
 
 The `ollama` provider ships with this module (`src/providers/ollama.ts`,
 `container/agent-runner/src/providers/ollama.ts`): Ollama speaks the Anthropic

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -20,6 +20,7 @@ import { GROUPS_DIR } from './config.js';
 import type { McpServerConfig } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { readGroupPersona } from './group-persona.js';
+import { FALLBACK_FRAGMENT_NAME } from './modules/fallback/fragment.js';
 import type { AgentGroup } from './types.js';
 
 // Fragment holding a template's persona prepend. Imported FIRST (before the
@@ -116,6 +117,18 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
   const persona = readGroupPersona(groupDir);
   if (persona) {
     desired.set(PERSONA_FRAGMENT, { type: 'inline', content: persona });
+  }
+
+  // The fallback module writes its degradation-notice fragment straight to
+  // disk (not through this compose step) because non-Claude providers read
+  // fragments via glob, not the composed CLAUDE.md. Preserve it here the same
+  // way persona.md is preserved, or the prune below would delete it on the
+  // next spawn while fallback is still active. Tier inversion (this file has
+  // no other module dependency) — same precedent as approvals/primitive.ts
+  // importing from the permissions module.
+  const fallbackFragmentPath = path.join(fragmentsDir, FALLBACK_FRAGMENT_NAME);
+  if (fs.existsSync(fallbackFragmentPath)) {
+    desired.set(FALLBACK_FRAGMENT_NAME, { type: 'inline', content: fs.readFileSync(fallbackFragmentPath, 'utf-8') });
   }
 
   // Reconcile: drop stale, write desired.

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import { GROUPS_DIR } from './config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
+import { applyProviderOverride } from './provider-override.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
 export interface McpServerConfig {
@@ -79,6 +80,7 @@ export function materializeContainerJson(agentGroupId: string): ContainerConfig 
   if (!row) throw new Error(`Container config not found for agent group: ${agentGroupId}`);
 
   const config = configFromDb(row, group);
+  config.provider = applyProviderOverride(config.provider ?? 'claude');
 
   const p = path.join(GROUPS_DIR, group.folder, 'container.json');
   const dir = path.dirname(p);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,6 +34,7 @@ import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { validateAdditionalMounts } from './modules/mount-security/index.js';
+import { applyProviderOverride } from './provider-override.js';
 // Provider host-side config barrel — each provider that needs host-side
 // container setup self-registers on import.
 import './providers/index.js';
@@ -135,7 +136,7 @@ async function spawnContainer(session: Session): Promise<void> {
   // idempotent: it only writes paths that don't already exist, so this call
   // is a no-op for groups that have spawned before. Runs before the provider
   // contribution so a surfaces-providing provider finds the group dir ready.
-  const providerName = resolveProviderName(session.agent_provider, containerConfig.provider);
+  const providerName = applyProviderOverride(resolveProviderName(session.agent_provider, containerConfig.provider));
   initGroupFilesystem(agentGroup, { provider: providerName });
 
   // Resolve the effective provider + any host-side contribution it declares
@@ -250,7 +251,7 @@ function resolveProviderContribution(
   agentGroup: AgentGroup,
   containerConfig: import('./container-config.js').ContainerConfig,
 ): { provider: string; contribution: ProviderContainerContribution } {
-  const provider = resolveProviderName(session.agent_provider, containerConfig.provider);
+  const provider = applyProviderOverride(resolveProviderName(session.agent_provider, containerConfig.provider));
   const fn = getProviderContainerConfig(provider);
   const contribution = fn
     ? fn({
@@ -452,6 +453,15 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Passthrough MOCK_PROVIDER_FAIL / MOCK_RESET_AT from host env so the mock
+  // provider can simulate usage-limit failures in fallback integration tests.
+  // Only forwarded in non-production environments to prevent accidental
+  // test-mode contamination.
+  if (process.env.NODE_ENV !== 'production' && process.env.MOCK_PROVIDER_FAIL)
+    args.push('-e', `MOCK_PROVIDER_FAIL=${process.env.MOCK_PROVIDER_FAIL}`);
+  if (process.env.NODE_ENV !== 'production' && process.env.MOCK_RESET_AT)
+    args.push('-e', `MOCK_RESET_AT=${process.env.MOCK_RESET_AT}`);
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -18,6 +18,9 @@ import { moduleApprovalsPendingApprovals } from './module-approvals-pending-appr
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
+import { moduleFallbackState } from './module-fallback-state.js';
+import { moduleFallbackModel } from './module-fallback-model.js';
+import { moduleFallbackEvents } from './module-fallback-events.js';
 
 export interface Migration {
   version: number;
@@ -52,6 +55,9 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration019,
+  moduleFallbackState,
+  moduleFallbackModel,
+  moduleFallbackEvents,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a

--- a/src/db/migrations/module-fallback-events.ts
+++ b/src/db/migrations/module-fallback-events.ts
@@ -1,0 +1,18 @@
+import type { Migration } from './index.js';
+
+export const moduleFallbackEvents: Migration = {
+  version: 22,
+  name: 'fallback-events',
+  up(db) {
+    db.exec(`
+      CREATE TABLE fallback_events (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp  TEXT NOT NULL DEFAULT (datetime('now')),
+        event_type TEXT NOT NULL,
+        reason     TEXT,
+        details    TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_fallback_events_ts ON fallback_events(timestamp);
+    `);
+  },
+};

--- a/src/db/migrations/module-fallback-model.ts
+++ b/src/db/migrations/module-fallback-model.ts
@@ -1,0 +1,10 @@
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+export const moduleFallbackModel: Migration = {
+  version: 21,
+  name: 'fallback-state-model',
+  up(db: Database.Database) {
+    db.prepare('ALTER TABLE fallback_state ADD COLUMN backup_model TEXT').run();
+  },
+};

--- a/src/db/migrations/module-fallback-state.ts
+++ b/src/db/migrations/module-fallback-state.ts
@@ -1,0 +1,39 @@
+import type { Migration } from './index.js';
+
+/**
+ * `fallback_state` — single-row (id=1) global state for the LLM fallback
+ * module. Persisted so a host restart resumes in whatever state it left off
+ * (active/inactive, auto/forced, next retry time) rather than forgetting the
+ * switch ever happened.
+ */
+export const moduleFallbackState: Migration = {
+  version: 19,
+  name: 'fallback-state',
+  up(db) {
+    db.exec(`
+      CREATE TABLE fallback_state (
+        id                 INTEGER PRIMARY KEY CHECK (id = 1),
+        active             INTEGER NOT NULL DEFAULT 0,
+        mode               TEXT,
+        classification     TEXT,
+        reason             TEXT,
+        backup_provider    TEXT,
+        entered_at         TEXT,
+        reset_at           TEXT,
+        next_retry_at      TEXT,
+        retry_count        INTEGER NOT NULL DEFAULT 0,
+        probing            INTEGER NOT NULL DEFAULT 0,
+        probe_message_id   TEXT,
+        probe_session_id   TEXT,
+        probe_started_at   TEXT,
+        origin_session_id  TEXT,
+        origin_group_id    TEXT,
+        last_error         TEXT,
+        updated_at         TEXT NOT NULL
+      );
+
+      INSERT INTO fallback_state (id, active, retry_count, probing, updated_at)
+      VALUES (1, 0, 0, 0, datetime('now'));
+    `);
+  },
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -224,6 +224,13 @@ CREATE TABLE IF NOT EXISTS session_routing (
   platform_id  TEXT,
   thread_id    TEXT
 );
+
+-- Pending fallback switch notice. Host writes when entering fallback mode;
+-- delivery poll prepends it to the first real chat response and deletes it.
+CREATE TABLE IF NOT EXISTS fallback_pending_notices (
+  session_id  TEXT PRIMARY KEY,
+  notice_text TEXT NOT NULL
+);
 `;
 
 /** Container-owned: outbound messages + processing acknowledgments. */

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -386,6 +386,25 @@ async function deliverMessage(
     return;
   }
 
+  // Prepend any pending fallback notice to the first real chat response so
+  // the switch warning arrives alongside the answer, not as a standalone
+  // message before the user has interacted.
+  if (msg.kind === 'chat') {
+    try {
+      const pendingNotice = inDb
+        .prepare('SELECT notice_text FROM fallback_pending_notices WHERE session_id = ?')
+        .get(session.id) as { notice_text: string } | undefined;
+      if (pendingNotice) {
+        content.text = pendingNotice.notice_text + '\n\n' + (content.text || '');
+        msg.content = JSON.stringify(content);
+        inDb.prepare('DELETE FROM fallback_pending_notices WHERE session_id = ?').run(session.id);
+      }
+    } catch {
+      // Table might not exist yet (pre-schema sessions) — ignore, the notice
+      // was already delivered via the immediate fallback path.
+    }
+  }
+
   // Read file attachments from outbox if the content declares files.
   // File I/O lives in session-manager.ts (symmetric with inbound
   // extractAttachmentFiles) — delivery just hands buffers to the adapter.

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -164,6 +164,17 @@ async function sweep(): Promise<void> {
   }
   // MODULE-HOOK:approvals-reason-sweep:end
 
+  // Drive the auto-return-to-native probe state machine off the global
+  // fallback_state row. Central-DB scan, once per tick — not per session.
+  // MODULE-HOOK:fallback-return-sweep:start
+  try {
+    const { sweepFallbackReturn } = await import('./modules/fallback/sweep.js');
+    await sweepFallbackReturn();
+  } catch (err) {
+    log.error('Fallback return sweep failed', { err });
+  }
+  // MODULE-HOOK:fallback-return-sweep:end
+
   setTimeout(sweep, SWEEP_INTERVAL_MS);
 }
 
@@ -220,6 +231,19 @@ async function sweepSession(session: Session): Promise<void> {
     }
 
     const alive = isContainerRunning(session.id);
+
+    // 2.5. Response-guarantee check: takes precedence over the generic
+    // retry-with-backoff path below, so an overdue trigger message is
+    // claimed by fallback (provider switch, or double-fault notice) rather
+    // than silently retried past the 10-minute guarantee.
+    // MODULE-HOOK:fallback-session-sweep:start
+    try {
+      const { sweepFallbackSession } = await import('./modules/fallback/sweep.js');
+      await sweepFallbackSession(inDb, outDb, session);
+    } catch (err) {
+      log.error('Fallback session sweep failed', { sessionId: session.id, err });
+    }
+    // MODULE-HOOK:fallback-session-sweep:end
 
     // 3. Running-container SLA: absolute ceiling + per-claim stuck rules.
     // Skip on the same iteration that just woke the container — it hasn't

--- a/src/modules/fallback/cli.ts
+++ b/src/modules/fallback/cli.ts
@@ -1,0 +1,80 @@
+/**
+ * `ncl fallback status|force|return` — operator-only CLI mirror of the
+ * `/fallback` chat command (commands.ts). Not in dispatch.ts's group-scope
+ * whitelist, so a group-scoped agent can never reach it; a global-scoped
+ * (owner) agent can, same as every other unrestricted resource.
+ */
+import { registerResource } from '../../cli/crud.js';
+import { enterFallback, exitFallback } from './controller.js';
+import { getFallbackState } from './db.js';
+import { statusNotice } from './notices.js';
+import { getActiveSessions } from '../../db/sessions.js';
+import { log } from '../../log.js';
+
+registerResource({
+  name: 'fallback',
+  plural: 'fallback',
+  table: 'fallback_state',
+  description:
+    'Install-wide LLM fallback state — single global row. Switches the whole install to the backup provider when the native one (Claude) exhausts limits, and back. See `/fallback` for the chat-side equivalent.',
+  idColumn: 'id',
+  columns: [
+    { name: 'active', type: 'boolean', description: 'Whether the install is currently on the backup provider.' },
+    {
+      name: 'mode',
+      type: 'string',
+      description: '"auto" auto-returns when limits reset; "forced" only via `fallback return`.',
+      enum: ['auto', 'forced'],
+    },
+    {
+      name: 'classification',
+      type: 'string',
+      description: 'Why fallback triggered.',
+      enum: ['quota', 'billing', 'overload', 'timeout', 'manual'],
+    },
+    {
+      name: 'backup_provider',
+      type: 'string',
+      description: 'Provider name currently overriding native (e.g. "opencode").',
+    },
+  ],
+  operations: {},
+  customOperations: {
+    status: {
+      access: 'open',
+      description: 'Show current fallback state (active provider, mode, reason, next retry).',
+      handler: async () => {
+        const state = getFallbackState();
+        return { ...state, summary: statusNotice(state) };
+      },
+    },
+    force: {
+      access: 'approval',
+      description:
+        'Force the install onto the backup provider now. Never auto-returns — only `fallback return` exits it.',
+      handler: async () => {
+        const sessions = getActiveSessions();
+        const originSession = sessions[0];
+        await enterFallback({
+          mode: 'forced',
+          classification: 'manual',
+          reason: 'manual ncl fallback force',
+          resetAt: null,
+          originSessionId: originSession?.id ?? null,
+          originGroupId: originSession?.agent_group_id ?? null,
+        });
+        return getFallbackState();
+      },
+    },
+    return: {
+      access: 'approval',
+      description: 'Return the install to the native provider now, regardless of whether it has actually recovered.',
+      handler: async () => {
+        const before = getFallbackState();
+        if (!before.active) return before;
+        exitFallback({ via: 'manual' });
+        return getFallbackState();
+      },
+    },
+  },
+});

--- a/src/modules/fallback/commands.test.ts
+++ b/src/modules/fallback/commands.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockWriteOutboundDirect = vi.fn();
+vi.mock('../../session-manager.js', () => ({
+  writeOutboundDirect: (...args: unknown[]) => mockWriteOutboundDirect(...args),
+}));
+
+const mockEnterFallback = vi.fn();
+const mockExitFallback = vi.fn();
+vi.mock('./controller.js', () => ({
+  enterFallback: (...args: unknown[]) => mockEnterFallback(...args),
+  exitFallback: (...args: unknown[]) => mockExitFallback(...args),
+}));
+
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createUser } from '../permissions/db/users.js';
+import { grantRole } from '../permissions/db/user-roles.js';
+import type { Session } from '../../types.js';
+import { enterFallbackState } from './db.js';
+import { interceptFallbackCommand } from './commands.js';
+
+const AGENT_GROUP_ID = 'group-1';
+const OTHER_GROUP_ID = 'group-2';
+const OWNER_ID = 'telegram:owner';
+const ADMIN_ID = 'telegram:scoped-admin';
+const PLAIN_USER_ID = 'telegram:plain';
+
+const deliveryAddr = { channelType: 'telegram', platformId: 'chat-1', threadId: null };
+
+function makeSession(agentGroupId: string): Session {
+  return {
+    id: 'sess-1',
+    agent_group_id: agentGroupId,
+    messaging_group_id: 'mg-1',
+    thread_id: null,
+    agent_provider: 'claude',
+    status: 'active',
+    container_status: 'running',
+    last_active: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+  };
+}
+
+function chatContent(text: string): string {
+  return JSON.stringify({ text });
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  vi.clearAllMocks();
+
+  createAgentGroup({
+    id: AGENT_GROUP_ID,
+    name: 'Group 1',
+    folder: 'group-1',
+    agent_provider: 'claude',
+    created_at: new Date().toISOString(),
+  });
+  createAgentGroup({
+    id: OTHER_GROUP_ID,
+    name: 'Group 2',
+    folder: 'group-2',
+    agent_provider: 'claude',
+    created_at: new Date().toISOString(),
+  });
+
+  createUser({ id: OWNER_ID, kind: 'user', display_name: 'Owner', created_at: new Date().toISOString() });
+  createUser({ id: ADMIN_ID, kind: 'user', display_name: 'Admin', created_at: new Date().toISOString() });
+  createUser({ id: PLAIN_USER_ID, kind: 'user', display_name: 'Plain', created_at: new Date().toISOString() });
+
+  grantRole({
+    user_id: OWNER_ID,
+    role: 'owner',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: new Date().toISOString(),
+  });
+  grantRole({
+    user_id: ADMIN_ID,
+    role: 'admin',
+    agent_group_id: AGENT_GROUP_ID,
+    granted_by: OWNER_ID,
+    granted_at: new Date().toISOString(),
+  });
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('interceptFallbackCommand — not a fallback command', () => {
+  it('returns false and does nothing for unrelated chat content', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('ciao'),
+      OWNER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(false);
+    expect(mockWriteOutboundDirect).not.toHaveBeenCalled();
+  });
+});
+
+describe('interceptFallbackCommand — auth gating', () => {
+  it('denies a plain member and replies with the denial notice', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback status'),
+      PLAIN_USER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+    const [, , payload] = mockWriteOutboundDirect.mock.calls[0];
+    expect(JSON.parse(payload.content).text).toMatch(/owner|admin|fallback commands/i);
+    expect(mockEnterFallback).not.toHaveBeenCalled();
+  });
+
+  it('denies a scoped admin acting on a different agent group', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback status'),
+      ADMIN_ID,
+      makeSession(OTHER_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockEnterFallback).not.toHaveBeenCalled();
+  });
+
+  it('allows a scoped admin acting on their own agent group', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback status'),
+      ADMIN_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the global owner regardless of agent group', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback status'),
+      OWNER_ID,
+      makeSession(OTHER_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies when there is no userId', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback force'),
+      null,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockEnterFallback).not.toHaveBeenCalled();
+  });
+});
+
+describe('interceptFallbackCommand — subcommand parsing', () => {
+  it('treats bare /fallback as status', async () => {
+    await interceptFallbackCommand(chatContent('/fallback'), OWNER_ID, makeSession(AGENT_GROUP_ID), deliveryAddr);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+    expect(mockEnterFallback).not.toHaveBeenCalled();
+    expect(mockExitFallback).not.toHaveBeenCalled();
+  });
+
+  it('treats an unrecognized argument as status rather than leaking to the agent', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback bogus'),
+      OWNER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+  });
+
+  it('is case-insensitive on both command and subcommand', async () => {
+    await interceptFallbackCommand(chatContent('/FALLBACK FORCE'), OWNER_ID, makeSession(AGENT_GROUP_ID), deliveryAddr);
+    expect(mockEnterFallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('interceptFallbackCommand — force', () => {
+  it('calls enterFallback with forced/manual bookkeeping tied to the current session', async () => {
+    const session = makeSession(AGENT_GROUP_ID);
+    await interceptFallbackCommand(chatContent('/fallback force'), OWNER_ID, session, deliveryAddr);
+
+    expect(mockEnterFallback).toHaveBeenCalledTimes(1);
+    const arg = mockEnterFallback.mock.calls[0][0];
+    expect(arg.mode).toBe('forced');
+    expect(arg.classification).toBe('manual');
+    expect(arg.originSessionId).toBe(session.id);
+    expect(arg.originGroupId).toBe(session.agent_group_id);
+  });
+});
+
+describe('interceptFallbackCommand — return', () => {
+  it('does not call exitFallback when fallback is not active, and replies with status instead', async () => {
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback return'),
+      OWNER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockExitFallback).not.toHaveBeenCalled();
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+    const [, , payload] = mockWriteOutboundDirect.mock.calls[0];
+    expect(JSON.parse(payload.content).text).toContain('Fallback not active');
+  });
+
+  it('calls exitFallback unconditionally (manual) when fallback is active', async () => {
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-1',
+      originGroupId: AGENT_GROUP_ID,
+    });
+
+    const handled = await interceptFallbackCommand(
+      chatContent('/fallback return'),
+      OWNER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockExitFallback).toHaveBeenCalledTimes(1);
+    expect(mockExitFallback).toHaveBeenCalledWith({ via: 'manual' });
+    // No status reply is sent directly by commands.ts in this branch — exitFallback owns notification.
+    expect(mockWriteOutboundDirect).not.toHaveBeenCalled();
+  });
+});
+
+describe('interceptFallbackCommand — content parsing', () => {
+  it('falls back to raw content when JSON.parse fails', async () => {
+    const handled = await interceptFallbackCommand(
+      '/fallback status',
+      OWNER_ID,
+      makeSession(AGENT_GROUP_ID),
+      deliveryAddr,
+    );
+    expect(handled).toBe(true);
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/fallback/commands.ts
+++ b/src/modules/fallback/commands.ts
@@ -1,0 +1,128 @@
+/**
+ * `/fallback` chat command interceptor — owner/admin only, handled entirely
+ * host-side so it works even when Claude (the native provider) is dead.
+ * Called from router.ts's deliverToAgent, right before the existing command
+ * gate. Returning true means "handled" — the caller must not write an
+ * inbound row for this message.
+ */
+import { getDb, hasTable } from '../../db/connection.js';
+import { deliverSessionMessages } from '../../delivery.js';
+import { log } from '../../log.js';
+import { writeOutboundDirect } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+import { enterFallback, exitFallback } from './controller.js';
+import { getFallbackState } from './db.js';
+import { commandDeniedNotice, statusNotice } from './notices.js';
+
+export interface DeliveryAddress {
+  channelType: string | null;
+  platformId: string | null;
+  threadId: string | null;
+}
+
+type FallbackSubcommand = 'status' | 'force' | 'return';
+
+function parseFallbackCommand(text: string): FallbackSubcommand | null {
+  const parts = text.trim().split(/\s+/);
+  if ((parts[0] ?? '').toLowerCase() !== '/fallback') return null;
+  const sub = (parts[1] ?? 'status').toLowerCase();
+  if (sub === 'force') return 'force';
+  if (sub === 'return') return 'return';
+  // 'status', no argument, or any unrecognized argument all fall
+  // back to status — always "handled" so a typo doesn't leak to the agent.
+  return 'status';
+}
+
+/** Same query as command-gate.ts's isAdmin — owner or admin, global or scoped to this agent group. */
+function isOwnerOrAdmin(userId: string | null, agentGroupId: string): boolean {
+  if (!userId) return false;
+  const db = getDb();
+  if (!hasTable(db, 'user_roles')) return false; // safety: deny all when permissions module missing
+  const row = db
+    .prepare(
+      `SELECT 1 FROM user_roles
+       WHERE user_id = ?
+         AND (role = 'owner' OR role = 'admin')
+         AND (agent_group_id IS NULL OR agent_group_id = ?)
+       LIMIT 1`,
+    )
+    .get(userId, agentGroupId);
+  return row != null;
+}
+
+async function reply(session: Session, deliveryAddr: DeliveryAddress, text: string): Promise<void> {
+  writeOutboundDirect(session.agent_group_id, session.id, {
+    id: `fallback-cmd-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    kind: 'chat',
+    platformId: deliveryAddr.platformId,
+    channelType: deliveryAddr.channelType,
+    threadId: deliveryAddr.threadId,
+    content: JSON.stringify({ text }),
+  });
+  // Push immediately — this is a host-composed reply that doesn't need the
+  // container, but the 1s "active" delivery poll only covers sessions whose
+  // container is currently running/idle. Without this, a command sent while
+  // the container is stopped would sit until the 60s sweep poll instead.
+  try {
+    await deliverSessionMessages(session);
+  } catch (err) {
+    log.warn('Failed to push immediate delivery for fallback command reply', { sessionId: session.id, err });
+  }
+}
+
+export async function interceptFallbackCommand(
+  rawContent: string,
+  userId: string | null,
+  session: Session,
+  deliveryAddr: DeliveryAddress,
+): Promise<boolean> {
+  let text: string;
+  try {
+    const parsed = JSON.parse(rawContent);
+    text = typeof (parsed as { text?: unknown }).text === 'string' ? (parsed as { text: string }).text.trim() : '';
+  } catch {
+    text = rawContent.trim();
+  }
+
+  const sub = parseFallbackCommand(text);
+  if (sub === null) return false;
+
+  if (!isOwnerOrAdmin(userId, session.agent_group_id)) {
+    await reply(session, deliveryAddr, commandDeniedNotice());
+    log.info('Fallback command denied', { userId, agentGroupId: session.agent_group_id, sub });
+    return true;
+  }
+
+  log.info('Fallback command received', { userId, agentGroupId: session.agent_group_id, sub });
+
+  switch (sub) {
+    case 'status':
+      await reply(session, deliveryAddr, statusNotice(getFallbackState()));
+      break;
+    case 'force':
+      await enterFallback({
+        mode: 'forced',
+        classification: 'manual',
+        reason: 'manual /fallback force',
+        resetAt: null,
+        originSessionId: session.id,
+        originGroupId: session.agent_group_id,
+        messageIds: [],
+      });
+      break;
+    case 'return': {
+      // Guard against a no-op restart-storm: exitFallback restarts every
+      // active agent group's container, which is only meaningful work if the
+      // install was actually running on the backup. If it wasn't, statusNotice
+      // already says so — no reason to disrupt every live session.
+      if (!getFallbackState().active) {
+        await reply(session, deliveryAddr, statusNotice(getFallbackState()));
+        break;
+      }
+      exitFallback({ via: 'manual' });
+      break;
+    }
+  }
+
+  return true;
+}

--- a/src/modules/fallback/controller.test.ts
+++ b/src/modules/fallback/controller.test.ts
@@ -1,0 +1,596 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../env.js', () => ({
+  readEnvFile: () => ({}),
+}));
+
+const mockKillContainer = vi.fn();
+const mockWakeContainer = vi.fn();
+const mockIsContainerRunning = vi.fn();
+vi.mock('../../container-runner.js', () => ({
+  killContainer: (...args: unknown[]) => mockKillContainer(...args),
+  wakeContainer: (...args: unknown[]) => mockWakeContainer(...args),
+  isContainerRunning: (...args: unknown[]) => {
+    const fn = mockIsContainerRunning as unknown as (...a: unknown[]) => boolean;
+    return fn(...args);
+  },
+}));
+
+const mockRestartAgentGroupContainers = vi.fn();
+vi.mock('../../container-restart.js', () => ({
+  restartAgentGroupContainers: (...args: unknown[]) => mockRestartAgentGroupContainers(...args),
+}));
+
+const mockGetAllAgentGroups = vi.fn(() => [] as Array<{ id: string }>);
+vi.mock('../../db/agent-groups.js', () => ({
+  getAllAgentGroups: () => mockGetAllAgentGroups(),
+}));
+
+const mockGetMessagingGroup = vi.fn();
+vi.mock('../../db/messaging-groups.js', () => ({
+  getMessagingGroup: (...args: unknown[]) => mockGetMessagingGroup(...args),
+}));
+
+const mockDeleteOrphanProcessingClaims = vi.fn((..._args: unknown[]) => 0);
+const mockMarkMessageFailed = vi.fn();
+vi.mock('../../db/session-db.js', () => ({
+  deleteOrphanProcessingClaims: (...args: unknown[]) => mockDeleteOrphanProcessingClaims(...args),
+  markMessageFailed: (...args: unknown[]) => mockMarkMessageFailed(...args),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock('../../db/sessions.js', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+const mockGetDeliveryAdapter = vi.fn(() => null);
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => mockGetDeliveryAdapter(),
+}));
+
+const mockOpenInboundDb = vi.fn();
+const mockOpenOutboundDbRw = vi.fn();
+const mockWriteOutboundDirect = vi.fn();
+const mockWriteSessionMessage = vi.fn();
+vi.mock('../../session-manager.js', () => ({
+  openInboundDb: (...args: unknown[]) => mockOpenInboundDb(...args),
+  openOutboundDbRw: (...args: unknown[]) => mockOpenOutboundDbRw(...args),
+  writeOutboundDirect: (...args: unknown[]) => mockWriteOutboundDirect(...args),
+  writeSessionMessage: (...args: unknown[]) => mockWriteSessionMessage(...args),
+}));
+
+const mockPickApprover = vi.fn((..._args: unknown[]) => [] as unknown[]);
+const mockPickApprovalDelivery = vi.fn(async (..._args: unknown[]) => null as unknown);
+vi.mock('../approvals/primitive.js', () => ({
+  pickApprover: (...args: unknown[]) => mockPickApprover(...args),
+  pickApprovalDelivery: (...args: unknown[]) => mockPickApprovalDelivery(...args),
+}));
+
+const mockWriteDegradationFragmentForAllGroups = vi.fn();
+const mockRemoveDegradationFragmentForAllGroups = vi.fn();
+vi.mock('./fragment.js', () => ({
+  writeDegradationFragmentForAllGroups: () => mockWriteDegradationFragmentForAllGroups(),
+  removeDegradationFragmentForAllGroups: () => mockRemoveDegradationFragmentForAllGroups(),
+}));
+
+const mockSummarizeClaudeTranscript = vi.fn((..._args: unknown[]) => null as string | null);
+const mockSummarizeBackupConversation = vi.fn((..._args: unknown[]) => null as string | null);
+vi.mock('./summary.js', () => ({
+  summarizeClaudeTranscript: (...args: unknown[]) => mockSummarizeClaudeTranscript(...args),
+  summarizeBackupConversation: (...args: unknown[]) => mockSummarizeBackupConversation(...args),
+}));
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import type { Session } from '../../types.js';
+import { enterFallbackState, getFallbackState, setProbe } from './db.js';
+import {
+  enterFallback,
+  exitFallback,
+  handleDoubleFaultTimeout,
+  handleFallbackReport,
+  handleProbeTimeout,
+  handleProviderError,
+  isBackupUsable,
+  representMessages,
+  startReturnProbe,
+} from './controller.js';
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-origin',
+    agent_group_id: 'group-origin',
+    messaging_group_id: 'mg-1',
+    thread_id: null,
+    agent_provider: 'claude',
+    status: 'active',
+    container_status: 'running',
+    last_active: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  vi.clearAllMocks();
+  mockIsContainerRunning.mockReturnValue(true);
+  mockGetAllAgentGroups.mockReturnValue([]);
+  mockGetDeliveryAdapter.mockReturnValue(null);
+  mockPickApprover.mockReturnValue([]);
+  mockPickApprovalDelivery.mockResolvedValue(null);
+  mockDeleteOrphanProcessingClaims.mockReturnValue(0);
+  delete process.env.FALLBACK_PROVIDER;
+  delete process.env.OPENCODE_MODEL;
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('isBackupUsable', () => {
+  it('is false when no backup provider is configured', () => {
+    expect(isBackupUsable()).toBe(false);
+  });
+
+  it('is false for opencode without a model configured', () => {
+    process.env.FALLBACK_PROVIDER = 'opencode';
+    expect(isBackupUsable()).toBe(false);
+  });
+
+  it('is true for opencode with a model configured', () => {
+    process.env.FALLBACK_PROVIDER = 'opencode';
+    process.env.OPENCODE_MODEL = 'some-model';
+    expect(isBackupUsable()).toBe(true);
+  });
+
+  it('is true for a non-opencode backup provider without a model', () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    expect(isBackupUsable()).toBe(true);
+  });
+});
+
+describe('representMessages', () => {
+  it('only flips processing rows back to pending, leaving other statuses untouched', () => {
+    const db = { data: new Map<string, string>() };
+    const calls: Array<{ id: string; status: string }> = [];
+    const fakeDb = {
+      prepare: () => ({
+        run: (id: string) => {
+          calls.push({ id, status: 'checked' });
+        },
+      }),
+      transaction: (fn: (ids: string[]) => void) => (ids: string[]) => fn(ids),
+    } as unknown as import('better-sqlite3').Database;
+
+    representMessages(fakeDb, ['m1', 'm2']);
+    expect(calls.map((c) => c.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('is a no-op for an empty message list', () => {
+    let prepared = false;
+    const fakeDb = {
+      prepare: () => {
+        prepared = true;
+        return { run: vi.fn() };
+      },
+    } as unknown as import('better-sqlite3').Database;
+    representMessages(fakeDb, []);
+    expect(prepared).toBe(false);
+  });
+});
+
+describe('enterFallback — no backup usable (rule 11)', () => {
+  it('notifies the origin session, marks trigger messages failed, kills the container, and does not change state', async () => {
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+    const fakeInDb = {};
+    mockOpenInboundDb.mockReturnValue({ ...fakeInDb, close: vi.fn() });
+
+    await enterFallback({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'quota exhausted',
+      resetAt: null,
+      originSessionId: origin.id,
+      originGroupId: origin.agent_group_id,
+      messageIds: ['m1'],
+    });
+
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+    expect(mockMarkMessageFailed).toHaveBeenCalledWith(expect.anything(), 'm1');
+    expect(mockKillContainer).toHaveBeenCalledWith(origin.id, 'fallback-no-backup');
+    expect(getFallbackState().active).toBe(false);
+  });
+});
+
+describe('enterFallback — backup usable', () => {
+  beforeEach(() => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+  });
+
+  it('activates fallback state, writes the fragment, notifies, and restarts the origin session', async () => {
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+    const insertNoticeRun = vi.fn();
+    mockOpenInboundDb.mockReturnValue({
+      prepare: () => ({ run: insertNoticeRun }),
+      transaction: (fn: (ids: string[]) => void) => (ids: string[]) => fn(ids),
+      close: vi.fn(),
+    });
+
+    await enterFallback({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'quota exhausted',
+      resetAt: null,
+      originSessionId: origin.id,
+      originGroupId: origin.agent_group_id,
+      messageIds: ['m1'],
+    });
+
+    const state = getFallbackState();
+    expect(state.active).toBe(true);
+    expect(state.backupProvider).toBe('mock');
+    expect(mockWriteDegradationFragmentForAllGroups).toHaveBeenCalledTimes(1);
+    // switch notice is deferred into fallback_pending_notices, delivered with the next chat response
+    expect(insertNoticeRun).toHaveBeenCalledWith(origin.id, expect.any(String));
+    expect(mockWriteOutboundDirect).not.toHaveBeenCalled();
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(1); // origin session restart briefing
+    expect(mockKillContainer).toHaveBeenCalledWith(origin.id, 'fallback-switch', expect.any(Function));
+  });
+
+  it('restarts every other agent group but skips the origin group', async () => {
+    const origin = makeSession({ agent_group_id: 'group-origin' });
+    mockGetSession.mockReturnValue(origin);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+    mockOpenInboundDb.mockReturnValue({ close: vi.fn() });
+    mockGetAllAgentGroups.mockReturnValue([{ id: 'group-origin' }, { id: 'group-other' }]);
+
+    await enterFallback({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      resetAt: null,
+      originSessionId: origin.id,
+      originGroupId: origin.agent_group_id,
+      messageIds: [],
+    });
+
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledTimes(1);
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledWith('group-other', 'fallback-switch', expect.any(String));
+  });
+
+  it('restarts every agent group when there is no origin session (CLI-invoked force)', async () => {
+    mockGetAllAgentGroups.mockReturnValue([{ id: 'group-a' }, { id: 'group-b' }]);
+
+    await enterFallback({
+      mode: 'forced',
+      classification: 'manual',
+      reason: 'manual /fallback force',
+      resetAt: null,
+      originSessionId: null,
+      originGroupId: null,
+      messageIds: [],
+    });
+
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledTimes(2);
+    expect(getFallbackState().active).toBe(true);
+    expect(getFallbackState().mode).toBe('forced');
+  });
+
+  it('seeds a nextRetryAt for auto mode with no known resetAt, so the return-probe sweep has a due time to check against', async () => {
+    mockGetAllAgentGroups.mockReturnValue([]);
+
+    await enterFallback({
+      mode: 'auto',
+      classification: 'billing',
+      reason: 'Credit balance is too low',
+      resetAt: null,
+      originSessionId: null,
+      originGroupId: null,
+      messageIds: [],
+    });
+
+    const state = getFallbackState();
+    expect(state.nextRetryAt).not.toBeNull();
+    expect(Date.parse(state.nextRetryAt!)).toBeGreaterThan(Date.now());
+  });
+
+  it('leaves nextRetryAt null for forced mode, which never auto-probes back', async () => {
+    mockGetAllAgentGroups.mockReturnValue([]);
+
+    await enterFallback({
+      mode: 'forced',
+      classification: 'manual',
+      reason: 'manual /fallback force',
+      resetAt: null,
+      originSessionId: null,
+      originGroupId: null,
+      messageIds: [],
+    });
+
+    expect(getFallbackState().nextRetryAt).toBeNull();
+  });
+});
+
+describe('exitFallback', () => {
+  beforeEach(() => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    mockGetAllAgentGroups.mockReturnValue([{ id: 'group-origin' }, { id: 'group-other' }]);
+  });
+
+  it('via probe: clears state, removes the fragment, and skips restarting the origin group', () => {
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+
+    exitFallback({ via: 'probe' });
+
+    expect(getFallbackState().active).toBe(false);
+    expect(mockRemoveDegradationFragmentForAllGroups).toHaveBeenCalledTimes(1);
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledTimes(1);
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledWith('group-other', 'fallback-return', expect.any(String));
+  });
+
+  it('via manual: restarts every agent group, including the origin group', () => {
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+
+    exitFallback({ via: 'manual' });
+
+    expect(mockRestartAgentGroupContainers).toHaveBeenCalledTimes(2);
+    const calledGroups = mockRestartAgentGroupContainers.mock.calls.map((c) => c[0]);
+    expect(calledGroups).toContain('group-origin');
+    expect(calledGroups).toContain('group-other');
+  });
+});
+
+describe('startReturnProbe', () => {
+  it('writes a probe message on the origin session and sets probe bookkeeping', () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+
+    startReturnProbe(1000);
+
+    expect(mockWriteSessionMessage).toHaveBeenCalledTimes(1);
+    const state = getFallbackState();
+    expect(state.probing).toBe(true);
+    expect(state.probeSessionId).toBe(origin.id);
+    expect(mockKillContainer).toHaveBeenCalledWith(origin.id, 'fallback-return-probe', expect.any(Function));
+  });
+
+  it('is a no-op when there is no recorded origin session', () => {
+    startReturnProbe(1000);
+    expect(mockWriteSessionMessage).not.toHaveBeenCalled();
+    expect(mockKillContainer).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleProbeTimeout', () => {
+  it('marks the probe message completed, bumps retry, and restarts the probe session', () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    setProbe({
+      probing: true,
+      probeMessageId: 'probe-1',
+      probeSessionId: 'sess-origin',
+      probeStartedAt: new Date().toISOString(),
+    });
+    const origin = makeSession();
+    mockGetSession.mockReturnValue(origin);
+    const runCalls: string[] = [];
+    mockOpenInboundDb.mockReturnValue({
+      prepare: () => ({ run: (id: string) => runCalls.push(id) }),
+      close: vi.fn(),
+    });
+
+    handleProbeTimeout();
+
+    const state = getFallbackState();
+    expect(state.probing).toBe(false);
+    expect(state.retryCount).toBe(1);
+    expect(mockKillContainer).toHaveBeenCalledWith(origin.id, 'fallback-probe-timeout', expect.any(Function));
+  });
+
+  it('is a no-op when not currently probing', () => {
+    handleProbeTimeout();
+    expect(mockKillContainer).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleDoubleFaultTimeout', () => {
+  it('marks all given messages failed and notifies the origin conversation', () => {
+    const origin = makeSession();
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+    const fakeInDb = {} as import('better-sqlite3').Database;
+
+    handleDoubleFaultTimeout(origin, fakeInDb, ['m1', 'm2']);
+
+    expect(mockMarkMessageFailed).toHaveBeenCalledTimes(2);
+    expect(mockMarkMessageFailed).toHaveBeenCalledWith(fakeInDb, 'm1');
+    expect(mockMarkMessageFailed).toHaveBeenCalledWith(fakeInDb, 'm2');
+    expect(mockWriteOutboundDirect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleFallbackReport', () => {
+  const fakeInDb = () =>
+    ({
+      prepare: () => ({ run: vi.fn() }),
+      transaction: (fn: (ids: string[]) => void) => (ids: string[]) => fn(ids),
+    }) as unknown as import('better-sqlite3').Database;
+
+  it('silently re-falls-back when the return probe itself hits a limit', () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    setProbe({
+      probing: true,
+      probeMessageId: 'probe-1',
+      probeSessionId: 'sess-origin',
+      probeStartedAt: new Date().toISOString(),
+    });
+    const session = makeSession();
+
+    return handleFallbackReport({ classification: 'quota', messageIds: ['probe-1'] }, session, fakeInDb()).then(() => {
+      const state = getFallbackState();
+      expect(state.probing).toBe(false);
+      expect(state.retryCount).toBe(1);
+      expect(mockKillContainer).toHaveBeenCalledWith(session.id, 'fallback-reprobe-limit', expect.any(Function));
+    });
+  });
+
+  it('re-presents and restarts when a report arrives while already active (not probing)', async () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    const session = makeSession();
+
+    await handleFallbackReport({ classification: 'quota', messageIds: ['m1'] }, session, fakeInDb());
+
+    expect(mockKillContainer).toHaveBeenCalledWith(session.id, 'fallback-already-active', expect.any(Function));
+  });
+
+  it('enters fallback when inactive and a backup is usable', async () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    const session = makeSession();
+    mockGetSession.mockReturnValue(session);
+    mockGetMessagingGroup.mockReturnValue({ id: 'mg-1', channel_type: 'telegram', platform_id: 'chat-1' });
+    mockOpenInboundDb.mockReturnValue({ close: vi.fn() });
+
+    await handleFallbackReport({ classification: 'overload', messageIds: [] }, session, fakeInDb());
+
+    expect(getFallbackState().active).toBe(true);
+    expect(getFallbackState().classification).toBe('overload');
+  });
+});
+
+describe('handleProviderError', () => {
+  const fakeInDb = {} as import('better-sqlite3').Database;
+
+  it('silently re-falls-back when probing', () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    setProbe({
+      probing: true,
+      probeMessageId: 'probe-1',
+      probeSessionId: 'sess-origin',
+      probeStartedAt: new Date().toISOString(),
+    });
+    const session = makeSession();
+    const probeSession = makeSession({ id: 'sess-origin' });
+    mockGetSession.mockReturnValue(probeSession);
+    mockOpenInboundDb.mockReturnValue({
+      prepare: vi.fn(() => ({ run: vi.fn() })),
+      close: vi.fn(),
+    });
+
+    return handleProviderError({ message: 'boom' }, session, fakeInDb).then(() => {
+      const state = getFallbackState();
+      expect(state.probing).toBe(false);
+      expect(state.retryCount).toBe(1);
+      expect(mockKillContainer).toHaveBeenCalledWith(
+        session.id,
+        'fallback-reprobe-generic-error',
+        expect.any(Function),
+      );
+    });
+  });
+
+  it('records the last error without restarting when already active (double fault)', async () => {
+    process.env.FALLBACK_PROVIDER = 'mock';
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'mock',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 'sess-origin',
+      originGroupId: 'group-origin',
+    });
+    const session = makeSession();
+
+    await handleProviderError({ message: 'backup down too' }, session, fakeInDb);
+
+    expect(getFallbackState().lastError).toBe('backup down too');
+    expect(mockKillContainer).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op (besides logging) when native provider is running and fallback is inactive', async () => {
+    const session = makeSession();
+    await handleProviderError({ message: 'native hiccup' }, session, fakeInDb);
+    expect(getFallbackState().lastError).toBeNull();
+    expect(mockKillContainer).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/fallback/controller.ts
+++ b/src/modules/fallback/controller.ts
@@ -1,0 +1,515 @@
+/**
+ * Host fallback orchestration — the only place that actually switches the
+ * install to/from the backup provider, notifies the owner, and restarts
+ * containers. `override.ts` decides which provider is *effective* given
+ * state; this file is what *changes* that state.
+ */
+import type Database from 'better-sqlite3';
+import { killContainer, wakeContainer } from '../../container-runner.js';
+import { restartAgentGroupContainers } from '../../container-restart.js';
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { deleteOrphanProcessingClaims, markMessageFailed } from '../../db/session-db.js';
+import { getSession } from '../../db/sessions.js';
+import { deliverSessionMessages, getDeliveryAdapter } from '../../delivery.js';
+import { readEnvFile } from '../../env.js';
+import { log } from '../../log.js';
+import { openInboundDb, openOutboundDbRw, writeOutboundDirect, writeSessionMessage } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
+import {
+  bumpRetry,
+  clearFallbackState,
+  enterFallbackState,
+  getFallbackState,
+  setLastError,
+  setProbe,
+  type FallbackClassification,
+  type FallbackMode,
+} from './db.js';
+import { nextRetryAt } from './decide.js';
+import { removeDegradationFragmentForAllGroups, writeDegradationFragmentForAllGroups } from './fragment.js';
+import {
+  doubleFaultNotice,
+  forwardBriefing,
+  noBackupNotice,
+  returnBriefing,
+  returnNotice,
+  shortReturnBriefing,
+  shortSwitchBriefing,
+  switchAutoNotice,
+  switchForcedNotice,
+} from './notices.js';
+import { summarizeBackupConversation, summarizeClaudeTranscript } from './summary.js';
+
+const envConfig = readEnvFile(['FALLBACK_PROVIDER', 'OPENCODE_MODEL', 'OLLAMA_MODEL']);
+
+function fallbackProviderEnv(): string {
+  return process.env.FALLBACK_PROVIDER || envConfig.FALLBACK_PROVIDER || '';
+}
+
+function opencodeModelEnv(): string {
+  return process.env.OPENCODE_MODEL || envConfig.OPENCODE_MODEL || '';
+}
+
+function ollamaModelEnv(): string {
+  return process.env.OLLAMA_MODEL || envConfig.OLLAMA_MODEL || '';
+}
+
+/**
+ * Runtime check (spec rule 11): a backup provider must be configured and, if
+ * it's `opencode`, a model must be set too. The OneCLI secret itself can't be
+ * verified host-side — a missing/invalid credential surfaces later as an
+ * auth failure at runtime, which is the "double fault" case handled by
+ * `handleProviderError`, not this check.
+ */
+export function isBackupUsable(): boolean {
+  const provider = fallbackProviderEnv();
+  if (!provider) return false;
+  if (provider === 'opencode' && !opencodeModelEnv()) return false;
+  return true;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function nextRetryIso(retryCount: number): string {
+  return new Date(nextRetryAt(retryCount, Date.now())).toISOString();
+}
+
+function markMessageCompleted(inDb: Database.Database, messageId: string): void {
+  inDb.prepare("UPDATE messages_in SET status = 'completed' WHERE id = ?").run(messageId);
+}
+
+/** UPDATE → pending, without touching `tries` — these messages weren't the provider's fault. */
+export function representMessages(inDb: Database.Database, messageIds: string[]): void {
+  if (messageIds.length === 0) return;
+  const stmt = inDb.prepare("UPDATE messages_in SET status = 'pending' WHERE id = ? AND status = 'processing'");
+  const tx = inDb.transaction((ids: string[]) => {
+    for (const id of ids) stmt.run(id);
+  });
+  tx(messageIds);
+}
+
+async function notifyApprover(session: Session, text: string): Promise<void> {
+  try {
+    const approvers = pickApprover(session.agent_group_id);
+    const originChannelType = session.messaging_group_id
+      ? (getMessagingGroup(session.messaging_group_id)?.channel_type ?? '')
+      : '';
+    const target = await pickApprovalDelivery(approvers, originChannelType);
+    if (!target) {
+      log.warn('Fallback notice: no reachable approver DM', { sessionId: session.id });
+      return;
+    }
+    const adapter = getDeliveryAdapter();
+    if (adapter) {
+      await adapter.deliver(
+        target.messagingGroup.channel_type,
+        target.messagingGroup.platform_id,
+        null,
+        'chat',
+        JSON.stringify({ text }),
+      );
+    }
+  } catch (err) {
+    log.warn('Failed to deliver fallback notice to approver', { sessionId: session.id, err });
+  }
+}
+
+/** Writes straight into the origin conversation's outbound.db; falls back to an approver DM if that's not possible. */
+async function notifyConversationOrOwner(session: Session, text: string): Promise<void> {
+  try {
+    const mg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+    if (!mg) throw new Error('origin session has no messaging group');
+    writeOutboundDirect(session.agent_group_id, session.id, {
+      id: generateId('fallback-notice'),
+      kind: 'chat',
+      platformId: mg.platform_id,
+      channelType: mg.channel_type,
+      threadId: session.thread_id,
+      content: JSON.stringify({ text }),
+    });
+  } catch (err) {
+    log.warn('Falling back to approver DM for fallback notice', { sessionId: session.id, err });
+    await notifyApprover(session, text);
+    return;
+  }
+  // Push immediately instead of waiting on a poll — this notice is
+  // host-composed and doesn't need the container, but the 1s "active"
+  // delivery poll only covers sessions whose container is currently
+  // running/idle. If it isn't, only the 60s sweep poll would eventually
+  // pick this up, turning an instant notice into a up-to-a-minute wait.
+  try {
+    await deliverSessionMessages(session);
+  } catch (err) {
+    log.warn('Failed to push immediate delivery for fallback notice', { sessionId: session.id, err });
+  }
+}
+
+function restartOriginSession(session: Session, briefing: string): void {
+  writeSessionMessage(session.agent_group_id, session.id, {
+    id: generateId('fallback-switch'),
+    kind: 'chat',
+    timestamp: new Date().toISOString(),
+    platformId: session.agent_group_id,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({ text: briefing, sender: 'system', senderId: 'system' }),
+    onWake: 1,
+  });
+
+  killContainer(session.id, 'fallback-switch', () => {
+    try {
+      const outDb = openOutboundDbRw(session.agent_group_id, session.id);
+      try {
+        const cleared = deleteOrphanProcessingClaims(outDb);
+        if (cleared > 0)
+          log.info('Cleared orphan processing claims after fallback switch', { sessionId: session.id, cleared });
+      } finally {
+        outDb.close();
+      }
+    } catch (err) {
+      log.warn('Failed to clear orphan processing claims after fallback switch', { sessionId: session.id, err });
+    }
+    const s = getSession(session.id);
+    if (s) wakeContainer(s);
+  });
+}
+
+/** Restarts a session's container and waits for it to fully exit before waking a fresh one. */
+function killAndWake(session: Session, reason: string): void {
+  killContainer(session.id, reason, () => {
+    const s = getSession(session.id);
+    if (s) wakeContainer(s);
+  });
+}
+
+export interface EnterFallbackOpts {
+  mode: FallbackMode;
+  classification: FallbackClassification;
+  reason: string;
+  resetAt: string | null;
+  originSessionId: string | null;
+  originGroupId: string | null;
+  /** Trigger messages left `processing` by the caller, to be re-presented on the backup provider. */
+  messageIds?: string[];
+}
+
+/**
+ * Switches the install to the backup provider (spec's central transition).
+ * No-ops into rule 11 (immediate failure notice, no state change) if no
+ * backup is usable.
+ */
+export async function enterFallback(opts: EnterFallbackOpts): Promise<void> {
+  const originSession = opts.originSessionId ? getSession(opts.originSessionId) : undefined;
+  const messageIds = opts.messageIds ?? [];
+
+  if (!isBackupUsable()) {
+    log.warn('Fallback triggered but no backup provider is configured (rule 11)', {
+      classification: opts.classification,
+      reason: opts.reason,
+      originSessionId: opts.originSessionId,
+    });
+    if (originSession) {
+      await notifyConversationOrOwner(originSession, noBackupNotice(opts.classification, opts.resetAt));
+      if (messageIds.length > 0) {
+        const inDb = openInboundDb(originSession.agent_group_id, originSession.id);
+        try {
+          for (const id of messageIds) markMessageFailed(inDb, id);
+        } finally {
+          inDb.close();
+        }
+      }
+      killContainer(originSession.id, 'fallback-no-backup');
+    }
+    return;
+  }
+
+  const backupProvider = fallbackProviderEnv();
+  const model =
+    backupProvider === 'opencode' ? opencodeModelEnv() : backupProvider === 'ollama' ? ollamaModelEnv() : null;
+  // Forced fallback never auto-probes back (spec rule 13, decide.ts) so it
+  // has no retry schedule. Auto fallback needs one seeded immediately —
+  // otherwise decideFallbackSweep's dueAt is NaN forever and the install
+  // never attempts a return-to-native probe on its own.
+  const initialNextRetry = opts.mode === 'forced' ? null : (opts.resetAt ?? nextRetryIso(0));
+
+  enterFallbackState({
+    mode: opts.mode,
+    classification: opts.classification,
+    reason: opts.reason,
+    backupProvider,
+    backupModel: model,
+    resetAt: opts.resetAt,
+    nextRetryAt: initialNextRetry,
+    originSessionId: opts.originSessionId,
+    originGroupId: opts.originGroupId,
+  });
+
+  if (originSession && messageIds.length > 0) {
+    const inDb = openInboundDb(originSession.agent_group_id, originSession.id);
+    try {
+      representMessages(inDb, messageIds);
+    } finally {
+      inDb.close();
+    }
+  }
+
+  try {
+    writeDegradationFragmentForAllGroups();
+  } catch (err) {
+    log.warn('Failed to write fallback degradation fragment', { err });
+  }
+
+  const notice =
+    opts.mode === 'forced'
+      ? switchForcedNotice(backupProvider, model)
+      : switchAutoNotice(opts.classification, backupProvider, opts.resetAt, model);
+  if (originSession) {
+    try {
+      const inDb = openInboundDb(originSession.agent_group_id, originSession.id);
+      inDb.prepare('CREATE TABLE IF NOT EXISTS fallback_pending_notices (session_id TEXT, notice_text TEXT)').run();
+      inDb
+        .prepare('INSERT OR REPLACE INTO fallback_pending_notices (session_id, notice_text) VALUES (?, ?)')
+        .run(originSession.id, notice);
+      inDb.close();
+      log.info('Deferred fallback notice — will be delivered with next chat response', { sessionId: originSession.id });
+    } catch (err) {
+      log.warn('Failed to store deferred fallback notice, falling back to immediate delivery', {
+        sessionId: originSession.id,
+        err,
+      });
+      await notifyConversationOrOwner(originSession, notice);
+    }
+  }
+
+  let forwardSummary: string | null = null;
+  if (originSession) {
+    try {
+      forwardSummary = summarizeClaudeTranscript(originSession.agent_group_id, originSession.id);
+    } catch (err) {
+      log.warn('Failed to build forward context summary', { err });
+    }
+  }
+  const briefing = forwardBriefing(forwardSummary, backupProvider, model);
+
+  if (originSession) {
+    restartOriginSession(originSession, briefing);
+  }
+  for (const group of getAllAgentGroups()) {
+    if (originSession && group.id === originSession.agent_group_id) continue;
+    try {
+      restartAgentGroupContainers(group.id, 'fallback-switch', shortSwitchBriefing(backupProvider, model));
+    } catch (err) {
+      log.warn('Failed to restart agent group for fallback switch', { groupId: group.id, err });
+    }
+  }
+
+  log.warn('Entered fallback', {
+    mode: opts.mode,
+    classification: opts.classification,
+    resetAt: opts.resetAt,
+    originSessionId: opts.originSessionId,
+    originGroupId: opts.originGroupId,
+    backupProvider,
+  });
+}
+
+/**
+ * Returns the install to the native provider. `via: 'probe'` is called only
+ * after a successful automatic return probe (the origin session is already
+ * running native — it isn't restarted); `via: 'manual'` is the unconditional
+ * `/fallback return` command path (the origin group's containers are still
+ * on the backup and must be restarted like any other group).
+ */
+export function exitFallback(opts: { via: 'probe' | 'manual' }): void {
+  const state = getFallbackState();
+  const originSession = state.originSessionId ? getSession(state.originSessionId) : undefined;
+  const originGroupId = originSession?.agent_group_id ?? state.originGroupId ?? null;
+
+  clearFallbackState();
+
+  try {
+    removeDegradationFragmentForAllGroups();
+  } catch (err) {
+    log.warn('Failed to remove fallback degradation fragment', { err });
+  }
+
+  if (originSession) {
+    void notifyConversationOrOwner(originSession, returnNotice());
+  }
+
+  for (const group of getAllAgentGroups()) {
+    if (opts.via === 'probe' && originGroupId && group.id === originGroupId) continue;
+    try {
+      restartAgentGroupContainers(group.id, 'fallback-return', shortReturnBriefing());
+    } catch (err) {
+      log.warn('Failed to restart agent group after fallback return', { groupId: group.id, err });
+    }
+  }
+
+  log.warn('Exited fallback', {
+    via: opts.via,
+    previousClassification: state.classification,
+    retryCount: state.retryCount,
+  });
+}
+
+/** Starts an automatic return-to-native probe: the origin session is restarted on native Claude for one turn. */
+export function startReturnProbe(now: number): void {
+  const state = getFallbackState();
+  if (!state.originSessionId) {
+    log.warn('Cannot start return probe: no origin session recorded');
+    return;
+  }
+  const session = getSession(state.originSessionId);
+  if (!session) {
+    log.warn('Cannot start return probe: origin session no longer exists', { sessionId: state.originSessionId });
+    return;
+  }
+
+  let returnSummary: string | null = null;
+  try {
+    returnSummary = summarizeBackupConversation(session.agent_group_id, state.enteredAt);
+  } catch (err) {
+    log.warn('Failed to build return-probe context summary', { err });
+  }
+
+  const probeMessageId = generateId('fallback-probe');
+  writeSessionMessage(session.agent_group_id, session.id, {
+    id: probeMessageId,
+    kind: 'chat',
+    timestamp: new Date(now).toISOString(),
+    platformId: session.agent_group_id,
+    channelType: 'agent',
+    threadId: null,
+    content: JSON.stringify({ text: returnBriefing(returnSummary), sender: 'system', senderId: 'system' }),
+    onWake: 1,
+  });
+
+  setProbe({
+    probing: true,
+    probeMessageId,
+    probeSessionId: session.id,
+    probeStartedAt: new Date(now).toISOString(),
+  });
+
+  killAndWake(session, 'fallback-return-probe');
+  log.info('Started fallback return probe', { sessionId: session.id, probeMessageId });
+}
+
+/** Probe never completed within its window — back off and stay on the backup. Silent (spec: no chat notice). */
+export function handleProbeTimeout(): void {
+  const state = getFallbackState();
+  if (!state.probing || !state.probeSessionId) return;
+  const session = getSession(state.probeSessionId);
+  log.warn('Return probe timed out — reverting to backup', { sessionId: state.probeSessionId });
+
+  if (session && state.probeMessageId) {
+    const inDb = openInboundDb(session.agent_group_id, session.id);
+    try {
+      markMessageCompleted(inDb, state.probeMessageId);
+    } finally {
+      inDb.close();
+    }
+  }
+
+  bumpRetry(nextRetryIso(state.retryCount));
+
+  if (session) {
+    killAndWake(session, 'fallback-probe-timeout');
+  }
+}
+
+/** The backup provider itself breached the response guarantee — no third fallback to switch to, so just fail and notify (no retry loop). */
+export function handleDoubleFaultTimeout(session: Session, inDb: Database.Database, messageIds: string[]): void {
+  log.warn('Backup provider also breached the response guarantee (double fault)', {
+    sessionId: session.id,
+    messageIds,
+  });
+  for (const id of messageIds) markMessageFailed(inDb, id);
+  void notifyConversationOrOwner(session, doubleFaultNotice());
+}
+
+/**
+ * Delivery-action handler for `fallback_report` — the container reporting a
+ * hit limit. See fallback-report.ts (container side) for the payload shape.
+ */
+export async function handleFallbackReport(
+  content: Record<string, unknown>,
+  session: Session,
+  inDb: Database.Database,
+): Promise<void> {
+  const classification = content.classification as FallbackClassification;
+  const resetAt = typeof content.resetAt === 'number' ? new Date(content.resetAt).toISOString() : null;
+  const message = typeof content.message === 'string' ? content.message : '';
+  const messageIds = Array.isArray(content.messageIds) ? (content.messageIds as string[]) : [];
+  const state = getFallbackState();
+
+  if (state.probing) {
+    // Rule 10: the return probe itself hit a limit again — silent re-fallback.
+    // The probe message is marked completed (never re-presented to the
+    // backup) so the return briefing never ends up in front of it.
+    log.warn('Return probe hit a limit — silent re-fallback', { sessionId: session.id, classification });
+    const rest = messageIds.filter((id) => id !== state.probeMessageId);
+    if (state.probeMessageId && messageIds.includes(state.probeMessageId)) {
+      markMessageCompleted(inDb, state.probeMessageId);
+    }
+    if (rest.length > 0) representMessages(inDb, rest);
+    bumpRetry(nextRetryIso(state.retryCount));
+    killAndWake(session, 'fallback-reprobe-limit');
+    return;
+  }
+
+  if (state.active) {
+    // Duplicate report while already in fallback — just re-present and restart.
+    log.info('Fallback report while already active — re-presenting', { sessionId: session.id, classification });
+    representMessages(inDb, messageIds);
+    killAndWake(session, 'fallback-already-active');
+    return;
+  }
+
+  await enterFallback({
+    mode: 'auto',
+    classification,
+    reason: message || classification,
+    resetAt,
+    originSessionId: session.id,
+    originGroupId: session.agent_group_id,
+    messageIds,
+  });
+}
+
+/**
+ * Delivery-action handler for `provider_error` — a generic (non-limit)
+ * provider error. The container already surfaced a single user-facing
+ * message for this, so this handler only updates state/bookkeeping.
+ */
+export async function handleProviderError(
+  content: Record<string, unknown>,
+  session: Session,
+  _inDb: Database.Database,
+): Promise<void> {
+  const message = typeof content.message === 'string' ? content.message : '';
+  const state = getFallbackState();
+
+  if (state.probing) {
+    log.warn('Return probe failed with a generic error — silent re-fallback', { sessionId: session.id, message });
+    bumpRetry(nextRetryIso(state.retryCount));
+    killAndWake(session, 'fallback-reprobe-generic-error');
+    return;
+  }
+
+  if (state.active) {
+    setLastError(message);
+    log.warn('Provider error while fallback active (double fault) — already surfaced to chat by the container', {
+      sessionId: session.id,
+      message,
+    });
+    return;
+  }
+
+  log.info('Provider error reported (native provider, no fallback active)', { sessionId: session.id, message });
+}

--- a/src/modules/fallback/db.test.ts
+++ b/src/modules/fallback/db.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { bumpRetry, clearFallbackState, enterFallbackState, getFallbackState, setLastError, setProbe } from './db.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('fallback_state — seed row', () => {
+  it('is seeded inactive by the migration', () => {
+    const state = getFallbackState();
+    expect(state.active).toBe(false);
+    expect(state.mode).toBeNull();
+    expect(state.backupProvider).toBeNull();
+    expect(state.retryCount).toBe(0);
+    expect(state.probing).toBe(false);
+  });
+});
+
+describe('enterFallbackState', () => {
+  it('activates the row and resets retry/probe bookkeeping', () => {
+    const state = enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'quota exhausted',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: '2026-01-01T00:00:00.000Z',
+      nextRetryAt: null,
+      originSessionId: 'sess-1',
+      originGroupId: 'group-1',
+    });
+
+    expect(state.active).toBe(true);
+    expect(state.mode).toBe('auto');
+    expect(state.classification).toBe('quota');
+    expect(state.reason).toBe('quota exhausted');
+    expect(state.backupProvider).toBe('opencode');
+    expect(state.resetAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(state.retryCount).toBe(0);
+    expect(state.probing).toBe(false);
+    expect(state.originSessionId).toBe('sess-1');
+    expect(state.originGroupId).toBe('group-1');
+    expect(state.enteredAt).not.toBeNull();
+  });
+
+  it('clears any leftover probe/retry bookkeeping from a prior cycle', () => {
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r1',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 's1',
+      originGroupId: 'g1',
+    });
+    setProbe({ probing: true, probeMessageId: 'm1', probeSessionId: 's1', probeStartedAt: new Date().toISOString() });
+    bumpRetry(new Date(Date.now() + 60_000).toISOString());
+
+    const state = enterFallbackState({
+      mode: 'auto',
+      classification: 'overload',
+      reason: 'r2',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 's2',
+      originGroupId: 'g2',
+    });
+
+    expect(state.probing).toBe(false);
+    expect(state.probeMessageId).toBeNull();
+    expect(state.retryCount).toBe(0);
+    expect(state.nextRetryAt).toBeNull();
+  });
+});
+
+describe('clearFallbackState', () => {
+  it('resets every field to its inactive defaults', () => {
+    enterFallbackState({
+      mode: 'forced',
+      classification: 'manual',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 's1',
+      originGroupId: 'g1',
+    });
+    setLastError('boom');
+
+    const state = clearFallbackState();
+    expect(state.active).toBe(false);
+    expect(state.mode).toBeNull();
+    expect(state.classification).toBeNull();
+    expect(state.backupProvider).toBeNull();
+    expect(state.originSessionId).toBeNull();
+    expect(state.originGroupId).toBeNull();
+    expect(state.lastError).toBeNull();
+  });
+});
+
+describe('setProbe', () => {
+  it('records probe bookkeeping without touching active/mode', () => {
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 's1',
+      originGroupId: 'g1',
+    });
+
+    const startedAt = new Date().toISOString();
+    const state = setProbe({
+      probing: true,
+      probeMessageId: 'probe-1',
+      probeSessionId: 's1',
+      probeStartedAt: startedAt,
+    });
+
+    expect(state.active).toBe(true);
+    expect(state.probing).toBe(true);
+    expect(state.probeMessageId).toBe('probe-1');
+    expect(state.probeSessionId).toBe('s1');
+    expect(state.probeStartedAt).toBe(startedAt);
+  });
+});
+
+describe('bumpRetry', () => {
+  it('increments retry_count, sets next_retry_at, and clears probe fields', () => {
+    enterFallbackState({
+      mode: 'auto',
+      classification: 'quota',
+      reason: 'r',
+      backupModel: null,
+      backupProvider: 'opencode',
+      resetAt: null,
+      nextRetryAt: null,
+      originSessionId: 's1',
+      originGroupId: 'g1',
+    });
+    setProbe({
+      probing: true,
+      probeMessageId: 'probe-1',
+      probeSessionId: 's1',
+      probeStartedAt: new Date().toISOString(),
+    });
+
+    const nextRetry = new Date(Date.now() + 5 * 60_000).toISOString();
+    const state = bumpRetry(nextRetry);
+
+    expect(state.retryCount).toBe(1);
+    expect(state.nextRetryAt).toBe(nextRetry);
+    expect(state.probing).toBe(false);
+    expect(state.probeMessageId).toBeNull();
+
+    const state2 = bumpRetry(new Date(Date.now() + 10 * 60_000).toISOString());
+    expect(state2.retryCount).toBe(2);
+  });
+});
+
+describe('setLastError', () => {
+  it('records the message without changing active/mode', () => {
+    setLastError('generic provider error');
+    const state = getFallbackState();
+    expect(state.lastError).toBe('generic provider error');
+    expect(state.active).toBe(false);
+  });
+});

--- a/src/modules/fallback/db.ts
+++ b/src/modules/fallback/db.ts
@@ -1,0 +1,212 @@
+/**
+ * `fallback_state` accessors — single-row (id=1) global state.
+ *
+ * No caching: every function reads/writes the row directly. The row is tiny,
+ * writes are rare (one per switch/probe/retry), and direct reads mean a host
+ * restart trivially resumes in whatever state the DB says — no in-memory
+ * state to reconcile on boot.
+ */
+import { getDb } from '../../db/connection.js';
+
+export type FallbackMode = 'auto' | 'forced';
+export type FallbackClassification = 'quota' | 'billing' | 'overload' | 'timeout' | 'manual';
+
+export interface FallbackState {
+  active: boolean;
+  mode: FallbackMode | null;
+  classification: FallbackClassification | null;
+  reason: string | null;
+  backupProvider: string | null;
+  backupModel: string | null;
+  enteredAt: string | null;
+  resetAt: string | null;
+  nextRetryAt: string | null;
+  retryCount: number;
+  probing: boolean;
+  probeMessageId: string | null;
+  probeSessionId: string | null;
+  probeStartedAt: string | null;
+  originSessionId: string | null;
+  originGroupId: string | null;
+  lastError: string | null;
+  updatedAt: string;
+}
+
+interface FallbackStateRow {
+  active: number;
+  mode: string | null;
+  classification: string | null;
+  reason: string | null;
+  backup_provider: string | null;
+  backup_model: string | null;
+  entered_at: string | null;
+  reset_at: string | null;
+  next_retry_at: string | null;
+  retry_count: number;
+  probing: number;
+  probe_message_id: string | null;
+  probe_session_id: string | null;
+  probe_started_at: string | null;
+  origin_session_id: string | null;
+  origin_group_id: string | null;
+  last_error: string | null;
+  updated_at: string;
+}
+
+function rowToState(row: FallbackStateRow): FallbackState {
+  return {
+    active: row.active === 1,
+    mode: row.mode as FallbackMode | null,
+    classification: row.classification as FallbackClassification | null,
+    reason: row.reason,
+    backupProvider: row.backup_provider,
+    backupModel: (row as { backup_model?: string | null }).backup_model ?? null,
+    enteredAt: row.entered_at,
+    resetAt: row.reset_at,
+    nextRetryAt: row.next_retry_at,
+    retryCount: row.retry_count,
+    probing: row.probing === 1,
+    probeMessageId: row.probe_message_id,
+    probeSessionId: row.probe_session_id,
+    probeStartedAt: row.probe_started_at,
+    originSessionId: row.origin_session_id,
+    originGroupId: row.origin_group_id,
+    lastError: row.last_error,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Reads the single global row. Always present — seeded by the migration. */
+export function getFallbackState(): FallbackState {
+  const row = getDb().prepare('SELECT * FROM fallback_state WHERE id = 1').get() as FallbackStateRow | undefined;
+  if (!row) {
+    throw new Error('fallback_state seed row (id=1) is missing — migration may be incomplete');
+  }
+  return rowToState(row);
+}
+
+export interface EnterFallbackParams {
+  mode: FallbackMode;
+  classification: FallbackClassification;
+  reason: string;
+  backupProvider: string;
+  backupModel: string | null;
+  resetAt: string | null;
+  nextRetryAt: string | null;
+  originSessionId: string | null;
+  originGroupId: string | null;
+}
+
+/** Switches the install to the backup provider. Resets retry bookkeeping. */
+export function enterFallbackState(params: EnterFallbackParams): FallbackState {
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `UPDATE fallback_state SET
+         active = 1,
+         mode = @mode,
+         classification = @classification,
+         reason = @reason,
+         backup_provider = @backupProvider,
+         backup_model = @backupModel,
+          entered_at = @now,
+          reset_at = @resetAt,
+          next_retry_at = @nextRetryAt,
+         retry_count = 0,
+         probing = 0,
+         probe_message_id = NULL,
+         probe_session_id = NULL,
+         probe_started_at = NULL,
+         origin_session_id = @originSessionId,
+         origin_group_id = @originGroupId,
+         last_error = NULL,
+         updated_at = @now
+       WHERE id = 1`,
+    )
+    .run({ ...params, now });
+  return getFallbackState();
+}
+
+/** Returns the install to the native provider. Clears all switch bookkeeping. */
+export function clearFallbackState(): FallbackState {
+  getDb()
+    .prepare(
+      `UPDATE fallback_state SET
+         active = 0,
+         mode = NULL,
+         classification = NULL,
+         reason = NULL,
+         backup_provider = NULL,
+         backup_model = NULL,
+         entered_at = NULL,
+         reset_at = NULL,
+         next_retry_at = NULL,
+         retry_count = 0,
+         probing = 0,
+         probe_message_id = NULL,
+         probe_session_id = NULL,
+         probe_started_at = NULL,
+         origin_session_id = NULL,
+         origin_group_id = NULL,
+         last_error = NULL,
+         updated_at = @now
+       WHERE id = 1`,
+    )
+    .run({ now: new Date().toISOString() });
+  return getFallbackState();
+}
+
+export interface SetProbeParams {
+  probing: boolean;
+  probeMessageId: string | null;
+  probeSessionId: string | null;
+  probeStartedAt: string | null;
+}
+
+/** Marks (or clears) an in-flight return-to-native probe attempt. */
+export function setProbe(params: SetProbeParams): FallbackState {
+  getDb()
+    .prepare(
+      `UPDATE fallback_state SET
+         probing = @probing,
+         probe_message_id = @probeMessageId,
+         probe_session_id = @probeSessionId,
+         probe_started_at = @probeStartedAt,
+         updated_at = @now
+       WHERE id = 1`,
+    )
+    .run({ ...params, probing: params.probing ? 1 : 0, now: new Date().toISOString() });
+  return getFallbackState();
+}
+
+/** Records a failed return attempt and schedules the next one. */
+export function bumpRetry(nextRetryAt: string): FallbackState {
+  getDb()
+    .prepare(
+      `UPDATE fallback_state SET
+         retry_count = retry_count + 1,
+         next_retry_at = @nextRetryAt,
+         probing = 0,
+         probe_message_id = NULL,
+         probe_session_id = NULL,
+         probe_started_at = NULL,
+         updated_at = @now
+       WHERE id = 1`,
+    )
+    .run({ nextRetryAt, now: new Date().toISOString() });
+  return getFallbackState();
+}
+
+/** Records the last error seen (diagnostics only — doesn't change active/mode). */
+export function setLastError(message: string): void {
+  getDb()
+    .prepare(`UPDATE fallback_state SET last_error = @message, updated_at = @now WHERE id = 1`)
+    .run({ message, now: new Date().toISOString() });
+}
+
+/** Records a diagnostic event in the fallback_events table (spec rule: every switch/probe/failure gets logged). */
+export function logFallbackEvent(eventType: string, reason?: string | null, details?: string | null): void {
+  getDb()
+    .prepare(`INSERT INTO fallback_events (timestamp, event_type, reason, details) VALUES (?, ?, ?, ?)`)
+    .run(new Date().toISOString(), eventType, reason ?? null, details ?? null);
+}

--- a/src/modules/fallback/decide.test.ts
+++ b/src/modules/fallback/decide.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FallbackState } from './db.js';
+import { decideFallbackSweep, nextRetryAt, RESPONSE_GUARANTEE_MS, RETURN_BACKOFF_MIN } from './decide.js';
+
+function baseState(overrides: Partial<FallbackState> = {}): FallbackState {
+  return {
+    active: false,
+    mode: null,
+    classification: null,
+    reason: null,
+    backupModel: null,
+    backupProvider: null,
+    enteredAt: null,
+    resetAt: null,
+    nextRetryAt: null,
+    retryCount: 0,
+    probing: false,
+    probeMessageId: null,
+    probeSessionId: null,
+    probeStartedAt: null,
+    originSessionId: null,
+    originGroupId: null,
+    lastError: null,
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('nextRetryAt', () => {
+  it('walks the backoff schedule by retry count', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < RETURN_BACKOFF_MIN.length; i++) {
+      expect(nextRetryAt(i, now)).toBe(now + RETURN_BACKOFF_MIN[i] * 60_000);
+    }
+  });
+
+  it('caps at the last backoff entry beyond the schedule length', () => {
+    const now = 1_000_000;
+    const last = RETURN_BACKOFF_MIN[RETURN_BACKOFF_MIN.length - 1];
+    expect(nextRetryAt(RETURN_BACKOFF_MIN.length + 5, now)).toBe(now + last * 60_000);
+  });
+});
+
+describe('decideFallbackSweep — forced mode', () => {
+  it('never probes, regardless of resetAt/nextRetryAt', () => {
+    const state = baseState({ active: true, mode: 'forced', resetAt: new Date(0).toISOString() });
+    const decision = decideFallbackSweep({
+      nowMs: Date.now(),
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'none' });
+  });
+});
+
+describe('decideFallbackSweep — auto mode, not probing', () => {
+  it('starts a probe once resetAt has passed', () => {
+    const state = baseState({ active: true, mode: 'auto', resetAt: new Date(1000).toISOString() });
+    const decision = decideFallbackSweep({
+      nowMs: 2000,
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'start-probe' });
+  });
+
+  it('starts a probe once nextRetryAt has passed when resetAt is unknown', () => {
+    const state = baseState({ active: true, mode: 'auto', resetAt: null, nextRetryAt: new Date(1000).toISOString() });
+    const decision = decideFallbackSweep({
+      nowMs: 2000,
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'start-probe' });
+  });
+
+  it('does nothing before the due time', () => {
+    const state = baseState({ active: true, mode: 'auto', resetAt: new Date(5000).toISOString() });
+    const decision = decideFallbackSweep({
+      nowMs: 2000,
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'none' });
+  });
+
+  it('does nothing when neither resetAt nor nextRetryAt is set', () => {
+    const state = baseState({ active: true, mode: 'auto' });
+    const decision = decideFallbackSweep({
+      nowMs: Date.now(),
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'none' });
+  });
+});
+
+describe('decideFallbackSweep — auto mode, probing', () => {
+  it('reports probe-success when the probe row completed', () => {
+    const state = baseState({ active: true, mode: 'auto', probing: true, probeStartedAt: new Date(0).toISOString() });
+    const decision = decideFallbackSweep({
+      nowMs: 1000,
+      state,
+      probeRowStatus: 'completed',
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'probe-success' });
+  });
+
+  it('reports probe-timeout after 10 minutes without completion', () => {
+    const startedAt = 0;
+    const state = baseState({
+      active: true,
+      mode: 'auto',
+      probing: true,
+      probeStartedAt: new Date(startedAt).toISOString(),
+    });
+    const decision = decideFallbackSweep({
+      nowMs: startedAt + 10 * 60_000 + 1,
+      state,
+      probeRowStatus: 'pending',
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'probe-timeout' });
+  });
+
+  it('does nothing while still within the probe window', () => {
+    const startedAt = 0;
+    const state = baseState({
+      active: true,
+      mode: 'auto',
+      probing: true,
+      probeStartedAt: new Date(startedAt).toISOString(),
+    });
+    const decision = decideFallbackSweep({
+      nowMs: startedAt + 60_000,
+      state,
+      probeRowStatus: 'pending',
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'none' });
+  });
+
+  it('prefers probe-success over an elapsed timeout window', () => {
+    const startedAt = 0;
+    const state = baseState({
+      active: true,
+      mode: 'auto',
+      probing: true,
+      probeStartedAt: new Date(startedAt).toISOString(),
+    });
+    const decision = decideFallbackSweep({
+      nowMs: startedAt + 20 * 60_000,
+      state,
+      probeRowStatus: 'completed',
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'probe-success' });
+  });
+});
+
+describe('decideFallbackSweep — not active, response guarantee', () => {
+  it('reports guarantee-breach for messages older than the 10-minute window', () => {
+    const state = baseState({ active: false });
+    const decision = decideFallbackSweep({
+      nowMs: Date.now(),
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [
+        { id: 'm1', ageMs: RESPONSE_GUARANTEE_MS + 1 },
+        { id: 'm2', ageMs: RESPONSE_GUARANTEE_MS - 1 },
+      ],
+    });
+    expect(decision).toEqual({ type: 'guarantee-breach', messageIds: ['m1'] });
+  });
+
+  it('extends the threshold for a declared long-running Bash call', () => {
+    const state = baseState({ active: false });
+    const declaredBashMs = 20 * 60_000;
+    const decision = decideFallbackSweep({
+      nowMs: Date.now(),
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [{ id: 'm1', ageMs: RESPONSE_GUARANTEE_MS + 1 }],
+      declaredBashMs,
+    });
+    // Below the extended threshold (declaredBashMs + 60s) — not a breach.
+    expect(decision).toEqual({ type: 'none' });
+  });
+
+  it('returns none when no message is overdue', () => {
+    const state = baseState({ active: false });
+    const decision = decideFallbackSweep({
+      nowMs: Date.now(),
+      state,
+      probeRowStatus: null,
+      overdueTriggerMessages: [],
+    });
+    expect(decision).toEqual({ type: 'none' });
+  });
+});

--- a/src/modules/fallback/decide.ts
+++ b/src/modules/fallback/decide.ts
@@ -1,0 +1,90 @@
+import type { FallbackState } from './db.js';
+
+/**
+ * Every message that enters the assistant must produce a response or a
+ * limit-reached notice within this window (spec rule 15). Also the floor
+ * for how long a declared-long-running Bash tool call gets before its
+ * message counts as "stuck" rather than "busy".
+ */
+export const RESPONSE_GUARANTEE_MS = 10 * 60_000;
+
+/** Growing backoff (minutes) between return-to-native probe attempts when the reset time is unknown. Capped at the last entry. */
+export const RETURN_BACKOFF_MIN = [5, 10, 20, 40, 60];
+
+/** Next wall-clock time (ms) to retry the native provider, given how many attempts have already failed. */
+export function nextRetryAt(retryCount: number, nowMs: number): number {
+  const idx = Math.min(retryCount, RETURN_BACKOFF_MIN.length - 1);
+  return nowMs + RETURN_BACKOFF_MIN[idx] * 60_000;
+}
+
+export type ProbeRowStatus = 'pending' | 'completed' | 'failed' | null;
+
+export interface OverdueTriggerMessage {
+  id: string;
+  ageMs: number;
+}
+
+export interface DecideFallbackSweepParams {
+  nowMs: number;
+  state: FallbackState;
+  /** Status of the outbound row the in-flight return probe is waiting on, if any. */
+  probeRowStatus: ProbeRowStatus;
+  /** Trigger messages (kind requiring a response) currently claimed/processing, with their claim age. */
+  overdueTriggerMessages: OverdueTriggerMessage[];
+  /** Longest declared Bash-tool budget among the session's in-flight messages, if any. */
+  declaredBashMs?: number;
+}
+
+export type FallbackSweepAction =
+  | { type: 'none' }
+  | { type: 'start-probe' }
+  | { type: 'probe-timeout' }
+  | { type: 'probe-success' }
+  | { type: 'guarantee-breach'; messageIds: string[] };
+
+/**
+ * Pure decision function for the two host-sweep hooks (sweepFallbackSession,
+ * sweepFallbackReturn). Takes a snapshot of state and returns one action —
+ * all side effects (DB writes, container kills, notifications) live in the
+ * caller.
+ */
+export function decideFallbackSweep(params: DecideFallbackSweepParams): FallbackSweepAction {
+  const { nowMs, state, probeRowStatus, overdueTriggerMessages, declaredBashMs = 0 } = params;
+
+  // Forced fallback never auto-probes back (spec rule 13) — only a manual
+  // `/fallback return` command exits it.
+  if (state.active && state.mode === 'forced') {
+    return { type: 'none' };
+  }
+
+  if (state.active && state.mode === 'auto') {
+    if (state.probing) {
+      if (probeRowStatus === 'completed') return { type: 'probe-success' };
+      if (probeRowStatus === 'failed') return { type: 'probe-timeout' };
+      const startedAt = state.probeStartedAt ? Date.parse(state.probeStartedAt) : NaN;
+      if (!Number.isNaN(startedAt) && nowMs - startedAt > 10 * 60_000) {
+        return { type: 'probe-timeout' };
+      }
+      return { type: 'none' };
+    }
+
+    const dueAtStr = state.nextRetryAt ?? state.resetAt;
+    const dueAt = dueAtStr ? Date.parse(dueAtStr) : NaN;
+    if (!Number.isNaN(dueAt) && nowMs >= dueAt) {
+      return { type: 'start-probe' };
+    }
+    return { type: 'none' };
+  }
+
+  // Fallback not active: check the 10-minute response guarantee. A long
+  // declared Bash call isn't "stuck" — extend the threshold to cover it.
+  if (!state.active) {
+    const threshold = Math.max(RESPONSE_GUARANTEE_MS, declaredBashMs + 60_000);
+    const breached = overdueTriggerMessages.filter((m) => m.ageMs > threshold).map((m) => m.id);
+    if (breached.length > 0) {
+      return { type: 'guarantee-breach', messageIds: breached };
+    }
+  }
+
+  return { type: 'none' };
+}

--- a/src/modules/fallback/fragment.ts
+++ b/src/modules/fallback/fragment.ts
@@ -1,0 +1,55 @@
+/**
+ * Degradation-notice fragment written to every agent group's
+ * `.claude-fragments/` while fallback is active. Written as a concrete file
+ * (not just appended to the composed CLAUDE.md) because non-Claude
+ * providers (e.g. OpenCode) read fragments via glob, not the composed file —
+ * see claude-md-compose.ts's preservation check for the Claude/default side.
+ */
+import fs from 'fs';
+import path from 'path';
+import { GROUPS_DIR } from '../../config.js';
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { log } from '../../log.js';
+import { getFallbackState } from './db.js';
+
+/** Exported so claude-md-compose.ts's preservation check can target the same file without duplicating the name. */
+export const FALLBACK_FRAGMENT_NAME = 'zz-fallback.md';
+
+export function buildFallbackFragmentContent(provider: string, model: string | null): string {
+  const modelName = model ?? provider;
+  return `## Fallback mode
+
+Claude has exhausted its limits. If asked what model you are, respond only: "Current model: ${modelName} via ${provider}." Do not add anything else.
+If asked to do something you cannot do, state it openly.\n`;
+}
+
+function fragmentPath(folder: string): string {
+  return path.join(GROUPS_DIR, folder, '.claude-fragments', FALLBACK_FRAGMENT_NAME);
+}
+
+/** Writes the degradation-notice fragment for every agent group. Best-effort. */
+export function writeDegradationFragmentForAllGroups(): void {
+  const state = getFallbackState();
+  const content = buildFallbackFragmentContent(state.backupProvider ?? 'unknown', state.backupModel);
+  for (const group of getAllAgentGroups()) {
+    try {
+      const p = fragmentPath(group.folder);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content);
+    } catch (err) {
+      log.warn('Failed to write fallback degradation fragment', { agentGroupId: group.id, err });
+    }
+  }
+}
+
+/** Removes the degradation-notice fragment for every agent group. Best-effort. */
+export function removeDegradationFragmentForAllGroups(): void {
+  for (const group of getAllAgentGroups()) {
+    try {
+      const p = fragmentPath(group.folder);
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    } catch (err) {
+      log.warn('Failed to remove fallback degradation fragment', { agentGroupId: group.id, err });
+    }
+  }
+}

--- a/src/modules/fallback/index.ts
+++ b/src/modules/fallback/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Fallback module barrel — registers the `fallback_report` / `provider_error`
+ * delivery actions and wires the global provider override to live DB state.
+ * Import for side effects only (see src/modules/index.ts).
+ */
+import { registerDeliveryAction } from '../../delivery.js';
+import { unguarded } from '../../guard/index.js';
+import { log } from '../../log.js';
+import { registerGlobalProviderOverride } from '../../provider-override.js';
+import { getFallbackState } from './db.js';
+import { handleFallbackReport, handleProviderError } from './controller.js';
+import { effectiveProvider } from './override.js';
+import './cli.js';
+
+registerDeliveryAction(
+  'fallback_report',
+  handleFallbackReport,
+  unguarded('provider self-report of a usage-limit signal — no user/agent input, nothing to authorize'),
+);
+registerDeliveryAction(
+  'provider_error',
+  handleProviderError,
+  unguarded('provider self-report of a non-limit error — no user/agent input, nothing to authorize'),
+);
+
+registerGlobalProviderOverride((native) => {
+  try {
+    return effectiveProvider(native, getFallbackState());
+  } catch (err) {
+    log.warn('Failed to read fallback state for provider override — falling back to native', { err });
+    return native;
+  }
+});

--- a/src/modules/fallback/notices.test.ts
+++ b/src/modules/fallback/notices.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FallbackState } from './db.js';
+import {
+  commandDeniedNotice,
+  doubleFaultNotice,
+  forwardBriefing,
+  noBackupNotice,
+  returnBriefing,
+  returnNotice,
+  shortReturnBriefing,
+  shortSwitchBriefing,
+  statusNotice,
+  switchAutoNotice,
+  switchForcedNotice,
+} from './notices.js';
+
+function baseState(overrides: Partial<FallbackState> = {}): FallbackState {
+  return {
+    active: false,
+    mode: null,
+    classification: null,
+    reason: null,
+    backupModel: null,
+    backupProvider: null,
+    enteredAt: null,
+    resetAt: null,
+    nextRetryAt: null,
+    retryCount: 0,
+    probing: false,
+    probeMessageId: null,
+    probeSessionId: null,
+    probeStartedAt: null,
+    originSessionId: null,
+    originGroupId: null,
+    lastError: null,
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('notices — pure text, no side effects', () => {
+  it('switchAutoNotice mentions the backup provider and the classification reason', () => {
+    const text = switchAutoNotice('quota', 'opencode', null);
+    expect(text).toContain('opencode');
+    expect(text).toContain('quota exhausted');
+  });
+
+  it('switchAutoNotice includes a formatted reset time when known', () => {
+    const text = switchAutoNotice('overload', 'opencode', new Date('2026-01-01T10:00:00Z').toISOString());
+    expect(text).toContain('Reset expected');
+  });
+
+  it('switchForcedNotice mentions the backup provider', () => {
+    expect(switchForcedNotice('opencode')).toContain('opencode');
+  });
+
+  it('noBackupNotice explains there is no backup available', () => {
+    const text = noBackupNotice('billing', null);
+    expect(text).toContain('credit exhausted');
+    expect(text).toContain('no backup model');
+  });
+
+  it('returnNotice and shortReturnBriefing are non-empty distinct strings', () => {
+    expect(returnNotice().length).toBeGreaterThan(0);
+    expect(shortReturnBriefing().length).toBeGreaterThan(0);
+  });
+
+  it('doubleFaultNotice and commandDeniedNotice are non-empty', () => {
+    expect(doubleFaultNotice().length).toBeGreaterThan(0);
+    expect(commandDeniedNotice().length).toBeGreaterThan(0);
+  });
+
+  it('forwardBriefing appends the summary only when provided', () => {
+    const withoutSummary = forwardBriefing(null, 'opencode', null);
+    const withSummary = forwardBriefing('user: ciao\nassistant: ciao a te', 'opencode', null);
+    expect(withoutSummary).not.toContain('Summary');
+    expect(withSummary).toContain('Summary');
+    expect(withSummary).toContain('ciao a te');
+  });
+
+  it('returnBriefing appends the summary only when provided', () => {
+    const withoutSummary = returnBriefing(null);
+    const withSummary = returnBriefing('scambio precedente');
+    expect(withoutSummary).not.toContain('summary');
+    expect(withSummary).toContain('scambio precedente');
+  });
+
+  it('shortSwitchBriefing mentions the backup provider', () => {
+    expect(shortSwitchBriefing('opencode', null)).toContain('opencode');
+  });
+
+  it('statusNotice reports inactive state plainly', () => {
+    const text = statusNotice(baseState({ active: false }));
+    expect(text).toContain('Fallback not active');
+  });
+
+  it('statusNotice reports auto mode with next-retry info', () => {
+    const state = baseState({
+      active: true,
+      mode: 'auto',
+      backupModel: null,
+      backupProvider: 'opencode',
+      classification: 'quota',
+      enteredAt: new Date(0).toISOString(),
+      nextRetryAt: new Date(60_000).toISOString(),
+    });
+    const text = statusNotice(state);
+    expect(text).toContain('opencode');
+    expect(text).toContain('automatic');
+    expect(text).toContain('Next return attempt');
+  });
+
+  it('statusNotice reports forced mode without a next-retry line', () => {
+    const state = baseState({
+      active: true,
+      mode: 'forced',
+      backupModel: null,
+      backupProvider: 'opencode',
+      classification: 'manual',
+    });
+    const text = statusNotice(state);
+    expect(text).toContain('forced');
+    expect(text).toContain('/fallback return');
+  });
+});

--- a/src/modules/fallback/notices.ts
+++ b/src/modules/fallback/notices.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure, snapshot-testable English text for every fallback-visible chat
+ * notice. No side effects, no DB/IO — callers decide where the text goes.
+ */
+import { TIMEZONE } from '../../config.js';
+import type { FallbackClassification, FallbackState } from './db.js';
+
+function reasonLabel(classification: FallbackClassification | null): string {
+  switch (classification) {
+    case 'quota':
+      return 'quota exhausted';
+    case 'billing':
+      return 'credit exhausted';
+    case 'overload':
+      return 'service overloaded';
+    case 'timeout':
+      return 'no response within time limit';
+    case 'manual':
+      return 'manual request';
+    default:
+      return 'unknown reason';
+  }
+}
+
+function formatResetAt(resetAt: string | null): string | null {
+  if (!resetAt) return null;
+  const d = new Date(resetAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString('en-US', {
+    timeZone: TIMEZONE,
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/** Rule: automatic switch to the backup provider. */
+export function switchAutoNotice(
+  classification: FallbackClassification,
+  backupProvider: string,
+  resetAt: string | null,
+  model?: string | null,
+): string {
+  const reset = formatResetAt(resetAt);
+  const resetPart = reset ? ` Reset expected: ${reset}.` : '';
+  const modelPart = model ? ` (${model})` : '';
+  return `⚠️ Claude has exhausted its limits (${reasonLabel(classification)}). Switching to ${backupProvider}${modelPart}.${resetPart}`;
+}
+
+/** Rule 13: owner-forced switch, never auto-returns. */
+export function switchForcedNotice(backupProvider: string, model?: string | null): string {
+  const modelPart = model ? ` (${model})` : '';
+  return `🔧 Fallback manually forced to ${backupProvider}${modelPart}.`;
+}
+
+/** Rule 11: limits hit and no backup configured — message left failed, not silently re-presented. */
+export function noBackupNotice(classification: FallbackClassification, resetAt: string | null): string {
+  const reset = formatResetAt(resetAt);
+  const resetPart = reset ? ` Reset expected: ${reset}.` : '';
+  return `⚠️ Claude has exhausted its limits (${reasonLabel(classification)}) and no backup model is available.${resetPart} You can configure a backup by re-running setup.`;
+}
+
+/** Successful return to the native provider. */
+export function returnNotice(): string {
+  return '✅ Returned to Claude.';
+}
+
+/** Both fallback and the return probe/backup are stuck — no further auto-retry loop. */
+export function doubleFaultNotice(): string {
+  return '⚠️ The backup model also did not respond in time. Try again later.';
+}
+
+export function commandDeniedNotice(): string {
+  return 'Only owner or admin can use /fallback commands.';
+}
+
+/** Rule 6: the assistant must declare, not pretend, when running on the backup model. */
+export function forwardBriefing(summary: string | null, backupProvider: string, model: string | null): string {
+  const modelPart = model ? model : backupProvider;
+  const base = [
+    `Claude has exhausted its limits — you are now responding via ${backupProvider}.`,
+    `Respond normally to any question, including generic questions about who you are.`,
+    `Only when explicitly asked what model you are, state: "Current model: ${modelPart} via ${backupProvider}." — do not pretend to be Claude.`,
+    `If asked to do something you cannot do (missing tool, missing capability), state it openly rather than trying or pretending.`,
+  ].join(' ');
+  return summary ? `${base}\n\nSummary of recent conversation:\n${summary}` : base;
+}
+
+/** Rule 9: briefing sent to the return-probe attempt; doubles as the return summary on success. */
+export function returnBriefing(summary: string | null): string {
+  const base = 'Attempting to respond as Claude — checking if limits are available again.';
+  return summary ? `${base}\n\nMeanwhile, summary of exchanges on the backup model:\n${summary}` : base;
+}
+
+/** Short wake-up nudge for other agent groups restarted alongside a switch/return (not the origin conversation). */
+export function shortSwitchBriefing(backupProvider: string, model: string | null): string {
+  const modelPart = model ? ` (${model})` : '';
+  return `Responding in place of Claude (limits exhausted) via ${backupProvider}${modelPart}. Not Claude — if asked what model I am, I say the truth.`;
+}
+
+export function shortReturnBriefing(): string {
+  return 'Claude again.';
+}
+
+export function statusNotice(state: FallbackState): string {
+  if (!state.active) {
+    return 'Active model: Claude. Fallback not active.';
+  }
+  const modeLabel = state.mode === 'forced' ? 'forced' : 'automatic';
+  const modelPart = state.backupModel ? ` on ${state.backupModel}` : '';
+  const lines = [
+    `Active model: ${state.backupProvider}${modelPart} (${modeLabel} fallback).`,
+    `Reason: ${reasonLabel(state.classification)}.`,
+  ];
+  if (state.enteredAt) lines.push(`Since: ${formatResetAt(state.enteredAt) ?? state.enteredAt}.`);
+  if (state.mode === 'auto') {
+    const nextAttempt = formatResetAt(state.nextRetryAt ?? state.resetAt);
+    lines.push(nextAttempt ? `Next return attempt: ${nextAttempt}.` : 'Next return attempt: not yet scheduled.');
+  } else {
+    lines.push('Manual return only (`/fallback return`).');
+  }
+  return lines.join('\n');
+}

--- a/src/modules/fallback/override.test.ts
+++ b/src/modules/fallback/override.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FallbackState } from './db.js';
+import { effectiveProvider } from './override.js';
+
+function baseState(overrides: Partial<FallbackState> = {}): FallbackState {
+  return {
+    active: false,
+    mode: null,
+    classification: null,
+    reason: null,
+    backupModel: null,
+    backupProvider: null,
+    enteredAt: null,
+    resetAt: null,
+    nextRetryAt: null,
+    retryCount: 0,
+    probing: false,
+    probeMessageId: null,
+    probeSessionId: null,
+    probeStartedAt: null,
+    originSessionId: null,
+    originGroupId: null,
+    lastError: null,
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('effectiveProvider', () => {
+  it('returns native when fallback is not active', () => {
+    expect(effectiveProvider('claude', baseState({ active: false }))).toBe('claude');
+  });
+
+  it('returns the backup provider when fallback is active and not probing', () => {
+    const state = baseState({ active: true, backupModel: null, backupProvider: 'opencode' });
+    expect(effectiveProvider('claude', state)).toBe('opencode');
+  });
+
+  it('returns native during a return probe, even though fallback is still active', () => {
+    const state = baseState({ active: true, backupModel: null, backupProvider: 'opencode', probing: true });
+    expect(effectiveProvider('claude', state)).toBe('claude');
+  });
+
+  it('returns native when active but no backup provider is recorded', () => {
+    const state = baseState({ active: true, backupModel: null, backupProvider: null });
+    expect(effectiveProvider('claude', state)).toBe('claude');
+  });
+
+  it('is a no-op for a group whose native provider already equals the backup', () => {
+    const state = baseState({ active: true, backupModel: null, backupProvider: 'opencode' });
+    expect(effectiveProvider('opencode', state)).toBe('opencode');
+  });
+});

--- a/src/modules/fallback/override.ts
+++ b/src/modules/fallback/override.ts
@@ -1,0 +1,16 @@
+import type { FallbackState } from './db.js';
+
+/**
+ * Pure decision: which provider should actually run, given a group's native
+ * provider and the current fallback state.
+ *
+ * Identity (native wins) when: fallback isn't active, a return probe is in
+ * flight (the probe session must actually try the native provider), no
+ * backup provider is configured, or the group's native provider already
+ * *is* the backup (nothing to override).
+ */
+export function effectiveProvider(native: string, state: FallbackState): string {
+  if (!state.active || state.probing || !state.backupProvider) return native;
+  if (native === state.backupProvider) return native;
+  return state.backupProvider;
+}

--- a/src/modules/fallback/summary.ts
+++ b/src/modules/fallback/summary.ts
@@ -1,0 +1,156 @@
+/**
+ * Best-effort, host-side context summaries for the fallback switch/return
+ * briefings. Both directions read from disk rather than calling a model —
+ * the whole point is to work even when the model that would normally
+ * summarize (Claude) is the one that's down.
+ */
+import fs from 'fs';
+import path from 'path';
+import { DATA_DIR, GROUPS_DIR } from '../../config.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { openOutboundDb } from '../../session-manager.js';
+import { log } from '../../log.js';
+
+const MAX_SUMMARY_CHARS = 4000;
+const MAX_PAIRS = 10;
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** Node port of providers/claude.ts's parseTranscript — same .jsonl shape. */
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+      /* skip unparseable lines */
+    }
+  }
+  return messages;
+}
+
+function findTranscriptPath(agentGroupId: string, claudeSessionId: string): string | null {
+  const projects = path.join(DATA_DIR, 'v2-sessions', agentGroupId, '.claude-shared', 'projects');
+  let dirs: string[];
+  try {
+    dirs = fs.readdirSync(projects);
+  } catch {
+    return null;
+  }
+  for (const dir of dirs) {
+    const candidate = path.join(projects, dir, `${claudeSessionId}.jsonl`);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Reads the Claude SDK session id the poll-loop stored as its continuation token. */
+function readClaudeContinuation(agentGroupId: string, sessionId: string): string | null {
+  try {
+    const outDb = openOutboundDb(agentGroupId, sessionId);
+    try {
+      const row = outDb.prepare("SELECT value FROM session_state WHERE key = 'continuation:claude'").get() as
+        | { value: string }
+        | undefined;
+      return row?.value ?? null;
+    } finally {
+      outDb.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function renderSummary(messages: ParsedMessage[]): string {
+  const recent = messages.slice(-MAX_PAIRS * 2);
+  const joined = recent.map((m) => `**${m.role === 'user' ? 'User' : 'Assistant'}**: ${m.content}`).join('\n');
+  return joined.length > MAX_SUMMARY_CHARS ? `${joined.slice(0, MAX_SUMMARY_CHARS)}...` : joined;
+}
+
+/**
+ * Forward ("outgoing") briefing: last ~10 exchanges from Claude's own .jsonl
+ * transcript, read directly off the `.claude-shared` mount — never calls the
+ * (possibly limit-hit) Claude model itself. Returns null on any failure or
+ * if there's nothing to summarize.
+ */
+export function summarizeClaudeTranscript(agentGroupId: string, sessionId: string): string | null {
+  const claudeSessionId = readClaudeContinuation(agentGroupId, sessionId);
+  if (!claudeSessionId) return null;
+  const transcriptPath = findTranscriptPath(agentGroupId, claudeSessionId);
+  if (!transcriptPath) return null;
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf-8');
+    const messages = parseTranscript(content);
+    if (messages.length === 0) return null;
+    return renderSummary(messages);
+  } catch (err) {
+    log.warn('Failed to read Claude transcript for fallback summary', { agentGroupId, sessionId, err });
+    return null;
+  }
+}
+
+/**
+ * Return ("return") briefing: markdown files the backup provider archived
+ * into its `conversations/` folder while Claude was down (mtime >=
+ * `enteredAt`). Providers with no on-disk transcript of their own rely on
+ * `onExchangeComplete` writing there directly (see providers/types.ts).
+ */
+export function summarizeBackupConversation(agentGroupId: string, enteredAt: string | null): string | null {
+  if (!enteredAt) return null;
+  const group = getAgentGroup(agentGroupId);
+  if (!group) return null;
+
+  const conversationsDir = path.join(GROUPS_DIR, group.folder, 'conversations');
+  let files: string[];
+  try {
+    files = fs.readdirSync(conversationsDir);
+  } catch {
+    return null;
+  }
+
+  const sinceMs = Date.parse(enteredAt);
+  const relevant = files
+    .map((f) => {
+      const p = path.join(conversationsDir, f);
+      try {
+        return { path: p, mtimeMs: fs.statSync(p).mtimeMs };
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (f): f is { path: string; mtimeMs: number } => f !== null && (Number.isNaN(sinceMs) || f.mtimeMs >= sinceMs),
+    )
+    .sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  if (relevant.length === 0) return null;
+
+  const chunks: string[] = [];
+  for (const f of relevant) {
+    try {
+      chunks.push(fs.readFileSync(f.path, 'utf-8'));
+    } catch {
+      /* skip unreadable file */
+    }
+  }
+  if (chunks.length === 0) return null;
+  const joined = chunks.join('\n\n---\n\n');
+  return joined.length > MAX_SUMMARY_CHARS ? `${joined.slice(0, MAX_SUMMARY_CHARS)}...` : joined;
+}

--- a/src/modules/fallback/sweep.ts
+++ b/src/modules/fallback/sweep.ts
@@ -1,0 +1,150 @@
+/**
+ * Host-sweep hooks for the fallback module — dynamically imported from
+ * host-sweep.ts (MODULE-HOOK convention) so core has no static dependency on
+ * this optional module.
+ */
+import type Database from 'better-sqlite3';
+import { killContainer } from '../../container-runner.js';
+import { getContainerState } from '../../db/session-db.js';
+import { getSession } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { parseSqliteUtc } from '../../host-sweep.js';
+import { openInboundDb } from '../../session-manager.js';
+import type { Session } from '../../types.js';
+import {
+  enterFallback,
+  exitFallback,
+  handleDoubleFaultTimeout,
+  handleProbeTimeout,
+  startReturnProbe,
+} from './controller.js';
+import { getFallbackState } from './db.js';
+import {
+  decideFallbackSweep,
+  RESPONSE_GUARANTEE_MS,
+  type OverdueTriggerMessage,
+  type ProbeRowStatus,
+} from './decide.js';
+
+function declaredBashMs(outDb: Database.Database | null): number {
+  if (!outDb) return 0;
+  const state = getContainerState(outDb);
+  if (!state || state.current_tool !== 'Bash') return 0;
+  return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : 0;
+}
+
+function overdueTriggerMessages(inDb: Database.Database, nowMs: number): OverdueTriggerMessage[] {
+  const rows = inDb
+    .prepare("SELECT id, timestamp FROM messages_in WHERE trigger = 1 AND status IN ('pending', 'processing')")
+    .all() as Array<{ id: string; timestamp: string }>;
+  return rows
+    .map((r) => ({ id: r.id, ageMs: nowMs - parseSqliteUtc(r.timestamp) }))
+    .filter((m) => !Number.isNaN(m.ageMs));
+}
+
+/**
+ * Per-session hook, called once per sweep tick for every active session,
+ * before the generic SLA/retry steps in sweepSession — fallback takes
+ * precedence over the generic retry-with-backoff path so an overdue row is
+ * handled once, by whichever mechanism notices it first.
+ */
+export async function sweepFallbackSession(
+  inDb: Database.Database,
+  outDb: Database.Database | null,
+  session: Session,
+): Promise<void> {
+  const nowMs = Date.now();
+  const overdue = overdueTriggerMessages(inDb, nowMs);
+  if (overdue.length === 0) return;
+
+  const state = getFallbackState();
+
+  if (state.active) {
+    // The backup provider itself breached the guarantee — there's no third
+    // provider to fall back to. Fail these messages and notify once; the
+    // regular retry machinery is bypassed so this can't turn into a loop.
+    const threshold = Math.max(RESPONSE_GUARANTEE_MS, declaredBashMs(outDb) + 60_000);
+    const breached = overdue.filter((m) => m.ageMs > threshold).map((m) => m.id);
+    if (breached.length === 0) return;
+    killContainer(session.id, 'fallback-double-fault');
+    handleDoubleFaultTimeout(session, inDb, breached);
+    return;
+  }
+
+  const decision = decideFallbackSweep({
+    nowMs,
+    state,
+    probeRowStatus: null,
+    overdueTriggerMessages: overdue,
+    declaredBashMs: declaredBashMs(outDb),
+  });
+
+  if (decision.type !== 'guarantee-breach') return;
+
+  log.warn('Response guarantee breached — entering fallback', {
+    sessionId: session.id,
+    messageIds: decision.messageIds,
+  });
+  await enterFallback({
+    mode: 'auto',
+    classification: 'timeout',
+    reason: 'response-guarantee-breach',
+    resetAt: null,
+    originSessionId: session.id,
+    originGroupId: session.agent_group_id,
+    messageIds: decision.messageIds,
+  });
+}
+
+function readProbeRowStatus(agentGroupId: string, sessionId: string, messageId: string): ProbeRowStatus {
+  const inDb = openInboundDb(agentGroupId, sessionId);
+  try {
+    const row = inDb.prepare('SELECT status FROM messages_in WHERE id = ?').get(messageId) as
+      | { status: string }
+      | undefined;
+    if (!row) return null;
+    if (row.status === 'completed') return 'completed';
+    if (row.status === 'failed') return 'failed';
+    return 'pending';
+  } finally {
+    inDb.close();
+  }
+}
+
+/**
+ * Once-per-tick hook (not per session) — drives the auto-return probe state
+ * machine off the global fallback_state row.
+ */
+export async function sweepFallbackReturn(): Promise<void> {
+  const state = getFallbackState();
+  if (!state.active) return;
+
+  let probeRowStatus: ProbeRowStatus = null;
+  if (state.probing && state.probeSessionId && state.probeMessageId) {
+    const probeSession = getSession(state.probeSessionId);
+    if (probeSession) {
+      probeRowStatus = readProbeRowStatus(probeSession.agent_group_id, probeSession.id, state.probeMessageId);
+    }
+  }
+
+  const decision = decideFallbackSweep({
+    nowMs: Date.now(),
+    state,
+    probeRowStatus,
+    overdueTriggerMessages: [],
+  });
+
+  switch (decision.type) {
+    case 'start-probe':
+      startReturnProbe(Date.now());
+      break;
+    case 'probe-success':
+      exitFallback({ via: 'probe' });
+      break;
+    case 'probe-timeout':
+      handleProbeTimeout();
+      break;
+    default:
+      break;
+  }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -21,3 +21,4 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './fallback/index.js';

--- a/src/provider-override.ts
+++ b/src/provider-override.ts
@@ -1,0 +1,25 @@
+/**
+ * Global provider override seam.
+ *
+ * `resolveProviderName()` (container-runner.ts) computes each agent group's
+ * *native* provider and must stay pure — it has no idea a fallback module
+ * might exist. This seam lets an optional module (src/modules/fallback)
+ * wrap that native choice with an install-wide override, without the core
+ * resolver ever importing from an optional module.
+ *
+ * No override registered → applyProviderOverride is the identity function,
+ * so core behaves exactly as it did before this file existed.
+ */
+export type ProviderOverrideFn = (native: string) => string;
+
+let overrideFn: ProviderOverrideFn | null = null;
+
+/** Called once at module import time by the module that owns the override policy. */
+export function registerGlobalProviderOverride(fn: ProviderOverrideFn): void {
+  overrideFn = fn;
+}
+
+/** Applied at every provider-selection call site. Identity when no module is installed. */
+export function applyProviderOverride(native: string): string {
+  return overrideFn ? overrideFn(native) : native;
+}

--- a/src/providers/env-helpers.ts
+++ b/src/providers/env-helpers.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+export function mergeNoProxy(current: string | undefined, additions: string): string {
+  if (!current?.trim()) return additions;
+  const parts = new Set(
+    current
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  for (const addition of additions.split(',')) {
+    const trimmed = addition.trim();
+    if (trimmed) parts.add(trimmed);
+  }
+  return [...parts].join(',');
+}
+
+export function readDotEnv(): Record<string, string> {
+  try {
+    const file = fs.readFileSync(path.join(process.cwd(), '.env'), 'utf-8');
+    const result: Record<string, string> = {};
+    for (const line of file.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      result[key] = value;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,3 +4,4 @@
 // needs (claude) don't appear here.
 //
 // Skills add a new provider by appending one import line below.
+import './ollama.js';

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,0 +1,17 @@
+import { mergeNoProxy, readDotEnv } from './env-helpers.js';
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+registerProviderContainerConfig('ollama', (ctx) => {
+  const env: Record<string, string> = {
+    NO_PROXY: mergeNoProxy(ctx.hostEnv.NO_PROXY, 'host.docker.internal'),
+    no_proxy: mergeNoProxy(ctx.hostEnv.no_proxy, 'host.docker.internal'),
+  };
+
+  // Read OLLAMA_* from process.env first, then from .env as fallback.
+  const envFile = readDotEnv();
+  for (const key of ['OLLAMA_BASE_URL', 'OLLAMA_MODEL'] as const) {
+    const value = ctx.hostEnv[key] || envFile[key];
+    if (value) env[key] = value;
+  }
+  return { env };
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -481,6 +481,22 @@ async function deliverToAgent(
     threadId: effectiveThreadId,
   };
 
+  // Owner-only /fallback command — handled entirely host-side (status/force/
+  // return) so it works even when the native provider is dead. Runs before
+  // the command gate below since it isn't an admin-command-gate case, it's a
+  // fully separate command namespace.
+  // MODULE-HOOK:fallback-command:start
+  if (event.message.kind === 'chat' || event.message.kind === 'chat-sdk') {
+    try {
+      const { interceptFallbackCommand } = await import('./modules/fallback/commands.js');
+      const handled = await interceptFallbackCommand(event.message.content, userId, session, deliveryAddr);
+      if (handled) return;
+    } catch (err) {
+      log.error('Fallback command interceptor failed', { agentGroupId: agent.agent_group_id, err });
+    }
+  }
+  // MODULE-HOOK:fallback-command:end
+
   // Command gate: classify slash commands before they reach the container.
   // Filtered commands are dropped silently. Denied admin commands get a
   // permission-denied response written directly to messages_out.


### PR DESCRIPTION
## What

Automatic install-wide failover to a backup LLM provider when Claude hits a **real** usage limit — quota exhausted, billing failure, or persistent API overload. Transient per-minute rate limits do not trigger a switch. Full writeup in [docs/fallback.md](docs/fallback.md).

- **Detection (container):** `limit-detect.ts` classifies `rate_limit_event` (rejected → quota), `api_retry` streaks (≥6 or >5min → overload), and billing error text. `ProviderLimitError` aborts the stream; the poll loop writes a `fallback_report` system action and leaves the claimed messages `processing`.
- **Switch (host):** the fallback module enters a persistent state (`fallback_state`, single row), re-presents the stuck messages, notifies the owner, writes a degradation fragment for all groups, and restarts containers through a new `applyProviderOverride` seam.
- **Return probe:** the host sweep retries the native provider on the origin session with [5,10,20,40,60]min backoff; only a confirmed clean turn switches everyone back.
- **Response guarantee:** any trigger message stuck >10min forces fallback entry even if the container never reported (wedged/crashed container) — the host-side safety net a container-only design can't provide.
- **Operator surface:** owner-only `/fallback status|force|return` chat command (works while Claude is down — handled host-side), `ncl fallback` CLI, switch/return/double-fault notices, `fallback_events` audit log.
- **Backup providers:** generic via `FALLBACK_PROVIDER` in `.env`. Ships an `ollama` provider (Anthropic-compatible local endpoint) so the fallback path survives network/billing-wide outages; `opencode` is supported when installed via `/add-opencode`.

## Why

When Claude runs out of quota mid-conversation, messages currently stall silently or surface as raw `Error:` dumps. This has been running in production on my install for several weeks (the state machine, probe backoff, and message re-presentation all hardened against real outages).

Related work: #3057 approaches the same problem container-side (mid-turn Claude↔Codex handoff). As discussed in [my comment there](https://github.com/nanocoai/nanoclaw/pull/3057#issuecomment-4996870489), the two designs are complementary — this PR is the host-side tier: persistent state, operator control, return probing, and the >10min response guarantee that a container-only design cannot cover (a wedged container never reports). Happy to converge on a two-tier design if maintainers prefer.

## How it works

Skill-shaped module: everything lives in `src/modules/fallback/` behind one barrel import in `src/modules/index.ts`, with `MODULE-HOOK` fences in `host-sweep.ts` / `router.ts` (dynamic imports, failure-isolated), name-keyed module migrations, and the `provider-override.ts` seam consulted at container spawn. Container side adds `limit-detect.ts` + `fallback-report.ts` and two classification hooks in the Claude provider's event translation. The mock provider grows `MOCK_PROVIDER_FAIL` / `MOCK_RESET_AT` (forwarded only when `NODE_ENV !== 'production'`) for integration coverage.

Per CONTRIBUTING, features should be skills: if you'd rather take this as an `/add-fallback` skill with the code on a registry branch, I'm happy to repackage — the module boundary was built for exactly that.

## How it was tested

- `pnpm test`: 1227/1227 pass
- `bun test` (agent-runner): all pass except one pre-existing timeout that also fails on a clean `upstream/main` checkout in my environment (`task-run turn wiring` 5s timeout)
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`: clean
- New coverage: 6 host test files (state machine, decision logic, notices, commands, override, db), `limit-detect.test.ts`, `mock.test.ts`, 3 poll-loop integration tests (quota, billing, provider_error paths)
- Production: weeks of real quota events on my install, including auto-switch → probe → auto-return cycles and the double-fault path

## Usage

```bash
# .env — local backup (ships in this PR):
FALLBACK_PROVIDER=ollama
OLLAMA_MODEL=qwen3:14b

# or a cloud backup through OpenCode (requires /add-opencode) — any model
# OpenCode can route (OpenRouter, OpenAI, Google, DeepSeek, direct API keys, ...):
# FALLBACK_PROVIDER=opencode
# OPENCODE_MODEL=openrouter/deepseek/deepseek-v4-pro
```

Nothing else to configure. On a limit event the owner gets a switch notice; `/fallback status` shows the current state; `/fallback force` / `/fallback return` override manually. With no `FALLBACK_PROVIDER` set, behavior is unchanged except a clear owner notice instead of a silent stall.

- [x] Feature skill
