### PR TITLE
docs: rewrite branch maintenance guide for the registry-branch model

### DIFF
--- a/docs/BRANCH-FORK-MAINTENANCE.md
+++ b/docs/BRANCH-FORK-MAINTENANCE.md
@@ -1,30 +1,34 @@
-# Branch & Fork Maintenance Guidelines
+# Branch and fork maintenance
+
+How the long-lived branches on `nanocoai/nanoclaw` relate to `main` and how to keep them in sync. This is the maintainer view: [skills-model.md](skills-model.md) explains the customization model itself, and [CONTRIBUTING.md](../CONTRIBUTING.md) covers contributing a channel or provider.
 
 ## Structure
 
-**`nanocoai/nanoclaw`** (upstream) — core engine with skill definitions (`.claude/skills/`). No channel code on `main`.
+**`main`** — core engine plus skill definitions (`.claude/skills/`). It carries the shared channel machinery every install needs (`src/channels/`: adapter interface, channel registry, Chat SDK bridge, CLI channel, ask-question flow, channel defaults) and the default Claude provider — but no optional channel adapters and no alternative providers.
 
-**Channel forks** (`nanoclaw-whatsapp`, `nanoclaw-telegram`, `nanoclaw-slack`, etc.) — each fork = upstream + one channel's code applied. Users clone upstream, then merge a fork into their clone to add a channel.
+**Registry branches** (`channels`, `providers`) — long-lived branches carrying the code that channel and provider skills install. `channels` holds every channel adapter with its tests (`src/channels/telegram.ts`, `src/channels/telegram-registration.test.ts`, …); `providers` holds the alternative agent providers (OpenCode, Codex). The `/add-*` skills on `main` fetch files from these branches (`git show origin/channels:<path> > <path>`) — an additive copy into the user's clone, never a merge. (Not every provider needs branch code: `/add-ollama-provider` is configuration-only and redirects the built-in Claude path.)
 
-**`skill/*` and `feat/*` branches on upstream** — add features unrelated to channels (e.g. `skill/compact`, `skill/apple-container`). Users merge these into their clone to add capabilities. Channel-specific skill branches that duplicate the forks (e.g. `skill/whatsapp`, `skill/telegram`) are legacy.
+**Legacy mechanisms** — the channel fork repos (`nanoclaw-whatsapp`, `nanoclaw-telegram`, …) and the `skill/*` branches (`skill/compact`, `skill/apple-container`, …) are the pre-skills delivery model: applied code that users merged into their clones. They are frozen (no forward merges since spring 2026) and superseded by the registry branches and `/add-*` skills. Don't build on them and don't forward-merge them.
 
 ## How users add capabilities
 
 ```
 user clones upstream main
-  ├── merges nanoclaw-whatsapp fork  → adds WhatsApp
-  ├── merges skill/compact branch    → adds /compact command
-  └── merges skill/apple-container   → switches to Apple Container
+  ├── runs /add-whatsapp   → skill copies the adapter in from the channels branch
+  ├── runs /add-opencode   → skill copies the provider in from the providers branch
+  └── runs /add-<tool>     → skill copies files in from its own folder
 ```
+
+Registry-backed installs are additive fetch-and-copies; other skills ship their files in their own folder or are instruction-only. Either way a user's clone never merges a registry branch, and registry branches are never merged back into `main`. [skills-model.md](skills-model.md) explains why.
 
 ## Merge directions
 
 ```
-upstream main ──→ channel forks     (forward merge to keep forks caught up)
-upstream main ──→ skill branches    (forward merge to keep branches caught up)
+upstream main ──→ channels     (forward merge to keep adapters building against current core)
+upstream main ──→ providers    (forward merge, same reason)
 ```
 
-Forks and skill branches carry applied code changes. Users merge them into their own clones/forks to add capabilities. They are never merged back into upstream `main`.
+Fixes to existing adapters and providers land as PRs based directly on the registry branch. New channels and providers are contributed from a branch off `main` (see [Adding a new channel or provider](#adding-a-new-channel-or-provider)); maintainers land the code portion on the registry branch. Nothing merges back into `main`.
 
 ## Forward merge procedure
 
@@ -32,50 +36,42 @@ Forks and skill branches carry applied code changes. Users merge them into their
 # In your local nanoclaw checkout
 git checkout main && git pull
 
-# For a fork:
-git fetch nanoclaw-whatsapp
-git checkout -B whatsapp-merge nanoclaw-whatsapp/main
+git checkout -B channels origin/channels
 git merge main
 # Resolve conflicts (see below)
-# Remove upstream-only workflows (re-added by every merge since main has them):
-git rm .github/workflows/bump-version.yml .github/workflows/update-tokens.yml 2>/dev/null
-git push nanoclaw-whatsapp HEAD:main
-git checkout main && git branch -D whatsapp-merge
-
-# For a skill branch:
-git checkout -B skill/compact origin/skill/compact
-git merge main
-# Resolve conflicts (see below)
-git push origin skill/compact
-git checkout main && git branch -D skill/compact
+git push origin channels
+git checkout main && git branch -D channels
 ```
+
+Same procedure for `providers`.
+
+This procedure assumes the branch is reasonably current. A registry branch left unmerged for months will conflict far beyond the table below — treat a large catch-up as its own reviewed effort, build and test both branches afterward, and update the table from that merge's actual receipts.
 
 ## Conflict resolution
 
-The same files conflict every time:
+Files with known mechanical resolutions:
 
 | File | Resolution |
 |------|------------|
-| `package.json` | Take main's version + keep fork/branch-specific deps |
+| `package.json` | Take main's version + keep branch-specific deps |
 | `pnpm-lock.yaml` | `git checkout main -- pnpm-lock.yaml && pnpm install` |
-| `.env.example` | Combine: main's entries + fork/branch-specific entries |
+| `.env.example` | Combine: main's entries + branch-specific entries |
 | `repo-tokens/badge.svg` | Take main's version (auto-generated) |
 
 Source code changes (e.g. `src/types.ts`, `src/index.ts`) usually auto-merge cleanly, but can conflict if both sides modify the same lines. **Always build and test after every forward merge** — auto-merged code can be silently wrong (e.g. referencing a renamed function or using a removed parameter) even when git reports no conflicts.
 
 ## When to merge forward
 
-After any main change that touches shared files (`package.json`, `src/index.ts`, `CLAUDE.md`, etc.). Small frequent merges = trivial conflicts. Large infrequent merges = painful.
+After any main change that touches shared files (`package.json`, `src/index.ts`, `CLAUDE.md`, etc.). Small frequent merges = trivial conflicts. Large infrequent merges = painful. A registry branch that drifts far behind main also means every `/add-*` install copies in code written against an old core.
 
-## Fork setup
+## Adding a new channel or provider
 
-When creating a new channel fork:
+Skills replaced fork setup. The short version ([CONTRIBUTING.md](../CONTRIBUTING.md) has the full flow):
 
-1. Fork `nanoclaw` to `nanoclaw-{channel}`
-2. Remove upstream-only workflows: `bump-version.yml`, `update-tokens.yml`
-3. Add channel code, deps, env vars
-4. Forward-merge main immediately to establish a clean baseline
+1. Build the adapter or provider following [skill-guidelines.md](skill-guidelines.md): a self-registering module, one appended barrel import, and a registration test that imports the real barrel.
+2. Write the `/add-<name>` skill in `.claude/skills/` on `main` — a SKILL.md with the fetch-and-copy steps and a REMOVE.md that reverses them.
+3. Open a PR from a branch off `main`; maintainers land the code portion on the registry branch.
 
 ## Dependencies
 
-Forks and branches add their own deps on top of upstream's. When upstream adds or removes a dependency, verify that forks/branches still build after the next forward merge — transitive dependency changes can break downstream code.
+Registry branches add their own deps on top of upstream's. Skill `nc:dep` directives pin exact versions at install time (the supply-chain policy rejects ranges and `latest`). When upstream adds or removes a dependency, verify the registry branches still build after the next forward merge — transitive dependency changes can break adapter code.


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

docs/BRANCH-FORK-MAINTENANCE.md still describes the old delivery model: users merging channel fork repos (nanoclaw-whatsapp and friends) and skill/* branches into their clones. That model was replaced by the registry branches (channels, providers) plus the /add-* skills, and this file never caught up. The extend pages on docs.nanoclaw.dev already describe the current model; this doc was the last holdout.

What the rewrite says:

- main is the core engine plus skill definitions. Shared channel machinery and the default Claude provider stay in core; optional adapters and alternative providers do not.
- channels and providers are registry branches. Skills copy files from them (`git show origin/channels:<path>`), and nothing ever merges them.
- The old channel fork repos and skill/* branches are marked legacy, frozen since spring 2026.
- The forward-merge procedure now targets the registry branches, with a warning that a branch left unmerged for a long time conflicts far beyond the usual table and a large catch-up should be planned as its own reviewed effort.
- The dependency section now describes the nc:dep exact-version pinning instead of claiming everything is pinned.

The doc stays timeless on purpose: no point-in-time drift numbers in the committed record. Current branch state belongs in a tracking issue, which I will file separately.

Verified against main 0b034342, channels 6ee516ad, providers f2b75837. The install mechanism is code, not just prose: setup/install-github.sh runs the literal `git fetch origin channels` and `git show origin/channels:...` copy, and setup/lib/channels-remote.sh exists only to resolve the remote for those copies.

Needs a colleague review before merge.

Assisted by Claude; reviewed and verified by a human before submission.
