### PR TITLE
fix(add-matrix): ship the matrix-js-sdk ESM fix as a pnpm patch, not a node_modules edit

### DIFF
--- a/.claude/skills/add-matrix/SKILL.md
+++ b/.claude/skills/add-matrix/SKILL.md
@@ -44,25 +44,35 @@ track (not the `@chat-adapter/*` family), so it carries its own pin:
 @beeper/chat-adapter-matrix@0.2.0
 ```
 
-### 4. Patch matrix-js-sdk ESM imports
+### 4. Wire the ESM-fix pnpm patch
 
 The adapter's published dist references `matrix-js-sdk/lib/...` without `.js`
-extensions, which fails under Node 22 strict ESM resolution. Add the missing
-extensions (idempotent — safe to re-run). Re-run this after every `pnpm install`
-that touches the adapter:
+extensions, which Node's ESM loader rejects — once the barrel imports the
+adapter, the host crashes at startup. Trunk ships the fix as a pnpm patch
+(`patches/@beeper__chat-adapter-matrix@0.2.0.patch`); wire it into the
+workspace so every future `pnpm install` re-applies it. (The previous
+in-place node_modules edit silently reverted on any reinstall — observed as
+a production host crash-loop.)
 
 ```nc:run effect:external
 node -e '
-  const fs = require("fs"), path = require("path");
-  const root = "node_modules/.pnpm";
-  const dir = fs.readdirSync(root).find(d => d.startsWith("@beeper+chat-adapter-matrix@"));
-  if (!dir) { console.log("Matrix adapter not installed"); process.exit(0); }
-  const f = path.join(root, dir, "node_modules/@beeper/chat-adapter-matrix/dist/index.js");
-  fs.writeFileSync(f, fs.readFileSync(f, "utf8").replace(
-    /from "(matrix-js-sdk\/lib\/[^"]+?)(?<!\.js)"/g, "from \"$1.js\""
-  ));
-  console.log("Patched", f);
+  const fs = require("fs");
+  const f = "pnpm-workspace.yaml";
+  let s = fs.readFileSync(f, "utf8");
+  if (s.includes("@beeper/chat-adapter-matrix@0.2.0")) {
+    console.log("patchedDependencies entry already present");
+  } else {
+    if (!/^patchedDependencies:/m.test(s)) s = s.trimEnd() + "\n\npatchedDependencies:\n";
+    s = s.replace(/^patchedDependencies:\n/m,
+      "patchedDependencies:\n  \x27@beeper/chat-adapter-matrix@0.2.0\x27: patches/@beeper__chat-adapter-matrix@0.2.0.patch\n");
+    fs.writeFileSync(f, s);
+    console.log("patchedDependencies entry added");
+  }
 '
+```
+
+```nc:run effect:external
+pnpm install --no-frozen-lockfile
 ```
 
 ### 5. Build

--- a/patches/@beeper__chat-adapter-matrix@0.2.0.patch
+++ b/patches/@beeper__chat-adapter-matrix@0.2.0.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/index.js b/dist/index.js
+index 3360d7352fec0df580a474088205519227cc8be0..57e5a5b02fe9973789808888e5bb59f69141f1a6 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -21,9 +21,9 @@ import sdk, {
+   ThreadFilterType,
+   THREAD_RELATION_TYPE
+ } from "matrix-js-sdk";
+-import { MatrixError } from "matrix-js-sdk/lib/http-api/errors";
+-import { decodeRecoveryKey } from "matrix-js-sdk/lib/crypto-api/recovery-key";
+-import { logger as matrixSDKLogger } from "matrix-js-sdk/lib/logger";
++import { MatrixError } from "matrix-js-sdk/lib/http-api/errors.js";
++import { decodeRecoveryKey } from "matrix-js-sdk/lib/crypto-api/recovery-key.js";
++import { logger as matrixSDKLogger } from "matrix-js-sdk/lib/logger.js";
+ import { marked } from "marked";
+ import {
+   HTMLElement,
+@@ -33,8 +33,8 @@ import {
+ 
+ // src/store/chat-state-matrix-store.ts
+ import { MatrixEvent } from "matrix-js-sdk";
+-import { SyncAccumulator } from "matrix-js-sdk/lib/sync-accumulator";
+-import { MemoryStore } from "matrix-js-sdk/lib/store/memory";
++import { SyncAccumulator } from "matrix-js-sdk/lib/sync-accumulator.js";
++import { MemoryStore } from "matrix-js-sdk/lib/store/memory.js";
+ var STORE_VERSION = 1;
+ var DEFAULT_PERSIST_INTERVAL_MS = 3e4;
+ function normalizeStringRecord(value) {


### PR DESCRIPTION
## Problem

`@beeper/chat-adapter-matrix@0.2.0`'s published dist deep-imports `matrix-js-sdk/lib/...` without `.js` extensions, which Node's ESM loader rejects. The skill's current step 4 fixes this by editing `dist/index.js` inside node_modules — but that edit silently reverts on any reinstall. Observed in production: a routine lockfile-changing update reinstalled the pristine tarball and the host crash-looped at startup (`ERR_MODULE_NOT_FOUND` from the channel barrel import).

## Fix

Ship the fix as `patches/@beeper__chat-adapter-matrix@0.2.0.patch`; the skill wires `patchedDependencies` into `pnpm-workspace.yaml` so every future install re-applies it automatically. Skill-conformance suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)