### PR TITLE
fix(telegram): retry transient bot identity lookup

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelSetup, InboundMessage } from './adapter.js';
+
+const bridgeSetup = vi.hoisted(() => vi.fn());
+
+vi.mock('@chat-adapter/telegram', () => ({
+  createTelegramAdapter: () => ({}),
+}));
+
+vi.mock('../env.js', () => ({
+  readEnvFile: () => ({ TELEGRAM_BOT_TOKEN: 'test-token' }),
+}));
+
+vi.mock('./chat-sdk-bridge.js', () => ({
+  createChatSdkBridge: () => ({
+    name: 'telegram',
+    channelType: 'telegram',
+    supportsThreads: false,
+    setup: bridgeSetup,
+    teardown: vi.fn(),
+    isConnected: () => true,
+    deliver: vi.fn(),
+  }),
+}));
+
+vi.mock('../db/messaging-groups.js', () => ({
+  getMessagingGroupByPlatform: () => ({ id: 'mg-1' }),
+  updateMessagingGroup: vi.fn(),
+  createMessagingGroup: vi.fn(),
+}));
+
+vi.mock('../modules/permissions/db/user-roles.js', () => ({
+  hasAnyOwner: () => true,
+  grantRole: vi.fn(),
+}));
+
+vi.mock('../modules/permissions/db/users.js', () => ({
+  upsertUser: vi.fn(),
+}));
+
+import { initChannelAdapters, teardownChannelAdapters } from './channel-registry.js';
+import { _resetForTest, _setStorePathForTest, createPairing, getStatus } from './telegram-pairing.js';
+import './telegram.js';
+
+const hostSetup: ChannelSetup = {
+  onInbound: vi.fn(),
+  onInboundEvent: vi.fn(),
+  onMetadata: vi.fn(),
+  onAction: vi.fn(),
+};
+
+let tmpDir: string;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-adapter-'));
+  _setStorePathForTest(path.join(tmpDir, 'pairings.json'));
+  bridgeSetup.mockClear();
+  vi.mocked(hostSetup.onInbound).mockClear();
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  _resetForTest();
+  _setStorePathForTest(null);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('telegram pairing identity lookup', () => {
+  it('recovers from a transient getMe failure without weakening bot-name matching', async () => {
+    let getMeCalls = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/getMe')) {
+        getMeCalls += 1;
+        if (getMeCalls === 1) throw new TypeError('fetch failed');
+        return new Response(JSON.stringify({ ok: true, result: { username: 'realbot' } }));
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await initChannelAdapters(() => hostSetup);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(getMeCalls).toBe(2);
+
+    const intercepted = bridgeSetup.mock.calls[0]?.[0] as ChannelSetup;
+    const accepted = await createPairing('main');
+    await intercepted.onInbound('telegram:123', null, inbound(`@realbot ${accepted.code}`));
+    expect(getStatus(accepted.code)).toBe('consumed');
+
+    const rejected = await createPairing('main');
+    await intercepted.onInbound('telegram:123', null, inbound(`@otherbot ${rejected.code}`));
+    expect(getStatus(rejected.code)).toBe('pending');
+    expect(getMeCalls).toBe(2);
+  });
+});
+
+function inbound(text: string): InboundMessage {
+  return {
+    id: 'message-1',
+    kind: 'chat-sdk',
+    content: { text, author: { userId: 'user-1' } },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -59,16 +59,11 @@ function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
   };
 }
 
-/** Look up the bot username via Telegram getMe. Cached after first call. */
+/** Look up the bot username via Telegram getMe. */
 async function fetchBotUsername(token: string): Promise<string | null> {
-  try {
-    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
-    const json = (await res.json()) as { ok: boolean; result?: { username?: string } };
-    return json.ok ? (json.result?.username ?? null) : null;
-  } catch (err) {
-    log.warn('Telegram getMe failed', { err });
-    return null;
-  }
+  const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+  const json = (await res.json()) as { ok: boolean; result?: { username?: string } };
+  return json.ok ? (json.result?.username ?? null) : null;
 }
 
 function isGroupPlatformId(platformId: string): boolean {
@@ -228,7 +223,10 @@ registerChannelAdapter('telegram', {
       maxTextLength: 4000,
     });
 
-    const botUsernamePromise = fetchBotUsername(token);
+    const botUsernamePromise = withRetry(() => fetchBotUsername(token), 'getMe').catch((err) => {
+      log.warn('Telegram getMe failed', { err });
+      return null;
+    });
 
     const wrapped: ChannelAdapter = {
       ...bridge,


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### What

Retry Telegram's startup `getMe` request when it fails because of a transient network error.

### Why

Telegram pairing resolves the bot username once and caches the resulting promise. Previously, the first network failure was caught and converted to `null`, so that failed result was cached for the lifetime of the process. Valid pairing codes were then passed through as normal messages and pairing could not recover until NanoClaw restarted.

### How

Reuse Telegram's existing bounded `withRetry` helper for `getMe`: at most five attempts with exponential backoff. A successful username remains cached, exact `@botname` matching is unchanged, and a persistent outage still fails open to normal message handling after the retry limit.

No new state, dependency, retry helper, or background loop is introduced.

### Verification

- Focused Telegram suites: 28 tests passed.
- The regression test proves that `getMe` can fail once and succeed on retry, the real bot name is accepted, a different bot name is rejected, and no extra lookup occurs after success.
- Formatting passed; focused lint has 0 errors.

The `channels` branch's full build remains blocked by its existing unresolved `@deltachat/stdio-rpc-server` import. Its full test run reached 429 passing tests with 11 unrelated channel-registration failures; all focused Telegram tests are green.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
