### PR TITLE
test(uninstall): skip the chmod-based backup-failure test when running as root

### DIFF
--- a/setup/uninstall/remove.test.ts
+++ b/setup/uninstall/remove.test.ts
@@ -57,10 +57,7 @@ describe('executePlan', () => {
     fs.mkdirSync(path.join(dir, 'nested'), { recursive: true });
     fs.writeFileSync(path.join(dir, 'nested', 'f.txt'), 'x');
 
-    const { notes } = executePlan(
-      [{ kind: 'delete-path', item: { what: 'Data', where: dir, path: dir } }],
-      deps(),
-    );
+    const { notes } = executePlan([{ kind: 'delete-path', item: { what: 'Data', where: dir, path: dir } }], deps());
 
     expect(fs.existsSync(dir)).toBe(false);
     expect(notes).toEqual([]);
@@ -136,7 +133,10 @@ describe('executePlan', () => {
     expect(notes).toEqual([]);
   });
 
-  it('keeps .env when the backup fails', () => {
+  // root ignores directory permission bits, so the chmod below cannot make
+  // the backup fail — the test's premise doesn't exist when running as root
+  // (e.g. an LXC install whose service and test runs are root).
+  it.skipIf(typeof process.getuid === 'function' && process.getuid() === 0)('keeps .env when the backup fails', () => {
     const envPath = path.join(tempDir, '.env');
     fs.writeFileSync(envPath, 'KEY=secret');
     fs.chmodSync(tempDir, 0o555); // backup destination unwritable


### PR DESCRIPTION
## Problem

`executePlan > keeps .env when the backup fails` forces the failure with `fs.chmodSync(tempDir, 0o555)` — but root ignores directory permission bits, so the backup succeeds and the test false-fails on every root-run install (e.g. LXC containers, where the service and its test runs are root). Observed as a permanently red suite on three LXC installs.

## Fix

`it.skipIf(typeof process.getuid === 'function' && process.getuid() === 0)` — the test stays meaningful for non-root POSIX runs and skips cleanly where its premise can't occur (`getuid` guarded for Windows).

Verified both ways: 12/12 pass as a regular user; 11 pass + 1 skip as root on an LXC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)