### PR TITLE
fix(onecli): block legacy Gmail API routes

### DIFF
--- a/docs/onecli-upgrades.md
+++ b/docs/onecli-upgrades.md
@@ -64,6 +64,33 @@ cd ~/.onecli && ONECLI_VERSION=<old-version> docker compose up -d
 
 If the NanoClaw update itself is being rolled back, also pin `@onecli-sh/sdk` back to its previous version in `package.json` and run `pnpm install`. Vault data is unaffected in both directions.
 
+## 5. Reconcile NanoClaw security guardrails
+
+NanoClaw setup installs three global block rules for Gmail's legacy routes on
+`www.googleapis.com`. Without them, Gmail traffic can bypass a policy written
+only against the canonical `gmail.googleapis.com` host. Existing installations
+should reconcile the rules once after updating NanoClaw:
+
+```bash
+pnpm exec tsx setup/index.ts --step onecli --reuse
+onecli rules list --max 1000
+```
+
+The setup step must report `GMAIL_GUARDRAILS=verified`. The rules list must
+contain these enabled blocks:
+
+| Name                             | Host                 | Path              |
+| -------------------------------- | -------------------- | ----------------- |
+| `nanoclaw:security:gmail-legacy` | `www.googleapis.com` | `/gmail/*`        |
+| `nanoclaw:security:gmail-batch`  | `www.googleapis.com` | `/batch/gmail/*`  |
+| `nanoclaw:security:gmail-upload` | `www.googleapis.com` | `/upload/gmail/*` |
+
+The rules are deliberately path-scoped: they do not block Calendar, Drive, or
+other Google APIs on the shared legacy host. Setup is idempotent and verifies
+the rules after writing them. If a rule with one of these names already exists
+with a different shape, setup stops instead of overwriting it; inspect and
+correct that conflict in OneCLI, then rerun the command.
+
 ## The CLI binary (`onecli-cli` pin)
 
 The `onecli` host CLI is pinned the same way, under `onecli-cli` in `versions.json`. Setup installs exactly that version by direct release download — it never resolves "latest". When an update moves this pin, replace the binary with the pinned release:

--- a/setup/onecli.test.ts
+++ b/setup/onecli.test.ts
@@ -1,13 +1,11 @@
 /**
- * The step DETECTS gateway /v1 compatibility and warns (pointing at
- * docs/onecli-upgrades.md) — it does not migrate the gateway; that's the
- * agent's job via /update-nanoclaw. The verify helper must distinguish
- * incompatible (pre-/v1 server: warn) from unreachable (transient: nothing to
- * say) so the warning only fires on a real pre-/v1 server.
+ * The step detects gateway /v1 compatibility and installs NanoClaw-owned
+ * security guardrails. Tests stay hermetic by injecting the OneCLI command
+ * runner; no live gateway is required.
  */
 import { describe, expect, it } from 'vitest';
 
-import { verifyGatewayV1 } from './onecli.js';
+import { GMAIL_LEGACY_GUARDRAILS, ensureGmailLegacyGuardrails, type RunOnecli, verifyGatewayV1 } from './onecli.js';
 
 function fakeFetch(behavior: 'ok' | '404' | 'down'): typeof fetch {
   return (async () => {
@@ -25,5 +23,87 @@ describe('verifyGatewayV1', () => {
   });
   it('unreachable on connection failure', async () => {
     expect(await verifyGatewayV1('http://x', fakeFetch('down'))).toBe('unreachable');
+  });
+});
+
+interface TestRule {
+  name: string;
+  hostPattern: string;
+  pathPattern: string;
+  action: string;
+  enabled: boolean;
+}
+
+function flag(args: string[], name: string): string {
+  const index = args.indexOf(name);
+  if (index === -1 || args[index + 1] === undefined) throw new Error(`missing ${name}`);
+  return args[index + 1]!;
+}
+
+function fakeOnecli(initial: TestRule[] = []): { rules: TestRule[]; calls: string[][]; run: RunOnecli } {
+  const rules = initial.map((rule) => ({ ...rule }));
+  const calls: string[][] = [];
+  const run: RunOnecli = (args) => {
+    calls.push(args);
+    if (args[0] === 'rules' && args[1] === 'list') return JSON.stringify({ data: rules });
+    if (args[0] === 'rules' && args[1] === 'create') {
+      rules.push({
+        name: flag(args, '--name'),
+        hostPattern: flag(args, '--host-pattern'),
+        pathPattern: flag(args, '--path-pattern'),
+        action: flag(args, '--action'),
+        enabled: args.includes('--enabled'),
+      });
+      return JSON.stringify({ data: rules.at(-1) });
+    }
+    throw new Error(`unexpected onecli call: ${args.join(' ')}`);
+  };
+  return { rules, calls, run };
+}
+
+describe('ensureGmailLegacyGuardrails', () => {
+  it('creates and verifies the three narrow global block rules', () => {
+    const onecli = fakeOnecli();
+
+    const result = ensureGmailLegacyGuardrails(onecli.run);
+
+    expect(result.created).toEqual(GMAIL_LEGACY_GUARDRAILS.map((rule) => rule.name));
+    expect(onecli.rules).toEqual(GMAIL_LEGACY_GUARDRAILS);
+    const creates = onecli.calls.filter((args) => args[1] === 'create');
+    expect(creates).toHaveLength(3);
+    expect(creates.every((args) => !args.includes('--agent-id'))).toBe(true);
+    expect(creates.every((args) => flag(args, '--host-pattern') === 'www.googleapis.com')).toBe(true);
+    expect(creates.map((args) => flag(args, '--path-pattern'))).toEqual([
+      '/gmail/*',
+      '/batch/gmail/*',
+      '/upload/gmail/*',
+    ]);
+  });
+
+  it('is idempotent when every guardrail already has the exact safe shape', () => {
+    const onecli = fakeOnecli([...GMAIL_LEGACY_GUARDRAILS]);
+
+    const result = ensureGmailLegacyGuardrails(onecli.run);
+
+    expect(result.created).toEqual([]);
+    expect(result.existing).toEqual(GMAIL_LEGACY_GUARDRAILS.map((rule) => rule.name));
+    expect(onecli.calls.filter((args) => args[1] === 'create')).toEqual([]);
+  });
+
+  it('fails closed on a same-name rule with a weaker shape', () => {
+    const weakened = { ...GMAIL_LEGACY_GUARDRAILS[0]!, enabled: false };
+    const onecli = fakeOnecli([weakened]);
+
+    expect(() => ensureGmailLegacyGuardrails(onecli.run)).toThrow(/unexpected shape/);
+    expect(onecli.calls.filter((args) => args[1] === 'create')).toEqual([]);
+  });
+
+  it('fails closed when OneCLI does not persist a created rule', () => {
+    const run: RunOnecli = (args) => {
+      if (args[1] === 'list') return JSON.stringify({ data: [] });
+      return JSON.stringify({ data: {} });
+    };
+
+    expect(() => ensureGmailLegacyGuardrails(run)).toThrow(/did not persist Gmail guardrails/);
   });
 });

--- a/setup/onecli.ts
+++ b/setup/onecli.ts
@@ -28,6 +28,130 @@ function childEnv(): NodeJS.ProcessEnv {
   return { ...process.env, PATH: parts.join(path.delimiter) };
 }
 
+export interface GmailLegacyGuardrail {
+  name: string;
+  hostPattern: string;
+  pathPattern: string;
+  action: 'block';
+  enabled: true;
+}
+
+/**
+ * Gmail's canonical API host is gmail.googleapis.com. The legacy Google API
+ * host can route the same service through these path families, so a policy
+ * authored only against the canonical host can be bypassed. Keep these rules
+ * global and narrow: Calendar and Drive also use www.googleapis.com.
+ */
+export const GMAIL_LEGACY_GUARDRAILS: readonly GmailLegacyGuardrail[] = [
+  {
+    name: 'nanoclaw:security:gmail-legacy',
+    hostPattern: 'www.googleapis.com',
+    pathPattern: '/gmail/*',
+    action: 'block',
+    enabled: true,
+  },
+  {
+    name: 'nanoclaw:security:gmail-batch',
+    hostPattern: 'www.googleapis.com',
+    pathPattern: '/batch/gmail/*',
+    action: 'block',
+    enabled: true,
+  },
+  {
+    name: 'nanoclaw:security:gmail-upload',
+    hostPattern: 'www.googleapis.com',
+    pathPattern: '/upload/gmail/*',
+    action: 'block',
+    enabled: true,
+  },
+];
+
+interface OnecliRule {
+  name?: unknown;
+  hostPattern?: unknown;
+  pathPattern?: unknown;
+  action?: unknown;
+  enabled?: unknown;
+}
+
+export type RunOnecli = (args: string[]) => string;
+
+function runOnecli(args: string[]): string {
+  return execFileSync('onecli', args, {
+    encoding: 'utf-8',
+    env: childEnv(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function parseOnecliRules(output: string): OnecliRule[] {
+  const parsed = JSON.parse(output) as { data?: unknown } | unknown[];
+  const rows = Array.isArray(parsed) ? parsed : parsed.data;
+  if (!Array.isArray(rows)) throw new Error('OneCLI returned an invalid rules list');
+  return rows as OnecliRule[];
+}
+
+function matchesGuardrail(rule: OnecliRule, desired: GmailLegacyGuardrail): boolean {
+  return (
+    rule.name === desired.name &&
+    rule.hostPattern === desired.hostPattern &&
+    rule.pathPattern === desired.pathPattern &&
+    rule.action === desired.action &&
+    rule.enabled === desired.enabled
+  );
+}
+
+/**
+ * Reconcile the install-wide Gmail legacy-route blocks into OneCLI.
+ *
+ * Stable names make this idempotent. A same-name/different-shape rule is a
+ * hard conflict rather than something we overwrite: silently accepting a
+ * weakened security rule would reopen the bypass, while deleting a user's
+ * rule is outside NanoClaw's ownership.
+ */
+export function ensureGmailLegacyGuardrails(run: RunOnecli = runOnecli): { created: string[]; existing: string[] } {
+  const list = (): OnecliRule[] => parseOnecliRules(run(['rules', 'list', '--max', '1000']));
+  const current = list();
+  const created: string[] = [];
+  const existing: string[] = [];
+
+  for (const desired of GMAIL_LEGACY_GUARDRAILS) {
+    const named = current.find((rule) => rule.name === desired.name);
+    if (named) {
+      if (!matchesGuardrail(named, desired)) {
+        throw new Error(`OneCLI rule ${JSON.stringify(desired.name)} exists with an unexpected shape`);
+      }
+      existing.push(desired.name);
+      continue;
+    }
+
+    run([
+      'rules',
+      'create',
+      '--name',
+      desired.name,
+      '--host-pattern',
+      desired.hostPattern,
+      '--path-pattern',
+      desired.pathPattern,
+      '--action',
+      desired.action,
+      '--enabled',
+    ]);
+    created.push(desired.name);
+  }
+
+  const reconciled = list();
+  const missing = GMAIL_LEGACY_GUARDRAILS.filter(
+    (desired) => !reconciled.some((rule) => matchesGuardrail(rule, desired)),
+  );
+  if (missing.length > 0) {
+    throw new Error(`OneCLI did not persist Gmail guardrails: ${missing.map((rule) => rule.name).join(', ')}`);
+  }
+
+  return { created, existing };
+}
+
 function onecliVersion(): string | null {
   try {
     return execFileSync('onecli', ['version'], {
@@ -341,11 +465,14 @@ export async function run(args: string[]): Promise<void> {
     }
     const healthy = await pollHealth(remoteUrl, 5000);
     const v1Hint = healthy ? gatewayV1Hint(await verifyGatewayV1(remoteUrl)) : null;
+    const guardrails = ensureGmailLegacyGuardrails();
     emitStatus('ONECLI', {
       INSTALLED: true,
       REMOTE: true,
       ONECLI_URL: remoteUrl,
       HEALTHY: healthy,
+      GMAIL_GUARDRAILS: 'verified',
+      GMAIL_GUARDRAILS_CREATED: guardrails.created.length,
       STATUS: 'success',
       ...(v1Hint ? { GATEWAY_HINT: v1Hint } : {}),
       LOG: 'logs/setup.log',
@@ -382,11 +509,14 @@ export async function run(args: string[]): Promise<void> {
     log.info('Reusing existing OneCLI', { url });
     const healthy = await pollHealth(url, 5000);
     const v1Hint = healthy ? gatewayV1Hint(await verifyGatewayV1(url)) : null;
+    const guardrails = ensureGmailLegacyGuardrails();
     emitStatus('ONECLI', {
       INSTALLED: true,
       REUSED: true,
       ONECLI_URL: url,
       HEALTHY: healthy,
+      GMAIL_GUARDRAILS: 'verified',
+      GMAIL_GUARDRAILS_CREATED: guardrails.created.length,
       STATUS: 'success',
       ...(v1Hint ? { GATEWAY_HINT: v1Hint } : {}),
       LOG: 'logs/setup.log',
@@ -442,11 +572,14 @@ export async function run(args: string[]): Promise<void> {
 
   const healthy = await pollHealth(url, 15000);
   const v1Hint = healthy ? gatewayV1Hint(await verifyGatewayV1(url)) : null;
+  const guardrails = ensureGmailLegacyGuardrails();
 
   emitStatus('ONECLI', {
     INSTALLED: true,
     ONECLI_URL: url,
     HEALTHY: healthy,
+    GMAIL_GUARDRAILS: 'verified',
+    GMAIL_GUARDRAILS_CREATED: guardrails.created.length,
     // Install succeeded regardless — a failed health poll often just means
     // the endpoint is auth-gated or the gateway hasn't finished warming up.
     // The next step (auth) will surface a genuinely broken gateway via


### PR DESCRIPTION
## Summary
- add idempotent global OneCLI blocks for Gmail traffic through `www.googleapis.com`
- cover the standard, batch, and upload legacy paths
- verify the rules after setup and document reconciliation for existing installs

## Why
Gmail policies written against `gmail.googleapis.com` can be bypassed through legacy Google API routes. These narrow blocks close that path without affecting Calendar, Drive, or other Google APIs.

## Validation
- `pnpm test` (1,155 tests)
- `pnpm run build`
- `pnpm exec prettier --check setup/onecli.ts setup/onecli.test.ts docs/onecli-upgrades.md`