### PR TITLE
fix(add-whatsapp-cloud): copy the adoption module and document the row re-key

### DIFF
--- a/.claude/skills/add-whatsapp-cloud/SKILL.md
+++ b/.claude/skills/add-whatsapp-cloud/SKILL.md
@@ -23,6 +23,7 @@ Fetch the `channels` branch and copy the WhatsApp Cloud adapter into
 
 ```nc:copy from-branch:channels
 src/channels/whatsapp-cloud.ts
+src/channels/whatsapp-cloud-adoption.ts
 src/channels/whatsapp-cloud-registration.test.ts
 ```
 
@@ -69,12 +70,23 @@ below.
 
 Older copies of the adapter registered this bridge under the bare `whatsapp` key,
 which collided with the native Baileys adapter. It now registers under a distinct
-`whatsapp-cloud` instance (channelType stays `whatsapp`). Two consequences for an
-install that ran the previous version:
+`whatsapp-cloud` instance (channelType stays `whatsapp`). Three consequences for
+an install that ran the previous version:
 
 - **Webhook route moves** from `/webhook/whatsapp` to `/webhook/whatsapp-cloud`.
   Update the callback URL in your Meta App dashboard (WhatsApp > Configuration)
-  accordingly.
+  accordingly. This step stays manual, and until it is done Meta's posts hit the
+  old path and are rejected with a 404 that writes no log line, so the host log
+  looks idle rather than broken.
+- **Messaging groups re-key.** `messaging_groups` rows created before the change
+  are keyed `instance='whatsapp'`, while the adapter now looks them up as
+  `whatsapp-cloud`. Until they are re-keyed, inbound messages auto-create an
+  unwired duplicate group and the agent never answers. The signature in
+  `logs/nanoclaw.log` is an `Auto-created messaging group` line right after an
+  `Inbound DM received` line for a chat that already had a wired group. Re-key
+  with `ncl messaging-groups update <id> --instance whatsapp-cloud`; if a
+  duplicate already occupies the slot, park it first under any unused instance
+  name, since the uniqueness key is `channel_type + platform_id + instance`.
 - **Chat SDK state namespace moves.** Subscriptions in the `chat_sdk_*` tables
   re-key under the new instance, so previously-subscribed threads may need to
   re-engage the bot.


### PR DESCRIPTION
Companion to #3106. Draft because of a merge-order dependency, see below.

## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The `nc:copy` fence in `.claude/skills/add-whatsapp-cloud/SKILL.md` lists the files the skill pulls from the `channels` branch. #3106 adds `src/channels/whatsapp-cloud-adoption.ts` there and imports it from `whatsapp-cloud.ts`. Without this fence line the skill copies an adapter whose import target was never copied, and the install fails at the skill's own `pnpm run build` step.

Worth being explicit about the blast radius: that breaks installs which were working fine beforehand, not only the ones the adoption code exists to repair.

This also documents the `messaging_groups` re-key under "Upgrading an existing install". #3106 adds an equivalent note to the `channels`-branch copy of this SKILL.md, but that is not the copy operators read, and it carries no `nc:copy` fence at all. Worth settling which copy is authoritative; this PR assumes the one on `main` is.

## Merge order

This must not merge before #3106 lands on `channels`, or the copy step fetches a file that does not exist yet.

Merging #3106 first leaves a window in which any `/update-skills` breaks a working install. The zero-risk sequence is three steps:

1. land `whatsapp-cloud-adoption.ts` on `channels` without importing it from `whatsapp-cloud.ts`
2. merge this PR, so the fence copies a file that exists
3. wire the import on `channels`

If that is more ceremony than it is worth, merging #3106 and this one back to back is fine, as long as nobody runs `/update-skills` in between.

## How I verified it

- `skill-conformance`, `skill-directives` and `skill-policy` suites pass with the amended fence: 189 tests.
- The underlying breakage was reproduced on a live main-based install: copying #3106's files in and running `tsc --noEmit` failed with TS2305, and passes after the fixes pushed to that PR.

Assisted by Claude; reviewed and verified by a human before submission.
