### PR TITLE
[security] fix(approvals): privilege-proportional, target-excluded role-change approval routing

### DIFF
--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -64,6 +64,13 @@ vi.mock('../modules/approvals/index.js', () => ({
   requestApproval: approvalState.requestApproval,
 }));
 
+// dispatch re-verifies role-change approvers at apply time via these.
+const roleState = vi.hoisted(() => ({ owners: new Set<string>(), globalAdmins: new Set<string>() }));
+vi.mock('../modules/permissions/db/user-roles.js', () => ({
+  isOwner: (u: string) => roleState.owners.has(u),
+  isGlobalAdmin: (u: string) => roleState.globalAdmins.has(u),
+}));
+
 // Register a test command so dispatch has something to find
 import { register } from './registry.js';
 
@@ -160,6 +167,17 @@ register({
   },
 });
 
+// Role revoke — privilege-sensitive, approval-gated. Used by the approval-routing
+// tests below. (roles-grant is registered below.)
+register({
+  name: 'roles-revoke',
+  description: 'revoke a role (approval-gated)',
+  resource: 'roles',
+  access: 'approval',
+  parseArgs: (raw) => raw,
+  handler: async (args) => ({ revoked: args }),
+});
+
 // Commands that return data shaped like real resources (for post-handler filtering tests)
 register({
   name: 'groups-list-data',
@@ -230,12 +248,25 @@ register({
   handler: async (args) => ({ echo: args }),
 });
 
+// An approval-gated command (like `roles-grant`) to exercise the approval branch
+// and the role-change approval routing.
+register({
+  name: 'roles-grant',
+  description: 'test approval command',
+  resource: 'roles',
+  access: 'approval',
+  parseArgs: (raw) => raw,
+  handler: async (args) => ({ echo: args }),
+});
+
 import { dispatch } from './dispatch.js';
 import type { CallerContext } from './frame.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
   approvalState.observedContexts.length = 0;
+  roleState.owners.clear();
+  roleState.globalAdmins.clear();
   // Default: the four CLI-whitelisted resources with their real scopeFields.
   const scopeFields: Record<string, string> = {
     groups: 'id',
@@ -994,5 +1025,136 @@ describe('formatHuman hook', () => {
 
     expect(resp.ok).toBe(true);
     if (resp.ok) expect(resp.human).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Role-change approval routing (privilege-proportional, target-excluded)
+// ---------------------------------------------------------------------------
+
+describe('role-change approval routing', () => {
+  function constraintOf(): { minLevel?: string; excludeUserIds?: string[] } | undefined {
+    const call = approvalState.requestApproval.mock.calls[0]?.[0] as { approverConstraint?: unknown } | undefined;
+    return call?.approverConstraint as { minLevel?: string; excludeUserIds?: string[] } | undefined;
+  }
+
+  beforeEach(() => {
+    // Role commands are only reachable in global CLI scope.
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'global' });
+    mockGetSession.mockReturnValue({ id: 's1', agent_group_id: 'g1', messaging_group_id: 'mg1' });
+    mockGetAgentGroup.mockReturnValue({ id: 'g1', name: 'Group One' });
+  });
+
+  it('grant global admin (no --group): requires an OWNER approver, target excluded', async () => {
+    const resp = await dispatch(
+      { id: '1', command: 'roles-grant', args: { user: 'telegram:victim', role: 'admin' } },
+      agentCtx(),
+    );
+
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) expect(resp.error.code).toBe('approval-pending');
+    expect(constraintOf()).toEqual({ minLevel: 'owner', excludeUserIds: ['telegram:victim'] });
+  });
+
+  it('grant owner: requires an OWNER approver', async () => {
+    await dispatch({ id: '1', command: 'roles-grant', args: { user: 'telegram:x', role: 'owner' } }, agentCtx());
+    expect(constraintOf()).toEqual({ minLevel: 'owner', excludeUserIds: ['telegram:x'] });
+  });
+
+  it('revoke group-scoped admin (--group): a GLOBAL admin (or owner) may approve', async () => {
+    await dispatch(
+      { id: '1', command: 'roles-revoke', args: { user: 'telegram:x', role: 'admin', group: 'g1' } },
+      agentCtx(),
+    );
+    expect(constraintOf()).toEqual({ minLevel: 'global-admin', excludeUserIds: ['telegram:x'] });
+  });
+
+  it('unknown/garbled role fails strict (requires owner)', async () => {
+    await dispatch({ id: '1', command: 'roles-grant', args: { user: 'telegram:x' } }, agentCtx());
+    expect(constraintOf()).toEqual({ minLevel: 'owner', excludeUserIds: ['telegram:x'] });
+  });
+
+  it('non-role approval command carries NO approverConstraint (legacy routing unchanged)', async () => {
+    // groups-config-set-style approval command: register one on the fly.
+    register({
+      name: 'widgets-frob',
+      description: 'a non-role approval command',
+      resource: 'widgets',
+      access: 'approval',
+      parseArgs: (raw) => raw,
+      handler: async (args) => ({ ok: args }),
+    });
+    await dispatch({ id: '1', command: 'widgets-frob', args: { x: 1 } }, agentCtx());
+    expect(constraintOf()).toBeUndefined();
+    const payload = approvalState.requestApproval.mock.calls[0][0] as { payload: Record<string, unknown> };
+    expect(payload.payload.approverConstraint).toBeUndefined();
+  });
+
+  // --- apply-time re-verification (mirrors #2566) ---
+  //
+  // Adapted to the grant-carrying replay: the cli_command handler re-enters
+  // dispatch as the ORIGINAL caller with the verified approval row as its grant
+  // (not bare host). The apply-time approver re-check runs BEFORE the replay, so
+  // the two rejection cases return before the grant is ever used; the success
+  // case exposes a live grant via getPendingApproval so the guard re-check passes.
+
+  it('apply time: a demoted/unqualified approver cannot apply the change', async () => {
+    await dispatch({ id: '1', command: 'roles-grant', args: { user: 'telegram:victim', role: 'admin' } }, agentCtx());
+    const payload = (approvalState.requestApproval.mock.calls[0][0] as { payload: Record<string, unknown> }).payload;
+
+    expect(approvalState.approvalHandler).toBeTypeOf('function');
+    const notify = vi.fn();
+    // 'telegram:notowner' holds no owner role → must be rejected at apply.
+    await approvalState.approvalHandler!({
+      session: {},
+      payload,
+      approval: { approval_id: 'appr-role', action: 'cli_command', payload: JSON.stringify(payload) },
+      userId: 'telegram:notowner',
+      notify,
+    });
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toContain('NOT applied');
+  });
+
+  it('apply time: the target cannot apply their own change even if still owner', async () => {
+    roleState.owners.add('telegram:victim'); // still an owner, but is the target
+    await dispatch({ id: '1', command: 'roles-revoke', args: { user: 'telegram:victim', role: 'owner' } }, agentCtx());
+    const payload = (approvalState.requestApproval.mock.calls[0][0] as { payload: Record<string, unknown> }).payload;
+
+    const notify = vi.fn();
+    await approvalState.approvalHandler!({
+      session: {},
+      payload,
+      approval: { approval_id: 'appr-role', action: 'cli_command', payload: JSON.stringify(payload) },
+      userId: 'telegram:victim',
+      notify,
+    });
+
+    expect(notify.mock.calls[0][0]).toContain('NOT applied');
+    expect(notify.mock.calls[0][0]).toContain('self-approval');
+  });
+
+  it('apply time: a qualified owner applies the change (grant-carrying replay)', async () => {
+    roleState.owners.add('telegram:realowner');
+    await dispatch({ id: '1', command: 'roles-grant', args: { user: 'telegram:victim', role: 'admin' } }, agentCtx());
+    const payload = (approvalState.requestApproval.mock.calls[0][0] as { payload: Record<string, unknown> }).payload;
+
+    // The approved replay carries the live grant back into dispatch; the guard
+    // re-checks it against the pending row, so expose it via getPendingApproval.
+    const grant = { approval_id: 'appr-role', action: 'cli_command', payload: JSON.stringify(payload) };
+    mockGetPendingApproval.mockReturnValue(grant);
+
+    const notify = vi.fn();
+    await approvalState.approvalHandler!({
+      session: { id: 's1', agent_group_id: 'g1', messaging_group_id: 'mg1' },
+      payload,
+      approval: grant,
+      userId: 'telegram:realowner',
+      notify,
+    });
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toContain('approved and executed');
   });
 });

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -16,7 +16,13 @@ import { getContainerConfig } from '../db/container-configs.js';
 import { getAgentGroup } from '../db/agent-groups.js';
 import { getSession } from '../db/sessions.js';
 import { guard, type GuardActor } from '../guard/index.js';
-import { registerApprovalHandler, requestApproval } from '../modules/approvals/index.js';
+import {
+  registerApprovalHandler,
+  requestApproval,
+  type ApproverConstraint,
+  type ApproverLevel,
+} from '../modules/approvals/index.js';
+import { isGlobalAdmin, isOwner } from '../modules/permissions/db/user-roles.js';
 import type { PendingApproval } from '../types.js';
 import type { CallerContext, ErrorCode, RequestFrame, ResponseFrame } from './frame.js';
 import { localizeIsoTimestamps } from './format.js';
@@ -139,13 +145,28 @@ export async function dispatch(
       .map(([k, v]) => `--${k} ${v}`)
       .join(' ');
 
+    // Privilege-sensitive commands (role grant/revoke) must be routed to a
+    // sufficiently-privileged approver who is not the target of the change.
+    // Non-role approvals keep the legacy any-eligible-admin routing.
+    const approverConstraint = roleChangeApproverConstraint(cmd.resource, req.command, req.args);
+    // Propagate the caller context on the pending row so the approved replay
+    // re-enters dispatch as the original agent (not bare host).
+    const payload: Record<string, unknown> = {
+      frame: { id: req.id, command: req.command, args: req.args },
+      callerContext: ctx,
+    };
+    // Carried on the pending row so the approver can be re-verified at apply
+    // time (mirrors the channel-approval re-check discipline).
+    if (approverConstraint) payload.approverConstraint = approverConstraint;
+
     await requestApproval({
       session,
       agentName,
       action: 'cli_command',
-      payload: { frame: { id: req.id, command: req.command, args: req.args }, callerContext: ctx },
+      payload,
       title: `CLI: ${req.command}`,
       question: `Agent "${agentName}" wants to run:\n\`ncl ${req.command}${argSummary ? ' ' + argSummary : ''}\``,
+      approverConstraint,
     });
 
     return err(req.id, 'approval-pending', 'Approval request sent to admin. You will be notified of the result.');
@@ -215,8 +236,22 @@ export async function dispatch(
   }
 }
 
-registerApprovalHandler('cli_command', async ({ payload, approval, notify }) => {
+registerApprovalHandler('cli_command', async ({ payload, approval, userId, notify }) => {
   const frame = payload.frame as RequestFrame;
+
+  // Re-verify the approver still qualifies at apply time (they may have been
+  // demoted between card issue and click; or a stale/forged pin). This mirrors
+  // #2566's re-check-at-apply discipline. Only applies to constrained
+  // (privilege-sensitive) requests.
+  const constraint = payload.approverConstraint as ApproverConstraint | undefined;
+  if (constraint) {
+    const disqualification = approverDisqualification(userId, constraint);
+    if (disqualification) {
+      notify(`Your \`ncl ${frame.command}\` request was approved but NOT applied: ${disqualification}`);
+      return;
+    }
+  }
+
   const callerContext = parseCallerContext(payload.callerContext) ?? { caller: 'host' };
   const response = await dispatch(frame, callerContext, { grant: approval });
 
@@ -324,6 +359,62 @@ function editDistance(a: string, b: string, cap: number): number {
     if (rowMin >= cap) return cap;
   }
   return prev[b.length];
+}
+
+/**
+ * Approval-routing metadata for a role grant/revoke, or `undefined` for any
+ * other command. A role change must be authorized by an approver whose
+ * privilege is at least that of the role being changed, and never by the target
+ * of the change (no self-approval):
+ *   - changing an OWNER, or a GLOBAL admin (admin with no --group) → owner only
+ *   - changing a GROUP-scoped admin (admin with --group) → global admin or owner
+ * When the role can't be determined we fail strict (require an owner).
+ *
+ * This is the WHO-approves + fail-safety half of the fix. Card text/rendering
+ * (Issue B) is independent; if Issue B lands a shared role-change action type /
+ * describeRoleChange() helper, this local metadata should fold into it.
+ *
+ * C1/C4 seam (initiator principal / honor-authority): the CallerContext for an
+ * agent caller carries no VERIFIED human principal (there is no caller-context
+ * propagation through the approval replay in this lineage), and an agent must
+ * not be trusted to self-assert one. So we do NOT auto-approve owner-authorized
+ * changes here. If a verified initiating principal is ever plumbed into
+ * CallerContext, add it to `excludeUserIds` (never approve your own change) and
+ * short-circuit when the principal already holds privilege >= the change.
+ */
+function roleChangeApproverConstraint(
+  resource: string | undefined,
+  command: string,
+  args: Record<string, unknown>,
+): ApproverConstraint | undefined {
+  if (resource !== 'roles' || (command !== 'roles-grant' && command !== 'roles-revoke')) {
+    return undefined;
+  }
+  const target = typeof args.user === 'string' ? args.user : undefined;
+  const role = typeof args.role === 'string' ? args.role : undefined;
+  const group = args.group != null ? String(args.group) : null;
+
+  const isGroupScopedAdminChange = role === 'admin' && group !== null;
+  const minLevel: ApproverLevel = isGroupScopedAdminChange ? 'global-admin' : 'owner';
+
+  return { minLevel, excludeUserIds: target ? [target] : [] };
+}
+
+/**
+ * Returns a human-readable reason the given user may NOT authorize a
+ * constrained change, or `null` if they qualify. Used to re-verify the approver
+ * at apply time.
+ */
+function approverDisqualification(userId: string, constraint: ApproverConstraint): string | null {
+  if (!userId) return 'the approver could not be identified.';
+  if (constraint.excludeUserIds?.includes(userId)) {
+    return 'the approver is the target of the change (self-approval is not allowed).';
+  }
+  const qualified = constraint.minLevel === 'owner' ? isOwner(userId) : isOwner(userId) || isGlobalAdmin(userId);
+  if (!qualified) {
+    return `the approver no longer holds the required ${constraint.minLevel} privilege.`;
+  }
+  return null;
 }
 
 function err(id: string, code: ErrorCode, message: string): ResponseFrame {

--- a/src/modules/approvals/index.ts
+++ b/src/modules/approvals/index.ts
@@ -29,7 +29,13 @@ import { startOneCLIApprovalHandler, stopOneCLIApprovalHandler } from './onecli-
 
 // Public API re-exports so consumers import from the module root.
 export { requestApproval, registerApprovalHandler, notifyAgent } from './primitive.js';
-export type { ApprovalHandler, ApprovalHandlerContext, RequestApprovalOptions } from './primitive.js';
+export type {
+  ApprovalHandler,
+  ApprovalHandlerContext,
+  ApproverConstraint,
+  ApproverLevel,
+  RequestApprovalOptions,
+} from './primitive.js';
 // Host-sweep hook for ghosted "Reject with reason…" holds. The re-export also
 // loads reason-capture.js, registering its message-interceptor on import.
 export { sweepAwaitingReasonRejects } from './reason-capture.js';

--- a/src/modules/approvals/picks.test.ts
+++ b/src/modules/approvals/picks.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../../channels/channel-registry.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
 import { createUser } from '../permissions/db/users.js';
-import { grantRole } from '../permissions/db/user-roles.js';
-import { pickApprovalDelivery, pickApprover } from './primitive.js';
+import { grantRole, revokeRole } from '../permissions/db/user-roles.js';
+import { pickApprovalDelivery, pickApprover, pickPrivilegedApprover } from './primitive.js';
 
 function now(): string {
   return new Date().toISOString();
@@ -82,6 +82,12 @@ function seedUser(id: string, kind: string): void {
   createUser({ id, kind, display_name: null, created_at: now() });
 }
 
+/** Drop this user's global owner + global admin rows (test convenience). */
+function revokeAll(userId: string): void {
+  revokeRole(userId, 'owner', null);
+  revokeRole(userId, 'admin', null);
+}
+
 describe('pickApprover', () => {
   beforeEach(() => {
     seedAgentGroup('ag-1');
@@ -103,6 +109,51 @@ describe('pickApprover', () => {
 
   it('returns empty list when nobody is privileged', () => {
     expect(pickApprover('ag-1')).toEqual([]);
+  });
+});
+
+describe('pickPrivilegedApprover', () => {
+  beforeEach(() => {
+    seedAgentGroup('ag-1');
+    seedUser('u-owner', 'telegram');
+    seedUser('u-owner2', 'telegram');
+    seedUser('u-ga', 'telegram');
+    seedUser('u-sa', 'telegram');
+    grantRole({ user_id: 'u-owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    grantRole({ user_id: 'u-owner2', role: 'owner', agent_group_id: null, granted_by: null, granted_at: now() });
+    grantRole({ user_id: 'u-ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: now() });
+    grantRole({ user_id: 'u-sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: now() });
+  });
+
+  it('owner level: returns only owners (never a global or scoped admin), highest first', () => {
+    expect(pickPrivilegedApprover({ minLevel: 'owner' })).toEqual(['u-owner', 'u-owner2']);
+  });
+
+  it('global-admin level: returns owners then global admins, never a scoped admin', () => {
+    expect(pickPrivilegedApprover({ minLevel: 'global-admin' })).toEqual(['u-owner', 'u-owner2', 'u-ga']);
+  });
+
+  it('excludes the target of the change from the pool (no self-approval)', () => {
+    // Revoking u-owner's owner role must not route the card to u-owner.
+    expect(pickPrivilegedApprover({ minLevel: 'owner', excludeUserIds: ['u-owner'] })).toEqual(['u-owner2']);
+    // A scoped admin can never appear even if named as an exclude no-op.
+    expect(pickPrivilegedApprover({ minLevel: 'global-admin', excludeUserIds: ['u-ga'] })).toEqual([
+      'u-owner',
+      'u-owner2',
+    ]);
+  });
+
+  it('fails closed (empty) when the only eligible approver is the target', () => {
+    // Sole owner revoking their own owner role → nobody left to approve.
+    revokeAll('u-owner2');
+    expect(pickPrivilegedApprover({ minLevel: 'owner', excludeUserIds: ['u-owner'] })).toEqual([]);
+  });
+
+  it('fails closed (empty) when only juniors exist for an owner-level change', () => {
+    revokeAll('u-owner');
+    revokeAll('u-owner2');
+    // Only a global admin + scoped admin remain — neither qualifies for owner level.
+    expect(pickPrivilegedApprover({ minLevel: 'owner' })).toEqual([]);
   });
 });
 

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -135,6 +135,13 @@ export async function notifyApprovalResolved(event: ApprovalResolvedEvent): Prom
 /**
  * Ordered list of user IDs eligible to approve an action for the given agent
  * group. Preference: admins @ that group → global admins → owners.
+ *
+ * Note: this orders LOWEST privilege first — intentional for the common
+ * non-privileged approvals (create_agent, install_packages, add_mcp_server,
+ * OneCLI), where any eligible admin may approve and the same-channel tie-break
+ * matters more than rank. Privilege-sensitive actions (role changes) must NOT
+ * use this — they use `pickPrivilegedApprover`, which orders highest-first and
+ * fails closed.
  */
 export function pickApprover(agentGroupId: string | null): string[] {
   const approvers: string[] = [];
@@ -151,6 +158,50 @@ export function pickApprover(agentGroupId: string | null): string[] {
   }
   for (const r of getGlobalAdmins()) add(r.user_id);
   for (const r of getOwners()) add(r.user_id);
+
+  return approvers;
+}
+
+/** Privilege floor an approver must clear to authorize a privilege-sensitive action. */
+export type ApproverLevel = 'owner' | 'global-admin';
+
+/**
+ * Constrains approver selection for privilege-sensitive actions — today, role
+ * grant/revoke. When a caller passes this to `requestApproval`, the default
+ * group-admins-first ordering is bypassed: the pool is built only from users at
+ * or above `minLevel`, ordered HIGHEST privilege first, with `excludeUserIds`
+ * (the target of the change, and the initiator when known) removed. Delivery
+ * fails closed — if no qualified, non-conflicted, reachable approver exists the
+ * request is held and the agent is told why, never routed to a junior admin or
+ * to the target of the change (no self-approval).
+ */
+export interface ApproverConstraint {
+  minLevel: ApproverLevel;
+  excludeUserIds?: string[];
+}
+
+/**
+ * Ordered list of user IDs qualified to approve a privilege-sensitive action,
+ * HIGHEST privilege first: owners, then — only when `minLevel` is
+ * 'global-admin' — global admins. Group-scoped admins are never eligible.
+ * `excludeUserIds` drops conflicted users (the change's target, the initiator).
+ * Unlike `pickApprover` this never routes downward and never returns a scoped
+ * admin, so an empty result is the fail-safe signal for the caller to HOLD.
+ */
+export function pickPrivilegedApprover(constraint: ApproverConstraint): string[] {
+  const exclude = new Set(constraint.excludeUserIds ?? []);
+  const approvers: string[] = [];
+  const seen = new Set<string>();
+  const add = (id: string): void => {
+    if (exclude.has(id) || seen.has(id)) return;
+    seen.add(id);
+    approvers.push(id);
+  };
+
+  for (const r of getOwners()) add(r.user_id);
+  if (constraint.minLevel === 'global-admin') {
+    for (const r of getGlobalAdmins()) add(r.user_id);
+  }
 
   return approvers;
 }
@@ -218,6 +269,14 @@ export interface RequestApprovalOptions {
   question: string;
   /** Deliver the card to this specific user instead of all of the session group's admins. */
   approverUserId?: string;
+  /**
+   * Constrain approver selection for a privilege-sensitive action (role change).
+   * When set, the approver pool is built by `pickPrivilegedApprover` (qualified
+   * users only, highest privilege first, target/initiator excluded) and the
+   * chosen approver is pinned on `approver_user_id` so only they can resolve it.
+   * Ignored when `approverUserId` is given (the caller already pinned a user).
+   */
+  approverConstraint?: ApproverConstraint;
 }
 
 /**
@@ -227,11 +286,25 @@ export interface RequestApprovalOptions {
  * approval handler for this action via the response dispatcher.
  */
 export async function requestApproval(opts: RequestApprovalOptions): Promise<void> {
-  const { session, action, payload, title, question, agentName, approverUserId } = opts;
+  const { session, action, payload, title, question, agentName, approverUserId, approverConstraint } = opts;
 
-  const approvers = approverUserId ? [approverUserId] : pickApprover(session.agent_group_id);
+  let approvers: string[];
+  if (approverUserId) {
+    approvers = [approverUserId];
+  } else if (approverConstraint) {
+    approvers = pickPrivilegedApprover(approverConstraint);
+  } else {
+    approvers = pickApprover(session.agent_group_id);
+  }
   if (approvers.length === 0) {
-    notifyAgent(session, `${action} failed: no owner or admin configured to approve.`);
+    // Fail closed. For a constrained (privilege-sensitive) request there is no
+    // junior/target fallback — HOLD and tell the agent why.
+    notifyAgent(
+      session,
+      approverConstraint
+        ? `${action} failed: no sufficiently-privileged approver is available to authorize this change (self-approval by the target is not allowed).`
+        : `${action} failed: no owner or admin configured to approve.`,
+    );
     return;
   }
 
@@ -241,9 +314,20 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
 
   const target = await pickApprovalDelivery(approvers, originChannelType);
   if (!target) {
-    notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.`);
+    notifyAgent(
+      session,
+      approverConstraint
+        ? `${action} failed: no sufficiently-privileged approver is reachable on any channel to authorize this change.`
+        : `${action} failed: no DM channel found for any eligible approver.`,
+    );
     return;
   }
+
+  // Pin the chosen approver for constrained requests so only they can resolve
+  // the card (enforced by the response handler's authorized-click gate). For
+  // unconstrained requests keep the legacy behavior: any eligible admin may act
+  // unless the caller explicitly named one via approverUserId.
+  const pinnedApproverUserId = approverUserId ?? (approverConstraint ? target.userId : null);
 
   const approvalId = `appr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const normalizedOptions = normalizeOptions(APPROVAL_OPTIONS);
@@ -256,7 +340,7 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     created_at: new Date().toISOString(),
     title,
     options_json: JSON.stringify(normalizedOptions),
-    approver_user_id: approverUserId ?? null,
+    approver_user_id: pinnedApproverUserId,
   });
 
   const adapter = getDeliveryAdapter();

--- a/src/modules/approvals/request-approval.test.ts
+++ b/src/modules/approvals/request-approval.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for requestApproval's approver selection + fail-safety, focused on the
+ * privilege-proportional `approverConstraint` path (role changes) alongside the
+ * legacy any-eligible-admin path (create_agent, install_packages, OneCLI …).
+ *
+ * The DB / delivery / session-manager deps are mocked so we can assert exactly
+ * who the card is pinned + delivered to, and that no card goes out when no
+ * qualified, non-conflicted, reachable approver exists.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Session, UserRole } from '../../types.js';
+
+vi.mock('../../log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const roleRows = vi.hoisted(() => ({
+  owners: [] as UserRole[],
+  globalAdmins: [] as UserRole[],
+  scopedAdmins: new Map<string, UserRole[]>(),
+}));
+vi.mock('../permissions/db/user-roles.js', () => ({
+  getOwners: () => roleRows.owners,
+  getGlobalAdmins: () => roleRows.globalAdmins,
+  getAdminsOfAgentGroup: (agentGroupId: string) => roleRows.scopedAdmins.get(agentGroupId) ?? [],
+}));
+
+// Reachability: any user whose id is in `reachable` resolves to a DM.
+const reachable = vi.hoisted(() => new Set<string>());
+vi.mock('../permissions/user-dm.js', () => ({
+  ensureUserDm: async (userId: string) =>
+    reachable.has(userId)
+      ? { id: `mg-${userId}`, channel_type: userId.split(':')[0], platform_id: userId.split(':')[1] }
+      : null,
+}));
+
+vi.mock('../../db/messaging-groups.js', () => ({
+  getMessagingGroup: (_id: string) => ({ channel_type: 'telegram', platform_id: 'origin' }),
+}));
+
+const createdApprovals = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+vi.mock('../../db/sessions.js', () => ({
+  createPendingApproval: (row: Record<string, unknown>) => createdApprovals.push(row),
+  getSession: (_id: string) => null,
+}));
+
+const delivered = vi.hoisted(() => [] as Array<{ channelType: string; platformId: string }>);
+vi.mock('../../delivery.js', () => ({
+  getDeliveryAdapter: () => ({
+    deliver: async (channelType: string, platformId: string) => {
+      delivered.push({ channelType, platformId });
+      return undefined;
+    },
+  }),
+}));
+
+const notices = vi.hoisted(() => [] as string[]);
+vi.mock('../../session-manager.js', () => ({
+  writeSessionMessage: (_g: string, _s: string, msg: { content: string }) => {
+    notices.push(JSON.parse(msg.content).text as string);
+  },
+}));
+vi.mock('../../container-runner.js', () => ({ wakeContainer: async () => undefined }));
+
+import { requestApproval } from './primitive.js';
+
+const session: Session = {
+  id: 's1',
+  agent_group_id: 'ag-1',
+  messaging_group_id: 'mg-origin',
+  thread_id: null,
+  agent_provider: null,
+  status: 'active',
+  container_status: 'running',
+  last_active: null,
+  created_at: '2020-01-01',
+};
+
+beforeEach(() => {
+  roleRows.owners = [];
+  roleRows.globalAdmins = [];
+  roleRows.scopedAdmins = new Map();
+  reachable.clear();
+  createdApprovals.length = 0;
+  delivered.length = 0;
+  notices.length = 0;
+});
+
+function base() {
+  return {
+    session,
+    agentName: 'Agent',
+    action: 'cli_command',
+    payload: { frame: {} },
+    title: 't',
+    question: 'q',
+  };
+}
+
+describe('requestApproval — constrained (privilege-proportional) routing', () => {
+  it('pins + delivers to an owner (highest privilege), never the group admin, for an owner-level change', async () => {
+    roleRows.owners = [
+      { user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.globalAdmins = [
+      { user_id: 'telegram:ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.scopedAdmins.set('ag-1', [
+      { user_id: 'telegram:sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: '2020-01-01' },
+    ]);
+    reachable.add('telegram:owner');
+    reachable.add('telegram:ga');
+    reachable.add('telegram:sa');
+
+    await requestApproval({ ...base(), approverConstraint: { minLevel: 'owner' } });
+
+    expect(createdApprovals).toHaveLength(1);
+    expect(createdApprovals[0].approver_user_id).toBe('telegram:owner');
+    expect(delivered).toEqual([{ channelType: 'telegram', platformId: 'owner' }]);
+  });
+
+  it('excludes the target of the change — no self-approval', async () => {
+    roleRows.owners = [
+      { user_id: 'telegram:owner1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+      { user_id: 'telegram:owner2', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-02' },
+    ];
+    reachable.add('telegram:owner1');
+    reachable.add('telegram:owner2');
+
+    // owner1 is the target of the revoke → must route to owner2.
+    await requestApproval({
+      ...base(),
+      approverConstraint: { minLevel: 'owner', excludeUserIds: ['telegram:owner1'] },
+    });
+
+    expect(createdApprovals[0].approver_user_id).toBe('telegram:owner2');
+    expect(delivered).toEqual([{ channelType: 'telegram', platformId: 'owner2' }]);
+  });
+
+  it('HOLDs with a message when the only qualified approver is the target (no downward/target fallback)', async () => {
+    roleRows.owners = [
+      { user_id: 'telegram:owner1', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.globalAdmins = [
+      { user_id: 'telegram:ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    reachable.add('telegram:owner1');
+    reachable.add('telegram:ga');
+
+    await requestApproval({
+      ...base(),
+      approverConstraint: { minLevel: 'owner', excludeUserIds: ['telegram:owner1'] },
+    });
+
+    expect(createdApprovals).toHaveLength(0);
+    expect(delivered).toHaveLength(0);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('no sufficiently-privileged approver');
+  });
+
+  it('HOLDs when a qualified approver exists but is unreachable (never falls to a junior)', async () => {
+    roleRows.owners = [
+      { user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.globalAdmins = [
+      { user_id: 'telegram:ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    reachable.add('telegram:ga'); // owner not reachable; ga must NOT be used for an owner-level change
+
+    await requestApproval({ ...base(), approverConstraint: { minLevel: 'owner' } });
+
+    expect(createdApprovals).toHaveLength(0);
+    expect(delivered).toHaveLength(0);
+    expect(notices[0]).toContain('no sufficiently-privileged approver is reachable');
+  });
+
+  it('global-admin level: a global admin may approve a group-scoped admin change', async () => {
+    roleRows.globalAdmins = [
+      { user_id: 'telegram:ga', role: 'admin', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.scopedAdmins.set('ag-1', [
+      { user_id: 'telegram:sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: '2020-01-01' },
+    ]);
+    reachable.add('telegram:ga');
+    reachable.add('telegram:sa');
+
+    await requestApproval({
+      ...base(),
+      approverConstraint: { minLevel: 'global-admin', excludeUserIds: ['telegram:sa'] },
+    });
+
+    expect(createdApprovals[0].approver_user_id).toBe('telegram:ga');
+  });
+});
+
+describe('requestApproval — legacy (unconstrained) routing unchanged', () => {
+  it('non-role approval uses pickApprover order (scoped admin first) and does NOT pin approver_user_id', async () => {
+    roleRows.owners = [
+      { user_id: 'telegram:owner', role: 'owner', agent_group_id: null, granted_by: null, granted_at: '2020-01-01' },
+    ];
+    roleRows.scopedAdmins.set('ag-1', [
+      { user_id: 'telegram:sa', role: 'admin', agent_group_id: 'ag-1', granted_by: null, granted_at: '2020-01-01' },
+    ]);
+    reachable.add('telegram:owner');
+    reachable.add('telegram:sa');
+
+    await requestApproval({ ...base() });
+
+    // legacy ordering delivers to the scoped admin first; approver_user_id stays null.
+    expect(delivered).toEqual([{ channelType: 'telegram', platformId: 'sa' }]);
+    expect(createdApprovals[0].approver_user_id).toBeNull();
+  });
+
+  it('explicit approverUserId still pins that exact user', async () => {
+    reachable.add('telegram:someone');
+    await requestApproval({ ...base(), approverUserId: 'telegram:someone' });
+    expect(createdApprovals[0].approver_user_id).toBe('telegram:someone');
+  });
+});


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3099.

**What.** Role-change approvals are routed by privilege and can never be sent to the user being changed. Previously the approval for revoking someone's `admin` could be delivered to that same user (self-approval), and a higher-privileged action could be gated on a lower-privileged approver.

**Why.** `pickApprover` ordered approvers group-admins → global-admins → owners (lowest first) and `pickApprovalDelivery` picked the first reachable on the origin channel — so revoking X's admin routed the card to X. #2478 requires the *responder* to be an admin but does not stop an admin *target* self-approving, and adds no proportionality. Separation-of-duties gap in the trusted tier (`docs/SECURITY.md`).

**How it works.**
- Privilege-proportional, conflict-excluding approver selection for role-change commands: changing an owner or global admin → owner approver; a group-scoped admin → global-admin or owner. Never routes downward.
- The **target** is excluded from the approver pool — no self-approval.
- **Fail-safe:** no eligible, non-conflicted, sufficiently-privileged approver reachable → held with a clear message, never mis-delivered.
- Approver pinned via `approver_user_id` and re-verified at apply time (mirrors #2566).
- Legacy `pickApprover`/`pickApprovalDelivery` untouched for all other approvals (create_agent, install_packages, add_mcp_server, OneCLI, a2a).

**Scope / non-goals.** Routing the confirmation *to a sufficiently-privileged initiating caller* (self-confirm, incl. a caller's own self-revoke) is future work — it needs a host-captured *verified* initiating principal, which the current caller context does not carry for agent callers. The safe routing above stands regardless.

**Coordination with #3040.** `feat/approval-contract` (#3040) rewrites `primitive.ts`/adds `approver-rule.ts` but does not implement target-exclusion or proportionality, so this fix is complementary. If #3040 lands first, this re-targets onto `mayResolve` (target-exclusion) + `pickApprover` (proportionality).

**How it was tested.** New unit tests: target excluded; a group-admin can't be selected for a global-admin/owner change; owner selected for high-privilege changes; no valid approver → held; existing non-role approvals unchanged; apply-time re-verification. Full suite green.
