### PR TITLE
feat(container): bake caldav-mcp into the agent image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -22,6 +22,11 @@ ARG INSTALL_CJK_FONTS=false
 # pinned in cli-tools.json so a skill can add one with a json-merge; Bun (the
 # runtime) is pinned here because it installs from a different source.
 ARG BUN_VERSION=1.3.12
+# caldav-mcp: the CalDAV MCP server the /add-caldav-tool skill wires up. Baked
+# into the image so the skill needs no per-agent runtime install; pinned here
+# rather than in cli-tools.json because it is an MCP stdio server, not a CLI the
+# agent invokes as a command.
+ARG CALDAV_MCP_VERSION=0.8.0
 
 # ---- System dependencies -----------------------------------------------------
 # tini: correct PID 1 / signal forwarding so outbound.db writes finalize on
@@ -105,6 +110,11 @@ RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 COPY cli-tools.json install-cli-tools.sh /tmp/
 RUN --mount=type=cache,target=/root/.cache/pnpm \
     sh /tmp/install-cli-tools.sh /tmp/cli-tools.json
+
+# caldav-mcp MCP server (wired by the /add-caldav-tool skill). Installed via
+# pnpm so it goes through the same supply-chain policy as the CLIs above.
+RUN --mount=type=cache,target=/root/.cache/pnpm \
+    pnpm install -g "caldav-mcp@${CALDAV_MCP_VERSION}"
 
 # ---- ncl CLI wrapper ----------------------------------------------------------
 # Actual script lives in the mounted source at /app/src/cli/ncl.ts.


### PR DESCRIPTION
## What

Bake the `caldav-mcp` MCP server into the base agent image:
- A pinned `ARG CALDAV_MCP_VERSION=0.8.0`.
- A `pnpm install -g` step alongside the other global Node CLIs, so it goes through the same supply-chain policy.

## Why

The [`/add-caldav-tool`](https://github.com/nanocoai/nanoclaw/pull/2530) skill wires up `caldav-mcp`. Baking it into the image means an agent group enabling the skill needs no per-request runtime install — the server is already present.

Self-contained: no dependency on other MCP-server bakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)