### PR TITLE
db: validate container_configs.image_tag at the write seam

### DIFF
--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -272,7 +272,15 @@ registerResource({
         if (args.provider !== undefined) updates.provider = args.provider as string;
         if (args.model !== undefined) updates.model = args.model as string;
         if (args.effort !== undefined) updates.effort = args.effort as string;
-        if (args.image_tag !== undefined) updates.image_tag = args.image_tag as string;
+        // `--image-tag` is the documented spelling, but neither argv parser
+        // rewrites dashes to underscores (same reason `--cli-scope` is read both
+        // ways below), so accept either. The value is validated at the DB write
+        // seam in `updateContainerConfigScalars` — it becomes the `docker run`
+        // image argument, so only this install's base image or this group's own
+        // built image are accepted, and an out-of-allowlist value throws here.
+        if (args['image-tag'] !== undefined || args.image_tag !== undefined) {
+          updates.image_tag = (args['image-tag'] ?? args.image_tag) as string;
+        }
         if (args.assistant_name !== undefined) updates.assistant_name = args.assistant_name as string;
         if (args.max_messages_per_prompt !== undefined)
           updates.max_messages_per_prompt = Number(args.max_messages_per_prompt);

--- a/src/db/container-configs.test.ts
+++ b/src/db/container-configs.test.ts
@@ -1,18 +1,40 @@
 /**
- * ensureContainerConfig provider stamping (global-default-provider feature).
+ * Container config write-seam tests.
  *
- * Two load-bearing guarantees:
- *   1. A fresh row is stamped with the given provider (claude → NULL), so a new
- *      group is created on the instance default.
- *   2. An existing row is never overwritten (INSERT OR IGNORE), so enabling a
- *      non-claude default never retroactively flips existing groups.
+ * 1. `ensureContainerConfig` provider stamping (global-default-provider
+ *    feature). Two load-bearing guarantees:
+ *      a. A fresh row is stamped with the given provider (claude → NULL), so a
+ *         new group is created on the instance default.
+ *      b. An existing row is never overwritten (INSERT OR IGNORE), so enabling a
+ *         non-claude default never retroactively flips existing groups.
+ * 2. `updateContainerConfigScalars` image_tag allowlist. The column is consumed
+ *    unchecked as the `docker run` image argument (`buildContainerArgs`), so
+ *    only this install's base image and the group's own built image may be
+ *    written.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// A deliberately non-default base — proves the allowlist is derived from
+// CONTAINER_IMAGE_BASE at call time rather than from a baked
+// `nanoclaw-agent-v2-<slug>` pattern, which is what keeps the documented
+// CONTAINER_IMAGE_BASE / CONTAINER_IMAGE overrides working. Literals are
+// repeated below because a vi.mock factory is hoisted above the consts.
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual('../config.js');
+  return {
+    ...actual,
+    CONTAINER_IMAGE_BASE: 'registry.example.test/custom-agent',
+    CONTAINER_IMAGE: 'registry.example.test/custom-agent:latest',
+  };
+});
+
+const BASE = 'registry.example.test/custom-agent';
+const IMAGE = `${BASE}:latest`;
 
 import { initTestDb, closeDb } from './connection.js';
 import { runMigrations } from './migrations/index.js';
 import { createAgentGroup } from './agent-groups.js';
-import { ensureContainerConfig, getContainerConfig } from './container-configs.js';
+import { ensureContainerConfig, getContainerConfig, updateContainerConfigScalars } from './container-configs.js';
 
 function makeGroup(id: string): void {
   createAgentGroup({ id, name: id, folder: id, agent_provider: null, created_at: new Date().toISOString() });
@@ -55,5 +77,96 @@ describe('ensureContainerConfig provider stamping', () => {
     // must NOT change it — INSERT OR IGNORE keeps the row frozen.
     ensureContainerConfig('ag-existing');
     expect(getContainerConfig('ag-existing')?.provider).toBe('codex');
+  });
+});
+
+describe('updateContainerConfigScalars image_tag allowlist', () => {
+  const GID = 'ag-tagged';
+
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db);
+    makeGroup(GID);
+    ensureContainerConfig(GID);
+  });
+  afterEach(() => {
+    closeDb();
+  });
+
+  it("accepts the install base image and the group's own built image", () => {
+    // The two values the tree ever writes: `buildAgentGroupImage` stores
+    // `${CONTAINER_IMAGE_BASE}:${agentGroupId}` after a derived build, and the
+    // base image is the "no derived image" value.
+    updateContainerConfigScalars(GID, { image_tag: `${BASE}:${GID}` });
+    expect(getContainerConfig(GID)?.image_tag).toBe(`${BASE}:${GID}`);
+
+    updateContainerConfigScalars(GID, { image_tag: IMAGE });
+    expect(getContainerConfig(GID)?.image_tag).toBe(IMAGE);
+  });
+
+  it('accepts NULL and empty string as "inherit the base image"', () => {
+    // `containerConfig.imageTag || CONTAINER_IMAGE` treats both the same; this
+    // is how a derived image is retired (and what the registry reconcile does).
+    updateContainerConfigScalars(GID, { image_tag: `${BASE}:${GID}` });
+    updateContainerConfigScalars(GID, { image_tag: null });
+    expect(getContainerConfig(GID)?.image_tag).toBeNull();
+
+    updateContainerConfigScalars(GID, { image_tag: '' });
+    expect(getContainerConfig(GID)?.image_tag).toBe('');
+  });
+
+  it('rejects any image reference outside this install', () => {
+    const rejected = [
+      'evil.example.com/backdoor:latest', // a foreign registry
+      'nanoclaw-agent-v2-deadbeef:latest', // another install's slug
+      `${BASE}:ag-someone-else`, // another group's derived image
+      `${BASE}:${GID} --privileged`, // argument smuggling into the docker ref
+      BASE, // the repository with no tag — resolves to :latest elsewhere
+      'ubuntu', // an arbitrary public image
+    ];
+    for (const tag of rejected) {
+      expect(() => updateContainerConfigScalars(GID, { image_tag: tag })).toThrow(/Invalid image_tag/);
+    }
+    expect(getContainerConfig(GID)?.image_tag).toBeNull();
+  });
+
+  it('rejects a non-string value', () => {
+    // `ncl groups config update --image-tag` with no value parses to boolean
+    // true; without this it reached better-sqlite3 as an opaque bind error.
+    expect(() => updateContainerConfigScalars(GID, { image_tag: true as unknown as string })).toThrow(
+      /Invalid image_tag/,
+    );
+  });
+
+  it('aborts the whole update when the image_tag is rejected', () => {
+    // Validation runs before any field is bound, so a rejected tag must not
+    // leave the other scalars in the same call half-applied.
+    expect(() =>
+      updateContainerConfigScalars(GID, { model: 'opus', image_tag: 'evil.example.com/backdoor:latest' }),
+    ).toThrow(/Invalid image_tag/);
+    const row = getContainerConfig(GID);
+    expect(row?.model).toBeNull();
+    expect(row?.image_tag).toBeNull();
+  });
+
+  it('leaves the other scalar columns untouched by the check', () => {
+    updateContainerConfigScalars(GID, { model: 'opus', effort: 'high', cli_scope: 'global' });
+    const row = getContainerConfig(GID);
+    expect(row?.model).toBe('opus');
+    expect(row?.effort).toBe('high');
+    expect(row?.cli_scope).toBe('global');
+  });
+
+  it('offers no derived-image option for a group id that is not a valid tag', () => {
+    // Nothing in the tree generates such an id, but the column is reachable
+    // from imported/hand-edited rows and the tag is interpolated into a shell
+    // command by `buildAgentGroupImage`.
+    const weird = 'ag-$(touch /tmp/pwned)';
+    makeGroup(weird);
+    ensureContainerConfig(weird);
+    expect(() => updateContainerConfigScalars(weird, { image_tag: `${BASE}:${weird}` })).toThrow(/Invalid image_tag/);
+    // The base image is still writable — the id only gates the derived form.
+    updateContainerConfigScalars(weird, { image_tag: IMAGE });
+    expect(getContainerConfig(weird)?.image_tag).toBe(IMAGE);
   });
 });

--- a/src/db/container-configs.ts
+++ b/src/db/container-configs.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AGENT_PROVIDER } from '../config.js';
+import { CONTAINER_IMAGE, CONTAINER_IMAGE_BASE, DEFAULT_AGENT_PROVIDER } from '../config.js';
 import type { ContainerConfigRow } from '../types.js';
 import { getDb } from './connection.js';
 
@@ -72,6 +72,56 @@ export function ensureContainerConfig(agentGroupId: string, provider?: string | 
     .run(agentGroupId, stamped, new Date().toISOString());
 }
 
+/**
+ * Docker tag component grammar (`[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`). Applied to
+ * the agent group id before it is spliced into an image reference — every id
+ * generator in the tree produces `ag-<uuid>`-shaped ids, so this only ever fires
+ * on a hand-edited or imported row, but `buildAgentGroupImage` interpolates the
+ * resulting tag into a shell command string (`container-runner.ts`), so the
+ * assumption is enforced rather than trusted.
+ */
+const DOCKER_TAG_COMPONENT = /^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$/;
+
+/**
+ * `image_tag` is consumed unchecked as the `docker run` image argument
+ * (`buildContainerArgs` — `containerConfig.imageTag || CONTAINER_IMAGE`),
+ * so whatever lands in this column picks the image every container in the group
+ * runs. The one CLI verb that writes it is registered `access:'approval'`
+ * (`cli/resources/groups.ts`), so an agent gets a hold and an admin approval
+ * card rather than a silent write — this check is defense in depth at the write
+ * seam, which is also what covers `groups create`, host-side callers, and any
+ * future write path.
+ *
+ * Exactly two values are ever legitimate, and both are derived from this
+ * install's own image names: the base image itself, and the per-group image
+ * `buildAgentGroupImage` builds as `${CONTAINER_IMAGE_BASE}:${agentGroupId}`.
+ * Anything else — a foreign registry, another install's slug, another group's
+ * derived image — is rejected.
+ *
+ * The allowlist is built at call time instead of baked into a module-level
+ * pattern because both names are env-overridable in `config.ts`; a hardcoded
+ * `nanoclaw-agent-v2-…` regex would silently reject a legitimate
+ * `CONTAINER_IMAGE_BASE` override.
+ *
+ * NULL and '' are allowed and mean "inherit the base image" — `imageTag ||
+ * CONTAINER_IMAGE` treats them identically, and clearing the column is how a
+ * derived image is retired.
+ */
+function assertAllowedImageTag(agentGroupId: string, value: unknown): void {
+  if (value === null || value === '') return;
+  // A group id that isn't a valid tag component gets no derived-image option at
+  // all, rather than one we'd hand to `docker run` / `docker build` unexamined.
+  const derived = DOCKER_TAG_COMPONENT.test(agentGroupId) ? `${CONTAINER_IMAGE_BASE}:${agentGroupId}` : null;
+  if (value === CONTAINER_IMAGE || (derived !== null && value === derived)) return;
+
+  const allowed = [`"${CONTAINER_IMAGE}" (base image)`];
+  if (derived) allowed.push(`"${derived}" (this group's built image)`);
+  throw new Error(
+    `Invalid image_tag ${JSON.stringify(value)} for ${agentGroupId}: must be ` +
+      `${allowed.join(' or ')}, or empty to inherit the base image.`,
+  );
+}
+
 /** Update scalar fields on a config row. Only touches fields present in `updates`. */
 export function updateContainerConfigScalars(
   agentGroupId: string,
@@ -88,6 +138,9 @@ export function updateContainerConfigScalars(
   for (const [key, value] of Object.entries(updates)) {
     if (value !== undefined) {
       if (!SCALAR_COLUMNS.has(key)) throw new Error(`Invalid scalar column: ${key}`);
+      // Throws before the UPDATE is prepared, so a rejected image_tag aborts the
+      // whole call rather than half-applying the other fields alongside it.
+      if (key === 'image_tag') assertAllowedImageTag(agentGroupId, value);
       fields.push(`${key} = @${key}`);
       values[key] = value;
     }


### PR DESCRIPTION
## Problem

`ncl groups config update --image-tag <anything>` wrote an arbitrary, unvalidated string into `container_configs.image_tag` (`src/cli/resources/groups.ts`), and `src/container-runner.ts` consumes that value **unchecked** as the `docker run` image argument.

**Scope, stated accurately:** the `groups config update` verb is registered `access: 'approval'`, so a container-side agent gets a HOLD and an admin approval card rather than a silent write. This is defense in depth, not an unauthenticated escape. It is still an unvalidated string reaching a process-spawn argument, and the approval card is not a place a human can realistically audit an image reference.

## Fix

Validates in `updateContainerConfigScalars` — the DB write seam — rather than in the one CLI verb, so `groups create` and any host-side caller are covered by the same check.

The accepted values are the base image or `<base>:<safe-group-id>`. The allowlist is built from `CONTAINER_IMAGE_BASE` **at call time** rather than hardcoded as a regex, because `src/config.ts` permits that base to be overridden — a hardcoded pattern would reject legitimate tags on any install that overrides it.

## Testing

`pnpm run build`, `pnpm test` (1158 passed), `pnpm run format:check` all pass. New unit tests cover accepted tags, rejected tags, and the override case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)