### PR TITLE
fix(agent-runner): keep destination reply context local

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -209,6 +209,7 @@ describe('poll loop integration', () => {
     expect(out).toHaveLength(1);
     expect(out[0].platform_id).toBe('chan-new');
     expect(out[0].thread_id).toBeNull();
+    expect(out[0].in_reply_to).toBeNull();
 
     await loopPromise.catch(() => {});
   });

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -768,7 +768,7 @@ function sendToDestination(dest: DestinationEntry, body: string, routing: Routin
   const destRouting = resolveDestinationThread(channelType, platformId);
   writeMessageOut({
     id: generateId(),
-    in_reply_to: destRouting?.inReplyTo ?? routing.inReplyTo,
+    in_reply_to: destRouting?.inReplyTo ?? null,
     kind: 'chat',
     platform_id: platformId,
     channel_type: channelType,


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** Leave `in_reply_to` empty when an explicit destination has no inbound history, matching the existing `thread_id` behavior.

**Why:** Falling back to the waking batch's reply ID attaches a foreign conversation context to the outbound row. Downstream a2a routing can then discard an otherwise correctly addressed message while the send path reports success.

**How it works:** `sendToDestination` now uses only the destination-specific lookup for `in_reply_to`; the existing integration case for a destination with no inbound rows asserts both routing fields are null.

Closes #3136

## Test plan

- RED: `bun test src/integration.test.ts` failed because the new assertion received `"m1"` instead of `null`.
- GREEN: `bun test` — 154 passed, 1 intentionally skipped, 0 failed.
- `bun run typecheck`
- `git diff --check`

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
