### PR TITLE
Protect URLs from Telegram legacy-Markdown delimiter stripping

### DIFF
--- a/src/channels/telegram-markdown-sanitize.test.ts
+++ b/src/channels/telegram-markdown-sanitize.test.ts
@@ -58,10 +58,15 @@ describe('sanitizeTelegramLegacyMarkdown', () => {
     expect(sanitizeTelegramLegacyMarkdown('')).toBe('');
   });
 
-  it('wraps a bare URL containing an underscore so Telegram does not misparse it as italics', () => {
+  it('wraps a bare URL containing an underscore, percent-encoding it in the destination only', () => {
+    // The label keeps the human-readable underscore (the adapter's own
+    // markdown round-trip backslash-escapes it there); the destination is
+    // percent-encoded so @chat-adapter/telegram's post-render safe-boundary
+    // trim (a *different*, upstream bug — see the file header) doesn't see
+    // an unescaped `_` and truncate the message right before the link.
     const input = 'MR created: https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453';
     expect(sanitizeTelegramLegacyMarkdown(input)).toBe(
-      'MR created: [https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453](https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453)',
+      'MR created: [https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453](https://gitlab.com/lizo-ai/lizo-UI/-/merge%5Frequests/453)',
     );
   });
 
@@ -70,13 +75,18 @@ describe('sanitizeTelegramLegacyMarkdown', () => {
     // own underscore must not be stripped as collateral damage.
     const input = 'file_name and https://gitlab.com/x/-/merge_requests/1';
     const out = sanitizeTelegramLegacyMarkdown(input);
-    expect(out).toContain('merge_requests');
-    expect(out).toContain('[https://gitlab.com/x/-/merge_requests/1](https://gitlab.com/x/-/merge_requests/1)');
+    expect(out).toContain('merge_requests'); // label — human-readable
+    expect(out).toContain('[https://gitlab.com/x/-/merge_requests/1](https://gitlab.com/x/-/merge%5Frequests/1)');
   });
 
-  it('does not re-wrap a URL already inside a markdown link', () => {
+  it('does not re-wrap a URL already inside a markdown link, but still percent-encodes its destination', () => {
     const input = 'see [docs](https://example.com/a_b) for more';
-    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe('see [docs](https://example.com/a%5Fb) for more');
+  });
+
+  it('percent-encodes *, ~, and ` in a link destination too, not just _', () => {
+    const input = 'see [docs](https://example.com/a*b~c`d) for more';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe('see [docs](https://example.com/a%2Ab%7Ec%60d) for more');
   });
 
   it('leaves a URL already inside a code span untouched', () => {

--- a/src/channels/telegram-markdown-sanitize.test.ts
+++ b/src/channels/telegram-markdown-sanitize.test.ts
@@ -58,6 +58,32 @@ describe('sanitizeTelegramLegacyMarkdown', () => {
     expect(sanitizeTelegramLegacyMarkdown('')).toBe('');
   });
 
+  it('wraps a bare URL containing an underscore so Telegram does not misparse it as italics', () => {
+    const input = 'MR created: https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(
+      'MR created: [https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453](https://gitlab.com/lizo-ai/lizo-UI/-/merge_requests/453)',
+    );
+  });
+
+  it('protects a wrapped URL from the odd-underscore-count stripping pass', () => {
+    // One stray underscore elsewhere makes the total count odd; the URL's
+    // own underscore must not be stripped as collateral damage.
+    const input = 'file_name and https://gitlab.com/x/-/merge_requests/1';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).toContain('merge_requests');
+    expect(out).toContain('[https://gitlab.com/x/-/merge_requests/1](https://gitlab.com/x/-/merge_requests/1)');
+  });
+
+  it('does not re-wrap a URL already inside a markdown link', () => {
+    const input = 'see [docs](https://example.com/a_b) for more';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+  });
+
+  it('leaves a URL already inside a code span untouched', () => {
+    const input = 'see `https://example.com/merge_requests/1` for the raw link';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+  });
+
   it('replaces dash list bullets with • so the adapter does not re-emit `*` markers', () => {
     expect(sanitizeTelegramLegacyMarkdown('- one\n- two')).toBe('• one\n• two');
   });

--- a/src/channels/telegram-markdown-sanitize.ts
+++ b/src/channels/telegram-markdown-sanitize.ts
@@ -21,6 +21,33 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
     return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
   });
 
+  // Existing markdown links (e.g. `[docs](https://example.com/a_b)`) hide
+  // their URL from the bare-URL wrap below and get placeholder-protected
+  // here first, so an underscore in the link *destination* survives the
+  // delimiter-parity stripping a few lines down same as a code span would.
+  const LINK_PATTERN = /\[[^[\]\n]*\]\([^()\n]*\)/g;
+  text = text.replace(LINK_PATTERN, (m) => {
+    codeSegments.push(m);
+    return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
+  });
+
+  // Bare URLs (not already in a markdown link or code span, both already
+  // placeholder-protected above) commonly contain underscores — GitLab's
+  // /-/merge_requests/ path is the recurring offender. The delimiter-parity
+  // check below can't tell a URL's underscore from a real _italic_ marker,
+  // and Telegram's own legacy-Markdown parser chokes on an unescaped `_`
+  // inside a bare URL ("can't find end of a URL"), silently dropping the
+  // message after retries exhaust. Wrapping in `[url](url)` moves the
+  // underscore into the link *destination*, which Telegram does not
+  // re-parse for entities — keeps the link clickable, unlike backticks.
+  // Protected via the same placeholder mechanism as code spans (not inlined
+  // directly) so the parity/bracket checks below can't see or strip its `_`
+  // or `[`/`]` — those checks run on raw regex counts, not real parse state.
+  text = text.replace(/\bhttps?:\/\/[^\s<>\])]+/g, (m) => {
+    codeSegments.push(`[${m}](${m})`);
+    return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
+  });
+
   // The adapter re-parses and re-stringifies markdown before sending, which
   // rewrites `- item` list bullets into `* item` — injecting unbalanced
   // asterisks that Telegram's legacy Markdown parser then rejects. Replace

--- a/src/channels/telegram-markdown-sanitize.ts
+++ b/src/channels/telegram-markdown-sanitize.ts
@@ -12,6 +12,25 @@ const CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
 const PLACEHOLDER_PREFIX = '\x00CODE';
 const PLACEHOLDER_SUFFIX = '\x00';
 
+// @chat-adapter/telegram's own pre-send safety net — trimToMarkdownV2SafeBoundary
+// (node_modules/@chat-adapter/telegram/dist/index.js) — scans the FINAL rendered
+// text for unescaped *, _, ~, ` and silently truncates at the last unpaired one
+// if the total count is odd. It runs unconditionally (even when nothing needs
+// truncating for length) and doesn't know a link *destination* is exempt from
+// entity parsing — one bare `_` there (e.g. GitLab's /-/merge_requests/) is an
+// odd count on its own, so it chops the message right before the link. This is
+// NOT the same bug as the delimiter-parity check below (that one is ours, in
+// this file); it's upstream, in the adapter package, and survives even after
+// wrapping the URL in `[label](dest)` — only the label gets backslash-escaped
+// by the adapter's own round-trip, the destination doesn't. Percent-encoding
+// these four chars in the destination (not the label, so it stays readable)
+// sidesteps it — GitLab and every other server decode %5F etc. transparently,
+// confirmed the encoded and literal URLs 302 identically.
+const MARKDOWN_V2_TRIM_TRIGGER_CHARS = /[_*~`]/g;
+function encodeLinkDestination(url: string): string {
+  return url.replace(MARKDOWN_V2_TRIM_TRIGGER_CHARS, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
 export function sanitizeTelegramLegacyMarkdown(input: string): string {
   if (!input) return input;
 
@@ -25,9 +44,13 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
   // their URL from the bare-URL wrap below and get placeholder-protected
   // here first, so an underscore in the link *destination* survives the
   // delimiter-parity stripping a few lines down same as a code span would.
-  const LINK_PATTERN = /\[[^[\]\n]*\]\([^()\n]*\)/g;
-  text = text.replace(LINK_PATTERN, (m) => {
-    codeSegments.push(m);
+  // The destination also gets percent-encoded (see encodeLinkDestination
+  // above) so the adapter's own post-render safe-boundary trim doesn't choke
+  // on it after this function returns — protecting it here isn't enough,
+  // since that trim runs downstream of this whole sanitizer.
+  const LINK_PATTERN = /\[([^[\]\n]*)\]\(([^()\n]*)\)/g;
+  text = text.replace(LINK_PATTERN, (_m, label: string, url: string) => {
+    codeSegments.push(`[${label}](${encodeLinkDestination(url)})`);
     return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
   });
 
@@ -38,13 +61,13 @@ export function sanitizeTelegramLegacyMarkdown(input: string): string {
   // and Telegram's own legacy-Markdown parser chokes on an unescaped `_`
   // inside a bare URL ("can't find end of a URL"), silently dropping the
   // message after retries exhaust. Wrapping in `[url](url)` moves the
-  // underscore into the link *destination*, which Telegram does not
-  // re-parse for entities — keeps the link clickable, unlike backticks.
-  // Protected via the same placeholder mechanism as code spans (not inlined
-  // directly) so the parity/bracket checks below can't see or strip its `_`
-  // or `[`/`]` — those checks run on raw regex counts, not real parse state.
+  // underscore into the link *destination* — encoded there too, same reason
+  // as the existing-link case above. Protected via the same placeholder
+  // mechanism as code spans (not inlined directly) so the parity/bracket
+  // checks below can't see or strip its `_` or `[`/`]` — those checks run on
+  // raw regex counts, not real parse state.
   text = text.replace(/\bhttps?:\/\/[^\s<>\])]+/g, (m) => {
-    codeSegments.push(`[${m}](${m})`);
+    codeSegments.push(`[${m}](${encodeLinkDestination(m)})`);
     return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
   });
 


### PR DESCRIPTION
## Summary
- Bare URLs containing an underscore (GitLab's `/-/merge_requests/` path is the recurring case) break Telegram's legacy Markdown parser (`can't find end of a URL`), permanently dropping the message after 3 delivery retries with no visible error to the operator or agent.
- The delimiter-parity check in `sanitizeTelegramLegacyMarkdown` (strip `*`/`_` when their total count is odd) can't distinguish a URL's underscore from a real `_italic_` marker — it's a raw regex count, not real parse state, so an even number of "accidental" underscores across a message left them unstripped and still broke the real Telegram parser.
- Fix: wrap bare URLs in `[url](url)` — Telegram doesn't re-parse a link's destination for entities — and placeholder-protect both new and pre-existing markdown links the same way code spans already are, so the parity/bracket checks can't see or strip their `_`/`[`/`]`.

Found and reproduced via production logs: 4 permanently-lost Telegram messages in one day, all containing a bare GitLab MR link.

## Test plan
- [x] `pnpm exec vitest run src/channels/telegram-markdown-sanitize.test.ts` — 19/19 passing, including new cases for bare-URL wrapping, protecting the wrap from the parity-stripping pass, not double-wrapping URLs already inside a markdown link, and leaving URLs inside code spans untouched.
- [x] `pnpm run build` clean on this branch (pre-existing unrelated failure: `deltachat.ts` needs `@deltachat/stdio-rpc-server`, not installed in this checkout — unrelated to this change).