### PR TITLE
fix(session): pin agent-shared resolution to an anchor session

### DIFF
--- a/src/db/migrations/020-agent-shared-anchor.ts
+++ b/src/db/migrations/020-agent-shared-anchor.ts
@@ -1,0 +1,21 @@
+import type { Migration } from './index.js';
+
+/**
+ * Anchor flag for agent-shared session resolution on `sessions`.
+ *
+ * Without it, agent-shared wirings resolve to "newest active session in the
+ * agent group" on every message — so creating any newer session (a new
+ * shared-mode wiring, a recreated DM session) silently re-homes all
+ * agent-shared traffic into it mid-conversation. The first agent-shared
+ * resolution after this migration pins the session it lands on (exactly the
+ * one pre-migration behavior would have picked, so nothing moves at
+ * switch-on); later resolutions follow the pin. Deliberately no backfill:
+ * groups with no agent-shared traffic never get an anchor row.
+ */
+export const migration020: Migration = {
+  version: 20,
+  name: 'agent-shared-anchor',
+  up(db) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN agent_shared_anchor INTEGER NOT NULL DEFAULT 0;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -18,6 +18,7 @@ import { moduleApprovalsPendingApprovals } from './module-approvals-pending-appr
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
+import { migration020 } from './020-agent-shared-anchor.js';
 
 export interface Migration {
   version: number;
@@ -52,6 +53,7 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration019,
+  migration020,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -68,6 +68,27 @@ export function findSessionByAgentGroup(agentGroupId: string): Session | undefin
     .get(agentGroupId) as Session | undefined;
 }
 
+/**
+ * The session agent-shared traffic is pinned to, regardless of status. The
+ * caller decides what a closed anchor means (resolveSession re-anchors and
+ * warns); returning it either way is what lets re-homing be detected at all.
+ */
+export function findAgentSharedAnchor(agentGroupId: string): Session | undefined {
+  return getDb()
+    .prepare('SELECT * FROM sessions WHERE agent_group_id = ? AND agent_shared_anchor = 1 LIMIT 1')
+    .get(agentGroupId) as Session | undefined;
+}
+
+export function setAgentSharedAnchor(agentGroupId: string, sessionId: string): void {
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare('UPDATE sessions SET agent_shared_anchor = 0 WHERE agent_group_id = ? AND agent_shared_anchor = 1').run(
+      agentGroupId,
+    );
+    db.prepare('UPDATE sessions SET agent_shared_anchor = 1 WHERE id = ?').run(sessionId);
+  })();
+}
+
 export function getSessionsByAgentGroup(agentGroupId: string): Session[] {
   return getDb().prepare('SELECT * FROM sessions WHERE agent_group_id = ?').all(agentGroupId) as Session[];
 }

--- a/src/host-core.test.ts
+++ b/src/host-core.test.ts
@@ -28,7 +28,7 @@ import {
   readOutboxFiles,
   clearOutbox,
 } from './session-manager.js';
-import { getSession, findSession } from './db/sessions.js';
+import { getSession, findSession, updateSession } from './db/sessions.js';
 import type { InboundEvent } from './channels/adapter.js';
 
 // Mock container runner to prevent actual Docker spawning
@@ -1239,6 +1239,86 @@ describe('agent-shared session resolution', () => {
 
     const { session } = resolveSession('ag-1', null, null, 'agent-shared');
     expect(session.messaging_group_id).toBeNull();
+  });
+
+  // Anchor semantics: agent-shared traffic pins to the session its first
+  // message resolves to. Pre-anchor behavior was "newest active session
+  // wins" — creating any newer session in the group silently re-homed all
+  // agent-shared channels into it (e.g. a newly wired room session
+  // hijacking a live cli wiring mid-conversation).
+  function seedAnchorFixtures() {
+    createAgentGroup({
+      id: 'ag-1',
+      name: 'Agent',
+      folder: 'agent',
+      agent_provider: null,
+      created_at: now(),
+    });
+    for (const [id, platformId] of [
+      ['mg-dm', 'dm-1'],
+      ['mg-room', 'room-1'],
+    ]) {
+      createMessagingGroup({
+        id,
+        channel_type: 'discord',
+        platform_id: platformId,
+        name: id,
+        is_group: 1,
+        unknown_sender_policy: 'strict',
+        created_at: now(),
+      });
+    }
+  }
+
+  /** Force strict created_at ordering — same-ms ISO strings tie in ORDER BY. */
+  function bumpCreatedAt(sessionId: string, offsetMs: number) {
+    getDb()
+      .prepare('UPDATE sessions SET created_at = ? WHERE id = ?')
+      .run(new Date(Date.now() + offsetMs).toISOString(), sessionId);
+  }
+
+  it('stays anchored when a newer session appears in the group', () => {
+    seedAnchorFixtures();
+    const { session: dm } = resolveSession('ag-1', 'mg-dm', null, 'shared');
+    const { session: a1 } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(a1.id).toBe(dm.id); // first resolution lands on the newest active session and pins it
+
+    const { session: room } = resolveSession('ag-1', 'mg-room', null, 'shared');
+    bumpCreatedAt(room.id, 60_000);
+
+    // Negative control: pre-anchor behavior resolves this to `room`.
+    const { session: a2 } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(a2.id).toBe(dm.id);
+  });
+
+  it('re-homes to the newest active session only when the anchor closes', () => {
+    seedAnchorFixtures();
+    const { session: dm } = resolveSession('ag-1', 'mg-dm', null, 'shared');
+    resolveSession('ag-1', null, null, 'agent-shared'); // anchor dm
+    const { session: room } = resolveSession('ag-1', 'mg-room', null, 'shared');
+    bumpCreatedAt(room.id, 60_000);
+
+    updateSession(dm.id, { status: 'closed' });
+
+    const { session: a } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(a.id).toBe(room.id);
+    // ...and the new anchor holds even against a yet-newer session.
+    const { session: dm2 } = resolveSession('ag-1', 'mg-dm', null, 'shared');
+    bumpCreatedAt(dm2.id, 120_000);
+    const { session: a2 } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(a2.id).toBe(room.id);
+  });
+
+  it('a session created by agent-shared resolution is itself the anchor', () => {
+    seedAnchorFixtures();
+    const { session: first, created } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(created).toBe(true);
+
+    const { session: dm } = resolveSession('ag-1', 'mg-dm', null, 'shared');
+    bumpCreatedAt(dm.id, 60_000);
+
+    const { session: again } = resolveSession('ag-1', null, null, 'agent-shared');
+    expect(again.id).toBe(first.id);
   });
 });
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -22,10 +22,12 @@ import { ensureContainedInboxDir, isPathInside } from './inbox-safety.js';
 import { getMessagingGroup } from './db/messaging-groups.js';
 import {
   createSession,
+  findAgentSharedAnchor,
   findSystemSession,
   findSessionByAgentGroup,
   findSessionForAgent,
   getSession,
+  setAgentSharedAnchor,
   taskThreadId,
   updateSession,
 } from './db/sessions.js';
@@ -85,10 +87,28 @@ export function resolveSession(
   threadId: string | null,
   sessionMode: 'shared' | 'per-thread' | 'agent-shared',
 ): { session: Session; created: boolean } {
-  // agent-shared: single session per agent group, regardless of messaging group
+  // agent-shared: single session per agent group, regardless of messaging group.
+  // Resolution is pinned: the first message anchors whatever session it lands
+  // on, and later messages follow the anchor — never "newest active session",
+  // which silently re-homed all agent-shared channels whenever any newer
+  // session appeared in the group. Only a closed anchor moves the pin.
   if (sessionMode === 'agent-shared') {
+    const anchor = findAgentSharedAnchor(agentGroupId);
+    if (anchor?.status === 'active') {
+      return { session: anchor, created: false };
+    }
     const existing = findSessionByAgentGroup(agentGroupId);
     if (existing) {
+      setAgentSharedAnchor(agentGroupId, existing.id);
+      if (anchor) {
+        log.warn('agent-shared anchor re-homed (previous anchor closed)', {
+          agentGroupId,
+          from: anchor.id,
+          to: existing.id,
+        });
+      } else {
+        log.info('agent-shared traffic anchored', { agentGroupId, sessionId: existing.id });
+      }
       return { session: existing, created: false };
     }
   } else if (messagingGroupId) {
@@ -116,6 +136,9 @@ export function resolveSession(
   };
 
   createSession(session);
+  if (sessionMode === 'agent-shared') {
+    setAgentSharedAnchor(agentGroupId, id);
+  }
   initSessionFolder(agentGroupId, id);
   log.info('Session created', { id, agentGroupId, messagingGroupId, threadId: lookupThreadId, sessionMode });
 


### PR DESCRIPTION
## Problem

In agent-shared wirings, session resolution picked the NEWEST matching session. When multiple sessions exist for the same agent group (e.g. after a wiring change or a stale row), inbound messages from different channels re-home onto different sessions — a two-sessions-per-agent fork where each channel talks to a different conversation. Two agents sharing a room this way end up answering from forked histories, apparently 'fabricating' context at each other.

## Fix

Migration `020-agent-shared-anchor` adds an `anchor` marker; resolution pins agent-shared lookups to the anchored session instead of newest-first. Existing installs get their anchor seeded from the currently-active session. Covered by new host-core tests, including the negative control: a newer session appearing no longer steals the traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
