### PR TITLE
scripts: repair two dev scripts that rotted against the current architecture

### DIFF
--- a/scripts/sanity-live-poll.ts
+++ b/scripts/sanity-live-poll.ts
@@ -22,13 +22,28 @@
  * Keep this around. It ran for ~20 minutes once to map the failure modes
  * and it takes about 60s to run — cheap insurance.
  *
- * Requires: Docker Desktop running, nanoclaw-agent:latest image built.
+ * Requires: Docker Desktop running, and this install's agent image built
+ * (`./container/build.sh`).
+ *
+ * Two runtimes on purpose. The host half uses better-sqlite3 because the host
+ * is Node; the container half uses `bun:sqlite` because the agent-runner is
+ * Bun and the image carries no better-sqlite3 at all. Reaching for one library
+ * on both sides is what made this script stop running.
  */
 
 import { spawn, spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { mkdirSync, rmSync } from "node:fs";
 import Database from "better-sqlite3";
+
+import { getDefaultContainerImage } from "../src/install-slug.js";
+
+// Never hardcode the tag. Images are per-install (`nanoclaw-agent-v2-<slug>`),
+// so a literal `nanoclaw-agent:latest` is absent on a clean machine — and on a
+// machine that once ran an older NanoClaw it silently resolves to that stale
+// image, which is worse: a cross-mount regression test passing against bytes
+// nobody runs.
+const IMAGE = getDefaultContainerImage();
 
 const dbDir = join("/tmp", `nanoclaw-live-${Date.now()}`);
 mkdirSync(dbDir, { recursive: true });
@@ -48,17 +63,25 @@ for (const journalMode of ["DELETE", "WAL"]) {
   db.exec("CREATE TABLE msgs (seq INTEGER PRIMARY KEY, content TEXT)");
   db.close();
 
-  // Start container poller in background
+  // Start container poller in background. `bun`, not `node`: this has to be the
+  // same sqlite the agent-runner actually uses, or the script stops testing the
+  // thing it exists to test.
   const contProc = spawn("docker", [
     "run", "--rm", "-w", "/app",
     "-v", `${dbDir}:/workspace`,
-    "--entrypoint", "node",
-    "nanoclaw-agent:latest",
+    "--entrypoint", "bun",
+    IMAGE,
     "-e",
-    `const Database = require('better-sqlite3');
+    // bun:sqlite rather than better-sqlite3, and `db.run` for the pragma since
+    // bun:sqlite has no `.pragma()`. The statement is prepared once and reused
+    // across polls, exactly as before: a reused bun:sqlite statement re-executes
+    // and sees writes committed after it was prepared (verified — if it cached,
+    // this script would report a visibility failure that was really an artifact
+    // of its own probe).
+    `const { Database } = require('bun:sqlite');
      const db = new Database('/workspace/live.db', { readonly: true });
-     db.pragma('busy_timeout = 2000');
-     const stmt = db.prepare('SELECT COUNT(*) as n, MAX(seq) as hi FROM msgs');
+     db.run('PRAGMA busy_timeout = 2000');
+     const stmt = db.query('SELECT COUNT(*) as n, MAX(seq) as hi FROM msgs');
      let count = 0;
      const timer = setInterval(() => {
        const r = stmt.get();

--- a/scripts/test-v2-host.ts
+++ b/scripts/test-v2-host.ts
@@ -22,6 +22,7 @@ console.log('\n=== Step 1: Init central DB ===');
 import { initDb } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup } from '../src/db/agent-groups.js';
+import { ensureContainerConfig } from '../src/db/container-configs.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../src/db/messaging-groups.js';
 
 const centralDb = initDb(path.join(TEST_DIR, 'v2.db'));
@@ -40,6 +41,14 @@ createAgentGroup({
   agent_provider: 'claude',
   created_at: new Date().toISOString(),
 });
+
+// Container runtime config lives in its own table, and the spawn path requires
+// a row: `materializeContainerJson` throws rather than inventing defaults. Every
+// real creation path pairs these two calls — `group-init.ts`, `ncl groups
+// create`, `init-first-agent.ts`, `setup/register.ts` — and this script has to
+// as well now that it no longer goes through any of them. INSERT OR IGNORE, so
+// re-running is safe.
+ensureContainerConfig('ag-e2e', 'claude');
 
 createMessagingGroup({
   id: 'mg-e2e',


### PR DESCRIPTION
Two dev scripts had drifted from the architecture around them. Both are the same
shape: a script that predates a migration the rest of the tree completed, and
that nothing runs often enough to have caught it.

### `scripts/test-v2-host.ts`

Dies before it can spawn a container:

```
Container config not found for agent group: ag-e2e
```

It creates its agent group with `createAgentGroup` alone, but container runtime
config lives in its own table now and the spawn path requires a row —
`materializeContainerJson` throws rather than inventing defaults. Every real
creation path pairs the two calls (`group-init`, `ncl groups create`,
`init-first-agent`, `setup/register`); this script goes through none of them, so
it has to pair them itself.

Passing `claude` correctly stores `NULL` — that is how the built-in default is
represented, per `ensureContainerConfig`.

### `scripts/sanity-live-poll.ts`

Two faults, and the quieter one is worse.

**It cannot start.** The container-side probe runs `node` with
`require('better-sqlite3')`. The agent-runner moved to `bun:sqlite` and the image
carries no better-sqlite3 at all. Ported to `bun` + `bun:sqlite`, which is what
the runner actually uses — testing the real runtime is the point of the script.

A reused `bun:sqlite` statement re-executes and sees writes committed after it
was prepared. Checked rather than assumed: had it cached, this script would
report a visibility failure that was really an artefact of its own probe.

**It hardcodes `nanoclaw-agent:latest`.** Images are per-install
(`nanoclaw-agent-v2-<slug>`), so that tag is absent on a clean machine — and on a
machine that once ran an older NanoClaw it silently resolves to that stale image.
On the machine this was found on, it resolved to one built three months earlier.
A cross-mount regression test passing against bytes nobody runs is worse than one
that fails outright. Now resolved through `getDefaultContainerImage()`.

### Verification

Ran the repaired script end to end. In `DELETE` mode the container reader sees
each of the eight host writes within one poll; in `WAL` mode it sees none of
them:

```
=== DELETE ===
  [host] wrote+closed seq=1        poll count=1 max=1
  ...                              poll count=8 max=8

=== WAL ===
  [host] wrote+closed seq=1..8     poll count=0 max=null   (all ten polls)
```

That is exactly the invariant the script exists to guard — `journal_mode=DELETE`
is load-bearing for cross-mount visibility — and it still holds.

`test-v2-host.ts` was verified against the specific failure: the error above
before `ensureContainerConfig`, a materialized config after.

Typecheck clean, full suite green (1163 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
