### PR TITLE
fix(whatsapp): engage mention-mode wirings on typed @-mentions in groups

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -17,7 +17,9 @@ import {
   appendMediaFailureNote,
   computeIsMention,
   computeWhatsappDefaults,
+  hasMentionPills,
   isBotMentionedInGroup,
+  isBotTypedMention,
   parseWhatsAppMentions,
   resolveSharedMode,
   rewriteBotLidMention,
@@ -86,6 +88,75 @@ describe('isBotMentionedInGroup (#2560)', () => {
       },
     };
     expect(isBotMentionedInGroup(normalized, undefined, undefined)).toBe(false);
+  });
+});
+
+describe('typed @-mention fallback (#3085)', () => {
+  describe('isBotTypedMention', () => {
+    it('matches a typed @-mention of the assistant name, case-insensitively', () => {
+      expect(isBotTypedMention('@sprout are you there?', 'Sprout', BOT_PHONE_JID)).toBe(true);
+      expect(isBotTypedMention('hey @SPROUT look at this', 'Sprout', BOT_PHONE_JID)).toBe(true);
+    });
+
+    it('matches a typed @-mention of the bot phone number', () => {
+      expect(isBotTypedMention('@15550009999 ping', 'Sprout', BOT_PHONE_JID)).toBe(true);
+    });
+
+    it('requires a word boundary after the name', () => {
+      expect(isBotTypedMention('@Sprouted a new plan', 'Sprout', BOT_PHONE_JID)).toBe(false);
+    });
+
+    it('requires the @ prefix', () => {
+      expect(isBotTypedMention('Sprout are you there?', 'Sprout', BOT_PHONE_JID)).toBe(false);
+    });
+
+    it('does not match other @-names', () => {
+      expect(isBotTypedMention('@Maria can you check?', 'Sprout', BOT_PHONE_JID)).toBe(false);
+    });
+
+    it('escapes regex specials in the assistant name', () => {
+      expect(isBotTypedMention('@R2.D2 status?', 'R2.D2', BOT_PHONE_JID)).toBe(true);
+      expect(isBotTypedMention('@R2xD2 status?', 'R2.D2', BOT_PHONE_JID)).toBe(false);
+    });
+
+    it('matches names ending in non-ASCII letters (ASCII \\b never would)', () => {
+      expect(isBotTypedMention('@José hola', 'José', BOT_PHONE_JID)).toBe(true);
+      expect(isBotTypedMention('@小助手 status', '小助手', BOT_PHONE_JID)).toBe(true);
+    });
+
+    it('does not fire on emails or URL paths containing the name', () => {
+      expect(isBotTypedMention('write to ethan@sprout.com please', 'Sprout', BOT_PHONE_JID)).toBe(false);
+      expect(isBotTypedMention('https://x.com/@sprout/status/1', 'Sprout', BOT_PHONE_JID)).toBe(false);
+    });
+
+    it('still matches after punctuation openers', () => {
+      expect(isBotTypedMention('(@Sprout can you look?)', 'Sprout', BOT_PHONE_JID)).toBe(true);
+      expect(isBotTypedMention('¿@Sprout puedes?', 'Sprout', BOT_PHONE_JID)).toBe(true);
+    });
+
+    it('does not match a multi-word name by its first word alone', () => {
+      expect(isBotTypedMention('@Autónomos can you check', 'Autónomos Expert', BOT_PHONE_JID)).toBe(false);
+      expect(isBotTypedMention('@Autónomos Expert can you check', 'Autónomos Expert', BOT_PHONE_JID)).toBe(true);
+    });
+
+    it('matches on the name alone when the bot phone JID is unknown', () => {
+      expect(isBotTypedMention('@Sprout hi', 'Sprout', undefined)).toBe(true);
+    });
+  });
+
+  describe('hasMentionPills', () => {
+    it('is false for a message with no contextInfo or an empty mentionedJid', () => {
+      expect(hasMentionPills({})).toBe(false);
+      expect(hasMentionPills({ extendedTextMessage: { contextInfo: { mentionedJid: [] } } })).toBe(false);
+    });
+
+    it('is true when anyone at all is pilled, not just the bot', () => {
+      expect(
+        hasMentionPills({
+          extendedTextMessage: { contextInfo: { mentionedJid: ['15551112222@s.whatsapp.net'] } },
+        }),
+      ).toBe(true);
+    });
   });
 });
 

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -225,18 +225,68 @@ export function isBotMentionedInGroup(
   botLidUser: string | undefined,
 ): boolean {
   if (!botPhoneJid && !botLidUser) return false;
-  const mentionedJids: string[] = [
+  const botLidJid = botLidUser ? `${botLidUser}@lid` : undefined;
+  return collectMentionedJids(normalized).some((jid) => {
+    if (!jid) return false;
+    const bare = jid.split(':')[0];
+    return bare === botPhoneJid || bare === botLidJid;
+  });
+}
+
+function collectMentionedJids(normalized: MentionContextSource): string[] {
+  return [
     ...(normalized.extendedTextMessage?.contextInfo?.mentionedJid ?? []),
     ...(normalized.imageMessage?.contextInfo?.mentionedJid ?? []),
     ...(normalized.videoMessage?.contextInfo?.mentionedJid ?? []),
     ...(normalized.documentMessage?.contextInfo?.mentionedJid ?? []),
   ];
-  const botLidJid = botLidUser ? `${botLidUser}@lid` : undefined;
-  return mentionedJids.some((jid) => {
-    if (!jid) return false;
-    const bare = jid.split(':')[0];
-    return bare === botPhoneJid || bare === botLidJid;
-  });
+}
+
+/**
+ * Whether the message carries any mention pill at all, for anyone.
+ * Gates the typed-mention fallback below: when a pill exists, the `@`
+ * text in the body belongs to whoever was pilled, and text-matching it
+ * against the bot's names would false-fire on a group member whose
+ * name matches the assistant's.
+ */
+export function hasMentionPills(normalized: MentionContextSource): boolean {
+  return collectMentionedJids(normalized).length > 0;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Fallback detection for typed @-mentions of the bot in a group (#3085).
+ * Only the autocomplete pill carries `contextInfo.mentionedJid`, and the
+ * pill can only target the bot's contact name — a user who types
+ * `@<name>` and hits send produces plain text that
+ * `isBotMentionedInGroup` can never match, so mention-mode wirings
+ * silently ignore the message.
+ *
+ * Matches `@<assistant name>` and `@<bot phone number>` in the text,
+ * case-insensitive. The boundaries deliberately diverge from the
+ * chat-sdk `detectMention` shape (`@name\b`): its ASCII `\b` never
+ * matches after a name ending in an accented or CJK letter (`@José`,
+ * `@小助手`), and its missing leading guard false-fires on emails and
+ * URL paths (`ethan@sprout.com`, `x.com/@sprout/...`). Here the
+ * trailing boundary is Unicode-aware, and the char before `@` must not
+ * be a letter, digit, `_`, `@`, `/`, or `.`.
+ *
+ * Known limitation: only the full name matches. Typing the first word
+ * of a multi-word assistant name (`@Autónomos` for "Autónomos Expert")
+ * does not count — matching name prefixes would false-fire too easily.
+ *
+ * Callers must gate this on `!hasMentionPills(...)` (see that helper)
+ * and on dedicated mode: on a shared number the assistant's name in
+ * text can be ordinary human conversation about the assistant.
+ */
+export function isBotTypedMention(text: string, assistantName: string, botPhoneJid: string | undefined): boolean {
+  const botPhoneUser = botPhoneJid?.split('@')[0];
+  return [assistantName, botPhoneUser]
+    .filter((name): name is string => !!name)
+    .some((name) => new RegExp(`(?<![\\p{L}\\p{N}_@/.])@${escapeRegex(name)}(?![\\p{L}\\p{N}_])`, 'iu').test(text));
 }
 
 /**
@@ -857,8 +907,15 @@ registerChannelAdapter('whatsapp', {
             // Detect explicit @-mentions of the bot in groups. Detail in
             // isBotMentionedInGroup(); short version is contextInfo.mentionedJid
             // on text + caption-bearing messages, matched against the bot's
-            // phone JID and LID (#2560).
-            const botMentionedInGroup = isGroup && isBotMentionedInGroup(normalized, botPhoneJid, botLidUser);
+            // phone JID and LID (#2560). Typed `@<name>` text never carries a
+            // pill, so in dedicated mode fall back to text matching when the
+            // message pills nobody (#3085).
+            const botMentionedInGroup =
+              isGroup &&
+              (isBotMentionedInGroup(normalized, botPhoneJid, botLidUser) ||
+                (!WHATSAPP_SHARED &&
+                  !hasMentionPills(normalized) &&
+                  isBotTypedMention(content, ASSISTANT_NAME, botPhoneJid)));
 
             const inbound: InboundMessage = {
               id: msg.key.id || `wa-${Date.now()}`,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

In dedicated-number mode, a WhatsApp group message that pills nobody now also counts as a bot mention when its text contains `@<assistant name>` or `@<bot phone number>` (case-insensitive, word boundary). Messages that pill someone keep pill semantics, and shared-number mode is untouched.

### Why

Only the autocomplete pill carries `contextInfo.mentionedJid`, so typed `@<name>` text never set `isMention` and mention-mode wirings silently ignored it. Full mechanics and live receipts in #3085. This is option 1 there; the docs and observability options are separate follow-ups, so this PR does not close the issue.

### How it works

Two new pure helpers in `src/channels/whatsapp.ts`: `hasMentionPills` gates the fallback (pills always win, so a pill of a group member whose name matches the assistant's cannot false-fire) and `isBotTypedMention` does the text match. The match follows the idea of the chat-sdk `detectMention` the bridge channels already get, but the boundaries deliberately diverge from its `@name\b` shape: the trailing boundary is Unicode-aware (ASCII `\b` never matches after a name ending in an accented or CJK letter, like `@José` or `@小助手`), and a leading guard keeps emails and URL paths that contain the name (`ethan@sprout.com`, `x.com/@sprout/...`) from engaging the agent. Known limitation, also in the docstring: only the full assistant name matches, so typing the first word of a multi-word name does not count. The inbound site ORs the fallback into `botMentionedInGroup`, dedicated mode only.

### How it was tested

13 new unit tests on the helpers (`src/channels/whatsapp.test.ts`, 45/45): case-insensitivity, boundaries (including names ending in non-ASCII letters), email and URL non-matches, punctuation openers, multi-word names, regex-special escaping, phone-number match, pill gating. The full suite matches unmodified `channels` HEAD on this machine (11 files fail in both runs from optional adapter deps not installable here; the passing delta is exactly the new tests). tsc and prettier clean on the changed files. Not yet exercised against a live WhatsApp group.

Assisted by Claude; reviewed and verified by a human before submission.


