### PR TITLE
Add flight-checkin container skill

### DIFF
--- a/container/skills/flight-checkin/SKILL.md
+++ b/container/skills/flight-checkin/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: flight-checkin
+description: Complete online check-in for a flight on any airline — from a check-in reminder email or a direct user request. Finds the check-in link, completes the flow for all passengers, delivers boarding passes, and falls back to notifying the user with the confirmation number if anything blocks. Use when the user asks to check in for a flight, or when a scheduled task detects a check-in reminder email.
+allowed-tools: Bash(agent-browser:*), Bash(curl:*), Bash(timeout:*)
+---
+
+# Flight Check-in
+
+Completes online check-in for a booked flight via `agent-browser`, on any airline.
+
+## Passenger config (required)
+
+Passenger details live in `/workspace/agent/flight-checkin.json`:
+
+```json
+{
+  "lastNames": ["Smith", "Jones"],
+  "boardingPassEmails": ["person@example.com"]
+}
+```
+
+- `lastNames` — booking last names to try, in order (bookings may be under different travelers).
+- `boardingPassEmails` — where to email boarding passes when the airline offers it.
+
+If the file doesn't exist, ask the user for these once, save the file, and continue.
+
+## Safety rules (mandatory — a hung browser can kill this whole session)
+
+1. Prefix **every** `agent-browser` invocation with `timeout 120`.
+2. Abandon the check-in attempt entirely after **~10 minutes** total. Fall back to notifying (below). Never retry in a loop.
+3. Every `curl` gets `--max-time 30`.
+4. When triggered by an email watcher, **mark the email processed BEFORE attempting check-in** (see Dedupe below) — otherwise a failed attempt re-triggers the watcher forever.
+5. Keep existing seats. **Decline all paid upsells** — bags, seat upgrades, priority boarding, insurance. If the airline *requires* a payment to complete check-in (e.g. a mandatory bag fee), stop and ask the user — never enter payment details autonomously.
+
+## Dedupe (when triggered by an email watcher)
+
+The watcher task passes `emailId` in its script data. FIRST, before opening a browser:
+
+1. Append the `emailId` to `/workspace/agent/.checkin_processed.json` (create as a JSON array if missing).
+2. Mark the email read:
+   ```bash
+   curl --max-time 30 -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/messages/EMAIL_ID/modify" \
+     -H "Content-Type: application/json" -d '{"removeLabelIds":["UNREAD"]}'
+   ```
+3. If the email turns out not to be a real airline check-in reminder (hotel, marketing), stop silently — it is already marked processed.
+
+## Check-in flow
+
+1. Get the confirmation number, airline, flight, and check-in link — from the reminder email body, or by asking the user / checking workspace trip notes for a direct request.
+2. Open the check-in link from the email if present; otherwise the airline's standard online check-in page.
+3. Enter the confirmation number + each configured last name until the booking is found.
+4. Select all passengers, complete every step, keep seats, decline upsells.
+5. On the boarding-pass page: email passes to the configured addresses. If email isn't offered, screenshot each boarding pass and send the images to the chat.
+6. Message the chat: airline, flight, route, seats, sequence numbers, and where the passes went.
+
+## Fallback (check-in failed, timed out, or blocked)
+
+Send the chat a message with: airline, flight, **confirmation number**, departure time, and the check-in link so a human can finish in under a minute. State plainly what blocked you (e.g. "airline wants a bag fee", "page timed out"). Do not retry.
+
+## Setting up an automated watcher (optional)
+
+To check in automatically whenever a reminder email arrives, schedule an hourly task with `schedule_task` (requires the Gmail MCP tool / gateway to be set up for this group).
+
+- **script**: use the contents of `checkin-watcher.sh` (in this skill's directory) verbatim. It searches Gmail for recent check-in reminder emails, dedupes against `/workspace/agent/.checkin_processed.json`, and is fail-safe: every fetch has a timeout and any error resolves to `wakeAgent: false` — a watcher script must never be able to hang.
+- **prompt**:
+
+> A possible airline check-in reminder email was detected. Script data contains emailId, from, subject, and bodyPreview. Invoke the flight-checkin skill and follow it exactly — dedupe step FIRST, safety rules, and fallback if check-in can't complete. If the email is not a real airline check-in reminder, stop silently after the dedupe step.
+
+## Airline notes (grow this as you learn)
+
+- **Avelo**: check-in at `https://checkin.aveloair.com` — confirmation number + last name.

--- a/container/skills/flight-checkin/checkin-watcher.sh
+++ b/container/skills/flight-checkin/checkin-watcher.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Hourly Gmail watcher for airline check-in reminder emails.
+# Intended as the `script` of a schedule_task recurring task — see SKILL.md.
+# Prints {"wakeAgent": true, data: {...}} when a new reminder email is found,
+# {"wakeAgent": false} otherwise. Fail-safe: any error, non-OK response, or
+# timeout resolves to wakeAgent:false — a watcher script must never hang.
+node --input-type=module << 'SCRIPT'
+import { readFileSync, existsSync } from 'fs';
+const PROCESSED = '/workspace/agent/.checkin_processed.json';
+const processed = existsSync(PROCESSED) ? JSON.parse(readFileSync(PROCESSED, 'utf-8')) : [];
+const out = (o) => { console.log(JSON.stringify(o)); process.exit(0); };
+try {
+  const threeHoursAgo = Math.floor((Date.now() - 3 * 3600 * 1000) / 1000);
+  const query = `subject:("check-in" OR "check in" OR checkin) (flight OR boarding OR airline OR airways) after:${threeHoursAgo}`;
+  const r = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${encodeURIComponent(query)}&maxResults=5`, { signal: AbortSignal.timeout(30000) });
+  if (!r.ok) out({ wakeAgent: false });
+  const data = await r.json();
+  const msgs = (data.messages || []).filter(m => !processed.includes(m.id));
+  if (msgs.length === 0) out({ wakeAgent: false });
+  const msgR = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${msgs[0].id}?format=full`, { signal: AbortSignal.timeout(30000) });
+  const msg = await msgR.json();
+  const headers = msg.payload?.headers || [];
+  const subject = headers.find(h => h.name === 'Subject')?.value || '';
+  const from = headers.find(h => h.name === 'From')?.value || '';
+  let body = msg.snippet || '';
+  const parts = msg.payload?.parts || [msg.payload];
+  for (const part of parts) { if (part?.mimeType === 'text/plain' && part?.body?.data) { body = Buffer.from(part.body.data, 'base64').toString('utf-8'); break; } }
+  out({ wakeAgent: true, data: { emailId: msgs[0].id, from, subject, bodyPreview: body.slice(0, 4000) } });
+} catch {
+  out({ wakeAgent: false });
+}
+SCRIPT


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** A container skill that completes online flight check-in on any airline — triggered either by a direct user request ("check me in for my flight") or by an optional hourly Gmail watcher task that detects check-in reminder emails.

**Why:** Flight check-in is a common personal-assistant chore that's currently easy to get wrong as an ad-hoc scheduled task. Our first attempt at this (an agent-authored recurring task) hung its session for 30+ hours: a watcher script with a timeout-less fetch blocked the container's poll loop, and because the task only marked emails processed *after* a successful check-in, every failure re-triggered it forever. This skill packages the working flow plus the guardrails that prevent both failure modes.

**How it works:** Passenger details (booking last names, boarding-pass emails) live in a per-group `/workspace/agent/flight-checkin.json`, asked for once on first use — nothing personal in the skill itself. The agent finds the check-in link from the reminder email (or the airline's check-in page), completes the flow for all passengers via agent-browser, and emails or screenshots boarding passes. Safety rules are mandatory: every agent-browser call is `timeout`-wrapped, the attempt is capped at ~10 minutes, all upsells declined, no autonomous payment entry, and the triggering email is marked processed *before* the attempt so a failure can never loop. The optional watcher script (`checkin-watcher.sh`) is fail-safe: timeouts on every fetch, any error resolves to `wakeAgent: false`.

**How it was tested:** Running live on a Raspberry Pi 5 install — the watcher script runs hourly in a production group (completes cleanly with and without matching emails), and the check-in flow's safety rules came out of debugging the real 30-hour hang incident described above. Not yet exercised on a fresh clone.

**Usage:** Loaded automatically inside agent containers (skills: "all", or add `flight-checkin` to the group's skill selection). The agent invokes it when asked to check in for a flight; the SKILL.md includes the recipe for scheduling the automated watcher.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)