### PR TITLE
fix(agent-runner): route per-turn results by turn generation, not entry-frozen routing

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -540,3 +540,168 @@ describe('task-run turn wiring (real processQuery)', () => {
     expect(logs).not.toContain('second delivery decision handled');
   });
 });
+
+
+describe('turn-generation routing (regression)', () => {
+  // Incident shape: several batches pushed into a single long turn get
+  // answered by ONE result. A flat one-shift-per-result queue (or routing
+  // frozen at processQuery entry) leaves stale entries that mis-route later
+  // results — observed in production as replies delivered to a disconnected
+  // channel hours after its batches were answered. The observable door here
+  // is the error-result delivery (deliverErrorResult), which routes by the
+  // current turn generation.
+
+  function insertRouted(id: string, channelType: string, platformId: string, text: string) {
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, trigger, on_wake, platform_id, channel_type, thread_id, content)
+         VALUES (?, 'chat', datetime('now'), 'pending', 1, 0, ?, ?, NULL, ?)`,
+      )
+      .run(id, platformId, channelType, JSON.stringify({ sender: 'S', text }));
+  }
+
+  /**
+   * Query stub with manual result control: pushes are recorded (and NOT
+   * auto-answered), results emit only when the test calls emitResult —
+   * mirroring an SDK turn that consumes every queued push at once.
+   */
+  function makeSteppedQuery(): {
+    query: AgentQuery;
+    pushes: string[];
+    emitResult: (text: string, isError?: boolean) => void;
+    finish: () => void;
+  } {
+    const pushes: string[] = [];
+    const queued: ProviderEvent[] = [];
+    let waiting: (() => void) | null = null;
+    let finished = false;
+    const wake = (): void => {
+      waiting?.();
+      waiting = null;
+    };
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-1' };
+      for (;;) {
+        while (queued.length > 0) yield queued.shift()!;
+        if (finished) return;
+        await new Promise<void>((res) => {
+          waiting = res;
+        });
+      }
+    }
+    return {
+      pushes,
+      emitResult: (text: string, isError?: boolean) => {
+        queued.push(isError ? { type: 'result', text, isError: true } : { type: 'result', text });
+        wake();
+      },
+      finish: () => {
+        finished = true;
+        wake();
+      },
+      query: {
+        push: (m: string) => {
+          pushes.push(m);
+        },
+        end: () => {
+          finished = true;
+          wake();
+        },
+        events: events(),
+        abort: () => {
+          finished = true;
+          wake();
+        },
+      },
+    };
+  }
+
+  async function waitFor(cond: () => boolean, timeoutMs = 4000): Promise<void> {
+    const start = Date.now();
+    while (!cond()) {
+      if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+      await new Promise((res) => setTimeout(res, 50));
+    }
+  }
+
+  const textOuts = () =>
+    getUndeliveredMessages()
+      .map((m) => ({ row: m, body: JSON.parse(m.content) as { text?: string } }))
+      .filter((m) => typeof m.body.text === 'string' && m.body.text.length > 0);
+
+  it('a coalesced multi-push turn leaves no stale entries to hijack a later error notice', async () => {
+    const cliRouting = { platformId: 'local', channelType: 'cli', threadId: null, inReplyTo: 'm0' };
+    const { query, pushes, emitResult, finish } = makeSteppedQuery();
+    const run = processQuery(query, cliRouting, ['m0'], 'claude', undefined, 'prompt', undefined);
+
+    // Two Telegram batches ride into the active turn (separate poll ticks) —
+    // the SDK will answer BOTH with the next single result.
+    insertRouted('t1', 'telegram', 'tg-dm', 'question one');
+    await waitFor(() => pushes.length >= 1);
+    insertRouted('t2', 'telegram', 'tg-dm', 'question two');
+    await waitFor(() => pushes.length >= 2);
+
+    // Turn 1 ends answering the ORIGINAL cli batch; nothing user-visible.
+    emitResult('<internal>opener handled</internal>');
+    // Turn 2 answers BOTH telegram batches at once.
+    emitResult('<internal>both questions handled via send_message</internal>');
+    // Turn 3: a non-retryable provider error with no <message> envelope. The
+    // notice must reach the channel of the CURRENT generation lineage
+    // (telegram, via latest-batch fallback) — not the cli channel that
+    // opened the query (frozen routing) or a stale FIFO leftover.
+    insertRouted('t3', 'telegram', 'tg-dm', 'still there?');
+    await waitFor(() => pushes.length >= 3);
+    emitResult('Credit balance too low to continue.', true);
+    await waitFor(() => textOuts().length >= 1);
+
+    const notice = textOuts()[0];
+    expect(notice.row.channel_type).toBe('telegram');
+    expect(notice.row.platform_id).toBe('tg-dm');
+    expect(notice.row.in_reply_to).toBe('t3');
+
+    finish();
+    await run;
+  });
+
+  it('spurious extra result falls back to the latest batch, not the query-opening channel', async () => {
+    const discordRouting = { platformId: 'chan-old', channelType: 'discord', threadId: null, inReplyTo: 'm0' };
+    const { query, pushes, emitResult, finish } = makeSteppedQuery();
+    const run = processQuery(query, discordRouting, ['m0'], 'claude', undefined, 'prompt', undefined);
+
+    emitResult('<internal>opener handled</internal>');
+    insertRouted('t1', 'telegram', 'tg-dm', 'ping');
+    await waitFor(() => pushes.length >= 1);
+    emitResult('<internal>answered</internal>');
+    // Generation is now empty; an extra error result must use latest-batch
+    // routing, not revive the channel that opened the query.
+    emitResult('Gateway unreachable.', true);
+    await waitFor(() => textOuts().length >= 1);
+
+    const notice = textOuts()[0];
+    expect(notice.row.channel_type).toBe('telegram');
+
+    finish();
+    await run;
+  });
+
+  it('negative control: one-result-per-push does not over-rotate into misdelivery', async () => {
+    const tgRouting = { platformId: 'tg-dm', channelType: 'telegram', threadId: null, inReplyTo: 'm0' };
+    const { query, pushes, emitResult, finish } = makeSteppedQuery();
+    const run = processQuery(query, tgRouting, ['m0'], 'claude', undefined, 'prompt', undefined);
+
+    insertRouted('c1', 'cli', 'local', 'question one');
+    await waitFor(() => pushes.length >= 1);
+    emitResult('<internal>opener handled</internal>');
+    insertRouted('c2', 'cli', 'local', 'question two');
+    await waitFor(() => pushes.length >= 2);
+    emitResult('<internal>answer one</internal>');
+    // Current generation is [c2]; an error now belongs to the cli channel.
+    emitResult('Provider quota exhausted.', true);
+    await waitFor(() => textOuts().length >= 1);
+
+    expect(textOuts()[0].row.channel_type).toBe('cli');
+
+    finish();
+    await run;
+  });
+});

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -354,11 +354,41 @@ export async function processQuery(
   // Once-per-turn guard for the task-run "<message> block was not delivered"
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
-  // Prompt queue for the exchange hook — each result event consumes the
-  // oldest unanswered prompt, except a wrapping-retry result, which answers
-  // the same prompt again. Unused (and unmaintained) when the provider
-  // doesn't implement `onExchangeComplete`.
-  const archivePrompts: string[] = [initialPrompt];
+  // Per-turn prompt/routing bookkeeping for result delivery and the
+  // exchange hook.
+  //
+  // `routing` is fixed at processQuery entry to the batch that opened the
+  // query — but the query stays open across many turns (see pollHandle
+  // below), and a later turn can be started by a follow-up from a completely
+  // different sender/channel (or a different session kind entirely). Without
+  // per-turn tracking, everything a result needs routing for — the taskRun
+  // gate, error-notice delivery, the exchange archive — falls back to the
+  // batch that opened the query, which may be days stale.
+  //
+  // Turn GENERATIONS, not a flat FIFO: prompts pushed while a turn is in
+  // flight are queued by the SDK and all consumed together by the NEXT turn,
+  // which answers them with ONE result. A flat queue shifts exactly one
+  // entry per result, so every coalesced batch leaves stale entries behind
+  // that then mis-route later results. So: `currentTurn*` holds the batches
+  // the in-flight (or next-starting) turn is answering; `pendingTurn*`
+  // accumulates pushes that arrive while it runs. A result routes to the
+  // LATEST batch of its generation and rotates the whole generation at once.
+  let currentTurnPrompts: string[] = [initialPrompt];
+  let currentTurnRouting: RoutingContext[] = [routing];
+  let pendingTurnPrompts: string[] = [];
+  let pendingTurnRouting: RoutingContext[] = [];
+  // Fallback when the current generation is empty at result time (a
+  // spurious extra result): the routing of the most recent batch — right or
+  // nearly right in every such scenario, and it self-corrects on the next
+  // inbound. Falling back to `routing` (frozen at entry) would revive
+  // whatever channel opened the query.
+  let lastBatchRouting: RoutingContext = routing;
+  const rotateGeneration = (): void => {
+    currentTurnPrompts = pendingTurnPrompts;
+    currentTurnRouting = pendingTurnRouting;
+    pendingTurnPrompts = [];
+    pendingTurnRouting = [];
+  };
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open avoids
@@ -439,7 +469,18 @@ export async function processQuery(
         unwrappedNudged = false;
         taskBlockNudged = false;
         query.push(prompt);
-        archivePrompts.push(prompt);
+        const followUpRouting = extractRouting(keep);
+        if (currentTurnRouting.length === 0) {
+          // No unanswered prompts in flight — this push starts the next turn.
+          currentTurnPrompts = [prompt];
+          currentTurnRouting = [followUpRouting];
+        } else {
+          // A turn is already answering `currentTurn*` — this push queues
+          // behind it and will be consumed by the turn after.
+          pendingTurnPrompts.push(prompt);
+          pendingTurnRouting.push(followUpRouting);
+        }
+        lastBatchRouting = followUpRouting;
         markCompleted(keptIds);
       } catch (err) {
         // Without this catch the rejection escapes the void IIFE and Node
@@ -501,32 +542,38 @@ export async function processQuery(
         // (send_message) mid-turn, or the message may not need a response
         // at all — either way the turn is finished.
         markCompleted(initialBatchIds);
+        // Routing for THIS turn — the latest batch of the generation this
+        // result answers, not the routing frozen at processQuery entry. When
+        // the turn answered several batches, the most recent sender is the
+        // best target (same rationale as lastBatchRouting).
+        const currentRouting =
+          currentTurnRouting[currentTurnRouting.length - 1] ?? lastBatchRouting;
         if (event.text) {
-          const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, routing);
-          const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
+          const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, currentRouting);
+          const willRetryTaskBlocks = shouldNudgeTaskBlocks(currentRouting.taskRun, taskBlocks, taskBlockNudged);
           // One-door task delivery: the final text becomes the run log entry
           // while explicit append-log calls remain optional additive notes.
           // Errors included: a failed run's text belongs in its log, not chat.
           // A corrective retry handles delivery only; its result is not a
           // second run summary.
-          if (routing.taskRun && !taskBlockNudged) autoAppendTaskLog(event.text);
-          if (sent === 0 && event.isError === true && !routing.taskRun) {
+          if (currentRouting.taskRun && !taskBlockNudged) autoAppendTaskLog(event.text);
+          if (sent === 0 && event.isError === true && !currentRouting.taskRun) {
             // Non-retryable error turn (e.g. a 403 billing_error) with no
             // <message> envelope: deliver the notice instead of dropping it as
             // scratchpad, and skip the re-wrap nudge — it would just re-hammer
             // the failing gateway turn after turn.
-            deliverErrorResult(event.text, routing);
+            deliverErrorResult(event.text, currentRouting);
             notifyExchangeComplete(onExchangeComplete, {
-              prompt: archivePrompts[0] ?? initialPrompt,
+              prompt: currentTurnPrompts.join('\n\n') || initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
               status: 'error',
             });
-            archivePrompts.shift();
+            rotateGeneration();
           } else {
             const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
             notifyExchangeComplete(onExchangeComplete, {
-              prompt: archivePrompts[0] ?? initialPrompt,
+              prompt: currentTurnPrompts.join('\n\n') || initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
               status: hasUnwrapped || willRetryTaskBlocks ? 'undelivered' : 'completed',
@@ -550,17 +597,17 @@ export async function processQuery(
               query.push(buildTaskBlockNudge(taskBlocks, names));
             }
             // A retry result (wrapping or task-block nudge) answers the SAME
-            // user prompt — keep it queued so the retry archives against it,
-            // not the nudge text.
-            if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
+            // generation — hold it so the retried result routes and archives
+            // against the same batches, not the nudge text.
+            if (!willRetryWrapping && !willRetryTaskBlocks) rotateGeneration();
           }
-        } else archivePrompts.shift();
+        } else rotateGeneration();
       }
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     notifyExchangeComplete(onExchangeComplete, {
-      prompt: archivePrompts[0] ?? initialPrompt,
+      prompt: currentTurnPrompts.join('\n\n') || initialPrompt,
       result: `Error: ${errMsg}`,
       continuation: queryContinuation ?? initialContinuation,
       status: 'error',


### PR DESCRIPTION
## Problem

`processQuery` fixes `routing` at entry to the batch that opened the query, but the query stays open across many turns, and a later turn can be started by a follow-up from a completely different channel. Everything a result needs routing for — the `taskRun` gate on one-door delivery, the error-notice delivery target (`deliverErrorResult`), the exchange archive — falls back to the opening batch, which may be days stale.

The exchange archive's flat prompt FIFO has the matching bug: the SDK coalesces prompts pushed during an active turn into ONE next turn answered by ONE result, so one-shift-per-result leaves stale entries behind.

Production incident that motivated this: four terminal-channel batches pushed into one long turn were answered once, leaving stale entries that later consumed two replies belonging to a different channel — delivered to a disconnected terminal instead of the sender.

## Fix

Track turn **generations**: batches pushed while a turn is in flight belong to the next turn as a unit; a result routes to the latest batch of its generation and rotates the whole generation at once, with a latest-batch fallback for spurious extra results. Wrapping and task-block retry results hold their generation so the retry routes against the same batches.

## Tests

Three regression tests (coalesced-turn incident shape, spurious-extra-result fallback, one-result-per-turn negative control) — all three fail against the entry-frozen routing, pass with the fix. Full agent-runner suite green, typecheck clean.

Running in production since 2026-07-13 (as a pre-one-door variant, re-ported here onto current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)