### PR TITLE
fix(chat-sdk): fall back to fetch(url) when attachment has no fetchData

### DIFF
--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Adapter, AdapterPostableMessage, RawMessage } from 'chat';
 
-import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, enrichAttachment, splitForLimit } from './chat-sdk-bridge.js';
 
 vi.mock('../webhook-server.js', () => ({
   registerWebhookAdapter: vi.fn(),
@@ -419,5 +419,76 @@ describe('createChatSdkBridge.deliver — display cards (send_card)', () => {
     expect(calls).toHaveLength(1);
     const msg = calls[0].message as { markdown?: string };
     expect(msg.markdown).toBe('plain hello');
+  });
+});
+
+describe('enrichAttachment', () => {
+  it('uses fetchData when present and returns base64-encoded data', async () => {
+    const buf = Buffer.from('hello attachment');
+    const att = {
+      type: 'image',
+      name: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      size: buf.length,
+      fetchData: vi.fn().mockResolvedValue(buf),
+    };
+    const result = await enrichAttachment(att);
+    expect(att.fetchData).toHaveBeenCalledOnce();
+    expect(result.data).toBe(buf.toString('base64'));
+    expect(result.type).toBe('image');
+    expect(result.name).toBe('photo.jpg');
+  });
+
+  it('falls back to fetch(url) when fetchData is absent and returns base64-encoded data', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      const att = { type: 'image', name: 'img.png', mimeType: 'image/png', url: 'https://cdn.example.com/img.png' };
+      const result = await enrichAttachment(att);
+      expect(mockFetch).toHaveBeenCalledWith('https://cdn.example.com/img.png');
+      expect(result.data).toBe(Buffer.from(bytes.buffer).toString('base64'));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('omits data when the URL fetch returns a non-ok status', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      const att = {
+        type: 'image',
+        name: 'img.png',
+        mimeType: 'image/png',
+        url: 'https://cdn.example.com/forbidden.png',
+      };
+      const result = await enrichAttachment(att);
+      expect(result.data).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('omits data when the URL fetch throws a network error', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('network failure'));
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      const att = { type: 'image', name: 'img.png', mimeType: 'image/png', url: 'https://cdn.example.com/img.png' };
+      const result = await enrichAttachment(att);
+      expect(result.data).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('omits data when neither fetchData nor url is present', async () => {
+    const att = { type: 'image', name: 'img.png', mimeType: 'image/png', size: 42 };
+    const result = await enrichAttachment(att);
+    expect(result.data).toBeUndefined();
+    expect(result.size).toBe(42);
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -134,6 +134,39 @@ export function splitForLimit(text: string, limit: number): string[] {
   return chunks;
 }
 
+/** @internal exported for testing */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function enrichAttachment(att: Record<string, any>): Promise<Record<string, any>> {
+  const entry: Record<string, any> = {
+    type: att.type,
+    name: att.name,
+    mimeType: att.mimeType,
+    size: att.size,
+    width: att.width,
+    height: att.height,
+  };
+  if (att.fetchData) {
+    try {
+      const buffer = await att.fetchData();
+      entry.data = buffer.toString('base64');
+    } catch (err) {
+      log.warn('Failed to download attachment', { type: att.type, err });
+    }
+  } else if (att.url) {
+    try {
+      const res = await fetch(att.url as string);
+      if (res.ok) {
+        entry.data = Buffer.from(await res.arrayBuffer()).toString('base64');
+      } else {
+        log.warn('Failed to download attachment from URL', { url: att.url, status: res.status });
+      }
+    } catch (err) {
+      log.warn('Failed to download attachment from URL', { url: att.url, err });
+    }
+  }
+  return entry;
+}
+
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
   // The instance name becomes a webhook route segment (the route regex is
@@ -165,28 +198,8 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
 
     // Download attachment data before serialization loses fetchData()
     if (message.attachments && message.attachments.length > 0) {
-      const enriched = [];
-      for (const att of message.attachments) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const entry: Record<string, any> = {
-          type: att.type,
-          name: att.name,
-          mimeType: att.mimeType,
-          size: att.size,
-          width: (att as unknown as Record<string, unknown>).width,
-          height: (att as unknown as Record<string, unknown>).height,
-        };
-        if (att.fetchData) {
-          try {
-            const buffer = await att.fetchData();
-            entry.data = buffer.toString('base64');
-          } catch (err) {
-            log.warn('Failed to download attachment', { type: att.type, err });
-          }
-        }
-        enriched.push(entry);
-      }
-      serialized.attachments = enriched;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      serialized.attachments = await Promise.all(message.attachments.map((a) => enrichAttachment(a as any)));
     }
 
     // Extract reply context via platform-specific hook


### PR DESCRIPTION
Check: [x] Fix                                                                                                                
                                                                                                                                
Description:                                                                                                                  
                                                                                                                                
Discord (and potentially other Chat SDK channels) can deliver attachments that carry a url field but no fetchData callback. The previous code in createChatSdkBridge only tried fetchData, so URL-only attachments were silently forwarded with no data — the agent received file metadata but couldn't read the content.                                                               
                                                                                                                                
What: Extracted the per-attachment enrichment into a standalone exported enrichAttachment function. It tries fetchData first; if absent, falls back to fetch(url). Both failure paths (non-2xx status, network error) log a warning and omit data rather than throwing, preserving the existing graceful-degradation behaviour.                                                        
                                                                                                                                
Why: Uploaded images from Discord users were invisible to the agent because Discord's Chat SDK adapter sets url rather than fetchData on the attachment object.                                                                                           
                                                                                                                                
How it was tested: 5 new unit tests cover all paths: fetchData happy path, URL fallback happy path, URL fetch returns non-ok status, URL fetch throws a network error, and neither field present. All 1156 host tests pass (pnpm test).    