### PR TITLE
feat(imessage): unified local+hosted adapter targeting spectrum-ts v11

### DIFF
--- a/src/channels/imessage-registration.test.ts
+++ b/src/channels/imessage-registration.test.ts
@@ -1,26 +1,20 @@
 /**
- * Integration test for the imessage channel's single reach-in: the self-registration
- * import in the `src/channels/index.ts` barrel. Importing the barrel runs imessage.ts's
- * top-level `registerChannelAdapter('imessage', …)`; without the import the channel is
- * silently absent.
+ * Integration test for the imessage channel's barrel reach-in: the
+ * self-registration import in `src/channels/index.ts`. Importing the barrel
+ * runs imessage.ts's top-level `registerChannelAdapter('imessage', …)`;
+ * without the import the channel is silently absent.
  *
- * Behavior, not structural: it imports the real barrel and asserts the registry
- * actually contains the channel. This reflects what happens at host boot — if the
- * `import './imessage.js';` line is deleted, or the barrel fails to evaluate for any
- * reason (so the channel genuinely would not register), this goes red. A structural
- * check of the import line would falsely pass in that second case.
+ * Behavior, not structural: it imports the real barrel and asserts the
+ * registry actually contains the channel. It goes red if the
+ * `import './imessage.js';` line is deleted or drifts, or if the barrel
+ * fails to evaluate (so the channel genuinely would not register).
  *
- * Importing the barrel is safe: registration is a pure top-level call, and imessage.ts
- * builds the SDK adapter / bridge only inside its factory (invoked at host startup),
- * never at import. It does require the adapter package (`chat-adapter-imessage`) to be installed,
- * which holds in a composed install: the skill's `pnpm install` step runs before this
- * test — so this test also implicitly guards that dependency (an unmocked import throws
- * if the package is missing).
- *
- * imessage is a Chat SDK channel: imessage.ts also consumes a load-bearing *core* API —
- * `createChatSdkBridge(...)` from ./chat-sdk-bridge.js. That core-consumption is a
- * typed call, so the build/typecheck leg (`pnpm run build`) guards it against upstream
- * drift, not this test. Every Chat SDK channel follows this same shape.
+ * It requires NO npm dependency: registration is a pure top-level call.
+ * Neither backend's package loads at module import — the hosted `spectrum-ts`
+ * only via a runtime dynamic import inside setup(), and the local
+ * `chat-adapter-imessage` only via a dynamic import inside the factory's local
+ * branch (never at module load). That's what lets the barrel evaluate before
+ * /add-imessage has installed either SDK.
  */
 import { describe, it, expect } from 'vitest';
 

--- a/src/channels/imessage.test.ts
+++ b/src/channels/imessage.test.ts
@@ -21,6 +21,7 @@ import {
   photonReactionEmoji,
   photonReactionTargetId,
   phoneTargetFromSpaceId,
+  readMediaWithRetry,
   resolveSpaceIdentity,
   type NormalizedInbound,
   type PhotonAttachment,
@@ -134,7 +135,8 @@ describe('normalizeContent', () => {
   const saver = async (c: { type: string }): Promise<PhotonAttachment | null> => ({
     type: c.type,
     name: 'file.bin',
-    localPath: 'attachments/file.bin',
+    size: 2,
+    data: Buffer.from([1, 2]).toString('base64'),
   });
 
   it('extracts plain text', async () => {
@@ -171,6 +173,38 @@ describe('normalizeContent', () => {
     await normalizeContent({ type: 'reaction', emoji: '👍' }, saver, out);
     expect(out.text).toBe('reaction:added:👍');
     expect(out.isReaction).toBe(true);
+  });
+});
+
+describe('readMediaWithRetry', () => {
+  it('returns bytes on first success without retrying', async () => {
+    const read = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const bytes = await readMediaWithRetry({ type: 'attachment', read }, { baseDelayMs: 1 });
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient stream reset and succeeds', async () => {
+    // Live photos surface ECONNRESET / gRPC RST_STREAM mid-transfer; a
+    // fresh read succeeds.
+    const read = vi
+      .fn<() => Promise<Uint8Array>>()
+      .mockRejectedValueOnce(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))
+      .mockRejectedValueOnce(new Error('13 INTERNAL: Received RST_STREAM with code 2'))
+      .mockResolvedValueOnce(new Uint8Array([7]));
+    const bytes = await readMediaWithRetry({ type: 'attachment', read }, { baseDelayMs: 1 });
+    expect(Array.from(bytes)).toEqual([7]);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error once attempts are exhausted', async () => {
+    const read = vi.fn(async (): Promise<Uint8Array> => {
+      throw new Error('read ECONNRESET');
+    });
+    await expect(readMediaWithRetry({ type: 'attachment', read }, { attempts: 3, baseDelayMs: 1 })).rejects.toThrow(
+      'ECONNRESET',
+    );
+    expect(read).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -323,6 +357,59 @@ describe('photon adapter (mocked SDK)', () => {
     expect((msg.content as { text: string }).text).toBe('hi bot');
     expect((msg.content as { senderId: string }).senderId).toBe('imessage:+15551112222');
     expect(host.metadata[0]).toEqual({ platformId: '+15551112222', isGroup: false });
+
+    await adapter.teardown();
+  });
+
+  it('delivers inbound media as base64 data for session-inbox staging', async () => {
+    const { sdk, queue } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    const space: SpectrumSpace = { id: '+15551112222', type: 'dm', phone: '+15551112222', send: async () => ({}) };
+    queue.push([
+      space,
+      {
+        id: 'm-media',
+        direction: 'inbound',
+        sender: { id: '+15551112222' },
+        content: {
+          type: 'group',
+          items: [
+            { content: { type: 'text', text: 'look at this' } },
+            {
+              content: {
+                type: 'attachment',
+                id: 'att1',
+                name: 'photo.heic',
+                mimeType: 'image/heic',
+                read: async () => new Uint8Array([9, 8, 7]),
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    await waitFor(() => host.inbound.length === 1);
+    const content = host.inbound[0].msg.content as {
+      text: string;
+      attachments: Array<{ type: string; name: string; mimeType?: string; size: number; data: string }>;
+    };
+    expect(content.text).toBe('look at this');
+    expect(content.attachments).toHaveLength(1);
+    const att = content.attachments[0];
+    // base64 `data` (no localPath): the host stages bytes into the session
+    // inbox and rewrites the entry — the adapter must not write to disk.
+    expect(att).not.toHaveProperty('localPath');
+    expect(att.name).toBe('photo.heic');
+    expect(att.mimeType).toBe('image/heic');
+    expect(att.size).toBe(3);
+    expect(Array.from(Buffer.from(att.data, 'base64'))).toEqual([9, 8, 7]);
 
     await adapter.teardown();
   });

--- a/src/channels/imessage.test.ts
+++ b/src/channels/imessage.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Photon adapter tests.
+ *
+ * Two layers:
+ *  1. Pure helpers (id/phone resolution, content normalization, formatting).
+ *  2. A mocked-SDK end-to-end pass: a fake `spectrum-ts` drives the real
+ *     adapter so inbound routing, ask_question, reactions, typing, outbound
+ *     delivery, and teardown all run the production code paths without a live
+ *     Photon account.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+import {
+  appendMediaFailureNote,
+  attachmentFilename,
+  chunkText,
+  createPhotonAdapter,
+  normalizeContent,
+  optionToCommand,
+  photonReactionEmoji,
+  photonReactionTargetId,
+  phoneTargetFromSpaceId,
+  resolveSpaceIdentity,
+  type NormalizedInbound,
+  type PhotonAttachment,
+  type PhotonSdk,
+  type SpectrumApp,
+  type SpectrumMessage,
+  type SpectrumSpace,
+} from './imessage.js';
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('phoneTargetFromSpaceId', () => {
+  it('returns a bare E.164 number as-is', () => {
+    expect(phoneTargetFromSpaceId('+15551234567')).toBe('+15551234567');
+  });
+  it('extracts the number from an iMessage DM chat GUID', () => {
+    expect(phoneTargetFromSpaceId('any;-;+15551234567')).toBe('+15551234567');
+  });
+  it('returns null for opaque group ids and junk', () => {
+    expect(phoneTargetFromSpaceId('iMessage;+;group-abc123')).toBeNull();
+    expect(phoneTargetFromSpaceId(undefined)).toBeNull();
+    expect(phoneTargetFromSpaceId('')).toBeNull();
+  });
+});
+
+describe('resolveSpaceIdentity', () => {
+  it('resolves a DM to the counterpart E.164 phone', () => {
+    const id = resolveSpaceIdentity(
+      { id: 'any;-;+15551234567', type: 'dm', phone: '+15551234567', send: async () => ({}) },
+      {},
+    );
+    expect(id).toEqual({ platformId: '+15551234567', isGroup: false });
+  });
+  it('falls back to the space id when a DM has no phone', () => {
+    const id = resolveSpaceIdentity({ id: 'opaque-dm-id', type: 'dm', send: async () => ({}) }, {});
+    expect(id).toEqual({ platformId: 'opaque-dm-id', isGroup: false });
+  });
+  it('resolves a group to its opaque space id', () => {
+    const id = resolveSpaceIdentity({ id: 'group-guid-xyz', type: 'group', send: async () => ({}) }, {});
+    expect(id).toEqual({ platformId: 'group-guid-xyz', isGroup: true });
+  });
+  it('reads identity off message.space when the stream space is bare', () => {
+    const msg: SpectrumMessage = {
+      space: { id: '+15550009999', type: 'dm', phone: '+15550009999', send: async () => ({}) },
+    };
+    const id = resolveSpaceIdentity(undefined, msg);
+    expect(id).toEqual({ platformId: '+15550009999', isGroup: false });
+  });
+  it('returns null when there is no id at all', () => {
+    expect(resolveSpaceIdentity(undefined, {})).toBeNull();
+  });
+});
+
+describe('optionToCommand', () => {
+  it('slugs a label into a slash command', () => {
+    expect(optionToCommand('Approve')).toBe('/approve');
+    expect(optionToCommand('Reject Request')).toBe('/reject-request');
+  });
+});
+
+describe('Photon reaction normalization', () => {
+  it('converts NanoClaw shortcodes and preserves raw emoji', () => {
+    expect(photonReactionEmoji('thumbs_up')).toBe('👍');
+    expect(photonReactionEmoji('heart')).toBe('❤️');
+    expect(photonReactionEmoji('👀')).toBe('👀');
+  });
+
+  it('removes the router agent-group suffix from Photon message ids', () => {
+    expect(photonReactionTargetId('spc-msg-123:ag-1234-abcd')).toBe('spc-msg-123');
+    expect(photonReactionTargetId('spc-msg-123')).toBe('spc-msg-123');
+  });
+});
+
+describe('attachmentFilename', () => {
+  it('keeps a safe provided name', () => {
+    expect(attachmentFilename({ type: 'attachment', name: 'photo.jpg' })).toBe('photo.jpg');
+  });
+  it('rejects a traversal name and synthesizes from mime', () => {
+    const name = attachmentFilename({ type: 'attachment', name: '../../etc/passwd', mimeType: 'image/png', id: 'abc' });
+    expect(name).toBe('attachment-abc.png');
+  });
+  it('defaults voice notes to .caf', () => {
+    expect(attachmentFilename({ type: 'voice', id: 'v1' })).toBe('voice-v1.caf');
+  });
+});
+
+describe('chunkText', () => {
+  it('returns a single chunk under the limit', () => {
+    expect(chunkText('hello', 100)).toEqual(['hello']);
+  });
+  it('splits long text on line boundaries', () => {
+    const text = 'a'.repeat(30) + '\n' + 'b'.repeat(30);
+    const chunks = chunkText(text, 40);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toContain('a'.repeat(30));
+  });
+});
+
+describe('appendMediaFailureNote', () => {
+  it('is a no-op with no failures', () => {
+    expect(appendMediaFailureNote('hi', [])).toBe('hi');
+  });
+  it('appends notes for failed downloads', () => {
+    expect(appendMediaFailureNote('hi', ['attachment'])).toBe('hi\n[attachment could not be downloaded]');
+  });
+});
+
+describe('normalizeContent', () => {
+  const saver = async (c: { type: string }): Promise<PhotonAttachment | null> => ({
+    type: c.type,
+    name: 'file.bin',
+    localPath: 'attachments/file.bin',
+  });
+
+  it('extracts plain text', async () => {
+    const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
+    await normalizeContent({ type: 'text', text: 'hello world' }, saver, out);
+    expect(out.text).toBe('hello world');
+  });
+
+  it('collects text + attachments from a mixed group', async () => {
+    const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
+    await normalizeContent(
+      {
+        type: 'group',
+        items: [
+          { content: { type: 'text', text: 'caption' } },
+          { content: { type: 'attachment', read: async () => new Uint8Array([1, 2]) } },
+        ],
+      },
+      saver,
+      out,
+    );
+    expect(out.text).toBe('caption');
+    expect(out.attachments).toHaveLength(1);
+  });
+
+  it('records a failure when media cannot be saved', async () => {
+    const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
+    await normalizeContent({ type: 'attachment' }, async () => null, out);
+    expect(out.failures).toEqual(['attachment']);
+  });
+
+  it('renders a reaction as a marker line', async () => {
+    const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
+    await normalizeContent({ type: 'reaction', emoji: '👍' }, saver, out);
+    expect(out.text).toBe('reaction:added:👍');
+    expect(out.isReaction).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mocked-SDK end-to-end
+// ---------------------------------------------------------------------------
+
+/** A pushable async queue standing in for `app.messages`. */
+class MessageQueue implements AsyncIterable<[SpectrumSpace, SpectrumMessage]> {
+  private items: Array<[SpectrumSpace, SpectrumMessage]> = [];
+  private waiters: Array<(r: IteratorResult<[SpectrumSpace, SpectrumMessage]>) => void> = [];
+  private done = false;
+
+  push(item: [SpectrumSpace, SpectrumMessage]): void {
+    const w = this.waiters.shift();
+    if (w) w({ value: item, done: false });
+    else this.items.push(item);
+  }
+  end(): void {
+    this.done = true;
+    let w = this.waiters.shift();
+    while (w) {
+      w({ value: undefined as never, done: true });
+      w = this.waiters.shift();
+    }
+  }
+  [Symbol.asyncIterator](): AsyncIterator<[SpectrumSpace, SpectrumMessage]> {
+    return {
+      next: (): Promise<IteratorResult<[SpectrumSpace, SpectrumMessage]>> => {
+        const item = this.items.shift();
+        if (item) return Promise.resolve({ value: item, done: false });
+        if (this.done) return Promise.resolve({ value: undefined as never, done: true });
+        return new Promise((resolve) => this.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+interface RecordedSend {
+  spaceId: string;
+  builder: { kind: string; payload: unknown };
+}
+
+function makeFakeSdk(options: { missingReactionTarget?: boolean } = {}) {
+  const queue = new MessageQueue();
+  const sends: RecordedSend[] = [];
+  const stop = vi.fn(async () => {});
+  const reacted: Array<{ messageId: string; emoji: string }> = [];
+
+  const makeSpace = (id: string, type: string, phone?: string): SpectrumSpace => ({
+    id,
+    type,
+    phone,
+    send: async (builder: unknown) => {
+      sends.push({ spaceId: id, builder: builder as { kind: string; payload: unknown } });
+      return { id: `sent-${sends.length}` };
+    },
+    getMessage: async (mid: string) =>
+      options.missingReactionTarget
+        ? undefined
+        : {
+            id: mid,
+            react: async (emoji: string) => {
+              reacted.push({ messageId: mid, emoji });
+              return { id: `reaction-${reacted.length}`, unsend: async () => {} };
+            },
+          },
+  });
+
+  const app: SpectrumApp = { messages: queue, stop };
+
+  const sdk: PhotonSdk = {
+    spectrum: {
+      Spectrum: async () => app,
+      text: (s: string) => ({ kind: 'text', payload: s }),
+      markdown: (s: string) => ({ kind: 'markdown', payload: s }),
+      typing: (state: 'start' | 'stop') => ({ kind: 'typing', payload: state }),
+      read: (message: SpectrumMessage) => ({ kind: 'read', payload: message.id }),
+      attachment: (p: string, opts?: unknown) => ({ kind: 'attachment', payload: { p, opts } }),
+      voice: (p: string, opts?: unknown) => ({ kind: 'voice', payload: { p, opts } }),
+    },
+    imessage: Object.assign(
+      (_app: SpectrumApp) => ({
+        space: {
+          create: async (target: string) => makeSpace(target, 'dm', target),
+          get: async (id: string) => makeSpace(id, 'group'),
+        },
+      }),
+      { config: () => ({}) },
+    ),
+  };
+
+  return { sdk, queue, sends, stop, reacted, makeSpace };
+}
+
+function makeHostConfig() {
+  const inbound: Array<{ platformId: string; msg: InboundMessage }> = [];
+  const metadata: Array<{ platformId: string; isGroup?: boolean }> = [];
+  const actions: Array<{ questionId: string; option: string; userId: string }> = [];
+  const config: ChannelSetup = {
+    onInbound: async (platformId, _threadId, msg) => {
+      inbound.push({ platformId, msg });
+    },
+    onInboundEvent: async () => {},
+    onMetadata: (platformId, _name, isGroup) => {
+      metadata.push({ platformId, isGroup });
+    },
+    onAction: (questionId, option, userId) => {
+      actions.push({ questionId, option, userId });
+    },
+  };
+  return { config, inbound, metadata, actions };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('photon adapter (mocked SDK)', () => {
+  it('routes an inbound DM as a platform-confirmed mention', async () => {
+    const { sdk, queue } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    expect(adapter.isConnected()).toBe(true);
+
+    const space: SpectrumSpace = {
+      id: 'any;-;+15551112222',
+      type: 'dm',
+      phone: '+15551112222',
+      send: async () => ({}),
+    };
+    queue.push([
+      space,
+      { id: 'm1', direction: 'inbound', sender: { id: '+15551112222' }, content: { type: 'text', text: 'hi bot' } },
+    ]);
+
+    await waitFor(() => host.inbound.length === 1);
+    const { platformId, msg } = host.inbound[0];
+    expect(platformId).toBe('+15551112222');
+    expect(msg.isMention).toBe(true);
+    expect(msg.isGroup).toBe(false);
+    expect((msg.content as { text: string }).text).toBe('hi bot');
+    expect((msg.content as { senderId: string }).senderId).toBe('imessage:+15551112222');
+    expect(host.metadata[0]).toEqual({ platformId: '+15551112222', isGroup: false });
+
+    await adapter.teardown();
+  });
+
+  it('routes an inbound group message without an auto-mention', async () => {
+    const { sdk, queue } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    const space: SpectrumSpace = { id: 'group-abc', type: 'group', send: async () => ({}) };
+    queue.push([
+      space,
+      { id: 'm2', direction: 'inbound', sender: { id: '+15559998888' }, content: { type: 'text', text: 'hello all' } },
+    ]);
+
+    await waitFor(() => host.inbound.length === 1);
+    expect(host.inbound[0].platformId).toBe('group-abc');
+    expect(host.inbound[0].msg.isMention).toBeUndefined();
+    expect(host.inbound[0].msg.isGroup).toBe(true);
+
+    await adapter.teardown();
+  });
+
+  it('still routes inbound messages when marking the chat read fails', async () => {
+    const { sdk, queue } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    const space: SpectrumSpace = {
+      id: '+15551112222',
+      type: 'dm',
+      phone: '+15551112222',
+      send: async (builder) => {
+        if ((builder as { kind?: string }).kind === 'read') throw new Error('read receipt unavailable');
+        return {};
+      },
+    };
+    queue.push([
+      space,
+      {
+        id: 'm-read-fails',
+        direction: 'inbound',
+        sender: { id: '+15551112222' },
+        content: { type: 'text', text: 'still deliver this' },
+      },
+    ]);
+
+    await waitFor(() => host.inbound.length === 1);
+    expect((host.inbound[0].msg.content as { text: string }).text).toBe('still deliver this');
+
+    await adapter.teardown();
+  });
+
+  it('ignores our own outbound echoes on the stream', async () => {
+    const { sdk, queue } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    const space: SpectrumSpace = { id: '+15551112222', type: 'dm', phone: '+15551112222', send: async () => ({}) };
+    queue.push([
+      space,
+      { id: 'echo', direction: 'outbound', sender: { id: 'bot' }, content: { type: 'text', text: 'my reply' } },
+    ]);
+    queue.push([
+      space,
+      {
+        id: 'real',
+        direction: 'inbound',
+        sender: { id: '+15551112222' },
+        content: { type: 'text', text: 'their msg' },
+      },
+    ]);
+
+    await waitFor(() => host.inbound.length === 1);
+    expect(host.inbound).toHaveLength(1);
+    expect((host.inbound[0].msg.content as { text: string }).text).toBe('their msg');
+
+    await adapter.teardown();
+  });
+
+  it('delivers markdown text to a DM (via space.create)', async () => {
+    const { sdk, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    await adapter.deliver('+15551112222', null, { kind: 'chat', content: { text: 'hello **there**' } });
+    expect(sends).toHaveLength(1);
+    expect(sends[0].spaceId).toBe('+15551112222');
+    expect(sends[0].builder.kind).toBe('markdown');
+    expect(sends[0].builder.payload).toBe('hello **there**');
+
+    await adapter.teardown();
+  });
+
+  it('tolerates a bare string outbound content', async () => {
+    const { sdk, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await adapter.deliver('+15551112222', null, { kind: 'chat', content: 'just a string' });
+    expect(sends).toHaveLength(1);
+    expect(sends[0].builder.payload).toBe('just a string');
+    await adapter.teardown();
+  });
+
+  it('sends plain text when markdown is disabled', async () => {
+    const { sdk, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: false, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await adapter.deliver('+15551112222', null, { kind: 'chat', content: { text: 'plain' } });
+    expect(sends[0].builder.kind).toBe('text');
+    await adapter.teardown();
+  });
+
+  it('reuses the inbound space for outbound (no create round trip)', async () => {
+    const { sdk, queue, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    const inboundSpaceSends: unknown[] = [];
+    const space: SpectrumSpace = {
+      id: '+15551112222',
+      type: 'dm',
+      phone: '+15551112222',
+      send: async (b) => {
+        inboundSpaceSends.push(b);
+        return { id: 'x' };
+      },
+    };
+    queue.push([
+      space,
+      { id: 'm', direction: 'inbound', sender: { id: '+15551112222' }, content: { type: 'text', text: 'hey' } },
+    ]);
+    await waitFor(() => host.inbound.length === 1);
+
+    await adapter.deliver('+15551112222', null, { kind: 'chat', content: { text: 'reply' } });
+    // The read receipt and reply both use the cached inbound space, avoiding
+    // a fresh space.create round trip.
+    expect(inboundSpaceSends).toHaveLength(2);
+    expect(inboundSpaceSends[0]).toEqual({ kind: 'read', payload: 'm' });
+    expect(inboundSpaceSends[1]).toEqual({ kind: 'markdown', payload: 'reply' });
+    expect(sends).toHaveLength(0);
+
+    await adapter.teardown();
+  });
+
+  it('renders ask_question as slash options and routes the reply to onAction', async () => {
+    const { sdk, queue, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+
+    await adapter.deliver('+15551112222', null, {
+      kind: 'chat',
+      content: {
+        type: 'ask_question',
+        questionId: 'q1',
+        title: 'Deploy?',
+        question: 'Ship it?',
+        options: ['Approve', 'Reject'],
+      },
+    });
+    const card = sends.find((s) => s.builder.kind === 'markdown');
+    expect(card).toBeTruthy();
+    expect(String(card!.builder.payload)).toContain('/approve');
+
+    // User replies "/approve" → onAction with the option value, not a wake.
+    const space: SpectrumSpace = { id: '+15551112222', type: 'dm', phone: '+15551112222', send: async () => ({}) };
+    queue.push([
+      space,
+      { id: 'r1', direction: 'inbound', sender: { id: '+15551112222' }, content: { type: 'text', text: '/approve' } },
+    ]);
+    await waitFor(() => host.actions.length === 1);
+    expect(host.actions[0]).toEqual({ questionId: 'q1', option: 'Approve', userId: '+15551112222' });
+    // The slash reply must NOT have woken the agent as a normal inbound.
+    expect(host.inbound).toHaveLength(0);
+
+    await adapter.teardown();
+  });
+
+  it('sends a tapback reaction using the raw Photon id and emoji', async () => {
+    const { sdk, reacted } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await adapter.deliver('group-abc', null, {
+      kind: 'chat',
+      content: { operation: 'reaction', messageId: 'm9:ag-1234-abcd', emoji: 'thumbs_up' },
+    });
+    expect(reacted).toEqual([{ messageId: 'm9', emoji: '👍' }]);
+    await adapter.teardown();
+  });
+
+  it('fails delivery when the reaction target cannot be resolved', async () => {
+    const { sdk } = makeFakeSdk({ missingReactionTarget: true });
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await expect(
+      adapter.deliver('group-abc', null, {
+        kind: 'chat',
+        content: { operation: 'reaction', messageId: 'missing:ag-1234-abcd', emoji: 'thumbs_up' },
+      }),
+    ).rejects.toThrow(/message not found/i);
+    await adapter.teardown();
+  });
+
+  it('emits a typing indicator', async () => {
+    const { sdk, sends } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await adapter.setTyping!('+15551112222', null);
+    expect(sends.some((s) => s.builder.kind === 'typing' && s.builder.payload === 'start')).toBe(true);
+    await adapter.teardown();
+  });
+
+  it('throws a clear error when the SDK is not installed', async () => {
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      {
+        loadSpectrum: async () => {
+          throw new Error("Cannot find module 'spectrum-ts'");
+        },
+      },
+    );
+    await expect(adapter.setup(host.config)).rejects.toThrow(/spectrum-ts.*not installed|add-imessage/i);
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('stops the app on teardown', async () => {
+    const { sdk, stop } = makeFakeSdk();
+    const host = makeHostConfig();
+    const adapter = createPhotonAdapter(
+      { projectId: 'p', projectSecret: 's', markdown: true, telemetry: false, maxInlineAttachmentBytes: 1000 },
+      { loadSpectrum: async () => sdk },
+    );
+    await adapter.setup(host.config);
+    await adapter.teardown();
+    expect(stop).toHaveBeenCalled();
+    expect(adapter.isConnected()).toBe(false);
+  });
+});

--- a/src/channels/imessage.test.ts
+++ b/src/channels/imessage.test.ts
@@ -8,6 +8,9 @@
  *     delivery, and teardown all run the production code paths without a live
  *     Photon account.
  */
+import fs from 'fs';
+import path from 'path';
+
 import { describe, it, expect, vi } from 'vitest';
 
 import type { ChannelSetup, InboundMessage } from './adapter.js';
@@ -691,5 +694,68 @@ describe('photon adapter (mocked SDK)', () => {
     await adapter.teardown();
     expect(stop).toHaveBeenCalled();
     expect(adapter.isConnected()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-SDK integration
+// ---------------------------------------------------------------------------
+//
+// The mocked-SDK tests above exercise handwritten structural typings, which
+// can silently drift from the real package. This block imports the actually
+// installed `spectrum-ts` and asserts every part of the surface the adapter
+// consumes. It runs wherever /add-imessage (hosted) has installed the pin —
+// including the upgrade flow's `vitest run src/channels/imessage.test.ts` —
+// and skips on checkouts without the package (it is deliberately not a
+// dependency of this branch).
+
+let realSpectrum: Record<string, unknown> | null = null;
+let realProvider: Record<string, unknown> | null = null;
+try {
+  const spectrumSpec: string = 'spectrum-ts';
+  const imessageSpec: string = 'spectrum-ts/providers/imessage';
+  realSpectrum = (await import(spectrumSpec)) as Record<string, unknown>;
+  realProvider = (await import(imessageSpec)) as Record<string, unknown>;
+} catch {
+  // Package not installed — integration block skips below.
+}
+
+describe.skipIf(!realSpectrum)('spectrum-ts SDK integration (real pinned package)', () => {
+  it('is the major version the adapter targets (v11)', async () => {
+    const { createRequire } = await import('module');
+    const req = createRequire(import.meta.url);
+    const pkgPath = path.join(path.dirname(req.resolve('spectrum-ts')), '..', 'package.json');
+    const version = String(JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version);
+    // Keep in sync with the /add-imessage pin (spectrum-ts@11.x). v10 renamed
+    // Spectrum()'s `providers` key to `platforms`; a different major here means
+    // the adapter's structural typings need re-reconciling.
+    expect(version.split('.')[0]).toBe('11');
+  });
+
+  it('exposes every module export the adapter consumes', () => {
+    const mod = realSpectrum!;
+    for (const fn of ['Spectrum', 'text', 'markdown', 'typing', 'read', 'attachment', 'voice'] as const) {
+      expect(typeof mod[fn], `spectrum-ts export ${fn}`).toBe('function');
+    }
+  });
+
+  it('exposes the imessage provider with a callable config()', () => {
+    const imessage = realProvider!.imessage as { (app: unknown): unknown; config: () => unknown };
+    expect(typeof imessage).toBe('function');
+    expect(typeof imessage.config).toBe('function');
+    expect(imessage.config()).toBeDefined();
+  });
+
+  it('builds the outbound content the adapter sends', () => {
+    const mod = realSpectrum! as {
+      text: (s: string) => unknown;
+      markdown: (s: string) => unknown;
+      typing: (state: 'start' | 'stop') => unknown;
+    };
+    // The exact builder shapes are the SDK's business — the adapter only
+    // requires that they are constructible and land in space.send() as-is.
+    expect(mod.text('hello')).toBeDefined();
+    expect(mod.markdown('**hello**')).toBeDefined();
+    expect(mod.typing('start')).toBeDefined();
   });
 });

--- a/src/channels/imessage.ts
+++ b/src/channels/imessage.ts
@@ -1,48 +1,854 @@
 /**
- * iMessage channel adapter (v2) — uses Chat SDK bridge.
- * Supports local mode (macOS Full Disk Access) and remote mode (Photon API).
- * Self-registers on import.
+ * iMessage channel adapter — one channel, two pluggable backends
+ * (skill-installed via /add-imessage). The factory picks a backend from
+ * config; only one is ever active per install.
+ *
+ *   - local   — the Chat SDK bridge over `chat-adapter-imessage`, reading
+ *               THIS Mac's signed-in iMessage account (chat.db; macOS + Full
+ *               Disk Access). Selected when IMESSAGE_ENABLED is truthy.
+ *   - hosted  — this native adapter, connecting to iMessage through Photon's
+ *               managed Spectrum platform using the TypeScript `spectrum-ts`
+ *               SDK directly on the host. Selected when PHOTON_PROJECT_ID /
+ *               PHOTON_PROJECT_SECRET are set.
+ *
+ * Set IMESSAGE_BACKEND=local|hosted to force one when both are configured.
+ *
+ * Hosted backend (the bulk of this file): unlike Hermes (whose gateway is
+ * Python and therefore needs a Node sidecar to run the SDK), NanoClaw's host
+ * is already Node, so the SDK runs in-process — no sidecar, no loopback HTTP,
+ * no extra supervised subprocess. Like Discord/Slack it is a
+ * persistent-connection channel — no webhook, no public URL, no signing
+ * secret. `spectrum-ts` holds a long-lived gRPC stream to Photon for both
+ * directions:
+ *   - Inbound:  the SDK's `app.messages` async iterator yields
+ *               `[space, message]` pairs. We normalize each to an
+ *               InboundMessage and hand it to the router. The consumer loop
+ *               re-subscribes with capped backoff if the stream ends/errors.
+ *   - Outbound: `deliver()` resolves the target space (a DM by phone, or a
+ *               group by its opaque space id) and calls `space.send(...)`.
+ *
+ * Hosted credentials come from `.env` (host-side; never enters a container):
+ *   PHOTON_PROJECT_ID       — the Spectrum project id (SDK `projectId`)
+ *   PHOTON_PROJECT_SECRET   — the project secret
+ * Both are provisioned frictionlessly by `scripts/photon-setup.ts`
+ * (`/add-imessage`), which runs Photon's device-login flow and creates the
+ * project, secret, user, and iMessage line for you.
+ *
+ * Neither backend's package (`chat-adapter-imessage`, `spectrum-ts`) is
+ * imported at module load: `spectrum-ts` loads via a runtime dynamic import in
+ * setup(), and `chat-adapter-imessage` via a dynamic import in the local
+ * factory branch — so the channel barrel evaluates (and this module registers)
+ * even when neither is installed. The factory returns an adapter only when a
+ * backend is configured, and setup() throws a clear "run /add-imessage" error
+ * if the hosted SDK is missing.
  */
-import { createiMessageAdapter } from 'chat-adapter-imessage';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
+import { isSafeAttachmentName } from '../attachment-safety.js';
+import { DATA_DIR } from '../config.js';
 import { readEnvFile } from '../env.js';
-import type { ChannelDefaults } from './adapter.js';
-import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { log } from '../log.js';
+import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import type { ChannelAdapter, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+// Type-only import from the baseline `chat` dep — no runtime cost, and the
+// local backend's `chat-adapter-imessage` is loaded dynamically (see the
+// factory) so this module still evaluates without that package installed.
+import type { Adapter } from 'chat';
+
+// ---------------------------------------------------------------------------
+// Minimal structural typings for the slice of `spectrum-ts` we consume.
+//
+// We intentionally do not `import` from 'spectrum-ts' at type level: the
+// package is installed on demand by /add-imessage, and the barrel must typecheck and
+// the barrel must evaluate without it. These interfaces mirror the shapes the
+// SDK returns (see the Hermes sidecar for the reference usage against v11).
+// ---------------------------------------------------------------------------
+
+/** A content node on an inbound message (text / media / group / reaction). */
+export interface SpectrumContent {
+  type: string;
+  text?: string;
+  id?: string | null;
+  name?: string | null;
+  mimeType?: string | null;
+  size?: number | null;
+  duration?: number;
+  items?: Array<{ id?: string | null; content?: SpectrumContent }>;
+  emoji?: string;
+  target?: { id?: string | null; direction?: string; content?: SpectrumContent } | null;
+  read?: () => Promise<Uint8Array>;
+}
+
+/** Handle returned by `target.react(emoji)` — retractable via unsend(). */
+export interface SpectrumReactionHandle {
+  id?: string | null;
+  unsend?: () => Promise<void>;
+}
+
+/** A resolved inbound message target, used for reactions. */
+export interface SpectrumTargetMessage {
+  id?: string | null;
+  react?: (emoji: string) => Promise<SpectrumReactionHandle | undefined>;
+}
+
+/** A conversation surface (a DM or a group). */
+export interface SpectrumSpace {
+  id?: string;
+  type?: string; // "dm" | "group"
+  phone?: string | null;
+  send: (builder: unknown) => Promise<{ id?: string | null } | undefined>;
+  getMessage?: (id: string) => Promise<SpectrumTargetMessage | undefined>;
+}
+
+/** An inbound message off the `app.messages` stream. */
+export interface SpectrumMessage {
+  id?: string | null;
+  direction?: string; // "inbound" | "outbound"
+  platform?: string;
+  sender?: { id?: string | null } | null;
+  space?: SpectrumSpace;
+  content?: SpectrumContent;
+  timestamp?: Date | string | null;
+}
+
+/** The running Spectrum app. */
+export interface SpectrumApp {
+  messages: AsyncIterable<[SpectrumSpace, SpectrumMessage]>;
+  stop: () => Promise<void>;
+}
+
+/** The `spectrum-ts` module surface we use. */
+export interface SpectrumModule {
+  Spectrum: (opts: {
+    projectId: string;
+    projectSecret: string;
+    /** v10 renamed `providers` to `platforms`. */
+    platforms: unknown[];
+    options?: Record<string, unknown>;
+    telemetry?: boolean;
+  }) => Promise<SpectrumApp>;
+  text: (s: string) => unknown;
+  markdown: (s: string) => unknown;
+  typing: (state: 'start' | 'stop') => unknown;
+  read: (message: SpectrumMessage) => unknown;
+  attachment: (filePath: string, opts?: { name?: string; mimeType?: string }) => unknown;
+  voice: (filePath: string, opts?: { name?: string; mimeType?: string }) => unknown;
+}
+
+/** The `spectrum-ts/providers/imessage` provider surface we use. */
+export interface ImessageProvider {
+  config: () => unknown;
+  (app: SpectrumApp): {
+    space: {
+      create: (target: string) => Promise<SpectrumSpace>;
+      get: (id: string) => Promise<SpectrumSpace | undefined>;
+    };
+  };
+}
+
+/** Loaded SDK bundle. */
+export interface PhotonSdk {
+  spectrum: SpectrumModule;
+  imessage: ImessageProvider;
+}
+
+/** Injection seam — tests supply a fake SDK; production dynamically imports. */
+export type SpectrumLoader = () => Promise<PhotonSdk>;
+
+const defaultLoader: SpectrumLoader = async () => {
+  // Non-literal specifiers keep tsc from resolving (and failing on) a module
+  // that may not be installed. Node resolves the bare specifier + subpath
+  // export at runtime once /add-imessage has installed spectrum-ts.
+  const spectrumSpec: string = 'spectrum-ts';
+  const imessageSpec: string = 'spectrum-ts/providers/imessage';
+  const spectrum = (await import(spectrumSpec)) as unknown as SpectrumModule;
+  const providerMod = (await import(imessageSpec)) as unknown as { imessage: ImessageProvider };
+  return { spectrum, imessage: providerMod.imessage };
+};
+
+// ---------------------------------------------------------------------------
+// Config + constants
+// ---------------------------------------------------------------------------
+
+export interface PhotonConfig {
+  projectId: string;
+  projectSecret: string;
+  /** Send agent replies as markdown (iMessage renders it natively). Default true. */
+  markdown: boolean;
+  /** Spectrum SDK telemetry. Default false. */
+  telemetry: boolean;
+  /** Cap on inbound attachment bytes we read + cache. Default 20 MB. */
+  maxInlineAttachmentBytes: number;
+}
+
+const DEFAULT_MAX_INLINE_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const RECONNECT_BACKOFF_START_MS = 1000;
+const RECONNECT_BACKOFF_MAX_MS = 30_000;
+const SPACE_CACHE_MAX = 2048;
+const PENDING_QUESTIONS_MAX = 64;
+const OUTBOUND_TEXT_CHUNK = 4000;
+
+const REACTION_EMOJI_ALIASES: Record<string, string> = {
+  thumbs_up: '👍',
+  '+1': '👍',
+  thumbs_down: '👎',
+  '-1': '👎',
+  heart: '❤️',
+  laugh: '😂',
+  joy: '😂',
+  exclamation: '‼️',
+  question: '❓',
+  eyes: '👀',
+  white_check_mark: '✅',
+  check: '✅',
+};
+
+// Photon represents a DM chat id either as a bare E.164 number or as the
+// iMessage chat GUID `any;-;+15551234567`. Both address the same DM and
+// `space.create` accepts the bare number, so we normalize to the number.
+const E164_RE = /^\+\d{6,15}$/;
+const DM_CHAT_GUID_RE = /^any;-;(\+\d{6,15})$/;
+
+const MIME_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/heic': '.heic',
+  'video/mp4': '.mp4',
+  'video/quicktime': '.mov',
+  'audio/mpeg': '.mp3',
+  'audio/mp4': '.m4a',
+  'audio/aac': '.aac',
+  'audio/ogg': '.ogg',
+  'audio/x-caf': '.caf',
+  'application/pdf': '.pdf',
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Extract the bare E.164 phone a space id addresses, or null. */
+export function phoneTargetFromSpaceId(spaceId: string | null | undefined): string | null {
+  if (typeof spaceId !== 'string') return null;
+  if (E164_RE.test(spaceId)) return spaceId;
+  const m = spaceId.match(DM_CHAT_GUID_RE);
+  return m ? m[1] : null;
+}
 
 /**
- * The operator's personal Apple ID is a shared identity — strangers DMing it
- * reach the human, not the bot, so auto-create stays 'strict'. iMessage
- * exposes no group-mention metadata ('dm-only'); group wirings default to a
- * name-pattern trigger instead ({name} = agent group name).
+ * Resolve the stable NanoClaw platform id + group flag for a message.
+ * DMs use the counterpart's E.164 number (addressable via space.create);
+ * groups use the opaque Spectrum space id.
  */
-const IMESSAGE_DEFAULTS: ChannelDefaults = {
-  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'strict' },
-  group: { engageMode: 'pattern', engagePattern: '\\b{name}\\b', threads: false, unknownSenderPolicy: 'strict' },
-  mentions: 'dm-only',
-};
+export function resolveSpaceIdentity(
+  space: SpectrumSpace | undefined,
+  message: SpectrumMessage,
+): { platformId: string; isGroup: boolean } | null {
+  const id = space?.id ?? message.space?.id ?? null;
+  const type = space?.type ?? message.space?.type ?? 'dm';
+  const phone = space?.phone ?? message.space?.phone ?? null;
+  const isGroup = type === 'group';
+  if (isGroup) {
+    if (!id) return null;
+    return { platformId: id, isGroup: true };
+  }
+  const dmPhone = (phone && E164_RE.test(phone) ? phone : null) ?? phoneTargetFromSpaceId(id);
+  const platformId = dmPhone ?? id;
+  if (!platformId) return null;
+  return { platformId, isGroup: false };
+}
+
+/** Normalize an option label to a slash command: "Approve" → "/approve". */
+export function optionToCommand(option: string): string {
+  return '/' + option.toLowerCase().replace(/\s+/g, '-');
+}
+
+/** Convert NanoClaw's cross-channel emoji shortcodes to values iMessage accepts. */
+export function photonReactionEmoji(emoji: string): string {
+  return REACTION_EMOJI_ALIASES[emoji] ?? emoji;
+}
+
+/** Remove the router's per-agent namespace before resolving a Photon message. */
+export function photonReactionTargetId(messageId: string): string {
+  return messageId.replace(/:ag-[A-Za-z0-9-]+$/, '');
+}
+
+/** Pick a safe on-disk filename for an inbound attachment. */
+export function attachmentFilename(content: SpectrumContent): string {
+  const raw = content.name ?? undefined;
+  if (raw && isSafeAttachmentName(raw)) return raw;
+  const ext = (content.mimeType && MIME_EXT[content.mimeType]) || (content.type === 'voice' ? '.caf' : '');
+  const stem = content.type === 'voice' ? 'voice' : content.type === 'attachment' ? 'attachment' : 'media';
+  const id = (content.id ?? '').replace(/[^A-Za-z0-9._-]/g, '') || String(Date.now());
+  return `${stem}-${id}${ext}`;
+}
+
+/** Split long outbound text on line boundaries so a huge reply isn't truncated. */
+export function chunkText(text: string, limit = OUTBOUND_TEXT_CHUNK): string[] {
+  if (text.length <= limit) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    let cut = remaining.lastIndexOf('\n', limit);
+    if (cut <= 0) cut = remaining.lastIndexOf(' ', limit);
+    if (cut <= 0) cut = limit;
+    chunks.push(remaining.slice(0, cut).trimEnd());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+/** A downloaded inbound attachment reference. */
+export interface PhotonAttachment {
+  type: string;
+  name: string;
+  localPath: string;
+}
+
+/** Extracted, normalized inbound payload built from a Spectrum message. */
+export interface NormalizedInbound {
+  text: string;
+  attachments: PhotonAttachment[];
+  failures: string[];
+  isReaction: boolean;
+}
+
+/**
+ * Walk a Spectrum content node into agent-visible text + downloaded
+ * attachments. `saveMedia` is injected (the adapter caches to disk; tests
+ * stub it) and receives the raw bytes + a chosen filename.
+ */
+export async function normalizeContent(
+  content: SpectrumContent | undefined,
+  saveMedia: (content: SpectrumContent) => Promise<PhotonAttachment | null>,
+  out: NormalizedInbound,
+): Promise<void> {
+  if (!content || typeof content !== 'object') return;
+  if (content.type === 'text') {
+    if (content.text) out.text = out.text ? `${out.text}\n${content.text}` : content.text;
+    return;
+  }
+  if (content.type === 'attachment' || content.type === 'voice') {
+    const saved = await saveMedia(content);
+    if (saved) out.attachments.push(saved);
+    else out.failures.push(content.type === 'voice' ? 'voice message' : 'attachment');
+    return;
+  }
+  if (content.type === 'group') {
+    for (const item of content.items ?? []) {
+      await normalizeContent(item?.content, saveMedia, out);
+    }
+    return;
+  }
+  if (content.type === 'reaction') {
+    const emoji = content.emoji || '';
+    if (emoji) {
+      out.isReaction = true;
+      const marker = `reaction:added:${emoji}`;
+      out.text = out.text ? `${out.text}\n${marker}` : marker;
+    }
+    return;
+  }
+}
+
+/** Append a visible note for media that failed to download. */
+export function appendMediaFailureNote(text: string, failures: string[]): string {
+  if (failures.length === 0) return text;
+  const note = failures.map((t) => `[${t} could not be downloaded]`).join(' ');
+  return text ? `${text}\n${note}` : note;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export function createPhotonAdapter(
+  config: PhotonConfig,
+  deps: { loadSpectrum?: SpectrumLoader } = {},
+): ChannelAdapter {
+  const loadSpectrum = deps.loadSpectrum ?? defaultLoader;
+
+  let app: SpectrumApp | null = null;
+  let sdk: PhotonSdk | null = null;
+  let im: ReturnType<ImessageProvider> | null = null;
+  let setupConfig: ChannelSetup;
+  let connected = false;
+  let shuttingDown = false;
+
+  // Space cache keyed by platform id (phone or group id) — avoids a
+  // create/get round trip on every outbound to a recently-seen conversation.
+  const spaceCache = new Map<string, SpectrumSpace>();
+
+  // Pending ask_user_question by platformId → { questionId, options }.
+  // The user answers by replying with a slash command (iMessage has no buttons).
+  const pendingQuestions = new Map<string, { questionId: string; options: NormalizedOption[] }>();
+
+  function cacheSpace(key: string, space: SpectrumSpace): void {
+    if (!key || !space) return;
+    if (spaceCache.has(key)) spaceCache.delete(key);
+    spaceCache.set(key, space);
+    if (spaceCache.size > SPACE_CACHE_MAX) {
+      const oldest = spaceCache.keys().next().value;
+      if (oldest !== undefined) spaceCache.delete(oldest);
+    }
+  }
+
+  function rememberInboundSpace(space: SpectrumSpace | undefined, platformId: string): void {
+    if (!space) return;
+    cacheSpace(platformId, space);
+    if (space.id) cacheSpace(space.id, space);
+  }
+
+  async function resolveSpace(platformId: string): Promise<SpectrumSpace> {
+    const cached = spaceCache.get(platformId);
+    if (cached) return cached;
+    if (!im) throw new Error('Photon adapter not connected');
+
+    const phone = phoneTargetFromSpaceId(platformId);
+    let space: SpectrumSpace | undefined;
+    if (phone) {
+      try {
+        space = await im.space.create(phone);
+      } catch (err) {
+        log.debug('Photon: phone → DM space.create failed', { platformId, err });
+      }
+    }
+    if (!space) {
+      try {
+        space = await im.space.get(platformId);
+      } catch (err) {
+        log.debug('Photon: space.get failed', { platformId, err });
+      }
+    }
+    if (!space) throw new Error(`Photon: unable to resolve space for ${platformId}`);
+    cacheSpace(platformId, space);
+    if (space.id) cacheSpace(space.id, space);
+    return space;
+  }
+
+  /** Read + cache an inbound media node to DATA_DIR/attachments. */
+  async function saveMedia(content: SpectrumContent): Promise<PhotonAttachment | null> {
+    if (typeof content.read !== 'function') return null;
+    if (typeof content.size === 'number' && content.size > config.maxInlineAttachmentBytes) {
+      log.warn('Photon: inbound attachment over inline cap, skipping', {
+        size: content.size,
+        cap: config.maxInlineAttachmentBytes,
+      });
+      return null;
+    }
+    let bytes: Uint8Array;
+    try {
+      bytes = await content.read();
+    } catch (err) {
+      log.warn('Photon: failed to read inbound attachment bytes', { err });
+      return null;
+    }
+    if (bytes.length > config.maxInlineAttachmentBytes) {
+      log.warn('Photon: inbound attachment over inline cap after read, skipping', { size: bytes.length });
+      return null;
+    }
+    const filename = attachmentFilename(content);
+    try {
+      const attachDir = path.join(DATA_DIR, 'attachments');
+      fs.mkdirSync(attachDir, { recursive: true });
+      fs.writeFileSync(path.join(attachDir, filename), Buffer.from(bytes));
+    } catch (err) {
+      log.warn('Photon: failed to write inbound attachment', { filename, err });
+      return null;
+    }
+    log.info('Photon: media downloaded', { type: content.type, filename });
+    return {
+      type: content.type === 'voice' ? 'voice' : 'attachment',
+      name: filename,
+      localPath: `attachments/${filename}`,
+    };
+  }
+
+  async function handleInbound(space: SpectrumSpace, message: SpectrumMessage): Promise<void> {
+    // Ignore our own outbound echoes. `direction` is only set on messages the
+    // provider has classified; when absent we treat it as inbound.
+    if (message.direction && message.direction !== 'inbound') return;
+
+    const identity = resolveSpaceIdentity(space, message);
+    if (!identity) {
+      log.debug('Photon: could not resolve space identity, dropping message');
+      return;
+    }
+    const { platformId, isGroup } = identity;
+    rememberInboundSpace(space, platformId);
+
+    // Remote iMessage marks the whole chat read. Keep this best-effort so a
+    // transient receipt failure never prevents the message from reaching the agent.
+    if (sdk) {
+      try {
+        await space.send(sdk.spectrum.read(message));
+      } catch (err) {
+        log.debug('Photon: failed to mark inbound message read', { platformId, messageId: message.id, err });
+      }
+    }
+
+    const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
+    await normalizeContent(message.content, saveMedia, out);
+    const text = appendMediaFailureNote(out.text, out.failures);
+
+    // Nothing usable (empty protocol frame, unsupported content) — drop.
+    if (!text && out.attachments.length === 0) return;
+
+    const sender = message.sender?.id ?? platformId;
+    const senderName = sender;
+    const ts = message.timestamp;
+    const timestamp = ts instanceof Date ? ts.toISOString() : ts ? String(ts) : new Date().toISOString();
+
+    setupConfig.onMetadata(platformId, undefined, isGroup);
+
+    // A pending ask_user_question answered by a slash-command reply routes to
+    // onAction instead of waking the agent with the raw "/approve" text.
+    const pending = pendingQuestions.get(platformId);
+    if (pending && text.trim().startsWith('/')) {
+      const cmd = text.trim().toLowerCase();
+      const matched = pending.options.find((o) => optionToCommand(o.label) === cmd);
+      if (matched) {
+        setupConfig.onAction(pending.questionId, matched.value, sender);
+        pendingQuestions.delete(platformId);
+        await deliverText(platformId, `${matched.selectedLabel}`).catch((err) =>
+          log.debug('Photon: failed to confirm question answer', { err }),
+        );
+        return;
+      }
+    }
+
+    const inbound: InboundMessage = {
+      id: message.id || `photon-${Date.now()}`,
+      kind: 'chat',
+      // DMs are addressed to the bot by definition → platform-confirmed mention
+      // so the router auto-engages / creates an approval-gated messaging group.
+      // In groups we leave it undefined and let the router fall back to
+      // agent-name text matching (iMessage groups carry no structured mention).
+      isMention: isGroup ? undefined : true,
+      isGroup,
+      content: {
+        text,
+        sender,
+        senderId: `imessage:${sender}`,
+        senderName,
+        isGroup,
+        ...(out.attachments.length > 0 && { attachments: out.attachments }),
+      },
+      timestamp,
+    };
+    await setupConfig.onInbound(platformId, null, inbound);
+    log.info('Photon message received', { platformId, isGroup });
+  }
+
+  /** The re-subscribing inbound consumer loop. */
+  async function consumeInbound(): Promise<void> {
+    let backoff = RECONNECT_BACKOFF_START_MS;
+    while (!shuttingDown) {
+      try {
+        if (!app) return;
+        for await (const [space, message] of app.messages) {
+          backoff = RECONNECT_BACKOFF_START_MS;
+          try {
+            await handleInbound(space, message);
+          } catch (err) {
+            log.error('Photon: error handling inbound message', { err });
+          }
+        }
+        if (shuttingDown) return;
+        log.warn('Photon: inbound stream ended — re-subscribing');
+      } catch (err) {
+        if (shuttingDown) return;
+        log.error('Photon: inbound stream errored — restarting', { err });
+      }
+      await new Promise((r) => setTimeout(r, backoff + Math.random() * backoff * 0.2));
+      backoff = Math.min(backoff * 2, RECONNECT_BACKOFF_MAX_MS);
+    }
+  }
+
+  /** Send plain-or-markdown text (chunked) to a resolved space. */
+  async function deliverText(platformId: string, text: string): Promise<string | undefined> {
+    if (!sdk) return undefined;
+    const space = await resolveSpace(platformId);
+    const chunks = chunkText(text);
+    let firstId: string | undefined;
+    for (let i = 0; i < chunks.length; i++) {
+      const builder = config.markdown ? sdk.spectrum.markdown(chunks[i]) : sdk.spectrum.text(chunks[i]);
+      const result = await space.send(builder);
+      if (i === 0) firstId = result?.id ?? undefined;
+    }
+    return firstId;
+  }
+
+  const adapter: ChannelAdapter = {
+    name: 'imessage',
+    channelType: 'imessage',
+    supportsThreads: false,
+
+    async setup(hostConfig: ChannelSetup): Promise<void> {
+      setupConfig = hostConfig;
+
+      try {
+        sdk = await loadSpectrum();
+      } catch (err) {
+        throw new Error(
+          'Photon: the `spectrum-ts` SDK is not installed. Run /add-imessage ' +
+            '(or `pnpm install spectrum-ts@11.0.0`) to enable the channel.',
+          { cause: err },
+        );
+      }
+
+      app = await sdk.spectrum.Spectrum({
+        projectId: config.projectId,
+        projectSecret: config.projectSecret,
+        platforms: [sdk.imessage.config()],
+        options: { flattenGroups: true },
+        telemetry: config.telemetry,
+      });
+      im = sdk.imessage(app);
+      connected = true;
+
+      // Fire-and-forget: the consumer loop owns its own reconnect lifecycle.
+      void consumeInbound();
+
+      log.info('Photon channel connected', { projectId: config.projectId });
+    },
+
+    async teardown(): Promise<void> {
+      shuttingDown = true;
+      connected = false;
+      const current = app;
+      app = null;
+      im = null;
+      if (current) {
+        try {
+          await Promise.race([current.stop(), new Promise((resolve) => setTimeout(resolve, 3000))]);
+        } catch (err) {
+          log.debug('Photon: app.stop() failed', { err });
+        }
+      }
+      log.info('Photon channel disconnected');
+    },
+
+    isConnected(): boolean {
+      return connected;
+    },
+
+    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+      if (!sdk) return undefined;
+      // Delivery normally passes an object; tolerate a bare string too.
+      if (typeof message.content === 'string') {
+        return message.content ? deliverText(platformId, message.content) : undefined;
+      }
+      const content = (message.content ?? {}) as Record<string, unknown>;
+
+      // ask_user_question → text + slash-command replies (no iMessage buttons).
+      if (content.type === 'ask_question' && content.questionId && content.options) {
+        const questionId = content.questionId as string;
+        const title = content.title as string;
+        const question = content.question as string;
+        if (!title) {
+          log.error('Photon: ask_question missing required title — skipping', { questionId });
+          return undefined;
+        }
+        const options: NormalizedOption[] = normalizeOptions(content.options as never);
+        const lines = options.map((o) => `  ${optionToCommand(o.label)} — ${o.label}`).join('\n');
+        const body = `**${title}**\n\n${question}\n\nReply with:\n${lines}`;
+        const msgId = await deliverText(platformId, body);
+        pendingQuestions.set(platformId, { questionId, options });
+        if (pendingQuestions.size > PENDING_QUESTIONS_MAX) {
+          const oldest = pendingQuestions.keys().next().value;
+          if (oldest !== undefined) pendingQuestions.delete(oldest);
+        }
+        return msgId;
+      }
+
+      // Reaction (tapback) on a prior message.
+      if (content.operation === 'reaction' && content.messageId && content.emoji) {
+        const messageId = photonReactionTargetId(content.messageId as string);
+        const emoji = photonReactionEmoji(content.emoji as string);
+        try {
+          const space = await resolveSpace(platformId);
+          const target = await space.getMessage?.(messageId);
+          if (!target?.react) {
+            throw new Error(`Photon message not found or cannot be reacted to: ${messageId}`);
+          }
+          await target.react(emoji);
+        } catch (err) {
+          log.error('Photon: failed to send reaction', { platformId, messageId, emoji, err });
+          throw err;
+        }
+        return undefined;
+      }
+
+      const rawText = (content.markdown as string) || (content.text as string) || '';
+      const files = message.files ?? [];
+
+      // Files first so a caption lands beneath the media in the chat. iMessage
+      // runs on a dedicated line here, so replies are not name-prefixed.
+      if (files.length > 0) {
+        await deliverFiles(platformId, files);
+      }
+      if (rawText) {
+        return deliverText(platformId, rawText);
+      }
+      return undefined;
+    },
+
+    async setTyping(platformId: string): Promise<void> {
+      if (!sdk || !connected) return;
+      try {
+        const space = await resolveSpace(platformId);
+        await space.send(sdk.spectrum.typing('start'));
+      } catch (err) {
+        log.debug('Photon: typing indicator failed', { platformId, err });
+      }
+    },
+  };
+
+  /** Send outbound file attachments via temp files spectrum-ts can read. */
+  async function deliverFiles(platformId: string, files: NonNullable<OutboundMessage['files']>): Promise<void> {
+    if (!sdk) return;
+    const space = await resolveSpace(platformId);
+    for (const file of files) {
+      const safeName = file.filename.replace(/[/\\\0]/g, '_');
+      const tempPath = path.join(
+        os.tmpdir(),
+        `photon-out-${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safeName}`,
+      );
+      try {
+        fs.writeFileSync(tempPath, file.data);
+        const builder = sdk.spectrum.attachment(tempPath, { name: file.filename });
+        await space.send(builder);
+      } catch (err) {
+        log.error('Photon: failed to send attachment', { platformId, filename: file.filename, err });
+      } finally {
+        try {
+          fs.unlinkSync(tempPath);
+        } catch {
+          /* best-effort temp cleanup */
+        }
+      }
+    }
+  }
+
+  return adapter;
+}
+
+// ---------------------------------------------------------------------------
+// Self-registration — one `imessage` channel; the factory picks the backend
+// ---------------------------------------------------------------------------
+
+function truthy(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((value ?? '').trim());
+}
+
+type Backend = 'local' | 'hosted';
+
+/**
+ * Decide which backend (if any) is configured. An explicit IMESSAGE_BACKEND
+ * wins; otherwise Photon credentials imply hosted and IMESSAGE_ENABLED implies
+ * local. Returns null when neither is set (the channel stays dormant).
+ */
+function pickBackend(env: Record<string, string | undefined>): Backend | null {
+  const explicit = (process.env.IMESSAGE_BACKEND ?? env.IMESSAGE_BACKEND ?? '').trim().toLowerCase();
+  if (explicit === 'local' || explicit === 'hosted') return explicit;
+
+  const hasPhoton =
+    Boolean(process.env.PHOTON_PROJECT_ID ?? env.PHOTON_PROJECT_ID) &&
+    Boolean(process.env.PHOTON_PROJECT_SECRET ?? env.PHOTON_PROJECT_SECRET);
+  const localEnabled = truthy(process.env.IMESSAGE_ENABLED ?? env.IMESSAGE_ENABLED);
+
+  if (hasPhoton && localEnabled) {
+    log.warn(
+      'iMessage: both Photon credentials and IMESSAGE_ENABLED are set — defaulting to the hosted ' +
+        'backend. Set IMESSAGE_BACKEND=local|hosted to choose explicitly.',
+    );
+    return 'hosted';
+  }
+  if (hasPhoton) return 'hosted';
+  if (localEnabled) return 'local';
+  return null;
+}
+
+/**
+ * Build the local backend: the Chat SDK bridge over `chat-adapter-imessage`,
+ * reading this Mac's signed-in iMessage account. The package is pulled via a
+ * non-literal dynamic specifier so tsc never resolves it and the barrel
+ * evaluates without it installed; /add-imessage (Local) installs it on demand.
+ */
+async function createLocalAdapter(): Promise<ChannelAdapter> {
+  const spec: string = 'chat-adapter-imessage';
+  let mod: { createiMessageAdapter: (opts: { local?: boolean }) => Adapter };
+  try {
+    mod = (await import(spec)) as unknown as typeof mod;
+  } catch (err) {
+    throw new Error(
+      'iMessage (local): the `chat-adapter-imessage` package is not installed. Run /add-imessage ' +
+        '(or `pnpm install chat-adapter-imessage@0.1.1`) to enable the local backend.',
+      { cause: err },
+    );
+  }
+  const raw = mod.createiMessageAdapter({ local: true });
+  // The community adapter omits channelIdFromThreadId; polyfill an identity fn.
+  const adapter = Object.assign(raw, { channelIdFromThreadId: (threadId: string) => threadId });
+  return createChatSdkBridge({ adapter, concurrency: 'concurrent', supportsThreads: false });
+}
 
 registerChannelAdapter('imessage', {
   factory: () => {
-    const env = readEnvFile(['IMESSAGE_ENABLED', 'IMESSAGE_LOCAL', 'IMESSAGE_SERVER_URL', 'IMESSAGE_API_KEY']);
-    const isLocal = env.IMESSAGE_LOCAL !== 'false';
-    if (isLocal && !env.IMESSAGE_ENABLED) return null;
-    if (!isLocal && !env.IMESSAGE_SERVER_URL) return null;
-    const rawAdapter = createiMessageAdapter({
-      local: isLocal,
-      serverUrl: env.IMESSAGE_SERVER_URL,
-      apiKey: env.IMESSAGE_API_KEY,
-    });
-    // Polyfill channelIdFromThreadId (community adapter doesn't implement it)
-    const imessageAdapter = Object.assign(rawAdapter, {
-      channelIdFromThreadId: (threadId: string) => threadId,
-    });
-    return createChatSdkBridge({
-      adapter: imessageAdapter,
-      concurrency: 'concurrent',
-      supportsThreads: false,
-      defaults: IMESSAGE_DEFAULTS,
+    const env = readEnvFile([
+      'IMESSAGE_BACKEND',
+      'IMESSAGE_ENABLED',
+      'PHOTON_PROJECT_ID',
+      'PHOTON_PROJECT_SECRET',
+      'PHOTON_MARKDOWN',
+      'PHOTON_TELEMETRY',
+      'PHOTON_MAX_INLINE_ATTACHMENT_BYTES',
+    ]);
+
+    const backend = pickBackend(env);
+    if (!backend) {
+      log.debug(
+        'iMessage: no backend configured — set PHOTON_PROJECT_ID/PHOTON_PROJECT_SECRET for hosted ' +
+          'or IMESSAGE_ENABLED=true for local. Skipping channel.',
+      );
+      return null;
+    }
+
+    if (backend === 'local') {
+      if (os.platform() !== 'darwin') {
+        log.warn("iMessage: the local backend reads this Mac's chat.db and requires macOS — skipping channel");
+        return null;
+      }
+      return createLocalAdapter();
+    }
+
+    // hosted (Photon)
+    const projectId = process.env.PHOTON_PROJECT_ID || env.PHOTON_PROJECT_ID;
+    const projectSecret = process.env.PHOTON_PROJECT_SECRET || env.PHOTON_PROJECT_SECRET;
+    if (!projectId || !projectSecret) {
+      log.debug('iMessage (hosted): PHOTON_PROJECT_ID / PHOTON_PROJECT_SECRET not set, skipping channel');
+      return null;
+    }
+    const markdownRaw = process.env.PHOTON_MARKDOWN ?? env.PHOTON_MARKDOWN;
+    const maxInline =
+      Number(process.env.PHOTON_MAX_INLINE_ATTACHMENT_BYTES || env.PHOTON_MAX_INLINE_ATTACHMENT_BYTES) ||
+      DEFAULT_MAX_INLINE_ATTACHMENT_BYTES;
+    return createPhotonAdapter({
+      projectId,
+      projectSecret,
+      // Default on — iMessage renders markdown natively.
+      markdown: markdownRaw === undefined ? true : markdownRaw !== 'false',
+      telemetry: truthy(process.env.PHOTON_TELEMETRY ?? env.PHOTON_TELEMETRY),
+      maxInlineAttachmentBytes: maxInline,
     });
   },
-  defaults: IMESSAGE_DEFAULTS,
 });

--- a/src/channels/imessage.ts
+++ b/src/channels/imessage.ts
@@ -47,19 +47,12 @@ import os from 'os';
 import path from 'path';
 
 import { isSafeAttachmentName } from '../attachment-safety.js';
-import { DATA_DIR } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
-import type {
-  ChannelAdapter,
-  ChannelDefaults,
-  ChannelSetup,
-  InboundMessage,
-  OutboundMessage,
-} from './adapter.js';
+import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
 // Type-only import from the baseline `chat` dep — no runtime cost, and the
 // local backend's `chat-adapter-imessage` is loaded dynamically (see the
 // factory) so this module still evaluates without that package installed.
@@ -187,7 +180,7 @@ export interface PhotonConfig {
   markdown: boolean;
   /** Spectrum SDK telemetry. Default false. */
   telemetry: boolean;
-  /** Cap on inbound attachment bytes we read + cache. Default 20 MB. */
+  /** Cap on inbound attachment bytes we read + inline for inbox staging. Default 20 MB. */
   maxInlineAttachmentBytes: number;
 }
 
@@ -312,11 +305,46 @@ export function chunkText(text: string, limit = OUTBOUND_TEXT_CHUNK): string[] {
   return chunks;
 }
 
-/** A downloaded inbound attachment reference. */
+/**
+ * A downloaded inbound attachment, carried as base64 `data`. The host stages
+ * the bytes into the session's inbox and rewrites the entry to a `localPath`
+ * — the adapter itself never touches disk.
+ */
 export interface PhotonAttachment {
   type: string;
   name: string;
-  localPath: string;
+  mimeType?: string;
+  size: number;
+  data: string;
+}
+
+const MEDIA_READ_ATTEMPTS = 3;
+const MEDIA_READ_RETRY_BASE_MS = 500;
+
+/**
+ * Read a media node's bytes, retrying transient stream failures. Large reads
+ * (live photos especially) can die mid-transfer with ECONNRESET / gRPC
+ * RST_STREAM; a fresh read usually succeeds. Exported for unit testing.
+ */
+export async function readMediaWithRetry(
+  content: SpectrumContent,
+  opts: { attempts?: number; baseDelayMs?: number } = {},
+): Promise<Uint8Array> {
+  const attempts = opts.attempts ?? MEDIA_READ_ATTEMPTS;
+  const baseDelayMs = opts.baseDelayMs ?? MEDIA_READ_RETRY_BASE_MS;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await content.read!();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < attempts) {
+        log.warn('Photon: attachment read failed — retrying', { type: content.type, attempt, err });
+        await new Promise((r) => setTimeout(r, baseDelayMs * attempt));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 /** Extracted, normalized inbound payload built from a Spectrum message. */
@@ -329,12 +357,12 @@ export interface NormalizedInbound {
 
 /**
  * Walk a Spectrum content node into agent-visible text + downloaded
- * attachments. `saveMedia` is injected (the adapter caches to disk; tests
- * stub it) and receives the raw bytes + a chosen filename.
+ * attachments. `readMedia` is injected (the adapter reads bytes into base64;
+ * tests stub it) and returns the payload the host stages into the inbox.
  */
 export async function normalizeContent(
   content: SpectrumContent | undefined,
-  saveMedia: (content: SpectrumContent) => Promise<PhotonAttachment | null>,
+  readMedia: (content: SpectrumContent) => Promise<PhotonAttachment | null>,
   out: NormalizedInbound,
 ): Promise<void> {
   if (!content || typeof content !== 'object') return;
@@ -343,14 +371,14 @@ export async function normalizeContent(
     return;
   }
   if (content.type === 'attachment' || content.type === 'voice') {
-    const saved = await saveMedia(content);
+    const saved = await readMedia(content);
     if (saved) out.attachments.push(saved);
     else out.failures.push(content.type === 'voice' ? 'voice message' : 'attachment');
     return;
   }
   if (content.type === 'group') {
     for (const item of content.items ?? []) {
-      await normalizeContent(item?.content, saveMedia, out);
+      await normalizeContent(item?.content, readMedia, out);
     }
     return;
   }
@@ -440,8 +468,13 @@ export function createPhotonAdapter(
     return space;
   }
 
-  /** Read + cache an inbound media node to DATA_DIR/attachments. */
-  async function saveMedia(content: SpectrumContent): Promise<PhotonAttachment | null> {
+  /**
+   * Read an inbound media node into a base64 payload. The adapter never
+   * writes to disk itself — the host stages `data` into the session's inbox
+   * (session-manager `extractAttachmentFiles`) and rewrites it to a
+   * `localPath` the container can read.
+   */
+  async function readMedia(content: SpectrumContent): Promise<PhotonAttachment | null> {
     if (typeof content.read !== 'function') return null;
     if (typeof content.size === 'number' && content.size > config.maxInlineAttachmentBytes) {
       log.warn('Photon: inbound attachment over inline cap, skipping', {
@@ -452,9 +485,9 @@ export function createPhotonAdapter(
     }
     let bytes: Uint8Array;
     try {
-      bytes = await content.read();
+      bytes = await readMediaWithRetry(content);
     } catch (err) {
-      log.warn('Photon: failed to read inbound attachment bytes', { err });
+      log.warn('Photon: failed to read inbound attachment bytes', { type: content.type, err });
       return null;
     }
     if (bytes.length > config.maxInlineAttachmentBytes) {
@@ -462,19 +495,13 @@ export function createPhotonAdapter(
       return null;
     }
     const filename = attachmentFilename(content);
-    try {
-      const attachDir = path.join(DATA_DIR, 'attachments');
-      fs.mkdirSync(attachDir, { recursive: true });
-      fs.writeFileSync(path.join(attachDir, filename), Buffer.from(bytes));
-    } catch (err) {
-      log.warn('Photon: failed to write inbound attachment', { filename, err });
-      return null;
-    }
-    log.info('Photon: media downloaded', { type: content.type, filename });
+    log.info('Photon: media received', { type: content.type, filename, size: bytes.length });
     return {
       type: content.type === 'voice' ? 'voice' : 'attachment',
       name: filename,
-      localPath: `attachments/${filename}`,
+      ...(content.mimeType ? { mimeType: content.mimeType } : {}),
+      size: bytes.length,
+      data: Buffer.from(bytes).toString('base64'),
     };
   }
 
@@ -502,7 +529,7 @@ export function createPhotonAdapter(
     }
 
     const out: NormalizedInbound = { text: '', attachments: [], failures: [], isReaction: false };
-    await normalizeContent(message.content, saveMedia, out);
+    await normalizeContent(message.content, readMedia, out);
     const text = appendMediaFailureNote(out.text, out.failures);
 
     // Nothing usable (empty protocol frame, unsupported content) — drop.

--- a/src/channels/imessage.ts
+++ b/src/channels/imessage.ts
@@ -53,7 +53,13 @@ import { log } from '../log.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
-import type { ChannelAdapter, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+import type {
+  ChannelAdapter,
+  ChannelDefaults,
+  ChannelSetup,
+  InboundMessage,
+  OutboundMessage,
+} from './adapter.js';
 // Type-only import from the baseline `chat` dep — no runtime cost, and the
 // local backend's `chat-adapter-imessage` is loaded dynamically (see the
 // factory) so this module still evaluates without that package installed.
@@ -746,6 +752,20 @@ export function createPhotonAdapter(
 // Self-registration — one `imessage` channel; the factory picks the backend
 // ---------------------------------------------------------------------------
 
+/**
+ * iMessage exposes no group-mention metadata, so mentions are DM-only (a DM is
+ * addressed to the bot by definition) and group wirings default to a
+ * name-pattern trigger ({name} = agent group name). Local runs on the
+ * operator's personal Apple ID — a shared identity where strangers DMing it
+ * reach the human, not the bot — so auto-create stays 'strict'; hosted keeps
+ * the same posture for unknown senders on the managed line.
+ */
+const IMESSAGE_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'strict' },
+  group: { engageMode: 'pattern', engagePattern: '\\b{name}\\b', threads: false, unknownSenderPolicy: 'strict' },
+  mentions: 'dm-only',
+};
+
 function truthy(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/i.test((value ?? '').trim());
 }
@@ -799,7 +819,12 @@ async function createLocalAdapter(): Promise<ChannelAdapter> {
   const raw = mod.createiMessageAdapter({ local: true });
   // The community adapter omits channelIdFromThreadId; polyfill an identity fn.
   const adapter = Object.assign(raw, { channelIdFromThreadId: (threadId: string) => threadId });
-  return createChatSdkBridge({ adapter, concurrency: 'concurrent', supportsThreads: false });
+  return createChatSdkBridge({
+    adapter,
+    concurrency: 'concurrent',
+    supportsThreads: false,
+    defaults: IMESSAGE_DEFAULTS,
+  });
 }
 
 registerChannelAdapter('imessage', {
@@ -851,4 +876,5 @@ registerChannelAdapter('imessage', {
       maxInlineAttachmentBytes: maxInline,
     });
   },
+  defaults: IMESSAGE_DEFAULTS,
 });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Companion to #2999, splitting the iMessage landing per review: this PR carries the
adapter code on the registry branch — trunk (#2999) keeps only the `/add-imessage`
skill, setup-wizard integration, and docs, matching every other channel.

**What's here** (registry-branch code only):

- `src/channels/imessage.ts` — one `imessage` channel, two skill-selected backends:
  **local** (Chat SDK bridge over `chat-adapter-imessage`, this Mac's `chat.db`) and
  **hosted** (native adapter over Photon's `spectrum-ts` gRPC stream: markdown,
  attachments in/out, tapbacks, read receipts, typing, `ask_user_question` via
  slash-command replies). Neither SDK is imported at module load — both load via
  dynamic import, so the channel barrel typechecks and evaluates with neither
  package installed; `/add-imessage` installs the chosen backend's package.
- `src/channels/imessage-registration.test.ts` — registry/barrel registration test
- `src/channels/imessage.test.ts` — focused adapter test suite plus a real-SDK
  integration block (see below)

**Review findings addressed here:**

- **Explicit ChannelDefaults restored** — group name-pattern trigger
  (`\b{name}\b`), `dm-only` mention signaling, strict unknown-sender policy;
  declared at both the registry entry and the local backend's bridge, and
  covered by `channel-declarations.test.ts`.
- **Inbound media goes through session-inbox staging** — attachments are carried
  as base64 `data` and staged by the host into
  `data/v2-sessions/<group>/<session>/inbox/<messageId>/` (with the standard
  symlink/containment defenses); the adapter never writes host-level
  `data/attachments/`. Verified live with a real live photo (HEIC staged to the
  session inbox; `data/attachments` never created).
- **Transient read failures retried** — `content.read()` gets 3 attempts with
  backoff; live photos could previously die mid-transfer with ECONNRESET /
  gRPC RST_STREAM and surface to the agent as `[attachment could not be
  downloaded]` on the first failure.
- **Real-SDK integration tests** — a `describe` block imports the actually
  installed `spectrum-ts` and asserts everything the adapter's structural
  typings assume: major version (v11), module exports, the imessage provider's
  callable `config()`, and the outbound content builders. Auto-skips on this
  branch (the SDK is intentionally not a dependency); runs on hosted installs
  and in the upgrade flow's `vitest run src/channels/imessage.test.ts`.

**spectrum-ts v11**: targets `spectrum-ts@11.0.0`. The only code-facing change from
v8 is v10's rename of the `Spectrum()` config key `providers` → `platforms`
(verified against the v11 typings). 11.0.0 is pinned deliberately — it's the newest
version clearing the 3-day `minimumReleaseAge` supply-chain gate.

**Verification**: 44/44 tests with the pin installed (40 + 4 auto-skipped on this
branch without it); typechecks against this branch's shared helpers. Full
`/add-imessage` install verified end-to-end on a fresh clone in a clean Ubuntu
24.04 VM (fetch → copy → pinned install → build → tests), including live iMessage
traffic — inbound text, group name-trigger, live-photo attachment staging — through
a Photon-hosted line.

**Landing order**: land this PR before #2999. (#2999's installer no longer
overwrites an existing `src/channels/imessage.ts`, so ordering only affects fresh
installs fetching from this branch.)

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone