### PR TITLE
Make reaction delivery best-effort

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -421,3 +421,41 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(msg.markdown).toBe('plain hello');
   });
 });
+
+describe('createChatSdkBridge.deliver — reactions are best-effort', () => {
+  it('does not throw when the platform rejects a reaction (no delivery failure/retry)', async () => {
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        name: 'telegram',
+        addReaction: async () => {
+          throw new Error('Bad Request: REACTION_INVALID');
+        },
+      } as unknown as Partial<Adapter>),
+      supportsThreads: false,
+    });
+    await expect(
+      bridge.deliver('telegram:42', null, {
+        kind: 'chat-sdk',
+        content: { operation: 'reaction', messageId: '123:456', emoji: 'white_check_mark' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('applies a reaction the platform accepts', async () => {
+    const calls: string[] = [];
+    const bridge = createChatSdkBridge({
+      adapter: stubAdapter({
+        name: 'telegram',
+        addReaction: async (_t: string, _m: string, emoji: string) => {
+          calls.push(emoji);
+        },
+      } as unknown as Partial<Adapter>),
+      supportsThreads: false,
+    });
+    await bridge.deliver('telegram:42', null, {
+      kind: 'chat-sdk',
+      content: { operation: 'reaction', messageId: '123:456', emoji: 'eyes' },
+    });
+    expect(calls).toEqual(['eyes']);
+  });
+});

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -423,7 +423,18 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
       }
 
       if (content.operation === 'reaction' && content.messageId && content.emoji) {
-        await adapter.addReaction(tid, content.messageId as string, content.emoji as string);
+        // Reactions are cosmetic: a platform rejecting one (e.g. an emoji outside
+        // its allowed set, like Telegram's fixed reaction list) must not fail
+        // delivery or trigger retries. Best-effort — log and move on.
+        try {
+          await adapter.addReaction(tid, content.messageId as string, content.emoji as string);
+        } catch (err) {
+          log.warn('Reaction not applied (best-effort)', {
+            adapter: adapter.name,
+            emoji: content.emoji,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

### Problem

A reaction is a cosmetic acknowledgment, but when a platform rejects one, `adapter.addReaction` throws, routing the message through the normal delivery retry path: 3 attempts, then a `Message delivery failed permanently` error.

This fires routinely on Telegram, whose message reactions are a fixed allowlist. Common ack emoji outside it (for example the shortcodes that resolve to the check mark or the rocket) return `Bad Request: REACTION_INVALID`, so every such reaction becomes three wasted delivery attempts plus a permanent-failure log line, which is noise for a decorative feature.

### Fix

Wrap `addReaction` in the Chat SDK bridge in a try/catch: log the rejection once at `warn` level and return so the message is marked delivered. Text, edit, and card delivery are unchanged and still fail loudly and retry. Channel-agnostic, it encodes no platform's reaction rules.

Complementary to #2627 (which aligns emoji encoding); this addresses delivery robustness.

### Tests

`chat-sdk-bridge.test.ts`: a rejected reaction resolves without throwing (no delivery failure or retry), and an accepted reaction is still applied.
