### PR TITLE
fix(whatsapp): validate recipient exists before sending

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -388,6 +388,10 @@ registerChannelAdapter('whatsapp', {
     // Group metadata cache with TTL
     const groupMetadataCache = new Map<string, { metadata: GroupMetadata; expiresAt: number }>();
 
+    // Verified-recipient cache: phone JID → is registered on WhatsApp.
+    // ponytail: unbounded Map, fine — one entry per distinct contact ever messaged.
+    const jidVerifiedCache = new Map<string, boolean>();
+
     // Pending questions: chatJid → { questionId, options }
     // User replies with /approve, /reject, etc. to answer
     const pendingQuestions = new Map<
@@ -571,12 +575,35 @@ registerChannelAdapter('whatsapp', {
       return { attachments: results, failures };
     }
 
+    // Validate an individual recipient exists on WhatsApp before sending.
+    // Baileys accepts any JID and returns a msg key even for non-existent
+    // numbers, so a typo'd number silently "delivers" into the void.
+    // Groups (@g.us) and broadcasts can't be checked this way — allow them.
+    async function recipientExists(jid: string): Promise<boolean> {
+      if (!jid.endsWith('@s.whatsapp.net')) return true;
+      if (jidVerifiedCache.get(jid)) return true;
+      try {
+        const res = (await sock.onWhatsApp(jid))?.[0];
+        if (res?.exists) {
+          jidVerifiedCache.set(jid, true);
+          return true;
+        }
+        log.error('Recipient not on WhatsApp — skipping send', { jid });
+        return false;
+      } catch (err) {
+        // Lookup failed (e.g. transient) — don't block the send, just proceed.
+        log.warn('onWhatsApp check failed, sending anyway', { jid, err });
+        return true;
+      }
+    }
+
     async function sendRawMessage(jid: string, text: string, mentions?: string[]): Promise<string | undefined> {
       if (!connected) {
         outgoingQueue.push({ jid, text, mentions });
         log.info('WA disconnected, message queued', { jid, queueSize: outgoingQueue.length });
         return;
       }
+      if (!(await recipientExists(jid))) return undefined;
       try {
         const payload: { text: string; mentions?: string[] } = { text };
         if (mentions && mentions.length > 0) payload.mentions = mentions;
@@ -982,6 +1009,7 @@ registerChannelAdapter('whatsapp', {
 
         // Send file attachments (first file gets the caption, rest are captionless)
         if (hasFiles) {
+          if (!(await recipientExists(platformId))) return;
           let captionUsed = false;
           for (const file of message.files!) {
             try {


### PR DESCRIPTION
## Problem

Baileys' `sock.sendMessage` accepts any JID and returns a message key even when the number isn't registered on WhatsApp. A typo'd recipient number therefore "succeeds" — the host logs `Message delivered` with a real-looking `platformMsgId` — but the message goes nowhere. Nothing surfaces the failure, so a wrong number silently drops outbound messages into the void.

(Hit in the wild: an agent transposed two digits of a recipient's number; every send reported success and the recipient never received anything.)

## Fix

Add `recipientExists(jid)` in the WhatsApp adapter:

- Calls `sock.onWhatsApp(jid)` before text and media sends.
- Non-existent individual number → `log.error` + skip, instead of sending to a phantom JID.
- Groups/broadcasts (`@g.us` etc.) skip the check — `onWhatsApp` only applies to `@s.whatsapp.net` user JIDs.
- Transient lookup failures fall through (send proceeds) so a flaky check never blocks legitimate sends.
- Results cached per JID to avoid repeated lookups.

Wired into both `sendRawMessage` (text, questions) and the media-attachment send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)