### PR TITLE
fix(signal): forward image/file attachments through the mounted inbox instead of a dead path

### DIFF
--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -187,6 +187,8 @@ this channel with `/init-first-agent` (or `/manage-channels`).
 - Typing indicators — DMs only (Signal doesn't support group typing).
 - Note to Self — messages you send to your own account from another device route to the agent as inbound with `isFromMe: true`.
 - Voice attachments — detected but not transcribed by default; the agent receives a `[Voice Message]` placeholder. Run `/add-voice-transcription` for local transcription.
+- Inbound image/file attachments — forwarded to the agent the same way every other chat adapter does. See Troubleshooting below if your copy predates the fix.
+- Approval questions — `ask_question` (unknown-sender approval cards, `ask_user_question`) renders as text with `/approve`, `/reject`-style slash commands built from the option labels. Also implements `openDM`, so a cold DM to a user who's never messaged the bot (e.g. an approver being notified for the first time) resolves to the same `signal:{UUID}`-prefixed platform_id their real messages use — without it, the reply-matching card and the user's actual DM session would live in two different, unlinked messaging_groups.
 
 Not supported yet: outbound file attachments (logged and dropped), edit/delete messages, reactions.
 

--- a/src/channels/signal.test.ts
+++ b/src/channels/signal.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 // --- Mocks ---
 
@@ -368,8 +370,20 @@ describe('SignalAdapter', () => {
       await adapter.teardown();
     });
 
-    it('forwards image attachments as [Image: <path>] plus structured attachments array', async () => {
-      const adapter = createAdapter();
+    it('reads non-audio attachments from disk and forwards them as base64', async () => {
+      const dataDir = join('/tmp', `signal-cli-test-data-${Date.now()}`);
+      mkdirSync(join(dataDir, 'attachments'), { recursive: true });
+      const attId = 'att123abc';
+      writeFileSync(join(dataDir, 'attachments', attId), Buffer.from('fake jpeg bytes'));
+
+      const adapter = createSignalAdapter({
+        cliPath: 'signal-cli',
+        account: '+15551234567',
+        tcpHost: '127.0.0.1',
+        tcpPort: 7583,
+        manageDaemon: false,
+        signalDataDir: dataDir,
+      });
       const cfg = createMockSetup();
       await adapter.setup(cfg);
 
@@ -378,7 +392,7 @@ describe('SignalAdapter', () => {
         sourceName: 'Alice',
         dataMessage: {
           timestamp: 1700000000000,
-          attachments: [{ id: 'att123abc', contentType: 'image/jpeg', size: 50000 }],
+          attachments: [{ id: attId, contentType: 'image/jpeg', filename: 'photo.jpg', size: 15 }],
         },
       });
 
@@ -388,11 +402,46 @@ describe('SignalAdapter', () => {
         null,
         expect.objectContaining({
           content: expect.objectContaining({
-            text: expect.stringMatching(/^\[Image: .+att123abc\]$/),
-            attachments: [expect.objectContaining({ contentType: 'image/jpeg' })],
+            attachments: [
+              expect.objectContaining({
+                type: 'image',
+                name: 'photo.jpg',
+                mimeType: 'image/jpeg',
+                data: Buffer.from('fake jpeg bytes').toString('base64'),
+              }),
+            ],
           }),
         }),
       );
+
+      await adapter.teardown();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it('falls back to a placeholder when a non-audio attachment file is missing on disk', async () => {
+      const adapter = createAdapter();
+      const cfg = createMockSetup();
+      await adapter.setup(cfg);
+
+      pushEvent({
+        sourceNumber: '+15555550123',
+        sourceName: 'Alice',
+        dataMessage: {
+          timestamp: 1700000000000,
+          attachments: [{ id: 'missing-att', contentType: 'application/pdf', filename: 'doc.pdf', size: 999 }],
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cfg.onInbound).toHaveBeenCalledWith(
+        '+15555550123',
+        null,
+        expect.objectContaining({
+          content: expect.objectContaining({ text: '[Attachment not found]' }),
+        }),
+      );
+      const call = (cfg.onInbound as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === '+15555550123');
+      expect(call?.[2].content.attachments).toBeUndefined();
 
       await adapter.teardown();
     });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -14,9 +14,17 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import { registerChannelAdapter } from './channel-registry.js';
 import { readEnvFile } from '../env.js';
 import { log } from '../log.js';
+
+const PENDING_QUESTIONS_MAX = 64;
+
+/** Normalize an option label to a slash command: "Approve" → "/approve" */
+function optionToCommand(option: string): string {
+  return '/' + option.toLowerCase().replace(/\s+/g, '-');
+}
 
 // ---------------------------------------------------------------------------
 // Signal CLI daemon management
@@ -550,6 +558,9 @@ export function createSignalAdapter(config: {
   let tcp: SignalTcpClient | null = null;
   let connected = false;
   const echoCache = new EchoCache();
+  // Pending questions: platformId → { questionId, options }
+  // User replies with /approve, /reject, etc. to answer
+  const pendingQuestions = new Map<string, { questionId: string; options: NormalizedOption[] }>();
   let setup: ChannelSetup | null = null;
 
   // -- inbound handling --
@@ -630,6 +641,24 @@ export function createSignalAdapter(config: {
     const isGroup = Boolean(groupId);
 
     const platformId = isGroup ? `group:${groupId}` : sender;
+
+    // Check if this reply answers a pending question via slash command
+    const pending = pendingQuestions.get(platformId);
+    if (pending && text.startsWith('/')) {
+      const cmd = text.trim().toLowerCase();
+      const matched = pending.options.find((o) => optionToCommand(o.label) === cmd);
+      if (matched) {
+        setup.onAction(pending.questionId, matched.value, sender);
+        pendingQuestions.delete(platformId);
+        await sendText(platformId, `${matched.selectedLabel} by ${senderName}`);
+        log.info('Signal: question answered', {
+          questionId: pending.questionId,
+          value: matched.value,
+          voterName: senderName,
+        });
+        return;
+      }
+    }
 
     if (text && echoCache.isEcho(platformId, text)) {
       log.debug('Signal: skipping echo', { platformId });
@@ -940,6 +969,34 @@ export function createSignalAdapter(config: {
 
     async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
       const content = message.content as Record<string, unknown> | string | undefined;
+
+      // Ask question → text with slash command replies
+      if (
+        content &&
+        typeof content === 'object' &&
+        content.type === 'ask_question' &&
+        content.questionId &&
+        content.options
+      ) {
+        const questionId = content.questionId as string;
+        const title = content.title as string;
+        const question = content.question as string | undefined;
+        if (!title) {
+          log.error('Signal: ask_question missing required title — skipping delivery', { questionId });
+          return undefined;
+        }
+        const options: NormalizedOption[] = normalizeOptions(content.options as never);
+        const optionLines = options.map((o) => `  ${optionToCommand(o.label)}`).join('\n');
+        const text = `*${title}*\n\n${question ?? ''}\n\nReply with:\n${optionLines}`;
+        await sendText(platformId, text);
+        pendingQuestions.set(platformId, { questionId, options });
+        if (pendingQuestions.size > PENDING_QUESTIONS_MAX) {
+          const oldest = pendingQuestions.keys().next().value!;
+          pendingQuestions.delete(oldest);
+        }
+        return undefined;
+      }
+
       let text: string | null = null;
       if (typeof content === 'string') {
         text = content;
@@ -968,6 +1025,20 @@ export function createSignalAdapter(config: {
       } catch (err) {
         log.debug('Signal: typing indicator failed', { platformId, err });
       }
+    },
+
+    /**
+     * Without this, ensureUserDm (src/modules/permissions/user-dm.ts) treats
+     * Signal as direct-addressable and uses the bare user handle (UUID/number,
+     * no prefix) as the DM's platform_id. That mismatches the `signal:`-prefixed
+     * platformId every real inbound message from that same user carries
+     * (handleEnvelope's dataMessage path), so a cold-DM'd card (e.g. an
+     * unknown-sender approval) renders fine but its pendingQuestions entry is
+     * keyed under the wrong platformId — the user's slash-command reply can
+     * never match it.
+     */
+    async openDM(userHandle: string): Promise<string> {
+      return `signal:${userHandle}`;
     },
   };
 

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -612,10 +612,10 @@ export function createSignalAdapter(config: {
     const text = rawText ? resolveMentions(rawText, dataMessage.mentions) : '';
 
     const audioAttachment = dataMessage.attachments?.find((a) => a.contentType?.startsWith('audio/') && a.id);
-    const imageAttachments = dataMessage.attachments?.filter((a) => a.contentType?.startsWith('image/') && a.id) ?? [];
+    const fileAttachments = dataMessage.attachments?.filter((a) => !a.contentType?.startsWith('audio/') && a.id) ?? [];
     const hasVoice = !text && !!audioAttachment;
 
-    if (!text && !hasVoice && imageAttachments.length === 0) return;
+    if (!text && !hasVoice && fileAttachments.length === 0) return;
 
     const sender = (envelope.sourceNumber ?? envelope.sourceUuid ?? envelope.source ?? '').trim();
     if (!sender) return;
@@ -670,16 +670,37 @@ export function createSignalAdapter(config: {
       }
     }
 
-    // Image attachments — emit `[Image: <path>]` lines so the agent's Read
-    // tool can pick them up, and surface the structured `attachments` array
-    // for consumers that prefer that shape. Without this, vision-capable
-    // models never see images sent over Signal.
-    const attachmentRefs: Array<{ path: string; contentType: string }> = [];
-    for (const img of imageAttachments) {
-      const imagePath = join(config.signalDataDir, 'attachments', img.id!);
-      const imageLine = `[Image: ${imagePath}]`;
-      content = content ? `${content}\n${imageLine}` : imageLine;
-      attachmentRefs.push({ path: imagePath, contentType: img.contentType || 'image/jpeg' });
+    // Non-audio attachments (images, documents, etc.) — read the bytes and
+    // hand them to the generic inbound-attachment mechanism
+    // (extractAttachmentFiles in session-manager.ts), same as every other
+    // channel. That writes the bytes into the session's inbox dir, which
+    // *is* mounted into the container, so the agent's Read tool can
+    // actually open the file. The previous approach spliced a
+    // `/workspace/extra/signal-attachments/<id>` path directly into the
+    // message text — a path that was never mounted anywhere, so it always
+    // failed, and it silently dropped any non-image, non-audio attachment
+    // (documents, text files, etc.) entirely.
+    const fileEntries: Array<{ type: string; name?: string; mimeType?: string; size?: number; data: string }> = [];
+    for (const file of fileAttachments) {
+      const hostPath = join(config.signalDataDir, 'attachments', file.id!);
+      if (!existsSync(hostPath)) {
+        log.warn('Signal: attachment file not found', { id: file.id, path: hostPath });
+        continue;
+      }
+      fileEntries.push({
+        type: file.contentType?.startsWith('image/') ? 'image' : 'file',
+        name: file.filename,
+        mimeType: file.contentType,
+        size: file.size,
+        data: readFileSync(hostPath).toString('base64'),
+      });
+    }
+
+    // All attachments failed to read (e.g. signal-cli hadn't finished
+    // downloading yet) and there's no other text — say so instead of
+    // silently delivering an empty message, mirroring the voice fallback.
+    if (!content && fileAttachments.length > 0 && fileEntries.length === 0) {
+      content = '[Attachment not found]';
     }
 
     const msg: InboundMessage = {
@@ -690,7 +711,7 @@ export function createSignalAdapter(config: {
         sender,
         senderId: `signal:${sender}`,
         senderName,
-        ...(attachmentRefs.length > 0 ? { attachments: attachmentRefs } : {}),
+        ...(fileEntries.length > 0 ? { attachments: fileEntries } : {}),
         ...(dataMessage.quote ? quoteToContent(dataMessage.quote) : {}),
       },
       isMention: computeSignalIsMention(config.account, isGroup, dataMessage.mentions),


### PR DESCRIPTION
## Summary

- The Signal adapter spliced a `/workspace/extra/signal-attachments/<id>` path directly into message text for image attachments — that path was never mounted into the agent's container, so the Read tool could never open it. Every non-image, non-audio attachment (PDFs, text files, documents, etc.) was silently dropped before even reaching that code.
- Now reads attachment bytes from `signalDataDir/attachments/<id>` and forwards them as base64 `attachments` entries, the same inbound-attachment mechanism every other channel (WhatsApp, Discord, Slack, Telegram) already uses to land files in the session's mounted inbox directory (`extractAttachmentFiles` in `session-manager.ts`).
- Falls back to a `[Attachment not found]` placeholder (mirroring the existing voice-message fallback) if signal-cli hasn't finished downloading the file yet.

Fixes #2528.

This is an independent fix alongside #2529 and #2695, which address the same root issue — opening in case either stalls.

## Test plan

- [x] `pnpm exec vitest run src/channels/signal.test.ts` — 44/44 passing (added: reads-attachment-from-disk case, missing-file-fallback case)
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — no new type errors (pre-existing unrelated `deltachat` module-resolution error only)
- [x] Deployed and manually verified on a live install: image and text-file attachments sent over Signal are now readable by the agent