### PR TITLE
feat(ncl): surface unknown-sender holds in `ncl approvals list`

### DIFF
--- a/src/cli/crud.ts
+++ b/src/cli/crud.ts
@@ -93,6 +93,15 @@ export interface ResourceDef {
   /** Non-standard verbs (grant, revoke, add, remove, restart, etc.). */
   customOperations?: Record<string, CustomOperation>;
   /**
+   * Extra rows to fold into `list` output beyond the backing `table` — for a
+   * resource whose logical collection spans more than one physical table. Runs
+   * after the table query and receives the same parsed `args` (so it can honor
+   * filters like `--status`); returned rows must already match the resource's
+   * column shape. Used by `approvals` to surface the separate
+   * `pending_sender_approvals` holds through one `ncl approvals list`.
+   */
+  extraListRows?: (args: Record<string, unknown>) => Record<string, unknown>[];
+  /**
    * Runs on `create` between explicit-arg collection and static column
    * defaults (two-pass create): fills omitted columns with context-aware
    * values (e.g. channel adapter declarations) and cross-validates the
@@ -180,9 +189,14 @@ function genericList(def: ResourceDef) {
     // Newest first: without an ORDER BY the LIMIT silently hides the most
     // recently inserted rows once a table outgrows it (bit `sessions list`
     // past 200 sessions — a just-created session was invisible).
-    return getDb()
+    const rows = getDb()
       .prepare(`SELECT ${cols} FROM ${def.table}${where} ORDER BY rowid DESC LIMIT ?`)
-      .all(...params);
+      .all(...params) as Record<string, unknown>[];
+    if (!def.extraListRows) return rows;
+    // Fold in rows from sibling tables (e.g. sender-approval holds) first so
+    // they stay visible even when the backing table already fills the limit,
+    // then cap the merged surface at the same limit.
+    return [...def.extraListRows(args), ...rows].slice(0, limit);
   };
 }
 

--- a/src/cli/resources/approvals.test.ts
+++ b/src/cli/resources/approvals.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `ncl approvals list` folds the separate unknown-sender holds
+ * (pending_sender_approvals) into its output as action:'sender_admit', so an
+ * operator — and the e2e sender-admit scenarios — can discover and resolve
+ * them through the one approvals surface. Regression guard for that fold-in.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { createPendingApproval } from '../../db/sessions.js';
+import { createPendingSenderApproval } from '../../modules/permissions/db/pending-sender-approvals.js';
+import { dispatch } from '../dispatch.js';
+import type { CallerContext } from '../frame.js';
+import './approvals.js';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-approvals-list' };
+});
+
+const HOST: CallerContext = { caller: 'host' };
+const now = () => new Date().toISOString();
+
+async function listApprovals(args: Record<string, unknown> = {}): Promise<Array<Record<string, unknown>>> {
+  const resp = await dispatch({ id: 'l', command: 'approvals-list', args }, HOST);
+  if (!resp.ok) throw new Error(`approvals-list failed: ${resp.error.message}`);
+  return resp.data as Array<Record<string, unknown>>;
+}
+
+function seedSenderApproval(id: string, sender: string): void {
+  createPendingSenderApproval({
+    id,
+    messaging_group_id: 'mg-1',
+    agent_group_id: 'ag-1',
+    sender_identity: sender,
+    sender_name: null,
+    original_message: '{"kind":"chat"}',
+    approver_user_id: 'e2e-control:owner',
+    created_at: now(),
+    title: 'Unknown sender wants in',
+    options_json: '[]',
+  });
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  createAgentGroup({ id: 'ag-1', name: 'Agent', folder: 'agent', agent_provider: null, created_at: now() });
+  createMessagingGroup({
+    id: 'mg-1',
+    channel_type: 'e2e-control',
+    platform_id: 'chat-1',
+    instance: 'e2e-control',
+    name: 'Chat',
+    is_group: 0,
+    unknown_sender_policy: 'request_approval',
+    created_at: now(),
+  });
+});
+
+afterEach(() => closeDb());
+
+describe('approvals list — sender-admit fold-in', () => {
+  it('folds pending_sender_approvals in as action:sender_admit, alongside pending_approvals rows', async () => {
+    createPendingApproval({
+      approval_id: 'appr-1',
+      request_id: 'appr-1',
+      action: 'onecli_credential',
+      payload: '{}',
+      created_at: now(),
+      title: 'cred',
+      options_json: '[]',
+    });
+    seedSenderApproval('nsa-1', 'cli:local');
+
+    const rows = await listApprovals();
+
+    const sender = rows.find((r) => r.approval_id === 'nsa-1');
+    expect(sender).toMatchObject({ approval_id: 'nsa-1', action: 'sender_admit', status: 'pending' });
+    // union, not replacement — the ordinary pending_approvals row is still there
+    expect(rows.some((r) => r.approval_id === 'appr-1' && r.action === 'onecli_credential')).toBe(true);
+  });
+
+  it('honors --action sender_admit (only folded rows) and excludes them under a non-pending --status', async () => {
+    createPendingApproval({
+      approval_id: 'appr-2',
+      request_id: 'appr-2',
+      action: 'install_packages',
+      payload: '{}',
+      created_at: now(),
+      title: 'pkg',
+      options_json: '[]',
+    });
+    seedSenderApproval('nsa-2', 'cli:bob');
+
+    expect((await listApprovals({ action: 'sender_admit' })).map((r) => r.approval_id)).toEqual(['nsa-2']);
+    expect((await listApprovals({ status: 'rejected' })).some((r) => r.approval_id === 'nsa-2')).toBe(false);
+  });
+});

--- a/src/cli/resources/approvals.ts
+++ b/src/cli/resources/approvals.ts
@@ -1,4 +1,5 @@
 import { registerResource } from '../crud.js';
+import { listPendingSenderApprovals } from '../../modules/permissions/db/pending-sender-approvals.js';
 
 registerResource({
   name: 'approval',
@@ -27,7 +28,7 @@ registerResource({
       name: 'action',
       type: 'string',
       description:
-        'Action type — matches the registered approval handler (e.g. install_packages, add_mcp_server, onecli_credential).',
+        "Action type — matches the registered approval handler (e.g. install_packages, add_mcp_server, onecli_credential). 'sender_admit' rows are unknown-sender holds folded in from pending_sender_approvals; they resolve through the same click path.",
     },
     { name: 'payload', type: 'json', description: 'JSON payload carried through to the approval handler.' },
     { name: 'created_at', type: 'string', description: 'Auto-set.' },
@@ -50,4 +51,30 @@ registerResource({
     { name: 'options_json', type: 'json', description: 'Card button options as JSON array.' },
   ],
   operations: { list: 'open', get: 'open' },
+  // Unknown-sender holds live in their own table (pending_sender_approvals),
+  // but resolve through the same click path (handleSenderApprovalResponse
+  // claims the same questionId). Fold them into this list as
+  // action:'sender_admit' so an operator can see and act on every pending hold
+  // from one surface. Self-filter on the list filters so `--status`/`--action`
+  // stay honest; these rows are always pending until approve/deny deletes them.
+  extraListRows: (args) => {
+    if (args.action !== undefined && args.action !== 'sender_admit') return [];
+    if (args.status !== undefined && args.status !== 'pending') return [];
+    return listPendingSenderApprovals().map((row) => ({
+      approval_id: row.id,
+      session_id: null,
+      request_id: row.id,
+      action: 'sender_admit',
+      payload: row.original_message,
+      created_at: row.created_at,
+      agent_group_id: row.agent_group_id,
+      channel_type: null,
+      platform_id: null,
+      platform_message_id: null,
+      expires_at: null,
+      status: 'pending',
+      title: row.title,
+      options_json: row.options_json,
+    }));
+  },
 });

--- a/src/modules/permissions/db/pending-sender-approvals.ts
+++ b/src/modules/permissions/db/pending-sender-approvals.ts
@@ -48,6 +48,10 @@ export function getPendingSenderApproval(id: string): PendingSenderApproval | un
     | undefined;
 }
 
+export function listPendingSenderApprovals(): PendingSenderApproval[] {
+  return getDb().prepare('SELECT * FROM pending_sender_approvals ORDER BY rowid DESC').all() as PendingSenderApproval[];
+}
+
 export function hasInFlightSenderApproval(messagingGroupId: string, senderIdentity: string): boolean {
   const row = getDb()
     .prepare('SELECT 1 AS x FROM pending_sender_approvals WHERE messaging_group_id = ? AND sender_identity = ?')


### PR DESCRIPTION
## What

Fold unknown-sender holds (`pending_sender_approvals`) into `ncl approvals list` as `action: 'sender_admit'`, so they're visible and resolvable from the CLI.

## Why

The `request_approval` unknown-sender flow creates its hold in a **separate** `pending_sender_approvals` table, but `ncl approvals list` only reads `pending_approvals`. So an operator could never see or resolve an unknown-sender hold from `ncl` — the hold fired (card delivered to the approver) but was invisible to the CLI.

This also surfaced as a false failure in the `nanoclaw-e2e` `sender-admit-*` scenarios: they discover the hold via `ncl approvals list` filtered to `action === 'sender_admit'`, find nothing, and report "the unknown sender was not held" — even though the host log shows it *was* held (`Unknown-sender approval card delivered approvalId="nsa-…"`).

## How

- **`src/cli/crud.ts`** — add an opt-in `extraListRows?(args)` hook to `ResourceDef` (mirrors the existing optional hooks like `resolveDefaults` / `postCommit`); `genericList` folds its rows in, newest-first, capped at the same `limit`.
- **`src/modules/permissions/db/pending-sender-approvals.ts`** — `listPendingSenderApprovals()`.
- **`src/cli/resources/approvals.ts`** — project `pending_sender_approvals` rows into the approvals column shape as `action: 'sender_admit'`, self-filtering on `--action` / `--status` so those stay honest.

Resolution is **unchanged** — the same `onAction` click path already claims these questionIds (`handleSenderApprovalResponse`), so approve/reject/replay work once the row is visible. No new resolution code.

Scope note: `pending_channel_approvals` is the same shape and could be folded in the same way — left as a follow-up to keep this focused.

## Testing

- New `src/cli/resources/approvals.test.ts` — asserts the fold-in appears as `sender_admit`, coexists with `pending_approvals` rows (union, not replace), and honors `--action` / `--status`.
- Full host suite green (**1153 passed**), `tsc` + prettier clean. The two pre-existing `preserve-caught-error` eslint errors in `crud.ts` are unrelated (present on `main`).
- Verified end-to-end by the `nanoclaw-e2e` `approval-suite` (PR #14) — the two `sender-admit` scenarios go green with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
