### PR TITLE
uninstall: remove per-agent-group derived images, not just <base>:latest

### DIFF
--- a/setup/uninstall/flow.ts
+++ b/setup/uninstall/flow.ts
@@ -325,7 +325,15 @@ function serviceRows(inv: Inventory, home: string): { what: string; where: strin
   if (s.containerIds.length > 0) {
     rows.push({ what: 'Running containers', where: `${s.containerIds.length} container(s)` });
   }
-  if (s.image) rows.push({ what: 'Container image', where: s.image });
+  for (const image of s.images) {
+    // Anything but `:latest` is a per-agent-group image built by
+    // install_packages. Label it — the tag is a bare agent-group id, which
+    // tells the user nothing about what they're being asked to delete.
+    rows.push({
+      what: image.endsWith(':latest') ? 'Container image' : 'Container image (agent group)',
+      where: image,
+    });
+  }
   if (s.nclSymlink) rows.push({ what: 'Command-line tool (ncl)', where: tilde(s.nclSymlink, home) });
   return rows;
 }

--- a/setup/uninstall/plan.test.ts
+++ b/setup/uninstall/plan.test.ts
@@ -20,7 +20,11 @@ function inventory(overrides: Partial<Inventory> = {}): Inventory {
     service: {
       launchdPlist: '/home/u/Library/LaunchAgents/com.nanoclaw-v2-abcd1234.plist',
       containerIds: ['c1', 'c2'],
-      image: 'nanoclaw-agent-v2-abcd1234:latest',
+      // As scan orders them: per-agent-group images, base tag last.
+      images: [
+        'nanoclaw-agent-v2-abcd1234:ag-1783009453197-319n7n',
+        'nanoclaw-agent-v2-abcd1234:latest',
+      ],
       nclSymlink: '/home/u/.local/bin/ncl',
     },
     data: [
@@ -138,8 +142,18 @@ describe('buildRemovalPlan conditional actions', () => {
     expect(kinds(buildRemovalPlan(inv, allYes()))).not.toContain('backup-env');
   });
 
+  it('removes every image tag, per-agent-group ones before the base', () => {
+    const actions = buildRemovalPlan(inventory(), allYes());
+    expect(
+      actions.filter((a) => a.kind === 'rmi').map((a) => (a.kind === 'rmi' ? a.image : '')),
+    ).toEqual([
+      'nanoclaw-agent-v2-abcd1234:ag-1783009453197-319n7n',
+      'nanoclaw-agent-v2-abcd1234:latest',
+    ]);
+  });
+
   it('always re-sweeps containers and processes with a confirmed service group', () => {
-    const inv = inventory({ service: { containerIds: [] } });
+    const inv = inventory({ service: { containerIds: [], images: [] } });
     const actions = buildRemovalPlan(inv, allYes());
     const actionKinds = kinds(actions);
     expect(actionKinds).not.toContain('rmi');

--- a/setup/uninstall/plan.ts
+++ b/setup/uninstall/plan.ts
@@ -92,8 +92,12 @@ export function buildRemovalPlan(inv: Inventory, d: Decisions): RemovalAction[] 
       runtime: inv.containerRuntime,
       labelFilter: `nanoclaw-install=${inv.slug}`,
     });
-    if (s.image) {
-      actions.push({ kind: 'rmi', runtime: inv.containerRuntime, image: s.image });
+    // One action per tag, in scan order (per-agent-group images before the
+    // base they were built FROM). Keeping them separate means a tag that
+    // won't delete — still in use by a container we couldn't remove — is its
+    // own note and never blocks the remaining images.
+    for (const image of s.images) {
+      actions.push({ kind: 'rmi', runtime: inv.containerRuntime, image });
     }
     if (s.nclSymlink) {
       actions.push({ kind: 'rm-ncl-symlink', linkPath: s.nclSymlink });

--- a/setup/uninstall/remove.test.ts
+++ b/setup/uninstall/remove.test.ts
@@ -125,6 +125,33 @@ describe('executePlan', () => {
     expect(notes.some((n) => n.includes('docker rmi img:latest'))).toBe(true);
   });
 
+  it('removes every image tag independently, one rmi per action', () => {
+    // The planner emits one rmi per tag (per-agent-group images, then the
+    // base). A tag that won't delete must not strand the ones after it.
+    const calls: string[][] = [];
+    const runCommand: RunCommand = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      return { status: args[1] === 'base:ag-stuck' ? 1 : 0, stdout: '' };
+    };
+
+    const { notes } = executePlan(
+      [
+        { kind: 'rmi', runtime: 'docker', image: 'base:ag-stuck' },
+        { kind: 'rmi', runtime: 'docker', image: 'base:ag-ok' },
+        { kind: 'rmi', runtime: 'docker', image: 'base:latest' },
+      ],
+      deps({ runCommand }),
+    );
+
+    expect(calls).toEqual([
+      ['docker', 'rmi', 'base:ag-stuck'],
+      ['docker', 'rmi', 'base:ag-ok'],
+      ['docker', 'rmi', 'base:latest'],
+    ]);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('docker rmi base:ag-stuck');
+  });
+
   it('removes .env only after a successful backup', () => {
     const envPath = path.join(tempDir, '.env');
     fs.writeFileSync(envPath, 'KEY=secret');

--- a/setup/uninstall/scan.test.ts
+++ b/setup/uninstall/scan.test.ts
@@ -5,7 +5,11 @@ import path from 'path';
 
 import Database from 'better-sqlite3';
 
-import { getLaunchdLabel, getSystemdUnit } from '../../src/install-slug.js';
+import {
+  getContainerImageBase,
+  getLaunchdLabel,
+  getSystemdUnit,
+} from '../../src/install-slug.js';
 import type { RunCommand } from './onecli-agents.js';
 import { detectExistingInstall, scanInstall, type ScanDeps } from './scan.js';
 
@@ -39,11 +43,12 @@ function deps(overrides: Partial<ScanDeps> = {}): ScanDeps {
   };
 }
 
-const dockerUp = (containerIds: string[], hasImage: boolean) =>
+/** Docker up: `ps` yields container ids, `images` yields repo:tag lines. */
+const dockerUp = (containerIds: string[], imageTags: string[]) =>
   fakeRun({
     docker: (args) => {
       if (args[0] === 'ps') return { status: 0, stdout: containerIds.join('\n') + '\n' };
-      if (args[0] === 'image') return { status: hasImage ? 0 : 1, stdout: '' };
+      if (args[0] === 'images') return { status: 0, stdout: imageTags.join('\n') + '\n' };
       return { status: 1, stdout: '' };
     },
   });
@@ -77,7 +82,7 @@ describe('scanInstall path groups', () => {
     expect(inv.runtime).toEqual([]);
     expect(inv.user).toEqual([]);
     expect(inv.service.containerIds).toEqual([]);
-    expect(inv.service.image).toBeUndefined();
+    expect(inv.service.images).toEqual([]);
   });
 });
 
@@ -116,17 +121,80 @@ describe('scanInstall service artifacts', () => {
   });
 
   it('captures container ids and image when docker is up', () => {
-    const inv = scanInstall(deps({ runCommand: dockerUp(['abc123', 'def456'], true) }));
+    const base = getContainerImageBase(root);
+    expect(base).toMatch(/^nanoclaw-agent-v2-[0-9a-f]{8}$/);
+
+    const inv = scanInstall(
+      deps({ runCommand: dockerUp(['abc123', 'def456'], [`${base}:latest`]) }),
+    );
     expect(inv.service.containerIds).toEqual(['abc123', 'def456']);
-    expect(inv.service.image).toMatch(/^nanoclaw-agent-v2-[0-9a-f]{8}:latest$/);
+    expect(inv.service.images).toEqual([`${base}:latest`]);
     expect(inv.notes).toEqual([]);
+  });
+
+  it('inventories per-agent-group images, ordered before the base tag', () => {
+    const base = getContainerImageBase(root);
+    const inv = scanInstall(
+      deps({
+        runCommand: dockerUp(
+          [],
+          // Fed base-first: docker's own order (created-desc) is not something
+          // the scan may rely on, so the re-order has to be real.
+          [`${base}:latest`, `${base}:ag-1783009453197-319n7n`, `${base}:ag-other`],
+        ),
+      }),
+    );
+    // Children first: the base is the FROM of every derived image.
+    expect(inv.service.images).toEqual([
+      `${base}:ag-1783009453197-319n7n`,
+      `${base}:ag-other`,
+      `${base}:latest`,
+    ]);
+  });
+
+  it('scopes the image query to this checkout so a peer install is untouched', () => {
+    const calls: string[][] = [];
+    const inv = scanInstall(
+      deps({
+        runCommand: (cmd, args) => {
+          calls.push([cmd, ...args]);
+          return cmd === 'docker' ? { status: 0, stdout: '' } : { status: 1, stdout: '' };
+        },
+      }),
+    );
+    // Repository is the slug-bearing base; only the TAG is wildcarded, so a
+    // sibling checkout's `nanoclaw-agent-v2-<otherSlug>` can never match.
+    expect(calls).toContainEqual([
+      'docker',
+      'images',
+      '--filter',
+      `reference=${getContainerImageBase(root)}:*`,
+      '--format',
+      '{{.Repository}}:{{.Tag}}',
+    ]);
+    expect(inv.service.images).toEqual([]);
   });
 
   it('degrades with a manual-cleanup note when docker is unavailable', () => {
     const inv = scanInstall(deps());
     expect(inv.service.containerIds).toEqual([]);
-    expect(inv.service.image).toBeUndefined();
+    expect(inv.service.images).toEqual([]);
     expect(inv.notes.some((n) => n.includes("'docker' unavailable"))).toBe(true);
+  });
+
+  it('notes the wildcard rmi command when only the image query fails', () => {
+    const inv = scanInstall(
+      deps({
+        runCommand: fakeRun({
+          docker: (args) =>
+            args[0] === 'ps' ? { status: 0, stdout: '' } : { status: 1, stdout: '' },
+        }),
+      }),
+    );
+    expect(inv.service.images).toEqual([]);
+    expect(
+      inv.notes.some((n) => n.includes(`reference='${getContainerImageBase(root)}:*'`)),
+    ).toBe(true);
   });
 });
 

--- a/setup/uninstall/scan.ts
+++ b/setup/uninstall/scan.ts
@@ -47,7 +47,13 @@ export interface ServiceInventory {
   systemdSystemUnit?: string;
   pidFile?: string;
   containerIds: string[];
-  image?: string;
+  /**
+   * Every tag under this checkout's image base: the `<base>:latest` image
+   * plus the per-agent-group images `install_packages` builds as
+   * `<base>:<agentGroupId>` (container-runner.ts `buildAgentGroupImage`).
+   * Ordered per-agent-group first, `<base>:latest` last — see `imageTags`.
+   */
+  images: string[];
   nclSymlink?: string;
 }
 
@@ -157,7 +163,7 @@ function scanService(
   notes: string[],
 ): ServiceInventory {
   const { projectRoot, home, platform, runCommand } = deps;
-  const service: ServiceInventory = { containerIds: [] };
+  const service: ServiceInventory = { containerIds: [], images: [] };
 
   if (platform === 'darwin') {
     const plist = path.join(
@@ -179,7 +185,12 @@ function scanService(
 
   // Container label matches what container-runner.ts stamps at spawn time.
   const installLabel = `nanoclaw-install=${slug}`;
-  const image = `${getContainerImageBase(projectRoot)}:latest`;
+  // A *repository* name, not a full reference. The slug is in the repository
+  // itself, so every tag under it is ours and the wildcard cannot reach a
+  // peer install — docker's reference filter matches the repository exactly
+  // (verified: `reference=nanoclaw-agent:*` does not match
+  // `nanoclaw-agent-v2-<slug>`).
+  const imageBase = getContainerImageBase(projectRoot);
   let runtimeOk = true;
   try {
     const ps = runCommand(containerRuntime, [
@@ -201,8 +212,22 @@ function scanService(
   }
   if (runtimeOk) {
     try {
-      const inspect = runCommand(containerRuntime, ['image', 'inspect', image]);
-      if (inspect.status === 0) service.image = image;
+      // Enumerate, don't inspect one tag: an agent group that ever ran
+      // install_packages has its own `<base>:<agentGroupId>` image, and
+      // inspecting only `<base>:latest` left every one of those behind
+      // (multi-GB each) after an uninstall reported success.
+      const images = runCommand(containerRuntime, [
+        'images',
+        '--filter',
+        `reference=${imageBase}:*`,
+        '--format',
+        '{{.Repository}}:{{.Tag}}',
+      ]);
+      if (images.status === 0) {
+        service.images = imageTags(images.stdout, `${imageBase}:latest`);
+      } else {
+        runtimeOk = false;
+      }
     } catch {
       runtimeOk = false;
     }
@@ -211,7 +236,8 @@ function scanService(
     notes.push(
       `Containers/image: '${containerRuntime}' unavailable; remove later with: ` +
         `${containerRuntime} ps -aq --filter label=${installLabel} | xargs -r ${containerRuntime} rm -f; ` +
-        `${containerRuntime} rmi ${image}`,
+        `${containerRuntime} images --filter reference='${imageBase}:*' ` +
+        `--format '{{.Repository}}:{{.Tag}}' | xargs -r ${containerRuntime} rmi`,
     );
   }
 
@@ -237,6 +263,23 @@ function scanService(
   }
 
   return service;
+}
+
+/**
+ * Parse `<runtime> images --format` output into removal order: per-agent-group
+ * tags first, `<base>:latest` last.
+ *
+ * Derived images are built `FROM <base>:latest`, so a runtime tracking parent
+ * links refuses to delete the base while a child references it. Docker 29
+ * refcounts layers and doesn't care — child-first is free insurance that also
+ * keeps the confirmation table ordered.
+ */
+function imageTags(stdout: string, baseTag: string): string[] {
+  const tags = stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return [...tags.filter((t) => t !== baseTag), ...tags.filter((t) => t === baseTag)];
 }
 
 function scanOnecli(


### PR DESCRIPTION
## Problem

`setup/uninstall/scan.ts` inventoried the agent image with a single `docker image inspect <base>:latest`. But `buildAgentGroupImage` (`src/container-runner.ts`) tags per-agent-group derived images as `<base>:<agentGroupId>` whenever an agent runs `install_packages`.

Those images were never scanned, never listed, and never removed. Any install where an agent ever installed a package leaves multi-GB images behind after a full uninstall.

This is reproducible on any machine that has used `install_packages` — `docker images | grep nanoclaw-agent-v2` after an uninstall shows the orphans.

## Fix

Enumerates with `docker images --filter reference=<base>:*`, which stays slug-scoped so a peer install's images are never touched — the same scoping property the existing code relies on.

Derived tags are listed in the confirmation output so the user sees what will be deleted rather than being surprised.

Removal is ordered **child-first**: derived images are built `FROM <base>:latest`, and a runtime that tracks parent links refuses to delete a base with dependent children. Docker 29 refcounts layers and does not care either way, so this is free insurance that also keeps the confirmation table ordered.

## Testing

`pnpm run build`, `pnpm test` (1156 passed), `pnpm run format:check` all pass. Updated `scan.test.ts`, `plan.test.ts` and `remove.test.ts`, which asserted the old single-tag behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)