### PR TITLE
fix: honor WEBHOOK_PORT from .env

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./env.js', () => ({
+  readEnvFile: (keys: string[]) => (keys.includes('WEBHOOK_PORT') ? { WEBHOOK_PORT: '3918' } : {}),
+}));
+
+const originalWebhookPort = process.env.WEBHOOK_PORT;
+
+afterEach(() => {
+  if (originalWebhookPort === undefined) delete process.env.WEBHOOK_PORT;
+  else process.env.WEBHOOK_PORT = originalWebhookPort;
+  vi.resetModules();
+});
+
+describe('webhook port config', () => {
+  it('reads WEBHOOK_PORT from .env config', async () => {
+    delete process.env.WEBHOOK_PORT;
+    const { getWebhookPort } = await import('./config.js');
+
+    expect(getWebhookPort()).toBe(3918);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const envConfig = readEnvFile([
   'ASSISTANT_HAS_OWN_NUMBER',
   'ONECLI_URL',
   'ONECLI_API_KEY',
+  'WEBHOOK_PORT',
   'TZ',
   'DEFAULT_AGENT_PROVIDER',
   'CONTAINER_CPU_LIMIT',
@@ -74,6 +75,9 @@ export const INSTALL_SLUG = getInstallSlug(PROJECT_ROOT);
 export const CONTAINER_INSTALL_LABEL = `nanoclaw-install=${INSTALL_SLUG}`;
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY = process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+export function getWebhookPort(): number {
+  return parseInt(process.env.WEBHOOK_PORT || envConfig.WEBHOOK_PORT || '3000', 10);
+}
 // Per-container resource caps, passed through to `docker run`. Default empty =
 // no flag added = today's unbounded behavior (don't OOM existing OSS workloads).
 // Operators opt in: CONTAINER_CPU_LIMIT=2, CONTAINER_MEMORY_LIMIT=8g.

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -14,9 +14,8 @@ import http from 'http';
 
 import type { Chat } from 'chat';
 
+import { getWebhookPort } from './config.js';
 import { log } from './log.js';
-
-const DEFAULT_PORT = 3000;
 
 interface WebhookEntry {
   chat: Chat;
@@ -110,7 +109,7 @@ export function registerWebhookHandler(path: string, handler: RawWebhookHandler)
 function ensureServer(): void {
   if (server) return;
 
-  const port = parseInt(process.env.WEBHOOK_PORT || String(DEFAULT_PORT), 10);
+  const port = getWebhookPort();
 
   server = http.createServer(async (req, res) => {
     const url = req.url || '/';


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #2901.

`WEBHOOK_PORT` now follows NanoClaw's normal configuration precedence: a real process environment variable wins, then `.env`, then port 3000. The webhook server reads the value through `config.ts`, while a focused regression test verifies that the `.env` key is requested and used.

Tested with Node 22:

- RED: `pnpm exec vitest run src/config.test.ts` failed because the config path did not expose the `.env` value.
- GREEN: `pnpm test` — 96 files and 1164 tests passed.
- `pnpm run build`, `pnpm typecheck`, `pnpm format:check`, and ESLint on the three touched files passed with zero errors.

The repository-wide `pnpm lint` command still reports 10 pre-existing errors in files outside this diff; this change adds none.
