### PR TITLE
fix(chat): keep typing active for processing turns

### DIFF
--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -108,6 +108,16 @@ export function markProcessing(ids: string[]): void {
   })();
 }
 
+/** Release claims that were not handed to a query so the messages can be retried. */
+export function releaseProcessing(ids: string[]): void {
+  if (ids.length === 0) return;
+  const db = getOutboundDb();
+  const stmt = db.prepare("DELETE FROM processing_ack WHERE message_id = ? AND status = 'processing'");
+  db.transaction(() => {
+    for (const id of ids) stmt.run(id);
+  })();
+}
+
 /** Mark messages as completed — updates processing_ack in outbound.db. */
 export function markCompleted(ids: string[]): void {
   if (ids.length === 0) return;

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -438,6 +438,44 @@ describe('error result with no <message> envelope', () => {
   });
 });
 
+describe('follow-up claim ownership', () => {
+  it('releases a follow-up claim when the query ends during its pre-task script', async () => {
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 'sess-1' };
+      insertMessage('t2', 'task', {
+        prompt: 'check later',
+        script: 'sleep 1; echo \'{"wakeAgent": true}\'',
+      });
+
+      const deadline = Date.now() + 5_000;
+      while (
+        !getOutboundDb().prepare("SELECT 1 FROM processing_ack WHERE message_id = 't2'").get() &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(getOutboundDb().prepare("SELECT status FROM processing_ack WHERE message_id = 't2'").get()).toEqual({
+        status: 'processing',
+      });
+      yield { type: 'result', text: '' };
+    }
+
+    const query: AgentQuery = { push: () => {}, end: () => {}, events: events(), abort: () => {} };
+    await processQuery(query, ERR_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    const deadline = Date.now() + 5_000;
+    while (
+      getOutboundDb().prepare("SELECT 1 FROM processing_ack WHERE message_id = 't2'").get() &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    expect(getOutboundDb().prepare("SELECT 1 FROM processing_ack WHERE message_id = 't2'").get()).toBeNull();
+    expect(getPendingMessages().map((message) => message.id)).toContain('t2');
+  });
+});
+
 describe('isCorruptionError', () => {
   it('matches the Docker Desktop macOS torn-read symptom', () => {
     expect(isCorruptionError('database disk image is malformed')).toBe(true);
@@ -510,6 +548,11 @@ describe('task-run turn wiring (real processQuery)', () => {
         await new Promise((r) => setTimeout(r, 50));
       }
 
+      const claim = getOutboundDb().prepare('SELECT status FROM processing_ack WHERE message_id = ?').get('t2') as
+        | { status: string }
+        | undefined;
+      expect(claim?.status).toBe('processing');
+
       // Turn 2 repeats the mistake. This receives a second independent nudge
       // only if the follow-up path reset taskBlockNudged.
       yield { type: 'result', text: '<message to="local-cli">fire two result</message>' };
@@ -538,5 +581,10 @@ describe('task-run turn wiring (real processQuery)', () => {
     expect(logs[1]).toContain('[undelivered → local-cli] fire two result');
     expect(logs).not.toContain('first delivery decision handled');
     expect(logs).not.toContain('second delivery decision handled');
+
+    const completed = getOutboundDb().prepare('SELECT status FROM processing_ack WHERE message_id = ?').get('t2') as
+      | { status: string }
+      | undefined;
+    expect(completed?.status).toBe('completed');
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -2,6 +2,7 @@ import { findByName, getAllDestinations, type DestinationEntry } from './destina
 import {
   getPendingMessages,
   markProcessing,
+  releaseProcessing,
   markCompleted,
   markScriptSkipped,
   type MessageInRow,
@@ -354,11 +355,16 @@ export async function processQuery(
   // Once-per-turn guard for the task-run "<message> block was not delivered"
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
-  // Prompt queue for the exchange hook — each result event consumes the
-  // oldest unanswered prompt, except a wrapping-retry result, which answers
-  // the same prompt again. Unused (and unmaintained) when the provider
-  // doesn't implement `onExchangeComplete`.
-  const archivePrompts: string[] = [initialPrompt];
+  // Each result consumes the oldest prompt and its claimed messages, except a
+  // wrapping retry, which continues the same turn.
+  const pendingTurns: Array<{ prompt: string; messageIds: string[] }> = [
+    { prompt: initialPrompt, messageIds: initialBatchIds },
+  ];
+
+  function completeCurrentPrompt(): void {
+    const turn = pendingTurns.shift();
+    if (turn) markCompleted(turn.messageIds);
+  }
 
   // Concurrent polling: push follow-ups into the active query as they arrive.
   // We do NOT force-end the stream on silence — keeping the query open avoids
@@ -377,6 +383,8 @@ export async function processQuery(
     pollInFlight = true;
 
     void (async () => {
+      let claimedIds: string[] = [];
+      let handedToQuery = false;
       try {
         const pending = getPendingMessages();
 
@@ -409,6 +417,7 @@ export async function processQuery(
 
         const newIds = newMessages.map((m) => m.id);
         markProcessing(newIds);
+        claimedIds = newIds;
 
         // Run pre-task scripts on follow-ups too — without this, a task that
         // arrives during an active query (e.g. a */10 monitoring cron) bypasses
@@ -429,8 +438,8 @@ export async function processQuery(
 
         if (keep.length === 0) return;
         // Re-check done — the outer query may have finished while the script
-        // was awaited. Pushing into a closed stream is wasted work; the
-        // claimed messages get released by the host's processing-claim sweep.
+        // was awaited. Pushing into a closed stream is wasted work; the finally
+        // below releases the claims so the next query can pick them up.
         if (done) return;
 
         const keptIds = keep.map((m) => m.id);
@@ -439,8 +448,8 @@ export async function processQuery(
         unwrappedNudged = false;
         taskBlockNudged = false;
         query.push(prompt);
-        archivePrompts.push(prompt);
-        markCompleted(keptIds);
+        pendingTurns.push({ prompt, messageIds: keptIds });
+        handedToQuery = true;
       } catch (err) {
         // Without this catch the rejection escapes the void IIFE and Node
         // terminates the container on unhandled-rejection. The initial-batch
@@ -474,7 +483,11 @@ export async function processQuery(
           corruptionStreak = 0;
         }
       } finally {
-        pollInFlight = false;
+        try {
+          if (!handedToQuery) releaseProcessing(claimedIds);
+        } finally {
+          pollInFlight = false;
+        }
       }
     })();
   }, ACTIVE_POLL_INTERVAL_MS);
@@ -494,13 +507,9 @@ export async function processQuery(
         // Claude session with no prior context.
         setContinuation(providerName, event.continuation);
       } else if (event.type === 'result') {
-        // A result — with or without text — means the turn is done. Mark
-        // the initial batch completed now so the host sweep doesn't see
-        // stale 'processing' claims while the query stays open for
-        // follow-up pushes. The agent may have responded via MCP
-        // (send_message) mid-turn, or the message may not need a response
-        // at all — either way the turn is finished.
-        markCompleted(initialBatchIds);
+        // A result — with or without text — completes the oldest queued turn.
+        // The agent may have responded via MCP (send_message) mid-turn, or the
+        // message may not need a response at all.
         if (event.text) {
           const { sent, hasUnwrapped, taskBlocks } = dispatchResultText(event.text, routing);
           const willRetryTaskBlocks = shouldNudgeTaskBlocks(routing.taskRun, taskBlocks, taskBlockNudged);
@@ -517,16 +526,16 @@ export async function processQuery(
             // the failing gateway turn after turn.
             deliverErrorResult(event.text, routing);
             notifyExchangeComplete(onExchangeComplete, {
-              prompt: archivePrompts[0] ?? initialPrompt,
+              prompt: pendingTurns[0]?.prompt ?? initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
               status: 'error',
             });
-            archivePrompts.shift();
+            completeCurrentPrompt();
           } else {
             const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
             notifyExchangeComplete(onExchangeComplete, {
-              prompt: archivePrompts[0] ?? initialPrompt,
+              prompt: pendingTurns[0]?.prompt ?? initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
               status: hasUnwrapped || willRetryTaskBlocks ? 'undelivered' : 'completed',
@@ -552,21 +561,22 @@ export async function processQuery(
             // A retry result (wrapping or task-block nudge) answers the SAME
             // user prompt — keep it queued so the retry archives against it,
             // not the nudge text.
-            if (!willRetryWrapping && !willRetryTaskBlocks) archivePrompts.shift();
+            if (!willRetryWrapping && !willRetryTaskBlocks) completeCurrentPrompt();
           }
-        } else archivePrompts.shift();
+        } else completeCurrentPrompt();
       }
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     notifyExchangeComplete(onExchangeComplete, {
-      prompt: archivePrompts[0] ?? initialPrompt,
+      prompt: pendingTurns[0]?.prompt ?? initialPrompt,
       result: `Error: ${errMsg}`,
       continuation: queryContinuation ?? initialContinuation,
       status: 'error',
     });
     throw err;
   } finally {
+    markCompleted(pendingTurns.flatMap((turn) => turn.messageIds));
     done = true;
     clearInterval(pollHandle);
   }

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -489,7 +489,12 @@ export async function processQuery(
           pollInFlight = false;
         }
       }
-    })();
+    })().catch((err) => {
+      log(`Follow-up cleanup failed: ${err instanceof Error ? err.message : String(err)}. Exiting for retry.`);
+      done = true;
+      clearInterval(pollHandle);
+      setTimeout(() => process.exit(75), 100);
+    });
   }, ACTIVE_POLL_INTERVAL_MS);
 
   try {
@@ -576,9 +581,9 @@ export async function processQuery(
     });
     throw err;
   } finally {
-    markCompleted(pendingTurns.flatMap((turn) => turn.messageIds));
     done = true;
     clearInterval(pollHandle);
+    markCompleted(pendingTurns.flatMap((turn) => turn.messageIds));
   }
 
   return { continuation: queryContinuation };

--- a/container/agent-runner/src/upload-trace.test.ts
+++ b/container/agent-runner/src/upload-trace.test.ts
@@ -67,7 +67,7 @@ describe('poll loop — /upload-trace command', () => {
 
 async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
   return Promise.race([
-    runPollLoop({ provider, providerName: 'mock', cwd: '/tmp' }),
+    runPollLoop({ provider, providerName: 'mock', cwd: '/tmp', signal }),
     new Promise<void>((_, reject) => {
       signal.addEventListener('abort', () => reject(new Error('aborted')));
     }),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -492,7 +492,7 @@ If a result produced text but no valid block, the agent-runner pushes a one-time
 
 Message editing is supported as an explicit operation (agent calls an `edit_message` tool), not as a streaming mechanism.
 
-Typing indicators: host sets typing when a container is active for a session, clears when the container exits or a response appears in messages_out.
+Typing indicators: the host starts typing for an engaged inbound message and refreshes it while the session has an active `processing_ack` claim, with a short grace period while a cold container starts. It stops when the turn completes or the container exits.
 
 ### Message Batching
 

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -202,6 +202,11 @@ export function getProcessingClaims(outDb: Database.Database): ProcessingClaim[]
     .all() as ProcessingClaim[];
 }
 
+/** True once the runner has claimed this message, regardless of its final status. */
+export function hasProcessingAck(outDb: Database.Database, messageId: string): boolean {
+  return outDb.prepare('SELECT 1 FROM processing_ack WHERE message_id = ?').get(messageId) !== undefined;
+}
+
 /**
  * Delete orphan 'processing' rows. Called by the host after killing a
  * container so the leftover claim doesn't trip claim-stuck on the next sweep

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -32,7 +32,7 @@ import { isUnguarded, type Unguarded } from './guard/index.js';
 import { log } from './log.js';
 import { normalizeOptions } from './channels/ask-question.js';
 import { clearOutbox, openInboundDb, openOutboundDb, readOutboxFiles } from './session-manager.js';
-import { pauseTypingRefreshAfterDelivery, setTypingAdapter } from './modules/typing/index.js';
+import { setTypingAdapter } from './modules/typing/index.js';
 import type { OutboundFile } from './channels/adapter.js';
 import type { PendingApproval, Session } from './types.js';
 
@@ -204,16 +204,6 @@ async function drainSession(session: Session): Promise<void> {
         const platformMsgId = await deliverMessage(msg, session, inDb);
         markDelivered(inDb, msg.id, platformMsgId ?? null);
         deliveryAttempts.delete(msg.id);
-
-        // Pause the typing indicator after a real user-facing message
-        // lands on the user's screen, so the client has time to visually
-        // clear the indicator before the next heartbeat tick brings it
-        // back. Skip the pause for internal traffic (system actions,
-        // agent-to-agent routing) — the user doesn't see those and
-        // shouldn't get a gap in their typing indicator for them.
-        if (msg.kind !== 'system' && msg.channel_type !== 'agent') {
-          pauseTypingRefreshAfterDelivery(session.id);
-        }
       } catch (err) {
         const attempts = (deliveryAttempts.get(msg.id) ?? 0) + 1;
         deliveryAttempts.set(msg.id, attempts);

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -1,12 +1,15 @@
 /**
- * Typing-refresh instance forwarding tests.
+ * Typing-refresh behavior tests.
  *
  * Three tick sites can fire setTyping — the immediate tick on a new
  * refresher, the 4s interval tick, and the immediate re-trigger when
  * startTypingRefresh is called for an already-refreshing session. All three
  * must forward the adapter instance, or a named instance's typing indicator
- * fires through the wrong bot.
+ * fires through the wrong bot. The lifecycle case also verifies that a live
+ * processing claim keeps refreshes alive through a silent provider wait.
  */
+import fs from 'fs';
+
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 
 vi.mock('../../config.js', async () => {
@@ -14,6 +17,7 @@ vi.mock('../../config.js', async () => {
   return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-typing' };
 });
 
+import { initSessionFolder, openOutboundDbRw } from '../../session-manager.js';
 import { setTypingAdapter, startTypingRefresh, stopTypingRefresh } from './index.js';
 
 type Call = { channelType: string; platformId: string; threadId: string | null; instance?: string };
@@ -29,18 +33,20 @@ function captureAdapter() {
 }
 
 beforeEach(() => {
+  fs.rmSync('/tmp/nanoclaw-test-typing', { recursive: true, force: true });
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   stopTypingRefresh('sess-1');
   vi.useRealTimers();
+  fs.rmSync('/tmp/nanoclaw-test-typing', { recursive: true, force: true });
 });
 
 describe('startTypingRefresh — instance forwarding', () => {
   it('immediate tick passes the instance to the adapter', async () => {
     const calls = captureAdapter();
-    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-tester');
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'slack', 'slack:C1', null, 'slack-tester');
     await vi.advanceTimersByTimeAsync(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({
@@ -53,7 +59,7 @@ describe('startTypingRefresh — instance forwarding', () => {
 
   it('interval ticks inside the grace window pass the stored entry instance', async () => {
     const calls = captureAdapter();
-    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
     await vi.advanceTimersByTimeAsync(0);
     calls.length = 0;
 
@@ -69,12 +75,12 @@ describe('startTypingRefresh — instance forwarding', () => {
 
   it('re-trigger on an active session passes (and stores) the new instance', async () => {
     const calls = captureAdapter();
-    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-tester');
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'slack', 'slack:C1', null, 'slack-tester');
     await vi.advanceTimersByTimeAsync(0);
     calls.length = 0;
 
     // Second call for the same session: immediate tick with the new value.
-    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', null, 'slack-worker');
+    startTypingRefresh('sess-1', 'ag-1', 'message-2', 'slack', 'slack:C1', null, 'slack-worker');
     await vi.advanceTimersByTimeAsync(0);
     expect(calls).toHaveLength(1);
     expect(calls[0].instance).toBe('slack-worker');
@@ -88,7 +94,7 @@ describe('startTypingRefresh — instance forwarding', () => {
 
   it('re-trigger with a changed address updates the whole entry — interval ticks stay self-consistent', async () => {
     const calls = captureAdapter();
-    startTypingRefresh('sess-1', 'ag-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'slack', 'slack:C1', 'T1', 'slack-tester');
     await vi.advanceTimersByTimeAsync(0);
     calls.length = 0;
 
@@ -96,7 +102,7 @@ describe('startTypingRefresh — instance forwarding', () => {
     // (agent-shared sessions span messaging groups). The stored entry must
     // not tear: keeping the old address with the new instance would hand a
     // telegram platformId to the slack-tester adapter on the next tick.
-    startTypingRefresh('sess-1', 'ag-1', 'telegram', 'tg:99', null, 'telegram');
+    startTypingRefresh('sess-1', 'ag-1', 'message-2', 'telegram', 'tg:99', null, 'telegram');
     await vi.advanceTimersByTimeAsync(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({
@@ -119,5 +125,52 @@ describe('startTypingRefresh — instance forwarding', () => {
         instance: 'telegram',
       });
     }
+  });
+});
+
+describe('startTypingRefresh — turn lifecycle', () => {
+  it('keeps refreshing through silent work and stops when the turn completes', async () => {
+    initSessionFolder('ag-1', 'sess-1');
+    const db = openOutboundDbRw('ag-1', 'sess-1');
+    db.prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)').run(
+      'message-1',
+      'processing',
+      new Date().toISOString(),
+    );
+    db.close();
+
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'telegram', 'tg:99', null, 'telegram');
+
+    // Cross the 15s cold-start grace period without heartbeat updates.
+    // The processing claim must keep the 4s refresh alive.
+    await vi.advanceTimersByTimeAsync(20_500);
+    expect(calls).toHaveLength(6);
+
+    const completedDb = openOutboundDbRw('ag-1', 'sess-1');
+    completedDb.prepare("UPDATE processing_ack SET status = 'completed' WHERE message_id = 'message-1'").run();
+    completedDb.close();
+
+    const callsAtCompletion = calls.length;
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(calls).toHaveLength(callsAtCompletion);
+  });
+
+  it('does not refresh after a fast turn completes inside startup grace', async () => {
+    initSessionFolder('ag-1', 'sess-1');
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'telegram', 'tg:99', null, 'telegram');
+    await vi.advanceTimersByTimeAsync(0);
+
+    const db = openOutboundDbRw('ag-1', 'sess-1');
+    db.prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)').run(
+      'message-1',
+      'completed',
+      new Date().toISOString(),
+    );
+    db.close();
+
+    await vi.advanceTimersByTimeAsync(4_500);
+    expect(calls).toHaveLength(1);
   });
 });

--- a/src/modules/typing/index.test.ts
+++ b/src/modules/typing/index.test.ts
@@ -173,4 +173,33 @@ describe('startTypingRefresh — turn lifecycle', () => {
     await vi.advanceTimersByTimeAsync(4_500);
     expect(calls).toHaveLength(1);
   });
+
+  it('ignores processing claims from a different message', async () => {
+    initSessionFolder('ag-1', 'sess-1');
+    const db = openOutboundDbRw('ag-1', 'sess-1');
+    const insert = db.prepare('INSERT INTO processing_ack (message_id, status, status_changed) VALUES (?, ?, ?)');
+    insert.run('message-1', 'completed', new Date().toISOString());
+    insert.run('message-2', 'processing', new Date().toISOString());
+    db.close();
+
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'telegram', 'tg:99', null, 'telegram');
+
+    await vi.advanceTimersByTimeAsync(4_500);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('retries after processing state cannot be read', async () => {
+    initSessionFolder('ag-1', 'sess-1');
+    const calls = captureAdapter();
+    startTypingRefresh('sess-1', 'ag-1', 'message-1', 'telegram', 'tg:99', null, 'telegram');
+    fs.rmSync('/tmp/nanoclaw-test-typing', { recursive: true, force: true });
+
+    await vi.advanceTimersByTimeAsync(20_500);
+    expect(calls).toHaveLength(6);
+
+    initSessionFolder('ag-1', 'sess-1');
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(calls).toHaveLength(6);
+  });
 });

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -4,12 +4,8 @@
  * Most platforms expire a typing indicator after 5–10s, so a one-shot
  * call on message arrival goes stale long before the agent finishes
  * thinking. This module keeps it alive by re-firing `setTyping` on a
- * short interval — but only while the agent is actually WORKING, gated
- * on the heartbeat file's mtime after an initial grace period.
- *
- * After delivering a user-facing message, the refresh is paused for
- * POST_DELIVERY_PAUSE_MS so the client-side indicator can visually
- * clear.
+ * short interval — but only while the agent has a turn in progress,
+ * after an initial grace period for cold container startup.
  *
  * Default module status:
  *   - Lives in src/modules/ for signaling (not really core), but ships
@@ -17,32 +13,16 @@
  *   - Removing requires editing src/router.ts, src/delivery.ts, and
  *     src/container-runner.ts to drop the calls.
  */
-import fs from 'fs';
-
-import { heartbeatPath } from '../../session-manager.js';
+import { getProcessingClaims, hasProcessingAck } from '../../db/session-db.js';
+import { openOutboundDb } from '../../session-manager.js';
 
 const TYPING_REFRESH_MS = 4000;
 /**
  * Grace window from startTypingRefresh: fire typing unconditionally
- * for this long regardless of heartbeat state. Covers container
- * spawn/wake latency (5–12s on cold start before first heartbeat).
+ * for this long regardless of processing state. Covers container
+ * spawn/wake latency before the runner claims the message.
  */
 const TYPING_GRACE_MS = 15000;
-/**
- * After the grace window, a heartbeat must be mtimed within this
- * many ms of now to count as "agent is working." Heartbeats land
- * every few hundred ms during active work, so 6s is well above
- * the working floor and small enough to stop typing quickly when
- * the agent goes idle.
- */
-const HEARTBEAT_FRESH_MS = 6000;
-/**
- * After we deliver a user-facing message, pause typing for this
- * long so the client-side indicator has time to visually clear.
- * Tuned for the longest common expiry (Discord ~10s). The interval
- * stays running; ticks inside the pause just skip the setTyping call.
- */
-const POST_DELIVERY_PAUSE_MS = 10000;
 
 interface TypingAdapter {
   setTyping?(channelType: string, platformId: string, threadId: string | null, instance?: string): Promise<void>;
@@ -50,6 +30,7 @@ interface TypingAdapter {
 
 interface TypingTarget {
   agentGroupId: string;
+  messageId: string;
   channelType: string;
   platformId: string;
   threadId: string | null;
@@ -57,7 +38,6 @@ interface TypingTarget {
   instance?: string;
   interval: NodeJS.Timeout;
   startedAt: number;
-  pausedUntil: number; // epoch ms; 0 = not paused
 }
 
 let adapter: TypingAdapter | null = null;
@@ -87,19 +67,28 @@ async function triggerTyping(
   }
 }
 
-function isHeartbeatFresh(agentGroupId: string, sessionId: string): boolean {
-  const hbPath = heartbeatPath(agentGroupId, sessionId);
+function shouldRefreshTyping(
+  agentGroupId: string,
+  sessionId: string,
+  messageId: string,
+  withinGrace: boolean,
+): boolean {
   try {
-    const stat = fs.statSync(hbPath);
-    return Date.now() - stat.mtimeMs < HEARTBEAT_FRESH_MS;
+    const db = openOutboundDb(agentGroupId, sessionId);
+    try {
+      return getProcessingClaims(db).length > 0 || (withinGrace && !hasProcessingAck(db, messageId));
+    } finally {
+      db.close();
+    }
   } catch {
-    return false;
+    return withinGrace;
   }
 }
 
 export function startTypingRefresh(
   sessionId: string,
   agentGroupId: string,
+  messageId: string,
   channelType: string,
   platformId: string,
   threadId: string | null,
@@ -109,12 +98,10 @@ export function startTypingRefresh(
   if (existing) {
     // Already refreshing. Fire an immediate tick for the new inbound
     // event and reset the grace window — the new message restarts
-    // the container-wake latency budget. Also clear any lingering
-    // post-delivery pause: a new inbound means the user expects
-    // typing to show immediately.
+    // the container-wake latency budget.
     triggerTyping(channelType, platformId, threadId, instance).catch(() => {});
     existing.startedAt = Date.now();
-    existing.pausedUntil = 0;
+    existing.messageId = messageId;
     // Keep the stored entry self-consistent: a re-trigger can arrive from
     // a different chat address (agent-shared sessions span messaging
     // groups, possibly on different platforms/instances), so the address
@@ -135,18 +122,13 @@ export function startTypingRefresh(
     const entry = typingRefreshers.get(sessionId);
     if (!entry) return; // stopped externally since this tick was scheduled
 
-    // Inside a post-delivery pause: skip setTyping but keep the
-    // interval running so we resume automatically once the pause
-    // expires.
-    if (entry.pausedUntil > Date.now()) return;
-
     const withinGrace = Date.now() - entry.startedAt < TYPING_GRACE_MS;
-    if (withinGrace || isHeartbeatFresh(entry.agentGroupId, sessionId)) {
+    if (shouldRefreshTyping(entry.agentGroupId, sessionId, entry.messageId, withinGrace)) {
       triggerTyping(entry.channelType, entry.platformId, entry.threadId, entry.instance).catch(() => {});
       return;
     }
 
-    // Out of grace AND heartbeat stale — agent is idle, stop refreshing.
+    // Out of grace and no active turn — the agent is idle.
     clearInterval(entry.interval);
     typingRefreshers.delete(sessionId);
   }, TYPING_REFRESH_MS);
@@ -154,26 +136,14 @@ export function startTypingRefresh(
   interval.unref();
   typingRefreshers.set(sessionId, {
     agentGroupId,
+    messageId,
     channelType,
     platformId,
     threadId,
     instance,
     interval,
     startedAt,
-    pausedUntil: 0,
   });
-}
-
-/**
- * Pause the typing refresh for POST_DELIVERY_PAUSE_MS. Called after
- * a user-facing message is delivered so the client-side indicator
- * has a chance to visually clear before the agent's next SDK event
- * pushes it back on. No-op if no refresh is active for this session.
- */
-export function pauseTypingRefreshAfterDelivery(sessionId: string): void {
-  const entry = typingRefreshers.get(sessionId);
-  if (!entry) return;
-  entry.pausedUntil = Date.now() + POST_DELIVERY_PAUSE_MS;
 }
 
 export function stopTypingRefresh(sessionId: string): void {

--- a/src/modules/typing/index.ts
+++ b/src/modules/typing/index.ts
@@ -76,12 +76,16 @@ function shouldRefreshTyping(
   try {
     const db = openOutboundDb(agentGroupId, sessionId);
     try {
-      return getProcessingClaims(db).length > 0 || (withinGrace && !hasProcessingAck(db, messageId));
+      return (
+        getProcessingClaims(db).some((claim) => claim.message_id === messageId) ||
+        (withinGrace && !hasProcessingAck(db, messageId))
+      );
     } finally {
       db.close();
     }
   } catch {
-    return withinGrace;
+    // A transient read failure is not evidence that the turn ended.
+    return true;
   }
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -504,8 +504,9 @@ async function deliverToAgent(
     }
   }
 
+  const messageId = messageIdForAgent(event.message.id, agent.agent_group_id);
   writeSessionMessage(session.agent_group_id, session.id, {
-    id: messageIdForAgent(event.message.id, agent.agent_group_id),
+    id: messageId,
     kind: event.message.kind,
     timestamp: event.message.timestamp,
     platformId: deliveryAddr.platformId,
@@ -533,6 +534,7 @@ async function deliverToAgent(
     startTypingRefresh(
       session.id,
       session.agent_group_id,
+      messageId,
       event.channelType,
       event.platformId,
       effectiveThreadId,


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Keep the typing indicator active for the full lifetime of a foreground user turn, then stop refreshing it as soon as that turn completes.

### Why

The host previously used container heartbeat freshness to refresh typing. A heartbeat proves that the container is alive, not that a user turn is still running. During long, silent work, the platform's typing action could therefore expire and make the agent appear stuck.

Closes #1805.

### How

- Use the tracked message's existing `processing_ack` claim after a short cold-start grace period.
- Keep follow-up claims active until their provider result completes, and release claims abandoned before reaching the query.
- Stop follow-up polling before the final acknowledgement, and restart safely if claim cleanup cannot complete.
- Retry transient host-side claim read failures on the next normal typing tick.
- Remove the delivery-time pause; the completed claim now stops typing directly.

This is channel-generic: every adapter implementing the existing `setTyping` method benefits. Scheduled tasks remain isolated in their own sessions and do not start typing.

### Verification

- GitHub CI passed.
- Host build and TypeScript checks passed.
- Host suite: 94 files, 1,155 tests passed.
- Agent-runner suite: 155 passed, 1 skipped.
- Focused typing tests: 8 passed.
- Focused poll-loop and upload-trace tests: 39 passed.
- Changed files pass formatting and lint with 0 errors.

Repo-wide lint retains the existing baseline of 10 errors and 119 warnings.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
