### PR TITLE
feat: per-agent-group timezone override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,8 @@ Two rules, no exceptions:
 - **Storage**: every timestamp written from JS is `new Date().toISOString()` (ISO-8601 UTC with `Z`). Never `datetime('now')` — its naive `YYYY-MM-DD HH:MM:SS` shape is misparsed as local time by `new Date()` and breaks string comparisons against ISO values. In pure-SQL contexts (skill snippets) use `strftime('%Y-%m-%dT%H:%M:%fZ','now')`. SQL-side *comparisons* wrap both sides in `datetime()`.
 - **Display**: anything shown to an agent or a user renders in the install timezone — `formatLocalTime` (prose) or `formatLocalStamp` (log lines) from `src/timezone.ts` / `container/agent-runner/src/timezone.ts`. `--json` output, DB values, and operator logs stay ISO.
 
+An agent group can override the install timezone (`ncl groups config update --timezone <IANA>`, `""` clears; approval-gated for agent callers). The override grounds that group's scheduling (cron interpretation, `--process-after`, run-log stamps — effective immediately) and the container's `TZ` env (effective on respawn). Host-side operator display (`ncl` human output) stays in the install timezone. Resolution: `resolveGroupTimezone` in `src/container-config.ts` — group override → install global.
+
 ## Supply Chain Security (pnpm)
 
 This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspace.yaml`. New package versions must exist on the npm registry for 3 days before pnpm will resolve them.

--- a/container/agent-runner/src/mcp-tools/cli.instructions.md
+++ b/container/agent-runner/src/mcp-tools/cli.instructions.md
@@ -31,6 +31,7 @@ Additional resources (available under `global` scope only): messaging-groups, wi
 ### When to use
 
 - **Looking up your own config** — `ncl groups get` or `ncl groups config get` to see your container config.
+- **Setting your timezone** — if the user's timezone differs from yours (the `<context timezone="..."/>` header), `ncl groups config update --timezone <IANA id>` (`""` clears back to the install default). Requires approval; schedules follow immediately, message display after restart.
 - **Restarting your container** — `ncl groups restart` (with optional `--rebuild` and `--message`).
 - **Checking who's in your group** — `ncl members list`.
 - **Seeing your destinations** — `ncl destinations list`.

--- a/container/agent-runner/src/mcp-tools/cli.instructions.md
+++ b/container/agent-runner/src/mcp-tools/cli.instructions.md
@@ -31,7 +31,6 @@ Additional resources (available under `global` scope only): messaging-groups, wi
 ### When to use
 
 - **Looking up your own config** — `ncl groups get` or `ncl groups config get` to see your container config.
-- **Setting your timezone** — if the user's timezone differs from yours (the `<context timezone="..."/>` header), `ncl groups config update --timezone <IANA id>` (`""` clears back to the install default). Requires approval; schedules follow immediately, message display after restart.
 - **Restarting your container** — `ncl groups restart` (with optional `--rebuild` and `--message`).
 - **Checking who's in your group** — `ncl members list`.
 - **Seeing your destinations** — `ncl destinations list`.

--- a/container/agent-runner/src/mcp-tools/scheduling.instructions.md
+++ b/container/agent-runner/src/mcp-tools/scheduling.instructions.md
@@ -20,6 +20,6 @@ ncl tasks delete ping-a25c
 
 Use good judgement on whether it's appropriate to check in with the user about the task prompt before task creation, and if so, whether to share verbatim or a description of it.
 
-`--process-after` accepts UTC timestamps or naive local timestamps interpreted in the instance timezone (shown in the `<context timezone="..."/>` header).
+`--process-after` accepts UTC timestamps or naive local timestamps interpreted in your group's timezone (shown in the `<context timezone="..."/>` header — the install default unless a group override is set).
 
 Run `ncl tasks create --help` for schedules, options, and pre-task gate scripts (checks that run before you wake).

--- a/container/agent-runner/src/mcp-tools/scheduling.instructions.md
+++ b/container/agent-runner/src/mcp-tools/scheduling.instructions.md
@@ -20,6 +20,6 @@ ncl tasks delete ping-a25c
 
 Use good judgement on whether it's appropriate to check in with the user about the task prompt before task creation, and if so, whether to share verbatim or a description of it.
 
-`--process-after` accepts UTC timestamps or naive local timestamps interpreted in your group's timezone (shown in the `<context timezone="..."/>` header — the install default unless a group override is set).
+`--process-after` accepts UTC timestamps or naive local timestamps interpreted in the instance timezone (shown in the `<context timezone="..."/>` header).
 
 Run `ncl tasks create --help` for schedules, options, and pre-task gate scripts (checks that run before you wake).

--- a/container/skills/welcome/SKILL.md
+++ b/container/skills/welcome/SKILL.md
@@ -68,6 +68,12 @@ There are no special commands. Users just talk naturally. If they want something
 
 ---
 
+## Timezone — mention briefly
+
+One line, woven in naturally: your schedules and timestamps follow the timezone in your `<context timezone="..."/>` header — the install default unless one was set for this agent — and it can be changed if they're somewhere else. If they want a change, run `ncl groups config update --timezone <IANA id>` (requires admin approval; schedules follow immediately, message display after the next restart).
+
+---
+
 ## Shape memory to the user's world (agent-internal, not part of the tour)
 
 From the first conversation onward, pay attention to the parts of the user's world that

--- a/container/skills/welcome/SKILL.md
+++ b/container/skills/welcome/SKILL.md
@@ -68,12 +68,6 @@ There are no special commands. Users just talk naturally. If they want something
 
 ---
 
-## Timezone — mention briefly
-
-One line, woven in naturally: your schedules and timestamps follow the timezone in your `<context timezone="..."/>` header — the install default unless one was set for this agent — and it can be changed if they're somewhere else. If they want a change, run `ncl groups config update --timezone <IANA id>` (requires admin approval; schedules follow immediately, message display after the next restart).
-
----
-
 ## Shape memory to the user's world (agent-internal, not part of the tour)
 
 From the first conversation onward, pay attention to the parts of the user's world that

--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -303,7 +303,7 @@ CREATE TABLE schema_version (
 
 ### 1.15 `container_configs`
 
-Per-agent-group container runtime config. Source of truth for provider, model, packages, MCP servers, mounts, CLI scope, etc. Materialized to `groups/<folder>/container.json` at spawn time.
+Per-agent-group container runtime config. Source of truth for provider, model, packages, MCP servers, mounts, CLI scope, timezone, etc. Materialized to `groups/<folder>/container.json` at spawn time.
 
 ```sql
 CREATE TABLE container_configs (
@@ -320,9 +320,12 @@ CREATE TABLE container_configs (
   packages_npm           TEXT NOT NULL DEFAULT '[]',
   additional_mounts      TEXT NOT NULL DEFAULT '[]',
   cli_scope              TEXT NOT NULL DEFAULT 'group',   -- disabled | group | global
+  timezone               TEXT,                            -- IANA id; NULL = install-global TZ (added by migration 20)
   updated_at             TEXT NOT NULL
 );
 ```
+
+`timezone` overrides the install-global timezone for one agent group: host-side scheduling (cron interpretation, `--process-after`, run-log stamps) resolves it live via `resolveGroupTimezone` (`src/container-config.ts`); the container gets it as its `TZ` env on next respawn. Set via `ncl groups config update --timezone <IANA>` (`""` clears back to NULL) or `ncl groups create --timezone`.
 
 - **Readers:** `src/container-config.ts`, `src/container-runner.ts`, `src/cli/dispatch.ts` (scope enforcement), `src/claude-md-compose.ts`
 - **Writers:** `src/db/container-configs.ts`, `src/modules/self-mod/apply.ts`, `src/backfill-container-configs.ts`
@@ -425,6 +428,8 @@ Several early migrations were later renamed/retired and replaced by "module" fil
 | 16 | `messaging-group-instance` | `016-messaging-group-instance.ts` | `messaging_groups` gets an `instance` column (adapter-instance dimension); table recreate (`disableForeignKeys: true`) backfills `instance = channel_type` on every existing row and relaxes the `UNIQUE` to `(channel_type, platform_id, instance)` |
 | 17 | `agent-message-policies` | `017-agent-message-policies.ts` | `agent_message_policies` (see §1.18) |
 | 18 | `approvals-approver-user-id` | `018-approvals-approver-user-id.ts` | `pending_approvals.approver_user_id` — names a single required approver for a2a message-gate policies |
+| 19 | `wiring-threads-override` | `019-wiring-threads.ts` | `messaging_group_agents.threads` — per-wiring thread-policy override (NULL = adapter default) |
+| 20 | `container-config-timezone` | `020-container-config-timezone.ts` | `container_configs.timezone` — per-agent-group timezone override (NULL = install-global) |
 
 Numbers 5 and 6 are intentionally absent — migrations were renumbered during early development.
 

--- a/src/backfill-container-configs.ts
+++ b/src/backfill-container-configs.ts
@@ -65,6 +65,7 @@ export function backfillContainerConfigs(): void {
       packages_npm: JSON.stringify(legacy.packages?.npm ?? []),
       additional_mounts: JSON.stringify(legacy.additionalMounts ?? []),
       cli_scope: 'group',
+      timezone: null,
       updated_at: new Date().toISOString(),
     };
 

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -14,8 +14,27 @@ import {
 } from '../../db/container-configs.js';
 import { initGroupFilesystem } from '../../group-init.js';
 import { createAgentFromTemplate } from '../../templates/create-agent.js';
+import { isValidTimezone } from '../../timezone.js';
 import type { AgentGroup, ContainerConfigRow } from '../../types.js';
 import { registerResource } from '../crud.js';
+
+/**
+ * Parse a --timezone flag: undefined = not passed, null = explicit clear
+ * (empty string → follow the install default), otherwise a validated IANA id.
+ * Invalid ids throw here, in the handler — for agent callers that is after
+ * approval (rare, self-healing: a retry raises a fresh card).
+ */
+function parseTimezoneFlag(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  const tz = String(value);
+  if (tz === '') return null;
+  if (!isValidTimezone(tz)) {
+    throw new Error(
+      `invalid --timezone: "${tz}" is not an IANA timezone id (e.g. "Europe/Lisbon"); pass "" to follow the install default`,
+    );
+  }
+  return tz;
+}
 
 /** Deserialize JSON columns for display. */
 function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
@@ -33,6 +52,7 @@ function presentConfig(row: ContainerConfigRow): Record<string, unknown> {
     packages_npm: JSON.parse(row.packages_npm),
     additional_mounts: JSON.parse(row.additional_mounts),
     cli_scope: row.cli_scope,
+    timezone: row.timezone,
     updated_at: row.updated_at,
   };
 }
@@ -74,11 +94,14 @@ registerResource({
       description:
         'Create (or return the existing) agent group with its container config. Idempotent on --folder. ' +
         'With --template <ref>, stamp from a local template under templates/ (MCP servers + instructions ' +
-        '+ skills + paused recurring tasks). Use --folder <slug> and --name <display name>.',
+        '+ skills + paused recurring tasks). Use --folder <slug> and --name <display name>. ' +
+        'Optional --timezone <IANA id> sets the group timezone (template task schedules fire in it); like --name, it is ignored when the folder already exists.',
       handler: async (args) => {
+        const timezone = parseTimezoneFlag(args.timezone) ?? undefined;
         if (args.template) {
           return createAgentFromTemplate(String(args.template), {
             name: args.name ? String(args.name) : undefined,
+            timezone,
           });
         }
         const folder = args.folder as string;
@@ -103,6 +126,7 @@ registerResource({
         // instance default provider (`ensureContainerConfig` inside) — per-group
         // `groups config update --provider` still wins.
         initGroupFilesystem(group);
+        if (timezone) updateContainerConfigScalars(id, { timezone });
         return getAgentGroupByFolder(folder);
       },
     },
@@ -256,7 +280,8 @@ registerResource({
       access: 'approval',
       description:
         'Update container config scalar fields. Changes are saved but do NOT take effect until you run `ncl groups restart`. ' +
-        'Use --id <group-id> and any of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope.',
+        'Use --id <group-id> and any of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, ' +
+        '--timezone (IANA id like "Europe/Lisbon"; "" clears back to the install default; scheduled-task times follow it immediately, message display after restart).',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
@@ -266,10 +291,19 @@ registerResource({
         const updates: Partial<
           Pick<
             ContainerConfigRow,
-            'provider' | 'model' | 'effort' | 'image_tag' | 'assistant_name' | 'max_messages_per_prompt' | 'cli_scope'
+            | 'provider'
+            | 'model'
+            | 'effort'
+            | 'image_tag'
+            | 'assistant_name'
+            | 'max_messages_per_prompt'
+            | 'cli_scope'
+            | 'timezone'
           >
         > = {};
         if (args.provider !== undefined) updates.provider = args.provider as string;
+        const timezone = parseTimezoneFlag(args.timezone);
+        if (timezone !== undefined) updates.timezone = timezone;
         if (args.model !== undefined) updates.model = args.model as string;
         if (args.effort !== undefined) updates.effort = args.effort as string;
         if (args.image_tag !== undefined) updates.image_tag = args.image_tag as string;
@@ -286,7 +320,7 @@ registerResource({
 
         if (Object.keys(updates).length === 0) {
           throw new Error(
-            'Nothing to update — provide at least one of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope',
+            'Nothing to update — provide at least one of: --provider, --model, --effort, --image-tag, --assistant-name, --max-messages-per-prompt, --cli-scope, --timezone',
           );
         }
 

--- a/src/cli/resources/tasks.ts
+++ b/src/cli/resources/tasks.ts
@@ -2,7 +2,8 @@ import fs from 'fs';
 
 import type Database from 'better-sqlite3';
 
-import { GROUPS_DIR } from '../../config.js';
+import { GROUPS_DIR, TIMEZONE } from '../../config.js';
+import { resolveGroupTimezone } from '../../container-config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import {
   findTaskSessions,
@@ -185,6 +186,7 @@ function createTask(args: Record<string, unknown>, ctx: CallerContext) {
     processAfter: str(args.process_after),
     script,
     dangerouslyOverrideRecurrenceLimit: bool(args.dangerously_override_recurrence_limit),
+    timezone: resolveGroupTimezone(group),
   });
   const { session, row } = createScheduledTask(group, prepared, {
     originSessionId: ctx.caller === 'agent' ? ctx.sessionId : null,
@@ -330,24 +332,34 @@ function updateTaskCommand(args: Record<string, unknown>, ctx: CallerContext) {
   const id = taskId(args);
   const update: TaskUpdate = {};
   if (typeof args.prompt === 'string') update.prompt = args.prompt;
-  if (args.process_after !== undefined) update.processAfter = parseProcessAfter(args.process_after);
   const recurrence = normalizeNullableString(args.recurrence);
   const script = normalizeNullableString(args.script);
-  if (recurrence !== undefined) {
-    validateRecurrence(recurrence);
-    // Effective script AFTER this update: the new value when provided
-    // (including an explicit clear), else whatever the task already has.
-    let scriptAfter: string | null = script !== undefined ? script : null;
-    if (script === undefined) {
-      for (const session of selectedSessions(args, ctx)) {
-        const row = withInbound(session, (db) => selectTask(db, id));
-        if (row) {
-          scriptAfter = parseContent(row.content).script;
-          break;
-        }
+
+  // Wall-clock fields (--process-after, cron grid) are interpreted in the
+  // owning group's timezone, so the task's group must be resolved before
+  // parsing. The same lookup yields the task's current script for the
+  // recurrence-limit check.
+  let ownerGroup: string | undefined;
+  let currentScript: string | null = null;
+  if (args.process_after !== undefined || recurrence !== undefined) {
+    for (const session of selectedSessions(args, ctx)) {
+      const row = withInbound(session, (db) => selectTask(db, id));
+      if (row) {
+        ownerGroup = session.agent_group_id;
+        currentScript = parseContent(row.content).script;
+        break;
       }
     }
-    enforceRecurrenceLimit(recurrence, bool(args.dangerously_override_recurrence_limit), scriptAfter != null);
+  }
+  const tz = ownerGroup ? resolveGroupTimezone(ownerGroup) : TIMEZONE;
+
+  if (args.process_after !== undefined) update.processAfter = parseProcessAfter(args.process_after, tz);
+  if (recurrence !== undefined) {
+    validateRecurrence(recurrence, tz);
+    // Effective script AFTER this update: the new value when provided
+    // (including an explicit clear), else whatever the task already has.
+    const scriptAfter: string | null = script !== undefined ? script : currentScript;
+    enforceRecurrenceLimit(recurrence, bool(args.dangerously_override_recurrence_limit), scriptAfter != null, tz);
     update.recurrence = recurrence;
   }
   if (script !== undefined) update.script = script;

--- a/src/container-config.test.ts
+++ b/src/container-config.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Group-timezone resolution (agent-level timezone feature).
+ *
+ * The chain is: valid per-group override → install-global TIMEZONE. An
+ * invalid stored value (hand-edited DB — the ncl write path validates) must
+ * fall back to the global timezone, not silently become UTC, and must never
+ * be materialized into container.json.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { TIMEZONE } from './config.js';
+import { configFromDb, resolveGroupTimezone } from './container-config.js';
+import { createAgentGroup } from './db/agent-groups.js';
+import { closeDb, initTestDb } from './db/connection.js';
+import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from './db/container-configs.js';
+import { runMigrations } from './db/migrations/index.js';
+import type { AgentGroup } from './types.js';
+
+const GROUP: AgentGroup = {
+  id: 'ag-tz',
+  name: 'tz',
+  folder: 'tz',
+  agent_provider: null,
+  created_at: new Date().toISOString(),
+};
+
+describe('resolveGroupTimezone', () => {
+  beforeEach(() => {
+    runMigrations(initTestDb());
+    createAgentGroup(GROUP);
+    ensureContainerConfig(GROUP.id);
+  });
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('returns the install-global timezone when no override is set', () => {
+    expect(resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
+    expect(resolveGroupTimezone('ag-no-such-group')).toBe(TIMEZONE);
+  });
+
+  it('returns a valid override, and falls back to global on an invalid stored value', () => {
+    updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
+    expect(resolveGroupTimezone(GROUP.id)).toBe('Asia/Tokyo');
+
+    updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
+    expect(resolveGroupTimezone(GROUP.id)).toBe(TIMEZONE);
+  });
+
+  it('configFromDb ships a valid timezone to the container and drops an invalid one', () => {
+    updateContainerConfigScalars(GROUP.id, { timezone: 'Asia/Tokyo' });
+    expect(configFromDb(getContainerConfig(GROUP.id)!, GROUP).timezone).toBe('Asia/Tokyo');
+
+    updateContainerConfigScalars(GROUP.id, { timezone: 'Not/AZone' });
+    expect(configFromDb(getContainerConfig(GROUP.id)!, GROUP).timezone).toBeUndefined();
+  });
+});

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -11,9 +11,10 @@
 import fs from 'fs';
 import path from 'path';
 
-import { GROUPS_DIR } from './config.js';
+import { GROUPS_DIR, TIMEZONE } from './config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { getAgentGroup } from './db/agent-groups.js';
+import { isValidTimezone } from './timezone.js';
 import type { AgentGroup, ContainerConfigRow } from './types.js';
 
 export interface McpServerConfig {
@@ -43,6 +44,18 @@ export interface ContainerConfig {
   maxMessagesPerPrompt?: number;
   model?: string;
   effort?: string;
+  timezone?: string;
+}
+
+/**
+ * Effective timezone for an agent group: per-group override → install global.
+ * The ncl write path validates, but a hand-edited DB value must not silently
+ * flip scheduling to UTC — an invalid override falls back to the global tz,
+ * same as no override.
+ */
+export function resolveGroupTimezone(agentGroupId: string): string {
+  const tz = getContainerConfig(agentGroupId)?.timezone;
+  return tz && isValidTimezone(tz) ? tz : TIMEZONE;
 }
 
 /** Build a `ContainerConfig` from a DB row + agent group identity. */
@@ -63,6 +76,7 @@ export function configFromDb(row: ContainerConfigRow, group: AgentGroup): Contai
     maxMessagesPerPrompt: row.max_messages_per_prompt ?? undefined,
     model: row.model ?? undefined,
     effort: row.effort ?? undefined,
+    timezone: row.timezone && isValidTimezone(row.timezone) ? row.timezone : undefined,
   };
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -451,7 +451,7 @@ async function buildContainerArgs(
 
   // Environment — only vars read by code we don't own.
   // Everything NanoClaw-specific is in container.json (read by runner at startup).
-  args.push('-e', `TZ=${TIMEZONE}`);
+  args.push('-e', `TZ=${containerConfig.timezone ?? TIMEZONE}`);
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {

--- a/src/db/container-configs.test.ts
+++ b/src/db/container-configs.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { initTestDb, closeDb } from './connection.js';
 import { runMigrations } from './migrations/index.js';
 import { createAgentGroup } from './agent-groups.js';
-import { ensureContainerConfig, getContainerConfig } from './container-configs.js';
+import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from './container-configs.js';
 
 function makeGroup(id: string): void {
   createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: new Date().toISOString() });
@@ -55,5 +55,18 @@ describe('ensureContainerConfig provider stamping', () => {
     // must NOT change it — INSERT OR IGNORE keeps the row frozen.
     ensureContainerConfig('ag-existing');
     expect(getContainerConfig('ag-existing')?.provider).toBe('codex');
+  });
+
+  it('sets and clears the timezone override (NULL = follow the install default)', () => {
+    makeGroup('ag-tz');
+    ensureContainerConfig('ag-tz');
+    expect(getContainerConfig('ag-tz')?.timezone).toBeNull();
+
+    updateContainerConfigScalars('ag-tz', { timezone: 'Asia/Tokyo' });
+    expect(getContainerConfig('ag-tz')?.timezone).toBe('Asia/Tokyo');
+
+    // `ncl groups config update --timezone ""` maps to null — the clear path.
+    updateContainerConfigScalars('ag-tz', { timezone: null });
+    expect(getContainerConfig('ag-tz')?.timezone).toBeNull();
   });
 });

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -10,6 +10,7 @@ const SCALAR_COLUMNS = new Set([
   'assistant_name',
   'max_messages_per_prompt',
   'cli_scope',
+  'timezone',
 ]);
 const JSON_COLUMNS = new Set(['skills', 'mcp_servers', 'packages_apt', 'packages_npm', 'additional_mounts']);
 
@@ -30,11 +31,11 @@ export function createContainerConfig(config: ContainerConfigRow): void {
       `INSERT INTO container_configs (
         agent_group_id, provider, model, effort, image_tag, assistant_name,
         max_messages_per_prompt, skills, mcp_servers, packages_apt, packages_npm,
-        additional_mounts, updated_at
+        additional_mounts, timezone, updated_at
       ) VALUES (
         @agent_group_id, @provider, @model, @effort, @image_tag, @assistant_name,
         @max_messages_per_prompt, @skills, @mcp_servers, @packages_apt, @packages_npm,
-        @additional_mounts, @updated_at
+        @additional_mounts, @timezone, @updated_at
       )`,
     )
     .run(config);
@@ -78,7 +79,14 @@ export function updateContainerConfigScalars(
   updates: Partial<
     Pick<
       ContainerConfigRow,
-      'provider' | 'model' | 'effort' | 'image_tag' | 'assistant_name' | 'max_messages_per_prompt' | 'cli_scope'
+      | 'provider'
+      | 'model'
+      | 'effort'
+      | 'image_tag'
+      | 'assistant_name'
+      | 'max_messages_per_prompt'
+      | 'cli_scope'
+      | 'timezone'
     >
   >,
 ): void {

--- a/src/db/migrations/020-container-config-timezone.ts
+++ b/src/db/migrations/020-container-config-timezone.ts
@@ -1,0 +1,18 @@
+import type { Migration } from './index.js';
+
+/**
+ * Per-agent-group timezone override on `container_configs`.
+ *
+ * NULL = follow the install-global timezone (TZ in .env / system), matching
+ * pre-migration behavior for every existing row — deliberately no backfill.
+ * A non-NULL value is a validated IANA id (rejected at the ncl write path);
+ * it grounds host-side scheduling (cron parsing, --process-after, run-log
+ * stamps) immediately and the container's TZ env on next respawn.
+ */
+export const migration020: Migration = {
+  version: 20,
+  name: 'container-config-timezone',
+  up(db) {
+    db.exec(`ALTER TABLE container_configs ADD COLUMN timezone TEXT;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -18,6 +18,7 @@ import { moduleApprovalsPendingApprovals } from './module-approvals-pending-appr
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
+import { migration020 } from './020-container-config-timezone.js';
 
 export interface Migration {
   version: number;
@@ -52,6 +53,7 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration019,
+  migration020,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a

--- a/src/modules/scheduling/create.ts
+++ b/src/modules/scheduling/create.ts
@@ -63,29 +63,34 @@ export function makeTaskId(name: unknown): string {
   return slug ? `${slug}-${hex(4)}` : `t-${hex(6)}`;
 }
 
-export function parseProcessAfter(value: unknown): string {
+export function parseProcessAfter(value: unknown, tz: string = TIMEZONE): string {
   if (typeof value !== 'string' || value.length === 0) throw new Error('--process-after is required');
-  const date = parseZonedToUtc(value, TIMEZONE);
+  const date = parseZonedToUtc(value, tz);
   if (Number.isNaN(date.getTime())) throw new Error(`invalid --process-after: ${value}`);
   return date.toISOString();
 }
 
-export function validateRecurrence(value: string | null | undefined): void {
+export function validateRecurrence(value: string | null | undefined, tz: string = TIMEZONE): void {
   if (!value) return;
   try {
-    CronExpressionParser.parse(value, { tz: TIMEZONE });
+    CronExpressionParser.parse(value, { tz });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`invalid --recurrence: ${msg}`, { cause: err });
   }
 }
 
-export function enforceRecurrenceLimit(recurrence: string | null, override: boolean, hasScript: boolean): void {
+export function enforceRecurrenceLimit(
+  recurrence: string | null,
+  override: boolean,
+  hasScript: boolean,
+  tz: string = TIMEZONE,
+): void {
   // A gate script is the sanctioned mitigation: a skipped fire costs no agent
   // tokens, so scripted tasks may poll faster without the explicit override.
   if (!recurrence || override || hasScript) return;
   const horizon = Date.now() + 24 * 60 * 60 * 1000;
-  const interval = CronExpressionParser.parse(recurrence, { tz: TIMEZONE });
+  const interval = CronExpressionParser.parse(recurrence, { tz });
   let fires = 0;
   while (fires <= MAX_DAILY_FIRES) {
     const next = interval.next();
@@ -95,7 +100,12 @@ export function enforceRecurrenceLimit(recurrence: string | null, override: bool
   if (fires > MAX_DAILY_FIRES) throw new Error(RECURRENCE_LIMIT_WARNING);
 }
 
-/** Validate task semantics and derive its first run without writing anything. */
+/**
+ * Validate task semantics and derive its first run without writing anything.
+ * `timezone` grounds wall-clock interpretation (cron grid, naive
+ * --process-after) — pass the owning group's effective timezone
+ * (`resolveGroupTimezone`); it defaults to the install-global one.
+ */
 export function prepareScheduledTask(input: {
   name?: string;
   prompt: string;
@@ -103,20 +113,22 @@ export function prepareScheduledTask(input: {
   processAfter?: string;
   script?: string | null;
   dangerouslyOverrideRecurrenceLimit?: boolean;
+  timezone?: string;
 }): PreparedScheduledTask {
   if (!input.prompt) throw new Error('--prompt is required');
   const recurrence = input.recurrence ?? null;
   const script = input.script ?? null;
-  validateRecurrence(recurrence);
-  enforceRecurrenceLimit(recurrence, input.dangerouslyOverrideRecurrenceLimit === true, script !== null);
+  const tz = input.timezone ?? TIMEZONE;
+  validateRecurrence(recurrence, tz);
+  enforceRecurrenceLimit(recurrence, input.dangerouslyOverrideRecurrenceLimit === true, script !== null, tz);
 
   let processAfter: string;
   if (input.processAfter === undefined && recurrence) {
-    const next = CronExpressionParser.parse(recurrence, { tz: TIMEZONE }).next().toISOString();
+    const next = CronExpressionParser.parse(recurrence, { tz }).next().toISOString();
     if (!next) throw new Error(`--recurrence has no upcoming run: ${recurrence}`);
     processAfter = next;
   } else {
-    processAfter = parseProcessAfter(input.processAfter);
+    processAfter = parseProcessAfter(input.processAfter, tz);
   }
 
   return { name: input.name, prompt: input.prompt, recurrence, script, processAfter };

--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -28,6 +28,14 @@ vi.mock('../../db/agent-groups.js', () => ({
   getAgentGroup: (id: string) => (id === 'ag-test' ? { id, folder: 'g-test' } : undefined),
 }));
 
+// resolveGroupTimezone reads the group's config row from the central DB
+// (not initialized here). Default: no override → falls back to the mocked
+// install TIMEZONE; individual tests set an override to test precedence.
+const containerConfigState = vi.hoisted(() => ({ timezone: null as string | null }));
+vi.mock('../../db/container-configs.js', () => ({
+  getContainerConfig: () => ({ timezone: containerConfigState.timezone }),
+}));
+
 const TEST_DIR = '/tmp/nanoclaw-recurrence-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
 
@@ -52,6 +60,7 @@ function fakeSession(): Session {
 }
 
 afterEach(() => {
+  containerConfigState.timezone = null;
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
@@ -104,9 +113,31 @@ describe('handleRecurrence', () => {
     const follow = db.prepare(`SELECT process_after FROM messages_in WHERE id != 'task-tz'`).get() as {
       process_after: string;
     };
-    // Drop the `{ tz: TIMEZONE }` option in recurrence.ts and this reads
+    // Drop the `{ tz }` option in recurrence.ts and this reads
     // T09:00:00 (09:00 UTC) instead — red, even on a UTC CI runner.
     expect(follow.process_after).toMatch(/T00:00:00/);
+  });
+
+  it('re-arms in the group timezone override, not the install TIMEZONE', async () => {
+    // Install tz is pinned to Asia/Tokyo above; the group override must win.
+    // Asia/Kolkata is UTC+5:30 with no DST: 09:00 local === 03:30 UTC, exactly.
+    containerConfigState.timezone = 'Asia/Kolkata';
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-group-tz',
+      seriesId: 'task-group-tz',
+      processAfter: '2020-01-01T00:00:00.000Z',
+      recurrence: '0 9 * * *',
+      content: JSON.stringify({ prompt: 'daily digest' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='completed' WHERE id='task-group-tz'`).run();
+
+    await handleRecurrence(db, fakeSession());
+
+    const follow = db.prepare(`SELECT process_after FROM messages_in WHERE id != 'task-group-tz'`).get() as {
+      process_after: string;
+    };
+    expect(follow.process_after).toMatch(/T03:30:00/);
   });
 
   it('does not clone rows whose recurrence is already cleared', async () => {

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -14,7 +14,7 @@
 import type Database from 'better-sqlite3';
 import { CronExpressionParser } from 'cron-parser';
 
-import { TIMEZONE } from '../../config.js';
+import { resolveGroupTimezone } from '../../container-config.js';
 import { log } from '../../log.js';
 import type { Session } from '../../types.js';
 import { clearRecurrence, getCompletedRecurring, insertRecurrence, trailingFailedRuns } from './db.js';
@@ -49,6 +49,10 @@ function appendHostTaskNote(agentGroupId: string, seriesId: string, note: string
 
 export async function handleRecurrence(inDb: Database.Database, session: Session): Promise<void> {
   const recurring = getCompletedRecurring(inDb);
+  // Resolved per call, not cached at module load: a group timezone change
+  // (approved `groups config update --timezone`) must shift the series from
+  // the very next re-arm.
+  const tz = resolveGroupTimezone(session.agent_group_id);
 
   for (const msg of recurring) {
     try {
@@ -56,7 +60,7 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
       // (src/v1/task-scheduler.ts:20-49); without it, a task written "0 9 * * *"
       // by an agent running in a user's local TZ fires at 09:00 UTC instead of
       // 09:00 user-local.
-      const interval = CronExpressionParser.parse(msg.recurrence, { tz: TIMEZONE });
+      const interval = CronExpressionParser.parse(msg.recurrence, { tz });
       const cronNext = interval.next().toDate();
       const newId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 

--- a/src/modules/scheduling/run-log.ts
+++ b/src/modules/scheduling/run-log.ts
@@ -9,7 +9,8 @@
  */
 import fs from 'fs';
 
-import { GROUPS_DIR, TIMEZONE } from '../../config.js';
+import { GROUPS_DIR } from '../../config.js';
+import { resolveGroupTimezone } from '../../container-config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { formatLocalStamp } from '../../timezone.js';
 
@@ -24,7 +25,7 @@ export function appendRunLog(
   const ag = getAgentGroup(agentGroupId);
   if (!ag) throw new Error(`agent group not found: ${agentGroupId}`);
 
-  const timestamp = formatLocalStamp(new Date(), TIMEZONE);
+  const timestamp = formatLocalStamp(new Date(), resolveGroupTimezone(agentGroupId));
   const dir = `${GROUPS_DIR}/${ag.folder}/tasks`;
   const file = `${dir}/${series}.md`;
   fs.mkdirSync(dir, { recursive: true });

--- a/src/templates/create-agent.test.ts
+++ b/src/templates/create-agent.test.ts
@@ -120,6 +120,30 @@ describe('createAgentFromTemplate', () => {
     expect(fs.existsSync(path.join(GROUPS_DIR, g.folder, 'tasks', 'weekday-briefing.md'))).toBe(false);
   });
 
+  it('stamps a valid timezone onto the config row and grounds template task first runs in it', () => {
+    writeTask('daily-digest', '0 9 * * *', 'Send the digest.');
+
+    const g = createAgentFromTemplate('sales/sdr', { name: 'SDR TZ', timezone: 'Asia/Tokyo' });
+    expect(getContainerConfig(g.id)?.timezone).toBe('Asia/Tokyo');
+
+    const sessions = findTaskSessions(g.id);
+    const db = new Database(inboundDbPath(g.id, sessions[0].id), { readonly: true });
+    const row = db.prepare("SELECT process_after FROM messages_in WHERE kind = 'task'").get() as {
+      process_after: string;
+    };
+    db.close();
+
+    // 09:00 in Tokyo (no DST) is always 00:00 UTC. A first run computed in the
+    // install-global timezone would only produce this if the test host itself
+    // ran in JST.
+    expect(row.process_after).toMatch(/T00:00:00/);
+  });
+
+  it('ignores an invalid timezone — the group follows the install default', () => {
+    const g = createAgentFromTemplate('sales/sdr', { name: 'SDR Bad TZ', timezone: 'Not/AZone' });
+    expect(getContainerConfig(g.id)?.timezone).toBeNull();
+  });
+
   it('forwards multiline scripts unchanged through the shared task creation path', () => {
     const script = 'count=2\necho \'{"wakeAgent": true, "data": {"count": 2}}\'';
     writeTask('alert-watch', '*/15 * * * *', 'Investigate new alerts.', script);

--- a/src/templates/create-agent.ts
+++ b/src/templates/create-agent.ts
@@ -2,9 +2,14 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
-import { DATA_DIR, GROUPS_DIR } from '../config.js';
+import { DATA_DIR, GROUPS_DIR, TIMEZONE } from '../config.js';
 import { createAgentGroup } from '../db/agent-groups.js';
-import { ensureContainerConfig, updateContainerConfigJson } from '../db/container-configs.js';
+import {
+  ensureContainerConfig,
+  updateContainerConfigJson,
+  updateContainerConfigScalars,
+} from '../db/container-configs.js';
+import { isValidTimezone } from '../timezone.js';
 import { assertValidGroupFolder, resolveGroupFolderPath } from '../group-folder.js';
 import { stageGroupPersona } from '../group-persona.js';
 import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
@@ -15,6 +20,8 @@ import { parseTemplate } from './parse.js';
 
 export interface CreateAgentOptions {
   name?: string;
+  /** IANA timezone for the new group; template task schedules fire in it. Omit to follow the install default. */
+  timezone?: string;
 }
 
 /**
@@ -35,6 +42,11 @@ export interface CreateAgentOptions {
 export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions): AgentGroup {
   const dir = resolveLocalTemplate(ref);
   const tpl = parseTemplate(dir);
+  // The group doesn't exist yet, so resolveGroupTimezone can't apply — the
+  // effective timezone is derived from the option here and stamped onto the
+  // config row below, BEFORE tasks are created, so a template task's first
+  // run and its later re-arms agree on the same zone.
+  const timezone = opts?.timezone && isValidTimezone(opts.timezone) ? opts.timezone : undefined;
   const tasks = tpl.tasks.map((task) => {
     try {
       return prepareScheduledTask({
@@ -42,6 +54,7 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
         prompt: task.prompt,
         recurrence: task.schedule,
         script: task.script,
+        timezone: timezone ?? TIMEZONE,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -58,6 +71,7 @@ export function createAgentFromTemplate(ref: string, opts?: CreateAgentOptions):
   const group: AgentGroup = { id, name, folder, agent_provider: null, created_at: new Date().toISOString() };
   createAgentGroup(group);
   ensureContainerConfig(id);
+  if (timezone) updateContainerConfigScalars(id, { timezone });
 
   // group-init.ts owns the mkdir at first spawn, but it isn't called here — so we
   // create the dir ourselves to land instructions.prepend.md + context/.

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ContainerConfigRow {
   packages_npm: string; // JSON: string[]
   additional_mounts: string; // JSON: AdditionalMountConfig[]
   cli_scope: string; // 'disabled' | 'group' | 'global'
+  timezone: string | null; // IANA id; NULL = follow the install-global timezone
   updated_at: string;
 }
 


### PR DESCRIPTION
Adds an optional IANA timezone override per agent group, stored in `container_configs` (migration 020).

- `ncl groups config update --timezone <IANA>` sets it, `""` clears; approval-gated for agent callers
- Resolution via `resolveGroupTimezone`: group override → install global
- Grounds the group's scheduling immediately: cron interpretation, `--process-after`, run-log stamps
- Sets the container's `TZ` env on respawn; container instructions surface the active timezone to the agent
- Host-side operator display (`ncl` human output) stays in the install timezone
- Templates can seed a timezone at group creation