### PR TITLE
fix(cli): add --rw flag to groups config add-mount

### DIFF
--- a/.claude/skills/add-gcal-tool/SKILL.md
+++ b/.claude/skills/add-gcal-tool/SKILL.md
@@ -168,10 +168,11 @@ This is a **host-only / operator** verb — it's rejected from inside a containe
 ncl groups config add-mount \
   --id <group-id> \
   --host "$HOME/.calendar-mcp" \
-  --container .calendar-mcp
+  --container .calendar-mcp \
+  --rw
 ```
 
-`--container` is relative (mount-security rejects absolute paths — additional mounts land at `/workspace/extra/<relative>`). No `--ro`: the MCP server may rewrite `credentials.json` on token refresh, so the mount must be read-write.
+`--container` is relative (mount-security rejects absolute paths — additional mounts land at `/workspace/extra/<relative>`). `--rw` is required: the MCP server may rewrite `credentials.json` on token refresh, so the mount must be read-write, and mounts default to read-only unless a mount explicitly asks for `--rw` (and the mount-allowlist root permits it).
 
 The mount also needs to be in the external mount allowlist (`~/.config/nanoclaw/mount-allowlist.json`) to take effect at spawn — see the Phase 1 "Verify mount allowlist covers the path" step. A container restart (`ncl groups restart`) is needed for the mount to apply.
 

--- a/.claude/skills/add-gmail-tool/SKILL.md
+++ b/.claude/skills/add-gmail-tool/SKILL.md
@@ -187,10 +187,11 @@ Register the mount with the host-only `ncl groups config add-mount` verb. For ea
 ncl groups config add-mount \
   --id <group-id> \
   --host "$HOME/.gmail-mcp" \
-  --container .gmail-mcp
+  --container .gmail-mcp \
+  --rw
 ```
 
-`--host` is the host path, `--container` is the in-container path (relative, lands at `/workspace/extra/.gmail-mcp`). No `--ro` — the MCP server writes refreshed token state back into the mount. The verb is idempotent (a re-run skips if the mount is already present) and operator-only (host-side; rejected from inside a container), so run it from a host operator shell when applying this skill.
+`--host` is the host path, `--container` is the in-container path (relative, lands at `/workspace/extra/.gmail-mcp`). `--rw` is required — the MCP server writes refreshed token state back into the mount, and mounts default to read-only unless a mount explicitly asks for `--rw` (and the mount-allowlist root permits it). The verb is idempotent (a re-run skips if the mount is already present) and operator-only (host-side; rejected from inside a container), so run it from a host operator shell when applying this skill.
 
 **Why the container path is relative:** `mount-security` rejects absolute `containerPath` values. Additional mounts are prefixed with `/workspace/extra/`, so `containerPath: ".gmail-mcp"` lands at `/workspace/extra/.gmail-mcp`. The MCP server's `GMAIL_OAUTH_PATH` / `GMAIL_CREDENTIALS_PATH` env vars point at that absolute location inside the container.
 

--- a/src/cli/resources/groups.test.ts
+++ b/src/cli/resources/groups.test.ts
@@ -258,4 +258,41 @@ describe('groups config add-mount / remove-mount (host-only)', () => {
     expect(rm.ok).toBe(true);
     expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([]);
   });
+
+  it('adds a read-write mount when --rw is passed', async () => {
+    const GID = 'ag-mount-rw';
+    createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+    const args = { id: GID, host: '/data/.calendar-mcp', container: '.calendar-mcp', rw: true };
+
+    const add = await dispatch({ id: 'r1', command: 'groups-config-add-mount', args }, { caller: 'host' });
+    expect(add.ok).toBe(true);
+    expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([
+      { hostPath: '/data/.calendar-mcp', containerPath: '.calendar-mcp', readonly: false },
+    ]);
+  });
+
+  it('omits readonly entirely when neither --ro nor --rw is passed', async () => {
+    const GID = 'ag-mount-default';
+    createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+    const args = { id: GID, host: '/data/.thing', container: '.thing' };
+
+    const add = await dispatch({ id: 'r1', command: 'groups-config-add-mount', args }, { caller: 'host' });
+    expect(add.ok).toBe(true);
+    expect(JSON.parse(getContainerConfig(GID)!.additional_mounts)).toEqual([
+      { hostPath: '/data/.thing', containerPath: '.thing' },
+    ]);
+  });
+
+  it('rejects passing both --ro and --rw', async () => {
+    const GID = 'ag-mount-conflict';
+    createAgentGroup({ id: GID, name: 'm', folder: 'm', agent_provider: null, created_at: now() });
+    ensureContainerConfig(GID);
+    const args = { id: GID, host: '/data/.thing', container: '.thing', ro: true, rw: true };
+
+    const add = await dispatch({ id: 'r1', command: 'groups-config-add-mount', args }, { caller: 'host' });
+    expect(add.ok).toBe(false);
+    expect((add as { ok: false; error: { message: string } }).error.message).toMatch(/only one of --ro or --rw/i);
+  });
 });

--- a/src/cli/resources/groups.ts
+++ b/src/cli/resources/groups.ts
@@ -452,7 +452,11 @@ registerResource({
       description:
         "Mount a host directory into a group's containers. OPERATOR-ONLY — never runnable from " +
         'inside a container (mounting host paths is a filesystem-access boundary). Requires ' +
-        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> [--ro].',
+        '`ncl groups restart` to take effect. Use --id <group-id> --host <host-path> --container <container-path> ' +
+        '[--ro | --rw]. Default (neither flag) is read-only — the mount-security allowlist only grants read-write ' +
+        'when a mount explicitly asks for it via --rw, and only if the allowed root also permits it. ' +
+        '<container-path> must be relative — mount-security rejects absolute paths and always lands additional ' +
+        'mounts at /workspace/extra/<container-path>.',
       handler: async (args) => {
         const id = args.id as string;
         if (!id) throw new Error('--id is required');
@@ -460,13 +464,17 @@ registerResource({
         const containerPath = (args.container ?? args['container-path']) as string | undefined;
         if (!hostPath || !containerPath) throw new Error('Provide --host <host-path> and --container <container-path>');
 
+        const ro = args.ro || args.readonly;
+        const rw = args.rw || args['read-write'];
+        if (ro && rw) throw new Error('Provide only one of --ro or --rw, not both');
+
         const row = getContainerConfig(id);
         if (!row) throw new Error(`No container config for group: ${id}`);
 
         const mount: AdditionalMountConfig = {
           hostPath,
           containerPath,
-          ...(args.ro || args.readonly ? { readonly: true } : {}),
+          ...(ro ? { readonly: true } : rw ? { readonly: false } : {}),
         };
         const existing = JSON.parse(row.additional_mounts) as AdditionalMountConfig[];
         if (!existing.some((m) => m.hostPath === hostPath && m.containerPath === containerPath)) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** `ncl groups config add-mount` can only ever write `readonly: true` (via `--ro`) or omit the field entirely — there was no way to write `readonly: false`. Adds a `--rw` flag (rejecting `--ro`+`--rw` together).

**Why:** `mount-security`'s validator (`src/modules/mount-security/index.ts`) only grants a read-write mount when `mount.readonly === false` explicitly — an omitted field is always forced read-only, even when the allowlist root permits RW. Since `add-mount` could never produce `readonly: false`, every additional mount added through this verb has been silently forced to read-only regardless of intent or allowlist permissions.

This is a real regression, not theoretical: the `add-gmail-tool` and `add-gcal-tool` skill docs already document `.gmail-mcp`/`.calendar-mcp` mounts as needing RW ("No `--ro` — the MCP server writes refreshed token state back into the mount"), because they used to write `readonly:false` via raw SQL. When those skills were migrated onto `add-mount` (`d3380638`), that RW guarantee silently broke — the CLI had no way to ask for it. I hit this directly trying to mount a personal directory read-write; it came back read-only with no error.

**How it works:** Adds `--rw` (sets `readonly: false` explicitly) alongside the existing `--ro`, with a mutual-exclusion check. Updates `add-gmail-tool`/`add-gcal-tool` SKILL.md examples to pass `--rw` explicitly instead of relying on an implicit default that the validator never actually honored.

**How it was tested:** Added CLI-layer tests: `--rw` sets `readonly:false`, neither flag omits the field (existing default-RO behavior unaffected), and `--ro`+`--rw` together is rejected. Full host suite passes (`pnpm test`, 1167 tests). Verified end-to-end against a live install: added a mount with `--rw`, confirmed `readonly:false` persisted in `container_configs`, restarted the container, and confirmed via `docker inspect` that the resulting bind mount has `"RW": true`.

**Usage:** `ncl groups config add-mount --id <group-id> --host <path> --container <relative-path> --rw`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>