### PR TITLE
fix(templates): prepend all top-level context Markdown

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -74,6 +74,8 @@ Notes:
 - **No provider, model, effort, or packages in a template.** Those are set on
   the agent later via `ncl groups config update`. The runtime defaults to the
   install's configured provider.
+- **Template trees may contain only regular files and real directories.**
+  Symlinks and special files are rejected before any template content is read.
 - **Keep all top-level context files focused (under ~200 lines combined).** They're
   always in the agent's prompt, and some providers cap that doc (Codex ~32 KB),
   so over-long instructions get truncated. Put bulk material in `skills/` or

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -51,7 +51,8 @@ is optional and defaults sensibly:
 <template>/
 ├── context/
 │   ├── instructions.md        # REQUIRED: the agent's standing persona; marks the folder as a template
-│   └── additional_context/    # optional: extra .md files, referenced from instructions.md by relative path
+│   ├── *.md                   # optional: any other immediate Markdown file is also prepended
+│   └── additional_context/    # optional: extra .md files, referenced by relative path
 │       └── *.md
 ├── .mcp.json             # optional: MCP servers (command + args), NO secrets
 ├── skills/<name>/        # optional: one folder per skill (SKILL.md + any references/), copied whole
@@ -61,8 +62,9 @@ is optional and defaults sensibly:
 
 | Path | Loaded as | Required |
 |------|-----------|----------|
-| `context/instructions.md` | The agent's persona, prepended to its `CLAUDE.md`/`AGENTS.md` every spawn (system-prompt tier, any provider) | **Yes** |
-| `context/**/*.md` (others) | Extra context, copied into the agent's workspace with the same layout relative to `instructions.md` | No |
+| `context/instructions.md` | `instructions.prepend.md`, prepended first to `CLAUDE.md`/`AGENTS.md` every spawn (system-prompt tier, any provider) | **Yes** |
+| Other immediate `context/*.md` files | `<name>.prepend.md`, prepended alphabetically after `instructions.md` | No |
+| `context/additional_context/**/*.md` | Extra context copied into the agent's workspace with the same layout relative to `instructions.md` | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers (written verbatim to container config) | No |
 | `skills/<name>/` | A skill, auto-triggered by its `description` | No |
 | `tasks/*.md` | Recurring scheduled tasks, created paused pending user activation | No |
@@ -72,9 +74,10 @@ Notes:
 - **No provider, model, effort, or packages in a template.** Those are set on
   the agent later via `ncl groups config update`. The runtime defaults to the
   install's configured provider.
-- **Keep `instructions.md` focused (under ~200 lines).** It's always in the
-  agent's prompt, and some providers cap that doc (Codex ~32 KB), so an over-long
-  persona gets truncated. Put bulk material in `skills/` or extra context files instead.
+- **Keep all top-level context files focused (under ~200 lines combined).** They're
+  always in the agent's prompt, and some providers cap that doc (Codex ~32 KB),
+  so over-long instructions get truncated. Put bulk material in `skills/` or
+  `additional_context/` instead.
 - Skills are copied into the agent's own skills overlay, keyed to that group,
   never shared across groups.
 
@@ -130,21 +133,23 @@ run passed while paused, the task is eligible immediately.
 
 ### Referencing extra context files
 
-Extra `.md` files under `context/` (by convention in an `additional_context/`
-subfolder) are copied into the agent's workspace preserving their position
-relative to `instructions.md` — a template file at
-`context/additional_context/pricing.md` is readable by the agent as
+Markdown files directly beside `instructions.md` are standing instructions and
+are automatically prepended. Extra files that should be read only when relevant
+belong under `context/additional_context/`; they are copied into the agent's
+workspace preserving their position relative to `instructions.md`. A template
+file at `context/additional_context/pricing.md` is readable by the agent as
 `additional_context/pricing.md`, the same relative path you'd use from
 `instructions.md` itself. Nothing is injected automatically: the agent only
-reads an extra file if `instructions.md` points to it, so reference every file
-you ship.
+reads an extra file if one of the prepended files points to it, so reference
+every file you ship.
 
 ```markdown
 Pricing rules live in `additional_context/pricing.md`. Read it before quoting a price.
 ```
 
-Context files are copied when you stamp, so files added to the template later
-won't reach an already-created agent. Re-stamp the same name to update it.
+Context and prepend files are copied when you stamp, so files added to the
+template later won't reach an already-created agent. Create a new agent to use
+the updated template.
 
 ## MCP servers and credentials
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -71,6 +71,9 @@ is optional and defaults sensibly:
 
 Notes:
 
+- **Install only templates you trust.** A template supplies standing
+  instructions, MCP launch commands, skills, and scheduled-task prompts that
+  become part of the agent's behavior.
 - **No provider, model, effort, or packages in a template.** Those are set on
   the agent later via `ncl groups config update`. The runtime defaults to the
   install's configured provider.

--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -56,6 +56,7 @@ describe('composeGroupClaudeMd persona prepend', () => {
     const ag = group('ag-persona', 'persona-group');
     seed(ag);
     writePersona(ag.folder, 'You are an SDR agent.\n');
+    fs.writeFileSync(path.join(GROUPS_DIR, ag.folder, 'tools.prepend.md'), 'Use the sales tools.\n');
 
     composeGroupClaudeMd(ag);
 
@@ -63,7 +64,7 @@ describe('composeGroupClaudeMd persona prepend', () => {
     expect(imports[0]).toBe('@./.claude-fragments/persona.md');
     expect(imports[1]).toBe('@./.claude-shared.md');
     expect(fs.readFileSync(path.join(GROUPS_DIR, ag.folder, '.claude-fragments', 'persona.md'), 'utf-8')).toBe(
-      'You are an SDR agent.',
+      'You are an SDR agent.\n\nUse the sales tools.',
     );
   });
 

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -22,8 +22,8 @@ import { getContainerConfig } from './db/container-configs.js';
 import { readGroupPersona } from './group-persona.js';
 import type { AgentGroup } from './types.js';
 
-// Fragment holding a template's persona prepend. Imported FIRST (before the
-// shared base) so the persona is the top of the composed system prompt.
+// Fragment holding a group's standing-instruction prepends. Imported FIRST
+// (before the shared base) so they lead the composed system prompt.
 const PERSONA_FRAGMENT = 'persona.md';
 
 // Symlink targets are container paths — dangling on host (hence the readlink
@@ -37,7 +37,7 @@ const SHARED_MCP_TOOLS_CONTAINER_BASE = '/app/src/mcp-tools';
 const MCP_TOOLS_HOST_SUBPATH = path.join('container', 'agent-runner', 'src', 'mcp-tools');
 
 const COMPOSED_HEADER =
-  '<!-- Composed at spawn - do not edit. Standing instructions: instructions.prepend.md. Memory: memory/. -->';
+  '<!-- Composed at spawn - do not edit. Standing instructions: *.prepend.md. Memory: memory/. -->';
 
 /**
  * Regenerate `groups/<folder>/CLAUDE.md` from the shared base, enabled skill
@@ -111,8 +111,8 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
     }
   }
 
-  // Template persona (if any) — inline so it survives the prune below; imported
-  // first (see the imports assembly) so it prepends the composed system prompt.
+  // Group prepends (if any) — inline so they survive the prune below; imported
+  // first (see the imports assembly) so they lead the composed system prompt.
   const persona = readGroupPersona(groupDir);
   if (persona) {
     desired.set(PERSONA_FRAGMENT, { type: 'inline', content: persona });

--- a/src/group-persona.test.ts
+++ b/src/group-persona.test.ts
@@ -41,12 +41,13 @@ describe('readGroupPersona', () => {
     expect(readGroupPersona(TMP)).toBe('You are an SDR agent.\n\nBehavior instructions.\n\nTools instructions.');
   });
 
-  it('does not follow a symlink', () => {
+  it('skips a symlink without dropping valid prepend files', () => {
     const target = path.join(TMP, 'outside.md');
     fs.writeFileSync(target, 'host-only content\n');
     fs.symlinkSync(target, path.join(TMP, PERSONA_PREPEND_FILE));
+    fs.writeFileSync(path.join(TMP, 'tools.prepend.md'), 'Safe tools.\n');
 
-    expect(readGroupPersona(TMP)).toBeNull();
+    expect(readGroupPersona(TMP)).toBe('Safe tools.');
     expect(log.warn).toHaveBeenCalledWith(
       'Could not read group standing instructions; omitting prepend file',
       expect.objectContaining({ file: path.join(TMP, PERSONA_PREPEND_FILE) }),

--- a/src/group-persona.test.ts
+++ b/src/group-persona.test.ts
@@ -32,9 +32,13 @@ describe('readGroupPersona', () => {
     expect(readGroupPersona(TMP)).toBeNull();
   });
 
-  it('returns the trimmed content when present', () => {
+  it('combines instructions first and remaining prepend files alphabetically', () => {
+    fs.writeFileSync(path.join(TMP, 'tools.prepend.md'), '\nTools instructions.\n');
     fs.writeFileSync(path.join(TMP, PERSONA_PREPEND_FILE), '\nYou are an SDR agent.\n\n');
-    expect(readGroupPersona(TMP)).toBe('You are an SDR agent.');
+    fs.writeFileSync(path.join(TMP, 'behavior.prepend.md'), 'Behavior instructions.\n');
+    fs.writeFileSync(path.join(TMP, 'ignored.md'), 'Not prepended.\n');
+
+    expect(readGroupPersona(TMP)).toBe('You are an SDR agent.\n\nBehavior instructions.\n\nTools instructions.');
   });
 
   it('does not follow a symlink', () => {
@@ -44,8 +48,19 @@ describe('readGroupPersona', () => {
 
     expect(readGroupPersona(TMP)).toBeNull();
     expect(log.warn).toHaveBeenCalledWith(
-      'Could not read group standing instructions; omitting persona',
+      'Could not read group standing instructions; omitting prepend file',
       expect.objectContaining({ file: path.join(TMP, PERSONA_PREPEND_FILE) }),
+    );
+  });
+
+  it('omits prepends when the group directory cannot be read', () => {
+    fs.rmSync(TMP, { recursive: true });
+    fs.writeFileSync(TMP, 'not a directory');
+
+    expect(readGroupPersona(TMP)).toBeNull();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Could not enumerate group standing instructions; omitting prepend files',
+      expect.objectContaining({ groupDir: TMP }),
     );
   });
 });

--- a/src/group-persona.ts
+++ b/src/group-persona.ts
@@ -3,8 +3,11 @@ import path from 'path';
 
 import { log } from './log.js';
 
-/** Per-group standing instructions prepended to every provider's project document. */
-export const PERSONA_PREPEND_FILE = 'instructions.prepend.md';
+/** Suffix identifying persistent per-group files composed before the shared instructions. */
+export const GROUP_PREPEND_SUFFIX = '.prepend.md';
+
+/** Primary per-group prepend, always composed before sibling prepend files. */
+export const PERSONA_PREPEND_FILE = `instructions${GROUP_PREPEND_SUFFIX}`;
 
 /**
  * Create a group's standing instructions without following or replacing an
@@ -24,18 +27,44 @@ export function stageGroupPersona(groupDir: string, instructions: string): boole
   }
 }
 
-/** Read a group's standing instructions without following symlinks. */
+/** Read a group's prepend files without following symlinks. */
 export function readGroupPersona(groupDir: string): string | null {
-  const file = path.join(groupDir, PERSONA_PREPEND_FILE);
-  let fd: number | undefined;
+  let files: string[];
   try {
-    fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
-    if (!fs.fstatSync(fd).isFile()) return null;
-    const content = fs.readFileSync(fd, 'utf-8').trim();
-    return content || null;
+    files = fs
+      .readdirSync(groupDir)
+      .filter((file) => file.endsWith(GROUP_PREPEND_SUFFIX))
+      .sort((a, b) => {
+        if (a === PERSONA_PREPEND_FILE) return -1;
+        if (b === PERSONA_PREPEND_FILE) return 1;
+        return a < b ? -1 : a > b ? 1 : 0;
+      });
+    // eslint-disable-next-line no-catch-all/no-catch-all -- standing instructions are best-effort; filesystem errors must not block agent spawn
   } catch (err) {
     if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') return null;
-    log.warn('Could not read group standing instructions; omitting persona', {
+    log.warn('Could not enumerate group standing instructions; omitting prepend files', {
+      groupDir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  const content = files
+    .map((file) => readPrependFile(path.join(groupDir, file)))
+    .filter((part): part is string => part !== null)
+    .join('\n\n');
+  return content || null;
+}
+
+function readPrependFile(file: string): string | null {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK);
+    if (!fs.fstatSync(fd).isFile()) return null;
+    return fs.readFileSync(fd, 'utf-8').trim() || null;
+    // eslint-disable-next-line no-catch-all/no-catch-all -- one unreadable prepend must not block agent spawn or the remaining prepends
+  } catch (err) {
+    if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') return null;
+    log.warn('Could not read group standing instructions; omitting prepend file', {
       file,
       error: err instanceof Error ? err.message : String(err),
     });

--- a/src/group-persona.ts
+++ b/src/group-persona.ts
@@ -29,16 +29,9 @@ export function stageGroupPersona(groupDir: string, instructions: string): boole
 
 /** Read a group's prepend files without following symlinks. */
 export function readGroupPersona(groupDir: string): string | null {
-  let files: string[];
+  let prependFiles: string[];
   try {
-    files = fs
-      .readdirSync(groupDir)
-      .filter((file) => file.endsWith(GROUP_PREPEND_SUFFIX))
-      .sort((a, b) => {
-        if (a === PERSONA_PREPEND_FILE) return -1;
-        if (b === PERSONA_PREPEND_FILE) return 1;
-        return a < b ? -1 : a > b ? 1 : 0;
-      });
+    prependFiles = listPrependFiles(groupDir);
     // eslint-disable-next-line no-catch-all/no-catch-all -- standing instructions are best-effort; filesystem errors must not block agent spawn
   } catch (err) {
     if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') return null;
@@ -48,17 +41,27 @@ export function readGroupPersona(groupDir: string): string | null {
     });
     return null;
   }
-  const content = files
-    .map((file) => readPrependFile(path.join(groupDir, file)))
-    .filter((part): part is string => part !== null)
-    .join('\n\n');
-  return content || null;
+
+  const sections: string[] = [];
+  for (const file of prependFiles) {
+    const content = readPrependFile(path.join(groupDir, file));
+    if (content) sections.push(content);
+  }
+  return sections.length > 0 ? sections.join('\n\n') : null;
+}
+
+function listPrependFiles(groupDir: string): string[] {
+  const files = fs.readdirSync(groupDir).filter((file) => file.endsWith(GROUP_PREPEND_SUFFIX));
+  const siblings = files.filter((file) => file !== PERSONA_PREPEND_FILE).sort();
+  return files.includes(PERSONA_PREPEND_FILE) ? [PERSONA_PREPEND_FILE, ...siblings] : siblings;
 }
 
 function readPrependFile(file: string): string | null {
   let fd: number | undefined;
   try {
-    fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK);
+    // Refuse symlinks, and do not wait on special files before fstat rejects them.
+    const safeReadFlags = fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK;
+    fd = fs.openSync(file, safeReadFlags);
     if (!fs.fstatSync(fd).isFile()) return null;
     return fs.readFileSync(fd, 'utf-8').trim() || null;
     // eslint-disable-next-line no-catch-all/no-catch-all -- one unreadable prepend must not block agent spawn or the remaining prepends

--- a/src/templates/create-agent.test.ts
+++ b/src/templates/create-agent.test.ts
@@ -30,7 +30,7 @@ function writeTemplate(): void {
   const t = path.join(TEMPLATES_DIR, 'sales', 'sdr');
   fs.mkdirSync(path.join(t, 'context', 'additional_context'), { recursive: true });
   fs.writeFileSync(path.join(t, 'context', 'instructions.md'), 'You are an SDR agent.\n');
-  fs.writeFileSync(path.join(t, 'context', 'playbook.md'), '# Playbook\n');
+  fs.writeFileSync(path.join(t, 'context', 'tools.md'), '# Tools\n');
   fs.writeFileSync(path.join(t, 'context', 'additional_context', 'faq.md'), '# FAQ\n');
   fs.writeFileSync(
     path.join(t, '.mcp.json'),
@@ -82,16 +82,20 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(skill)).toBe(true);
   });
 
-  it('writes MCP servers to the container config and context extras at their template-relative paths', () => {
+  it('writes MCP servers to the container config', () => {
     const g = createAgentFromTemplate('sales/sdr', { name: 'SDR Mcp' });
 
     const cfg = getContainerConfig(g.id);
     expect(cfg).toBeTruthy();
     expect(JSON.parse(cfg!.mcp_servers)).toHaveProperty('hubspot');
-    // Extras land relative to the group root, exactly as they sit relative to
-    // instructions.md in the template — no context/ prefix in between.
+  });
+
+  it('writes top-level context as prepends and preserves nested additional context', () => {
+    const g = createAgentFromTemplate('sales/sdr', { name: 'SDR Context' });
+
     const groupDir = path.join(GROUPS_DIR, g.folder);
-    expect(fs.existsSync(path.join(groupDir, 'playbook.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(groupDir, 'tools.prepend.md'), 'utf-8')).toBe('# Tools\n');
+    expect(fs.existsSync(path.join(groupDir, 'tools.md'))).toBe(false);
     expect(fs.existsSync(path.join(groupDir, 'additional_context', 'faq.md'))).toBe(true);
     expect(fs.existsSync(path.join(groupDir, 'context'))).toBe(false);
   });

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -11,7 +11,7 @@ import {
 } from '../db/container-configs.js';
 import { isValidTimezone } from '../timezone.js';
 import { assertValidGroupFolder, resolveGroupFolderPath } from '../group-folder.js';
-import { stageGroupPersona } from '../group-persona.js';
+import { GROUP_PREPEND_SUFFIX, stageGroupPersona } from '../group-persona.js';
 import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
 import { createScheduledTask, prepareScheduledTask } from '../modules/scheduling/create.js';
 import type { AgentGroup } from '../types.js';
@@ -30,12 +30,12 @@ export interface CreateAgentOptions {
  * context extras, skills, and paused recurring tasks, but nothing else (no policy,
  * packages, or provider).
  *
- * The template persona is written to the provider-neutral `instructions.prepend.md`
- * (see src/group-persona.ts). Each provider's project-doc composer inlines it at
- * the TOP of the doc it generates every spawn, so the persona is system-prompt
- * tier regardless of which provider the group ends up running. Because the file
- * is provider-agnostic, placement needs no provider knowledge at stamp time (the
- * provider is DB-resolved later, at first spawn).
+ * Top-level template context files are written to provider-neutral `*.prepend.md`
+ * files (see src/group-persona.ts). Each provider's project-doc composer
+ * inlines them at the TOP of the doc it generates every spawn, so they are
+ * system-prompt tier regardless of which provider the group ends up running.
+ * Because the files are provider-agnostic, placement needs no provider
+ * knowledge at stamp time (the provider is DB-resolved later, at first spawn).
  *
  * Returns the created group; the caller wires it to a channel as usual.
  */
@@ -74,7 +74,7 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   if (timezone) updateContainerConfigScalars(id, { timezone });
 
   // group-init.ts owns the mkdir at first spawn, but it isn't called here — so we
-  // create the dir ourselves to land instructions.prepend.md + context/.
+  // create the dir ourselves to land prepend files + additional context.
   const groupDir = path.resolve(GROUPS_DIR, folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
@@ -82,13 +82,11 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   // CLAUDE.md/AGENTS.md every spawn (system-prompt tier on any provider).
   stageGroupPersona(groupDir, tpl.instructions);
 
-  // Context extras keep their template-relative layout, placed next to the doc
-  // the persona is inlined into — so a reference written in instructions.md
-  // (e.g. `additional_context/faq.md`) resolves unchanged in the agent's
-  // workspace. Nothing is injected into the persona; referencing each file from
-  // instructions.md is the template author's job (docs/templates.md).
+  // Top-level context files are standing instructions; nested context keeps its
+  // template-relative layout for explicit references from the prepended files.
   for (const { name: file, content } of tpl.contextExtras) {
-    const dest = path.join(groupDir, file);
+    const destination = path.dirname(file) === '.' ? `${path.basename(file, '.md')}${GROUP_PREPEND_SUFFIX}` : file;
+    const dest = path.join(groupDir, destination);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.writeFileSync(dest, content);
   }

--- a/src/templates/local-dir.test.ts
+++ b/src/templates/local-dir.test.ts
@@ -28,6 +28,18 @@ describe('resolveLocalTemplate', () => {
     expect(() => resolveLocalTemplate('sales/../../etc', base)).toThrow(/escapes/);
   });
 
+  it('rejects a ref that escapes the base through an intermediate symlink', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'tpl-local-outside-'));
+    fs.mkdirSync(path.join(outside, 'sdr'));
+    fs.symlinkSync(outside, path.join(base, 'linked'));
+
+    try {
+      expect(() => resolveLocalTemplate('linked/sdr', base)).toThrow(/escapes/);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   it('rejects an absolute ref', () => {
     expect(() => resolveLocalTemplate('/etc', base)).toThrow(/relative/);
   });

--- a/src/templates/local-dir.ts
+++ b/src/templates/local-dir.ts
@@ -5,10 +5,11 @@ import { TEMPLATES_DIR } from '../config.js';
 
 /**
  * Resolve a LOCAL template ref to an absolute directory under `base`
- * (TEMPLATES_DIR by default). Lexical containment only — no realpathSync, no
- * symlink resolution (out of threat model). Mirrors ensureWithinBase() in
- * group-folder.ts. Refs are legitimately multi-segment (e.g. "sales/sdr"), so
- * this does NOT reuse isValidGroupFolder (which rejects "/").
+ * (TEMPLATES_DIR by default). Checks both lexical and canonical containment so
+ * symlinked ref components cannot escape `base`; parseTemplate() separately
+ * rejects symlinks inside the selected template tree. Refs are legitimately
+ * multi-segment (e.g. "sales/sdr"), so this does NOT reuse isValidGroupFolder
+ * (which rejects "/").
  *
  * Rejects: empty / untrimmed refs, absolute paths, a leading "~", and any ref
  * that escapes `base` after resolution. Throws if the resolved path is missing
@@ -28,6 +29,10 @@ export function resolveLocalTemplate(ref: string, base: string = TEMPLATES_DIR):
   }
   if (!fs.existsSync(candidate) || !fs.statSync(candidate).isDirectory()) {
     throw new Error(`Template not found: "${ref}" (looked in ${base})`);
+  }
+  const realRel = path.relative(fs.realpathSync(base), fs.realpathSync(candidate));
+  if (realRel.startsWith('..') || path.isAbsolute(realRel)) {
+    throw new Error(`Template ref escapes the templates directory: "${ref}"`);
   }
   return candidate;
 }

--- a/src/templates/parse.test.ts
+++ b/src/templates/parse.test.ts
@@ -75,6 +75,14 @@ describe('parseTemplate', () => {
     expect(tpl.tasks).toEqual([]);
   });
 
+  it('rejects symlinks before reading template content', () => {
+    write('context/instructions.md', 'Be helpful.');
+    write('secret.txt', 'host-only content');
+    fs.symlinkSync(path.join(dir, 'secret.txt'), path.join(dir, 'context', 'tools.md'));
+
+    expect(() => parseTemplate(dir)).toThrow(/unsafe template path.*context\/tools\.md/i);
+  });
+
   it.each([
     ['missing frontmatter', 'Run it.', /must start with ---/],
     ['unknown field', '---\ncron: 0 9 * * *\n---\nRun it.', /only schedule and script/],

--- a/src/templates/parse.ts
+++ b/src/templates/parse.ts
@@ -27,6 +27,23 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+function assertSafeTemplateTree(dir: string): void {
+  if (!fs.lstatSync(dir).isDirectory()) throw new Error('Unsafe template path: .');
+
+  const directories = [{ absolute: dir, relative: '' }];
+  while (directories.length > 0) {
+    const current = directories.pop()!;
+    for (const entry of fs.readdirSync(current.absolute, { withFileTypes: true })) {
+      const relative = path.join(current.relative, entry.name);
+      if (entry.isDirectory()) {
+        directories.push({ absolute: path.join(current.absolute, entry.name), relative });
+      } else if (!entry.isFile()) {
+        throw new Error(`Unsafe template path: ${relative}; only regular files and directories are allowed`);
+      }
+    }
+  }
+}
+
 /**
  * Read and validate a template folder into a typed object. The folder and
  * context/instructions.md are required; optional task files are strict so a
@@ -34,6 +51,7 @@ function asRecord(value: unknown): Record<string, unknown> {
  */
 export function parseTemplate(dir: string): Template {
   if (!fs.existsSync(dir)) throw new Error(`Template folder not found: ${dir}`);
+  assertSafeTemplateTree(dir);
 
   const mcpServers = asRecord(asRecord(readJson(path.join(dir, '.mcp.json'))).mcpServers);
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -38,6 +38,9 @@ standing brief and marks the folder as a template.
 
 Notes:
 
+- **Install only templates you trust.** Standing instructions, MCP launch
+  commands, skills, and scheduled-task prompts become part of the agent's
+  behavior.
 - **Every Markdown file directly beside `instructions.md` is prepended.**
   `<name>.md` becomes `<name>.prepend.md` in the agent. `instructions.md` is
   composed first; additional prepend files follow alphabetically.

--- a/templates/README.md
+++ b/templates/README.md
@@ -41,6 +41,8 @@ Notes:
 - **Every Markdown file directly beside `instructions.md` is prepended.**
   `<name>.md` becomes `<name>.prepend.md` in the agent. `instructions.md` is
   composed first; additional prepend files follow alphabetically.
+- **Use only regular files and real directories.** Symlinks and special files
+  are rejected before any template content is read.
 - **Extra context is copied preserving its layout relative to `instructions.md`**
   (`context/additional_context/faq.md` → `additional_context/faq.md` in the
   agent's workspace). Nothing is referenced automatically — a prepended file

--- a/templates/README.md
+++ b/templates/README.md
@@ -28,6 +28,7 @@ standing brief and marks the folder as a template.
 ├── context/
 │   ├── instructions.md        # REQUIRED: the agent's standing persona, prepended to its
 │   │                          #           CLAUDE.md/AGENTS.md every spawn
+│   ├── *.md                   # optional: any other immediate Markdown file is also prepended
 │   └── additional_context/    # optional: extra .md files
 │       └── *.md
 ├── .mcp.json             # optional: { "mcpServers": { ... } } — command + args, NO secrets
@@ -36,10 +37,14 @@ standing brief and marks the folder as a template.
 ```
 
 Notes:
+
+- **Every Markdown file directly beside `instructions.md` is prepended.**
+  `<name>.md` becomes `<name>.prepend.md` in the agent. `instructions.md` is
+  composed first; additional prepend files follow alphabetically.
 - **Extra context is copied preserving its layout relative to `instructions.md`**
   (`context/additional_context/faq.md` → `additional_context/faq.md` in the
-  agent's workspace). Nothing is referenced automatically — `instructions.md`
-  must point to each file (e.g. "Pricing rules live in
+  agent's workspace). Nothing is referenced automatically — a prepended file
+  must point to each extra file (e.g. "Pricing rules live in
   `additional_context/pricing.md`").
 - **No provider, no model, no packages.** A template is instructions + MCP
   servers + skills. The agent's runtime/provider is chosen separately


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Template stamping now treats every Markdown file directly under `context/` as standing instructions:

- `context/instructions.md` becomes `instructions.prepend.md` and is composed first.
- Other immediate `context/*.md` files become `<name>.prepend.md` and are composed in deterministic alphabetical order.
- Files under `context/additional_context/` remain copy-only and keep their relative paths.

### Why

Templates often need separate always-on instruction files such as `tools.md`, `guardrails.md`, and `workflow.md`. Previously only `instructions.md` entered the provider project document; other Markdown files were copied into the workspace and required explicit reads.

### How it works

The template stamper maps immediate context files to the existing provider-neutral `.prepend.md` surface. The shared persona reader discovers and safely reads those fragments, keeps `instructions.prepend.md` first, skips symlinks and non-regular files, and returns one composed block to the existing project-document composer. No provider-specific change is required.

The template import boundary now validates the complete tree before reading content. Symlinks and special files are rejected, preventing a template from redirecting host reads or copied skill content outside its own directory.

The template documentation now distinguishes always-on top-level Markdown from opt-in `additional_context` files, documents the safe-tree and trusted-template requirements, and clarifies that stamping is a one-time copy.

### Security review

- Template refs remain lexically contained under `templates/`.
- Destination names come only from immediate directory entries; nested paths preserve their existing layout.
- Runtime prepend reads use `O_NOFOLLOW | O_NONBLOCK`, require a regular file via `fstat`, and isolate per-file failures.
- Template parsing rejects symlinks, FIFOs, sockets, devices, and other non-regular tree entries before content is read.
- The feature adds no dependencies and does not change credential or secret handling.
- Templates remain trusted agent configuration by design; the docs now explicitly tell operators to review them before installation.

### Testing

- Added a red-then-green regression test for a template symlink targeting host-only content.
- `pnpm exec vitest run src/templates/parse.test.ts src/templates/create-agent.test.ts src/group-persona.test.ts src/claude-md-compose.test.ts` (36 tests)
- `pnpm exec tsc --noEmit`
- Changed-file ESLint (0 errors; 2 pre-existing warnings in `src/claude-md-compose.ts`)
- `pnpm test` (94 files, 1,154 tests)
- Manual adversarial check with valid prepends plus a FIFO and directory masquerading as prepend files; valid content composed without blocking.
- Manual smoke test with `instructions.md`, `guardrails.md`, `tools.md`, `workflow.md`, and nested `additional_context/reference.md`; verified stamped files and composed ordering in the generated agent workspace.
