### PR TITLE
fix(claude): only abort on a rejected rate_limit_event; split rate_limit vs quota

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -35,9 +35,10 @@ export interface SdkRateLimitInfo {
  *
  * The SDK emits this "when rate limit info changes": it is TELEMETRY, and
  * `status` is usually 'allowed' (here's your remaining headroom). We used to
- * treat every one as a terminal error, which aborted perfectly healthy turns
- * across every room — the agent stopped mid-work and posted a rate-limit notice
- * for what was only a status update. **Only 'rejected' is an actual block.**
+ * treat every one as a terminal quota error: on a stock install that logged a
+ * spurious "Rate limit (retryable: false, quota)" on perfectly healthy turns
+ * (#3016), and any consumer acting on the classification aborted those turns
+ * outright. **Only 'rejected' is an actual block.**
  *
  * When it IS rejected the SDK tells us WHY, so we distinguish properly instead
  * of guessing: `errorCode: 'credits_required'` / `overageDisabledReason:
@@ -584,10 +585,9 @@ export class ClaudeProvider implements AgentProvider {
           // The SDK emits this "when rate limit info CHANGES" — it is telemetry,
           // not necessarily an error. `rate_limit_info.status` is usually
           // 'allowed' (here's your remaining headroom). Treating every one of
-          // these as a terminal error aborted perfectly healthy turns across
-          // every room — the agent would stop mid-work and post a rate-limit
-          // notice for what was just a status update. ONLY 'rejected' is an
-          // actual block.
+          // these as a terminal quota error logged a spurious rate-limit line
+          // on healthy turns (#3016) — and aborted them outright wherever the
+          // classification is acted on. ONLY 'rejected' is an actual block.
           //
           // When it IS rejected the SDK tells us WHY, so we can finally
           // distinguish the two cases properly instead of guessing:

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -21,6 +21,48 @@ function log(msg: string): void {
   console.error(`[claude-provider] ${msg}`);
 }
 
+export interface SdkRateLimitInfo {
+  status?: string;
+  resetsAt?: number;
+  rateLimitType?: string;
+  utilization?: number;
+  errorCode?: string;
+  overageDisabledReason?: string;
+}
+
+/**
+ * Map an SDK `rate_limit_event` to a provider event — or to NOTHING.
+ *
+ * The SDK emits this "when rate limit info changes": it is TELEMETRY, and
+ * `status` is usually 'allowed' (here's your remaining headroom). We used to
+ * treat every one as a terminal error, which aborted perfectly healthy turns
+ * across every room — the agent stopped mid-work and posted a rate-limit notice
+ * for what was only a status update. **Only 'rejected' is an actual block.**
+ *
+ * When it IS rejected the SDK tells us WHY, so we distinguish properly instead
+ * of guessing: `errorCode: 'credits_required'` / `overageDisabledReason:
+ * 'out_of_credits'` means genuinely out of credits (billing); anything else is a
+ * transient window limit that resets (`resetsAt`, `rateLimitType`).
+ *
+ * Returns null when the event is informational (do not disturb the turn).
+ */
+export function classifyRateLimitEvent(
+  info: SdkRateLimitInfo | undefined,
+): { message: string; classification: 'rate_limit' | 'quota' } | null {
+  if (info?.status !== 'rejected') return null;
+  const outOfCredits = info.errorCode === 'credits_required' || info.overageDisabledReason === 'out_of_credits';
+  let detail = '';
+  if (typeof info.resetsAt === 'number' && Number.isFinite(info.resetsAt)) {
+    const ms = info.resetsAt < 1e12 ? info.resetsAt * 1000 : info.resetsAt;
+    detail = ` (resets ${new Date(ms).toISOString()})`;
+  }
+  const window = info.rateLimitType ? ` [${info.rateLimitType}]` : '';
+  return {
+    message: `${outOfCredits ? 'Out of credits' : 'Rate limit'}${window}${detail}`,
+    classification: outOfCredits ? 'quota' : 'rate_limit',
+  };
+}
+
 // Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
 // don't fit our async message-passing model (they're designed for Claude
 // Code's interactive UI and would hang here).
@@ -539,7 +581,33 @@ export class ClaudeProvider implements AgentProvider {
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
         } else if (message.type === 'rate_limit_event') {
-          yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
+          // The SDK emits this "when rate limit info CHANGES" — it is telemetry,
+          // not necessarily an error. `rate_limit_info.status` is usually
+          // 'allowed' (here's your remaining headroom). Treating every one of
+          // these as a terminal error aborted perfectly healthy turns across
+          // every room — the agent would stop mid-work and post a rate-limit
+          // notice for what was just a status update. ONLY 'rejected' is an
+          // actual block.
+          //
+          // When it IS rejected the SDK tells us WHY, so we can finally
+          // distinguish the two cases properly instead of guessing:
+          //   errorCode 'credits_required' / overageDisabledReason
+          //   'out_of_credits'  → genuinely out of credits (billing)
+          //   otherwise         → a transient window limit that resets.
+          const info = (message as { rate_limit_info?: SdkRateLimitInfo }).rate_limit_info;
+          const blocked = classifyRateLimitEvent(info);
+          if (!blocked) {
+            // Informational ('allowed' / 'allowed_warning') — never kill the turn.
+            if (info?.status === 'allowed_warning') {
+              log(
+                `rate-limit warning: ${info.rateLimitType ?? 'window'} at ${
+                  info.utilization != null ? `${Math.round(info.utilization * 100)}%` : 'high'
+                } utilization`,
+              );
+            }
+          } else {
+            yield { type: 'error', message: blocked.message, retryable: false, classification: blocked.classification };
+          }
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
           const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';

--- a/container/agent-runner/src/providers/rate-limit.test.ts
+++ b/container/agent-runner/src/providers/rate-limit.test.ts
@@ -1,9 +1,10 @@
 /**
  * Regression: the SDK's `rate_limit_event` is TELEMETRY ("emitted when rate
  * limit info changes"), not an error. We used to treat every one as terminal,
- * which aborted healthy turns across every room and posted a rate-limit notice
- * for what was only a status update (13 spurious aborts across 6 rooms before
- * this was caught). Only status='rejected' is an actual block — and when it is,
+ * which logged a spurious quota error on healthy turns (#3016) and, in
+ * consumers that act on the classification, aborted them outright (13 spurious
+ * aborts across 6 rooms in one downstream install before this was caught).
+ * Only status='rejected' is an actual block — and when it is,
  * the SDK tells us whether it's a transient window limit or genuinely no credits.
  */
 import { describe, expect, it } from 'bun:test';

--- a/container/agent-runner/src/providers/rate-limit.test.ts
+++ b/container/agent-runner/src/providers/rate-limit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression: the SDK's `rate_limit_event` is TELEMETRY ("emitted when rate
+ * limit info changes"), not an error. We used to treat every one as terminal,
+ * which aborted healthy turns across every room and posted a rate-limit notice
+ * for what was only a status update (13 spurious aborts across 6 rooms before
+ * this was caught). Only status='rejected' is an actual block — and when it is,
+ * the SDK tells us whether it's a transient window limit or genuinely no credits.
+ */
+import { describe, expect, it } from 'bun:test';
+import { classifyRateLimitEvent } from './claude.js';
+
+describe('classifyRateLimitEvent', () => {
+  it('ignores informational events — the turn must not be disturbed', () => {
+    expect(classifyRateLimitEvent({ status: 'allowed' })).toBeNull();
+    expect(classifyRateLimitEvent({ status: 'allowed', utilization: 0.42, rateLimitType: 'five_hour' })).toBeNull();
+    expect(classifyRateLimitEvent({ status: 'allowed_warning', utilization: 0.91 })).toBeNull();
+    expect(classifyRateLimitEvent(undefined)).toBeNull();
+    expect(classifyRateLimitEvent({})).toBeNull();
+  });
+
+  it('treats a rejected window limit as a transient rate limit, not billing', () => {
+    const r = classifyRateLimitEvent({ status: 'rejected', rateLimitType: 'five_hour' });
+    expect(r).not.toBeNull();
+    expect(r!.classification).toBe('rate_limit');
+    expect(r!.message).toContain('Rate limit');
+    expect(r!.message).toContain('five_hour');
+    expect(r!.message).not.toContain('Out of credits');
+  });
+
+  it('surfaces the reset time when the SDK provides one (seconds or ms)', () => {
+    const secs = classifyRateLimitEvent({ status: 'rejected', resetsAt: 1_700_000_000 });
+    const ms = classifyRateLimitEvent({ status: 'rejected', resetsAt: 1_700_000_000_000 });
+    expect(secs!.message).toContain('resets');
+    // both encodings must land on the same instant
+    expect(secs!.message).toBe(ms!.message);
+  });
+
+  it('reports genuine credit exhaustion as a billing problem', () => {
+    const byErrorCode = classifyRateLimitEvent({ status: 'rejected', errorCode: 'credits_required' });
+    expect(byErrorCode!.classification).toBe('quota');
+    expect(byErrorCode!.message).toContain('Out of credits');
+
+    const byOverage = classifyRateLimitEvent({ status: 'rejected', overageDisabledReason: 'out_of_credits' });
+    expect(byOverage!.classification).toBe('quota');
+    expect(byOverage!.message).toContain('Out of credits');
+  });
+});


### PR DESCRIPTION
Fixes the `rate_limit_event` handling discussed in #3016.

The SDK emits `rate_limit_event` as telemetry ("when rate limit info changes") — `status` is usually `allowed` (remaining-headroom info). The current mapping in `claude.ts` turns *every* one into a terminal `quota` error, which aborts healthy turns and misreports transient window limits as billing exhaustion. (#2965 activated this latent mapping.)

This PR:
- Treats only `status: 'rejected'` as a block; informational events return `null` and never disturb the turn.
- When rejected, splits the classification off the SDK's own signals — `errorCode: 'credits_required'` / `overageDisabledReason: 'out_of_credits'` → `quota` (billing); otherwise → `rate_limit` (transient window that resets). The classification is consumed downstream, so distinguishing them matters.
- Guards `resetsAt` for seconds-vs-milliseconds.
- Adds `classifyRateLimitEvent` + a 4-case regression test.

`classification` is already an open string on the error type, so no type change is needed. Thanks @glifocat for the review and for confirming it applies to current main.

Refs #3016
