### PR TITLE
fix(agent-runner): never deliver silence, never deliver <internal> thinking

### DIFF
--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -132,6 +132,19 @@ export function getRoutingBySeq(
   return outRow ?? null;
 }
 
+/**
+ * Highest seq currently in messages_out. Used by the poll-loop to snapshot a
+ * per-turn baseline: MCP tools (send_message, send_file, …) write outbound rows
+ * directly and never touch the in-process `sent` counter, so a turn that
+ * answered via a tool then ended with bare scratchpad looks identical to a
+ * silent drop. Comparing this against a turn-start baseline reveals whether the
+ * agent actually delivered anything out-of-band before the never-silent
+ * fallback fires. Reads outbound only — inbound activity never moves it.
+ */
+export function getMaxOutboundSeq(): number {
+  return (getOutboundDb().prepare('SELECT COALESCE(MAX(seq), 0) AS m FROM messages_out').get() as { m: number }).m;
+}
+
 /** Get undelivered messages (for host polling — reads from outbound.db). */
 export function getUndeliveredMessages(): MessageOutRow[] {
   return getOutboundDb()

--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -6,7 +6,7 @@ import { getPendingMessages } from './db/messages-in.js';
 import { getContinuation, setContinuation } from './db/session-state.js';
 import { MockProvider } from './providers/mock.js';
 import type { ProviderExchange } from './providers/types.js';
-import { runPollLoop } from './poll-loop.js';
+import { runPollLoop, FALLBACK_PREFIX } from './poll-loop.js';
 
 beforeEach(() => {
   initTestSessionDb();
@@ -114,20 +114,26 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
-  it('bare text produces no outbound messages (scratchpad only)', async () => {
+  it('bare text is nudged once, then delivered raw (never-silent fallback)', async () => {
     insertMessage('m1', { sender: 'Alice', text: 'hello' }, { platformId: 'chan-1', channelType: 'discord' });
 
-    // Agent responds with bare text — no <message to="..."> wrapping
+    // Agent responds with bare text — no <message to="..."> wrapping — and (via
+    // the mock) repeats it after the corrective nudge. The first bare turn is
+    // scratchpad only (nudge, no delivery); the nudged retry that STILL comes
+    // back bare is delivered raw with a marker rather than dropped silently.
     const provider = new MockProvider({}, () => 'I am thinking about this...');
     const controller = new AbortController();
     const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
 
-    // Wait long enough for the poll loop to process
-    await sleep(1000);
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
     controller.abort();
 
     const out = getUndeliveredMessages();
-    expect(out).toHaveLength(0);
+    expect(out).toHaveLength(1);
+    const text = JSON.parse(out[0].content).text as string;
+    expect(text).toContain(FALLBACK_PREFIX);
+    expect(text).toContain('I am thinking about this...');
+    expect(out[0].platform_id).toBe('chan-1');
 
     await loopPromise.catch(() => {});
   });

--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from './db/connection.js';
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
-import { getUndeliveredMessages } from './db/messages-out.js';
+import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { isCorruptionError, processQuery } from './poll-loop.js';
+import { isCorruptionError, processQuery, FALLBACK_PREFIX } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -538,5 +538,136 @@ describe('task-run turn wiring (real processQuery)', () => {
     expect(logs[1]).toContain('[undelivered → local-cli] fire two result');
     expect(logs).not.toContain('first delivery decision handled');
     expect(logs).not.toContain('second delivery decision handled');
+  });
+});
+
+// --- Never-silent delivery fallback (chat turns) ---
+// A chat turn whose first result had no <message> envelope gets one corrective
+// nudge. Before this fix, if the nudged retry ALSO came back bare, the text was
+// dropped as scratchpad and the user saw silence. Now the raw text is delivered
+// with a clear marker — unless the agent already answered out-of-band via an
+// MCP tool this turn.
+
+const CHAT_ROUTING = {
+  platformId: 'chan-1',
+  channelType: 'discord',
+  threadId: null,
+  inReplyTo: 'm1',
+};
+
+function fallbackRows(): Array<{ text: string; platform_id: string | null }> {
+  return getUndeliveredMessages()
+    .filter((m) => m.kind === 'chat' && JSON.parse(m.content).text?.startsWith(FALLBACK_PREFIX))
+    .map((m) => ({ text: JSON.parse(m.content).text as string, platform_id: m.platform_id }));
+}
+
+describe('never-silent delivery fallback (chat turns)', () => {
+  it('delivers raw text (marked) when a nudged chat turn STILL ends bare', async () => {
+    const pushes: string[] = [];
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // First bare result → one corrective nudge, nothing delivered yet.
+      yield { type: 'result', text: 'here is my thinking but I forgot to wrap it' };
+      // Nudged retry STILL bare → never-silent fallback delivers the raw text.
+      yield { type: 'result', text: 'still forgot to wrap, oops' };
+    }
+    const query: AgentQuery = {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    };
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    // Exactly one nudge fired (once-per-turn), then the fallback delivered.
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(1);
+    const delivered = fallbackRows();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].text).toContain(FALLBACK_PREFIX);
+    expect(delivered[0].text).toContain('still forgot to wrap, oops');
+    expect(delivered[0].platform_id).toBe('chan-1');
+  });
+
+  it('does NOT fall back when the agent already answered via an MCP tool this turn', async () => {
+    // HAZARD: send_message writes an outbound row directly and never bumps the
+    // in-process `sent` counter. A turn that answered via the tool then trailed
+    // off into bare scratchpad must not be re-delivered as raw text.
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Simulate the MCP send_message tool firing mid-turn.
+      writeMessageOut({
+        id: 'mcp-1',
+        in_reply_to: 'm1',
+        kind: 'chat',
+        platform_id: 'chan-1',
+        channel_type: 'discord',
+        thread_id: null,
+        content: JSON.stringify({ text: 'answered via the send_message tool' }),
+      });
+      yield { type: 'result', text: 'internal note after sending' };
+      yield { type: 'result', text: 'more internal note after the nudge' };
+    }
+    const query: AgentQuery = { push: () => {}, end: () => {}, events: events(), abort: () => {} };
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    // No fallback row — the MCP send is the only outbound message.
+    expect(fallbackRows()).toHaveLength(0);
+    const all = getUndeliveredMessages().filter((m) => m.kind === 'chat');
+    expect(all).toHaveLength(1);
+    expect(JSON.parse(all[0].content).text).toBe('answered via the send_message tool');
+  });
+
+  it('task-mode turns never fall back (bare text is the normal run-log ending)', async () => {
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      yield { type: 'result', text: 'nothing new in the feeds' };
+      yield { type: 'result', text: 'still nothing new' };
+    }
+    const query: AgentQuery = { push: () => {}, end: () => {}, events: events(), abort: () => {} };
+
+    await processQuery(query, TASK_ROUTING, ['t1'], 'claude', undefined, 'prompt', undefined);
+
+    expect(fallbackRows()).toHaveLength(0);
+    expect(getUndeliveredMessages().filter((m) => m.kind === 'chat')).toHaveLength(0);
+  });
+
+  it('resets the once-per-turn nudge guard on a follow-up turn (per-turn scope)', async () => {
+    // Pins that unwrappedNudged is per-turn, not session-lifetime: a follow-up
+    // push must earn its OWN nudge. If the guard failed to reset, turn two would
+    // get no nudge AND be force-delivered as a fallback instead.
+    const pushes: string[] = [];
+    async function* events(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'init', continuation: 's1' };
+      // Turn 1: one bare result → nudge 1.
+      yield { type: 'result', text: 'bare turn one' };
+      // A new chat message arrives while the query is open — the follow-up
+      // poller pushes it and must reset the per-turn nudge guard.
+      insertMessage('m2', 'chat', { sender: 'B', text: 'a fresh question' });
+      const deadline = Date.now() + 5000;
+      while (!pushes.some((p) => p.includes('a fresh question')) && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      // Turn 2: one bare result → nudge 2 only if the guard reset.
+      yield { type: 'result', text: 'bare turn two' };
+    }
+    const query: AgentQuery = {
+      push: (m: string) => {
+        pushes.push(m);
+      },
+      end: () => {},
+      events: events(),
+      abort: () => {},
+    };
+
+    await processQuery(query, CHAT_ROUTING, ['m1'], 'claude', undefined, 'prompt', undefined);
+
+    // Two independent nudges — proves the guard reset between turns.
+    expect(pushes.filter((p) => p.includes('was not delivered'))).toHaveLength(2);
+    // Each turn had a single bare result, so no fallback ever fired.
+    expect(fallbackRows()).toHaveLength(0);
   });
 });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -668,7 +668,15 @@ export const FALLBACK_PREFIX = '⚠ undelivered agent output (sent raw):';
  * separate so the marker and the log line stay distinct from the provider-error
  * path (which carries an already-user-facing notice, no marker).
  */
-function deliverFallbackResult(text: string, routing: RoutingContext): void {
+export function deliverFallbackResult(text: string, routing: RoutingContext): void {
+  // <internal> content stays private even on this last-resort path — the agent
+  // explicitly marked it not-for-delivery, and models routinely narrate the
+  // user in there ("the user is asking about...").
+  const deliverable = stripInternalTags(text);
+  if (!deliverable) {
+    log('Nudged chat turn had only <internal> content — nothing delivered');
+    return;
+  }
   log('Nudged chat turn still had no <message> envelope — delivering raw text as never-silent fallback');
   writeMessageOut({
     id: generateId(),
@@ -677,7 +685,7 @@ function deliverFallbackResult(text: string, routing: RoutingContext): void {
     platform_id: routing.platformId,
     channel_type: routing.channelType,
     thread_id: routing.threadId,
-    content: JSON.stringify({ text: `${FALLBACK_PREFIX}\n${text}` }),
+    content: JSON.stringify({ text: `${FALLBACK_PREFIX}\n${deliverable}` }),
   });
 }
 
@@ -685,6 +693,9 @@ function deliverFallbackResult(text: string, routing: RoutingContext): void {
  * Parse the agent's final text for <message to="name">...</message> blocks
  * and dispatch each one to its resolved destination. Text outside of blocks
  * (including <internal>...</internal>) is scratchpad — logged but not sent.
+ * <internal>...</internal> content is also stripped from INSIDE message
+ * bodies before delivery: the tag marks private thinking regardless of
+ * where the model placed it.
  *
  * The agent must always wrap output in <message to="name">...</message>
  * blocks, even with a single destination. Bare text is scratchpad only.
@@ -734,7 +745,14 @@ export function dispatchResultText(
       scratchpadParts.push(`[dropped: unknown destination "${toName}"] ${body}`);
       continue;
     }
-    sendToDestination(dest, body, routing);
+    // Models steered toward <internal> scratchpad tags sometimes place them
+    // INSIDE the envelope; the tag means not-for-delivery wherever it sits.
+    const deliverable = stripInternalTags(body);
+    if (!deliverable) {
+      log(`<message to="${toName}"> contained only <internal> content — nothing delivered`);
+      continue;
+    }
+    sendToDestination(dest, deliverable, routing);
     sent++;
   }
   if (lastIndex < text.length) {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -6,7 +6,7 @@ import {
   markScriptSkipped,
   type MessageInRow,
 } from './db/messages-in.js';
-import { writeMessageOut } from './db/messages-out.js';
+import { writeMessageOut, getMaxOutboundSeq } from './db/messages-out.js';
 import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import {
   clearContinuation,
@@ -354,6 +354,14 @@ export async function processQuery(
   // Once-per-turn guard for the task-run "<message> block was not delivered"
   // nudge — mirrors unwrappedNudged for chat turns.
   let taskBlockNudged = false;
+  // Snapshot of the outbound seq at the start of the current turn. MCP tools
+  // (send_message, send_file) write outbound rows directly and never touch the
+  // in-process `sent` counter, so this is the only in-loop signal that the
+  // agent already delivered something out-of-band. Reset per turn alongside the
+  // nudge guards (initial batch here; follow-up pushes below). Gates the
+  // never-silent fallback so a turn that answered via a tool then trailed off
+  // into bare scratchpad is NOT re-delivered as raw text.
+  let outboundBaselineSeq = getMaxOutboundSeq();
   // Prompt queue for the exchange hook — each result event consumes the
   // oldest unanswered prompt, except a wrapping-retry result, which answers
   // the same prompt again. Unused (and unmaintained) when the provider
@@ -438,6 +446,7 @@ export async function processQuery(
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;
         taskBlockNudged = false;
+        outboundBaselineSeq = getMaxOutboundSeq();
         query.push(prompt);
         archivePrompts.push(prompt);
         markCompleted(keptIds);
@@ -525,12 +534,31 @@ export async function processQuery(
             archivePrompts.shift();
           } else {
             const willRetryWrapping = hasUnwrapped && !unwrappedNudged;
+            // Never-silent fallback: a chat turn that was already nudged once
+            // and STILL came back with no <message> envelope would otherwise be
+            // dropped as scratchpad, leaving the user staring at silence. Deliver
+            // the raw text instead — UNLESS the agent already answered this turn
+            // out-of-band via an MCP tool (send_message/send_file bump the
+            // outbound seq without touching `sent`), in which case re-delivering
+            // the trailing scratchpad would double-send. hasUnwrapped already
+            // implies !taskRun && sent === 0; the extra guards are spelled out
+            // for intent.
+            const mcpDeliveredThisTurn = getMaxOutboundSeq() > outboundBaselineSeq;
+            const willFallbackDeliver =
+              hasUnwrapped && unwrappedNudged && !routing.taskRun && sent === 0 && !mcpDeliveredThisTurn;
             notifyExchangeComplete(onExchangeComplete, {
               prompt: archivePrompts[0] ?? initialPrompt,
               result: event.text,
               continuation: queryContinuation ?? initialContinuation,
-              status: hasUnwrapped || willRetryTaskBlocks ? 'undelivered' : 'completed',
+              status: willFallbackDeliver
+                ? 'fallback'
+                : hasUnwrapped || willRetryTaskBlocks
+                  ? 'undelivered'
+                  : 'completed',
             });
+            if (willFallbackDeliver) {
+              deliverFallbackResult(event.text, routing);
+            }
             if (willRetryWrapping) {
               unwrappedNudged = true;
               const destinations = getAllDestinations();
@@ -622,6 +650,34 @@ function deliverErrorResult(text: string, routing: RoutingContext): void {
     channel_type: routing.channelType,
     thread_id: routing.threadId,
     content: JSON.stringify({ text }),
+  });
+}
+
+/**
+ * Prefix stamped on raw agent text delivered by the never-silent fallback, so
+ * the recipient can tell this was the agent's unwrapped scratchpad surfaced
+ * after a failed re-wrap nudge — not a normal, deliberately-addressed reply.
+ */
+export const FALLBACK_PREFIX = '⚠ undelivered agent output (sent raw):';
+
+/**
+ * Last-resort delivery for a chat turn that was nudged to re-wrap its output
+ * and STILL produced no <message> envelope. Rather than drop the text as
+ * scratchpad (silent from the user's side), send the raw text — clearly marked
+ * — to the channel the batch arrived on. Mirror of deliverErrorResult; kept
+ * separate so the marker and the log line stay distinct from the provider-error
+ * path (which carries an already-user-facing notice, no marker).
+ */
+function deliverFallbackResult(text: string, routing: RoutingContext): void {
+  log('Nudged chat turn still had no <message> envelope — delivering raw text as never-silent fallback');
+  writeMessageOut({
+    id: generateId(),
+    in_reply_to: routing.inReplyTo,
+    kind: 'chat',
+    platform_id: routing.platformId,
+    channel_type: routing.channelType,
+    thread_id: routing.threadId,
+    content: JSON.stringify({ text: `${FALLBACK_PREFIX}\n${text}` }),
   });
 }
 

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -54,7 +54,16 @@ export interface ProviderExchange {
   result: string | null;
   /** Continuation/thread id in effect for the exchange, if any. */
   continuation?: string;
-  status: 'completed' | 'undelivered' | 'error';
+  /**
+   * Terminal disposition of the round-trip:
+   * - `completed` — output was wrapped and delivered normally.
+   * - `undelivered` — output had no <message> envelope (nudge pending, or the
+   *   agent already answered out-of-band via an MCP tool).
+   * - `fallback` — a nudged chat turn still ended bare, so the raw text was
+   *   delivered as a never-silent fallback rather than dropped.
+   * - `error` — the turn ended in a provider error.
+   */
+  status: 'completed' | 'undelivered' | 'fallback' | 'error';
 }
 
 /**

--- a/container/agent-runner/src/task-delivery.test.ts
+++ b/container/agent-runner/src/task-delivery.test.ts
@@ -10,7 +10,14 @@ import { closeSessionDb, getInboundDb, getOutboundDb, initTestSessionDb } from '
 import { getUndeliveredMessages, writeMessageOut } from './db/messages-out.js';
 import { getTaskSeriesId } from './db/session-routing.js';
 import { sendFile, sendMessage } from './mcp-tools/core.js';
-import { autoAppendTaskLog, buildTaskBlockNudge, dispatchResultText, shouldNudgeTaskBlocks } from './poll-loop.js';
+import {
+  autoAppendTaskLog,
+  buildTaskBlockNudge,
+  deliverFallbackResult,
+  dispatchResultText,
+  FALLBACK_PREFIX,
+  shouldNudgeTaskBlocks,
+} from './poll-loop.js';
 import type { RoutingContext } from './formatter.js';
 
 function seedSessionRouting(channelType: string | null, platformId: string | null, threadId: string | null): void {
@@ -181,6 +188,50 @@ describe('final-output blocks in a task run', () => {
     }[];
     expect(rows).toHaveLength(1);
     expect(JSON.parse(rows[0].content).text).toContain('[undelivered → family] digest');
+  });
+});
+
+describe('<internal> scratchpad privacy', () => {
+  const chatRouting: RoutingContext = { ...taskRouting, taskRun: false };
+
+  it('strips <internal> content from inside a delivered message body', () => {
+    const { sent } = dispatchResultText(
+      '<message to="family"><internal>\nThe user is greeting me. Keep it brief.\n</internal>\nhi!</message>',
+      chatRouting,
+    );
+
+    expect(sent).toBe(1);
+    const rows = getUndeliveredMessages();
+    expect(rows).toHaveLength(1);
+    const { text } = JSON.parse(rows[0].content) as { text: string };
+    expect(text).toBe('hi!');
+  });
+
+  it('delivers nothing for a message block that is only <internal> content', () => {
+    const { sent, hasUnwrapped } = dispatchResultText(
+      '<message to="family"><internal>private thinking</internal></message>',
+      chatRouting,
+    );
+
+    expect(sent).toBe(0);
+    expect(hasUnwrapped).toBe(false);
+    expect(getUndeliveredMessages()).toHaveLength(0);
+  });
+
+  it('strips <internal> content from never-silent fallback text', () => {
+    deliverFallbackResult('<internal>the user said thanks</internal>\nThanks!', chatRouting);
+
+    const rows = getUndeliveredMessages();
+    expect(rows).toHaveLength(1);
+    const { text } = JSON.parse(rows[0].content) as { text: string };
+    expect(text).toBe(`${FALLBACK_PREFIX}\nThanks!`);
+    expect(text).not.toContain('<internal>');
+  });
+
+  it('delivers nothing when fallback text is entirely <internal> content', () => {
+    deliverFallbackResult('<internal>only private thinking</internal>', chatRouting);
+
+    expect(getUndeliveredMessages()).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

A chat turn whose output has no `<message to="name">...</message>` envelope gets one corrective nudge. Before this change, if the nudged retry also came back bare, the poll-loop archived the turn and delivered nothing: the model did the work, the tokens were spent, and the user stared at silence with no signal that anything happened.

This adds a never-silent fallback: when a nudged chat turn still ends with no envelope, the raw text is delivered to the channel the batch arrived on, prefixed with a plain marker so it reads as surfaced scratchpad rather than a deliberately addressed reply. The exchange is recorded with a new `'fallback'` status on `ProviderExchange` so hooks can tell the paths apart.

Two guards keep it from over-delivering:

- **MCP out-of-band gate.** `send_message` / `send_file` write outbound rows directly and never touch the in-process `sent` counter, so a turn that answered via a tool and then trailed off into bare scratchpad would look identical to a silent drop. The loop snapshots the outbound seq at the start of each turn (reset on follow-up pushes alongside the nudge guards) and skips the fallback when it advanced.
- **Task-mode exclusion.** Task runs end in bare run-log text by design; they never fall back (already excluded by the `hasUnwrapped` gate, spelled out explicitly in the condition).

Motivation is a live failure, not a hypothetical. On a demo install (`main` 641963c1 plus `/add-opencode`, vLLM serving Qwen3.6-35B on a DGX Spark), a compacted OpenCode session answered three consecutive turns with correct content but no envelope. The runner logged `agent output had no <message to="..."> blocks — nothing was sent` three times; the user saw nothing and the backend billed every token. Local models drift off envelope discipline far more than Claude does (compaction summaries drop the standing instruction), and when they do, dropped-with-a-marker beats vanished. A reply wrapped to an unknown destination is a different drop path and is not changed here.

A second fix rides the same delivery path. The steering that teaches local models the envelope also tells them to put private thinking in `<internal>...</internal>` tags, but delivery only honored the tag outside `<message>` blocks: a model that opens the envelope first and then thinks ships its monologue to the user. Seen live on the same demo install (Gemma 4 narrating the user on Mattermost, three leaked posts). Delivery now strips `<internal>` content from message bodies and from the fallback text before sending, and a body or fallback that is only `<internal>` content delivers nothing. The tag means private wherever the model puts it.

Refs #2393 (the never-silent fallback now guarantees a visible reply for the truncated-closing-tag case, though it delivers the raw marker-prefixed text rather than repairing the envelope) and #3026 (the out-of-band delivery gate here covers only the fallback path; the nudge re-run that issue describes is out of scope for this PR).

## Verified

- `bun test` on the agent-runner suite at this head: 162 pass, 0 fail. New tests cover the fallback delivery, the MCP out-of-band hazard (tool send then bare trailer does not double-deliver), task-mode exclusion, and the per-turn reset of the nudge guard. Four more pin the `<internal>` strip: in-body strip, internal-only body, fallback strip, internal-only fallback. The integration test that had pinned the old silent-drop behavior is updated to pin the new contract.
- `tsc` adds no new errors.
- Both fixes are running on the live DGX Spark demo install (never-silent since 2026-07-24, the internal strip since 2026-07-26): normal enveloped traffic produces zero fallback deliveries, the marker path is exercised by the test suite, and post-deploy replies on Mattermost and the web channel are clean.

Assisted by Claude; reviewed and verified by a human before submission.


