### PR TITLE
fix(host): sanitize inbox attachment paths to a safe character class

### DIFF
--- a/src/session-manager.attachments.test.ts
+++ b/src/session-manager.attachments.test.ts
@@ -28,6 +28,7 @@ vi.mock('./config.js', async () => {
 });
 
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { openInboundDb } from './db/session-db.js';
 import { createSession } from './db/sessions.js';
 import { initSessionFolder, sessionDir, writeSessionMessage } from './session-manager.js';
 import type { Session } from './types.js';
@@ -99,5 +100,112 @@ describe('extractAttachmentFiles — inbox-root symlink containment (#2828 sibli
     const escaped = path.join(canaryDir, 'evil-inbox-root', 'pwn.txt');
     expect(fs.existsSync(escaped)).toBe(false);
     expect(fs.readdirSync(canaryDir)).toHaveLength(0);
+  });
+});
+
+describe('extractAttachmentFiles — scoped message ids keep colon-free inbox dirs', () => {
+  // Message ids can carry a per-agent scope suffix (`<id>:ag-<groupId>`).
+  // A colon inside the inbox path segment breaks downstream consumers that
+  // parse `path:line` (agent read tools) or split mount specs on `:` (docker
+  // CLI). The id itself must stay untouched; only the directory name is
+  // sanitized. Seen live on 2026-07-25: an agent reported an uploaded file
+  // missing while it sat readable in its container, because its read tool
+  // split the metadata path at the colon.
+  it('writes the attachment under a sanitized dir and points localPath at it', () => {
+    const scopedId = 'web-1784959140240-i:ag-6e9d6f1b-77e1-4cbf-b86c-e9fd062a2c19';
+    const content = JSON.stringify({
+      text: 'md upload',
+      attachments: [{ name: 'plan.md', mimeType: 'text/plain', data: Buffer.from('# plan\n').toString('base64') }],
+    });
+
+    writeSessionMessage(AG, SESS, {
+      id: scopedId,
+      kind: 'chat',
+      timestamp: now(),
+      platformId: 'web:local',
+      channelType: 'web',
+      threadId: null,
+      content,
+    });
+
+    const sanitized = scopedId.replace(/:/g, '-');
+    const written = path.join(sessionDir(AG, SESS), 'inbox', sanitized, 'plan.md');
+    expect(fs.existsSync(written)).toBe(true);
+    expect(fs.readFileSync(written, 'utf8')).toBe('# plan\n');
+
+    const inboxEntries = fs.readdirSync(path.join(sessionDir(AG, SESS), 'inbox'));
+    for (const entry of inboxEntries) expect(entry.includes(':')).toBe(false);
+
+    const db = openInboundDb(path.join(sessionDir(AG, SESS), 'inbound.db'));
+    const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get(scopedId) as
+      | { content: string }
+      | undefined;
+    db.close();
+    expect(row).toBeDefined();
+    const att = JSON.parse(row!.content).attachments[0];
+    expect(att.localPath).toBe(`inbox/${sanitized}/plan.md`);
+    expect(att.localPath.includes(':')).toBe(false);
+  });
+
+  it('leaves an already-clean message id byte-for-byte unchanged', () => {
+    const cleanId = 'web-1784959140240-0';
+    const content = JSON.stringify({
+      text: 'clean id',
+      attachments: [{ name: 'a.md', mimeType: 'text/plain', data: Buffer.from('a\n').toString('base64') }],
+    });
+    writeSessionMessage(AG, SESS, {
+      id: cleanId,
+      kind: 'chat',
+      timestamp: now(),
+      platformId: 'web:local',
+      channelType: 'web',
+      threadId: null,
+      content,
+    });
+    expect(fs.existsSync(path.join(sessionDir(AG, SESS), 'inbox', cleanId, 'a.md'))).toBe(true);
+  });
+
+  it('sanitizes the whole consumer-hostile class, not just one colon', () => {
+    const uglyId = 'id:with:many colons and spaces';
+    const content = JSON.stringify({
+      text: 'ugly id',
+      attachments: [{ name: 'b.md', mimeType: 'text/plain', data: Buffer.from('b\n').toString('base64') }],
+    });
+    writeSessionMessage(AG, SESS, {
+      id: uglyId,
+      kind: 'chat',
+      timestamp: now(),
+      platformId: 'web:local',
+      channelType: 'web',
+      threadId: null,
+      content,
+    });
+    const dir = 'id-with-many-colons-and-spaces';
+    expect(fs.existsSync(path.join(sessionDir(AG, SESS), 'inbox', dir, 'b.md'))).toBe(true);
+  });
+
+  it('sanitizes attachment FILENAMES carrying the same class', () => {
+    const id = 'web-1784959140240-1';
+    const content = JSON.stringify({
+      text: 'colon filename',
+      attachments: [{ name: 'foo:bar.md', mimeType: 'text/plain', data: Buffer.from('fb\n').toString('base64') }],
+    });
+    writeSessionMessage(AG, SESS, {
+      id,
+      kind: 'chat',
+      timestamp: now(),
+      platformId: 'web:local',
+      channelType: 'web',
+      threadId: null,
+      content,
+    });
+    const written = path.join(sessionDir(AG, SESS), 'inbox', id, 'foo-bar.md');
+    expect(fs.existsSync(written)).toBe(true);
+    const db2 = openInboundDb(path.join(sessionDir(AG, SESS), 'inbound.db'));
+    const row2 = db2.prepare('SELECT content FROM messages_in WHERE id = ?').get(id) as { content: string };
+    db2.close();
+    const att2 = JSON.parse(row2.content).attachments[0];
+    expect(att2.name).toBe('foo-bar.md');
+    expect(att2.localPath).toBe(`inbox/${id}/foo-bar.md`);
   });
 });

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -315,6 +315,26 @@ function extractAttachmentFiles(
     return contentStr;
   }
 
+  // On-disk names for this message's attachments. isSafeAttachmentName (above
+  // and per-file below) already rejects the escape class (path separators,
+  // NUL, non-basenames); what it deliberately allows through is the
+  // consumer-hostile class: colons, whitespace, and other shell-noise that is
+  // legal in a filename but breaks the things that CONSUME these paths.
+  // Agent read tools parse `path:line` and split at a colon, docker CLI mount
+  // specs split on `:`, scp does too. Message ids hit this for real: the
+  // router's fanout scoping names them `<id>:ag-<groupId>`, and the scoped id
+  // was used verbatim as the inbox directory name. Seen live: an uploaded
+  // file at `inbox/web-...-i:ag-.../x.md` existed in the container, but the
+  // agent's read tool split at the colon and reported the file missing.
+  // Sanitize the whole class, not just the colon: any character outside
+  // [A-Za-z0-9._-] becomes a dash, for the directory name AND the stored
+  // filename. Ids and names stay untouched everywhere else (rows, dedup,
+  // logs). Distinct ids that differ only in sanitized characters could map to
+  // one directory; the per-file `wx` write below refuses to overwrite, so the
+  // worst case is a logged skip, never silent corruption.
+  const sanitizeForPath = (name: string): string => name.replace(/[^A-Za-z0-9._-]/g, '-');
+  const inboxDirName = sanitizeForPath(messageId);
+
   const inboxRoot = path.join(sessionDir(agentGroupId, sessionId), 'inbox');
   // Resolved lazily on the first attachment that actually carries bytes, so a
   // message whose attachments have no inline `data` never creates an inbox dir.
@@ -328,7 +348,7 @@ function extractAttachmentFiles(
     if (typeof att.data !== 'string') continue;
 
     const rawName = deriveAttachmentName(att);
-    const filename = isSafeAttachmentName(rawName) ? rawName : `attachment-${Date.now()}`;
+    const filename = isSafeAttachmentName(rawName) ? sanitizeForPath(rawName) : `attachment-${Date.now()}`;
     if (filename !== rawName) {
       log.warn('Refused unsafe attachment filename, would escape inbox', {
         messageId,
@@ -338,7 +358,7 @@ function extractAttachmentFiles(
     }
 
     if (!inboxResolved) {
-      inboxDir = ensureContainedInboxDir(inboxRoot, messageId, { messageId });
+      inboxDir = ensureContainedInboxDir(inboxRoot, inboxDirName, { messageId });
       inboxResolved = true;
     }
     // Unsafe inbox (symlink / escape) — no attachment can be written safely.
@@ -363,7 +383,7 @@ function extractAttachmentFiles(
     }
 
     att.name = filename;
-    att.localPath = `inbox/${messageId}/${filename}`;
+    att.localPath = `inbox/${inboxDirName}/${filename}`;
     delete att.data;
     changed = true;
     log.debug('Saved attachment to inbox', { messageId, filename, size: att.size });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

When the router fans an inbound message out to agents, `messageIdForAgent` namespaces the id as `<id>:<agentGroupId>` to keep `messages_in.id` unique per session (`src/router.ts:560`). `extractAttachmentFiles` then uses that scoped id, colon included, as the inbox directory name, so every channel attachment lands at a path like `inbox/web-1784959140240-i:ag-6e9d6f1b-.../plan.md`.

A colon inside a path segment is poison for the things that consume these paths. Agent read tools parse `path:line` and split at the colon, docker CLI mount specs split on `:`, and scp does too. The practical result: the agent is handed an attachment path it cannot open even though the file is right there.

This bit for real on a live install. A markdown file uploaded through a channel produced the reply "I couldn't locate the file on disk" quoting the exact metadata path, while `docker exec` in that same agent container showed the file present and readable at that exact path. The agent's read tool had split the path at the colon in the directory name and stat'ed a nonexistent prefix.

`isSafeAttachmentName` already rejects the escape class (path separators, NUL, non-basenames), so the open hole is exactly the consumer-hostile class it deliberately allows: colons, whitespace, and similar. The fix closes the class rather than the instance: any character outside `[A-Za-z0-9._-]` becomes a dash, applied to the inbox directory name and to the stored attachment filename, since an uploaded name like `foo:bar.md` hits the same trap. Ids and original names are untouched everywhere else, so rows, fanout dedup, and log lines keep the raw values.

Collision invariant, stated explicitly: two distinct ids that differ only in sanitized characters could map to the same directory. Ids are already namespaced unique per session, and the per-file `wx` write refuses to overwrite an existing target, so the worst case is a logged skip of one attachment, never silent corruption or cross-message overwrite.

No backfill: `localPath` is stored at write time, so existing inbox directories keep working for already-delivered messages, and attachments already written under a colon path stay broken exactly as they are today. Only new writes change.

Writer audit: `ensureContainedInboxDir` has exactly two callers. This one, and the agent-to-agent path (`src/modules/agent-to-agent/agent-route.ts:104`), whose ids are `a2a-<ts>-<rand>` with no unsafe characters by construction; it is left unchanged. If a2a ids ever grow a scope suffix, the same sanitization applies there.

## Verified

- New tests in `session-manager.attachments.test.ts`: a real scoped id lands under the sanitized directory with a matching stored `localPath` and no colon anywhere in `inbox/`; an already-clean id is unchanged byte-for-byte; an id with multiple colons plus spaces sanitizes as a class; a `foo:bar.md` filename is stored and written as `foo-bar.md`. The scoped-id and class tests fail against the unsanitized code (verified by stashing the fix and rerunning).
- Both session-manager suites: 8 pass, 0 fail.
- Live before/after on a demo install at `main` 641963c1: before, the uploaded markdown was unreadable by the agent as described above; after, a fresh upload landed at `inbox/web-1784960064020-0-ag-.../` (dash where the colon was) and the agent read a re-shared markdown file through a real channel round-trip.

Assisted by Claude; reviewed and verified by a human before submission.
