### PR TITLE
feat(webhook): configurable bind address via WEBHOOK_HOST

### DIFF
--- a/src/webhook-server.test.ts
+++ b/src/webhook-server.test.ts
@@ -103,4 +103,19 @@ describe('registerWebhookAdapter — route/handler split', () => {
     const res = await post('/webhook/nope', 'x');
     expect(res.status).toBe(404);
   });
+
+  it('WEBHOOK_HOST restricts the bind address; loopback still serves', async () => {
+    process.env.WEBHOOK_HOST = '127.0.0.1';
+    try {
+      const { chat, calls } = stubChat('loopback');
+      registerWebhookAdapter(chat, 'slack');
+
+      const res = await post('/webhook/slack', 'payload-loopback');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ via: 'loopback' });
+      expect(calls).toEqual(['payload-loopback']);
+    } finally {
+      delete process.env.WEBHOOK_HOST;
+    }
+  });
 });

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -17,6 +17,7 @@ import type { Chat } from 'chat';
 import { log } from './log.js';
 
 const DEFAULT_PORT = 3000;
+const DEFAULT_HOST = '0.0.0.0';
 
 interface WebhookEntry {
   chat: Chat;
@@ -111,6 +112,7 @@ function ensureServer(): void {
   if (server) return;
 
   const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
+  const host = process.env.WEBHOOK_HOST || DEFAULT_HOST;
 
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';
@@ -159,8 +161,8 @@ function ensureServer(): void {
     }
   });
 
-  server.listen(port, '0.0.0.0', () => {
-    log.info('Webhook server started', { port, adapters: [...routes.keys()] });
+  server.listen(port, host, () => {
+    log.info('Webhook server started', { host, port, adapters: [...routes.keys()] });
   });
 }
 


### PR DESCRIPTION
## What

Adds a `WEBHOOK_HOST` environment variable to the webhook server.  Default remains `0.0.0.0`, so existing deployments are byte-for-byte unaffected.

## Why

`webhook-server.ts` hardcodes `server.listen(port, '0.0.0.0')`, so the server is exposed on every interface even for deployments that receive no direct webhooks — e.g. Telegram via long-polling against a local bot-api server, or setups that front the webhook port with a reverse proxy / tunnel.  Operators who want to bind to loopback (or one specific interface) currently cannot.

## Changes

- `src/webhook-server.ts`: read `WEBHOOK_HOST` (default `0.0.0.0`), pass to `listen()`, include `host` in the startup log line (+4/-2)
- `src/webhook-server.test.ts`: one new test following the file's existing real-server/fixed-port conventions — sets `WEBHOOK_HOST=127.0.0.1`, asserts the server still serves on loopback, restores env in `finally`

## Verification

- `vitest run src/webhook-server.test.ts`: **5 passed** (4 existing + 1 new); startup logs show `host="0.0.0.0"` for the default-path tests and `host="127.0.0.1"` for the new one
- `tsc --noEmit`: clean
- `eslint` on both files: 0 errors, 1 pre-existing warning (`no-catch-all` at webhook-server.ts:155, present on main)
- `prettier --check` on both files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)