### PR TITLE
fix(compose): respect container.json skill selection for CLAUDE.md fragments

### DIFF
--- a/src/claude-md-compose.test.ts
+++ b/src/claude-md-compose.test.ts
@@ -15,7 +15,7 @@ vi.mock('./log.js', () => ({
 }));
 
 import { composeGroupClaudeMd } from './claude-md-compose.js';
-import { ensureContainerConfig, updateContainerConfigScalars } from './db/container-configs.js';
+import { ensureContainerConfig, updateContainerConfigJson, updateContainerConfigScalars } from './db/container-configs.js';
 import { closeDb, createAgentGroup, initTestDb, runMigrations } from './db/index.js';
 import { PERSONA_PREPEND_FILE } from './group-persona.js';
 import type { AgentGroup } from './types.js';
@@ -114,5 +114,45 @@ describe('composeGroupClaudeMd scheduling instructions (ncl tasks reach-in)', ()
     const imports = importsOf(ag.folder);
     expect(imports).not.toContain('@./.claude-fragments/module-scheduling.md');
     expect(imports).not.toContain('@./.claude-fragments/module-cli.md');
+  });
+});
+
+describe('composeGroupClaudeMd skill fragments (container.json selection)', () => {
+  // Red-on-delete guard for the enabledSkills filter at the skill-fragment
+  // loop: a group's composed CLAUDE.md carries fragments only for skills the
+  // group actually has. Uses onecli-gateway — the one trunk skill that ships
+  // an instructions.md.
+  it("imports fragment-bearing skills at the default skills:'all'", () => {
+    const ag = group('ag-skills-all', 'skills-all-group');
+    seed(ag);
+
+    composeGroupClaudeMd(ag);
+
+    expect(importsOf(ag.folder)).toContain('@./.claude-fragments/skill-onecli-gateway.md');
+  });
+
+  it('excludes fragments of skills outside an explicit selection', () => {
+    const ag = group('ag-skills-few', 'skills-few-group');
+    seed(ag);
+    updateContainerConfigJson(ag.id, 'skills', ['agent-browser']);
+
+    composeGroupClaudeMd(ag);
+
+    expect(importsOf(ag.folder)).not.toContain('@./.claude-fragments/skill-onecli-gateway.md');
+  });
+
+  it('prunes a previously-composed fragment after the skill is deselected', () => {
+    const ag = group('ag-skills-prune', 'skills-prune-group');
+    seed(ag);
+
+    composeGroupClaudeMd(ag);
+    const fragPath = path.join(GROUPS_DIR, ag.folder, '.claude-fragments', 'skill-onecli-gateway.md');
+    expect(fs.lstatSync(fragPath).isSymbolicLink()).toBe(true);
+
+    updateContainerConfigJson(ag.id, 'skills', []);
+    composeGroupClaudeMd(ag);
+
+    expect(fs.existsSync(fragPath)).toBe(false);
+    expect(importsOf(ag.folder)).not.toContain('@./.claude-fragments/skill-onecli-gateway.md');
   });
 });

--- a/src/claude-md-compose.ts
+++ b/src/claude-md-compose.ts
@@ -18,6 +18,7 @@ import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
 import type { McpServerConfig } from './container-config.js';
+import { selectedSkillNames } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { readGroupPersona } from './group-persona.js';
 import type { AgentGroup } from './types.js';
@@ -64,11 +65,19 @@ export function composeGroupClaudeMd(group: AgentGroup): void {
     : {};
   const desired = new Map<string, { type: 'symlink' | 'inline'; content: string }>();
 
-  // Skill fragments — every skill that ships an `instructions.md`.
-  // TODO (shared-source refactor): respect `container.json` skill selection.
+  // Skill fragments — only for skills selected in `container.json` ('all' or
+  // an explicit list; resolved by selectedSkillNames, the same helper the
+  // runner uses for `.claude/skills/` symlinks, so both surfaces honor one
+  // selection). A selected skill only contributes a fragment if it ships an
+  // `instructions.md`. The DB default is 'all', so groups without an explicit
+  // list keep today's behavior.
   const skillsHostDir = path.join(process.cwd(), 'container', 'skills');
+  const enabledSkills = new Set(
+    selectedSkillNames({ skills: configRow ? (JSON.parse(configRow.skills) as string[] | 'all') : 'all' }),
+  );
   if (fs.existsSync(skillsHostDir)) {
     for (const skillName of fs.readdirSync(skillsHostDir)) {
+      if (!enabledSkills.has(skillName)) continue;
       const hostFragment = path.join(skillsHostDir, skillName, 'instructions.md');
       if (fs.existsSync(hostFragment)) {
         desired.set(`skill-${skillName}.md`, {

--- a/src/container-config.ts
+++ b/src/container-config.ts
@@ -58,6 +58,26 @@ export function resolveGroupTimezone(agentGroupId: string): string {
   return tz && isValidTimezone(tz) ? tz : TIMEZONE;
 }
 
+/**
+ * Resolve a group's skill selection to concrete names — `'all'` recomputes
+ * from `container/skills/` so newly-added upstream skills appear automatically.
+ * Shared by container-runner.ts (skill symlinks) and claude-md-compose.ts
+ * (skill instructions.md fragments) so both surfaces honor one selection.
+ */
+export function selectedSkillNames(containerConfig: Pick<ContainerConfig, 'skills'>): string[] {
+  if (containerConfig.skills !== 'all') return containerConfig.skills;
+  const sharedSkillsDir = path.join(process.cwd(), 'container', 'skills');
+  return fs.existsSync(sharedSkillsDir)
+    ? fs.readdirSync(sharedSkillsDir).filter((e) => {
+        try {
+          return fs.statSync(path.join(sharedSkillsDir, e)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+    : [];
+}
+
 /** Build a `ContainerConfig` from a DB row + agent group identity. */
 export function configFromDb(row: ContainerConfigRow, group: AgentGroup): ContainerConfig {
   return {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -23,7 +23,7 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
-import { materializeContainerJson } from './container-config.js';
+import { materializeContainerJson, selectedSkillNames } from './container-config.js';
 import { getContainerConfig } from './db/container-configs.js';
 import { updateContainerConfigScalars } from './db/container-configs.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
@@ -435,24 +435,6 @@ function syncSkillSymlinks(claudeDir: string, containerConfig: import('./contain
       );
     }
   }
-}
-
-/**
- * Resolve the group's skill selection to concrete names — `'all'` recomputes
- * from `container/skills/` so newly-added upstream skills appear automatically.
- */
-function selectedSkillNames(containerConfig: import('./container-config.js').ContainerConfig): string[] {
-  if (containerConfig.skills !== 'all') return containerConfig.skills;
-  const sharedSkillsDir = path.join(process.cwd(), 'container', 'skills');
-  return fs.existsSync(sharedSkillsDir)
-    ? fs.readdirSync(sharedSkillsDir).filter((e) => {
-        try {
-          return fs.statSync(path.join(sharedSkillsDir, e)).isDirectory();
-        } catch {
-          return false;
-        }
-      })
-    : [];
 }
 
 async function buildContainerArgs(


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** `composeGroupClaudeMd` now honors the `container.json` skills selection when adding `skill-<name>.md` fragments, closing the `TODO (shared-source refactor): respect container.json skill selection` at the skill-fragment loop.

**Why:** a group configured with an explicit skills list still received a fragment for *every* skill in `container/skills/` that ships an `instructions.md` — paying system-prompt context for skills it doesn't have. Worse, the two skill surfaces disagreed: `.claude/skills/` symlinks (container-runner) respected the selection while the composed CLAUDE.md described skills the group couldn't use.

**How it works:** `selectedSkillNames` moves from `container-runner.ts` to `container-config.ts` and is shared by both consumers, so the symlink surface and the fragment surface resolve one selection. The DB default is `'all'`, so groups without an explicit list keep today's behavior — no migration needed.

**How it was tested:** new red-on-delete test block in `claude-md-compose.test.ts` (fragment present at `skills:'all'`, absent outside an explicit selection, pruned on recompose after deselection) plus existing compose/runner/config suites — 27/27 green; `tsc --noEmit` clean on touched files. Also verified live on a 7-group install: after the fix, per-group fragments match each group's explicit list exactly (checked on freshly spawned containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
