### PR TITLE
mount-security: block ~/.config/nanoclaw and ~/.local/bin as mount roots

### DIFF
--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -36,7 +36,21 @@ export interface AllowedRoot {
 let cache: { path: string; mtimeMs: number; allowlist: MountAllowlist } | null = null;
 
 /**
- * Default blocked patterns - paths that should never be mounted
+ * Default blocked patterns - paths that should never be mounted.
+ *
+ * Entries are matched by {@link matchesBlockedPattern} as substrings of the
+ * mount's resolved realPath, so an entry may carry a separator
+ * (`.config/nanoclaw`) to pin a name to its parent instead of blocking every
+ * `.config` on the host.
+ *
+ * SCOPE — read this before treating the list as protection. The check runs
+ * exactly once, against the realPath of the mount ROOT (`validateMount`
+ * below), and does NOT descend. It stops an operator from *naming* one of
+ * these paths as a mount; it does nothing about what lives underneath an
+ * allowed root. Allowlist `~` (or `~/.config`) and every credential below it
+ * is mounted regardless of what this list says. That is a structural property
+ * of a root-only check — closing it would need a walk of the mounted subtree,
+ * which nothing here does. Do not read an entry here as "this file is safe."
  */
 const DEFAULT_BLOCKED_PATTERNS = [
   '.ssh',
@@ -47,6 +61,17 @@ const DEFAULT_BLOCKED_PATTERNS = [
   '.gcloud',
   '.kube',
   '.docker',
+  // NanoClaw's own host-side state. The mount allowlist itself lives at
+  // ~/.config/nanoclaw/mount-allowlist.json specifically so a container agent
+  // cannot edit the rules that govern it (see the module header) — handing that
+  // directory to a container as a mount root would undo the whole arrangement.
+  // It is also where host credentials land as they are added.
+  '.config/nanoclaw',
+  // Host-executed helper binaries. Setup installs onecli and claude here and
+  // then invokes them by name as the operator, so a read-write mount of this
+  // directory is a container-to-host code-execution primitive: drop a file,
+  // wait for the host to run it.
+  '.local/bin',
   'credentials',
   '.env',
   '.netrc',
@@ -193,7 +218,14 @@ function getRealPath(p: string): string | null {
 }
 
 /**
- * Check if a path matches any blocked pattern
+ * Check if a path matches any blocked pattern.
+ *
+ * Substring match, both per path component and against the whole realPath —
+ * so `.env` also rejects `.envrc`, and a pattern may span a separator.
+ *
+ * Its only caller passes the realPath of the mount ROOT, so this answers
+ * "may this path be named as a mount?" and never "is anything blocked inside
+ * it?". See the note on {@link DEFAULT_BLOCKED_PATTERNS}.
  */
 function matchesBlockedPattern(realPath: string, blockedPatterns: string[]): string | null {
   const pathParts = realPath.split(path.sep);


### PR DESCRIPTION
## Problem

`DEFAULT_BLOCKED_PATTERNS` in `src/modules/mount-security/index.ts` covers `.ssh`, `.aws`, `.docker`, `.env`, `.npmrc` and friends — but not two paths that matter for NanoClaw specifically:

- **`~/.config/nanoclaw/`** holds `mount-allowlist.json`. That file lives outside the repo precisely so a container agent cannot edit the rules governing its own mounts. Handing that directory to a container as a mount root undoes the arrangement.
- **`~/.local/bin`** is where setup installs `onecli` and `claude`, which the host then invokes by name as the operator. A read-write mount of it is a container-to-host code execution primitive: drop a file, wait for the host to run it.

## Fix

Adds both to `DEFAULT_BLOCKED_PATTERNS`. `.config/nanoclaw` carries a separator so it pins the name to its parent rather than blocking every `.config` on the host — `matchesBlockedPattern` already substring-matches the resolved realPath, so this works without a matcher change.

## Also: documents the check's scope honestly

The header now states what this list does and does not do. The check runs **once, against the realPath of the mount root**, and does not descend. It stops an operator from *naming* one of these paths as a mount; it does nothing about what lives under an allowed root — allowlist `~` and every credential below it is mounted regardless.

That is a structural property of a root-only check, not something this PR changes. Closing it would need a walk of the mounted subtree. The comment says so plainly so nobody reads an entry here as "this file is safe."

## Testing

`pnpm run build`, `pnpm test` (1151 passed), `pnpm run format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)