### PR TITLE
fix(db): backfill destinations for existing wirings

### DIFF
--- a/docs/db-central.md
+++ b/docs/db-central.md
@@ -434,6 +434,7 @@ Several early migrations were later renamed/retired and replaced by "module" fil
 | 19 | `wiring-threads-override` | `019-wiring-threads.ts` | `messaging_group_agents.threads` — per-wiring thread-policy override (NULL = adapter default) |
 | 20 | `container-config-timezone` | `020-container-config-timezone.ts` | `container_configs.timezone` — per-agent-group timezone override (NULL = install-global) |
 | 21 | `approval-question-render-metadata` | `021-approval-question.ts` | `question` card-body column on all three approval tables so terminal edits retain the original request |
+| 22 | `backfill-wiring-destinations` | `022-backfill-wiring-destinations.ts` | Missing `agent_destinations` channel rows for wirings created after migration 4 ran; preserves existing destination names |
 
 Numbers 5 and 6 are intentionally absent — migrations were renumbered during early development.
 

--- a/src/db/migrations/022-backfill-wiring-destinations.test.ts
+++ b/src/db/migrations/022-backfill-wiring-destinations.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AgentDestination } from '../../types.js';
+import { createAgentGroup } from '../agent-groups.js';
+import { closeDb, getDb, initTestDb } from '../connection.js';
+import { createMessagingGroup } from '../messaging-groups.js';
+import { migration022 } from './022-backfill-wiring-destinations.js';
+import { migrations, runMigrations } from './index.js';
+
+const CREATED_AT = '2026-04-12T10:00:00.000Z';
+const legacyMigrations = migrations.filter((migration) => migration.name !== migration022.name);
+
+function seedAgent(id: string): void {
+  createAgentGroup({
+    id,
+    name: id,
+    folder: id,
+    agent_provider: null,
+    created_at: CREATED_AT,
+  });
+}
+
+function seedMessagingGroup(id: string, name: string | null): void {
+  createMessagingGroup({
+    id,
+    channel_type: 'whatsapp',
+    platform_id: `chat-${id}`,
+    name,
+    is_group: 1,
+    unknown_sender_policy: 'strict',
+    created_at: CREATED_AT,
+  });
+}
+
+function seedLegacyWiring(id: string, messagingGroupId: string, agentGroupId = 'agent-main'): void {
+  getDb()
+    .prepare(
+      `INSERT INTO messaging_group_agents (
+         id, messaging_group_id, agent_group_id,
+         engage_mode, engage_pattern, sender_scope, ignored_message_policy,
+         session_mode, priority, created_at
+       )
+       VALUES (?, ?, ?, 'pattern', '.', 'all', 'drop', 'shared', 0, ?)`,
+    )
+    .run(id, messagingGroupId, agentGroupId, CREATED_AT);
+}
+
+function destinations(): AgentDestination[] {
+  return getDb()
+    .prepare(
+      `SELECT agent_group_id, local_name, target_type, target_id, created_at
+       FROM agent_destinations
+       ORDER BY local_name`,
+    )
+    .all() as AgentDestination[];
+}
+
+describe('migration 022 — backfill wiring destinations', () => {
+  beforeEach(() => {
+    const db = initTestDb();
+    runMigrations(db, legacyMigrations);
+    seedAgent('agent-main');
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('backfills a destination for a wiring created after migration 004 ran', () => {
+    seedMessagingGroup('mg-family', 'Family Chat');
+    seedLegacyWiring('wiring-family', 'mg-family');
+    expect(destinations()).toEqual([]);
+
+    runMigrations(getDb());
+
+    expect(destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'channel',
+        target_id: 'mg-family',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+
+  it('preserves existing targets and avoids local-name collisions', () => {
+    seedAgent('agent-peer');
+    seedMessagingGroup('mg-existing', 'Family Chat');
+    seedMessagingGroup('mg-missing', 'Family Chat');
+    seedLegacyWiring('wiring-existing', 'mg-existing');
+    seedLegacyWiring('wiring-missing', 'mg-missing');
+
+    const db = getDb();
+    const insert = db.prepare(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insert.run('agent-main', 'custom-chat', 'channel', 'mg-existing', CREATED_AT);
+    insert.run('agent-main', 'family-chat', 'agent', 'agent-peer', CREATED_AT);
+
+    runMigrations(db);
+    migration022.up(db);
+
+    expect(destinations()).toEqual([
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'custom-chat',
+        target_type: 'channel',
+        target_id: 'mg-existing',
+        created_at: CREATED_AT,
+      },
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat',
+        target_type: 'agent',
+        target_id: 'agent-peer',
+        created_at: CREATED_AT,
+      },
+      {
+        agent_group_id: 'agent-main',
+        local_name: 'family-chat-2',
+        target_type: 'channel',
+        target_id: 'mg-missing',
+        created_at: CREATED_AT,
+      },
+    ]);
+  });
+});

--- a/src/db/migrations/022-backfill-wiring-destinations.ts
+++ b/src/db/migrations/022-backfill-wiring-destinations.ts
@@ -1,0 +1,82 @@
+import type Database from 'better-sqlite3';
+
+import type { Migration } from './index.js';
+
+/**
+ * Repair wirings created after `agent-destinations` had already run but
+ * before every wiring-creation path provisioned its companion destination.
+ *
+ * Existing destinations are authoritative: keep their local names and only
+ * add a channel destination when the wiring's target has none.
+ */
+export const migration022: Migration = {
+  version: 22,
+  name: 'backfill-wiring-destinations',
+  up(db: Database.Database) {
+    const takenByAgent = new Map<string, Set<string>>();
+    const existingNames = db.prepare('SELECT agent_group_id, local_name FROM agent_destinations').all() as Array<{
+      agent_group_id: string;
+      local_name: string;
+    }>;
+
+    for (const row of existingNames) {
+      const taken = takenByAgent.get(row.agent_group_id) ?? new Set<string>();
+      taken.add(row.local_name);
+      takenByAgent.set(row.agent_group_id, taken);
+    }
+
+    const missing = db
+      .prepare(
+        `SELECT
+           mga.agent_group_id,
+           mga.messaging_group_id,
+           mga.created_at,
+           mg.channel_type,
+           mg.name
+         FROM messaging_group_agents mga
+         JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+         LEFT JOIN agent_destinations ad
+           ON ad.agent_group_id = mga.agent_group_id
+          AND ad.target_type = 'channel'
+          AND ad.target_id = mga.messaging_group_id
+         WHERE ad.agent_group_id IS NULL
+         ORDER BY mga.agent_group_id, mga.created_at, mga.id`,
+      )
+      .all() as Array<{
+      agent_group_id: string;
+      messaging_group_id: string;
+      created_at: string;
+      channel_type: string;
+      name: string | null;
+    }>;
+
+    const insert = db.prepare(
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
+       VALUES (?, ?, 'channel', ?, ?)`,
+    );
+
+    for (const row of missing) {
+      const base = normalizeName(row.name || `${row.channel_type}-${row.messaging_group_id.slice(0, 8)}`);
+      const taken = takenByAgent.get(row.agent_group_id) ?? new Set<string>();
+      let localName = base;
+      let suffix = 2;
+      while (taken.has(localName)) {
+        localName = `${base}-${suffix}`;
+        suffix++;
+      }
+
+      insert.run(row.agent_group_id, localName, row.messaging_group_id, row.created_at);
+      taken.add(localName);
+      takenByAgent.set(row.agent_group_id, taken);
+    }
+  },
+};
+
+function normalizeName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'unnamed'
+  );
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -20,6 +20,7 @@ import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
 import { migration020 } from './020-container-config-timezone.js';
 import { migration021 } from './021-approval-question.js';
+import { migration022 } from './022-backfill-wiring-destinations.js';
 
 export interface Migration {
   version: number;
@@ -56,6 +57,7 @@ export const migrations: Migration[] = [
   migration019,
   migration020,
   migration021,
+  migration022,
 ];
 
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Adds migration 021 to provision missing channel destinations for existing messaging-group wirings. The migration preserves every existing destination and custom local name, skips wirings that already have a destination for their channel, and resolves local-name collisions within each agent group.

This repairs installs where the original agent-destinations migration had already run before affected wirings were created. Those wirings could receive messages, but explicit-destination replies were dropped because their own chat was absent from the agent's destination map.

Closes #3140

## Testing

- vitest run — 96 test files, 1165 tests passed
- tsc --noEmit
- ESLint on all changed TypeScript files
- Prettier check on src/**/*.ts
- git diff --check
