### PR TITLE
fix(whatsapp): shared-number mode silences the owner — don't blanket-drop fromMe messages

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -876,16 +876,23 @@ registerChannelAdapter('whatsapp', {
             // Filter bot's own messages to prevent echo loops.
             // In self-chat (user messaging their own number), all messages have
             // fromMe=true — use sentMessageCache to distinguish bot echoes from
-            // user-typed messages. For all other chats, the blanket fromMe
-            // filter is correct since the user's phone messages shouldn't wake
-            // the agent in third-party conversations.
+            // user-typed messages. In dedicated mode the blanket fromMe filter
+            // is correct for all other chats, since the user's phone messages
+            // shouldn't wake the agent in third-party conversations. In
+            // shared-number mode the OWNER'S messages are fromMe in every chat
+            // — treat all chats like self-chat (drop only known bot echoes),
+            // otherwise the owner can never address the bot outside self-chat.
             if (fromMe) {
               const isSelfChat = botPhoneJid && chatJid === botPhoneJid;
-              if (!isSelfChat) continue;
+              if (!WHATSAPP_SHARED && !isSelfChat) continue;
               if (sentMessageCache.has(msg.key.id || '')) continue;
             }
 
             const isBotMessage = WHATSAPP_SHARED ? content.startsWith(`${ASSISTANT_NAME}:`) : false;
+            // Shared-mode echo backstop: a bot-authored message that missed the
+            // sentMessageCache (e.g. redelivered after a restart) still carries
+            // the assistant-name prefix — never feed it back to the agent.
+            if (fromMe && isBotMessage) continue;
 
             // Check if this reply answers a pending question via slash command
             const pending = pendingQuestions.get(chatJid);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** In shared-number mode (`ASSISTANT_HAS_OWN_NUMBER` unset/false — the bot runs on the owner's own WhatsApp account), the fromMe echo filter drops every message the owner types outside self-chat. Since all of the owner's messages are `fromMe=true` on their own account, the owner is silenced in every group and DM: messages never reach the router and nothing is logged, so it presents as the bot ignoring its own operator.

**Why:** Hit in production immediately after updating a shared-number install to current `channels` — the operator's group messages stopped routing while other participants' messages still worked. The filter's comment ("the user's phone messages shouldn't wake the agent in third-party conversations") is correct for dedicated-number mode only.

**How it works:** When `WHATSAPP_SHARED` is true, every chat is treated like the existing self-chat path: the owner's typed messages are forwarded, and only known bot echoes are dropped via `sentMessageCache`. A prefix backstop (`fromMe && isBotMessage`) also drops bot-authored messages that miss the cache (e.g. redelivered after a restart), preventing echo loops. Dedicated-number mode behavior is unchanged.

**How it was tested:** Live on a shared-number Raspberry Pi install: before the patch, the owner's group messages produced only "Channel metadata discovered" with no routing; after, they route and get replies. Bot echo messages are confirmed still filtered (no loops). Dedicated-mode path is untouched by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)