### PR TITLE
fix(container): gate the follow-up poll on trigger=1 too

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -4,7 +4,7 @@ import { initTestSessionDb, closeSessionDb, getInboundDb, getOutboundDb } from '
 import { getPendingMessages, markCompleted } from './db/messages-in.js';
 import { getUndeliveredMessages } from './db/messages-out.js';
 import { formatMessages, extractRouting } from './formatter.js';
-import { isCorruptionError, processQuery } from './poll-loop.js';
+import { isCorruptionError, isTurnEligible, processQuery } from './poll-loop.js';
 import { MockProvider } from './providers/mock.js';
 import type { AgentQuery, ProviderEvent } from './providers/types.js';
 
@@ -108,22 +108,25 @@ describe('accumulate gate (trigger column)', () => {
     expect(byId.m2.trigger).toBe(1);
   });
 
-  it('trigger=0-only batch: gate predicate `some(trigger===1)` is false', () => {
+  it('trigger=0-only batch: isTurnEligible is false', () => {
     insertMessage('m1', 'chat', { sender: 'A', text: 'noise' }, { trigger: 0 });
     insertMessage('m2', 'chat', { sender: 'B', text: 'more noise' }, { trigger: 0 });
     const messages = getPendingMessages();
-    // This is the exact predicate the poll loop uses to skip accumulate-only
-    // batches — gate should be false, so the loop sleeps without waking the agent.
-    expect(messages.some((m) => m.trigger === 1)).toBe(false);
+    // Gate is false, so the loop sleeps without waking the agent.
+    expect(isTurnEligible(messages)).toBe(false);
   });
 
   it('mixed batch: gate is true → loop proceeds, accumulated rows ride along', () => {
     insertMessage('m1', 'chat', { sender: 'A', text: 'earlier chatter' }, { trigger: 0 });
     insertMessage('m2', 'chat', { sender: 'B', text: 'the real mention' }, { trigger: 1 });
     const messages = getPendingMessages();
-    expect(messages.some((m) => m.trigger === 1)).toBe(true);
+    expect(isTurnEligible(messages)).toBe(true);
     // Both messages are present for the formatter → agent sees the prior context.
     expect(messages.map((m) => m.id).sort()).toEqual(['m1', 'm2']);
+  });
+
+  it('empty batch is not turn-eligible', () => {
+    expect(isTurnEligible([])).toBe(false);
   });
 
   it('trigger column defaults to 1 for legacy inserts without explicit value', () => {
@@ -137,6 +140,50 @@ describe('accumulate gate (trigger column)', () => {
       .run();
     const [msg] = getPendingMessages();
     expect(msg.trigger).toBe(1);
+  });
+});
+
+describe('accumulate gate — follow-up poll into an active query', () => {
+  // Regression: the outer batch loop was gated but the follow-up poller (which
+  // pushes new rows into an already-running query) was not, so accumulate rows
+  // arriving mid-turn were handed to the agent as real prompts. With a chatty
+  // counterpart each reply drew another untriggered row, which extended the
+  // same turn, so the turn never ended. Reproduced 2026-07-25 on a Slack
+  // wiring with ignored_message_policy='accumulate'.
+
+  it('does not push an accumulate-only follow-up batch into a live turn', () => {
+    // The turn is already underway: its trigger=1 row was claimed and acked,
+    // so it no longer appears in getPendingMessages.
+    insertMessage('tag', 'chat', { sender: 'Jack', text: '@bot help' }, { trigger: 1 });
+    markCompleted(['tag']);
+
+    // Now untriggered chatter lands while that turn is still open.
+    insertMessage('n1', 'chat', { sender: 'Jack', text: '¿Enviar esta respuesta?' }, { trigger: 0 });
+    insertMessage('n2', 'chat', { sender: 'Jack', text: '¿Enviar esta respuesta?' }, { trigger: 0 });
+
+    const pending = getPendingMessages();
+    const newMessages = pending.filter((m) => m.kind !== 'system');
+    expect(newMessages.map((m) => m.id).sort()).toEqual(['n1', 'n2']);
+
+    // The follow-up poller must refuse this batch.
+    expect(isTurnEligible(newMessages)).toBe(false);
+  });
+
+  it('rows refused mid-turn stay pending and ride along with the next real trigger', () => {
+    insertMessage('n1', 'chat', { sender: 'Jack', text: 'chatter' }, { trigger: 0 });
+    expect(isTurnEligible(getPendingMessages())).toBe(false);
+
+    // Refused, not consumed — still pending for the next pass.
+    insertMessage('tag', 'chat', { sender: 'Jack', text: '@bot now I mean it' }, { trigger: 1 });
+    const next = getPendingMessages();
+    expect(isTurnEligible(next)).toBe(true);
+    expect(next.map((m) => m.id).sort()).toEqual(['n1', 'tag']);
+  });
+
+  it('a follow-up batch containing a real trigger IS pushed', () => {
+    insertMessage('n1', 'chat', { sender: 'Jack', text: 'chatter' }, { trigger: 0 });
+    insertMessage('n2', 'chat', { sender: 'Jack', text: '@bot another question' }, { trigger: 1 });
+    expect(isTurnEligible(getPendingMessages())).toBe(true);
   });
 });
 

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -83,6 +83,30 @@ export interface PollLoopConfig {
 }
 
 /**
+ * Is this batch allowed to drive an agent turn?
+ *
+ * Only if it contains at least one wake-eligible (trigger=1) row. trigger=0
+ * rows are accumulate context — stored by the router under
+ * `ignored_message_policy='accumulate'` so the agent has prior context when it
+ * IS eventually addressed, but never a reason to speak on their own. Callers
+ * leave an ineligible batch `pending`; it rides along with the next trigger=1
+ * message. Host-side `countDueMessages` gates wake-from-cold the same way
+ * (see src/db/session-db.ts).
+ *
+ * BOTH consumption paths must call this — the outer batch loop AND the
+ * follow-up poller that pushes into an already-active query. Gating only the
+ * outer loop is not a partial fix, it is no fix: an accumulate row landing
+ * while a turn is open would be pushed into the live query as if addressed to
+ * us. That produced a real runaway on 2026-07-25 — a Slack wiring set to
+ * 'accumulate' alongside a chatty bot counterpart, where every reply drew
+ * another untriggered prompt which extended the same turn, so the turn could
+ * never end and the two bots answered each other until the host was killed.
+ */
+export function isTurnEligible(messages: Array<{ trigger: number }>): boolean {
+  return messages.some((m) => m.trigger === 1);
+}
+
+/**
  * Main poll loop. Runs indefinitely until the process is killed.
  *
  * 1. Poll messages_in for pending rows
@@ -140,15 +164,11 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
       continue;
     }
 
-    // Accumulate gate: if the batch contains only trigger=0 rows
-    // (context-only, router-stored under ignored_message_policy='accumulate'),
-    // don't wake the agent. Leave them `pending` — they'll ride along the
-    // next time a real trigger=1 message lands via this same getPendingMessages
-    // query. Without this gate, a warm container keeps processing
-    // (and potentially responding to) every accumulate-only batch, defeating
-    // the "store as context, don't engage" contract. Host-side countDueMessages
-    // gates the same way for wake-from-cold (see src/db/session-db.ts).
-    if (!messages.some((m) => m.trigger === 1)) {
+    // Accumulate gate — see isTurnEligible. Leave the rows `pending`; they
+    // ride along the next time a real trigger=1 message lands via this same
+    // getPendingMessages query. Host-side countDueMessages gates the same way
+    // for wake-from-cold (see src/db/session-db.ts).
+    if (!isTurnEligible(messages)) {
       await sleep(POLL_INTERVAL_MS);
       continue;
     }
@@ -406,6 +426,11 @@ export async function processQuery(
         // host-generated welcome trigger with null thread vs a Discord DM reply).
         const newMessages = pending.filter((m) => m.kind !== 'system');
         if (newMessages.length === 0) return;
+
+        // Accumulate gate — see isTurnEligible. Leave the rows pending so they
+        // ride along with the next trigger=1 message instead of extending the
+        // live turn.
+        if (!isTurnEligible(newMessages)) return;
 
         const newIds = newMessages.map((m) => m.id);
         markProcessing(newIds);


### PR DESCRIPTION
Fixes #3132.

## Problem

`poll-loop.ts` has two message-consumption paths and only one was gated on `trigger`:

- `runPollLoop`'s outer batch loop skipped batches with no `trigger=1` row.
- `processQuery`'s follow-up poller — the `setInterval` that pushes newly-arrived rows into an already-active query — filtered only on `kind !== 'system'`.

So any accumulate (`trigger=0`) row landing while a turn was open went straight into `query.push()` as if addressed to the agent. The outer gate was bypassed whenever the agent was busy, defeating the `ignored_message_policy='accumulate'` contract.

It can also be self-sustaining. On a live install this produced a runaway: a Slack channel set to `accumulate` next to a bot that posts a confirmation prompt after every reply. The agent's first (legitimately triggered) turn never ended — each reply drew another untriggered prompt, pushed into the same turn, producing another reply. ~50 messages in 3 minutes; the triggering row stayed `processing` throughout; one container, no respawns. Full evidence in #3132.

## Fix

Extract the predicate as `isTurnEligible` and call it from **both** sites.

The extraction is the point, not incidental cleanup: the bug was that the invariant existed as an inline expression in one path, so the second path could omit it without anything looking wrong. Naming it once gives a single place for the rationale and one thing to grep for. Same class of defect as #2032, which was fixed for pre-task scripts on this very poller without generalizing.

Behavior is unchanged for every triggered path — a follow-up batch containing a real `trigger=1` row still pushes exactly as before. Refused rows are left `pending` (not consumed), so they ride along with the next real trigger and the agent still gets its prior context.

## Tests

Added coverage for the follow-up path specifically:

- accumulate-only follow-up batch is refused while a turn is open
- refused rows stay pending and ride along with the next real trigger
- a follow-up batch containing a real trigger is still pushed
- empty batch is not turn-eligible

The pre-existing tests only asserted the predicate against `getPendingMessages` results, which is exactly why a second ungated call site went unnoticed — they'd have passed just as happily with the bug in place. An existing test that exercises the real follow-up push path (`Pushing 1 follow-up message(s) into active query`) still passes, confirming legitimate follow-ups are unaffected.

`bun test`: 158 pass, 1 skip, 0 fail. `bun run typecheck`: clean.
