### PR TITLE
fix: report unavailable MCP servers

### DIFF
--- a/container/agent-runner/src/providers/claude.mcp-init.test.ts
+++ b/container/agent-runner/src/providers/claude.mcp-init.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, mock } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const sdkMessages: unknown[] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () =>
+    (async function* () {
+      for (const message of sdkMessages) yield message;
+    })(),
+}));
+
+const { ClaudeProvider } = await import('./claude.js');
+const { MEMORY_SESSION_HOOK } = await import('../memory/session-hook.js');
+
+describe('Claude SDK MCP init status', () => {
+  it('writes unavailable MCP servers to stderr without aborting init', async () => {
+    sdkMessages.length = 0;
+    sdkMessages.push({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'sess-mcp',
+      mcp_servers: [
+        { name: 'healthy', status: 'connected' },
+        { name: 'missing-runtime', status: 'failed' },
+        { name: 'intentionally-off', status: 'disabled' },
+      ],
+    });
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-mcp-init-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+    const logs: string[] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+    try {
+      const provider = new ClaudeProvider({});
+      provider.registerMemorySessionHook(MEMORY_SESSION_HOOK);
+      const query = provider.query({ prompt: 'hi', cwd: tmp });
+      const events = [];
+      for await (const event of query.events) events.push(event);
+
+      expect(events.some((event) => event.type === 'init' && event.continuation === 'sess-mcp')).toBe(true);
+      expect(logs).toContain(
+        '[claude-provider] ERROR: MCP server "missing-runtime" is unavailable ' +
+          '(status: failed); its tools will not be available',
+      );
+      expect(logs.some((line) => line.includes('healthy'))).toBe(false);
+      expect(logs.some((line) => line.includes('intentionally-off'))).toBe(false);
+    } finally {
+      console.error = originalConsoleError;
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/container/agent-runner/src/providers/claude.mcp-status.test.ts
+++ b/container/agent-runner/src/providers/claude.mcp-status.test.ts
@@ -18,11 +18,13 @@ describe('MCP server init diagnostics', () => {
     ]);
   });
 
-  it('keeps untrusted server names on one bounded log line', () => {
-    const longName = `bad\nserver${'x'.repeat(300)}`;
-    const [diagnostic] = mcpInitFailureDiagnostics([{ name: longName, status: 'failed' }]);
+  it('keeps untrusted server names and statuses on one bounded, control-free log line', () => {
+    const longName = `bad\nserver\u001B[31m\u0000\t${'x'.repeat(300)}`;
+    const [diagnostic] = mcpInitFailureDiagnostics([
+      { name: longName, status: 'failed\u0085\u2028\u2029' },
+    ]);
 
-    expect(diagnostic).not.toContain('\n');
+    expect(diagnostic).not.toMatch(/[\u0000-\u001F\u007F-\u009F\u2028\u2029]/);
     expect(diagnostic).toContain('bad server');
     expect(diagnostic!.length).toBeLessThan(300);
   });

--- a/container/agent-runner/src/providers/claude.mcp-status.test.ts
+++ b/container/agent-runner/src/providers/claude.mcp-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { mcpInitFailureDiagnostics } from './claude.js';
+
+describe('MCP server init diagnostics', () => {
+  it('reports failed, unauthenticated, and pending servers by name', () => {
+    expect(
+      mcpInitFailureDiagnostics([
+        { name: 'healthy', status: 'connected' },
+        { name: 'missing-runtime', status: 'failed' },
+        { name: 'remote-tools', status: 'needs-auth' },
+        { name: 'slow-start', status: 'pending' },
+        { name: 'intentionally-off', status: 'disabled' },
+      ]),
+    ).toEqual([
+      'ERROR: MCP server "missing-runtime" is unavailable (status: failed); its tools will not be available',
+      'ERROR: MCP server "remote-tools" is unavailable (status: needs-auth); its tools will not be available',
+      'ERROR: MCP server "slow-start" is unavailable (status: pending); its tools will not be available',
+    ]);
+  });
+
+  it('keeps untrusted server names on one bounded log line', () => {
+    const longName = `bad\nserver${'x'.repeat(300)}`;
+    const [diagnostic] = mcpInitFailureDiagnostics([{ name: longName, status: 'failed' }]);
+
+    expect(diagnostic).not.toContain('\n');
+    expect(diagnostic).toContain('bad server');
+    expect(diagnostic!.length).toBeLessThan(300);
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -64,6 +64,33 @@ export function classifyRateLimitEvent(
   };
 }
 
+interface SdkMcpServerSummary {
+  name: string;
+  status: string;
+}
+
+function sanitizeLogValue(value: string): string {
+  return value.replace(/[\r\n\u2028\u2029]/g, ' ').slice(0, 200);
+}
+
+/**
+ * Return actionable diagnostics for MCP servers that were expected to be
+ * available but were not connected when the SDK finished initialization.
+ *
+ * `disabled` is intentionally quiet: it represents an explicit configuration
+ * choice, not a failed capability. Error details are not present in the init
+ * message, so these diagnostics name only the server and its SDK status.
+ */
+export function mcpInitFailureDiagnostics(servers: SdkMcpServerSummary[] | undefined): string[] {
+  return (servers ?? [])
+    .filter((server) => server.status !== 'connected' && server.status !== 'disabled')
+    .map(
+      (server) =>
+        `ERROR: MCP server "${sanitizeLogValue(server.name)}" is unavailable ` +
+        `(status: ${sanitizeLogValue(server.status)}); its tools will not be available`,
+    );
+}
+
 // Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
 // don't fit our async message-passing model (they're designed for Claude
 // Code's interactive UI and would hang here).
@@ -570,6 +597,9 @@ export class ClaudeProvider implements AgentProvider {
         yield { type: 'activity' };
 
         if (message.type === 'system' && message.subtype === 'init') {
+          for (const diagnostic of mcpInitFailureDiagnostics(message.mcp_servers)) {
+            log(diagnostic);
+          }
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
           // `result` text exists only on subtype:"success"; error subtypes

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -70,7 +70,7 @@ interface SdkMcpServerSummary {
 }
 
 function sanitizeLogValue(value: string): string {
-  return value.replace(/[\r\n\u2028\u2029]/g, ' ').slice(0, 200);
+  return value.replace(/[\u0000-\u001F\u007F-\u009F\u2028\u2029]/g, ' ').slice(0, 200);
 }
 
 /**


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in the agent skills directory, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes https://github.com/nanocoai/nanoclaw/issues/2968

**What.** Report SDK init statuses for failed, unauthenticated, or still-pending MCP servers to stderr, naming the unavailable server and status. Connected servers and explicitly disabled servers remain quiet, and init continues normally.

**Why.** The SDK already reports per-server status, but NanoClaw discarded everything except the session id. A broken MCP command could therefore remove tools silently while the agent continued as if it still had those capabilities.

**How it works.** The provider converts non-connected init statuses into bounded, single-line ERROR diagnostics. It does not log raw SDK error details or configuration, avoiding credential disclosure and log-line injection.

**How it was tested.**

- focused MCP init translation and diagnostic tests: 4 passed
- complete agent-runner suite: 157 passed, 1 skipped, 0 failed
- complete host Vitest suite: passed
- host build and container TypeScript typecheck: passed
- changed-file Prettier check and `git diff --check`: passed

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
