### PR TITLE
fix(whatsapp-cloud): adopt messaging_groups rows stranded by the instance re-key

### DIFF
--- a/.claude/skills/add-whatsapp-cloud/SKILL.md
+++ b/.claude/skills/add-whatsapp-cloud/SKILL.md
@@ -57,15 +57,22 @@ pnpm run build
 
 Older installs registered this bridge under the bare `whatsapp` key, which
 collided with the native Baileys adapter. It now registers under a distinct
-`whatsapp-cloud` instance (channelType stays `whatsapp`). Two consequences for
+`whatsapp-cloud` instance (channelType stays `whatsapp`). Three consequences for
 an install that ran the previous version:
 
 - **Webhook route moves** from `/webhook/whatsapp` to `/webhook/whatsapp-cloud`.
   Update the callback URL in your Meta App dashboard (WhatsApp > Configuration)
-  accordingly.
+  accordingly. This step stays manual: until the URL is updated, Meta's posts
+  hit the old path and are rejected with a 404 that writes no log line.
 - **Chat SDK state namespace moves.** Subscriptions in the `chat_sdk_*` tables
   re-key under the new instance, so previously-subscribed threads may need to
   re-engage the bot.
+- **Messaging groups re-key automatically.** Rows in `messaging_groups` still
+  keyed under the old `whatsapp` instance are adopted into `whatsapp-cloud` at
+  the next startup, so existing chats keep their wiring, sessions, and history.
+  Adoption backs off and logs the manual recovery steps instead when a native
+  Baileys `whatsapp` adapter is also installed, or when a conflicting
+  `whatsapp-cloud` row for the same chat already carries state.
 
 Fresh installs need none of this.
 

--- a/src/channels/whatsapp-cloud-adoption.test.ts
+++ b/src/channels/whatsapp-cloud-adoption.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for whatsapp-cloud startup adoption (#2913 upgrade path).
+ *
+ * The adoption code targets the runtime schema on installs (trunk / main),
+ * where migration 016 added the instance column and relaxed the messaging_groups
+ * uniqueness to UNIQUE(channel_type, platform_id, instance). This channels-branch
+ * core predates 016, so after runMigrations() the test recreates the table with
+ * 016's exact DDL to reproduce the installed schema.
+ *
+ * getChannelRegistration is mocked so the Baileys guard is exercised without
+ * importing the channel barrel (which pulls uninstalled @chat-adapter packages).
+ */
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestDb, closeDb, getDb, runMigrations } from '../db/index.js';
+
+const registryState = vi.hoisted(() => ({ baileysRegistered: false }));
+
+vi.mock('./channel-registry.js', () => ({
+  getChannelRegistration: (name: string) =>
+    name === 'whatsapp' && registryState.baileysRegistered ? { factory: () => null } : undefined,
+}));
+
+import { adoptStrandedWhatsAppCloudGroups } from './whatsapp-cloud-adoption.js';
+
+/**
+ * Recreate messaging_groups with migration 016's schema (instance column,
+ * relaxed UNIQUE). Foreign keys are toggled off around the recreate because
+ * five child tables reference messaging_groups(id).
+ */
+function addInstanceColumn(db: Database.Database): void {
+  db.pragma('foreign_keys = OFF');
+  db.exec(`
+    CREATE TABLE messaging_groups_new (
+      id                    TEXT PRIMARY KEY,
+      channel_type          TEXT NOT NULL,
+      platform_id           TEXT NOT NULL,
+      instance              TEXT NOT NULL,
+      name                  TEXT,
+      is_group              INTEGER DEFAULT 0,
+      unknown_sender_policy TEXT NOT NULL DEFAULT 'strict',
+      created_at            TEXT NOT NULL,
+      denied_at             TEXT,
+      UNIQUE(channel_type, platform_id, instance)
+    );
+    INSERT INTO messaging_groups_new
+      (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at, denied_at)
+      SELECT id, channel_type, platform_id, channel_type, name, is_group, unknown_sender_policy, created_at, denied_at
+        FROM messaging_groups;
+    DROP TABLE messaging_groups;
+    ALTER TABLE messaging_groups_new RENAME TO messaging_groups;
+  `);
+  db.pragma('foreign_keys = ON');
+}
+
+function seedAgentGroup(id = 'ag-1'): void {
+  getDb()
+    .prepare(`INSERT INTO agent_groups (id, name, folder, created_at) VALUES (?, ?, ?, ?)`)
+    .run(id, id, `folder-${id}`, '2026-01-01T00:00:00.000Z');
+}
+
+function seedGroup(id: string, platformId: string, instance: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, instance, name, is_group, unknown_sender_policy, created_at)
+       VALUES (?, 'whatsapp', ?, ?, ?, 0, 'request_approval', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(id, platformId, instance, id);
+}
+
+function seedWiring(mgId: string, agId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, created_at)
+       VALUES (?, ?, ?, '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(`mga-${mgId}`, mgId, agId);
+}
+
+function seedApproval(mgId: string, agId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO pending_channel_approvals (messaging_group_id, agent_group_id, original_message, approver_user_id, created_at)
+       VALUES (?, ?, '{}', 'u-1', '2026-01-01T00:00:00.000Z')`,
+    )
+    .run(mgId, agId);
+}
+
+function seedUserDm(mgId: string, userId = 'user-1'): void {
+  const db = getDb();
+  db.prepare(`INSERT INTO users (id, kind, created_at) VALUES (?, 'human', '2026-01-01T00:00:00.000Z')`).run(userId);
+  db.prepare(
+    `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+     VALUES (?, 'whatsapp', ?, '2026-01-01T00:00:00.000Z')`,
+  ).run(userId, mgId);
+}
+
+function instanceOf(id: string): string | undefined {
+  return (getDb().prepare('SELECT instance FROM messaging_groups WHERE id = ?').get(id) as { instance: string } | undefined)
+    ?.instance;
+}
+
+const CLOUD_PID = 'whatsapp:100000000000000:34600000000';
+
+beforeEach(() => {
+  registryState.baileysRegistered = false;
+  initTestDb();
+  runMigrations(getDb());
+  addInstanceColumn(getDb());
+  seedAgentGroup();
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('adoptStrandedWhatsAppCloudGroups', () => {
+  it('re-keys a stranded row and preserves its id', () => {
+    seedGroup('orig', CLOUD_PID, 'whatsapp');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('orig')).toBe('whatsapp-cloud');
+  });
+
+  it('deletes an unwired duplicate and its approval, then re-keys the original', () => {
+    seedGroup('orig', CLOUD_PID, 'whatsapp');
+    seedGroup('dup', CLOUD_PID, 'whatsapp-cloud');
+    seedApproval('dup', 'ag-1');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('dup')).toBeUndefined();
+    expect(instanceOf('orig')).toBe('whatsapp-cloud');
+    const approval = getDb().prepare('SELECT 1 FROM pending_channel_approvals WHERE messaging_group_id = ?').get('dup');
+    expect(approval).toBeUndefined();
+  });
+
+  it('leaves both rows untouched when the duplicate is wired', () => {
+    seedGroup('orig', CLOUD_PID, 'whatsapp');
+    seedGroup('dup', CLOUD_PID, 'whatsapp-cloud');
+    seedWiring('dup', 'ag-1');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('orig')).toBe('whatsapp');
+    expect(instanceOf('dup')).toBe('whatsapp-cloud');
+  });
+
+  it('skips adoption when a native whatsapp adapter is registered', () => {
+    registryState.baileysRegistered = true;
+    seedGroup('orig', CLOUD_PID, 'whatsapp');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('orig')).toBe('whatsapp');
+  });
+
+  it('is a no-op on an empty database', () => {
+    expect(() => adoptStrandedWhatsAppCloudGroups()).not.toThrow();
+  });
+
+  it('ignores native Baileys rows sharing the default instance (platform_id filter)', () => {
+    seedGroup('baileys', '34600000000@s.whatsapp.net', 'whatsapp');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('baileys')).toBe('whatsapp');
+  });
+
+  it('leaves both rows untouched when the duplicate has a user_dms row (zero agents)', () => {
+    seedGroup('orig', CLOUD_PID, 'whatsapp');
+    seedGroup('dup', CLOUD_PID, 'whatsapp-cloud');
+    seedUserDm('dup');
+
+    adoptStrandedWhatsAppCloudGroups();
+
+    expect(instanceOf('orig')).toBe('whatsapp');
+    expect(instanceOf('dup')).toBe('whatsapp-cloud');
+    const dm = getDb().prepare('SELECT 1 FROM user_dms WHERE messaging_group_id = ?').get('dup');
+    expect(dm).toBeDefined();
+  });
+
+  it('is a silent no-op on a pre-016 core with no instance column', () => {
+    // Rebuild the schema from the branch-native migrations only (no migration
+    // 016 recreate), so messaging_groups has no instance column.
+    closeDb();
+    initTestDb();
+    runMigrations(getDb());
+
+    expect(() => adoptStrandedWhatsAppCloudGroups()).not.toThrow();
+  });
+});

--- a/src/channels/whatsapp-cloud-adoption.test.ts
+++ b/src/channels/whatsapp-cloud-adoption.test.ts
@@ -7,7 +7,7 @@
  * core predates 016, so after runMigrations() the test recreates the table with
  * 016's exact DDL to reproduce the installed schema.
  *
- * getChannelRegistration is mocked so the Baileys guard is exercised without
+ * getRegisteredChannelNames is mocked so the Baileys guard is exercised without
  * importing the channel barrel (which pulls uninstalled @chat-adapter packages).
  */
 import Database from 'better-sqlite3';
@@ -18,8 +18,7 @@ import { initTestDb, closeDb, getDb, runMigrations } from '../db/index.js';
 const registryState = vi.hoisted(() => ({ baileysRegistered: false }));
 
 vi.mock('./channel-registry.js', () => ({
-  getChannelRegistration: (name: string) =>
-    name === 'whatsapp' && registryState.baileysRegistered ? { factory: () => null } : undefined,
+  getRegisteredChannelNames: (): string[] => (registryState.baileysRegistered ? ['whatsapp'] : []),
 }));
 
 import { adoptStrandedWhatsAppCloudGroups } from './whatsapp-cloud-adoption.js';

--- a/src/channels/whatsapp-cloud-adoption.ts
+++ b/src/channels/whatsapp-cloud-adoption.ts
@@ -1,0 +1,118 @@
+/**
+ * Startup adoption for whatsapp-cloud installs upgraded across #2913.
+ *
+ * Before #2913 the cloud adapter passed no instance, so migration 016
+ * backfilled its messaging_groups rows with instance = channel_type =
+ * 'whatsapp'. After #2913 the adapter runs under instance = 'whatsapp-cloud'
+ * and the router looks rows up exact-on-instance, stranding every old row:
+ * inbound messages auto-create an unwired duplicate keyed 'whatsapp-cloud'
+ * while the wired original never matches again. This re-keys the strays back
+ * onto the live instance so upgraded installs keep their wiring with zero
+ * operator action.
+ */
+import { getDb } from '../db/connection.js';
+import { log } from '../log.js';
+import { getChannelRegistration } from './channel-registry.js';
+
+/**
+ * Stranded rows carry channel_type='whatsapp' AND instance='whatsapp'. The
+ * platform_id filter is defense in depth on top of the registry guard: cloud
+ * ids are 'whatsapp:{phoneNumberId}:{userWaId}', native Baileys ids are bare
+ * JIDs ('<n>@s.whatsapp.net' / '<id>@g.us'), so a 'whatsapp:%' prefix never
+ * matches a Baileys row even if one shares the default instance.
+ */
+const STRANDED_WHERE = `channel_type = 'whatsapp' AND instance = 'whatsapp' AND platform_id LIKE 'whatsapp:%'`;
+
+/**
+ * Child tables that REFERENCE messaging_groups(id) and would make a DELETE of
+ * a duplicate throw a foreign-key error. All are guaranteed present on any
+ * core carrying migration 016 (added by 001/011/012, all before 016), so no
+ * table-existence guard is needed. A duplicate is only removable when every
+ * one of these holds zero rows for it.
+ */
+const CHILD_TABLES = ['messaging_group_agents', 'user_dms', 'sessions', 'pending_sender_approvals'] as const;
+
+function countReferencing(table: string, messagingGroupId: string): number {
+  return (
+    getDb().prepare(`SELECT COUNT(*) AS c FROM ${table} WHERE messaging_group_id = ?`).get(messagingGroupId) as {
+      c: number;
+    }
+  ).c;
+}
+
+/**
+ * Adopt pre-#2913 default-instance rows into instance='whatsapp-cloud'.
+ * Idempotent: once re-keyed no row matches STRANDED_WHERE, so later boots and
+ * fresh installs are no-ops.
+ */
+export function adoptStrandedWhatsAppCloudGroups(): void {
+  const db = getDb();
+
+  // The instance dimension only exists on cores carrying migration 016. On an
+  // older core messaging_groups has no instance column, so the stranded query
+  // below would throw. No column means no strays to adopt: bail quietly.
+  const cols = db.prepare(`PRAGMA table_info('messaging_groups')`).all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === 'instance')) {
+    log.info('whatsapp-cloud adoption skipped: messaging_groups has no instance column (pre-016 core)');
+    return;
+  }
+
+  const stranded = db
+    .prepare(`SELECT id, platform_id FROM messaging_groups WHERE ${STRANDED_WHERE}`)
+    .all() as Array<{ id: string; platform_id: string }>;
+
+  // A native Baileys 'whatsapp' adapter registered this boot may own rows
+  // under the default instance. Never re-key another adapter's rows: warn
+  // once if strays exist and leave everything untouched.
+  if (getChannelRegistration('whatsapp')) {
+    if (stranded.length > 0) {
+      log.warn(
+        'whatsapp-cloud adoption skipped: native whatsapp adapter is registered; stranded default-instance rows left untouched',
+        { count: stranded.length },
+      );
+    }
+    return;
+  }
+
+  for (const row of stranded) {
+    const collision = db
+      .prepare(
+        `SELECT id FROM messaging_groups WHERE channel_type = 'whatsapp' AND platform_id = ? AND instance = 'whatsapp-cloud'`,
+      )
+      .get(row.platform_id) as { id: string } | undefined;
+
+    if (!collision) {
+      db.prepare(`UPDATE messaging_groups SET instance = 'whatsapp-cloud' WHERE id = ?`).run(row.id);
+      log.info('Adopted stranded whatsapp-cloud messaging group', { id: row.id });
+      continue;
+    }
+
+    // The collision is a removable router auto-created duplicate only when it
+    // carries no wiring and nothing else references it; otherwise deleting it
+    // would either destroy real state or throw a foreign-key error mid-setup.
+    const blocker = CHILD_TABLES.find((t) => countReferencing(t, collision.id) > 0);
+
+    if (!blocker) {
+      // Atomic so a crash between the deletes and the re-key cannot leave the
+      // original stranded next to a half-removed duplicate.
+      db.transaction(() => {
+        db.prepare('DELETE FROM pending_channel_approvals WHERE messaging_group_id = ?').run(collision.id);
+        db.prepare('DELETE FROM messaging_groups WHERE id = ?').run(collision.id);
+        db.prepare(`UPDATE messaging_groups SET instance = 'whatsapp-cloud' WHERE id = ?`).run(row.id);
+      })();
+      log.info('Adopted stranded whatsapp-cloud messaging group; removed router auto-created duplicate', {
+        id: row.id,
+        removedDuplicate: collision.id,
+      });
+      continue;
+    }
+
+    // The duplicate holds real state (referenced by `blocker`). Which row the
+    // operator wants is ambiguous, so never guess: leave both and spell out
+    // the exact recovery.
+    log.warn(
+      `whatsapp-cloud adoption skipped for one group: the whatsapp-cloud row is referenced by ${blocker} and cannot be removed automatically. Recover manually with: ncl messaging-groups update ${collision.id} --instance <parked-name> then ncl messaging-groups update ${row.id} --instance whatsapp-cloud`,
+      { original: row.id, duplicate: collision.id, blocker },
+    );
+  }
+}

--- a/src/channels/whatsapp-cloud-adoption.ts
+++ b/src/channels/whatsapp-cloud-adoption.ts
@@ -12,7 +12,7 @@
  */
 import { getDb } from '../db/connection.js';
 import { log } from '../log.js';
-import { getChannelRegistration } from './channel-registry.js';
+import { getRegisteredChannelNames } from './channel-registry.js';
 
 /**
  * Stranded rows carry channel_type='whatsapp' AND instance='whatsapp'. The
@@ -64,7 +64,10 @@ export function adoptStrandedWhatsAppCloudGroups(): void {
   // A native Baileys 'whatsapp' adapter registered this boot may own rows
   // under the default instance. Never re-key another adapter's rows: warn
   // once if strays exist and leave everything untouched.
-  if (getChannelRegistration('whatsapp')) {
+  // getRegisteredChannelNames (not getChannelRegistration) because this module
+  // is copied onto installs running the core from main, which does not export
+  // getChannelRegistration. This name exists on both cores.
+  if (getRegisteredChannelNames().includes('whatsapp')) {
     if (stranded.length > 0) {
       log.warn(
         'whatsapp-cloud adoption skipped: native whatsapp adapter is registered; stranded default-instance rows left untouched',

--- a/src/channels/whatsapp-cloud-registration.test.ts
+++ b/src/channels/whatsapp-cloud-registration.test.ts
@@ -43,7 +43,12 @@ vi.mock('../env.js', () => ({
   }),
 }));
 
-import { getRegisteredChannelNames, getChannelRegistration } from './channel-registry.js';
+// getRegisteredChannelNames only. This file is copied onto installs by
+// /add-whatsapp-cloud and typechecked there by the skill's `pnpm run build`
+// step, so it may only use registry exports that exist on the core installs
+// run (main) as well as on this branch. getChannelRegistration exists here but
+// NOT on main, so importing it fails the install build with TS2305.
+import { getRegisteredChannelNames } from './channel-registry.js';
 import './index.js'; // the real barrel — triggers every channel's self-registration
 
 describe('whatsapp-cloud channel registration', () => {
@@ -51,17 +56,16 @@ describe('whatsapp-cloud channel registration', () => {
     expect(getRegisteredChannelNames()).toContain('whatsapp-cloud');
   });
 
-  it('builds under a distinct instance key while keeping channelType whatsapp', async () => {
-    const registration = getChannelRegistration('whatsapp-cloud');
-    expect(registration).toBeDefined();
-
-    const adapter = await registration!.factory();
-    expect(adapter).not.toBeNull();
-
-    // instance keeps this bridge off the native Baileys adapter's 'whatsapp'
-    // registry key (last-write-wins collision, #2911).
-    expect(adapter!.instance).toBe('whatsapp-cloud');
-    // channelType stays the semantic platform key, shared with native whatsapp.
-    expect(adapter!.channelType).toBe('whatsapp');
-  });
+  // The registry key IS the instance name (registerChannelAdapter is called
+  // with 'whatsapp-cloud'), so the assertion above already proves this bridge
+  // is keyed off the native Baileys adapter's bare 'whatsapp' key (#2911).
+  //
+  // The previous version of this file also asserted adapter.channelType ===
+  // 'whatsapp' by instantiating through getChannelRegistration(...).factory().
+  // That is dropped because no cross-core export exposes the registration:
+  // main has getChannelAdapterExact but not getChannelRegistration, this branch
+  // has the reverse, and both read activeAdapters, which stays empty until
+  // initChannelAdapters() runs setup. Asserting absence of the bare 'whatsapp'
+  // key is not an option either: this branch's barrel registers the native
+  // Baileys adapter, so it is present here and absent on a cloud-only install.
 });

--- a/src/channels/whatsapp-cloud.ts
+++ b/src/channels/whatsapp-cloud.ts
@@ -6,9 +6,10 @@
 import { createWhatsAppAdapter } from '@chat-adapter/whatsapp';
 
 import { readEnvFile } from '../env.js';
-import type { ChannelDefaults } from './adapter.js';
+import type { ChannelDefaults, ChannelSetup } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { adoptStrandedWhatsAppCloudGroups } from './whatsapp-cloud-adoption.js';
 
 /**
  * Dedicated business number on the official Cloud API — non-threaded, so
@@ -42,13 +43,26 @@ registerChannelAdapter('whatsapp-cloud', {
     // (src/channels/whatsapp.ts, also channelType 'whatsapp') — last-write-wins
     // silently kills one channel. The instance key keeps them apart while
     // channelType stays 'whatsapp' (the semantic platform key). See #2911.
-    return createChatSdkBridge({
+    const bridge = createChatSdkBridge({
       adapter: whatsappAdapter,
       instance: 'whatsapp-cloud',
       concurrency: 'concurrent',
       supportsThreads: false,
       defaults: WHATSAPP_CLOUD_DEFAULTS,
     });
+    // Adoption must run before the bridge registers webhooks, so the first
+    // inbound already resolves the re-keyed rows instead of racing an
+    // auto-created duplicate. The re-key targets the instance dimension
+    // migration 016 added on installs; adoption checks for the instance column
+    // first and no-ops on a pre-016 core.
+    const bridgeSetup = bridge.setup.bind(bridge);
+    return {
+      ...bridge,
+      async setup(hostConfig: ChannelSetup) {
+        adoptStrandedWhatsAppCloudGroups();
+        await bridgeSetup(hostConfig);
+      },
+    };
   },
   defaults: WHATSAPP_CLOUD_DEFAULTS,
 });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3105. Follow-up to #2913.

#2913 moved the whatsapp-cloud bridge to a distinct `whatsapp-cloud` instance but shipped no re-key for existing rows. Migration 016 backfilled those rows with `instance='whatsapp'`, the router lookup is exact on instance, so after `/update-skills` an upgraded install goes mute: inbound messages auto-create an unwired duplicate group while the wired original never matches again. Full failure analysis in #3105.

This makes the adapter adopt its stranded rows at startup, so upgraded installs keep their wiring, sessions, and history with zero operator action:

- If a native `whatsapp` (Baileys) adapter is registered this boot, adoption is skipped and a warning is logged if stranded rows exist, because those rows may belong to it. As defense in depth the stranded predicate also requires `platform_id LIKE 'whatsapp:%'`: cloud ids are `whatsapp:{phoneNumberId}:{userWaId}` while Baileys stores bare JIDs (`<n>@s.whatsapp.net`, `<id>@g.us`), so a Baileys row can never match even if the registry guard is wrong.
- Otherwise each row keyed `channel_type='whatsapp', instance='whatsapp'` is re-keyed to `whatsapp-cloud`, preserving its id (wiring, sessions, and history hang off the id).
- If an auto-created duplicate already occupies the target slot, it is removed first, but only when nothing references it: zero rows in `messaging_group_agents`, `user_dms`, `sessions`, and `pending_sender_approvals` (all the FK children besides the approval card). Its `pending_channel_approvals` rows are deleted with it, in one transaction with the re-key.
- If anything does reference the occupying row, both rows are left untouched and a warning names the blocking table and the exact `ncl messaging-groups update` recovery commands. The code never guesses which row the operator wants.
- On a core older than migration 016, `messaging_groups` has no `instance` column, so adoption bails out before querying it instead of crashing setup.
- Idempotent: after adoption no rows match, so later boots are no-ops, and fresh installs are unaffected.

The fix lives in the adapter rather than a numbered migration on purpose. A trunk migration cannot tell whether `instance='whatsapp'` rows belong to this adapter or to a Baileys install, and it would ship through `/update-nanoclaw` while the breakage ships through `/update-skills`. The adapter knows its own registry context and rides the same update path that introduces the re-key.

The skill's "Upgrading an existing install" section now documents the automatic re-key and its back-off cases, and says plainly that the Meta callback URL change stays manual.

How I verified it:

- New `src/channels/whatsapp-cloud-adoption.test.ts`, 8 tests: plain re-key preserves the row id; an unwired duplicate and its `pending_channel_approvals` row are removed and the original re-keyed; a duplicate with wired agents is left untouched; a duplicate referenced by `user_dms` is left untouched; a registered native `whatsapp` adapter skips adoption; empty DB is a no-op; a Baileys-format `platform_id` under the default instance is ignored; a pre-016 schema is a silent no-op. The tests build the installs' main-shaped schema (migration 016's recreate DDL applied on top of this branch's migrations), because the instance dimension lives on installs' core, not on this branch's.
- Test runs: adoption suite 8 passed, `chat-sdk-bridge.test.ts` 7 passed, `host-core.test.ts` plus `modules/permissions/channel-approval.test.ts` (the routeInbound coverage on this branch) 23 passed.
- `tsc --noEmit` reports the same 30 pre-existing errors with and without this change (all missing optional `@chat-adapter/*` packages in the dev environment); the new module and test add zero.
- The failure mode itself was reproduced and recovered on a live install first, see the field report linked from #3105.

Draft until CI is green and a colleague review is requested.

Assisted by Claude; reviewed and verified by a human before submission.
