### PR TITLE
fix(roles): refuse revoking the last remaining owner

### DIFF
--- a/src/cli/resources/roles.test.ts
+++ b/src/cli/resources/roles.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Last-owner hard stop for `ncl roles revoke`.
+ *
+ * The global `owner` (agent_group_id = null) is the root of trust; reaching
+ * zero owners is unrecoverable, so revoking the sole remaining owner must be
+ * refused outright with NO database change. This must hold on every path that
+ * reaches the revoke handler — the guard lives in the handler itself, so the
+ * test drives it through `dispatch()` with a host caller, the same code path a
+ * post-approval replay takes.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { initTestDb, closeDb, runMigrations, getDb } from '../../db/index.js';
+import { dispatch } from '../dispatch.js';
+// Side-effect import: registers the `roles-*` commands (including revoke).
+import './roles.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function addUser(id: string): void {
+  getDb()
+    .prepare(`INSERT INTO users (id, kind, display_name, created_at) VALUES (?, 'telegram', ?, ?)`)
+    .run(id, id, now());
+}
+
+function grantOwner(userId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+       VALUES (?, 'owner', NULL, NULL, ?)`,
+    )
+    .run(userId, now());
+}
+
+function grantGlobalAdmin(userId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO user_roles (user_id, role, agent_group_id, granted_by, granted_at)
+       VALUES (?, 'admin', NULL, NULL, ?)`,
+    )
+    .run(userId, now());
+}
+
+function count(sql: string, ...params: unknown[]): number {
+  return (
+    getDb()
+      .prepare(sql)
+      .get(...params) as { c: number }
+  ).c;
+}
+
+function revoke(user: string, role: string, group?: string) {
+  const args: Record<string, unknown> = { user, role };
+  if (group !== undefined) args.group = group;
+  return dispatch({ id: 'req-revoke', command: 'roles-revoke', args }, { caller: 'host' });
+}
+
+describe('roles revoke — last-owner hard stop', () => {
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('refuses to revoke the sole remaining owner and makes no DB change', async () => {
+    addUser('u1');
+    grantOwner('u1');
+
+    const resp = await revoke('u1', 'owner');
+
+    expect(resp.ok).toBe(false);
+    expect((resp as { ok: false; error: { code: string; message: string } }).error.code).toBe('handler-error');
+    expect((resp as { ok: false; error: { message: string } }).error.message).toMatch(
+      /cannot revoke the last remaining owner/i,
+    );
+
+    // The owner row must still be present — no DB change.
+    expect(count(`SELECT COUNT(*) AS c FROM user_roles WHERE user_id = 'u1' AND role = 'owner'`)).toBe(1);
+  });
+
+  it('allows revoking one of several owners, leaving the others', async () => {
+    addUser('u1');
+    addUser('u2');
+    grantOwner('u1');
+    grantOwner('u2');
+
+    const resp = await revoke('u1', 'owner');
+
+    expect(resp.ok).toBe(true);
+    expect(count(`SELECT COUNT(*) AS c FROM user_roles WHERE user_id = 'u1' AND role = 'owner'`)).toBe(0);
+    expect(count(`SELECT COUNT(*) AS c FROM user_roles WHERE user_id = 'u2' AND role = 'owner'`)).toBe(1);
+  });
+
+  it('is unaffected when revoking a non-owner role even if only one owner exists', async () => {
+    addUser('u1');
+    addUser('u2');
+    grantOwner('u1');
+    grantGlobalAdmin('u2');
+
+    const resp = await revoke('u2', 'admin');
+
+    expect(resp.ok).toBe(true);
+    expect(count(`SELECT COUNT(*) AS c FROM user_roles WHERE user_id = 'u2' AND role = 'admin'`)).toBe(0);
+    // The sole owner is untouched.
+    expect(count(`SELECT COUNT(*) AS c FROM user_roles WHERE user_id = 'u1' AND role = 'owner'`)).toBe(1);
+  });
+
+  it('returns "role not found" for a non-existent role (guard does not mask it)', async () => {
+    addUser('u1');
+    grantOwner('u1');
+
+    // u1 has no admin role — the guard is owner-only, so the delete runs and
+    // reports the normal not-found error.
+    const resp = await revoke('u1', 'admin');
+
+    expect(resp.ok).toBe(false);
+    expect((resp as { ok: false; error: { message: string } }).error.message).toMatch(/role not found/i);
+  });
+});

--- a/src/cli/resources/roles.ts
+++ b/src/cli/resources/roles.ts
@@ -1,4 +1,5 @@
 import { getDb } from '../../db/connection.js';
+import { isLastOwner } from '../../modules/permissions/db/user-roles.js';
 import { registerResource } from '../crud.js';
 
 registerResource({
@@ -56,6 +57,12 @@ registerResource({
         const groupId = (args.group as string) ?? null;
         if (!userId) throw new Error('--user is required');
         if (!role) throw new Error('--role is required');
+        // Last-owner hard stop: the global owner is the root of trust and
+        // reaching zero owners is unrecoverable, so refuse to delete the sole
+        // remaining owner outright — before any DB change, on every path.
+        if (role === 'owner' && groupId === null && isLastOwner(userId)) {
+          throw new Error('cannot revoke the last remaining owner — grant another owner first');
+        }
         const result = getDb()
           .prepare('DELETE FROM user_roles WHERE user_id = ? AND role = ? AND agent_group_id IS ?')
           .run(userId, role, groupId);

--- a/src/modules/permissions/db/user-roles.ts
+++ b/src/modules/permissions/db/user-roles.ts
@@ -72,6 +72,16 @@ export function hasAnyOwner(): boolean {
   return !!row;
 }
 
+/**
+ * True when `userId` is the sole remaining global owner — revoking their owner
+ * role would leave zero owners, an unrecoverable state (no one could ever
+ * approve an owner-level action again).
+ */
+export function isLastOwner(userId: string): boolean {
+  const owners = getOwners();
+  return owners.length === 1 && owners[0].user_id === userId;
+}
+
 export function getGlobalAdmins(): UserRole[] {
   return getDb()
     .prepare('SELECT * FROM user_roles WHERE role = ? AND agent_group_id IS NULL ORDER BY granted_at')


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3100.

**What.** Revoking the **sole remaining global `owner`** is refused outright, with no database change.

**Why.** The global `owner` (`agent_group_id = null`) is the root of trust — the only tier that can approve owner-level actions. Reaching zero owners is unrecoverable. This is the one irreversible role change; everything below the owner tier is recoverable (an owner can re-grant), so no other "last-X" guard is warranted.

**How it works.**
- An `isLastOwner(userId)` helper next to `getOwners()`/`hasAnyOwner()`: true when the global-owner rows are exactly one and it belongs to that user.
- The guard sits in the `roles.ts` revoke handler — the single choke point — after arg validation and before the `DELETE`. It holds on every path that reaches revoke (host CLI direct, agent approved-replay) and throws `cannot revoke the last remaining owner — grant another owner first`, so no `DELETE` runs.
- Owner-only: revoking one of several owners still succeeds; non-owner revokes unaffected; revoking a role the user doesn't hold still reports "role not found".

**How it was tested.** New unit tests via `dispatch()` (host caller, real in-memory DB): sole owner → refused, row intact; one of two owners → succeeds; non-owner revoke with a single owner → unaffected; non-existent role → still "role not found". Full suite green.
