### PR TITLE
fix(chat-sdk-bridge): rehydrate inbound attachments when adapters carry no fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, enrichInboundAttachment, splitForLimit } from './chat-sdk-bridge.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -419,5 +419,46 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(calls).toHaveLength(1);
     const msg = calls[0].message as { markdown?: string };
     expect(msg.markdown).toBe('plain hello');
+  });
+});
+
+describe('enrichInboundAttachment', () => {
+  const baseAtt = { type: 'image', name: 'photo.heic', mimeType: 'image/heic', size: 123 };
+
+  it('uses fetchData when present', async () => {
+    const att = { ...baseAtt, fetchData: async () => Buffer.from('hello') };
+    const adapter = stubAdapter({});
+    const entry = await enrichInboundAttachment(att as never, adapter);
+    expect(entry.data).toBe(Buffer.from('hello').toString('base64'));
+    expect(entry.name).toBe('photo.heic');
+  });
+
+  it('recovers bytes via rehydrateAttachment when fetchData is absent (iMessage local file)', async () => {
+    const att = { ...baseAtt }; // no fetchData (stripped on serialize)
+    const adapter = stubAdapter({
+      rehydrateAttachment: (a) =>
+        ({ ...a, name: 'photo.jpg', mimeType: 'image/jpeg', fetchData: async () => Buffer.from('JPEGBYTES') }) as never,
+    });
+    const entry = await enrichInboundAttachment(att as never, adapter);
+    expect(entry.data).toBe(Buffer.from('JPEGBYTES').toString('base64'));
+    // corrected name/mimeType from rehydration win (HEIC→JPEG)
+    expect(entry.name).toBe('photo.jpg');
+    expect(entry.mimeType).toBe('image/jpeg');
+  });
+
+  it('leaves data unset when there is no fetchData and no rehydrator', async () => {
+    const entry = await enrichInboundAttachment({ ...baseAtt } as never, stubAdapter({}));
+    expect(entry.data).toBeUndefined();
+    expect(entry.name).toBe('photo.heic');
+  });
+
+  it('does not throw (and drops no message) when rehydrateAttachment throws', async () => {
+    const adapter = stubAdapter({
+      rehydrateAttachment: () => {
+        throw new Error('boom');
+      },
+    });
+    const entry = await enrichInboundAttachment({ ...baseAtt } as never, adapter);
+    expect(entry.data).toBeUndefined();
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -15,6 +15,7 @@ import {
   LinkButton,
   type CardChild,
   type Adapter,
+  type Attachment,
   type ConcurrencyStrategy,
   type Message as ChatMessage,
 } from 'chat';
@@ -134,6 +135,50 @@ export function splitForLimit(text: string, limit: number): string[] {
   return chunks;
 }
 
+/**
+ * Serialize one inbound attachment for the session inbox, eagerly resolving its
+ * bytes as base64 `data` so `session-manager.extractAttachmentFiles` can stage
+ * it into the container-mounted `inbox/`. The chat-sdk core drops `fetchData`
+ * when it serializes an inbound message, and some adapters never set it because
+ * their bytes live on the host rather than behind a URL. When `fetchData` is
+ * absent, let the adapter rebuild a downloader via `rehydrateAttachment` (e.g.
+ * iMessage resolves the file under ~/Library/Messages/Attachments and converts
+ * HEIC→JPEG). Guarded so a throwing adapter can never drop the whole inbound
+ * message; any corrected name/mimeType from rehydration wins.
+ */
+export async function enrichInboundAttachment(att: Attachment, adapter: Adapter): Promise<Record<string, unknown>> {
+  const entry: Record<string, unknown> = {
+    type: att.type,
+    name: att.name,
+    mimeType: att.mimeType,
+    size: att.size,
+    width: (att as unknown as Record<string, unknown>).width,
+    height: (att as unknown as Record<string, unknown>).height,
+  };
+  let source = att;
+  if (!source.fetchData && adapter.rehydrateAttachment) {
+    try {
+      const rehydrated = adapter.rehydrateAttachment(att);
+      if (rehydrated?.fetchData) {
+        source = rehydrated;
+        if (rehydrated.name) entry.name = rehydrated.name;
+        if (rehydrated.mimeType) entry.mimeType = rehydrated.mimeType;
+      }
+    } catch (err) {
+      log.warn('Failed to rehydrate attachment', { type: att.type, err });
+    }
+  }
+  if (source.fetchData) {
+    try {
+      const buffer = await source.fetchData();
+      entry.data = buffer.toString('base64');
+    } catch (err) {
+      log.warn('Failed to download attachment', { type: att.type, err });
+    }
+  }
+  return entry;
+}
+
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
   // The instance name becomes a webhook route segment (the route regex is
@@ -163,28 +208,11 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serialized = message.toJSON() as Record<string, any>;
 
-    // Download attachment data before serialization loses fetchData()
+    // Resolve attachment bytes to base64 before serialization loses fetchData()
     if (message.attachments && message.attachments.length > 0) {
       const enriched = [];
       for (const att of message.attachments) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entry: Record<string, any> = {
-          type: att.type,
-          name: att.name,
-          mimeType: att.mimeType,
-          size: att.size,
-          width: (att as unknown as Record<string, unknown>).width,
-          height: (att as unknown as Record<string, unknown>).height,
-        };
-        if (att.fetchData) {
-          try {
-            const buffer = await att.fetchData();
-            entry.data = buffer.toString('base64');
-          } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
-          }
-        }
-        enriched.push(entry);
+        enriched.push(await enrichInboundAttachment(att, adapter));
       }
       serialized.attachments = enriched;
     }


### PR DESCRIPTION
## Problem

The Chat SDK core drops `fetchData` when it serializes an inbound message, and some adapters never set it in the first place because the attachment bytes live on the **host** (e.g. a local file store) rather than behind a URL. In that case the bridge staged an attachment entry with no `data`, so the agent received only a filename — it could never see the image.

## Fix

Extract the per-attachment serialization into `enrichInboundAttachment(att, adapter)`:

- When `fetchData` is absent **and** the adapter implements the optional `rehydrateAttachment` hook (a first-class `Adapter` member in `chat`), let the adapter rebuild a downloader.
- Then resolve the bytes to base64 exactly as before.
- Guarded so a throwing adapter can never drop the whole inbound message; any corrected `name`/`mimeType` from rehydration wins.

This is generic bridge infra — any Chat SDK adapter whose attachment bytes live host-side can now implement `rehydrateAttachment` and have inbound images staged correctly. (The first consumer is the iMessage adapter on the `channels` branch, submitted separately.)

## Testing

- `pnpm run typecheck` clean
- `pnpm exec vitest run src/channels/chat-sdk-bridge.test.ts` — includes new cases for rehydration, absent-hook fallthrough, and a throwing-hook guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)