### PR TITLE
fix: mirror host-sent messages into the agent's context

### DIFF
--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -140,9 +140,15 @@ export function formatMessages(messages: MessageInRow[]): string {
   const taskMessages = messages.filter((m) => m.kind === 'task');
   const webhookMessages = messages.filter((m) => m.kind === 'webhook');
   const systemMessages = messages.filter((m) => m.kind === 'system');
+  const sentMessages = messages.filter((m) => m.kind === 'sent');
 
   const parts: string[] = [];
 
+  // Ahead of the incoming messages: what was already said on this agent's
+  // behalf is prior context for whatever the user is replying to.
+  if (sentMessages.length > 0) {
+    parts.push(...sentMessages.map(formatSentMessage));
+  }
   if (chatMessages.length > 0) {
     parts.push(formatChatMessages(chatMessages));
   }
@@ -239,6 +245,23 @@ function formatWebhookMessage(msg: MessageInRow): string {
   const event = content.event || 'unknown';
   const from = originAttr(msg);
   return `<webhook${from} source="${escapeXml(source)}" event="${escapeXml(event)}">${JSON.stringify(content.payload || content, null, 2)}</webhook>`;
+}
+
+/**
+ * A message the host already delivered to the user *on this agent's behalf* —
+ * an approval prompt, a reason prompt, a registration notice. The agent never
+ * composed it, so it is absent from its own turn history; without this, the
+ * user's reply to it arrives with no referent and the agent has to guess.
+ *
+ * Rendered as context, not as an instruction: it has already been sent and
+ * must not be repeated.
+ */
+function formatSentMessage(msg: MessageInRow): string {
+  const content = parseContent(msg.content);
+  const time = formatLocalTime(msg.timestamp, TIMEZONE);
+  return `<already_sent_to_user at="${escapeXml(time)}" note="sent on your behalf; do not repeat it">${escapeXml(
+    content.text || '',
+  )}</already_sent_to_user>`;
 }
 
 function formatSystemMessage(msg: MessageInRow): string {

--- a/src/agent-context.test.ts
+++ b/src/agent-context.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const writeSessionMessage = vi.fn();
+const getMessagingGroupByPlatform = vi.fn();
+const findSession = vi.fn();
+
+vi.mock('./session-manager.js', () => ({ writeSessionMessage }));
+vi.mock('./db/messaging-groups.js', () => ({ getMessagingGroupByPlatform }));
+vi.mock('./db/sessions.js', () => ({ findSession }));
+vi.mock('./log.js', () => ({ log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+
+const { recordAgentSent } = await import('./agent-context.js');
+
+describe('recordAgentSent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMessagingGroupByPlatform.mockReturnValue({ id: 'mg-1' });
+    findSession.mockReturnValue({ id: 'sess-1', agent_group_id: 'ag-1' });
+  });
+
+  it('mirrors the message into the session as context that does not wake the agent', () => {
+    recordAgentSent('signal', '+15551234567', 'Your request was approved.');
+
+    expect(writeSessionMessage).toHaveBeenCalledTimes(1);
+    const [agentGroupId, sessionId, msg] = writeSessionMessage.mock.calls[0];
+    expect(agentGroupId).toBe('ag-1');
+    expect(sessionId).toBe('sess-1');
+    expect(msg.kind).toBe('sent');
+    // The load-bearing assertion: trigger 1 here would make the agent reply to
+    // a message it never sent.
+    expect(msg.trigger).toBe(0);
+    expect(JSON.parse(msg.content).text).toBe('Your request was approved.');
+  });
+
+  it('is a no-op when the target has no messaging group', () => {
+    getMessagingGroupByPlatform.mockReturnValue(undefined);
+    recordAgentSent('signal', 'unknown', 'hello');
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no session exists for the target yet', () => {
+    findSession.mockReturnValue(undefined);
+    recordAgentSent('signal', '+15551234567', 'hello');
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+  });
+
+  it('never throws — a mirroring failure must not break the delivery it follows', () => {
+    writeSessionMessage.mockImplementation(() => {
+      throw new Error('db locked');
+    });
+    expect(() => recordAgentSent('signal', '+15551234567', 'hello')).not.toThrow();
+  });
+
+  it('ignores empty text', () => {
+    recordAgentSent('signal', '+15551234567', '');
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent-context.ts
+++ b/src/agent-context.ts
@@ -1,0 +1,64 @@
+/**
+ * Mirror host-originated outbound messages back into the agent's context.
+ *
+ * An agent's memory of a conversation is built from two things: messages the
+ * user sent it (`messages_in`), and turns it composed itself. Messages the
+ * *host* sends on the agent's behalf — approval prompts, reason prompts,
+ * registration notices — are neither. They reach the user over the adapter
+ * without ever passing through the agent, so the agent holds no record that
+ * they were sent. A user replying to one ("why?", "yes, go ahead", "what is
+ * this about?") lands on an agent with nothing to resolve the reference
+ * against.
+ *
+ * Fix: after a host-originated delivery, write a mirror row into the target
+ * session's `inbound.db` with `trigger: 0`, so it accumulates as context
+ * without waking the agent. The next time the agent is genuinely triggered it
+ * reads what was said on its behalf, and the user's reply has a referent.
+ */
+import { getMessagingGroupByPlatform } from './db/messaging-groups.js';
+import { findSession } from './db/sessions.js';
+import { writeSessionMessage } from './session-manager.js';
+import { log } from './log.js';
+
+/**
+ * Record a message the host delivered to a user on the agent's behalf.
+ *
+ * Best-effort and non-throwing: context mirroring must never break or delay
+ * the delivery it accompanies. Resolves the session from the delivery target,
+ * so it is a no-op when the target has no session yet (nothing is listening
+ * for a reply there anyway).
+ *
+ * Do NOT call this for messages the agent itself composed — those are already
+ * in its own turn history, and mirroring them would duplicate context.
+ */
+export function recordAgentSent(
+  channelType: string,
+  platformId: string,
+  text: string,
+  instance?: string,
+  threadId: string | null = null,
+): void {
+  if (!text) return;
+  try {
+    const mg = getMessagingGroupByPlatform(channelType, platformId, instance);
+    if (!mg) return;
+    const session = findSession(mg.id, threadId);
+    if (!session) return;
+
+    writeSessionMessage(session.agent_group_id, session.id, {
+      id: `sent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      kind: 'sent',
+      timestamp: new Date().toISOString(),
+      platformId,
+      channelType,
+      threadId,
+      content: JSON.stringify({ text }),
+      // Context only. A trigger-1 row here would make the agent respond to a
+      // notification it did not send — the duplicate-message failure this is
+      // meant to prevent, not cause.
+      trigger: 0,
+    });
+  } catch (err) {
+    log.warn('Failed to mirror host-sent message into agent context', { channelType, err });
+  }
+}

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -21,6 +21,7 @@
  * exposing just user-roles/user-dms) is more churn than it's worth. Revisit
  * if either module becomes genuinely optional (see REFACTOR_PLAN open q #3).
  */
+import { recordAgentSent } from '../../agent-context.js';
 import { normalizeOptions, type RawOption } from '../../channels/ask-question.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { createPendingApproval, deletePendingApproval, getSession } from '../../db/sessions.js';
@@ -274,6 +275,15 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
           question,
           options: APPROVAL_OPTIONS,
         }),
+      );
+      // The approval card is composed by the host, not the agent. Mirror its
+      // text so the approver's reply ("why?", "what is this for?") has a
+      // referent in the agent's context.
+      recordAgentSent(
+        target.messagingGroup.channel_type,
+        target.messagingGroup.platform_id,
+        `${title}: ${question}`,
+        target.messagingGroup.instance ?? undefined,
       );
     } catch (err) {
       log.error('Failed to deliver approval card', { action, approvalId, err });

--- a/src/modules/approvals/reason-capture.ts
+++ b/src/modules/approvals/reason-capture.ts
@@ -18,6 +18,7 @@
  * Reuses, not reinvents: the agent-naming prompt-then-capture pattern
  * (in-memory map + next-DM interceptor) and the shared finalizeReject path.
  */
+import { recordAgentSent } from '../../agent-context.js';
 import type { InboundEvent } from '../../channels/adapter.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import {
@@ -98,6 +99,9 @@ export async function armReasonCapture(approval: PendingApproval, session: Sessi
 
   try {
     await adapter.deliver(dm.channel_type, dm.platform_id, null, 'chat-sdk', JSON.stringify({ text: PROMPT_TEXT }));
+    // The agent did not compose this prompt, so without mirroring it the
+    // approver's free-text reason arrives as a reply to nothing.
+    recordAgentSent(dm.channel_type, dm.platform_id, PROMPT_TEXT);
   } catch (err) {
     log.error('reject-with-reason: reason prompt delivery failed, finalizing plain reject', {
       approvalId: approval.approval_id,


### PR DESCRIPTION
Fixes #3134.

Messages the host sends *on an agent's behalf* — approval cards, reject-reason prompts, registration notices — never pass through the container. They are absent from `messages_in` and absent from the agent's own turn history, so the agent holds no record that they were sent. A user replying to one arrives with nothing to resolve the reply against.

Observed on a live install: a host-generated notification was DM'd to the owner, who replied 21 seconds later with *"hmm. is that the one I set up for my commute?"* — a bare pronoun whose only referent was a message the agent had never seen.

## Approach

`recordAgentSent()` resolves the session from the delivery target and writes a mirror row into its `inbound.db` with **`trigger: 0`**.

`trigger: 0` is the load-bearing detail: the row accumulates as context and never wakes the agent. A trigger-1 row would make the agent respond to a notification it did not send, which is a worse bug than the one being fixed. Verified on a live install — the mirror row did not spawn a container; the container that did spawn was woken by the user's own reply.

Container-side, `kind: 'sent'` renders as:

```
<already_sent_to_user at="Jul 25, 2026, 12:00 PM" note="sent on your behalf; do not repeat it">…</already_sent_to_user>
```

`formatMessages` previously dropped unrecognised kinds silently, so without that branch the rows would be written and then discarded.

## Scope

Wired into the two approval paths that ask a human a question and expect a reply:

- `approvals/primitive.ts` — the approval card
- `approvals/reason-capture.ts` — the reject-reason prompt

Deliberately **not** wired into `src/delivery.ts`: those messages are the agent's own and already in its turn history — mirroring them would duplicate context. Other host-originated senders (`permissions/*`, `onecli-approvals.ts`) can opt in with the same one-line call; I kept this PR to one thing rather than sweeping every call site, and am happy to extend it if you'd prefer the sweep in one go.

`recordAgentSent` is best-effort and non-throwing — context mirroring must never break or delay the delivery it accompanies — and is a no-op when the target has no session yet.

## Testing

- 5 unit tests covering the mirror row, `trigger: 0`, both no-op paths, and the never-throws guarantee
- Full suite green: 95 files / 1156 tests
- Host typecheck and container typecheck clean
- Verified end-to-end on a live install: notice delivered → mirror row written with `trigger: 0` → agent not woken → agent resolved the user's pronoun correctly on the next real turn

## Notes

Complements #2423, which proposes the same mechanism for the case where delivery *fails*. This covers the case where delivery *succeeds* but the agent is never told. Neither subsumes the other.
