### PR TITLE
fix(container-runner): reconcile untracked orphan containers to prevent duplicate per-group spawns

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -168,10 +168,20 @@ async function spawnContainer(session: Session): Promise<void> {
   const { provider, contribution } = resolveProviderContribution(session, agentGroup, containerConfig);
 
   const mounts = buildMounts(agentGroup, session, containerConfig, provider, contribution);
-  const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}`;
+  const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}-${session.id}`;
   // OneCLI agent identifier is always the agent group id — stable across
   // sessions and reversible via getAgentGroup() for approval routing.
   const agentIdentifier = agentGroup.id;
+  // Pre-spawn reconcile: force-remove any orphan container for this group folder
+  // the host no longer tracks (perceived-exit zombie still polling the session
+  // DB). Done BEFORE the buildContainerArgs await (which can block on OneCLI
+  // setup) so an orphan cannot claim the due message in that window. #2466/#2659.
+  const trackedNames = new Set(Array.from(activeContainers.values()).map((entry) => entry.containerName));
+  const reaped = reapUntrackedForFolder(agentGroup.folder, trackedNames);
+  if (reaped.length > 0) {
+    log.warn('Reaped untracked orphan container(s) before spawn', { folder: agentGroup.folder, reaped });
+  }
+
   const args = await buildContainerArgs(
     mounts,
     containerName,
@@ -189,19 +199,6 @@ async function spawnContainer(session: Session): Promise<void> {
   // (host-sweep.ts line 87). Without this, the stale mtime can trigger an
   // immediate kill before the new container touches the file itself.
   fs.rmSync(heartbeatPath(agentGroup.id, session.id), { force: true });
-
-  // Pre-spawn reconcile: force-remove any orphan container for this group
-  // folder the host is no longer tracking (perceived-exit zombie still polling
-  // the session DB). Guarantees ≤1 live container per folder before we add one.
-  // Upstream #2466 (fix option 1) / #2659.
-  const trackedNames = new Set(Array.from(activeContainers.values()).map((entry) => entry.containerName));
-  const reaped = reapUntrackedForFolder(agentGroup.folder, trackedNames);
-  if (reaped.length > 0) {
-    log.warn('Reaped untracked orphan container(s) before spawn', {
-      folder: agentGroup.folder,
-      reaped,
-    });
-  }
 
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
@@ -230,11 +227,17 @@ async function spawnContainer(session: Session): Promise<void> {
   // on a wall-clock timer.
 
   container.on('close', (code) => {
-    activeContainers.delete(session.id);
-    // Don't trust process-close == container-dead: a signaled `docker run`
-    // client (code=null) can leave the `--rm` container alive as an orphan
-    // (upstream #2659). Force-remove by name — idempotent no-op if already gone.
-    forceRemoveContainer(containerName);
+    // Only release the slot if we still own it (a concurrent spawn for the same
+    // session must not have its tracking clobbered by our exit).
+    if (activeContainers.get(session.id)?.process === container) {
+      activeContainers.delete(session.id);
+    }
+    // A signaled `docker run` client (code=null) can leave the `--rm` container
+    // alive (upstream #2659). Only force-remove if no live tracked entry still
+    // uses this name (guards the name-collision race).
+    if (!Array.from(activeContainers.values()).some((entry) => entry.containerName === containerName)) {
+      forceRemoveContainer(containerName);
+    }
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     // code null = killed by signal (normal shutdown path), not a boot failure.
@@ -246,11 +249,13 @@ async function spawnContainer(session: Session): Promise<void> {
   });
 
   container.on('error', (err) => {
-    activeContainers.delete(session.id);
-    // Don't trust process-close == container-dead: a signaled `docker run`
-    // client (code=null) can leave the `--rm` container alive as an orphan
-    // (upstream #2659). Force-remove by name — idempotent no-op if already gone.
-    forceRemoveContainer(containerName);
+    if (activeContainers.get(session.id)?.process === container) {
+      activeContainers.delete(session.id);
+    }
+    // (upstream #2659) Only force-remove if no live tracked entry uses this name.
+    if (!Array.from(activeContainers.values()).some((entry) => entry.containerName === containerName)) {
+      forceRemoveContainer(containerName);
+    }
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     log.error('Container spawn error', { sessionId: session.id, err });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,10 +26,17 @@ import {
 import { materializeContainerJson } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars } from './db/container-configs.js';
-import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import {
+  CONTAINER_RUNTIME_BIN,
+  forceRemoveContainer,
+  hostGatewayArgs,
+  readonlyMountArgs,
+  reapUntrackedForFolder,
+  stopContainer,
+} from './container-runtime.js';
 import { EGRESS_NETWORK, egressNetworkArgs, ensureEgressNetwork } from './egress-lockdown.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
-import { getAgentGroup } from './db/agent-groups.js';
+import { getAgentGroup, getAllAgentGroups } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
 import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
@@ -74,6 +81,22 @@ export function getActiveContainerCount(): number {
 
 export function isContainerRunning(sessionId: string): boolean {
   return activeContainers.has(sessionId);
+}
+
+/** Reap any live NanoClaw container that this host no longer tracks. */
+export function reapAllUntracked(): string[] {
+  try {
+    const trackedNames = new Set(Array.from(activeContainers.values()).map((entry) => entry.containerName));
+    const folders = new Set(getAllAgentGroups().map((group) => group.folder));
+    const reaped = Array.from(folders).flatMap((folder) => reapUntrackedForFolder(folder, trackedNames));
+    if (reaped.length > 0) {
+      log.warn('Reaped untracked orphan container(s) during host sweep', { reaped });
+    }
+    return reaped;
+  } catch (err) {
+    log.warn('Failed to reconcile untracked containers during host sweep', { err });
+    return [];
+  }
 }
 
 /**
@@ -167,6 +190,19 @@ async function spawnContainer(session: Session): Promise<void> {
   // immediate kill before the new container touches the file itself.
   fs.rmSync(heartbeatPath(agentGroup.id, session.id), { force: true });
 
+  // Pre-spawn reconcile: force-remove any orphan container for this group
+  // folder the host is no longer tracking (perceived-exit zombie still polling
+  // the session DB). Guarantees ≤1 live container per folder before we add one.
+  // Upstream #2466 (fix option 1) / #2659.
+  const trackedNames = new Set(Array.from(activeContainers.values()).map((entry) => entry.containerName));
+  const reaped = reapUntrackedForFolder(agentGroup.folder, trackedNames);
+  if (reaped.length > 0) {
+    log.warn('Reaped untracked orphan container(s) before spawn', {
+      folder: agentGroup.folder,
+      reaped,
+    });
+  }
+
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
   activeContainers.set(session.id, { process: container, containerName });
@@ -195,6 +231,10 @@ async function spawnContainer(session: Session): Promise<void> {
 
   container.on('close', (code) => {
     activeContainers.delete(session.id);
+    // Don't trust process-close == container-dead: a signaled `docker run`
+    // client (code=null) can leave the `--rm` container alive as an orphan
+    // (upstream #2659). Force-remove by name — idempotent no-op if already gone.
+    forceRemoveContainer(containerName);
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     // code null = killed by signal (normal shutdown path), not a boot failure.
@@ -207,6 +247,10 @@ async function spawnContainer(session: Session): Promise<void> {
 
   container.on('error', (err) => {
     activeContainers.delete(session.id);
+    // Don't trust process-close == container-dead: a signaled `docker run`
+    // client (code=null) can leave the `--rm` container alive as an orphan
+    // (upstream #2659). Force-remove by name — idempotent no-op if already gone.
+    forceRemoveContainer(containerName);
     markContainerStopped(session.id);
     stopTypingRefresh(session.id);
     log.error('Container spawn error', { sessionId: session.id, err });

--- a/src/container-runtime.reap.test.ts
+++ b/src/container-runtime.reap.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,53 +6,60 @@ import { forceRemoveContainer, reapUntrackedForFolder } from './container-runtim
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-const execSyncMock = vi.mocked(execSync);
+const execFileSyncMock = vi.mocked(execFileSync);
 
 describe('reapUntrackedForFolder', () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
   });
 
   it('force-removes every untracked container and returns their names', () => {
-    execSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
+    execFileSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
 
     expect(reapUntrackedForFolder('dm-with-robby', new Set())).toEqual([
       'nanoclaw-v2-dm-with-robby-100',
       'nanoclaw-v2-dm-with-robby-200',
     ]);
-    expect(execSyncMock).toHaveBeenNthCalledWith(2, 'docker rm -f nanoclaw-v2-dm-with-robby-100', { stdio: 'pipe' });
-    expect(execSyncMock).toHaveBeenNthCalledWith(3, 'docker rm -f nanoclaw-v2-dm-with-robby-200', { stdio: 'pipe' });
+    // first execFileSync call is the `docker ps` query
+    expect(execFileSyncMock.mock.calls[0][0]).toBe('docker');
+    expect(execFileSyncMock.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['ps', '--filter', 'name=nanoclaw-v2-dm-with-robby-', '--format', '{{.Names}}']),
+    );
+    // subsequent calls force-remove each untracked container via argument vector
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(2, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-100'], { stdio: 'pipe' });
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(3, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], { stdio: 'pipe' });
   });
 
   it('leaves tracked containers running and removes only the untracked one', () => {
-    execSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
+    execFileSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
 
     expect(reapUntrackedForFolder('dm-with-robby', new Set(['nanoclaw-v2-dm-with-robby-100']))).toEqual([
       'nanoclaw-v2-dm-with-robby-200',
     ]);
-    expect(execSyncMock).toHaveBeenCalledTimes(2);
-    expect(execSyncMock).toHaveBeenLastCalledWith('docker rm -f nanoclaw-v2-dm-with-robby-200', { stdio: 'pipe' });
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock).toHaveBeenLastCalledWith('docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], { stdio: 'pipe' });
   });
 
   it('returns an empty list when docker ps throws', () => {
-    execSyncMock.mockImplementationOnce(() => {
+    execFileSyncMock.mockImplementationOnce(() => {
       throw new Error('runtime unavailable');
     });
 
     expect(reapUntrackedForFolder('dm-with-robby', new Set())).toEqual([]);
-    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('forceRemoveContainer', () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
   });
 
   it('swallows a throwing docker rm -f', () => {
-    execSyncMock.mockImplementationOnce(() => {
+    execFileSyncMock.mockImplementationOnce(() => {
       throw new Error('already gone');
     });
 

--- a/src/container-runtime.reap.test.ts
+++ b/src/container-runtime.reap.test.ts
@@ -29,8 +29,12 @@ describe('reapUntrackedForFolder', () => {
       expect.arrayContaining(['ps', '--filter', 'name=nanoclaw-v2-dm-with-robby-', '--format', '{{.Names}}']),
     );
     // subsequent calls force-remove each untracked container via argument vector
-    expect(execFileSyncMock).toHaveBeenNthCalledWith(2, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-100'], { stdio: 'pipe' });
-    expect(execFileSyncMock).toHaveBeenNthCalledWith(3, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], { stdio: 'pipe' });
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(2, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-100'], {
+      stdio: 'pipe',
+    });
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(3, 'docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], {
+      stdio: 'pipe',
+    });
   });
 
   it('leaves tracked containers running and removes only the untracked one', () => {
@@ -40,7 +44,9 @@ describe('reapUntrackedForFolder', () => {
       'nanoclaw-v2-dm-with-robby-200',
     ]);
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);
-    expect(execFileSyncMock).toHaveBeenLastCalledWith('docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], { stdio: 'pipe' });
+    expect(execFileSyncMock).toHaveBeenLastCalledWith('docker', ['rm', '-f', 'nanoclaw-v2-dm-with-robby-200'], {
+      stdio: 'pipe',
+    });
   });
 
   it('returns an empty list when docker ps throws', () => {

--- a/src/container-runtime.reap.test.ts
+++ b/src/container-runtime.reap.test.ts
@@ -1,0 +1,61 @@
+import { execSync } from 'child_process';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { forceRemoveContainer, reapUntrackedForFolder } from './container-runtime.js';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const execSyncMock = vi.mocked(execSync);
+
+describe('reapUntrackedForFolder', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it('force-removes every untracked container and returns their names', () => {
+    execSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
+
+    expect(reapUntrackedForFolder('dm-with-robby', new Set())).toEqual([
+      'nanoclaw-v2-dm-with-robby-100',
+      'nanoclaw-v2-dm-with-robby-200',
+    ]);
+    expect(execSyncMock).toHaveBeenNthCalledWith(2, 'docker rm -f nanoclaw-v2-dm-with-robby-100', { stdio: 'pipe' });
+    expect(execSyncMock).toHaveBeenNthCalledWith(3, 'docker rm -f nanoclaw-v2-dm-with-robby-200', { stdio: 'pipe' });
+  });
+
+  it('leaves tracked containers running and removes only the untracked one', () => {
+    execSyncMock.mockReturnValueOnce('nanoclaw-v2-dm-with-robby-100\nnanoclaw-v2-dm-with-robby-200\n' as never);
+
+    expect(reapUntrackedForFolder('dm-with-robby', new Set(['nanoclaw-v2-dm-with-robby-100']))).toEqual([
+      'nanoclaw-v2-dm-with-robby-200',
+    ]);
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+    expect(execSyncMock).toHaveBeenLastCalledWith('docker rm -f nanoclaw-v2-dm-with-robby-200', { stdio: 'pipe' });
+  });
+
+  it('returns an empty list when docker ps throws', () => {
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('runtime unavailable');
+    });
+
+    expect(reapUntrackedForFolder('dm-with-robby', new Set())).toEqual([]);
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('forceRemoveContainer', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it('swallows a throwing docker rm -f', () => {
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('already gone');
+    });
+
+    expect(() => forceRemoveContainer('nanoclaw-v2-dm-with-robby-100')).not.toThrow();
+  });
+});

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -13,8 +13,10 @@ vi.mock('./log.js', () => ({
 
 // Mock child_process — store the mock fn so tests can configure it
 const mockExecSync = vi.fn();
+const mockExecFileSync = vi.fn();
 vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
 import {

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import os from 'os';
 
 import { CONTAINER_INSTALL_LABEL } from './config.js';
@@ -40,7 +40,7 @@ export function stopContainer(name: string): void {
  */
 export function forceRemoveContainer(name: string): void {
   try {
-    execSync(`${CONTAINER_RUNTIME_BIN} rm -f ${name}`, { stdio: 'pipe' });
+    execFileSync(CONTAINER_RUNTIME_BIN, ['rm', '-f', name], { stdio: 'pipe' });
   } catch {
     /* already gone */
   }
@@ -57,10 +57,11 @@ export function forceRemoveContainer(name: string): void {
  */
 export function reapUntrackedForFolder(folder: string, tracked: Set<string>): string[] {
   try {
-    const out = execSync(`${CONTAINER_RUNTIME_BIN} ps --filter name=nanoclaw-v2-${folder}- --format '{{.Names}}'`, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-    });
+    const out = execFileSync(
+      CONTAINER_RUNTIME_BIN,
+      ['ps', '--filter', `name=nanoclaw-v2-${folder}-`, '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
+      { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
+    );
     const reaped: string[] = [];
     for (const name of out.trim().split('\n').filter(Boolean)) {
       if (tracked.has(name)) continue;

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -33,6 +33,46 @@ export function stopContainer(name: string): void {
   execSync(`${CONTAINER_RUNTIME_BIN} stop -t 1 ${name}`, { stdio: 'pipe' });
 }
 
+/**
+ * Force-remove a container by name (SIGKILL + rm). Stronger than
+ * stopContainer's `docker stop -t 1` — reaps containers dockerd won't stop
+ * gracefully (upstream #2659). Idempotent + best-effort.
+ */
+export function forceRemoveContainer(name: string): void {
+  try {
+    execSync(`${CONTAINER_RUNTIME_BIN} rm -f ${name}`, { stdio: 'pipe' });
+  } catch {
+    /* already gone */
+  }
+}
+
+/**
+ * Reap untracked NanoClaw containers for ONE agent-group folder. Lists running
+ * containers whose name matches `nanoclaw-v2-<folder>-*` and force-removes any
+ * NOT in `tracked` (the live activeContainers name set). Kills perceived-exit
+ * orphans (host lost the child-process handle but dockerd kept the `--rm`
+ * container alive) without touching legitimately-tracked containers.
+ * NOTE: docker's name filter is a substring match — the `tracked` set (exact
+ * names) is what protects live containers, so folder-name prefixing is safe.
+ */
+export function reapUntrackedForFolder(folder: string, tracked: Set<string>): string[] {
+  try {
+    const out = execSync(`${CONTAINER_RUNTIME_BIN} ps --filter name=nanoclaw-v2-${folder}- --format '{{.Names}}'`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+    const reaped: string[] = [];
+    for (const name of out.trim().split('\n').filter(Boolean)) {
+      if (tracked.has(name)) continue;
+      forceRemoveContainer(name);
+      reaped.push(name);
+    }
+    return reaped;
+  } catch {
+    return [];
+  }
+}
+
 /** Ensure the container runtime is running, starting it if needed. */
 export function ensureContainerRuntimeRunning(): void {
   try {

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -59,7 +59,15 @@ export function reapUntrackedForFolder(folder: string, tracked: Set<string>): st
   try {
     const out = execFileSync(
       CONTAINER_RUNTIME_BIN,
-      ['ps', '--filter', `name=nanoclaw-v2-${folder}-`, '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
+      [
+        'ps',
+        '--filter',
+        `name=nanoclaw-v2-${folder}-`,
+        '--filter',
+        `label=${CONTAINER_INSTALL_LABEL}`,
+        '--format',
+        '{{.Names}}',
+      ],
       { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
     );
     const reaped: string[] = [];

--- a/src/host-sweep-grace.test.ts
+++ b/src/host-sweep-grace.test.ts
@@ -25,6 +25,7 @@ vi.mock('./container-runner.js', () => ({
   isContainerRunning: vi.fn().mockReturnValue(false),
   wakeContainer: vi.fn().mockResolvedValue(true),
   killContainer: vi.fn(),
+  reapAllUntracked: vi.fn().mockReturnValue([]),
 }));
 
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -45,7 +45,7 @@ import {
 } from './db/session-db.js';
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbeatPath } from './session-manager.js';
-import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { isContainerRunning, killContainer, reapAllUntracked, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
 /**
@@ -142,6 +142,10 @@ async function sweep(): Promise<void> {
   } catch (err) {
     log.error('Egress lockdown re-heal failed', { err });
   }
+
+  // Reconcile the runtime against the host's authoritative in-memory set on
+  // every tick, including idle periods where no pre-spawn guard would run.
+  reapAllUntracked();
 
   try {
     const sessions = getActiveSessions();


### PR DESCRIPTION
## What
Reconcile untracked orphan containers so a single agent group can no longer accumulate duplicate containers polling the same session DB.

## Root cause (observed on a continuously-running host, `NRestarts=0`, 5d uptime)
One agent group reached **3 concurrent containers**. Trigger: a `*/15` scheduled task with a gate `script` that wakes a task-session container each tick. Two holes beyond the spawn-race in #2466:

1. **Perceived-exit orphans.** `container.on("close")` calls `activeContainers.delete(session.id)` but never force-removes the container. When the `docker run` client is signaled (`code=null`) while dockerd keeps the `--rm` container alive, it survives *untracked* and keeps polling `inbound.db`. Logs showed containers reporting `Container exited code=null` that `docker ps` still listed as `Up` minutes later.
2. **No runtime reconcile.** `cleanupOrphans()` runs only at boot (`index.ts`), so on a long-running host these orphans are never reaped. host-sweep only inspects tracked sessions heartbeats — an alive orphan keeps its own heartbeat fresh, so it stays invisible.

## Fix
- `forceRemoveContainer()` — `docker rm -f`, idempotent/best-effort.
- `reapUntrackedForFolder(folder, tracked)` — reap containers matching `nanoclaw-v2-<folder>-*` that are **not** in the tracked `activeContainers` name set.
- Pre-spawn guard in `wakeContainer` (implements #2466 fix option 1) + force-remove in `on("close")`/`on("error")`.
- `reapAllUntracked()` once per host-sweep tick — folder-scoped to known groups; never touches peer installs or tracked containers.

Legitimate chat+task concurrency is untouched (only *untracked* containers are reaped). Composes with #2659 (docker-stop PID fallback) and #2708 (reap on service stop). Fixes #2466.

## Test
`src/container-runtime.reap.test.ts` (mocked `execSync`): reaps untracked, skips tracked, swallows failures.
