### PR TITLE
fix(cli): render structured role-change approval cards

### DIFF
--- a/src/cli/approval-cards.ts
+++ b/src/cli/approval-cards.ts
@@ -1,0 +1,75 @@
+/**
+ * Action-specific approval-card renderers for `access:'approval'` CLI commands.
+ *
+ * The dispatcher (dispatch.ts) gates approval-required commands behind an admin
+ * card. By default that card just echoes the raw `ncl <command> <args>` line —
+ * fine for a benign command, opaque for a sensitive one (a privilege change
+ * shows a namespaced handle, no effect, no before/after).
+ *
+ * This module is the seam: a sensitive command registers a builder keyed by its
+ * command name; the builder returns a structured `{ title, question }` the
+ * dispatcher uses in place of the generic wording. Commands without a builder
+ * render exactly as before. Role grant/revoke is the first consumer; the actual
+ * role-change summary + wording lives in the permissions module so Issue C's
+ * routing can reuse it.
+ */
+import { getMessagingGroup } from '../db/messaging-groups.js';
+import { describeRoleChange, renderRoleChangeCard, type RoleChangeOp } from '../modules/permissions/role-change.js';
+import type { Session } from '../types.js';
+
+export interface ApprovalCard {
+  title: string;
+  question: string;
+}
+
+export interface ApprovalCardContext {
+  command: string;
+  args: Record<string, unknown>;
+  agentName: string;
+  session: Session;
+}
+
+type ApprovalCardBuilder = (ctx: ApprovalCardContext) => ApprovalCard;
+
+const builders = new Map<string, ApprovalCardBuilder>();
+
+/** Register a structured card builder for a specific `access:'approval'` command. */
+export function registerApprovalCard(command: string, builder: ApprovalCardBuilder): void {
+  builders.set(command, builder);
+}
+
+/**
+ * Build a structured approval card for `ctx.command`, or undefined when no
+ * builder is registered (dispatcher falls back to the generic raw-command card).
+ */
+export function buildApprovalCard(ctx: ApprovalCardContext): ApprovalCard | undefined {
+  return builders.get(ctx.command)?.(ctx);
+}
+
+/** Reconstruct the raw command line for the card's secondary "Command:" detail. */
+function rawCommandLine(command: string, args: Record<string, unknown>): string {
+  const argStr = Object.entries(args)
+    .map(([k, v]) => `--${k} ${v}`)
+    .join(' ');
+  return `ncl ${command}${argStr ? ' ' + argStr : ''}`;
+}
+
+/** Human-readable origin channel for a session, e.g. `slack (T012/C345)`. */
+function channelOf(session: Session): string {
+  const mg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+  if (mg) return `${mg.channel_type} (${mg.platform_id})`;
+  return session.messaging_group_id ?? 'direct (agent)';
+}
+
+// ── Registered builders ──
+
+for (const op of ['grant', 'revoke'] as const satisfies readonly RoleChangeOp[]) {
+  registerApprovalCard(`roles-${op}`, (ctx) => {
+    const summary = describeRoleChange(op, ctx.args);
+    return renderRoleChangeCard(summary, {
+      agentName: ctx.agentName,
+      channel: channelOf(ctx.session),
+      commandLine: rawCommandLine(ctx.command, ctx.args),
+    });
+  });
+}

--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -64,6 +64,14 @@ vi.mock('../modules/approvals/index.js', () => ({
   requestApproval: approvalState.requestApproval,
 }));
 
+// The approval-card hook is exercised in its own suite; here we mock it to
+// assert dispatch wires its structured card into requestApproval and falls
+// back to the generic raw-command card when the hook returns nothing.
+const mockBuildApprovalCard = vi.fn();
+vi.mock('./approval-cards.js', () => ({
+  buildApprovalCard: (...args: unknown[]) => mockBuildApprovalCard(...args),
+}));
+
 // Register a test command so dispatch has something to find
 import { register } from './registry.js';
 
@@ -230,8 +238,20 @@ register({
   handler: async (args) => ({ echo: args }),
 });
 
+// An approval-gated command (like `roles-grant`) to exercise the approval branch
+// and the structured approval-card wiring.
+register({
+  name: 'roles-grant',
+  description: 'test approval command',
+  resource: 'roles',
+  access: 'approval',
+  parseArgs: (raw) => raw,
+  handler: async (args) => ({ echo: args }),
+});
+
 import { dispatch } from './dispatch.js';
 import type { CallerContext } from './frame.js';
+import { requestApproval } from '../modules/approvals/index.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -994,5 +1014,48 @@ describe('formatHuman hook', () => {
 
     expect(resp.ok).toBe(true);
     if (resp.ok) expect(resp.human).toBeUndefined();
+  });
+});
+
+describe('approval card wiring', () => {
+  beforeEach(() => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'global' }); // roles isn't group-whitelisted
+    mockGetSession.mockReturnValue({ id: 's1', agent_group_id: 'g1', messaging_group_id: 'mg1' });
+    mockGetAgentGroup.mockReturnValue({ id: 'g1', name: 'corp-bot' });
+  });
+
+  it('uses the structured card from the hook when one is returned', async () => {
+    mockBuildApprovalCard.mockReturnValue({ title: 'Role grant: admin', question: 'structured body' });
+
+    const resp = await dispatch(
+      { id: '1', command: 'roles-grant', args: { user: 'slack:U0', role: 'admin' } },
+      agentCtx(),
+    );
+
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) expect(resp.error.code).toBe('approval-pending');
+    expect(mockBuildApprovalCard).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'roles-grant', agentName: 'corp-bot' }),
+    );
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'cli_command',
+        title: 'Role grant: admin',
+        question: 'structured body',
+      }),
+    );
+  });
+
+  it('falls back to the generic raw-command card when the hook returns nothing', async () => {
+    mockBuildApprovalCard.mockReturnValue(undefined);
+
+    await dispatch({ id: '1', command: 'roles-grant', args: { user: 'slack:U0', role: 'admin' } }, agentCtx());
+
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'CLI: roles-grant',
+        question: expect.stringContaining('ncl roles-grant --user slack:U0 --role admin'),
+      }),
+    );
   });
 });

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -18,6 +18,7 @@ import { getSession } from '../db/sessions.js';
 import { guard, type GuardActor } from '../guard/index.js';
 import { registerApprovalHandler, requestApproval } from '../modules/approvals/index.js';
 import type { PendingApproval } from '../types.js';
+import { buildApprovalCard } from './approval-cards.js';
 import type { CallerContext, ErrorCode, RequestFrame, ResponseFrame } from './frame.js';
 import { localizeIsoTimestamps } from './format.js';
 import { getResource } from './crud.js';
@@ -135,6 +136,10 @@ export async function dispatch(
     const agentGroup = getAgentGroup(ctx.agentGroupId);
     const agentName = agentGroup?.name ?? ctx.agentGroupId;
 
+    // Sensitive commands (role changes, …) supply a structured, human-readable
+    // card via the approval-card hook. Everything else falls back to echoing the
+    // raw command line. Action stays 'cli_command' so the same handler executes.
+    const card = buildApprovalCard({ command: req.command, args: req.args, agentName, session });
     const argSummary = Object.entries(req.args)
       .map(([k, v]) => `--${k} ${v}`)
       .join(' ');
@@ -144,8 +149,10 @@ export async function dispatch(
       agentName,
       action: 'cli_command',
       payload: { frame: { id: req.id, command: req.command, args: req.args }, callerContext: ctx },
-      title: `CLI: ${req.command}`,
-      question: `Agent "${agentName}" wants to run:\n\`ncl ${req.command}${argSummary ? ' ' + argSummary : ''}\``,
+      title: card?.title ?? `CLI: ${req.command}`,
+      question:
+        card?.question ??
+        `Agent "${agentName}" wants to run:\n\`ncl ${req.command}${argSummary ? ' ' + argSummary : ''}\``,
     });
 
     return err(req.id, 'approval-pending', 'Approval request sent to admin. You will be notified of the result.');

--- a/src/modules/permissions/role-change.test.ts
+++ b/src/modules/permissions/role-change.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { UserRole } from '../../types.js';
+
+// --- Mocks (DB accessors the summary reads) ---
+
+const mockGetAgentGroup = vi.fn();
+vi.mock('../../db/agent-groups.js', () => ({
+  getAgentGroup: (...args: unknown[]) => mockGetAgentGroup(...args),
+}));
+
+const mockGetUserRoles = vi.fn();
+vi.mock('./db/user-roles.js', () => ({
+  getUserRoles: (...args: unknown[]) => mockGetUserRoles(...args),
+}));
+
+const mockGetUser = vi.fn();
+vi.mock('./db/users.js', () => ({
+  getUser: (...args: unknown[]) => mockGetUser(...args),
+}));
+
+import { describeRoleChange, renderRoleChangeCard, ROLE_CHANGE_COMMANDS } from './role-change.js';
+
+const ORIGIN = {
+  agentName: 'corp-bot',
+  channel: 'slack (T01/C99)',
+  commandLine: 'ncl roles-grant --user slack:U0123 --role admin',
+};
+
+function role(partial: Partial<UserRole>): UserRole {
+  return {
+    user_id: 'slack:U0123',
+    role: 'admin',
+    agent_group_id: null,
+    granted_by: null,
+    granted_at: '2026-01-01',
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockReturnValue(undefined);
+  mockGetUserRoles.mockReturnValue([]);
+  mockGetAgentGroup.mockReturnValue(undefined);
+});
+
+describe('describeRoleChange', () => {
+  it('exposes the role-change command names for routing reuse', () => {
+    expect(ROLE_CHANGE_COMMANDS.has('roles-grant')).toBe(true);
+    expect(ROLE_CHANGE_COMMANDS.has('roles-revoke')).toBe(true);
+    expect(ROLE_CHANGE_COMMANDS.has('groups-list')).toBe(false);
+  });
+
+  it('resolves the target handle to a display name', () => {
+    mockGetUser.mockReturnValue({ id: 'slack:U0123', display_name: 'Jane Doe' });
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    expect(s.targetUserId).toBe('slack:U0123');
+    expect(s.targetDisplay).toBe('Jane Doe');
+  });
+
+  it('leaves display null when the user is unknown', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    expect(s.targetDisplay).toBeNull();
+  });
+
+  it('a scoped admin grant is a group scope with resolved group name', () => {
+    mockGetAgentGroup.mockReturnValue({ id: 'g-sales', name: 'sales-team' });
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    expect(s.scope).toEqual({ kind: 'group', groupId: 'g-sales', groupName: 'sales-team' });
+    expect(s.capabilities).toContain('this agent group');
+  });
+
+  it('a global admin grant (no --group) is global scope', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    expect(s.scope.kind).toBe('global');
+    expect(s.capabilities).toContain('all agent groups');
+  });
+
+  it('owner is always global even when --group is passed', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'owner', group: 'g-sales' });
+    expect(s.scope).toEqual({ kind: 'global', groupId: null, groupName: null });
+    expect(s.capabilities).toContain('full control');
+  });
+
+  it('computes before/after for a grant that adds a new scoped role', () => {
+    mockGetAgentGroup.mockImplementation((id: string) =>
+      id === 'g-mkt' ? { id, name: 'marketing' } : { id, name: 'sales-team' },
+    );
+    mockGetUserRoles.mockReturnValue([role({ role: 'admin', agent_group_id: 'g-mkt' })]);
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    expect(s.before).toHaveLength(1);
+    expect(s.after).toHaveLength(2);
+    expect(s.noop).toBe(false);
+  });
+
+  it('flags a grant of an already-held role as a no-op with unchanged after', () => {
+    mockGetUserRoles.mockReturnValue([role({ role: 'admin', agent_group_id: null })]);
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    expect(s.noop).toBe(true);
+    expect(s.after).toHaveLength(1);
+  });
+
+  it('computes before/after for a revoke that removes the matching role', () => {
+    mockGetUserRoles.mockReturnValue([
+      role({ role: 'admin', agent_group_id: 'g-sales' }),
+      role({ role: 'admin', agent_group_id: null }),
+    ]);
+    const s = describeRoleChange('revoke', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    expect(s.before).toHaveLength(2);
+    expect(s.after).toHaveLength(1);
+    expect(s.after[0].scope.kind).toBe('global');
+    expect(s.noop).toBe(false);
+  });
+
+  it('flags a revoke of a role the user does not hold as a no-op', () => {
+    mockGetUserRoles.mockReturnValue([]);
+    const s = describeRoleChange('revoke', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    expect(s.noop).toBe(true);
+    expect(s.after).toHaveLength(0);
+  });
+
+  it('accepts hyphenated arg keys', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin', 'granted-by': 'slack:U9' });
+    expect(s.targetUserId).toBe('slack:U0123');
+  });
+});
+
+describe('renderRoleChangeCard', () => {
+  it('titles by op and role, not the raw command', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    const { title, question } = renderRoleChangeCard(s, ORIGIN);
+    expect(title).toBe('Role grant: admin');
+    expect(question).not.toMatch(/^CLI:/);
+  });
+
+  it('shows WHO with display name and handle, WHAT, and origin', () => {
+    mockGetUser.mockReturnValue({ id: 'slack:U0123', display_name: 'Jane Doe' });
+    mockGetAgentGroup.mockReturnValue({ id: 'g-sales', name: 'sales-team' });
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    const { question } = renderRoleChangeCard(s, ORIGIN);
+    expect(question).toContain('Jane Doe (`slack:U0123`)');
+    expect(question).toContain('*Action:* Grant `admin` role');
+    expect(question).toContain('agent group "sales-team" (`g-sales`)');
+    expect(question).toContain('*Origin:* agent "corp-bot", channel slack (T01/C99)');
+  });
+
+  it('renders before -> after state lines', () => {
+    mockGetAgentGroup.mockImplementation((id: string) =>
+      id === 'g-mkt' ? { id, name: 'marketing' } : { id, name: 'sales-team' },
+    );
+    mockGetUserRoles.mockReturnValue([role({ role: 'admin', agent_group_id: 'g-mkt' })]);
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin', group: 'g-sales' });
+    const { question } = renderRoleChangeCard(s, ORIGIN);
+    expect(question).toContain('*Current roles:* admin @ "marketing"');
+    expect(question).toContain('*After approval:* admin @ "marketing", admin @ "sales-team"');
+  });
+
+  it('says (none) when the target currently holds no roles', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    const { question } = renderRoleChangeCard(s, ORIGIN);
+    expect(question).toContain('*Current roles:* (none)');
+    expect(question).toContain('*After approval:* admin (global)');
+  });
+
+  it('surfaces a no-op grant note', () => {
+    mockGetUserRoles.mockReturnValue([role({ role: 'admin', agent_group_id: null })]);
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    const { question } = renderRoleChangeCard(s, ORIGIN);
+    expect(question).toContain('No effect: the user already holds this role');
+  });
+
+  it('demotes the raw command to a trailing secondary detail', () => {
+    const s = describeRoleChange('grant', { user: 'slack:U0123', role: 'admin' });
+    const { question } = renderRoleChangeCard(s, ORIGIN);
+    expect(question).toContain('_Command:_ `ncl roles-grant --user slack:U0123 --role admin`');
+    // headline is the action, command is last
+    expect(question.indexOf('*Action:*')).toBeLessThan(question.indexOf('_Command:_'));
+  });
+});

--- a/src/modules/permissions/role-change.ts
+++ b/src/modules/permissions/role-change.ts
@@ -1,0 +1,206 @@
+/**
+ * Human-readable summary + card rendering for role-change approvals
+ * (`ncl roles grant` / `ncl roles revoke`).
+ *
+ * A role change is a privilege mutation: the raw command line
+ * (`ncl roles-grant --user slack:U0… --role admin --group g-…`) tells the
+ * approving admin almost nothing — a namespaced handle, no display name, no
+ * before/after state, no blast radius. This module resolves the handle to a
+ * name, describes what the role grants, and computes the target's current
+ * roles vs. the state after the change so the approval card states an actual
+ * consequence.
+ *
+ * The card wording lives here (not inlined into the CLI dispatcher) so the
+ * privilege-aware routing work (Issue C) can import `describeRoleChange()` to
+ * classify the request and pick an approver from the same structured summary,
+ * without duplicating the role/scope resolution. `renderRoleChangeCard()` is
+ * the presentation half and stays render-only.
+ */
+import type { UserRole } from '../../types.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getUserRoles } from './db/user-roles.js';
+import { getUser } from './db/users.js';
+
+/** CLI command names that mutate privileges. Exported for Issue C's routing. */
+export const ROLE_CHANGE_COMMANDS = new Set(['roles-grant', 'roles-revoke']);
+
+export type RoleChangeOp = 'grant' | 'revoke';
+
+export interface RoleScope {
+  kind: 'global' | 'group';
+  /** Null for a global role (owner, or global admin). */
+  groupId: string | null;
+  /** Resolved agent-group name, when a scoped role names a known group. */
+  groupName: string | null;
+}
+
+/** One role a user holds (or will hold), used for the before/after lists. */
+export interface RoleLine {
+  role: string;
+  scope: RoleScope;
+}
+
+export interface RoleChangeSummary {
+  op: RoleChangeOp;
+  /** Namespaced handle, e.g. `slack:U0123`. */
+  targetUserId: string;
+  /** Display name from the users table, or null when unknown. */
+  targetDisplay: string | null;
+  role: string;
+  scope: RoleScope;
+  /** Plain-English description of what the role can do. */
+  capabilities: string;
+  /** Target's roles before the change. */
+  before: RoleLine[];
+  /** Target's roles after the change is applied. */
+  after: RoleLine[];
+  /** True when the change has no effect (grant of a held role / revoke of an absent one). */
+  noop: boolean;
+}
+
+/** Normalize `--hyphen-keys` to underscore keys, matching crud.ts's parseArgs. */
+function normalizeArgs(raw: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) out[k.replace(/-/g, '_')] = v;
+  return out;
+}
+
+function resolveScope(role: string, groupId: string | null): RoleScope {
+  // Owner is always global regardless of any --group passed (the handler
+  // rejects owner+group, but the card describes what was requested).
+  if (role === 'owner' || !groupId) {
+    return { kind: 'global', groupId: null, groupName: null };
+  }
+  return { kind: 'group', groupId, groupName: getAgentGroup(groupId)?.name ?? null };
+}
+
+function toLine(r: UserRole): RoleLine {
+  return {
+    role: r.role,
+    scope:
+      r.agent_group_id === null
+        ? { kind: 'global', groupId: null, groupName: null }
+        : { kind: 'group', groupId: r.agent_group_id, groupName: getAgentGroup(r.agent_group_id)?.name ?? null },
+  };
+}
+
+function sameRole(a: RoleLine, role: string, groupId: string | null): boolean {
+  return a.role === role && a.scope.groupId === groupId;
+}
+
+function describeCapabilities(role: string, scope: RoleScope): string {
+  if (role === 'owner') return 'full control over all agent groups, users, and privilege grants';
+  if (role === 'admin') {
+    return scope.kind === 'global'
+      ? 'manage all agent groups and approve sensitive actions across the system'
+      : 'manage this agent group (implies membership) and approve sensitive actions for it';
+  }
+  return 'unknown role';
+}
+
+/**
+ * Resolve a role-change request into a structured, consequence-bearing summary.
+ * Reads the users and user_roles tables; performs no writes.
+ */
+export function describeRoleChange(op: RoleChangeOp, rawArgs: Record<string, unknown>): RoleChangeSummary {
+  const args = normalizeArgs(rawArgs);
+  const targetUserId = args.user != null ? String(args.user) : '';
+  const role = args.role != null ? String(args.role) : '';
+  const requestedGroup = args.group != null ? String(args.group) : null;
+
+  const scope = resolveScope(role, requestedGroup);
+  const effectiveGroupId = scope.groupId; // null once owner/global is normalized
+
+  const targetDisplay = targetUserId ? (getUser(targetUserId)?.display_name ?? null) : null;
+  const before = targetUserId ? getUserRoles(targetUserId).map(toLine) : [];
+
+  const held = before.some((l) => sameRole(l, role, effectiveGroupId));
+  let after: RoleLine[];
+  let noop: boolean;
+  if (op === 'grant') {
+    noop = held;
+    after = held ? before : [...before, { role, scope }];
+  } else {
+    noop = !held;
+    after = before.filter((l) => !sameRole(l, role, effectiveGroupId));
+  }
+
+  return {
+    op,
+    targetUserId,
+    targetDisplay,
+    role,
+    scope,
+    capabilities: describeCapabilities(role, scope),
+    before,
+    after,
+    noop,
+  };
+}
+
+function formatScope(scope: RoleScope): string {
+  if (scope.kind === 'global') return 'global (all agent groups)';
+  const label = scope.groupName ? `"${scope.groupName}" (\`${scope.groupId}\`)` : `\`${scope.groupId}\``;
+  return `agent group ${label}`;
+}
+
+function formatRoleLine(line: RoleLine): string {
+  if (line.scope.kind === 'global') return `${line.role} (global)`;
+  const label = line.scope.groupName ? `"${line.scope.groupName}"` : `\`${line.scope.groupId}\``;
+  return `${line.role} @ ${label}`;
+}
+
+function formatRoleList(lines: RoleLine[]): string {
+  return lines.length === 0 ? '(none)' : lines.map(formatRoleLine).join(', ');
+}
+
+export interface RoleChangeOrigin {
+  /** Requesting agent group's name. */
+  agentName: string;
+  /** Human-readable channel the request came from. */
+  channel: string;
+  /** Raw command line, shown as secondary detail only. */
+  commandLine: string;
+}
+
+/**
+ * Render the structured summary into an approval card ({ title, question }).
+ * House style follows the OneCLI / self-mod cards: `*Label:*` bold keys, one
+ * fact per line, raw command demoted to a trailing detail.
+ */
+export function renderRoleChangeCard(
+  summary: RoleChangeSummary,
+  origin: RoleChangeOrigin,
+): { title: string; question: string } {
+  const verb = summary.op === 'grant' ? 'Grant' : 'Revoke';
+  const roleLabel = summary.role || '(unspecified)';
+  const title = `Role ${summary.op}: ${roleLabel}`;
+
+  const who = summary.targetDisplay
+    ? `${summary.targetDisplay} (\`${summary.targetUserId || '?'}\`)`
+    : `\`${summary.targetUserId || '?'}\``;
+
+  const lines = [
+    `Agent "${origin.agentName}" requests a privilege change.`,
+    '',
+    `*Action:* ${verb} \`${roleLabel}\` role`,
+    `*User:* ${who}`,
+    `*Scope:* ${formatScope(summary.scope)}`,
+    `*Capabilities:* ${summary.capabilities}`,
+    `*Current roles:* ${formatRoleList(summary.before)}`,
+    `*After approval:* ${formatRoleList(summary.after)}`,
+  ];
+  if (summary.noop) {
+    lines.push(
+      summary.op === 'grant'
+        ? '_No effect: the user already holds this role._'
+        : '_No effect: the user does not currently hold this role._',
+    );
+  }
+  lines.push(
+    '',
+    `*Origin:* agent "${origin.agentName}", channel ${origin.channel}`,
+    `_Command:_ \`${origin.commandLine}\``,
+  );
+  return { title, question: lines.join('\n') };
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3098.

**What.** Role-change (`ncl roles grant`/`revoke`) approval cards now render a structured, human-readable consequence summary instead of echoing the raw command line. Non-sensitive commands are unchanged.

**Why.** Today an approval-gated command's card shows the raw command string (e.g. `ncl roles-revoke --user slack:U0… --role admin`) — a namespaced handle, no effect, no before/after. Same "approve a raw blob" defect already fixed for the OneCLI card (#2929) and `add_mcp_server` (#2998, closing [Security] #2762/#2827); this closes it for `ncl` command cards, starting with role changes.

**How it works.**
- A command-keyed card-builder registry (`buildApprovalCard`) lets a sensitive command supply a structured `{ title, question }`; anything without a builder falls back to the existing raw-command card.
- The role-change builder resolves the target's display name, states role + scope + capabilities, and shows **before → after**, with origin (agent, channel). Raw command demoted to a trailing detail.
- Action type stays `cli_command`, so the existing approve-and-execute handler is untouched.

**How it was tested.** New unit tests for the role-change summary (name resolution, scope wording, before/after, no-op notes) and for dispatch wiring the structured card into the approval request with fallback. Full suite green.
