### PR TITLE
Add the Adoption Companion pack (Memory Receipts + Knowledge Inventory)

### DIFF
--- a/.claude/skills/add-adoption-companion/REMOVE.md
+++ b/.claude/skills/add-adoption-companion/REMOVE.md
@@ -1,0 +1,101 @@
+# Remove the Adoption Companion pack
+
+Removal mirrors the pack's **two install scopes**. Pick the path you actually mean — they are not the same:
+
+| You want to… | Run | Touches |
+|---|---|---|
+| Take the pack off **one group** (others keep it) | **Part A only** | That group's Memory Receipts block. **Not** `container/skills/knowledge-inventory/`. |
+| **Fully uninstall** the pack from the fork (or you just removed it from the **last** group) | **Part A** for each group, then **Part B** | The blocks, then the fork-level skill directory. |
+
+Both parts are idempotent — safe to run when nothing was installed or it's already gone. Neither touches the user's `memory/` or the rest of their persona.
+
+---
+
+# Part A — Per-group removal (Memory Receipts)
+
+Strips the pack's managed block from one group's standing instructions. Run Steps 1–2 once per agent group that had it (`ncl groups list`).
+
+**This path does not remove Knowledge Inventory.** `container/skills/knowledge-inventory/` is fork-level — other groups in this fork may still be using it, and removing it here would silently break them. Leave it alone; it is Part B's job only.
+
+## 1. Strip the receipts block
+
+Deletes exactly the `<!-- adoption:receipts … -->` … `<!-- /adoption:receipts -->` span from the group's standing instructions. If no marker is present, the file is returned unchanged (**skip-if-absent** — idempotent by construction). Sibling `adoption:*` blocks from other features are left intact.
+
+```bash
+GROUP=<group-folder>          # the folder name from `ncl groups list`
+FILE="groups/$GROUP/instructions.prepend.md"
+test -f "$FILE" || { echo "no instructions.prepend.md — nothing to remove"; exit 0; }
+
+pnpm exec tsx --eval "
+import { readFileSync, writeFileSync } from 'fs';
+import { removeReceiptsBlock } from './src/adoption-receipts-block.ts';
+const f = process.argv[process.argv.length - 1];
+writeFileSync(f, removeReceiptsBlock(readFileSync(f, 'utf8')));
+" "$FILE"
+```
+
+Verify the markers are gone:
+
+```bash
+grep -c 'adoption:receipts' "$FILE"   # expect 0
+```
+
+## 2. Restart the group
+
+So the container re-composes its persona without the block.
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+## Note
+
+This removes the **installed block only**. It does not touch the user's memory, the rest of the persona, the fork-level `container/skills/knowledge-inventory/` directory, or the skill files under `.claude/skills/add-adoption-companion/`. To also delete the pack skill itself, remove that directory.
+
+---
+
+# Part B — Fork-level removal (Knowledge Inventory)
+
+**Only run this on an explicit full uninstall, or when you have just removed the pack from the *last* group that used it.** Knowledge Inventory lives at `container/skills/knowledge-inventory/`, which is repo-level: deleting it removes the tip from **every** agent group in this fork at once. If any other group still has the pack, stop here — Part A was enough.
+
+## 1. Delete the copied code and tests
+
+Reverses Step 0. Do this only on a full uninstall — the helper is what Part A's block-strip runs, so remove it *after* you have run Part A for every group.
+
+```bash
+rm -f src/adoption-receipts-block.ts src/adoption-receipts-block.test.ts \
+      src/adoption-companion-wiring.test.ts src/knowledge-inventory-skill.test.ts
+```
+
+## 2. Delete the installed skill directory
+
+Deletes what Step 5b copied to `container/skills/`. Skip-if-absent — idempotent by construction, so a second run is a clean no-op.
+
+```bash
+if [ -d container/skills/knowledge-inventory ]; then
+  rm -rf container/skills/knowledge-inventory
+  echo "knowledge-inventory: removed"
+else
+  echo "knowledge-inventory: already absent — skipping"
+fi
+```
+
+Verify it's gone:
+
+```bash
+test -d container/skills/knowledge-inventory && echo "STILL PRESENT" || echo "skill: gone"
+```
+
+This removes the **installed copy** only. The canonical copy under `.claude/skills/add-adoption-companion/add/` stays — that is the pack itself, and deleting it is a separate act (remove the skill directory). Because trunk never ships anything at `container/skills/knowledge-inventory/`, removal sticks: no update brings it back, and re-running `/add-adoption-companion` reinstalls it.
+
+## 3. Restart the groups
+
+Restart each group so it re-resolves its skills from the `container/skills/` listing at spawn. Groups also pick this up on their next message.
+
+```bash
+ncl groups restart --id <group-id>     # repeat per group, or let them restart naturally
+```
+
+## Note
+
+This deletes the pack's **copied files and the installed skill directory**. The user's `memory/` is untouched — the agent still remembers everything; it just no longer has the skill for showing an inventory of it. Memory Receipts blocks in any remaining group are unaffected (that's Part A's job).

--- a/.claude/skills/add-adoption-companion/SKILL.md
+++ b/.claude/skills/add-adoption-companion/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: add-adoption-companion
+description: Install the Adoption Companion pack — a growing bundle of opt-in "companion tips" that help a user adopt and kickstart their assistant. Ships two tips. Memory Receipts drops a light "📝 Noted" when the agent learns a durable fact, per agent group, on from install and off whenever the user says stop. Knowledge Inventory answers "what do you know about me?" with a plain-language picture of what the agent tracks, available to every group. Zero runtime code, reversible.
+---
+
+# Add Adoption Companion pack
+
+Installs the **Adoption Companion** pack — a growing bundle of small, opt-in **companion tips** that help a user adopt and kickstart their assistant. Each tip is self-contained at runtime; the pack is a distribution bundle, not a runtime coupling. Two tips ship today:
+
+| Tip | What the user gets | Scope | Toggle |
+|---|---|---|---|
+| **Memory Receipts** | a glanceable `📝 Noted` when the agent saves a durable fact, so they *see* it learn and can correct it in plain chat | one agent group | ships **on**; user can turn it off in chat |
+| **Knowledge Inventory** | they ask *"what do you know about me?"* and get a plain-language picture of what the agent tracks, plus an offer to add, fix, or stop tracking anything | every group in the fork | none |
+
+Adds **zero** runtime code — no MCP tools, no hooks, no core changes. The only code is a pure, install-time block helper (`resources/receipts-block.ts`).
+
+## How this install runs — two phases
+
+The two tips reach the agent by different mechanisms, so they install at different scopes. Do both phases:
+
+- **Step 0 — once per fork.** Copy the pack's code and tests into `src/`.
+- **Steps 1–4 — per agent group.** Memory Receipts is a managed block in that group's `instructions.prepend.md`. Repeat for each user-facing assistant you want it on.
+- **Step 5 — once per fork.** Knowledge Inventory is a container skill under `container/skills/`, which is repo-level: writing it makes the tip available to **every** group at once. Idempotent, so re-running it during a later per-group install is a no-op.
+
+## Step 0 — Copy the pack's code and tests into `src/`
+
+The block helper and the pack's three tests ship with the skill and are copied into `src/`, where `pnpm run test` and `tsc` already look. Run from the repo root:
+
+```bash
+S=.claude/skills/add-adoption-companion
+cp $S/resources/receipts-block.ts                    src/adoption-receipts-block.ts
+cp $S/resources/receipts-block.test.ts               src/adoption-receipts-block.test.ts
+cp $S/resources/adoption-companion-wiring.test.ts    src/adoption-companion-wiring.test.ts
+cp $S/resources/knowledge-inventory-skill.test.ts    src/knowledge-inventory-skill.test.ts
+```
+
+Run the helper's tests now; the two wiring tests need Step 5 to have run, so they come at the end:
+
+```bash
+pnpm exec vitest run src/adoption-receipts-block.test.ts
+```
+
+> **Why they differ.** A receipt must fire **mid-turn**, the moment a fact is saved — only always-in-prompt standing behavior guarantees that timing, and receipts should be opt-in per group, so a per-group block is both the reliable trigger and the correct blast radius. An inventory only ever fires **when the user asks**, so a model-invoked container skill is enough — and being fork-wide is safe, because it cannot interrupt anyone and only ever reveals that agent's own memory.
+
+## Step 1 — Identify the target agent group
+
+Receipts belong on the **user-facing assistant** group, not Builder/Researcher sub-agents (personas are per-group; sub-agents don't inherit). Repeat Steps 2–4 for each user-facing group you want it on.
+
+```bash
+ncl groups list
+```
+
+Note the group's folder under `groups/` (e.g. `groups/my-assistant/`).
+
+**Install on the group as-is — any session mode works, so keep the existing channel wiring.** Receipts read two per-group files that core loads at every session start regardless of session mode: the group's Core Memory (`memory/index.md`) and the block's `Receipts: ON/OFF` line. Saving, dedup, the toggle, and per-turn batching all hold even when each message lands in its own session.
+
+## Step 2 — Guard: confirm the group is on the new memory model
+
+These features read the group's memory tree, so the group must be on the shared-memory model. Two conditions prove it — check **both**:
+
+```bash
+GROUP=<group-folder>          # the folder name from `ncl groups list`
+
+# (a) UPDATED: the memory scaffold exists (auto-created on first boot)
+test -f "groups/$GROUP/memory/index.md" && echo "index.md: present" || echo "index.md: MISSING"
+
+# (b) MIGRATED: no durable content stranded in a legacy CLAUDE.local.md
+if [ -s "groups/$GROUP/CLAUDE.local.md" ]; then echo "CLAUDE.local.md: residual content — NOT migrated"; else echo "CLAUDE.local.md: clean"; fi
+```
+
+The two checks are **not** redundant: the scaffold auto-creates `index.md`, so its presence proves the version is new enough but **not** that old content moved over — the `CLAUDE.local.md`-residue check is what confirms migration.
+
+**If either fails, STOP.** Do not install. Tell the operator:
+
+> *"This group isn't on NanoClaw's new memory system yet. Run **update** + **`/migrate-memory`** for it first, then re-run `/add-adoption-companion`."*
+
+## Step 3 — Insert the block
+
+Writes a managed block, delimited `<!-- adoption:receipts v=1 -->` … `<!-- /adoption:receipts -->`, into the group's `instructions.prepend.md`. The delimiters are pure markers: they are how this skill finds the block to refresh, and how `REMOVE.md` finds it to strip. Everything between them is the tip's behavior, including the `Receipts: ON/OFF` line the agent reads and edits.
+
+A fresh install ships **`Receipts: ON`** — installing this tip *is* the opt-in, so it works from the first message rather than waiting for the user to discover a phrase that turns it on.
+
+Idempotent: appends the v1 block if absent; if a block already exists, it refreshes the body **and preserves the current `Receipts: ON/OFF` value** (a re-install never flips a user's OFF back to ON, or their ON back to OFF). Uses the pure helper — no core code runs.
+
+```bash
+FILE="groups/$GROUP/instructions.prepend.md"
+touch "$FILE"   # group-persona.ts stages this file with wx; we append to it
+
+pnpm exec tsx --eval "
+import { readFileSync, writeFileSync } from 'fs';
+import { applyReceiptsBlock } from './src/adoption-receipts-block.ts';
+const f = process.argv[process.argv.length - 1];
+writeFileSync(f, applyReceiptsBlock(readFileSync(f, 'utf8'), { version: 1 }));
+" "$FILE"
+```
+
+Verify the block landed once, on:
+
+```bash
+grep -c 'adoption:receipts v=1' "$FILE"   # expect 1
+grep 'Receipts:' "$FILE"                  # expect **Receipts: ON.** on a fresh install
+```
+
+## Step 4 — Restart the group so the new persona takes effect
+
+Standing-instruction changes apply on the next container spawn.
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+## Step 5 — Fork-level: install the Knowledge Inventory tip (once per fork)
+
+Run this once per fork — it makes Knowledge Inventory available to **every** agent group at once. Idempotent, so running it again during a later per-group install is a no-op.
+
+### 5a — Guard
+
+Same two conditions as Step 2 — the tip reads the new memory model. Check the group(s) you're installing for:
+
+```bash
+GROUP=<group-folder>
+test -f "groups/$GROUP/memory/index.md" && echo "index.md: present" || echo "index.md: MISSING"
+if [ -s "groups/$GROUP/CLAUDE.local.md" ]; then echo "CLAUDE.local.md: residual content — NOT migrated"; else echo "CLAUDE.local.md: clean"; fi
+```
+
+**If either fails, STOP** — do not install. Same operator message as Step 2:
+
+> *"This group isn't on NanoClaw's new memory system yet. Run **update** + **`/migrate-memory`** for it first, then re-run `/add-adoption-companion`."*
+
+### 5b — Copy the skill into `container/skills/`
+
+The tip ships inside this pack at `add/container/skills/knowledge-inventory/`, where `add/` mirrors the destination path from the repo root. This step copies it to `container/skills/knowledge-inventory/`, which core mounts and rescans at spawn — so **copying it there is what makes it exist for any agent**. Until this step runs, no group has the tip.
+
+Run from the repo root:
+
+```bash
+rsync -a "${CLAUDE_SKILL_DIR}/add/" .
+echo "knowledge-inventory: installed"
+```
+
+Overwriting is intentional and is what makes this idempotent: the copy under `add/` is canonical, so re-running is also how you take an update.
+
+This is why the tip is **not** in `container/skills/` in trunk. That directory is bind-mounted into every container and rescanned on every spawn, so a tip that shipped there would be live for every group the moment it merged — before anyone ran this installer. Keeping the canonical copy under `add/` means trunk carries the file but never at a path core reads.
+
+### 5c — Activate: restart the group
+
+**Restart activates the tip.** Groups also pick it up on their next message.
+
+```bash
+ncl groups restart --id <group-id>
+```
+
+**One caveat — explicit skill lists.** A group whose skill selection is an explicit array instead of `"all"` never gets a symlink for the new skill: the files are mounted but the agent never sees them, **silently**. Only v1-migrated groups can be in this state, but the check is one command:
+
+```bash
+ncl groups config get --id <group-id> | grep -i skills   # "all" → nothing to do
+```
+
+If it's an array, append the name. There is no `ncl` verb for this (skills is a JSON column; only `mcp_servers` and `packages_*` have add/remove verbs), so write it directly. The `json_type` + `NOT EXISTS` guards make this safe to re-run and a no-op on `"all"` rows:
+
+```bash
+pnpm exec tsx scripts/q.ts data/v2.db \
+  "UPDATE container_configs
+   SET skills = json_insert(skills, '\$[#]', 'knowledge-inventory')
+   WHERE agent_group_id = '<group-id>'
+     AND json_type(skills) = 'array'
+     AND NOT EXISTS (SELECT 1 FROM json_each(container_configs.skills) WHERE value = 'knowledge-inventory')"
+```
+
+Then restart that group. (Use `scripts/q.ts`, not the `sqlite3` CLI — setup never installs that binary; see `setup/verify.ts:5`.)
+
+### 5d — Verify the install
+
+Both tests read the composed project, so they only pass once Step 5b has landed the tip:
+
+```bash
+pnpm exec vitest run src/adoption-companion-wiring.test.ts src/knowledge-inventory-skill.test.ts
+```
+
+### 5e — Report the fork-level blast radius
+
+Do not let this scope be a surprise. See the Report section below.
+
+## Report
+
+Tell the operator — **both scopes**, explicitly:
+
+**Per-group (Memory Receipts):**
+- Memory receipts are **installed and ON** on `groups/<id>/` — the user will start seeing `📝 Noted` as soon as the agent saves a durable fact.
+- The **user** turns it off by asking in chat (e.g. *"stop telling me what you learned"*); the agent flips the block to `Receipts: OFF.` They turn it back on the same way (*"tell me when you learn something about me"*).
+- Off ≠ uninstall — memory keeps working; only the surfacing stops. Full removal is `REMOVE.md`.
+- A re-install preserves whatever the user chose; it never flips their OFF back on.
+
+**Fork-level (Knowledge Inventory):**
+- Knowledge Inventory is now available to **all assistants in this fork** (newly installed / already present — say which). This is by design: it only answers when asked, and only about that agent's own memory.
+- There is **no toggle** and nothing for the user to enable — they can just ask *"what do you know about me?"*.
+- It is **not** removed when you remove the pack from a single group (other groups may still use it). Only a full uninstall deletes it — see `REMOVE.md`.
+
+## Optional — install across all existing groups at once
+
+Receipts are **per-agent-group** (personas don't inherit between groups), so each user-facing group needs the block. To roll it out to every eligible existing group in one pass, run the guard + insert per group. Skip Builder/Researcher/utility groups — receipts belong on **user-facing assistants** only.
+
+```bash
+# List groups and their folders, then loop. Review the list first and exclude
+# any non-user-facing groups (builders, researchers, and any bot you don't
+# want receipting) by editing GROUPS.
+GROUPS="$(ls groups/)"        # or hand-pick: GROUPS="my-assistant my-other-assistant"
+
+for GROUP in $GROUPS; do
+  idx="groups/$GROUP/memory/index.md"; loc="groups/$GROUP/CLAUDE.local.md"
+  if [ ! -f "$idx" ] || [ -s "$loc" ]; then
+    echo "SKIP $GROUP — not migrated (run update + /migrate-memory first)"; continue
+  fi
+  FILE="groups/$GROUP/instructions.prepend.md"; touch "$FILE"
+  pnpm exec tsx --eval "
+import { readFileSync, writeFileSync } from 'fs';
+import { applyReceiptsBlock } from './src/adoption-receipts-block.ts';
+const f = process.argv[process.argv.length - 1];
+writeFileSync(f, applyReceiptsBlock(readFileSync(f, 'utf8'), { version: 1 }));
+" "$FILE"
+  echo "OK   $GROUP — installed ON"
+done
+```
+
+Every group ships `ON`; each user can turn their own off in chat. Re-running preserves each group's existing ON/OFF (idempotent). Restart each group (or let it restart on next message) to pick up the persona.
+
+Because this lands ON, the loop is a **live behavior change for every group it touches** — review the list before running it, and keep it to groups whose users you'd want receipting today.
+
+## Optional — inherit into newly created agents (template)
+
+New agents are stamped from a **template** (`context/instructions.md` → the new group's `instructions.prepend.md`); nothing is copied from the creating agent (`src/templates/create-agent.ts`). To make future agents inherit receipts, append the block to a template's `context/instructions.md`:
+
+```bash
+TPL="templates/<your-assistant-template>/context/instructions.md"
+pnpm exec tsx --eval "
+import { readFileSync, writeFileSync } from 'fs';
+import { applyReceiptsBlock } from './src/adoption-receipts-block.ts';
+const f = process.argv[process.argv.length - 1];
+writeFileSync(f, applyReceiptsBlock(readFileSync(f, 'utf8'), { version: 1 }));
+" "$TPL"
+```
+
+**Caveats:** (1) only agents created **via that template** (`ncl groups create --template …`) inherit it — not ones made by `/init-first-agent` or the setup wizard. (2) It blankets **every** agent from that template, so only add it to a **user-facing/assistant** template, never a generic or Builder one. (3) It ships `ON`, same as a direct install — every future agent from that template receipts from its first message until its user says stop.
+

--- a/.claude/skills/add-adoption-companion/add/container/skills/knowledge-inventory/SKILL.md
+++ b/.claude/skills/add-adoption-companion/add/container/skills/knowledge-inventory/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: knowledge-inventory
+description: Show the user a plain-language picture of what you know, remember, and track about them. Use when the user asks what you know about them, what you remember, what you have learned, or what you keep track of — and when they ask to see everything under one of those categories.
+---
+
+# Knowledge Inventory
+
+When the user asks what you know about them, show them **the shape of what you keep** — the kinds of things you track, roughly how many of each, a couple of examples, and the durable facts about them — then offer to add, fix, or stop tracking anything.
+
+A tidy notebook, not a database dump. You are showing a person their own world, not your storage.
+
+## 1. Check first, before you answer
+
+Confirm `memory/index.md` is the active store for this group. If it is missing — or the group still keeps its durable content in a legacy `CLAUDE.local.md` — do **not** improvise an inventory and do **not** describe the files.
+
+Say memory isn't set up yet, and phrase the next step as something for the user to **forward to whoever set you up**, never as something they run:
+
+```text example-output
+I'm not set up to keep track of things yet, so I don't have anything to show you.
+If you'd like that turned on, pass this to whoever set me up: my memory setup
+needs to be finished first.
+```
+
+Then stop. An honest blank beats a plausible invention.
+
+## 2. Read what is actually there
+
+1. `memory/index.md` — the durable facts about the user (the Core Memory section) and the map of folders.
+2. Walk the folder `index.md` files the map points to. Each folder is a category: **count its real entries** and pick 2–3 real entry names as examples.
+3. Optionally check which entries have the newest dates, for a "recently started keeping track of…" line.
+
+**Count from the folders. Never estimate, round, or infer a category that isn't there.** If a folder holds 3 entries, it is 3 — not "a few". If memory is nearly empty, say so.
+
+**Report every folder the map points at — with one exception.** Skip the memory's own definition (`system/`): that's how your memory works, not something you keep about the user. Everything else gets a line, including folders that look like your own operational notes. Don't silently drop a category because it seems uninteresting or internal — a picture with something quietly missing is worse than one that includes a line the user waves off, and they can only tell you to stop tracking something they can see. If a folder really is about your own operation, still name it plainly and say what it's for.
+
+## 3. Translate structure into the user's words
+
+This is the real work of this skill. Nothing internal reaches the user.
+
+| What you read | What you say |
+|---|---|
+| Core Memory lines in `index.md` | An **"About you"** section — the durable facts, in plain words |
+| A folder of `type: customer` entries + its index | A category line: **"Your customers — 12"**, plus 2–3 example names |
+| A folder with few entries | The same, with the honest small count: "Your suppliers — 3" |
+| Newest-dated entries | Optional: "Recently started keeping track of: …" |
+| Empty or scaffold-only memory | An honest "not much yet" message |
+
+Use **the user's vocabulary** — the names the memory already uses come from their world. Pluralize and prefix naturally: "your customers", "projects you're running", "people you work with". If the internal type name is `customer`, say "your customers".
+
+**Never say, in any surface:** `memory/`, `index.md`, "index", "concept file", "OKF", "entity type", "frontmatter", "Core Memory", "scaffold", "store", or any file path.
+
+That list is examples, not the whole rule. **The rule: no word that describes how your memory is built.** "I haven't picked up much yet" is right; "my memory is still just the empty scaffold" is the same sentence with the machinery showing. If a word would only make sense to someone who has seen your files, it doesn't belong in front of the user — even when the honest answer is that you know nothing.
+
+**Show the shape, not a transcript.** Categories, counts, a couple of examples. Do not recite every fact. Only expand a full list when the user asks for one specific category ("show me everything under customers") — then list that category only.
+
+## 4. Render for the channel
+
+Build the richest surface the channel supports; always provide the text.
+
+**HTML file (preferred where files land).** Write a **self-contained** HTML file to your workspace — inline CSS, no external stylesheets, fonts, scripts, or images; readable on a phone. A tile or row per category with its count, an "About you" panel, optionally a recent-additions strip. Then send it:
+
+```
+mcp__nanoclaw__send_file({
+  to: "<destination>",
+  path: "what-i-track.html",
+  filename: "what-I-track.html",
+  text: "<one-line plain summary>"
+})
+```
+
+The accompanying `text` is a one-line summary, not a preamble about the file.
+
+**Plain text (always available).** If files aren't supported, or as the universal floor, send a short grouped list with `send_message`:
+
+```text example-output
+Here's what I'm keeping track of for you:
+• Your customers — 12 (Ana, the downtown bakery, …)
+• Your suppliers — 3
+• Projects you're running — the new website, the winter catalog
+• About you — you prefer short answers; based in São Paulo
+
+Want me to add something, fix anything, or stop tracking one of these?
+```
+
+A card summary is fine on channels that render cards, but don't rely on its buttons being tappable — replies come back as free text either way. The HTML is the richer artifact; the text is the floor.
+
+When memory is sparse or empty, the same honesty applies:
+
+```text example-output
+Not much yet, honestly — just that you prefer short answers. Tell me about your
+work and the people in it, and I'll start keeping track.
+```
+
+## 5. Always offer control
+
+Close every inventory with an open invitation:
+
+```text example-output
+Want me to add something, fix anything, or stop tracking one of these?
+```
+
+Corrections come back as ordinary replies — "stop tracking suppliers", "my city is Rio, not São Paulo", "also keep track of my competitors". Apply them by editing memory under the rules in `memory/system/definition.md`, which already governs updating and pruning — including asking before discarding anything you're unsure about. Confirm what you changed in plain words, and make sure a later re-ask reflects it.

--- a/.claude/skills/add-adoption-companion/resources/adoption-companion-wiring.test.ts
+++ b/.claude/skills/add-adoption-companion/resources/adoption-companion-wiring.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Install/remove wiring guards for the Adoption Companion pack.
+//
+// Ships with the pack and is copied to src/ at install, so it runs against the
+// composed project — the add-dashboard idiom. The pack has two install scopes,
+// a per-group Memory Receipts block and a fork-level Knowledge Inventory
+// container skill, and they must not bleed into each other. That, plus the core
+// behavior the fork-level install depends on, is what this file guards. The
+// tip's own content invariants live in knowledge-inventory-skill.test.ts.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PACK = '.claude/skills/add-adoption-companion';
+const CANONICAL = join(repoRoot, PACK, 'add/container/skills/knowledge-inventory/SKILL.md');
+const INSTALLED = join(repoRoot, 'container/skills/knowledge-inventory/SKILL.md');
+
+const installer = readFileSync(join(repoRoot, PACK, 'SKILL.md'), 'utf8');
+const remove = readFileSync(join(repoRoot, PACK, 'REMOVE.md'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// A2 — Pack install / remove wiring
+// ---------------------------------------------------------------------------
+describe('A2 — pack install/remove wiring', () => {
+  it('A2.1 installer has a fork-level section with all four steps', () => {
+    expect(installer).toMatch(/fork-level/i);
+    // guard → copy in → activate → report
+    expect(installer).toMatch(/### 5a — Guard/);
+    expect(installer).toMatch(/### 5b — Copy the skill into `container\/skills\/`/);
+    expect(installer).toMatch(/### 5c — Activate/);
+    expect(installer).toMatch(/blast radius/i);
+  });
+
+  it('A2.1b the installer tells the operator to restart', () => {
+    // Activation is spawn-time, so restart is the whole step. Asserted as the
+    // positive DO step, never as a "no rebuild needed" non-step
+    // (skill-guidelines anti-pattern #7).
+    expect(installer).toMatch(/Restart activates the tip/);
+    expect(installer).toMatch(/ncl groups restart --id/);
+  });
+
+  it('A2.1c core still resolves skills at spawn, so restart is sufficient', () => {
+    // The load-bearing dependency behind A2.1b: a bare restart only picks the
+    // new skill up because core re-reads container/skills/ on every spawn and
+    // mounts it in. If upstream ever resolves skills at build time, or drops
+    // the mount, restart stops being enough and the installer needs a rebuild
+    // step — this must go red then, which is why it reads core's source rather
+    // than the installer's prose.
+    const runner = readFileSync(join(repoRoot, 'src/container-runner.ts'), 'utf8');
+
+    // (a) container/skills/ is mounted read-only at /app/skills.
+    expect(runner).toMatch(/'container',\s*'skills'/);
+    expect(runner).toMatch(/containerPath: '\/app\/skills', readonly: true/);
+
+    // (b) an "all" selection is recomputed from the directory listing at spawn,
+    // rather than read from stored config — that is what discovers a new dir.
+    const selection = runner.slice(runner.indexOf('function selectedSkillNames'));
+    expect(selection).toMatch(/containerConfig\.skills !== 'all'/);
+    expect(selection).toMatch(/readdirSync/);
+  });
+
+  it('A2.2 guard step names both migration conditions', () => {
+    const forkSection = installer.slice(installer.indexOf('### 5a — Guard'));
+    expect(forkSection).toContain('memory/index.md');
+    expect(forkSection).toContain('CLAUDE.local.md');
+    expect(forkSection).toMatch(/\/migrate-memory/);
+  });
+
+  it('A2.3 install copies from the pack, not from the fork s own git history', () => {
+    // Reading the payload out of git made install depend on repo state: from
+    // HEAD, re-install broke once an operator committed the removal
+    // (`git show HEAD:<path>` had nothing to read); from a branch, it depended
+    // on a remote being fetchable and correctly resolved. The pack carries its
+    // own payload, so a plain copy works in any checkout, offline, forever.
+    expect(installer).toMatch(/rsync -a "\$\{CLAUDE_SKILL_DIR\}\/add\/" \./);
+    expect(installer).not.toMatch(/git show/);
+    expect(installer).not.toMatch(/git fetch/);
+  });
+
+  it('A2.4 only the fork-level remove path deletes the installed skill dir', () => {
+    const partA = remove.slice(remove.indexOf('# Part A'), remove.indexOf('# Part B'));
+    const partB = remove.slice(remove.indexOf('# Part B'));
+
+    // Per-group removal must never rm the fork-level dir.
+    expect(partA).not.toMatch(/rm -rf .*knowledge-inventory/);
+    expect(partA).toMatch(/does not remove Knowledge Inventory/i);
+
+    // Fork-level removal does, and skips cleanly when already gone.
+    expect(partB).toMatch(/rm -rf container\/skills\/knowledge-inventory/);
+    expect(partB).toMatch(/already absent — skipping/);
+    expect(partB).toMatch(/explicit full uninstall|last\*{0,2} group/i);
+  });
+
+  it('A2.4b remove deletes the installed copies but never the pack s own payload', () => {
+    // The canonical copy under add/ is the pack itself. An rm that reached it
+    // would make the pack a one-shot: uninstall once, and re-install has
+    // nothing left to copy.
+    expect(remove).not.toMatch(/rm -rf? .*add\/container\/skills/);
+    expect(remove).not.toMatch(/rm -rf? .*CLAUDE_SKILL_DIR/);
+  });
+
+  it('A2.5 install and remove name the same installed paths (no drift)', () => {
+    for (const doc of [installer, remove]) {
+      expect(doc).toContain('container/skills/knowledge-inventory');
+      expect(doc).toContain('src/adoption-receipts-block.ts');
+    }
+  });
+
+  it('A2.5b the installed tip matches the pack s canonical copy', () => {
+    // This test only exists in an installed fork (it is copied to src/ by the
+    // installer), so the tip must be present — and byte-identical to what the
+    // pack ships, which is what proves Step 5b's rsync actually landed rather
+    // than silently half-copying.
+    expect(existsSync(INSTALLED)).toBe(true);
+    expect(readFileSync(INSTALLED, 'utf8')).toBe(readFileSync(CANONICAL, 'utf8'));
+  });
+
+  it('A2.6 the tip has exactly one canonical copy (no hand-maintained mirror)', () => {
+    // docs/skill-guidelines.md anti-pattern #9: a mirror kept in sync by hand
+    // drifts. add/ is the single source; the installed copy is derived from it
+    // by rsync and is not tracked. A2.5b asserts they agree.
+    expect(existsSync(join(repoRoot, PACK, 'assets'))).toBe(false);
+    expect(existsSync(join(repoRoot, PACK, 'container-skills'))).toBe(false);
+  });
+});

--- a/.claude/skills/add-adoption-companion/resources/knowledge-inventory-skill.test.ts
+++ b/.claude/skills/add-adoption-companion/resources/knowledge-inventory-skill.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Content invariants for the Knowledge Inventory container skill.
+//
+// Ships with the pack and is copied to src/ at install. It reads the *installed*
+// skill at container/skills/, so it doubles as install verification: it goes red
+// if Step 5b did not land the file, as well as if the content drifts.
+//
+// The feature is zero runtime code — prose plus the existing send_file /
+// send_message tools — so there is no helper to unit-test. These read the
+// shipped artifact and assert the invariants the spec pins down: the trigger
+// contract, the guard, the counting rule, and the no-jargon rule.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILL_PATH = 'container/skills/knowledge-inventory/SKILL.md';
+
+const skill = readFileSync(join(repoRoot, SKILL_PATH), 'utf8');
+
+// Terms that describe storage internals. Fine in behavioral prose (the agent
+// has to be told what to read); never in a string the user is shown.
+const JARGON = [
+  'memory/',
+  'index.md',
+  'concept file',
+  'OKF',
+  'entity type',
+  'frontmatter',
+  'Core Memory',
+  'CLAUDE.local.md',
+  '/workspace',
+  // Added after a live eval: an agent said "my memory's still just the empty
+  // scaffold" on an empty group. Not in the spec's blocklist, but it is
+  // storage vocabulary reaching the user. See evals/knowledge-inventory/RESULTS.md.
+  'scaffold',
+];
+
+/** Example output = a ```text example-output fence. Those are shown to users. */
+function exampleOutputs(md: string): string[] {
+  return [...md.matchAll(/```text example-output\n([\s\S]*?)```/g)].map((m) => m[1]);
+}
+
+describe('A1 — knowledge-inventory SKILL.md', () => {
+  const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+
+  it('A1.1 has frontmatter with the right name and a description', () => {
+    expect(frontmatter).toMatch(/^name: knowledge-inventory$/m);
+    expect(frontmatter).toMatch(/^description: \S.+/m);
+  });
+
+  it('A1.2 description names the reactive triggers (this is what model-invokes it)', () => {
+    const description = frontmatter.match(/^description: (.+)$/m)?.[1] ?? '';
+    for (const trigger of ['what you know', 'remember', 'track']) {
+      expect(description.toLowerCase()).toContain(trigger);
+    }
+  });
+
+  it('A1.3 guards on the active store and degrades honestly', () => {
+    expect(skill).toContain('memory/index.md');
+    // Forward-to-operator phrasing, never "run this yourself".
+    expect(skill).toMatch(/forward|pass this to whoever set me up/i);
+    expect(skill).toMatch(/do \*\*not\*\* improvise|do not improvise/i);
+  });
+
+  it('A1.4 reads Core Memory + walks folder indexes, and counts rather than invents', () => {
+    expect(skill).toMatch(/Core Memory/);
+    expect(skill).toMatch(/walk the folder .*index\.md/i);
+    expect(skill).toMatch(/count.*from the folders/i);
+    expect(skill).toMatch(/never estimate, round, or infer/i);
+  });
+
+  it('A1.5 carries the translation rules and the no-jargon rule', () => {
+    expect(skill).toMatch(/About you/);
+    expect(skill).toMatch(/user's (vocabulary|words)/i);
+    expect(skill).toMatch(/Your customers — 12/);
+    // The no-jargon rule must enumerate the blocklist for the agent.
+    expect(skill).toMatch(/Never say, in any surface/i);
+    for (const term of ['concept file', 'OKF', 'entity type', 'frontmatter']) {
+      expect(skill).toContain(term);
+    }
+  });
+
+  it('A1.5b states no-jargon as a principle, not just a word list', () => {
+    // Regression: "scaffold" leaked past an enumerated blocklist on a live run,
+    // because a list can only ban words someone thought of. The skill must
+    // carry the generative rule too.
+    expect(skill).toMatch(/list is examples, not the whole rule/i);
+    expect(skill).toMatch(/no word that describes how your memory is built/i);
+    expect(skill).toContain('scaffold');
+  });
+
+  it('A1.5c requires every mapped folder to be reported, except system/', () => {
+    // Regression: a live run silently dropped an operational folder (context/)
+    // from the inventory. Spec §2 says report the categories the map points at;
+    // system/ (the memory's own definition) is the one legitimate exclusion.
+    expect(skill).toMatch(/Report every folder the map points at/i);
+    expect(skill).toMatch(/system\//);
+    expect(skill).toMatch(/[Dd]on't silently drop a category/);
+  });
+
+  it('A1.6 names both rendering surfaces', () => {
+    expect(skill).toContain('send_file');
+    expect(skill).toMatch(/self-contained/i);
+    expect(skill).toMatch(/no external (stylesheets|assets)/i);
+    expect(skill).toContain('send_message');
+    expect(skill).toMatch(/plain text.*always available/i);
+  });
+
+  it('A1.7 offers control (add / fix / stop tracking)', () => {
+    expect(skill).toMatch(/add something, fix anything, or stop tracking/i);
+    expect(skill).toContain('system/definition.md');
+  });
+
+  it('A1.8 no jargon in user-facing example strings', () => {
+    const examples = exampleOutputs(skill);
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      for (const term of JARGON) {
+        expect(example).not.toContain(term);
+      }
+    }
+  });
+});

--- a/.claude/skills/add-adoption-companion/resources/receipts-block.test.ts
+++ b/.claude/skills/add-adoption-companion/resources/receipts-block.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Static / structural tests for the Memory Receipts companion tip
+ * (Adoption Companion pack).
+ * Design spec §A1 (block-template invariants), §A2 (helper unit tests),
+ * §A3 (skill wiring). Deterministic, never calls an LLM.
+ *
+ * Ships with the skill and is copied to src/ at install, alongside the helper
+ * it guards. Run: pnpm exec vitest run src/adoption-receipts-block.test.ts
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  RECEIPTS_VERSION,
+  renderReceiptsBlock,
+  applyReceiptsBlock,
+  removeReceiptsBlock,
+} from './adoption-receipts-block.js';
+
+const SKILL_DIR = path.resolve(__dirname, '../.claude/skills/add-adoption-companion');
+const read = (rel: string) => fs.readFileSync(path.join(SKILL_DIR, rel), 'utf8');
+
+const OPEN = `<!-- adoption:receipts v=${RECEIPTS_VERSION} -->`;
+const CLOSE = '<!-- /adoption:receipts -->';
+
+// ---------------------------------------------------------------------------
+// A1 — Block-template invariants
+// ---------------------------------------------------------------------------
+describe('A1 — block-template invariants', () => {
+  const block = renderReceiptsBlock(RECEIPTS_VERSION, 'OFF');
+
+  it('A1.1 balanced markers: exactly one open and one close', () => {
+    expect(block.match(/<!-- adoption:receipts v=\d+ -->/g)).toHaveLength(1);
+    expect(block.match(/<!-- \/adoption:receipts -->/g)).toHaveLength(1);
+  });
+
+  it('A1.2 version agreement: marker v= equals the declared version constant', () => {
+    const marker = block.match(/<!-- adoption:receipts v=(\d+) -->/);
+    expect(marker).not.toBeNull();
+    expect(Number(marker![1])).toBe(RECEIPTS_VERSION);
+  });
+
+  it('A1.3 rendered state line is exactly **Receipts: <state>.**', () => {
+    expect(block).toContain('**Receipts: OFF.**');
+    expect(renderReceiptsBlock(RECEIPTS_VERSION, 'ON')).toContain('**Receipts: ON.**');
+  });
+
+  it('A1.4 guard clause present', () => {
+    expect(block).toContain('Applies only when `memory/index.md` is your active memory store');
+  });
+
+  it('A1.5 toggle instructions present: flip ON/OFF + immediate, no-restart', () => {
+    expect(block).toMatch(/turn it on or off/i);
+    expect(block).toMatch(/no restart is needed/i);
+    expect(block).toContain('**Receipts:**');
+  });
+
+  it('A1.7 cold-turn clause present (works on first message; no greeting instead of engaging)', () => {
+    expect(block).toMatch(/first message of a session/i);
+    expect(block).toMatch(/greeting/i);
+  });
+
+  it('A1.6 no jargon in user-facing example strings', () => {
+    const blocklist = [
+      'memory/',
+      'index.md',
+      'instructions.prepend.md',
+      'OKF',
+      'concept file',
+      'entity type',
+      'Core Memory',
+      'frontmatter',
+    ];
+    // Only the strings shown to the user as examples (the 📝 lines) are checked.
+    const exampleLines = block.split('\n').filter((l) => l.includes('📝'));
+    expect(exampleLines.length).toBeGreaterThan(0);
+    for (const line of exampleLines) {
+      for (const term of blocklist) {
+        expect(line).not.toContain(term);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A2 — Block-mutation helper (apply / remove)
+// ---------------------------------------------------------------------------
+describe('A2 — apply/remove helper', () => {
+  const markerCount = (t: string) => (t.match(/<!-- adoption:receipts v=\d+ -->/g) || []).length;
+
+  it('A2.1 apply to file with no marker: appended once, prior content preserved', () => {
+    const prior = 'You are Nano, a helpful assistant.\n\n## Tone\nBe terse.\n';
+    const out = applyReceiptsBlock(prior, { version: 1 });
+    expect(markerCount(out)).toBe(1);
+    expect(out).toContain('You are Nano, a helpful assistant.');
+    expect(out).toContain('## Tone\nBe terse.');
+  });
+
+  it('A2.1b fresh install ships ON — installing the tip is the opt-in', () => {
+    expect(applyReceiptsBlock('persona\n', { version: 1 })).toContain('**Receipts: ON.**');
+    expect(applyReceiptsBlock('', { version: 1 })).toContain('**Receipts: ON.**');
+  });
+
+  it('A2.2 apply twice is idempotent (byte-identical, no duplicate)', () => {
+    const prior = 'persona text\n';
+    const once = applyReceiptsBlock(prior, { version: 1 });
+    const twice = applyReceiptsBlock(once, { version: 1 });
+    expect(twice).toBe(once);
+    expect(markerCount(twice)).toBe(1);
+  });
+
+  it('A2.3 update v1→v2 preserves ON', () => {
+    const v1 = `persona\n\n${renderReceiptsBlock(1, 'ON')}\n`;
+    const v2 = applyReceiptsBlock(v1, { version: 2 });
+    expect(v2).toContain('<!-- adoption:receipts v=2 -->');
+    expect(v2).toContain('**Receipts: ON.**');
+    expect(markerCount(v2)).toBe(1);
+  });
+
+  it('A2.4 update v1→v2 preserves a user OFF — a re-install never flips it back on', () => {
+    const v1 = `persona\n\n${renderReceiptsBlock(1, 'OFF')}\n`;
+    const v2 = applyReceiptsBlock(v1, { version: 2 });
+    expect(v2).toContain('<!-- adoption:receipts v=2 -->');
+    expect(v2).toContain('**Receipts: OFF.**');
+    expect(v2).not.toContain('**Receipts: ON.**');
+  });
+
+  it('A2.5 garbled state line on update falls back to the shipped default (ON)', () => {
+    const garbled = renderReceiptsBlock(1, 'OFF').replace(
+      '**Receipts: OFF.**  (Flip',
+      '**Receipts: MAYBE.**  (Flip',
+    );
+    const out = applyReceiptsBlock(`persona\n\n${garbled}\n`, { version: 2 });
+    expect(out).toContain('**Receipts: ON.**');
+  });
+
+  it('A2.6 apply to empty / whitespace-only file: written, no crash', () => {
+    expect(markerCount(applyReceiptsBlock('', { version: 1 }))).toBe(1);
+    expect(markerCount(applyReceiptsBlock('   \n\t\n', { version: 1 }))).toBe(1);
+  });
+
+  it('A2.7 remove deletes exactly the block span; surrounding persona intact', () => {
+    const installed = applyReceiptsBlock('top persona\n\nbottom persona\n', { version: 1 });
+    const removed = removeReceiptsBlock(installed);
+    expect(markerCount(removed)).toBe(0);
+    expect(removed).toContain('top persona');
+    expect(removed).toContain('bottom persona');
+    expect(removed).not.toMatch(/\n{3,}/);
+  });
+
+  it('A2.8 remove is idempotent when no marker present', () => {
+    const plain = 'just a persona, no block\n';
+    expect(removeReceiptsBlock(plain)).toBe(plain);
+  });
+
+  it('A2.9 remove leaves sibling adoption:* blocks intact', () => {
+    const sibling =
+      '<!-- adoption:digest v=1 -->\n## Digest\nbody\n<!-- /adoption:digest -->\n';
+    const installed = applyReceiptsBlock(`${sibling}\npersona\n`, { version: 1 });
+    const removed = removeReceiptsBlock(installed);
+    expect(removed).toContain('<!-- adoption:digest v=1 -->');
+    expect(removed).toContain('<!-- /adoption:digest -->');
+    expect(markerCount(removed)).toBe(0);
+  });
+
+  it('A2.10 malformed block (open, no close) is not corrupted — throws, no partial delete', () => {
+    const malformed = `persona\n${OPEN}\n## Memory receipts\n**Receipts: ON.**\n`;
+    expect(() => applyReceiptsBlock(malformed, { version: 1 })).toThrow(/unbalanced/i);
+    expect(() => removeReceiptsBlock(malformed)).toThrow(/unbalanced/i);
+  });
+
+  it('A2.11 CRLF / trailing whitespace tolerated; state parsed; output stable', () => {
+    const crlf = 'persona line\r\n\r\n'.concat(
+      renderReceiptsBlock(1, 'ON').replace(/\n/g, '\r\n'),
+      '\r\n',
+    );
+    const out = applyReceiptsBlock(crlf, { version: 1 });
+    expect(out).toContain('**Receipts: ON.**');
+    expect(applyReceiptsBlock(out, { version: 1 })).toBe(out); // stable
+  });
+
+  it('A2.12 two blocks accidentally present: apply de-dupes; remove clears all', () => {
+    const one = renderReceiptsBlock(1, 'OFF');
+    const doubled = `persona\n\n${one}\n\n${one}\n`;
+    const applied = applyReceiptsBlock(doubled, { version: 1 });
+    expect(markerCount(applied)).toBe(1);
+    expect(markerCount(removeReceiptsBlock(doubled))).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A3 — Skill wiring (read the artifact, assert presence)
+// ---------------------------------------------------------------------------
+describe('A3 — skill wiring', () => {
+  const skill = read('SKILL.md');
+  const remove = read('REMOVE.md');
+
+  it('A3.1 SKILL.md has the three steps: guard, insert block, report', () => {
+    expect(skill.toLowerCase()).toContain('guard');
+    expect(skill.toLowerCase()).toMatch(/insert (the )?block/);
+    expect(skill.toLowerCase()).toContain('report');
+  });
+
+  it('A3.2 guard names BOTH conditions (memory/index.md AND no residual CLAUDE.local.md)', () => {
+    expect(skill).toContain('memory/index.md');
+    expect(skill).toContain('CLAUDE.local.md');
+  });
+
+  it('A3.3 SKILL.md references `ncl groups list` and states per-group repetition', () => {
+    expect(skill).toContain('ncl groups list');
+    expect(skill.toLowerCase()).toMatch(/per (target )?group|repeat/);
+  });
+
+  it('A3.4 REMOVE.md targets the receipts markers and is skip-if-absent', () => {
+    expect(remove).toContain('adoption:receipts');
+    expect(remove.toLowerCase()).toMatch(/skip|idempotent|already gone|absent/);
+  });
+
+  it('A3.5 SKILL.md documents every tip the pack ships, and each one\'s scope', () => {
+    // The pack accretes tips. Its header went stale the first time that
+    // happened: the description still said "ships with the Memory Receipts
+    // tip" after Knowledge Inventory landed, and called the install
+    // per-group when the new tip is fork-wide. The description is what
+    // decides when the skill is invoked and what a user thinks they get, so
+    // adding a tip must update it. Add the new tip's name here when you add one.
+    for (const tip of ['Memory Receipts', 'Knowledge Inventory']) {
+      expect(skill).toContain(tip);
+    }
+    expect(skill).toMatch(/per agent group|one agent group/i);
+    expect(skill).toMatch(/every group in the fork|fork-level/i);
+  });
+
+  it('A3.6 marker strings in SKILL.md/REMOVE.md match the template exactly', () => {
+    expect(skill).toContain(OPEN);
+    expect(skill).toContain(CLOSE);
+    expect(remove).toContain(CLOSE);
+    // no drift: the SKILL marker equals the rendered template's marker
+    expect(renderReceiptsBlock(RECEIPTS_VERSION, 'OFF')).toContain(OPEN);
+  });
+});

--- a/.claude/skills/add-adoption-companion/resources/receipts-block.ts
+++ b/.claude/skills/add-adoption-companion/resources/receipts-block.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure, install-time block-mutation helper for the Memory Receipts companion tip
+ * (Adoption Companion pack).
+ *
+ * String in, string out — no I/O, no core imports, never runs on the agent's
+ * turn. The `/add-adoption-companion` SKILL reads a group's instructions.prepend.md,
+ * calls these, and writes the result back. Block template + helper contract are
+ * defined in the Memory Receipts design spec.
+ */
+
+/** Version of the shipped block template. Marker `v=N` must equal this. */
+export const RECEIPTS_VERSION = 1;
+
+type State = 'ON' | 'OFF';
+
+/**
+ * State a fresh install ships with. ON: installing the pack IS the opt-in —
+ * an operator ran `/add-adoption-companion` for this tip, so landing OFF would
+ * mean the feature they asked for does nothing until they discover a phrase to
+ * turn it on. Also the fallback when an existing block's state line is
+ * unreadable: unknown resolves to the shipped default, never to silence.
+ */
+const DEFAULT_STATE: State = 'ON';
+
+const OPEN_RE = /<!-- adoption:receipts v=\d+ -->/g;
+const CLOSE_RE = /<!-- \/adoption:receipts -->/g;
+const BLOCK_RE = /<!-- adoption:receipts v=\d+ -->[\s\S]*?<!-- \/adoption:receipts -->/g;
+
+/** Render the managed block for a given version and ON/OFF state. */
+export function renderReceiptsBlock(version: number, state: State): string {
+  return `<!-- adoption:receipts v=${version} -->
+## Memory receipts
+
+**Receipts: ${state}.**  (Flip this to ON when the user wants it, OFF when they ask to stop.)
+
+Applies only when \`memory/index.md\` is your active memory store.
+
+When **Receipts is ON** and you have just saved a NEW, meaningful durable fact
+about the user to Core Memory (their identity, a hard preference, a key person
+or project), tell them in one glanceable message using \`send_card\`:
+
+- title: "📝 Noted"; description: the fact in plain, everyday language.
+- Several new facts in one turn → ONE card with a short bullet list, not many.
+- Provide \`fallbackText\` (e.g. "📝 Noted: <fact>. Tell me if that's wrong.").
+- Display only. Do not block, do not use \`ask_user_question\`, do not rely on
+  buttons. If the user later corrects it, update memory per your memory
+  definition (prune/replace) — no receipt needed for the correction itself.
+
+Do NOT receipt: routine or low-signal notes, facts the user just stated this
+turn, or updates to already-confirmed facts. Never mention files, folders, or
+"memory" internals — this is a sticky note, not a log.
+
+This works on any turn, including the FIRST message of a session: your Core
+Memory and this state line are loaded every time, so you never need prior
+conversation to save a fact or receipt it. When a message carries a durable
+fact, address the message and persist the fact — do not open with a generic
+greeting instead of engaging with what the user said.
+
+When the user asks to turn it on or off ("stop telling me what you learned" /
+"tell me when you learn about me"), honor it THIS session immediately — you are
+reading the live state right now, so no restart is needed and never say one is.
+Also edit the **Receipts:** line above to ON or OFF so the choice persists into
+future sessions.
+<!-- /adoption:receipts -->`;
+}
+
+function assertBalanced(text: string): void {
+  const opens = (text.match(OPEN_RE) || []).length;
+  const closes = (text.match(CLOSE_RE) || []).length;
+  if (opens !== closes) {
+    throw new Error('Malformed adoption:receipts block: unbalanced markers (leaving file untouched)');
+  }
+}
+
+/** Read the current ON/OFF value from the first block; no readable value → DEFAULT_STATE. */
+function extractState(text: string): State {
+  const block = text.match(/<!-- adoption:receipts v=\d+ -->[\s\S]*?<!-- \/adoption:receipts -->/)?.[0];
+  if (!block) return DEFAULT_STATE;
+  const m = block.match(/\*\*Receipts:\s*(ON|OFF)\b/i);
+  return m ? (m[1].toUpperCase() as State) : DEFAULT_STATE;
+}
+
+/**
+ * Install or refresh the receipts block. Idempotent: existing block(s) are
+ * removed and one fresh block is appended, preserving the current ON/OFF state.
+ * A fresh install (no prior block) ships DEFAULT_STATE.
+ */
+export function applyReceiptsBlock(text: string, opts?: { version?: number }): string {
+  assertBalanced(text);
+  const version = opts?.version ?? RECEIPTS_VERSION;
+  const state = extractState(text);
+  const base = text.replace(BLOCK_RE, '').replace(/\n{3,}/g, '\n\n').trimEnd();
+  const block = renderReceiptsBlock(version, state);
+  return base ? `${base}\n\n${block}\n` : `${block}\n`;
+}
+
+/** Remove every receipts block; leave all other content (incl. sibling adoption:* blocks) intact. */
+export function removeReceiptsBlock(text: string): string {
+  assertBalanced(text);
+  if (!/<!-- adoption:receipts v=\d+ -->/.test(text)) return text;
+  const stripped = text.replace(BLOCK_RE, '').replace(/\n{3,}/g, '\n\n');
+  return stripped.trim() ? `${stripped.trimEnd()}\n` : '';
+}


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [x] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — `/add-adoption-companion`, a pack of opt-in "companion tips" that make the agent's memory visible and correctable. Two ship:

| Tip | What the user gets | Scope |
|---|---|---|
| **Memory Receipts** | a glanceable `📝 Noted` when the agent saves a durable fact, so they see it learn and can correct it in plain chat | one agent group, toggled in chat |
| **Knowledge Inventory** | they ask *"what do you know about me?"* and get a plain-language picture of what's tracked, plus an offer to add / fix / stop tracking | fork-wide, no toggle |

**Why** — memory is invisible today. The user can't tell what the agent kept, so they can't correct it. These two surface it: one proactively at the moment of saving, one on demand.

**How it works** — zero runtime code and zero source changes. No MCP tools, no hooks, no core changes, no config changes. The only code is Memory Receipts' pure install-time block helper.

The two tips install at different scopes because they reach the agent differently. A receipt must fire *mid-turn*, so it's a managed block in one group's standing instructions, per group, with a toggle. An inventory only fires *when asked*, so it's a container skill — model-invoked, fork-wide, untoggled, since it can't interrupt anyone.

Follows the `add-dashboard` idiom: the helper and the three tests ship in `resources/` and are copied into `src/` at install, where the default vitest config and `tsc` already look; `REMOVE.md` deletes them.

Knowledge Inventory's canonical copy lives under the pack at `add/container/skills/knowledge-inventory/`, mirroring its destination path, and Step 5b `rsync`s it to `container/skills/`. Trunk deliberately ships nothing at that live path: `container/skills/` is bind-mounted and rescanned at every spawn, so a tip shipped there would be live for every group the moment it merged — before anyone ran the installer, making the opt-in an accident rather than a design. Same shape as `/add-clidash`'s `add/tools/clidash`.

**How it was tested** — the install was run verbatim from `SKILL.md` on a clean checkout: 26 helper tests green at Step 0, 20 wiring/content tests green at Step 5d. Full suite in the installed state: 97 files / 1197 tests, `tsc --noEmit` clean. `REMOVE.md` returns the suite to exactly its pre-install baseline (94 files / 1151 tests) with no tracked modifications left behind, and re-install after uninstall works.

Guards are mutation-tested rather than trusted green — the suite goes red if Step 5b never ran, if the installed tip drifts from the pack's canonical copy, if Step 5b reverts to a `git show > dest` redirect, or if remove reaches the pack's own payload. Two are worth calling out: **A2.5b** asserts the installed tip is byte-identical to what the pack ships, so it doubles as install verification; **A2.1c** reads `container-runner.ts` to pin the read-only `/app/skills` mount and the `"all"` → `readdirSync` rescan, so "restart is sufficient" is guarded against core rather than against prose that can drift.

Behaviorally: four fixtures (rich / sparse / empty / not-migrated), then k=3 against real agents whose memory was built by ordinary conversation. No fabrication and no jargon in any run; exact counts every time.

**Usage** — `/add-adoption-companion`, then `REMOVE.md` to reverse (Part A per group, Part B for the fork-level tip).

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
