### PR TITLE
setup: fetch a hardened agent image instead of building it

### DIFF
--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -207,8 +207,18 @@ Check which areas changed to determine what to validate:
 - Check: `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`
 - If this fails because bun types are missing (`Cannot find type definition file for 'bun'`), skip with a note — type errors will surface at container runtime instead
 
-**Container image rebuild** (only if any `container/` files are in CHANGED_FILES):
-- `./container/build.sh`
+**Container image** (only if any `container/` files are in CHANGED_FILES, or the `agent-image` pin moved):
+
+Which command depends on where this install gets its image — check `.env` for `NANOCLAW_HARDENED_IMAGE=true`.
+
+- **Builds locally** (the default; flag absent or not `true`): `./container/build.sh`
+- **Pulls a pinned image** (flag is `true`): `./container/build.sh pull`. Never the bare form — it exits `3` on a pinned install rather than silently replacing the pulled bytes with a local build.
+
+A pinned install needs `pull` in either of two cases, so run it if either holds:
+- `git diff <backup-tag-from-step-1>..HEAD -- versions.json` shows the `agent-image` value changed. A new image was published; nothing re-pulls on its own.
+- Any `container/` file changed, `container/agent-runner/bun.lock` included.
+
+If `pull` refuses with a lockfile mismatch, that is the guard working, not a bug: the update moved `container/agent-runner/bun.lock` and no image has been published for the new lockfile yet. `/app/src` is bind-mounted from this checkout at spawn, so pairing the old image with the new source dies as a missing module inside a `--rm` container whose logs are discarded. Tell the user and offer the two real options — wait for a published image matching this checkout, or switch this install to local builds with `./container/build.sh build`.
 
 If build fails:
 - Show the error.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["custom.regex"],
+  "customManagers": [
+    {
+      "description": "The agent-image pin in versions.json, single-reference form. Matches only a digest-pinned reference: a bare tag is not something to bump, and the pull path warns about it separately.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.json$/"],
+      "matchStrings": [
+        "\"agent-image\"\\s*:\\s*\"(?<depName>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]{64})\""
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "autoReplaceStringTemplate": "\"agent-image\": \"{{{depName}}}@{{{newDigest}}}\""
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Never auto-merge here. The merge gate is the signature check in verify-agent-image.yml, which enables auto-merge itself only when cosign verifies the image against the publisher's identity. Renovate must not have a second, weaker opinion.",
+      "matchManagers": ["custom.regex"],
+      "automerge": false,
+      "labels": ["agent-image", "supply-chain"],
+      "commitMessageTopic": "agent image",
+      "commitMessageExtra": "to {{{newDigest}}}",
+      "prBodyNotes": [
+        "Merging this changes the bytes every pinned install runs.",
+        "",
+        "`verify-agent-image` must be green before this can merge: it re-pulls the digest and checks the manifest is a multi-arch index, that the agent-runner lock label matches `container/agent-runner/bun.lock` in this branch, that the image declares itself `hardened`, and that the size has not moved implausibly.",
+        "",
+        "Auto-merge switches on only if that job can also verify a publisher signature over the digest. Without one, this waits for a human — a label is a claim the pusher makes about themselves, and this file decides what other people execute."
+      ]
+    }
+  ],
+  "prConcurrentLimit": 1,
+  "rebaseWhen": "behind-base-branch"
+}

--- a/.github/workflows/verify-agent-image.yml
+++ b/.github/workflows/verify-agent-image.yml
@@ -1,0 +1,215 @@
+# Gate on the one file that decides what other people's machines execute.
+#
+# A digest bump in versions.json reaches every pinned install on its next
+# refresh, so this job is the last point at which anyone looks. Two tiers, and
+# the distinction is deliberate:
+#
+#   BLOCKING   shape checks — index, platforms, lock label, provenance, size.
+#              These catch a wrong or mismatched image. They are things the
+#              image asserts about itself, so they detect drift, not forgery.
+#
+#   AUTO-MERGE signature verification. The only check here that a registry
+#              write cannot satisfy on its own, so it is the only one allowed
+#              to remove the human. No signature, no auto-merge — never the
+#              other way round.
+#
+# Absent signer configuration, an unverifiable signature, a fork PR with no
+# OIDC, a missing role: every one of those ends with auto-merge off and the PR
+# waiting for a person. There is no path through this file where uncertainty
+# results in a merge.
+name: verify-agent-image
+
+on:
+  pull_request:
+    paths:
+      - versions.json
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC for the pull-only ECR role
+      pull-requests: write # only ever used to enable auto-merge
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the pin change
+        id: pin
+        run: |
+          set -euo pipefail
+          read_pin() {
+            # Single-reference form only. A per-platform object is deliberately
+            # not auto-bumped: the entries must move together, and a bot that
+            # bumps them independently can leave the architectures on bytes
+            # from two different builds.
+            git show "$1:versions.json" 2>/dev/null \
+              | tr -d '\n' \
+              | grep -o '"agent-image"[[:space:]]*:[[:space:]]*"[^"]*"' \
+              | head -n1 | sed 's/.*:[[:space:]]*"//; s/"$//'
+          }
+          NEW="$(read_pin "${{ github.event.pull_request.head.sha }}")"
+          OLD="$(read_pin "${{ github.event.pull_request.base.sha }}")"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+          if [ "$NEW" = "$OLD" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "versions.json changed but the agent-image pin did not — nothing to verify."
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$NEW" ]; then
+            echo "::error::The agent-image pin was removed or is no longer a single reference."
+            echo "A per-platform pin has to be reviewed and verified by hand." >&2
+            exit 1
+          fi
+          case "$NEW" in
+            *@sha256:*) ;;
+            *)
+              echo "::error::New pin '$NEW' is not digest-pinned."
+              echo "A mutable tag is fetched once and never re-checked, so what installs run" >&2
+              echo "would drift from what was reviewed here." >&2
+              exit 1
+              ;;
+          esac
+          echo "  old: ${OLD:-<none>}"
+          echo "  new: $NEW"
+
+      - name: Assume the pull-only role
+        if: steps.pin.outputs.changed == 'true'
+        id: aws
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AGENT_IMAGE_CI_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Registry login
+        if: steps.pin.outputs.changed == 'true' && steps.aws.outcome == 'success'
+        run: |
+          set -euo pipefail
+          REF='${{ steps.pin.outputs.new }}'
+          HOST="${REF%%/*}"
+          aws ecr get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin "$HOST"
+
+      # Everything below is BLOCKING. A red job here cannot merge at all.
+      - name: Manifest is a multi-arch index covering both platforms
+        if: steps.pin.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          REF='${{ steps.pin.outputs.new }}'
+          docker buildx imagetools inspect --raw "$REF" > /tmp/manifest.json
+          python3 - <<'PY'
+          import json, sys
+          m = json.load(open('/tmp/manifest.json'))
+          mt = m.get('mediaType', '')
+          if 'manifests' not in m:
+              print(f"::error::Pinned digest is a single-platform manifest ({mt}).")
+              print("One architecture would be served to every install, and the arch guard")
+              print("in container/pull.sh refuses the rest. Publish a multi-arch index.")
+              sys.exit(1)
+          plats = {
+              f"{e['platform']['os']}/{e['platform']['architecture']}"
+              for e in m['manifests']
+              if e.get('platform', {}).get('architecture') not in (None, 'unknown')
+          }
+          missing = {'linux/amd64', 'linux/arm64'} - plats
+          if missing:
+              print(f"::error::Index is missing {sorted(missing)}; it has {sorted(plats)}.")
+              sys.exit(1)
+          print(f"  index covers {sorted(plats)}")
+          PY
+
+      - name: Pull and check the image's own claims
+        if: steps.pin.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          REF='${{ steps.pin.outputs.new }}'
+          docker pull -q "$REF"
+
+          LOCK_ACTUAL="$(sha256sum container/agent-runner/bun.lock | cut -d' ' -f1)"
+          LOCK_IMAGE="$(docker image inspect --format '{{index .Config.Labels "dev.nanoclaw.agent-runner-lock-sha256"}}' "$REF")"
+          SOURCE="$(docker image inspect --format '{{index .Config.Labels "dev.nanoclaw.image-source"}}' "$REF")"
+
+          # /app/node_modules is baked from bun.lock while /app/src is mounted
+          # from the user's checkout at spawn. A mismatch dies as a missing
+          # module inside a --rm container whose logs are discarded, so it has
+          # to fail here instead.
+          if [ "$LOCK_IMAGE" != "$LOCK_ACTUAL" ]; then
+            echo "::error::Lock label mismatch."
+            echo "  image:    ${LOCK_IMAGE:-<unset>}" >&2
+            echo "  this ref: $LOCK_ACTUAL" >&2
+            echo "This image was built against a different container/agent-runner/bun.lock." >&2
+            exit 1
+          fi
+          if [ "$SOURCE" != "hardened" ]; then
+            echo "::error::image-source label is '${SOURCE:-<unset>}', expected 'hardened'."
+            echo "A published image must be built with --build-arg IMAGE_SOURCE=hardened, or" >&2
+            echo "--status reports every pulled install as a local build." >&2
+            exit 1
+          fi
+          echo "  lock label matches; image declares itself hardened"
+
+      - name: Size delta is plausible
+        if: steps.pin.outputs.changed == 'true' && steps.pin.outputs.old != ''
+        run: |
+          set -euo pipefail
+          total() {
+            docker buildx imagetools inspect --raw "$1" 2>/dev/null \
+              | python3 -c 'import json,sys; m=json.load(sys.stdin); print(sum(e.get("size",0) for e in m.get("manifests",[])) or 1)'
+          }
+          NEW=$(total '${{ steps.pin.outputs.new }}')
+          OLD=$(total '${{ steps.pin.outputs.old }}')
+          echo "  manifest bytes: old=$OLD new=$NEW"
+          # A coarse tripwire, not a measurement: catches a wholly different
+          # image landing on the pin. Real growth between CVE rebuilds is small.
+          python3 - "$OLD" "$NEW" <<'PY'
+          import sys
+          old, new = int(sys.argv[1]), int(sys.argv[2])
+          if old > 0 and (new > old * 3 or new * 3 < old):
+              print("::warning::Manifest size moved by more than 3x — worth a look before merging.")
+          PY
+
+      # AUTO-MERGE GATE. Nothing above can switch this on.
+      - name: Verify publisher signature
+        if: steps.pin.outputs.changed == 'true'
+        id: sig
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          IDENTITY='${{ vars.AGENT_IMAGE_SIGNER_IDENTITY }}'
+          ISSUER='${{ vars.AGENT_IMAGE_SIGNER_ISSUER }}'
+          if [ -z "$IDENTITY" ] || [ -z "$ISSUER" ]; then
+            echo "No signer configured (AGENT_IMAGE_SIGNER_IDENTITY / _ISSUER)."
+            echo "Signature verification skipped, so this PR needs a human."
+            exit 1
+          fi
+          curl -fsSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+          chmod +x /usr/local/bin/cosign
+          cosign verify \
+            --certificate-identity-regexp "$IDENTITY" \
+            --certificate-oidc-issuer "$ISSUER" \
+            '${{ steps.pin.outputs.new }}'
+
+      - name: Enable auto-merge
+        if: steps.pin.outputs.changed == 'true' && steps.sig.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Signature verified against the configured publisher identity."
+          gh pr merge --squash --auto '${{ github.event.pull_request.number }}'
+
+      - name: Explain why a human is still needed
+        if: steps.pin.outputs.changed == 'true' && steps.sig.outcome != 'success'
+        run: |
+          echo "::notice::Shape checks passed, but no verified publisher signature."
+          echo "Auto-merge stays off. Every check above is a claim the image makes about"
+          echo "itself; only a signature is something whoever pushed it could not forge."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ This project uses pnpm with `minimumReleaseAge: 4320` (3 days) in `pnpm-workspac
 | [docs/skill-directives.md](docs/skill-directives.md) | `nc:` directive reference: fence grammar, the eight kinds, effects, guards, lint |
 | [docs/skill-engine-seam.md](docs/skill-engine-seam.md) | Skill-engine consumer contract (wizard / pipeline / agent-relay) + boundary-rule rationale |
 | [docs/templates.md](docs/templates.md) | Agent templates: what they are, stamping via `ncl groups create --template` + the setup wizard, the OneCLI/MCP-credential model, supported providers, and how to contribute one |
+| [docs/hardened-image.md](docs/hardened-image.md) | Opt-in: pull the agent image from a registry instead of building it |
 
 ## Container Build Cache
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ See [docs/v1-to-v2-changes.md](docs/v1-to-v2-changes.md) for what's different an
 - **Credential security** — agents never hold raw API keys. Outbound requests route through [OneCLI's Agent Vault](https://github.com/onecli/onecli), which injects credentials at request time and enforces per-agent policies and rate limits.
 - **Agent templates**: stamp a ready-to-run agent (instructions + MCP tools + skills, no secrets) from a reusable bundle via `ncl groups create --template <ref>`. Templates load from the local `templates/` folder; populate it by hand or by copying from the [public library](https://github.com/nanocoai/nanoclaw-templates). See [docs/templates.md](docs/templates.md).
 
+## Accounts and what leaves your machine
+
+NanoClaw has no user accounts. The only thing it reports is anonymous setup diagnostics, and
+`NANOCLAW_NO_DIAGNOSTICS=1` turns those off. Your agents, messages, files and keys never leave
+your machine.
+
+One opt-in exception: you can [fetch a prebuilt agent image](docs/hardened-image.md) instead of
+building it locally. Fetching ours needs a free account, so we see your email address and when
+you ask for an image — nothing about your agents, and nothing after the image lands. Building
+locally needs no account and contacts nothing, and is the default.
+
 ## Usage
 
 Talk to your assistant with the trigger word (default: `@Andy`):

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -130,3 +130,22 @@ WORKDIR /workspace/group
 # Only applies to a bare `docker run` — the host spawn overrides ENTRYPOINT and
 # passes --init instead (see hardeningArgs in src/container-runner.ts).
 ENTRYPOINT ["/usr/bin/tini", "--", "/app/entrypoint.sh"]
+
+# ---- Provenance labels -------------------------------------------------------
+# LAST on purpose. An ARG invalidates every layer below it, so declaring these
+# up with the other build-args would make an otherwise-cached rebuild redo
+# `bun install` and the pnpm global CLIs on every existing install, for two
+# pieces of metadata. Labels have no filesystem effect, so they cost nothing here.
+#
+# Which lockfile the baked /app/node_modules came from: /app/src is mounted from
+# the host checkout at every spawn, so an image and a checkout whose lockfiles
+# disagree fail as a missing module inside a `--rm` container with no logs.
+# container/pull.sh checks this before retagging. build.sh passes it; a bare
+# `docker build` leaves it empty, which the pull path treats as unverifiable.
+#
+# image-source defaults to `local` so anything built from this file is honest
+# unless its builder says otherwise — the retag cannot forge it after the fact.
+ARG AGENT_RUNNER_LOCK_SHA256=
+LABEL dev.nanoclaw.agent-runner-lock-sha256="${AGENT_RUNNER_LOCK_SHA256}"
+ARG IMAGE_SOURCE=local
+LABEL dev.nanoclaw.image-source="${IMAGE_SOURCE}"

--- a/container/build.sh
+++ b/container/build.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Build the NanoClaw agent container image.
 #
+# Usage: ./container/build.sh [pull] [tag]
+#
+# `pull` hands off to container/pull.sh, which acquires the image from a
+# registry and retags it to the same local tag this script builds — the one
+# thing the host ever looks at. See that script for the settings it reads.
+#
 # Reads one optional build flag from ../.env:
 #   INSTALL_CJK_FONTS=true   — add Chinese/Japanese/Korean fonts (~200MB)
 # setup/container.ts reads the same file, so both build paths stay in sync.
@@ -18,8 +24,106 @@ cd "$SCRIPT_DIR"
 # shellcheck source=../setup/lib/install-slug.sh
 source "$PROJECT_ROOT/setup/lib/install-slug.sh"
 IMAGE_NAME="$(container_image_base)"
+
+# Record which agent-runner lockfile the baked /app/node_modules came from.
+# container/pull.sh recomputes this the same way and refuses an image whose
+# label disagrees with the checkout — see the lock check there for why.
+#
+# Computed here rather than beside the build because the pinned path below has
+# to compare it against the image's label to decide whether a rebuild is needed
+# at all, and that decision happens before any build argument is assembled.
+LOCK_FILE="$SCRIPT_DIR/agent-runner/bun.lock"
+LOCK_SHA=""
+if [ -f "$LOCK_FILE" ]; then
+    if command -v shasum >/dev/null 2>&1; then
+        LOCK_SHA="$(shasum -a 256 "$LOCK_FILE" | cut -d' ' -f1)"
+    elif command -v sha256sum >/dev/null 2>&1; then
+        LOCK_SHA="$(sha256sum "$LOCK_FILE" | cut -d' ' -f1)"
+    fi
+fi
+
+# Subcommand shift. Has to sit between IMAGE_NAME (which needs PROJECT_ROOT
+# above) and TAG (which takes the first positional): any earlier and the slug
+# isn't derived yet, any later and `build.sh pull` is read as a tag named
+# "pull". Everything after the subcommand still shifts down to $1, so
+# `build.sh pull v2` keeps meaning the same tag it does on the build path.
+PULL=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        pull|--pull) PULL="true"; shift ;;
+        build|--build) PULL="false"; shift ;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+
 TAG="${1:-latest}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
+# No explicit subcommand, on an install that pulls its image. Skills that add a
+# runtime dependency land here — they append to cli-tools.json (or edit the
+# Dockerfile) and then call this script bare, expecting a rebuild.
+#
+# A full rebuild would start from the public Node base and throw the published
+# image away, so an install that added the Vercel CLI would lose every layer its
+# publisher hardened. Overlay instead: one layer on top of the image already
+# here, applying the tool manifest. The published bytes stay underneath.
+#
+# The exception is the agent-runner's own dependencies. /app/node_modules is
+# baked into the base while /app/src is bind-mounted from this checkout at
+# spawn, so a checkout whose bun.lock has moved genuinely needs a base built
+# from itself and no overlay can fix it. That is the one case that still
+# refuses, and the image's own lock label is what tells the two apart.
+OVERLAY="false"
+if [ -z "$PULL" ]; then
+    HARDENED="${NANOCLAW_HARDENED_IMAGE:-}"
+    if [ -z "$HARDENED" ] && [ -f "$PROJECT_ROOT/.env" ]; then
+        HARDENED="$(grep '^NANOCLAW_HARDENED_IMAGE=' "$PROJECT_ROOT/.env" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]')"
+    fi
+    if [ "$(printf '%s' "${HARDENED:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+        IMAGE_LOCK="$(${CONTAINER_RUNTIME} image inspect \
+            --format '{{index .Config.Labels "dev.nanoclaw.agent-runner-lock-sha256"}}' \
+            "${IMAGE_NAME}:${TAG}" 2>/dev/null || true)"
+        if [ -n "$LOCK_SHA" ] && [ "$IMAGE_LOCK" = "$LOCK_SHA" ]; then
+            OVERLAY="true"
+            PULL="false"
+        else
+            echo "Refusing to build: this install pulls its agent image, and this checkout's" >&2
+            echo "container/agent-runner/bun.lock does not match the image that is here." >&2
+            echo "" >&2
+            echo "  image:    ${IMAGE_LOCK:-<no image, or no label>}" >&2
+            echo "  checkout: ${LOCK_SHA:-<could not compute>}" >&2
+            echo "" >&2
+            echo "The agent-runner's dependencies are baked into the image, so this one cannot" >&2
+            echo "be layered over — it needs a base built for this checkout." >&2
+            echo "" >&2
+            echo "  ./container/build.sh pull    fetch an image published for this checkout" >&2
+            echo "  ./container/build.sh build   build locally and leave the pulled-image path" >&2
+            exit 3
+        fi
+    else
+        PULL="false"
+    fi
+fi
+
+# An explicit `build` on a pinned install is a decision, not a one-off. Record
+# it, because the line above promises this "leaves the pulled-image path" and
+# until now it did not: .env still said hardened, so the next bare build refused
+# again and the next /update-nanoclaw would `pull` straight over the image just
+# built. One command, one consistent end state.
+#
+# Excludes the overlay path, which also sets PULL=false but is the opposite
+# decision: it keeps the published image and layers on it, so dropping the
+# install off the pinned path there would be exactly wrong.
+if [ "$PULL" = "false" ] && [ "$OVERLAY" = "false" ] && [ -f "$PROJECT_ROOT/.env" ]; then
+    CURRENT="$(grep '^NANOCLAW_HARDENED_IMAGE=' "$PROJECT_ROOT/.env" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    if [ "$CURRENT" = "true" ]; then
+        sed -i.bak 's/^NANOCLAW_HARDENED_IMAGE=.*/NANOCLAW_HARDENED_IMAGE=false/' "$PROJECT_ROOT/.env"
+        rm -f "$PROJECT_ROOT/.env.bak"
+        echo "This install now builds its own agent image (NANOCLAW_HARDENED_IMAGE=false)."
+        echo "Sign in again, or set it back to true, to return to the pulled image."
+    fi
+fi
 
 # Caller's env takes precedence; fall back to .env.
 if [ -z "${INSTALL_CJK_FONTS:-}" ] && [ -f "../.env" ]; then
@@ -28,17 +132,73 @@ fi
 
 BUILD_ARGS=()
 if [ "${INSTALL_CJK_FONTS:-false}" = "true" ]; then
-    echo "CJK fonts: enabled (adds ~200MB)"
-    BUILD_ARGS+=(--build-arg INSTALL_CJK_FONTS=true)
+    if [ "$PULL" = "true" ]; then
+        # A pulled image ships whatever font set its publisher baked in; this
+        # build-arg has nothing to act on.
+        echo "CJK fonts: ignored — this install pulls its image instead of building it"
+    else
+        echo "CJK fonts: enabled (adds ~200MB)"
+        BUILD_ARGS+=(--build-arg INSTALL_CJK_FONTS=true)
+    fi
 fi
 
-echo "Building NanoClaw agent container image..."
-echo "Image: ${IMAGE_NAME}:${TAG}"
+if [ -n "$LOCK_SHA" ]; then
+    BUILD_ARGS+=(--build-arg "AGENT_RUNNER_LOCK_SHA256=$LOCK_SHA")
+fi
 
-${CONTAINER_RUNTIME} build "${BUILD_ARGS[@]}" -t "${IMAGE_NAME}:${TAG}" .
+if [ "$PULL" = "true" ]; then
+    echo "Pulling NanoClaw agent container image..."
+    # Not exec'd: pull.sh runs as a child so `set -e` still carries its exit
+    # code and the trailing notes below print on both paths.
+    bash "$SCRIPT_DIR/pull.sh" "$TAG"
+elif [ "$OVERLAY" = "true" ]; then
+    echo "Adding tools to the published agent image..."
+    echo "Image: ${IMAGE_NAME}:${TAG}"
+
+    # One layer, re-applying the whole manifest rather than a computed delta:
+    # `pnpm install -g` at an already-installed pinned version is a no-op, so
+    # asking for all of them is both simpler and correct, and it means a skill
+    # only has to add its entry to cli-tools.json.
+    #
+    # `image-source` is deliberately NOT overwritten — the published bytes
+    # underneath are still exactly what the publisher hardened, and claiming
+    # otherwise would be as wrong as the inverse. What changes is that some
+    # tools on top were not part of that, which is what the new label records.
+    OVERLAY_DOCKERFILE="$(mktemp)"
+    trap 'rm -f "$OVERLAY_DOCKERFILE"' EXIT
+    {
+        echo "FROM ${IMAGE_NAME}:${TAG}"
+        echo "USER root"
+        echo "COPY cli-tools.json install-cli-tools.sh /tmp/"
+        echo "RUN sh /tmp/install-cli-tools.sh /tmp/cli-tools.json && \\"
+        echo "    rm -f /tmp/cli-tools.json /tmp/install-cli-tools.sh"
+        echo "USER node"
+        echo "LABEL dev.nanoclaw.unhardened-additions=\"cli-tools.json\""
+    } > "$OVERLAY_DOCKERFILE"
+
+    ${CONTAINER_RUNTIME} build -f "$OVERLAY_DOCKERFILE" -t "${IMAGE_NAME}:${TAG}" .
+else
+    echo "Building NanoClaw agent container image..."
+    echo "Image: ${IMAGE_NAME}:${TAG}"
+
+    ${CONTAINER_RUNTIME} build "${BUILD_ARGS[@]}" -t "${IMAGE_NAME}:${TAG}" .
+fi
 
 echo ""
-echo "Build complete!"
+if [ "$PULL" = "true" ]; then
+    echo "Pull complete!"
+elif [ "$OVERLAY" = "true" ]; then
+    echo "Tools added."
+    echo ""
+    echo "The published image underneath is unchanged, so you keep its hardening in"
+    echo "full. The tools just layered on top are a different matter: they were not"
+    echo "part of that build, nobody scanned them, and they may carry known"
+    echo "vulnerabilities of their own."
+    echo ""
+    echo "To have added dependencies hardened too: https://echo.ai"
+else
+    echo "Build complete!"
+fi
 echo "Image: ${IMAGE_NAME}:${TAG}"
 echo ""
 echo "Test with:"

--- a/container/pull.sh
+++ b/container/pull.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Acquire the NanoClaw agent container image from a registry instead of building
+# it here, then retag it to this install's local slug tag.
+#
+# The retag is the whole mechanism: nothing in src/ learns a registry exists. The
+# host spawns `nanoclaw-agent-v2-<slug>:latest` exactly as it does after
+# ./container/build.sh, and derived per-group images keep building with no network.
+#
+# Settings — caller's env wins, then ../.env, matching build.sh:
+#
+#   NANOCLAW_AGENT_IMAGE_REF        What to acquire. Pin by digest so the bytes
+#                                   landing under the local tag are the ones you
+#                                   chose. Falls back to the `agent-image` pin in
+#                                   versions.json; refuses to guess without one.
+#   NANOCLAW_ALLOW_UNLABELED_IMAGE  Accept an image with no agent-runner lock
+#                                   label. Off by default — see the lock check.
+#
+# setup/lib/registry-state.ts mirrors that precedence; keep the two in lockstep.
+#
+# Auth is entirely the operator's existing `docker login`. This script holds no
+# credentials and never prompts — it runs both under setup's step runner (stdin
+# discarded) and under the Linux `sg docker` re-exec (real TTY), so a prompt
+# would work in one path and hang forever in the other.
+#
+# Exits 2 when nothing is configured to acquire, 1 on any other failure.
+#
+# Usage: container/pull.sh [tag]      (tag defaults to latest)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# Same slug derivation as build.sh — the local tag has to be the one the host
+# already spawns (src/config.ts CONTAINER_IMAGE).
+# shellcheck source=../setup/lib/install-slug.sh
+source "$PROJECT_ROOT/setup/lib/install-slug.sh"
+IMAGE_NAME="$(container_image_base)"
+TAG="${1:-latest}"
+LOCAL_REF="${IMAGE_NAME}:${TAG}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
+# Caller's env takes precedence; fall back to .env.
+read_env_setting() {
+    if [ ! -f "$PROJECT_ROOT/.env" ]; then
+        return 0
+    fi
+    grep "^$1=" "$PROJECT_ROOT/.env" | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]'
+}
+
+# The committed pin, last in the precedence chain. setup/lib/version-pins.ts
+# reads the same file from the TypeScript side. versions.json is flat, one
+# level, string values only — so grep is enough, and this script keeps working
+# on a machine where setup hasn't installed node yet.
+read_version_pin() {
+    if [ ! -f "$PROJECT_ROOT/versions.json" ]; then
+        return 0
+    fi
+    grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$PROJECT_ROOT/versions.json" \
+        | head -n1 | sed 's/.*:[[:space:]]*"//; s/"$//'
+}
+
+# A per-platform pin: "agent-image": { "linux/amd64": "…", "linux/arm64": "…" }
+# for a publisher that ships per-architecture references rather than one
+# multi-arch index. Flatten first because the object spans lines, then pick the
+# one platform out of it. Still no jq and no node, for the reason above.
+read_version_pin_platform() {
+    if [ ! -f "$PROJECT_ROOT/versions.json" ]; then
+        return 0
+    fi
+    tr -d '\n' < "$PROJECT_ROOT/versions.json" \
+        | grep -o "\"$1\"[[:space:]]*:[[:space:]]*{[^}]*}" \
+        | head -n1 \
+        | grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+        | head -n1 | sed 's/.*:[[:space:]]*"//; s/"$//'
+}
+
+# Which platforms such a pin declares — for the error when none is this one.
+version_pin_platforms() {
+    if [ ! -f "$PROJECT_ROOT/versions.json" ]; then
+        return 0
+    fi
+    tr -d '\n' < "$PROJECT_ROOT/versions.json" \
+        | grep -o "\"$1\"[[:space:]]*:[[:space:]]*{[^}]*}" \
+        | head -n1 \
+        | grep -o "\"[^\"]*\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+        | sed 's/[[:space:]]*:.*//; s/"//g' \
+        | tr '\n' ' '
+}
+
+# Docker's architecture name for the daemon that will run the image, not the
+# host CPU's — with Docker Desktop, a remote daemon, or a cross-architecture
+# context the two differ, and the daemon is what actually executes.
+# `setup/lib/registry-state.ts` resolves it the same way; if these disagree,
+# --status compares against a pin the pull never used.
+host_arch() {
+    local a
+    a="$(${CONTAINER_RUNTIME} version --format '{{.Server.Arch}}' 2>/dev/null || true)"
+    if [ -n "$a" ]; then
+        printf '%s' "$a"
+        return 0
+    fi
+    # Daemon wouldn't say. uname's names are not Docker's.
+    case "$(uname -m)" in
+        x86_64|amd64) printf 'amd64' ;;
+        aarch64|arm64) printf 'arm64' ;;
+        *) printf '%s' "$(uname -m)" ;;
+    esac
+}
+
+# sha256 of the agent-runner lockfile. container/build.sh computes this the
+# same way and stamps it onto locally built images; keep the two in lockstep.
+lock_sha256() {
+    local f="$SCRIPT_DIR/agent-runner/bun.lock"
+    if [ ! -f "$f" ]; then
+        return 0
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$f" | cut -d' ' -f1
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$f" | cut -d' ' -f1
+    fi
+}
+
+HOST_ARCH="$(host_arch)"
+HOST_PLATFORM="linux/${HOST_ARCH}"
+
+REF="${NANOCLAW_AGENT_IMAGE_REF:-}"
+if [ -z "$REF" ]; then
+    REF="$(read_env_setting NANOCLAW_AGENT_IMAGE_REF)"
+fi
+if [ -z "$REF" ]; then
+    # A single reference covers a multi-arch index digest — docker resolves that
+    # to this platform on its own — and a publisher that ships only one arch.
+    REF="$(read_version_pin agent-image)"
+fi
+if [ -z "$REF" ]; then
+    REF="$(read_version_pin_platform agent-image "$HOST_PLATFORM")"
+    if [ -z "$REF" ]; then
+        PIN_PLATFORMS="$(version_pin_platforms agent-image)"
+        if [ -n "$PIN_PLATFORMS" ]; then
+            echo "No agent-image reference for ${HOST_PLATFORM}." >&2
+            echo "  versions.json pins: ${PIN_PLATFORMS}" >&2
+            echo "" >&2
+            echo "The pin ships per-architecture references and none is for this" >&2
+            echo "daemon. Build locally with \`./container/build.sh build\`, or set" >&2
+            echo "NANOCLAW_AGENT_IMAGE_REF to a reference for this architecture." >&2
+            exit 1
+        fi
+    fi
+fi
+ALLOW_UNLABELED="${NANOCLAW_ALLOW_UNLABELED_IMAGE:-}"
+if [ -z "$ALLOW_UNLABELED" ]; then
+    ALLOW_UNLABELED="$(read_env_setting NANOCLAW_ALLOW_UNLABELED_IMAGE)"
+fi
+
+if [ -z "$REF" ]; then
+    echo "No image reference configured — nothing to acquire." >&2
+    echo "" >&2
+    echo "Point NANOCLAW_AGENT_IMAGE_REF at the image, in the environment or in" >&2
+    echo ".env, and make sure this machine can already reach it (\`docker login" >&2
+    echo "<registry>\` if it needs credentials):" >&2
+    echo "" >&2
+    echo "  NANOCLAW_AGENT_IMAGE_REF=registry.example.com/nanoclaw/agent@sha256:<digest>" >&2
+    echo "" >&2
+    echo "A committed \"agent-image\" pin in versions.json serves the same purpose." >&2
+    echo "Or drop NANOCLAW_HARDENED_IMAGE from .env to go back to local builds." >&2
+    exit 2
+fi
+
+case "$REF" in
+    *@sha256:*) ;;
+    *)
+        echo "Note: ${REF} is not digest-pinned."
+        echo "  A mutable tag is fetched once and then never re-checked (see the guard"
+        echo "  below), so what you run can drift from what the publisher serves."
+        ;;
+esac
+
+# THE GUARD. `docker pull` has no offline cache-hit path — pulling a
+# locally-present, registry-qualified ref with the registry unreachable fails
+# outright, while `docker image inspect` on it succeeds. Without this, registry
+# reachability becomes a hard dependency of every ./container/build.sh caller:
+# ~15 /add-* skills, /update-nanoclaw and migrate-v2.sh.
+if ${CONTAINER_RUNTIME} image inspect "$REF" >/dev/null 2>&1; then
+    echo "Already present locally: ${REF}"
+else
+    echo "Pulling ${REF}..."
+    # The pull nonce. `docker-credential-nanoclaw` refuses to mint unless
+    # NANOCLAW_PULL_NONCE is set AND matches a 0600 file it can see, written
+    # less than five minutes ago — so the credential is only obtainable for the
+    # duration of a pull this script is actually running. It is not a boundary
+    # against a same-uid attacker (that process can read both the variable and
+    # the file, and the token itself); what it removes is the standing oracle,
+    # where anything on the machine could mint a credential attributed to this
+    # account at any moment. Setting it here is required: the helper hard-fails
+    # without it, so a gated pull cannot succeed if this block is removed.
+    #
+    # Installs pulling from a registry they already `docker login`ed to never
+    # reach the helper, and are unaffected.
+    NONCE_DIR="${HOME}/.config/nanoclaw"
+    NONCE_FILE="${NONCE_DIR}/.pull-nonce"
+    if mkdir -p "$NONCE_DIR" 2>/dev/null; then
+        chmod 700 "$NONCE_DIR" 2>/dev/null || true
+        NANOCLAW_PULL_NONCE="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+        # umask so the file is never briefly world-readable between create and chmod.
+        if (umask 177; printf '%s' "$NANOCLAW_PULL_NONCE" > "$NONCE_FILE") 2>/dev/null; then
+            export NANOCLAW_PULL_NONCE
+            # Client-asserted, recorded by the broker as a hint only.
+            NANOCLAW_PULL_REF="$REF"
+            export NANOCLAW_PULL_REF
+            trap 'rm -f "$NONCE_FILE"' EXIT
+        else
+            echo "Warning: couldn't write ${NONCE_FILE}; a gated pull will be refused by the credential helper." >&2
+        fi
+    else
+        echo "Warning: couldn't create ${NONCE_DIR}; a gated pull will be refused by the credential helper." >&2
+    fi
+
+    if ! ${CONTAINER_RUNTIME} pull "$REF"; then
+        echo "" >&2
+        echo "Pull failed for ${REF}." >&2
+        echo "  If the registry needs credentials, run \`docker login <registry>\` and" >&2
+        echo "  retry — this script deliberately has no credential handling of its own." >&2
+        exit 1
+    fi
+fi
+
+# Architecture. A pinned digest that resolves to a single-arch manifest is the
+# common way to end up with an amd64 image on an arm64 host: it runs, slowly,
+# under emulation, or not at all. A multi-arch index never trips this — docker
+# resolved it to this platform during the pull — so reaching here means the
+# reference really did name one architecture, and the wrong one.
+IMAGE_ARCH="$(${CONTAINER_RUNTIME} image inspect --format '{{.Architecture}}' "$REF")"
+if [ "$IMAGE_ARCH" != "$HOST_ARCH" ]; then
+    echo "" >&2
+    echo "Architecture mismatch — refusing to tag this image." >&2
+    echo "  image   ${IMAGE_ARCH}" >&2
+    echo "  daemon  ${HOST_ARCH}" >&2
+    echo "" >&2
+    echo "If the publisher ships per-architecture references rather than one" >&2
+    echo "multi-arch index, use the ${HOST_ARCH} reference." >&2
+    exit 1
+fi
+
+# Lock drift. /app/node_modules is baked in from container/agent-runner/bun.lock
+# while /app/src is bind-mounted from this checkout at every spawn. Pair an image
+# with a checkout whose lockfile moved and the agent dies on a missing module
+# inside a `--rm` container whose logs are discarded. Hard failure here, where
+# the operator is watching, beats silence at 3am.
+IMAGE_LOCK="$(${CONTAINER_RUNTIME} image inspect --format '{{index .Config.Labels "dev.nanoclaw.agent-runner-lock-sha256"}}' "$REF")"
+if [ "$IMAGE_LOCK" = "<no value>" ]; then
+    IMAGE_LOCK=""
+fi
+LOCAL_LOCK="$(lock_sha256)"
+
+if [ -z "$LOCAL_LOCK" ]; then
+    echo "Warning: couldn't hash container/agent-runner/bun.lock — skipping the lock check."
+elif [ -z "$IMAGE_LOCK" ]; then
+    if [ "$ALLOW_UNLABELED" = "true" ]; then
+        echo "Warning: ${REF} carries no agent-runner lock label; accepted via NANOCLAW_ALLOW_UNLABELED_IMAGE."
+    else
+        echo "" >&2
+        echo "${REF} carries no dev.nanoclaw.agent-runner-lock-sha256 label." >&2
+        echo "" >&2
+        echo "Without it there is no way to tell whether the image's baked" >&2
+        echo "/app/node_modules matches this checkout's agent-runner lockfile, and a" >&2
+        echo "mismatch surfaces as a missing module inside a --rm container whose logs" >&2
+        echo "are discarded." >&2
+        echo "" >&2
+        echo "Either use an image built from this Dockerfile (which stamps the label)," >&2
+        echo "or accept the risk deliberately with NANOCLAW_ALLOW_UNLABELED_IMAGE=true." >&2
+        exit 1
+    fi
+elif [ "$IMAGE_LOCK" != "$LOCAL_LOCK" ]; then
+    echo "" >&2
+    echo "Agent-runner lock drift — refusing to tag this image." >&2
+    echo "  image     ${IMAGE_LOCK}" >&2
+    echo "  checkout  ${LOCAL_LOCK}  (container/agent-runner/bun.lock)" >&2
+    echo "" >&2
+    echo "The image bakes /app/node_modules from the lockfile it was built with," >&2
+    echo "while /app/src is mounted from this checkout at spawn time. Running them" >&2
+    echo "together fails as a missing module inside a --rm container whose logs are" >&2
+    echo "discarded." >&2
+    echo "" >&2
+    echo "Use the image published for this checkout, or build locally:" >&2
+    echo "  ./container/build.sh" >&2
+    exit 1
+fi
+
+# The retag. From here on the image is indistinguishable, to every consumer,
+# from one this machine built itself.
+${CONTAINER_RUNTIME} tag "$REF" "$LOCAL_REF"
+
+# An image can carry several RepoDigests -- the same bytes pushed to more than
+# one repository all address identically, so docker lists them all. Taking [0]
+# reports whichever repository happens to sort first, which is routinely NOT the
+# one just pulled. Pick the entry whose repository matches $REF, and only fall
+# back to the first when nothing matches.
+REF_REPO="${REF%@*}"; REF_REPO="${REF_REPO%%:*}"
+DIGEST="$(${CONTAINER_RUNTIME} image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$REF" 2>/dev/null \
+    | grep -F "${REF_REPO}@" | head -n1 || true)"
+if [ -z "$DIGEST" ]; then
+    DIGEST="$(${CONTAINER_RUNTIME} image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "$REF" 2>/dev/null || true)"
+fi
+if [ -n "$DIGEST" ]; then
+    echo "Digest: ${DIGEST}"
+fi
+echo "Tagged ${REF} as ${LOCAL_REF}"

--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -1,0 +1,192 @@
+# Agent image: pull instead of build (opt-in)
+
+By default `./container/build.sh` builds the agent container on your machine from a public Node
+base — three to ten minutes, no account, no request to any service. **That stays the default and
+stays fully supported.**
+
+Alternatively an install can **fetch a prebuilt, hardened image** instead. It is retagged to
+exactly the name the build would have written (`nanoclaw-agent-v2-<slug>:latest`), so nothing
+downstream can tell the two apart: the host spawns the same tag either way, and derived per-group
+builds still work offline.
+
+That image is built by **[Echo](https://echo.ai)**, who rebuild the sandbox's contents — Chromium,
+Node, Bun, pnpm, git and the rest — from scratch with only the essentials, and patch what remains.
+Isolation already keeps a misbehaving agent away from your machine; this is the other half, and
+the reason it exists: the software the agent *uses* is worth patching too. Chromium alone is tens
+of millions of lines you did not write and do not track.
+
+Fetching ours needs no configuration — the image reference ships in `versions.json` and the
+account service is built in. Sign in and setup does the rest. It needs a free NanoClaw account;
+see [With a NanoClaw account](#with-a-nanoclaw-account) for what that involves and what it
+records.
+
+It is roughly an 800 MB download, served from `us-east-1` with no CDN in front of it, so how long
+it takes is mostly a question of your link to Virginia. Close by it is quick; from Europe or Asia
+on a domestic connection it can take longer than simply building the image, which is CPU-bound
+and parallel rather than one bandwidth-limited stream. Worth knowing before you trade an account
+for it — and `./container/build.sh build` is always there.
+
+The same path works against **any registry this machine can already `docker login` to** — a
+corporate Harbor, an internal mirror you populate yourself, a vendor registry you hold
+credentials for, even a `docker save`/`docker load` image. Set `NANOCLAW_HARDENED_IMAGE=true` and
+`NANOCLAW_AGENT_IMAGE_REF`; authentication is then whatever docker already holds, and no account
+is involved.
+
+## What it buys
+
+- **Patch currency in layers you did not write** — Chromium, Node, Bun, OS packages, glibc —
+  rebuilt and patched on Echo's CVE cadence rather than whenever you happen to re-run a build.
+  A local build gives you the standard upstream versions, which is where most container images
+  start; this keeps them current without you tracking any of it.
+- **A digest you chose.** Pin `repo@sha256:…` and the bytes under your local tag are those bytes
+  or the pull refuses.
+- **No multi-gigabyte local build** on every machine and reinstall.
+
+## What it does not buy
+
+**It does not contain the agent.** `/app/src` and `/app/skills` are read-only bind mounts from
+your own checkout at every spawn, and the container starts with `--entrypoint bash`, bypassing
+the image's entrypoint. The code your agent runs is the code in your checkout — unsigned, and
+reviewed by nobody but you.
+
+Containment is runtime configuration you own. `NANOCLAW_EGRESS_LOCKDOWN=true`, the mount
+allowlist, and per-group resource limits all do more here than any image can.
+
+## What changes
+
+| | Pull | Build |
+|---|---|---|
+| `install_packages` | Works, as a derived image | Works |
+| Non-Claude providers | Only if the publisher baked the CLI, or you add it | Work |
+| Custom `Dockerfile` edits | Replaced on the next refresh | Yours |
+| `INSTALL_CJK_FONTS` | Whatever the publisher baked — or `fonts-noto-cjk` via `install_packages` | Your choice |
+
+Nothing rebuilds the pinned image itself: `./container/build.sh` with no argument exits `3` and
+prints what to run instead, so a skill that rebuilds can't silently replace the pulled bytes.
+
+`install_packages` is the exception, and it works because it never rebuilds the base — it builds
+a small image `FROM` the one you pulled and adds your layers, then pins that group to it. The
+vendor's bytes are still underneath, unmodified.
+
+What that costs is the vendor's claim over that one group. Their scan covered the base, not
+whatever you added on top, so a derived image labels itself `derived` rather than inheriting
+`hardened` — `--status` will say so. A refresh clears these pins, and the group returns to the
+shared image, losing the extra packages.
+
+## Configuration
+
+All optional, all read from `.env` or the environment.
+
+| Variable | What it does |
+|---|---|
+| `NANOCLAW_HARDENED_IMAGE` | `true` makes this install pull instead of build. The sign-in sets it for you. |
+| `NANOCLAW_AGENT_IMAGE_REF` | The image to pull, ideally `repo@sha256:…`. Overrides the `agent-image` pin in `versions.json`. |
+| `NANOCLAW_REGISTRY_API` | Base URL of the account service. Defaults to ours; set it only to point at a different one. |
+| `NANOCLAW_REGISTRY_ENROLL_CODE` | Redeem an enrolment code without a browser. For CI. |
+| `NANOCLAW_REGISTRY_TOKEN` | Adopt an existing account token directly. |
+| `NANOCLAW_ALLOW_UNLABELED_IMAGE` | Accept an image with no agent-runner lock label — needed for a `docker save`/`load` or third-party image. |
+
+If you point this at your own registry you need none of these beyond
+`NANOCLAW_HARDENED_IMAGE` and a reference: authentication is whatever
+`docker login` already holds, and there is no account involved.
+
+## Architecture
+
+`amd64` and `arm64` both work. A local build always matches the machine it runs
+on, so nothing to configure there.
+
+For pulls, the reference decides. Point the pin at a **multi-arch index digest**
+and docker resolves it to the running platform by itself — one pin, both
+architectures, and the digest still pins content exactly:
+
+```json
+"agent-image": "repo@sha256:<index digest>"
+```
+
+A publisher that ships per-architecture references instead of one index can be
+pinned per platform, keyed by docker's platform string:
+
+```json
+"agent-image": {
+  "linux/amd64": "repo@sha256:…",
+  "linux/arm64": "repo@sha256:…"
+}
+```
+
+Either way the architecture that gets tagged is checked against the daemon's
+before anything is retagged, so a single-architecture reference on the wrong
+machine fails loudly instead of landing an image that only runs under emulation.
+
+## Using it
+
+```bash
+# refresh to the pinned image
+./container/build.sh pull
+
+# force a local build and leave the pull path
+./container/build.sh build
+
+# what am I actually running?
+pnpm exec tsx setup/index.ts --step registry
+
+# go back to building locally
+pnpm exec tsx setup/index.ts --step registry -- --opt-out
+```
+
+Nothing re-pulls on its own — `--refresh` is how a new image reaches you.
+
+`--status` reports what you asked for **and** what the local tag actually holds. Those can
+disagree, for instance if a pull failed and a local build filled in. The image carries its own
+provenance label, which a retag cannot forge, so the second answer is the trustworthy one.
+
+A group that previously ran `install_packages` is pinned to its own derived image and would keep
+spawning it. The pull path clears those pins, so such a group loses its extra packages and
+returns to the shared image.
+
+## With a NanoClaw account
+
+The hosted registry is gated, so fetching *our* image needs a free account. This is the only
+part of NanoClaw that involves an account or reports anything identifiable.
+
+```bash
+bash setup/registry-login.sh          # opens your browser
+bash setup/registry-login.sh --code <code>   # or an enrolment code, e.g. for CI
+```
+
+**What is collected:** your verified email address and identity-provider user id at sign-in; a
+timestamp, the image requested, and your IP truncated to a /24 at each fetch; and in the
+registry's own logs, that a pull happened against an opaque random token. Your email is read
+from the provider server-side, never taken from your machine, because it is the key your account
+is stored under.
+
+Sign-in also asks, once, whether you want occasional product email. It defaults to no, an
+unanswered prompt is a no, and declining changes nothing about the perk — you are already signed
+in by the time it appears. Saying yes stores the answer with the wording you were shown; every
+email carries an unsubscribe link, which is how you change your mind today.
+
+**What is never collected:** anything about your agents — no groups, channels, messages, prompts,
+files, or API keys. Nothing calls home once the image is local; the host runs a local tag and has
+no notion of a registry. We also cannot tell whether you ever *run* the image, only that you
+acquired one.
+
+The credential lives at `~/.config/nanoclaw/`, mode `0600`, and can do exactly one thing: ask for
+a short-lived, pull-only credential for one repository. `--logout` revokes it server-side and
+removes the docker credential helper.
+
+Your account is keyed on your **verified email**. Signing in with a personal address and later a
+work one gives you two separate accounts — deliberate, since merging on anything weaker is how
+account-takeover bugs happen — and there is no way to merge them today. Pick one address.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `./container/build.sh` exits 3 | Pinned install. `pull` to refresh, `build` to force local. |
+| Setup never offers the pull option | No `agent-image` pin in `versions.json` — nothing to fetch. |
+| Pull fails: lockfile mismatch | The image was built against a different `container/agent-runner/bun.lock`. Refresh the pin or build locally. |
+| Pull fails: architecture mismatch | The reference names one architecture and it isn't this daemon's. Use a multi-arch index, or the reference for this architecture. |
+| "No agent-image reference for linux/…" | The pin is per-platform and has no entry for this machine. Build locally, or set `NANOCLAW_AGENT_IMAGE_REF`. |
+| Pull fails: auth | `--status` shows whether the credential helper is wired; `--force` re-runs sign-in. |
+| Signed in, but `--status` says "build here" | Re-run sign-in with `--force`. |
+| Sign-in code expired | It lives 5 minutes. Run it again. |
+| "No NanoClaw registry at &lt;url&gt;" | `NANOCLAW_REGISTRY_API` is unset or wrong. The default host resolves but is not a registry, so this is a configuration error, not an outage. |

--- a/migrate-v2.sh
+++ b/migrate-v2.sh
@@ -527,14 +527,25 @@ else
   step_skip "No v1 container skills"
 fi
 
-# 3e. Build agent container image
+# 3e. Acquire the agent container image
 if command -v docker >/dev/null 2>&1; then
-  step_info "Building agent container image…"
+  # Honour an install that pulls rather than builds. The bare form deliberately
+  # exits 3 there rather than replacing pulled bytes with a local build, so
+  # calling it unconditionally would report "build failed" on a working install.
+  IMAGE_SOURCE_SETTING="$(grep '^NANOCLAW_HARDENED_IMAGE=' .env 2>/dev/null | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  if [ "$IMAGE_SOURCE_SETTING" = "true" ]; then
+    BUILD_ARGS="pull"
+    step_info "Fetching pinned agent container image…"
+  else
+    BUILD_ARGS=""
+    step_info "Building agent container image…"
+  fi
   BUILD_LOG="$STEPS_DIR/3e-container-build.log"
-  if bash container/build.sh > "$BUILD_LOG" 2>&1; then
-    step_ok "Container image built"
+  # shellcheck disable=SC2086 -- BUILD_ARGS is one optional literal word.
+  if bash container/build.sh $BUILD_ARGS > "$BUILD_LOG" 2>&1; then
+    step_ok "Container image ready"
     record_step "3e-build" "success"
-    log "Container build: success"
+    log "Container image: success (${BUILD_ARGS:-build})"
   else
     step_fail "Container build failed"
     record_step "3e-build" "failed"

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -39,8 +39,20 @@ import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register their picker entry + auth on import.
 import './providers/index.js';
 import { brightSelect } from './lib/bright-select.js';
+import { buildContainerImage } from './lib/container-build.js';
 import { offerClaudeOnFailure } from './lib/claude-handoff.js';
 import { setPickedProvider } from './lib/picked-provider.js';
+import {
+  AGENT_IMAGE_PIN,
+  AGENT_IMAGE_REF_ENV_KEY,
+  REGISTRY_LOGIN_SCRIPT,
+  imageSourceDecided,
+  readAgentImagePin,
+  loginScriptAvailable,
+  readImageSource,
+  writeImageSource,
+  type ImageSource,
+} from './lib/registry-state.js';
 import { upsertEnvVar } from './set-env.js';
 import {
   applyToEnv,
@@ -65,6 +77,12 @@ import { DEFAULT_AGENT_PROVIDER } from '../src/config.js';
 
 const CLI_AGENT_NAME = 'Terminal Agent';
 const RUN_START = Date.now();
+
+/** How an operator reaches the registry step again once setup has finished. */
+const REGISTRY_STEP = 'pnpm exec tsx setup/index.ts --step registry';
+
+/** `setup/registry-login.sh`'s "nothing was signed in, and that is fine" code. */
+const LOGIN_EXIT_SKIPPED = 2;
 
 type ChannelChoice = 'telegram' | 'discord' | 'whatsapp' | 'signal' | 'teams' | 'slack' | 'imessage' | 'other' | 'skip';
 
@@ -184,10 +202,14 @@ async function main(): Promise<void> {
 
   if (!skip.has('container')) {
     p.log.message(brandBody(dimWrap('Your assistant lives in its own sandbox. It can only see what you explicitly share.', 4)));
+    // Asked before the step runs, because the step is what acts on the answer.
+    await chooseImageSource();
     p.log.message(
       brandBody(
         dimWrap(
-          'The first build pulls a base image and installs a few tools. On a fresh machine this usually takes 3–10 minutes.',
+          readImageSource() === 'hardened'
+            ? 'Fetching the hardened image now. This takes around 20 minutes today — slower than we would like, and we are working on making it faster.'
+            : 'The first build pulls a base image and installs a few tools. On a fresh machine this usually takes 3–10 minutes.',
           4,
         ),
       ),
@@ -211,6 +233,22 @@ async function main(): Promise<void> {
           'container',
           "Docker was just installed but your shell doesn't know yet.",
           'Log out and back in (or run `newgrp docker` in a new shell), then retry.',
+        );
+      }
+      // The pull path fails for reasons a build never has, and "prune the build
+      // cache" is useless advice for both of them.
+      if (err === 'image_ref_not_configured') {
+        await fail(
+          'container',
+          'This install is set to fetch a pre-built sandbox image, but nothing says which one.',
+          `Set ${AGENT_IMAGE_REF_ENV_KEY} in .env (or add an "${AGENT_IMAGE_PIN}" pin to versions.json), or run \`${REGISTRY_STEP} -- --opt-out\` to build it here instead.`,
+        );
+      }
+      if (err === 'image_pull_failed') {
+        await fail(
+          'container',
+          "Couldn't fetch the sandbox image.",
+          `Check your connection and that authentication finished, then retry — or run \`${REGISTRY_STEP} -- --opt-out\` to build it here instead.`,
         );
       }
       await fail(
@@ -338,6 +376,31 @@ async function main(): Promise<void> {
     // same way (docs/provider-migration.md).
     agentProvider = await askAgentProviderChoice();
     setPickedProvider(agentProvider);
+
+    // A pulled image bakes /app/node_modules and the CLI manifest, and every
+    // non-claude runtime changes one of them — so it needs an image this
+    // machine builds. Settle it here: buildContainerImage() below refuses on a
+    // pinned install, and reaching that refusal aborts setup with no way out
+    // short of re-running it.
+    if (agentProvider !== 'claude' && readImageSource() === 'hardened') {
+      const leave = ensureAnswer(
+        await p.confirm({
+          message: `${agentProvider} needs a sandbox image built on this machine. Stop using the pre-built one?`,
+          initialValue: true,
+        }),
+      );
+      if (!leave) {
+        await fail(
+          'auth',
+          `${agentProvider} can't run on the pre-built sandbox image.`,
+          'Re-run setup and choose Claude to keep the pre-built image.',
+        );
+      }
+      writeImageSource('local');
+      setupLog.userInput('image_source', 'local');
+      p.log.info(brandBody('Switched back to a locally built sandbox image.'));
+    }
+
     let providerEntry = getSetupProvider(agentProvider);
     if (agentProvider !== 'claude' && !providerEntry) {
       // A non-claude provider picked from the hard-wired list isn't wired in
@@ -372,7 +435,17 @@ async function main(): Promise<void> {
       }
       s.stop(`${agentProvider} installed.`);
       p.log.info(brandBody('Rebuilding the container image with the new provider…'));
-      spawnSync('./container/build.sh', [], { stdio: 'inherit' });
+      // The rebuild is not optional here: the provider's CLI manifest is baked
+      // into the image, so continuing past a failed build would authenticate a
+      // runtime the container cannot actually start.
+      const rebuild = buildContainerImage();
+      if (!rebuild.ok) {
+        await fail(
+          `add-${agentProvider}`,
+          `Couldn't rebuild the container image for ${agentProvider}. ${rebuild.message}`,
+          rebuild.hint,
+        );
+      }
       await import(`./providers/${agentProvider}.js`);
       providerEntry = getSetupProvider(agentProvider);
     }
@@ -842,15 +915,159 @@ const INSTALLABLE_PROVIDERS = [
   { value: 'codex', label: 'Codex', hint: 'OpenAI — ChatGPT subscription or API key' },
 ] as const;
 
+/**
+ * Where the sandbox image comes from — build it here, or pull a pre-built one.
+ *
+ * Asked once, ahead of the container step, and persisted to `.env` *before* the
+ * sign-in runs. Both resume paths (fail()'s retry re-exec and
+ * maybeReexecUnderSg) rebuild NANOCLAW_SKIP from the steps that completed, and
+ * the sign-in is deliberately not a step — so an answer that lived only in this
+ * process would be gone by the time the resumed run reached here, and the
+ * operator would be asked again after already signing in.
+ *
+ * Returns having done nothing when the question is already settled, which also
+ * covers `NANOCLAW_HARDENED_IMAGE=true` passed in by a packaged flow.
+ */
+async function chooseImageSource(): Promise<void> {
+  if (imageSourceDecided()) return;
+
+  // The runtime pick happens later (the auth step), so this is the best signal
+  // available: an explicit preset, else the persisted install-wide default.
+  // Getting it wrong in the permissive direction is caught at that pick.
+  const plannedProvider = (
+    process.env.NANOCLAW_AGENT_PROVIDER?.trim() ||
+    DEFAULT_AGENT_PROVIDER ||
+    'claude'
+  ).toLowerCase();
+  if (plannedProvider !== 'claude') {
+    p.log.info(
+      brandBody(
+        `Building the sandbox here — the pre-built image is Claude-only, and ${plannedProvider} needs an image of its own.`,
+      ),
+    );
+    return;
+  }
+
+  // Nothing to fetch unless this copy ships a pinned image reference. Offering
+  // the choice anyway would take an account, a sign-in and a token from someone
+  // whose install then has no image to pull — so don't ask a question whose
+  // good answer cannot be honoured.
+  if (!readAgentImagePin()) return;
+
+  p.log.message(
+    brandBody(
+      dimWrap(
+        "Your assistant's sandbox contains a browser and a language runtime — Chromium, Node, Bun and a handful of tools. Isolation keeps a misbehaving agent away from your machine, but it does nothing about known vulnerabilities in that software itself.",
+        4,
+      ),
+    ),
+  );
+  p.log.message(
+    brandBody(
+      dimWrap(
+        'Our partner Echo (echo.ai) rebuilds those components from scratch with only the essentials and patches what remains, which takes the known-vulnerability count from thousands to near zero. Building here instead gives you the same software, straight from its public base image.',
+        4,
+      ),
+    ),
+  );
+  p.log.message(
+    brandBody(
+      dimWrap(
+        'Fetching it means authenticating with NanoClaw: we record your email address and that you fetched an image, nothing else. Building sends nothing at all.',
+        4,
+      ),
+    ),
+  );
+
+  const choice = ensureAnswer(
+    await brightSelect<ImageSource>({
+      message: "Where should your assistant's sandbox image come from?",
+      options: [
+        {
+          value: 'hardened',
+          label: 'Fetch the hardened image, built by Echo',
+          hint: 'recommended — patched components; ~20 min to download, needs authentication',
+        },
+        {
+          value: 'local',
+          label: 'Build it here',
+          hint: 'no account, nothing recorded; takes 3-10 min',
+        },
+      ],
+      initialValue: 'hardened',
+    }),
+  ) as ImageSource;
+  setupLog.userInput('image_source', choice);
+  phEmit('image_source_chosen', { source: choice });
+
+  writeImageSource(choice);
+  if (choice === 'local') return;
+
+  if (!loginScriptAvailable()) {
+    p.log.warn(
+      brandBody(
+        `This copy of NanoClaw has no ${REGISTRY_LOGIN_SCRIPT} — building the sandbox here instead.`,
+      ),
+    );
+    writeImageSource('local');
+    return;
+  }
+
+  p.log.step(brandBody('Authenticating with NanoClaw…'));
+  console.log(k.dim('   (a code appears below; finish in your browser)'));
+  console.log();
+  const start = Date.now();
+  const code = await runInheritScript('bash', [REGISTRY_LOGIN_SCRIPT]);
+  const durationMs = Date.now() - start;
+  console.log();
+
+  if (code !== 0) {
+    // Falling back rather than aborting: a local build is a complete, supported
+    // install, and stranding someone at the first step because a device flow
+    // timed out would be a worse trade than the patch currency they lose.
+    // The script exits 2 for a deliberate skip, which is not a failure and
+    // should not read as one in the log.
+    const skipped = code === LOGIN_EXIT_SKIPPED;
+    setupLog.step('registry-login', skipped ? 'skipped' : 'failed', durationMs, { EXIT_CODE: code });
+    phEmit('registry_login_declined', { exit_code: code, skipped });
+    writeImageSource('local');
+    p.log.warn(
+      brandBody(
+        skipped
+          ? 'Not authenticated — building the sandbox here instead.'
+          : "Authentication didn't finish — building the sandbox here instead.",
+      ),
+    );
+    p.log.message(k.dim(`Re-run setup to try again, or check with \`${REGISTRY_STEP} -- --status\`.`));
+    return;
+  }
+
+  setupLog.step('registry-login', 'interactive', durationMs, {});
+  p.log.success(brandBody("Authenticated. Your assistant's sandbox will be fetched, not built."));
+}
+
 async function askAgentProviderChoice(): Promise<string> {
   const installed = listSetupProviders();
   const installedNames = new Set(installed.map((entry) => entry.value));
   // Offer the hard-wired installable providers this install hasn't wired yet —
   // selecting one applies its `/add-<name>` SKILL.md in-process.
   const available = INSTALLABLE_PROVIDERS.filter((prov) => !installedNames.has(prov.value));
+  // On a pinned install every non-Claude runtime forces a local rebuild — the
+  // image bakes /app/node_modules and the CLI manifest, and each changes one.
+  // Say so on the option rather than only at the confirm two steps later, so
+  // the cost is visible while the choice is still being made. Shown only when
+  // this install pulls; on a local-build install it is not a trade-off.
+  const pinned = readImageSource() === 'hardened';
+  const note = (value: string, hint: string): string =>
+    pinned && value !== 'claude' ? `${hint} — ⚠ not in the pre-built image; needs a local build` : hint;
+
   const options = [
-    ...installed.map(({ value, label, hint }) => ({ value, label, hint })),
-    ...available.map((prov) => ({ value: prov.value, label: prov.label, hint: `${prov.hint} — installs now` })),
+    ...installed.map(({ value, label, hint }) => ({ value, label, hint: note(value, hint) })),
+    ...available.map((prov) => ({
+      value: prov.value,
+      label: prov.label,
+      hint: note(prov.value, `${prov.hint} — installs now`),
+    })),
   ];
   const preset = process.env.NANOCLAW_AGENT_PROVIDER?.trim().toLowerCase();
   if (preset) {
@@ -1402,8 +1619,32 @@ function detectExistingOnecli(): { version: string; apiHost: string } | null {
 
 function runInheritScript(cmd: string, args: string[]): Promise<number> {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { stdio: 'inherit' });
-    child.on('close', (code) => resolve(code ?? 1));
+    // Hand the terminal over before spawning, or the child's first prompt eats
+    // a keystroke that never reaches it.
+    //
+    // `stdio: 'inherit'` gives the child our own fd 0 — the same file
+    // description, not a copy. clack leaves stdin resumed between prompts and
+    // puts the TTY in raw mode during one, so this process is still reading
+    // that fd when the child starts. Bytes it pulls in are buffered here and
+    // are gone as far as the child is concerned, which is why "Press Enter"
+    // needed pressing twice: the first went to a parent nobody was asking.
+    const tty = Boolean(process.stdin.isTTY);
+    const wasRaw = tty && process.stdin.isRaw;
+    if (wasRaw) process.stdin.setRawMode(false);
+    process.stdin.pause();
+
+    // Tells the child it has a UI in front of it, so it can leave the
+    // reporting to us instead of printing its own alongside ours.
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env: { ...process.env, NANOCLAW_SETUP_WIZARD: '1' },
+    });
+    child.on('close', (code) => {
+      // Deliberately not restoring raw mode: clack sets it per prompt, and
+      // handing it back a cooked TTY is the state it expects to find.
+      process.stdin.resume();
+      resolve(code ?? 1);
+    });
   });
 }
 

--- a/setup/container.ts
+++ b/setup/container.ts
@@ -3,6 +3,7 @@
  * Replaces 03-setup-container.sh
  */
 import { execSync, spawnSync } from 'child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import path from 'path';
 import { setTimeout as sleep } from 'timers/promises';
 
@@ -78,6 +79,97 @@ function parseArgs(args: string[]): { runtime: string } {
   }
   return { runtime };
 }
+
+/**
+ * Read a setup-time setting: caller's env wins, `.env` is the fallback.
+ *
+ * Not `src/config.ts`'s `readEnvFile` — `setup/index.ts` never calls
+ * `applyToEnv`, so on a standalone `--step container` run (including the
+ * `sg docker` re-exec below) none of these keys are in process.env.
+ */
+function readSetting(projectRoot: string, name: string): string | undefined {
+  const fromEnv = process.env[name]?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const content = readFileSync(path.join(projectRoot, '.env'), 'utf-8');
+    const match = content.match(new RegExp(`^${name}=(.+)$`, 'm'));
+    return match?.[1].trim().replace(/^["']|["']$/g, '');
+  } catch (_err) {
+    return undefined;
+  }
+}
+
+/**
+ * Repository half of the committed `agent-image` pin, if there is one.
+ *
+ * The pin may also be an object keyed by platform. Architecture is irrelevant
+ * here — per-platform references differ in digest, not in repository — so any
+ * entry answers the question, and this avoids needing to know the daemon's
+ * architecture on a step that must work standalone.
+ */
+function pinnedRepo(projectRoot: string): string | undefined {
+  try {
+    const raw = readFileSync(path.join(projectRoot, 'versions.json'), 'utf-8');
+    const pin = (JSON.parse(raw) as Record<string, unknown>)['agent-image'];
+    const ref =
+      typeof pin === 'string'
+        ? pin
+        : pin && typeof pin === 'object' && !Array.isArray(pin)
+          ? Object.values(pin as Record<string, unknown>).find(
+              (v): v is string => typeof v === 'string' && v.trim().length > 0,
+            )
+          : undefined;
+    return ref ? ref.split('@')[0] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The registry digest behind the local tag, for the status block. Empty for a
+ * locally built image — it has no RepoDigests — which is why it is only read
+ * on the pull path.
+ *
+ * `expectRepo` is the repository we just pulled from. The same bytes pushed to
+ * more than one repository carry one RepoDigest each, all addressing identically,
+ * so taking the first reports whichever sorts first — routinely not the one in
+ * play. Match the expected repository and only fall back when nothing matches.
+ */
+function imageDigest(image: string, expectRepo?: string): string {
+  const res = spawnSync(
+    'docker',
+    ['image', 'inspect', '--format', '{{range .RepoDigests}}{{println .}}{{end}}', image],
+    { encoding: 'utf-8' },
+  );
+  if (res.status !== 0) return '';
+  const all = (res.stdout ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (expectRepo) {
+    const match = all.find((d) => d.startsWith(`${expectRepo}@`));
+    if (match) return match;
+  }
+  return all[0] ?? '';
+}
+
+/**
+ * What the image must satisfy for a spawn to work, mirroring what
+ * `buildContainerArgs` produces: `--entrypoint bash`, an arbitrary uid on
+ * macOS, HOME forced to /home/node. The caller pre-creates /workspace/group in
+ * the scratch mount the way the host owns a real session dir, so this asserts
+ * the image can use it, not that the daemon can conjure it.
+ */
+const SMOKE_SCRIPT = [
+  'set -e',
+  'command -v bun >/dev/null',
+  'command -v git >/dev/null',
+  'test -r /app/node_modules',
+  'test -w /home/node',
+  'test -w /workspace/group',
+  'touch /workspace/.heartbeat',
+  'echo "Container OK"',
+].join('\n');
 
 export async function run(args: string[]): Promise<void> {
   const projectRoot = process.cwd();
@@ -186,46 +278,134 @@ export async function run(args: string[]): Promise<void> {
     // .env is optional; absence is normal on a fresh checkout
   }
 
+  // Where the image comes from. pull.sh fetches pinned bytes and retags them to
+  // `image`, so everything past this point is identical either way. The other
+  // rebuild paths refuse when this is set, because `docker build -t <slug>:latest`
+  // would replace the pinned image in place with nothing downstream able to tell.
+  const source =
+    readSetting(projectRoot, 'NANOCLAW_HARDENED_IMAGE')?.toLowerCase() === 'true'
+      ? 'pull'
+      : 'build';
+
   // Build — stdio inherit so the parent setup runner can tail docker's
   // per-step output and render it in a rolling window. Previously we used
   // execSync which buffered everything; users couldn't tell whether a
-  // 3–10 minute build was making progress or hung.
+  // 3–10 minute build was making progress or hung. The pull path inherits
+  // stdio for the same reason: a cold pull is minutes of layer transfer.
   let buildOk = false;
-  log.info('Building container', { runtime, buildArgs });
-  const buildRes = spawnSync(
-    buildCmd.split(' ')[0],
-    [
-      ...buildCmd.split(' ').slice(1),
-      ...buildArgs.flatMap((a) => a.split(' ')),
-      '-t',
-      image,
-      '.',
-    ],
-    {
-      cwd: path.join(projectRoot, 'container'),
+  let digest = '';
+  let errorCode = '';
+  if (source === 'pull') {
+    log.info('Acquiring container image from registry', { image });
+    const pullRes = spawnSync('bash', [path.join(projectRoot, 'container', 'pull.sh')], {
+      cwd: projectRoot,
       stdio: 'inherit',
-    },
-  );
-  if (buildRes.status === 0) {
-    buildOk = true;
-    log.info('Container build succeeded');
+    });
+    if (pullRes.status === 0) {
+      buildOk = true;
+      // The pinned ref names the repository we pulled from; pass it so the
+      // reported digest is that repository's and not some other one the same
+      // bytes also live in.
+      digest = imageDigest(image, readSetting(projectRoot, 'NANOCLAW_AGENT_IMAGE_REF')?.split('@')[0] ?? pinnedRepo(projectRoot));
+      log.info('Container image acquired', { image, digest });
+
+      // Retagging the slug tag does nothing for an agent group pinned to its
+      // own derived image — `container-runner.ts:511` prefers that pin — so
+      // the reconcile is part of acquiring the image, not a follow-up.
+      // Imported here rather than at the top of the file so a local-build
+      // install never loads the DB layer at all, and so a problem in the
+      // reconcile can't stop an install that already has its image.
+      try {
+        const { reconcileDerivedImages } = await import('./registry-reconcile.js');
+        const reconciled = reconcileDerivedImages();
+        log.info('Derived agent-group images reconciled', {
+          cleared: reconciled.cleared.length,
+          removed: reconciled.removed.length,
+          foreign: reconciled.foreign.length,
+        });
+      } catch (err) {
+        // Loud, but not fatal: the image is pulled and tagged. What's left is
+        // groups still spawning pre-hardened derived images, which is exactly
+        // what `--step registry-reconcile` exists to fix by hand.
+        log.error('Could not reconcile derived agent-group images', { err });
+      }
+    } else {
+      // No fallback to a local build: that would swap the pinned image for
+      // locally built bytes under the same tag and then report success.
+      // pull.sh exits 2 when there is nothing configured to pull.
+      errorCode = pullRes.status === 2 ? 'image_ref_not_configured' : 'image_pull_failed';
+      log.error('Container image pull failed', { exitCode: pullRes.status, errorCode });
+    }
   } else {
-    log.error('Container build failed', { exitCode: buildRes.status });
+    log.info('Building container', { runtime, buildArgs });
+    const buildRes = spawnSync(
+      buildCmd.split(' ')[0],
+      [
+        ...buildCmd.split(' ').slice(1),
+        ...buildArgs.flatMap((a) => a.split(' ')),
+        '-t',
+        image,
+        '.',
+      ],
+      {
+        cwd: path.join(projectRoot, 'container'),
+        stdio: 'inherit',
+      },
+    );
+    if (buildRes.status === 0) {
+      buildOk = true;
+      log.info('Container build succeeded');
+    } else {
+      log.error('Container build failed', { exitCode: buildRes.status });
+    }
   }
 
-  // Test
+  // Test under the contract the runner actually spawns with, not merely "the
+  // image can run something". On macOS `--user` is an arbitrary uid with no
+  // passwd entry, so everything the agent touches must be world-accessible or
+  // owned through a mount — the old `--entrypoint /bin/echo` test ran as the
+  // image's default user and passed on images the agent could not start in.
+  // Scratch dir under data/ because that is where real session dirs live.
   let testOk = false;
   if (buildOk) {
     log.info('Testing container');
+    mkdirSync(path.join(projectRoot, 'data'), { recursive: true });
+    const workspace = mkdtempSync(path.join(projectRoot, 'data', 'container-smoke-'));
+    // 0777 because the mount has to be writable by the container's effective
+    // uid, which is only the host's on the path where --user is pushed.
+    chmodSync(workspace, 0o777);
+    // Pre-create the image's WORKDIR on the host rather than letting the daemon
+    // materialize it inside the mount. Production does exactly this — the host
+    // owns the session dir and its `group/` before the container ever starts
+    // (buildMounts in src/container-runner.ts) — and daemons disagree about who
+    // owns a WORKDIR auto-created inside a bind mount, so relying on that would
+    // make the smoke test stricter than the thing it is meant to model.
+    mkdirSync(path.join(workspace, 'group'), { recursive: true });
+    chmodSync(path.join(workspace, 'group'), 0o777);
     try {
-      const output = execSync(
-        `echo '{}' | ${runCmd} run -i --rm --entrypoint /bin/echo ${image} "Container OK"`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-      );
-      testOk = output.includes('Container OK');
-      log.info('Container test result', { testOk });
-    } catch {
-      log.error('Container test failed');
+      const testArgs = ['run', '--rm', '-v', `${workspace}:/workspace`];
+      const hostUid = process.getuid?.();
+      const hostGid = process.getgid?.();
+      if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+        testArgs.push('--user', `${hostUid}:${hostGid}`, '-e', 'HOME=/home/node');
+      }
+      testArgs.push('--entrypoint', 'bash', image, '-c', SMOKE_SCRIPT);
+      const testRes = spawnSync(runCmd, testArgs, { encoding: 'utf-8' });
+      testOk = testRes.status === 0 && (testRes.stdout ?? '').includes('Container OK');
+      if (testOk) {
+        log.info('Container test result', { testOk });
+      } else {
+        log.error('Container test failed', {
+          exitCode: testRes.status,
+          stderr: (testRes.stderr ?? '').trim().slice(-500),
+        });
+      }
+    } finally {
+      try {
+        rmSync(workspace, { recursive: true, force: true });
+      } catch (err) {
+        log.warn('Could not remove the smoke-test workspace', { workspace, err });
+      }
     }
   }
 
@@ -234,9 +414,12 @@ export async function run(args: string[]): Promise<void> {
   emitStatus('SETUP_CONTAINER', {
     RUNTIME: runtime,
     IMAGE: image,
+    SOURCE: source,
+    ...(digest ? { DIGEST: digest } : {}),
     BUILD_OK: buildOk,
     TEST_OK: testOk,
     STATUS: status,
+    ...(errorCode ? { ERROR: errorCode } : {}),
     LOG: 'logs/setup.log',
   });
 

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -25,6 +25,8 @@ const STEPS: Record<
   auth: () => import('./auth.js'),
   'provider-auth': () => import('./provider-auth.js'),
   'cli-agent': () => import('./cli-agent.js'),
+  registry: () => import('./registry.js'),
+  'registry-reconcile': () => import('./registry-reconcile.js'),
   // >>> nanoclaw:setup-steps
   // <<< nanoclaw:setup-steps
 };

--- a/setup/install-cred-helper.ts
+++ b/setup/install-cred-helper.ts
@@ -1,0 +1,437 @@
+/**
+ * Installs `docker-credential-nanoclaw` and points docker at it for exactly one
+ * registry.
+ *
+ * The helper is a standalone script, not a repo module: docker execs it from an
+ * arbitrary cwd, and uninstalling NanoClaw deletes this checkout while the
+ * helper stays on PATH. So installing means copying the source out of the tree
+ * and stamping an absolute shebang onto the copy — `#!/usr/bin/env node` would
+ * resolve through whatever nvm/asdf shim happens to be in the spawning
+ * process's PATH, which is not reliably anything when the spawner is docker.
+ *
+ * Wiring is one `credHelpers` key in `~/.docker/config.json`, read-modify-write
+ * around every other key. That key is a pointer — no secret is written there,
+ * which is also why uninstall must never run `docker logout`: logout would
+ * revoke the credential of any other install sharing this machine.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+import { log } from '../src/log.js';
+import { readAgentImagePin, registryAuthPath } from './lib/registry-state.js';
+import { emitStatus } from './status.js';
+
+/** Docker resolves `credHelpers[host] = "<name>"` to `docker-credential-<name>` on PATH. */
+export const CRED_HELPER_NAME = 'nanoclaw';
+export const HELPER_BINARY_NAME = `docker-credential-${CRED_HELPER_NAME}`;
+
+/**
+ * Must match `HELPER_ID` in `setup/registry/credential-helper.mjs`. Install
+ * verifies the installed binary prints it, so drift fails at install time
+ * rather than silently making uninstall refuse to clean up.
+ */
+const HELPER_MARKER = 'nanoclaw-docker-credential-helper';
+
+/** Preferred first; `~/.local/bin` is the unprivileged fallback, as in setup/onecli.ts. */
+const BIN_DIRS = ['/usr/local/bin', path.join(os.homedir(), '.local', 'bin')];
+
+/**
+ * A registry hostname, optionally with a port — never a URL. Docker Hub is
+ * keyed as `https://index.docker.io/v1/`, so a scheme here is a sign someone
+ * generalized from the wrong example; ECR wants the plain host.
+ */
+const HOSTNAME_RE = /^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:\d{1,5})?$/;
+
+export interface CredHelperOptions {
+  /** The registry to wire. Defaults to the one recorded by login. */
+  registryHost?: string;
+  /** Override the install directory. Defaults to the first writable of BIN_DIRS. */
+  binDir?: string;
+  /** Override `~/.docker/config.json`. Honors `DOCKER_CONFIG` by default. */
+  dockerConfigPath?: string;
+}
+
+export interface CredHelperInstallResult {
+  helperPath: string;
+  registryHost: string;
+  dockerConfigPath: string;
+  dockerConfigChanged: boolean;
+  /** False means docker will not find the helper — the caller should say so. */
+  onPath: boolean;
+}
+
+export interface CredHelperRemovalResult {
+  removedBinaries: string[];
+  /** Binaries left alone because they are not ours. */
+  keptBinaries: string[];
+  removedHosts: string[];
+  dockerConfigPath: string;
+  dockerConfigChanged: boolean;
+}
+
+export interface CredHelperStatus {
+  installed: boolean;
+  helperPath?: string;
+  wiredHosts: string[];
+  dockerConfigPath: string;
+}
+
+function helperSourcePath(): string {
+  return fileURLToPath(new URL('registry/credential-helper.mjs', import.meta.url));
+}
+
+export function dockerConfigPath(override?: string): string {
+  if (override) return override;
+  const base = process.env.DOCKER_CONFIG?.trim() || path.join(os.homedir(), '.docker');
+  return path.join(base, 'config.json');
+}
+
+/**
+ * Which registry to wire. The image pin is the authoritative answer — it is the
+ * reference `container/pull.sh` will hand docker, and wiring any other host
+ * would route the pull past this helper. Sign-in may also record a `registry`,
+ * which wins because it reflects the entitlement the token was issued against.
+ */
+export function resolveRegistryHost(explicit?: string): string {
+  const candidates = [
+    explicit,
+    readRecordedRegistry(),
+    registryFromRef(readAgentImagePin()),
+    process.env.NANOCLAW_REGISTRY_HOST,
+  ];
+  const host = candidates.find((c) => c && c.trim())?.trim();
+  if (!host) {
+    throw new Error(
+      'No registry host to wire. Pass one, pin the agent image in versions.json, or sign in first so ' +
+        `${registryAuthPath()} records which registry this install pulls from.`,
+    );
+  }
+  if (!HOSTNAME_RE.test(host)) {
+    throw new Error(`Not a registry hostname: ${host} (expected e.g. 1234.dkr.ecr.us-east-1.amazonaws.com, no scheme)`);
+  }
+  return host.toLowerCase();
+}
+
+function readRecordedRegistry(): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(registryAuthPath(), 'utf-8'));
+    const registry = (parsed as { registry?: unknown } | null)?.registry;
+    return typeof registry === 'string' ? registry : undefined;
+  } catch (_err) {
+    // Absent before sign-in, and unreadable is the same answer: we don't know.
+    return undefined;
+  }
+}
+
+/**
+ * The registry a pullable reference names, by docker's own rule: the first path
+ * component is a hostname only when it carries a dot or a port, or is
+ * `localhost`. Anything else is a Docker Hub short name with no registry in it.
+ */
+function registryFromRef(ref: string | undefined): string | undefined {
+  const slash = ref?.indexOf('/') ?? -1;
+  if (!ref || slash === -1) return undefined;
+  const first = ref.slice(0, slash);
+  return first === 'localhost' || first.includes('.') || first.includes(':') ? first : undefined;
+}
+
+function chooseBinDir(override?: string): string {
+  const dirs = override ? [override] : BIN_DIRS;
+  for (const dir of dirs) {
+    try {
+      fs.accessSync(dir, fs.constants.W_OK);
+      return dir;
+    } catch (_err) {
+      // Not writable, or absent — /usr/local/bin does not exist on a fresh
+      // Apple Silicon machine. Fall through to the next candidate.
+    }
+  }
+  const fallback = dirs[dirs.length - 1];
+  fs.mkdirSync(fallback, { recursive: true });
+  return fallback;
+}
+
+/** Swap the source's shebang for one naming this exact node binary. */
+export function renderHelper(source: string, nodePath: string): string {
+  const body = source.startsWith('#!') ? source.slice(source.indexOf('\n') + 1) : source;
+  return `#!${nodePath}\n${body}`;
+}
+
+/**
+ * Write through a temp file in the same directory. Replacing a running
+ * executable in place is `ETXTBSY` on Linux and a torn read for a pull already
+ * in flight; a rename is atomic and gives the old inode to whoever holds it.
+ */
+function writeExecutable(dest: string, contents: string): void {
+  const tmp = `${dest}.tmp-${process.pid}`;
+  try {
+    fs.writeFileSync(tmp, contents, { mode: 0o755 });
+    fs.chmodSync(tmp, 0o755);
+    fs.renameSync(tmp, dest);
+  } catch (err) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch (_cleanupErr) {
+      // Nothing more to do; the original error is the one that matters.
+    }
+    throw err;
+  }
+}
+
+function isOurBinary(file: string): boolean {
+  try {
+    return fs.readFileSync(file, 'utf-8').includes(HELPER_MARKER);
+  } catch (_err) {
+    return false;
+  }
+}
+
+function onPath(dir: string): boolean {
+  const entries = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  return entries.some((entry) => path.resolve(entry) === path.resolve(dir));
+}
+
+interface DockerConfig {
+  credHelpers?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/**
+ * Refuses to guess at a config it cannot parse. This file can hold every
+ * registry credential on the machine, so "rewrite it from scratch" is not an
+ * acceptable recovery.
+ */
+function readDockerConfig(file: string): DockerConfig {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+  if (!raw.trim()) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${file} is not valid JSON, so it cannot be edited safely: ${(err as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${file} is not a JSON object, so it cannot be edited safely`);
+  }
+  const config = parsed as DockerConfig;
+  const helpers = config.credHelpers;
+  if (helpers !== undefined && (typeof helpers !== 'object' || Array.isArray(helpers))) {
+    throw new Error(`${file} has a credHelpers value that is not an object — fix it by hand`);
+  }
+  return config;
+}
+
+/** Tab-indented to match what the docker CLI itself writes, keeping diffs quiet. */
+function writeDockerConfig(file: string, config: DockerConfig): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  let mode = 0o600;
+  try {
+    mode = fs.statSync(file).mode & 0o777;
+  } catch (_err) {
+    // New file: 0600, matching what docker creates.
+  }
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(config, null, '\t')}\n`, { mode });
+  fs.renameSync(tmp, file);
+}
+
+export function installCredentialHelper(options: CredHelperOptions = {}): CredHelperInstallResult {
+  const registryHost = resolveRegistryHost(options.registryHost);
+
+  // Read the docker config before writing anything: an unparsable one aborts
+  // the install, and it should abort it before a binary lands on PATH.
+  const configFile = dockerConfigPath(options.dockerConfigPath);
+  const config = readDockerConfig(configFile);
+
+  const binDir = chooseBinDir(options.binDir);
+  const helperPath = path.join(binDir, HELPER_BINARY_NAME);
+  writeExecutable(helperPath, renderHelper(fs.readFileSync(helperSourcePath(), 'utf-8'), process.execPath));
+
+  // Proves the shebang resolves and that this binary is the one uninstall will
+  // recognize — both silent failures otherwise, discovered mid-pull.
+  const check = spawnSync(helperPath, ['version'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  if (check.status !== 0 || !(check.stdout ?? '').includes(HELPER_MARKER)) {
+    throw new Error(
+      `${helperPath} did not run after install (exit ${check.status}): ${(check.stderr ?? check.error?.message ?? '').trim()}`,
+    );
+  }
+
+  const credHelpers = config.credHelpers ?? {};
+  const dockerConfigChanged = credHelpers[registryHost] !== CRED_HELPER_NAME;
+  if (dockerConfigChanged) {
+    credHelpers[registryHost] = CRED_HELPER_NAME;
+    config.credHelpers = credHelpers;
+    writeDockerConfig(configFile, config);
+  }
+
+  const reachable = onPath(binDir);
+  // Debug, not info: `log.info` writes to stdout, and the only success-path
+  // caller is the interactive sign-in, where this lands as a timestamped
+  // diagnostic mid-conversation. The cases needing attention are `log.warn`
+  // below, which goes to stderr.
+  log.debug('Installed the docker credential helper', {
+    helperPath,
+    registryHost,
+    dockerConfigChanged,
+    onPath: reachable,
+  });
+  if (!reachable) {
+    log.warn('Helper directory is not on PATH — docker will not find it', { binDir });
+  }
+
+  return { helperPath, registryHost, dockerConfigPath: configFile, dockerConfigChanged, onPath: reachable };
+}
+
+/**
+ * Removes our key and our binary, nothing else.
+ *
+ * Every `credHelpers` entry pointing at us goes, not just the currently
+ * configured host, so a registry change earlier in this install's life cannot
+ * strand a key that routes pulls to a helper that no longer exists.
+ */
+export function uninstallCredentialHelper(options: CredHelperOptions = {}): CredHelperRemovalResult {
+  const removedBinaries: string[] = [];
+  const keptBinaries: string[] = [];
+  const dirs = options.binDir ? [options.binDir] : BIN_DIRS;
+  for (const dir of dirs) {
+    const file = path.join(dir, HELPER_BINARY_NAME);
+    if (!fs.existsSync(file)) continue;
+    if (!isOurBinary(file)) {
+      keptBinaries.push(file);
+      continue;
+    }
+    try {
+      fs.rmSync(file);
+      removedBinaries.push(file);
+    } catch (err) {
+      log.warn('Could not remove the credential helper', { file, err });
+      keptBinaries.push(file);
+    }
+  }
+
+  const configFile = dockerConfigPath(options.dockerConfigPath);
+  const removedHosts: string[] = [];
+  let dockerConfigChanged = false;
+  try {
+    const config = readDockerConfig(configFile);
+    const credHelpers = config.credHelpers ?? {};
+    for (const [host, helper] of Object.entries(credHelpers)) {
+      if (helper === CRED_HELPER_NAME) {
+        delete credHelpers[host];
+        removedHosts.push(host);
+      }
+    }
+    if (removedHosts.length > 0) {
+      if (Object.keys(credHelpers).length === 0) delete config.credHelpers;
+      else config.credHelpers = credHelpers;
+      writeDockerConfig(configFile, config);
+      dockerConfigChanged = true;
+    }
+  } catch (err) {
+    // An unparsable docker config is the user's to fix; the binary is already
+    // gone, so a stale pointer fails loudly rather than silently minting.
+    log.warn('Left the docker config alone', { configFile, err });
+  }
+
+  log.info('Removed the docker credential helper', { removedBinaries, removedHosts });
+  return { removedBinaries, keptBinaries, removedHosts, dockerConfigPath: configFile, dockerConfigChanged };
+}
+
+export function credentialHelperStatus(options: CredHelperOptions = {}): CredHelperStatus {
+  const dirs = options.binDir ? [options.binDir] : BIN_DIRS;
+  const helperPath = dirs.map((dir) => path.join(dir, HELPER_BINARY_NAME)).find((file) => isOurBinary(file));
+
+  const configFile = dockerConfigPath(options.dockerConfigPath);
+  let wiredHosts: string[] = [];
+  try {
+    const config = readDockerConfig(configFile);
+    wiredHosts = Object.entries(config.credHelpers ?? {})
+      .filter(([, helper]) => helper === CRED_HELPER_NAME)
+      .map(([host]) => host);
+  } catch (err) {
+    log.warn('Could not read the docker config', { configFile, err });
+  }
+
+  return { installed: helperPath !== undefined, helperPath, wiredHosts, dockerConfigPath: configFile };
+}
+
+function parseArgs(args: string[]): { mode: 'install' | 'uninstall' | 'status'; options: CredHelperOptions } {
+  const options: CredHelperOptions = {};
+  let mode: 'install' | 'uninstall' | 'status' = 'install';
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--uninstall') mode = 'uninstall';
+    else if (args[i] === '--status') mode = 'status';
+    else if (args[i] === '--registry-host' && args[i + 1]) options.registryHost = args[++i];
+    else if (args[i] === '--bin-dir' && args[i + 1]) options.binDir = args[++i];
+    else if (args[i] === '--docker-config' && args[i + 1]) options.dockerConfigPath = args[++i];
+  }
+  return { mode, options };
+}
+
+/** Never prompts — reachable from setup's step runner, which discards stdin. */
+export async function run(args: string[]): Promise<void> {
+  const { mode, options } = parseArgs(args);
+
+  if (mode === 'status') {
+    const status = credentialHelperStatus(options);
+    emitStatus('CRED_HELPER', {
+      INSTALLED: status.installed,
+      ...(status.helperPath ? { HELPER: status.helperPath } : {}),
+      HOSTS: status.wiredHosts.join(',') || '(none)',
+      DOCKER_CONFIG: status.dockerConfigPath,
+      STATUS: 'success',
+    });
+    return;
+  }
+
+  if (mode === 'uninstall') {
+    const removal = uninstallCredentialHelper(options);
+    emitStatus('CRED_HELPER', {
+      REMOVED: removal.removedBinaries.join(',') || '(none)',
+      ...(removal.keptBinaries.length ? { KEPT: removal.keptBinaries.join(',') } : {}),
+      HOSTS: removal.removedHosts.join(',') || '(none)',
+      DOCKER_CONFIG: removal.dockerConfigPath,
+      CONFIG_EDITED: removal.dockerConfigChanged,
+      STATUS: 'success',
+    });
+    return;
+  }
+
+  const result = installCredentialHelper(options);
+  const pathHint = `Add ${path.dirname(result.helperPath)} to PATH or docker cannot find the helper`;
+  emitStatus('CRED_HELPER', {
+    HELPER: result.helperPath,
+    HOST: result.registryHost,
+    DOCKER_CONFIG: result.dockerConfigPath,
+    ON_PATH: result.onPath,
+    STATUS: 'success',
+    ...(result.onPath ? {} : { HINT: pathHint }),
+  });
+}
+
+/** True when this file is the entry point rather than an import. */
+function invokedDirectly(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  // realpath because node resolves a module's own URL through symlinks while
+  // argv[1] keeps whatever the caller typed — on macOS /tmp and /var alone are
+  // enough to make the naive comparison fail.
+  const resolved = fs.existsSync(entry) ? fs.realpathSync(entry) : entry;
+  return import.meta.url === pathToFileURL(resolved).href;
+}
+
+if (invokedDirectly()) {
+  run(process.argv.slice(2)).catch((err: unknown) => {
+    log.error('Credential helper install failed', { err });
+    process.exit(1);
+  });
+}

--- a/setup/lib/container-build.ts
+++ b/setup/lib/container-build.ts
@@ -1,0 +1,77 @@
+/**
+ * The one seam through which setup rebuilds the agent container image.
+ *
+ * Both callers used to shell out to `build.sh` directly and drop the result:
+ * `setup/auto.ts` ignored the exit status outright, so a failed build read like
+ * a successful one and the run carried on against a stale image.
+ *
+ * It also refuses when the image is pinned. An install that pulled its image
+ * holds those bytes under the local slug tag, and an unconditional
+ * `docker build -t <slug>:latest` replaces them in place — same name, different
+ * bytes, invisible downstream, because the tag is all `src/container-runner.ts`
+ * ever looks at. `build.sh` refuses too; this is the earlier, better-worded stop.
+ *
+ * The result is returned, never printed: `setup/auto.ts` renders it through
+ * clack's `fail()`, the standalone step through `console.error` + exit.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { HARDENED_IMAGE_ENV_KEY, readImageSource } from './registry-state.js';
+
+/**
+ * Discriminated so a caller that has checked `ok` gets a `message` typed
+ * `string`, not `string | undefined` — the failure branch is the whole point.
+ */
+export type ContainerBuildResult =
+  | { ok: true }
+  | {
+      ok: false;
+      /** One user-facing sentence naming the failure. */
+      message: string;
+      /** What the operator can do about it. */
+      hint?: string;
+    };
+
+/**
+ * Rebuild the agent container image, refusing when the image is pinned.
+ *
+ * Synchronous with inherited stdio — docker's own output is the progress
+ * indicator. Callers must inspect the result.
+ */
+export function buildContainerImage(projectRoot: string = process.cwd()): ContainerBuildResult {
+  if (readImageSource() === 'hardened') {
+    return {
+      ok: false,
+      message: `This install runs a pinned agent image (${HARDENED_IMAGE_ENV_KEY}=true in .env), and a local build would overwrite it under the same tag.`,
+      hint: `Run \`./container/build.sh pull\` to refresh the pinned image, or remove ${HARDENED_IMAGE_ENV_KEY} from .env to go back to locally built ones.`,
+    };
+  }
+
+  const script = path.join(projectRoot, 'container', 'build.sh');
+  const res = spawnSync(script, [], { cwd: projectRoot, stdio: 'inherit' });
+
+  if (res.error) {
+    return {
+      ok: false,
+      message: `Couldn't run ${script}: ${res.error.message}`,
+      hint: 'Check that the script exists at that path and is executable.',
+    };
+  }
+  if (res.signal) {
+    return {
+      ok: false,
+      message: `The container image build was terminated by ${res.signal}.`,
+      hint: 'If you interrupted it, re-run when ready. Otherwise it was most likely killed for memory — give Docker more, then retry.',
+    };
+  }
+  if (res.status !== 0) {
+    return {
+      ok: false,
+      message: `The container image build failed (exit ${res.status}).`,
+      hint: 'The build output above has the reason. Docker must be running, and the build needs network access to fetch base layers.',
+    };
+  }
+
+  return { ok: true };
+}

--- a/setup/lib/registry-state.test.ts
+++ b/setup/lib/registry-state.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The agent-image pin has two shapes, and picking the wrong reference for the
+ * running machine is not a visible failure — it is an image that pulls, retags
+ * onto the local tag, and then either emulates or dies at spawn inside a `--rm`
+ * container whose logs are discarded.
+ *
+ * The `container/pull.sh` half of this resolution is shell and is covered by
+ * the sibling assertions at the bottom: the two readers must stay in step,
+ * because --status compares against whatever pull.sh actually used.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+import { pinnedPlatforms, resolvePinForPlatform } from './registry-state.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const PER_ARCH = {
+  'linux/amd64': 'reg.example.com/nanoclaw/agent@sha256:aaaa',
+  'linux/arm64': 'reg.example.com/nanoclaw/agent@sha256:bbbb',
+};
+
+describe('resolvePinForPlatform', () => {
+  it('returns a single reference unchanged for every platform', () => {
+    // A multi-arch index is docker's job to resolve. Second-guessing it here is
+    // how you end up pulling the wrong child.
+    const ref = 'reg.example.com/nanoclaw/agent@sha256:cccc';
+    expect(resolvePinForPlatform(ref, 'linux/amd64')).toBe(ref);
+    expect(resolvePinForPlatform(ref, 'linux/arm64')).toBe(ref);
+  });
+
+  it('selects the matching entry from a per-platform pin', () => {
+    expect(resolvePinForPlatform(PER_ARCH, 'linux/amd64')).toBe(PER_ARCH['linux/amd64']);
+    expect(resolvePinForPlatform(PER_ARCH, 'linux/arm64')).toBe(PER_ARCH['linux/arm64']);
+  });
+
+  it('returns undefined rather than any reference when the platform is absent', () => {
+    // Falling back to "some other architecture's image" would be worse than
+    // failing: it pulls and retags before anything notices.
+    expect(resolvePinForPlatform(PER_ARCH, 'linux/riscv64')).toBeUndefined();
+  });
+
+  it('ignores shapes that are not a reference', () => {
+    expect(resolvePinForPlatform(undefined, 'linux/arm64')).toBeUndefined();
+    expect(resolvePinForPlatform(null, 'linux/arm64')).toBeUndefined();
+    expect(resolvePinForPlatform('', 'linux/arm64')).toBeUndefined();
+    expect(resolvePinForPlatform('   ', 'linux/arm64')).toBeUndefined();
+    expect(resolvePinForPlatform([PER_ARCH], 'linux/arm64')).toBeUndefined();
+    expect(resolvePinForPlatform({ 'linux/arm64': 42 }, 'linux/arm64')).toBeUndefined();
+  });
+
+  it('trims, so a stray newline in a hand-edited pin still resolves', () => {
+    expect(resolvePinForPlatform({ 'linux/arm64': ' repo@sha256:dddd\n' }, 'linux/arm64')).toBe(
+      'repo@sha256:dddd',
+    );
+  });
+});
+
+describe('pinnedPlatforms', () => {
+  it('lists the platforms an object pin declares', () => {
+    expect(pinnedPlatforms(PER_ARCH)).toEqual(['linux/amd64', 'linux/arm64']);
+  });
+
+  it('is empty for a single reference, which declares no platforms', () => {
+    expect(pinnedPlatforms('repo@sha256:cccc')).toEqual([]);
+    expect(pinnedPlatforms(undefined)).toEqual([]);
+  });
+
+  it('omits entries that are not usable references', () => {
+    expect(pinnedPlatforms({ 'linux/amd64': 'repo@sha256:aaaa', 'linux/arm64': '' })).toEqual([
+      'linux/amd64',
+    ]);
+  });
+});
+
+describe('the shell reader stays in step', () => {
+  const pullSh = fs.readFileSync(path.join(here, '..', '..', 'container', 'pull.sh'), 'utf-8');
+
+  it('resolves the daemon architecture, not the host CPU', () => {
+    // Docker Desktop, a remote daemon and a cross-architecture context all make
+    // these differ, and the daemon is what executes the image.
+    expect(pullSh).toContain("version --format '{{.Server.Arch}}'");
+  });
+
+  it('reads a per-platform pin as well as a single reference', () => {
+    expect(pullSh).toContain('read_version_pin_platform');
+    expect(pullSh).toContain('version_pin_platforms');
+  });
+
+  it('keys per-platform lookups on linux/<arch>, as this module does', () => {
+    expect(pullSh).toContain('HOST_PLATFORM="linux/${HOST_ARCH}"');
+  });
+});

--- a/setup/lib/registry-state.ts
+++ b/setup/lib/registry-state.ts
@@ -1,0 +1,442 @@
+/**
+ * Reader/writer for agent-image source state — and, on the gated path, for who
+ * this install is to the registry.
+ *
+ * Intent and reality are two separate reads, because a pulled image is retagged
+ * onto the same local tag a build writes — so `.env` can claim "hardened" while
+ * a fallback build actually ran. Never treat intent as evidence:
+ *
+ *   readImageSource()    — what the operator asked for (`.env`)
+ *   inspectAgentImage()  — what the local tag resolves to (docker)
+ *
+ * `setup/container.ts` and `container/build.sh` still parse the key themselves
+ * (the former can't import from `setup/lib` on a standalone `--step container`
+ * run; the latter is bash). All readers compare trimmed + lower-cased against
+ * `true` — keep it that way.
+ *
+ * The account half (credential file, broker URL, docker `credHelpers` pointer)
+ * lives here for the same reason the image half does: the login flow, the
+ * `registry` step and uninstall all touch it, and three private copies of
+ * "where is the token" is how they end up disagreeing.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { readEnvFile } from '../../src/env.js';
+import { getDefaultContainerImage } from '../../src/install-slug.js';
+import { upsertEnvVar } from '../set-env.js';
+import { readVersionPinValue } from './version-pins.js';
+
+/** `.env` key carrying the opt-in. Read by setup and by `container/build.sh`. */
+export const HARDENED_IMAGE_ENV_KEY = 'NANOCLAW_HARDENED_IMAGE';
+
+/**
+ * `versions.json` key holding the full pullable reference, digest included.
+ * One key rather than a repo/digest pair so the halves cannot drift apart.
+ *
+ * Two shapes. A single string is the normal one and covers both a multi-arch
+ * index digest — which docker resolves to the running platform by itself, so
+ * nothing here has to think about architecture — and a single-architecture
+ * digest from a publisher that ships only one. An object keyed by docker
+ * platform string is for a publisher that ships per-architecture references
+ * instead of one index:
+ *
+ *   "agent-image": "repo@sha256:…"
+ *   "agent-image": { "linux/amd64": "repo@sha256:…", "linux/arm64": "repo@sha256:…" }
+ */
+export const AGENT_IMAGE_PIN = 'agent-image';
+
+/**
+ * Per-machine override of that reference, so an operator can point at their own
+ * registry without editing a committed file. `container/pull.sh` reads it too.
+ */
+export const AGENT_IMAGE_REF_ENV_KEY = 'NANOCLAW_AGENT_IMAGE_REF';
+
+/**
+ * Provenance label. Only a build can set it, so it travels with the bytes and
+ * survives the retag that erases every other difference.
+ */
+export const IMAGE_SOURCE_LABEL = 'dev.nanoclaw.image-source';
+
+/** What the operator asked for. */
+export type ImageSource = 'local' | 'hardened';
+
+/**
+ * What the tag on this machine actually is. `missing` means docker answered
+ * and has no such image; `unknown` means we could not ask it at all.
+ */
+export type ActualImageSource = ImageSource | 'derived' | 'missing' | 'unknown';
+
+/** Caller's env wins, then `.env`. The one place this key is parsed in TS. */
+function rawImageSourceSetting(): string | undefined {
+  const env = readEnvFile([HARDENED_IMAGE_ENV_KEY]);
+  return process.env[HARDENED_IMAGE_ENV_KEY] || env[HARDENED_IMAGE_ENV_KEY];
+}
+
+/**
+ * Fresh read every call: setup writes this key and reads it back in one run.
+ *
+ * Deliberately not exported from `src/config.ts`. The host never needs it — the
+ * pull retags onto the local slug tag, so nothing in `src/` learns a registry
+ * exists. If this key ever has to reach the host process, that invariant broke.
+ */
+export function readImageSource(): ImageSource {
+  return rawImageSourceSetting()?.trim().toLowerCase() === 'true' ? 'hardened' : 'local';
+}
+
+/**
+ * Whether anyone has answered the question yet — an absent key and an explicit
+ * `false` both read as `local` from `readImageSource`, and setup has to tell
+ * them apart: the first means "ask", the second means "they said no, don't ask
+ * again". That distinction is what makes a resumed run stop re-prompting, so
+ * `writeImageSource` writes `false` rather than deleting the line.
+ */
+export function imageSourceDecided(): boolean {
+  return (rawImageSourceSetting() ?? '').trim() !== '';
+}
+
+/**
+ * Opting out writes `false` rather than deleting the line — an explicit "no"
+ * is visible in `.env` and survives a resumed setup; an absent key isn't.
+ */
+export function writeImageSource(source: ImageSource): void {
+  upsertEnvVar(HARDENED_IMAGE_ENV_KEY, source === 'hardened' ? 'true' : 'false');
+}
+
+/**
+ * The image reference this install pulls, or undefined when unpinned.
+ *
+ * Precedence mirrors `container/pull.sh` — env, then `.env`, then the
+ * `versions.json` pin — so verify reports what actually got pulled.
+ *
+ * Soft where the read throws: "no pin" is the normal permanent state of
+ * every local-build install. On the hardened path treat `undefined` as "not
+ * configured to pull" and say so; never as a reason to fall back quietly.
+ */
+export function readAgentImagePin(): string | undefined {
+  const env = readEnvFile([AGENT_IMAGE_REF_ENV_KEY]);
+  const override = process.env[AGENT_IMAGE_REF_ENV_KEY]?.trim() || env[AGENT_IMAGE_REF_ENV_KEY];
+  if (override) return override;
+  try {
+    const pin = readVersionPinValue(AGENT_IMAGE_PIN);
+    // Only the object shape needs to know the platform, and asking costs a
+    // docker spawn — so don't ask on the single-reference path, which is both
+    // the common one and the one that works before docker is even installed.
+    if (typeof pin === 'string') return pin.trim() || undefined;
+    return resolvePinForPlatform(pin, dockerPlatform());
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pick one platform's reference out of whatever shape the pin has. A string
+ * pin is returned as-is for every platform: resolving a multi-arch index is
+ * docker's job, and second-guessing it here is how you end up pulling the
+ * wrong child.
+ *
+ * Exported for tests — callers want `readAgentImagePin`.
+ */
+export function resolvePinForPlatform(pin: unknown, platform: string): string | undefined {
+  if (typeof pin === 'string') return pin.trim() || undefined;
+  if (!pin || typeof pin !== 'object' || Array.isArray(pin)) return undefined;
+  const value = (pin as Record<string, unknown>)[platform];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+/** Platforms an object-shaped pin declares. Empty for a single reference. */
+export function pinnedPlatforms(pin: unknown): string[] {
+  if (!pin || typeof pin !== 'object' || Array.isArray(pin)) return [];
+  return Object.entries(pin as Record<string, unknown>)
+    .filter(([, v]) => typeof v === 'string' && v.trim())
+    .map(([k]) => k)
+    .sort();
+}
+
+/**
+ * Set when the file pins something but nothing for this machine — the one case
+ * where "no pin" would otherwise be reported as "this install doesn't pull",
+ * which is a materially different and wrong answer.
+ */
+export function unsupportedPlatformPin(): { platform: string; available: string[] } | undefined {
+  try {
+    const pin = readVersionPinValue(AGENT_IMAGE_PIN);
+    const available = pinnedPlatforms(pin);
+    if (available.length === 0) return undefined;
+    const platform = dockerPlatform();
+    return resolvePinForPlatform(pin, platform) ? undefined : { platform, available };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Docker's platform string for the daemon that will run the pull.
+ *
+ * The *daemon's* architecture, not this process's: with Docker Desktop, a
+ * remote daemon or a cross-architecture context, the machine running node is
+ * not the machine running the container. `container/pull.sh` resolves it the
+ * same way for the same reason — if these two disagree, `--status` compares
+ * against a pin the pull never used.
+ */
+let cachedPlatform: string | undefined;
+export function dockerPlatform(): string {
+  if (cachedPlatform) return cachedPlatform;
+  const res = spawnSync('docker', ['version', '--format', '{{.Server.Arch}}'], {
+    encoding: 'utf-8',
+  });
+  const fromDaemon = res.status === 0 ? res.stdout.trim() : '';
+  cachedPlatform = `linux/${fromDaemon || nodeArchToDocker(process.arch)}`;
+  return cachedPlatform;
+}
+
+/** Node's architecture names are not docker's. */
+function nodeArchToDocker(arch: string): string {
+  return arch === 'x64' ? 'amd64' : arch;
+}
+
+/** The `sha256:…` half of the pin. Undefined when unpinned or not a digest ref. */
+export function readAgentImageDigest(): string | undefined {
+  return splitDigest(readAgentImagePin());
+}
+
+/**
+ * The registry host the pin points at — the `credHelpers` key docker looks up
+ * when it pulls, and the only host this install's helper should ever answer for.
+ *
+ * Derived from the pin rather than configured separately so the pointer cannot
+ * outlive the reference that justified it. Docker's own rule for telling a
+ * registry host from a Docker Hub namespace: the first segment counts as a host
+ * only if it has a dot, a port, or is `localhost`.
+ */
+export function readRegistryHost(): string | undefined {
+  const ref = readAgentImagePin();
+  if (!ref || !ref.includes('/')) return undefined;
+  const first = ref.slice(0, ref.indexOf('/'));
+  return first.includes('.') || first.includes(':') || first === 'localhost'
+    ? first
+    : undefined;
+}
+
+export interface AgentImageInspection {
+  /** The local tag inspected — `nanoclaw-agent-v2-<slug>:latest`. */
+  ref: string;
+  /** Local image ID (`sha256:…` over the config blob). Absent when not present. */
+  id?: string;
+  /**
+   * Registry manifest digest — set only for an image that arrived over the
+   * wire. A `docker build` never produces one. This is the value to compare
+   * against `readAgentImageDigest()`.
+   */
+  registryDigest?: string;
+  labels: Record<string, string>;
+  source: ActualImageSource;
+}
+
+/**
+ * What the slug tag actually resolves to. `missing` means docker ran and said
+ * no; `unknown` means we couldn't ask. A merely-stopped daemon also exits
+ * non-zero, so confirm reachability first if the distinction has to be trusted.
+ */
+export function inspectAgentImage(projectRoot: string = process.cwd()): AgentImageInspection {
+  const ref = getDefaultContainerImage(projectRoot);
+  const res = spawnSync('docker', ['image', 'inspect', ref], { encoding: 'utf-8' });
+
+  if (res.error) return { ref, labels: {}, source: 'unknown' };
+  if (res.status !== 0) return { ref, labels: {}, source: 'missing' };
+
+  let entry: DockerInspectEntry | undefined;
+  try {
+    const parsed: unknown = JSON.parse(res.stdout);
+    entry = Array.isArray(parsed) ? (parsed[0] as DockerInspectEntry | undefined) : undefined;
+  } catch {
+    // Docker answered with something we can't read. Refusing to guess is the
+    // point of this function, so don't downgrade it to "local".
+    return { ref, labels: {}, source: 'unknown' };
+  }
+  if (!entry) return { ref, labels: {}, source: 'unknown' };
+
+  // `Config.Labels` is null, not absent, on an image with no labels.
+  const labels = entry.Config?.Labels ?? {};
+  // Match the repository we expect rather than taking [0]: the same bytes pushed
+  // to two repositories produce two RepoDigests, and the first is often the wrong
+  // one to report back to an operator.
+  const digests = entry.RepoDigests ?? [];
+  const pinnedRepo = readAgentImagePin()?.split('@')[0];
+  const preferred = pinnedRepo ? digests.find((d) => d.startsWith(`${pinnedRepo}@`)) : undefined;
+  const registryDigest = splitDigest(preferred ?? digests[0]);
+
+  return { ref, id: entry.Id, registryDigest, labels, source: resolveActualSource(labels, registryDigest) };
+}
+
+/** The subset of `docker image inspect` output this module reads. */
+interface DockerInspectEntry {
+  Id?: string;
+  RepoDigests?: string[];
+  Config?: { Labels?: Record<string, string> | null };
+}
+
+/**
+ * Label first — it's baked in and neither the pull nor the retag can forge it.
+ * `RepoDigests` is the fallback for images predating the label: `docker build`
+ * leaves it empty, a registry populates it. Only a fallback because a
+ * `docker save`/`load` sneakernet image has none and would read as local.
+ */
+function resolveActualSource(
+  labels: Record<string, string>,
+  registryDigest: string | undefined,
+): ActualImageSource {
+  const declared = labels[IMAGE_SOURCE_LABEL];
+  // `derived` is a per-group image built on top of one of the other two. It has
+  // to be its own answer: it inherits the base's RepoDigest-derived provenance
+  // and would otherwise read as the base's bytes, which it no longer is.
+  if (declared === 'hardened' || declared === 'local' || declared === 'derived') return declared;
+  return registryDigest ? 'hardened' : 'local';
+}
+
+/**
+ * `repo@sha256:…` → `sha256:…`. Undefined for a bare tag. Takes the first when
+ * an image carries several — they address identical content.
+ */
+function splitDigest(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const at = ref.lastIndexOf('@');
+  return at === -1 ? undefined : ref.slice(at + 1);
+}
+
+// ─── account state ─────────────────────────────────────────────────────
+//
+// Only reached on the gated path: a local-build install never signs in, never
+// writes a credential, and never gets a `credHelpers` entry.
+//
+// The *write* side lives elsewhere on purpose — `setup/registry-login.ts` owns
+// the credential files (it is a standalone driver spawned under inherited
+// stdio) and `setup/install-cred-helper.ts` owns the docker pointer (it also
+// installs the binary the pointer names). This is the read side those two
+// share with the `registry` step, so "am I signed in" has one answer.
+
+/** The sign-in entry point, run through `runInheritScript` (it needs a TTY). */
+export const REGISTRY_LOGIN_SCRIPT = 'setup/registry-login.sh';
+
+/**
+ * Whether this checkout can run the sign-in at all. The caller has to know
+ * before spawning it: the script arrives with the gated path, so a checkout
+ * that predates it fails as an opaque `bash: … No such file` and exit 127,
+ * which reads exactly like a user who abandoned the device flow.
+ */
+export function loginScriptAvailable(projectRoot: string = process.cwd()): boolean {
+  return fs.existsSync(path.join(projectRoot, REGISTRY_LOGIN_SCRIPT));
+}
+
+/**
+ * Broker base URL override.
+ */
+export const BROKER_URL_ENV_KEY = 'NANOCLAW_REGISTRY_API';
+
+/**
+ * The deployed account service, and the single definition of it —
+ * `setup/registry-login.ts` imports this rather than keeping its own copy,
+ * because two constants that must agree eventually will not.
+ *
+ * This and the `agent-image` pin in versions.json name two halves of one
+ * deployment and have to move together: the docker credential helper is wired
+ * to the host derived from the *pin*, while the credential it presents is
+ * minted by *this* service. Point them at different deployments and the
+ * mismatch surfaces as an authentication failure at pull time, long after the
+ * thing that caused it.
+ *
+ * Getting this wrong fails quietly rather than loudly, which is why it is a
+ * constant rather than a setting. Any other deployment of the same service
+ * answers every route identically, so a default aimed at the wrong one still
+ * signs people in, still issues tokens, and still looks like success — it just
+ * records the accounts somewhere nobody is looking, against an identity
+ * provider nobody meant to use. Override it per-install with
+ * `NANOCLAW_REGISTRY_API`; a fork pointing at its own service should change it
+ * here, alongside the pin.
+ */
+export const DEFAULT_BROKER_URL = 'https://registry.nanoclaw.dev';
+
+/**
+ * `account.json` as the sign-in writes it. Everything is optional except the
+ * token, because a credential from an older login is still a credential and
+ * reporting "signed in, details unknown" beats reporting "not signed in".
+ */
+export interface RegistryAccount {
+  version?: number;
+  /** Broker this token is valid against; a token is meaningless without it. */
+  api?: string;
+  account_id?: string;
+  email?: string;
+  /** Opaque bearer. Never printed, never logged, never sent to a partner. */
+  token: string;
+  /** Registry hostname the token is good for, once the broker has named one. */
+  registry?: string;
+  entitlements?: string[];
+  created_at?: string;
+}
+
+/** Per-user, not per-checkout: uninstalling one copy must not sign out another. */
+function configDir(): string {
+  return path.join(os.homedir(), '.config', 'nanoclaw');
+}
+
+/** The account record — what a human and `--status` read. */
+export function registryAccountPath(): string {
+  return path.join(configDir(), 'account.json');
+}
+
+/** The credential helper's minimal view of the same token. */
+export function registryAuthPath(): string {
+  return path.join(configDir(), 'registry-auth.json');
+}
+
+/**
+ * The signed-in account, or undefined when there is none. A malformed or
+ * truncated file reads as "not signed in" rather than throwing — the next move
+ * (sign in again) is the same either way.
+ */
+export function readRegistryAccount(): RegistryAccount | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(registryAccountPath(), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const account = parsed as RegistryAccount;
+  return typeof account.token === 'string' && account.token ? account : undefined;
+}
+
+/**
+ * Remove both halves of the credential, returning the paths that existed.
+ *
+ * Both, always: leaving `registry-auth.json` behind would keep a live token on
+ * disk for the credential helper to hand out, which is the exact thing signing
+ * out is for.
+ */
+export function clearRegistryAccount(): string[] {
+  const removed: string[] = [];
+  for (const file of [registryAccountPath(), registryAuthPath()]) {
+    if (!fs.existsSync(file)) continue;
+    fs.rmSync(file, { force: true });
+    removed.push(file);
+  }
+  return removed;
+}
+
+/**
+ * Where to reach the broker.
+ *
+ * The credential's own `api` outranks the compiled-in default because a token
+ * is only revocable at the broker that minted it — falling back to the default
+ * would silently no-op a logout against a staging deployment. An explicit env
+ * override still wins, so pointing elsewhere is possible but deliberate.
+ */
+export function readBrokerUrl(account?: RegistryAccount): string {
+  const env = readEnvFile([BROKER_URL_ENV_KEY]);
+  const override = process.env[BROKER_URL_ENV_KEY]?.trim() || env[BROKER_URL_ENV_KEY];
+  const url = override || account?.api || DEFAULT_BROKER_URL;
+  return url.replace(/\/+$/, '');
+}

--- a/setup/lib/version-pins.ts
+++ b/setup/lib/version-pins.ts
@@ -22,10 +22,20 @@ const VERSIONS_FILE = path.resolve(
  * missing — a missing pin is an install-tree defect, not a runtime condition.
  */
 export function readVersionPin(component: string): string {
-  const pins: unknown = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf-8'));
-  const value = (pins as Record<string, unknown>)[component];
+  const value = readVersionPinValue(component);
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`versions.json has no pin for "${component}"`);
   }
   return value;
+}
+
+/**
+ * The raw pin, whatever shape it is. Only `agent-image` needs this: it may be a
+ * single reference or one per platform, and `readVersionPin` above deliberately
+ * refuses anything but a string so the version pins it serves cannot silently
+ * become structured.
+ */
+export function readVersionPinValue(component: string): unknown {
+  const pins: unknown = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf-8'));
+  return (pins as Record<string, unknown>)[component];
 }

--- a/setup/provider-auth.ts
+++ b/setup/provider-auth.ts
@@ -12,8 +12,7 @@
  * provider rewrite, no service changes. Provider install skills call this as
  * their auth step so there is exactly one auth implementation per provider.
  */
-import { execSync } from 'child_process';
-
+import { buildContainerImage } from './lib/container-build.js';
 import { getSetupProvider, listSetupProviders } from './providers/registry.js';
 import { applyProviderSkill } from './providers/install.js';
 // Provider payloads self-register on import.
@@ -57,7 +56,14 @@ export async function run(args: string[]): Promise<void> {
     }
     if (changed) {
       console.log('Provider payload installed — rebuilding the container image…');
-      execSync('./container/build.sh', { stdio: 'inherit' });
+      const rebuild = buildContainerImage();
+      if (!rebuild.ok) {
+        // Stop here rather than authenticating a runtime the image can't start:
+        // the payload files are mounted, but the CLI manifest is baked in.
+        console.error(`Couldn't rebuild the container image for ${name}: ${rebuild.message}`);
+        if (rebuild.hint) console.error(rebuild.hint);
+        process.exit(1);
+      }
     }
     if (!entry) {
       await import(`./providers/${name}.js`);

--- a/setup/registry-login.sh
+++ b/setup/registry-login.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Interactive sign-in for the gated agent-image path.
+#
+# This is a `runInheritScript` target, never a step-runner step. The step
+# runner spawns with stdin discarded and gives up on a child that goes quiet
+# for 60 seconds; a device-code wait is minutes of deliberate silence at a
+# prompt the user has to answer. Same reasoning as the Claude subscription
+# sign-in next door, and the only reason a shell wrapper exists at all: one
+# stable path to spawn with `stdio: 'inherit'`, and a preflight that fails
+# with something an operator can act on instead of "command not found".
+#
+# `exec` hands the terminal straight to the driver so a Ctrl-C during the wait
+# reaches the process that owns the prompt rather than this shell.
+#
+# Env (all optional, all read by the driver itself):
+#   NANOCLAW_REGISTRY_TOKEN        Existing account token — adopt it, no prompts
+#   NANOCLAW_REGISTRY_ENROLL_CODE  Operator-issued code — enroll, no prompts
+#   NANOCLAW_REGISTRY_API          Broker base URL
+#   NANOCLAW_WORKOS_CLIENT_ID      Device-flow client id (public, not a secret)
+#
+# Exit codes:
+#   0  signed in, or already signed in
+#   2  deliberately skipped — the caller may continue on the unauthenticated
+#      path (no credentials supplied under --non-interactive, or user declined)
+#   1  failed
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# A node or pnpm installed into ~/.local/bin earlier in this same setup run is
+# invisible to a freshly spawned shell; setup/auto.ts repairs PATH the same way
+# before its own interactive scripts.
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+hash -r 2>/dev/null || true
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm not found — sign-in needs it to run the setup driver." >&2
+  echo "Run setup's environment step first, or install pnpm and re-run." >&2
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+exec pnpm exec tsx setup/registry-login.ts "$@"

--- a/setup/registry-login.ts
+++ b/setup/registry-login.ts
@@ -1,0 +1,1192 @@
+/**
+ * Sign-in driver for the gated agent-image path. Spawned by
+ * `setup/registry-login.sh` under inherited stdio.
+ *
+ * Two ways in, one outcome: an opaque account token on disk, which the docker
+ * credential helper later exchanges for a short-lived registry password.
+ *
+ *   device flow      OAuth 2.0 device authorization grant (RFC 8628) against
+ *                    WorkOS AuthKit — for a human at a terminal.
+ *   enrollment code  An operator-issued code. This is the CI path, the fleet
+ *                    path, and the escape hatch for anyone who declines social
+ *                    login. It needs no identity provider at all, which is what
+ *                    keeps the whole stack testable before a tenant exists.
+ *
+ * WorkOS contract (https://workos.com/docs/authkit/cli-auth and
+ * https://workos.com/docs/reference/authkit/cli-auth): both endpoints take
+ * `application/x-www-form-urlencoded` bodies, the device response carries
+ * `device_code` / `user_code` / `verification_uri` / `verification_uri_complete`
+ * / `expires_in` / `interval`, and **no client secret is involved** — the device
+ * grant is a public-client flow, so the only WorkOS value this file ever holds
+ * is a client id. Errors come back as HTTP 400 with `{error, error_description}`.
+ *
+ * The device-code card prints as plain stdout, never a status block: no runner
+ * in this tree renders a block mid-stream, so a card emitted that way would be
+ * swallowed. Only the terminal result is a status block.
+ *
+ * Files written, all under a 0700 directory:
+ *   ~/.config/nanoclaw/account.json        the account record + token (0600)
+ *   ~/.config/nanoclaw/registry-auth.json  the credential helper's view (0600)
+ *   ~/.config/nanoclaw/host-id             per-machine id for the mint log (0600)
+ *
+ * The helper reads files rather than the environment because docker spawns it
+ * with an environment we do not control. `registry-auth.json` is its contract,
+ * not ours — `{ broker_url, registry, token }`, exactly those names.
+ */
+import { spawn } from 'child_process';
+import { randomBytes } from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import readline from 'readline/promises';
+import { setTimeout as sleep } from 'timers/promises';
+import { pathToFileURL } from 'url';
+
+import * as p from '@clack/prompts';
+
+import { installCredentialHelper } from './install-cred-helper.js';
+import { readEnvFile } from '../src/env.js';
+import { DEFAULT_BROKER_URL, readAgentImagePin, writeImageSource } from './lib/registry-state.js';
+import { commandExists, isHeadless, isWSL } from './platform.js';
+import { emitStatus } from './status.js';
+
+/** Broker base. Overridable so a fork, a staging stack, or a test can retarget. */
+
+/**
+ * WorkOS's shared endpoints, not a per-tenant domain — the tenant is identified
+ * entirely by the client id, which is why these can be constants and the client
+ * id cannot.
+ */
+const DEFAULT_DEVICE_ENDPOINT = 'https://api.workos.com/user_management/authorize/device';
+const DEFAULT_TOKEN_ENDPOINT = 'https://api.workos.com/user_management/authenticate';
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+const ENV = {
+  api: 'NANOCLAW_REGISTRY_API',
+  token: 'NANOCLAW_REGISTRY_TOKEN',
+  enrollCode: 'NANOCLAW_REGISTRY_ENROLL_CODE',
+  clientId: 'NANOCLAW_WORKOS_CLIENT_ID',
+  deviceEndpoint: 'NANOCLAW_WORKOS_DEVICE_ENDPOINT',
+  tokenEndpoint: 'NANOCLAW_WORKOS_TOKEN_ENDPOINT',
+} as const;
+
+const CONFIG_DIR = path.join(os.homedir(), '.config', 'nanoclaw');
+const ACCOUNT_FILE = path.join(CONFIG_DIR, 'account.json');
+const REGISTRY_AUTH_FILE = path.join(CONFIG_DIR, 'registry-auth.json');
+const HOST_ID_FILE = path.join(CONFIG_DIR, 'host-id');
+
+/** Ceiling on a device wait regardless of what the provider's `expires_in` says. */
+const MAX_DEVICE_WAIT_MS = 900_000;
+const HTTP_TIMEOUT_MS = 20_000;
+const PROBE_TIMEOUT_MS = 8_000;
+/**
+ * RFC 8628 §3.5 puts the `slow_down` step at 5 seconds. WorkOS documents a
+ * smaller one; the spec's is compliant with both and costs a few seconds of
+ * latency at worst.
+ */
+const SLOW_DOWN_STEP_MS = 5_000;
+/** Consecutive transport failures tolerated mid-poll before giving up. */
+const MAX_POLL_TRANSPORT_FAILURES = 10;
+
+/** Exit code meaning "nothing was signed in, and that is fine" — see the wrapper. */
+const EXIT_SKIPPED = 2;
+
+/**
+ * True when `setup/auto.ts` spawned us, which means there is a UI in front of
+ * the user already reporting the outcome. Everything this driver would say
+ * about success is then a second copy of it, printed in a different voice.
+ *
+ * Standalone runs get the confirmation, because there is nothing else to give
+ * it. The variable is set at the spawn site, not in `.env` — it describes this
+ * invocation, not the install.
+ */
+const SPAWNED_BY_WIZARD = process.env.NANOCLAW_SETUP_WIZARD === '1';
+
+/**
+ * Whether anything is parsing our stdout. Set from `--non-interactive` / no TTY.
+ *
+ * This driver is the one setup surface that is not a `--step`: it needs a TTY
+ * and minutes of deliberate silence, so `setup/auto.ts` runs it through
+ * `runInheritScript` and reads only its exit code. Nothing in the tree parses a
+ * REGISTRY_LOGIN block — so on the interactive path emitting one prints machine
+ * syntax into the middle of a conversation with a human.
+ *
+ * Still emitted when there is no human: `--code` and the token-from-environment
+ * paths are the CI surfaces, and a caller wrapping those has nothing else
+ * structured to read.
+ */
+let machineReadable = false;
+
+/** `emitStatus`, minus the case where the only reader is a person. */
+function emitLoginStatus(fields: Parameters<typeof emitStatus>[1]): void {
+  if (machineReadable) emitStatus('REGISTRY_LOGIN', fields);
+}
+
+export interface AccountCredential {
+  version: 1;
+  /** The broker this token is valid against; a token is meaningless without it. */
+  api: string;
+  account_id: string;
+  email?: string;
+  /** Opaque bearer, hashed at rest by the broker. Never a JWT, never parsed here. */
+  token: string;
+  /** Registry hostname this token is good for, once known. */
+  registry?: string;
+  entitlements: string[];
+  created_at: string;
+}
+
+/**
+ * A sign-in, plus the one piece of account state that is not part of the
+ * credential. `emailUpdates` is `null` when this account has never been asked
+ * about product email, which is what makes the prompt fire exactly once
+ * per account rather than once per machine.
+ *
+ * Deliberately not a field on `AccountCredential`: that shape is written to
+ * disk, and a marketing preference has no business in a credential file.
+ */
+interface EnrollResult {
+  credential: AccountCredential;
+  emailUpdates: boolean | null;
+}
+
+/** Sign-in failure with a sentence for the user and, where possible, a way out. */
+class LoginError extends Error {
+  constructor(
+    message: string,
+    readonly hint?: string,
+  ) {
+    super(message);
+    this.name = 'LoginError';
+  }
+}
+
+type LoginMethod = 'device' | 'code' | 'token';
+
+interface Options {
+  interactive: boolean;
+  /** Sign in again even when a valid credential is already on disk. */
+  force: boolean;
+  api?: string;
+  code?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Small parsing helpers. Every remote body is `unknown` until proven otherwise.
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+
+interface HttpRequest {
+  method: 'GET' | 'POST';
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+interface HttpResult {
+  status: number;
+  body: Record<string, unknown> | undefined;
+}
+
+/**
+ * Throws only on transport failure — an HTTP error status is data here, because
+ * the device grant signals `authorization_pending` as a 400 and that is the
+ * normal case, not an exception.
+ */
+async function http(url: string, req: HttpRequest, timeoutMs: number): Promise<HttpResult> {
+  const res = await fetch(url, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  let body: Record<string, unknown> | undefined;
+  try {
+    const parsed: unknown = text ? JSON.parse(text) : undefined;
+    body = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    // A proxy's HTML error page, most likely. The status still tells us enough.
+  }
+  return { status: res.status, body };
+}
+
+function form(fields: Record<string, string>): HttpRequest {
+  return {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      accept: 'application/json',
+    },
+    body: new URLSearchParams(fields).toString(),
+  };
+}
+
+function json(payload: unknown, bearer?: string): HttpRequest {
+  return {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      ...(bearer ? { authorization: `Bearer ${bearer}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+/**
+ * The probe is a read, and both the broker's route table and the API Gateway
+ * stack declare it `GET /v1/session/probe`. A POST routes to nothing: the
+ * gateway 404s before the Lambda runs, `probeSession` reads that as
+ * "unreachable", and an expired or revoked token then looks like an offline
+ * broker instead of a signal to sign in again.
+ */
+function bearerGet(bearer: string): HttpRequest {
+  return {
+    method: 'GET',
+    headers: { accept: 'application/json', authorization: `Bearer ${bearer}` },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// On-disk state
+
+/**
+ * Atomic, owner-only write. `writeFileSync`'s mode argument applies only when
+ * the file is created, so a pre-existing world-readable temp file would keep
+ * its mode — hence the explicit chmod before the rename rather than after.
+ */
+function writeSecretFile(file: string, contents: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(path.dirname(file), 0o700);
+  } catch {
+    // Pre-existing directory we don't own the mode of. The file mode below is
+    // the one that actually protects the token.
+  }
+  const tmp = `${file}.tmp`;
+  fs.writeFileSync(tmp, contents, { mode: 0o600 });
+  fs.chmodSync(tmp, 0o600);
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * A random per-machine id for the broker's mint log. Deliberately **not**
+ * `data/install-id`: that one is the diagnostics identifier, and reusing it
+ * would mean opting out of diagnostics no longer de-identifies you.
+ */
+function ensureHostId(): string {
+  const existing = str(readFileOrUndefined(HOST_ID_FILE));
+  if (existing) return existing;
+  const id = randomBytes(16).toString('hex');
+  try {
+    writeSecretFile(HOST_ID_FILE, `${id}\n`);
+  } catch {
+    // Not worth failing a sign-in over; the id is a telemetry join key.
+  }
+  return id;
+}
+
+function readFileOrUndefined(file: string): string | undefined {
+  try {
+    return fs.readFileSync(file, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+function readAccountCredential(): AccountCredential | undefined {
+  const raw = readFileOrUndefined(ACCOUNT_FILE);
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.log(`Ignoring an unreadable credential at ${ACCOUNT_FILE}; signing in again.`);
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const o = parsed as Record<string, unknown>;
+  const token = str(o.token);
+  const accountId = str(o.account_id);
+  if (!token || !accountId) return undefined;
+  return {
+    version: 1,
+    api: str(o.api) ?? resolveApiBase(),
+    account_id: accountId,
+    email: str(o.email),
+    token,
+    registry: str(o.registry),
+    entitlements: strings(o.entitlements),
+    created_at: str(o.created_at) ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * The registry hostname the token is good for. The credential helper keys on it
+ * and refuses to answer for any other host, so a wrong value costs a failed
+ * pull rather than a leaked token. The broker is authoritative; the pinned
+ * image reference is the fallback, since it names the same registry by
+ * construction. A bare `org/image` ref names Docker Hub, not a host, so it is
+ * rejected rather than read as one.
+ */
+function resolveRegistryHost(fromBroker: string | undefined): string | undefined {
+  if (fromBroker) {
+    return fromBroker.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').split('/')[0].toLowerCase();
+  }
+  const first = readAgentImagePin()?.split('/')[0];
+  return first && (first.includes('.') || first.includes(':')) ? first.toLowerCase() : undefined;
+}
+
+/**
+ * Two files, one token. `account.json` is the record a human reads;
+ * `registry-auth.json` is the credential helper's contract — its field names,
+ * kept minimal because the helper runs with no repo on its path and no cwd
+ * worth trusting. Any cached password the helper stashed there is dropped: a
+ * new token invalidates it.
+ */
+function persistCredential(cred: AccountCredential): void {
+  const record: AccountCredential = { ...cred, registry: resolveRegistryHost(cred.registry) };
+  writeSecretFile(ACCOUNT_FILE, `${JSON.stringify(record, null, 2)}\n`);
+  ensureHostId();
+  writeSecretFile(
+    REGISTRY_AUTH_FILE,
+    `${JSON.stringify({ version: 1, broker_url: record.api, registry: record.registry ?? '', token: record.token }, null, 2)}\n`,
+  );
+  if (!record.registry) {
+    console.log('   Note: no registry is pinned yet, so the image pull will have nothing to authenticate against.');
+  }
+  wireDockerCredentialHelper(record.registry);
+
+  // Record that this install pulls, HERE rather than at the call sites.
+  //
+  // There are four ways to finish a sign-in — a token or an enrolment code
+  // from the environment, a code typed at the prompt, and the browser flow —
+  // and every one ends up in this function. Setting it at the call sites means
+  // setting it in four places and missing one, which is exactly what happened:
+  // a successful non-interactive sign-in left .env saying "build here", so the
+  // container step built locally and the pull silently never happened.
+  //
+  // setup/auto.ts also writes this before launching the sign-in, for its own
+  // resume-safety reasons. Both are idempotent; --opt-out reverses either.
+  writeImageSource('hardened');
+}
+
+/**
+ * Point docker at the helper, here, because holding a token and not being able
+ * to spend it is indistinguishable from not being signed in: docker only calls
+ * the helper for a host listed in its own `credHelpers`, so without this the
+ * pull goes out anonymous and fails against a private registry.
+ *
+ * Deliberately after the credential is on disk (the installer reads the
+ * registry back out of it), and deliberately non-fatal — a sign-in that
+ * succeeded is worth keeping even when we cannot write to a bin directory, and
+ * `--step registry -- --status` reports the gap.
+ */
+function wireDockerCredentialHelper(registry?: string): void {
+  if (!registry) return;
+  try {
+    const result = installCredentialHelper({ registryHost: registry });
+    if (!result.onPath) {
+      console.log(`   Note: ${path.dirname(result.helperPath)} is not on PATH, so docker will not find the helper.`);
+    }
+  } catch (err) {
+    console.log(`   Note: couldn't point docker at the credential helper (${message(err)}).`);
+    console.log('   Run `pnpm exec tsx setup/install-cred-helper.ts` once that is fixed.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Broker
+
+function resolveApiBase(override?: string): string {
+  // process.env, then .env, then the default — same order and same key as
+  // setup/lib/registry-state.ts, which states outright that the two must stay
+  // in lockstep. A process.env-only read diverges the moment an operator sets
+  // the key in .env.
+  const raw = override ?? str(process.env[ENV.api]) ?? str(readEnvFile([ENV.api])[ENV.api]) ?? DEFAULT_BROKER_URL;
+  return raw.replace(/\/+$/, '');
+}
+
+interface ClientRecord {
+  os: string;
+  arch: string;
+  nanoclaw_version: string;
+  host_id: string;
+}
+
+function clientRecord(): ClientRecord {
+  let version = 'unknown';
+  try {
+    const pkg: unknown = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+    version = str((pkg as Record<string, unknown>)?.version) ?? 'unknown';
+  } catch {
+    // Running from somewhere other than the checkout root. Not worth failing over.
+  }
+  return { os: process.platform, arch: process.arch, nanoclaw_version: version, host_id: ensureHostId() };
+}
+
+type ProbeState =
+  | { state: 'ok'; account_id: string; email?: string; registry?: string; entitlements: string[] }
+  | { state: 'unauthorized' }
+  | { state: 'unreachable'; reason: string };
+
+/** Is this token still good? Used for idempotence, so it must not be fatal. */
+async function probeSession(api: string, token: string): Promise<ProbeState> {
+  let res: HttpResult;
+  try {
+    res = await http(`${api}/v1/session/probe`, bearerGet(token), PROBE_TIMEOUT_MS);
+  } catch (err) {
+    return { state: 'unreachable', reason: message(err) };
+  }
+  if (res.status === 401 || res.status === 403) return { state: 'unauthorized' };
+  if (res.status !== 200) return { state: 'unreachable', reason: `HTTP ${res.status}` };
+  const accountId = str(res.body?.account_id);
+  if (!accountId) return { state: 'unreachable', reason: 'the service returned no account id' };
+  return {
+    state: 'ok',
+    account_id: accountId,
+    email: str(res.body?.email),
+    registry: str(res.body?.registry),
+    entitlements: readEntitlements(res.body),
+  };
+}
+
+type EnrollBody =
+  | { method: 'code'; code: string; client: ClientRecord }
+  | { method: 'idp'; provider: 'workos'; access_token: string; client: ClientRecord };
+
+/**
+ * The broker's wire shape, which is not this file's storage shape.
+ *
+ * `install_id` is top-level and mandatory there: it is the idempotency key that
+ * stops a resumed setup burning a second use of a single-use enrollment code,
+ * so it cannot stay buried in the client record. The IdP path names the bearer
+ * `workos_token` because the field is provider-specific by design, while
+ * `method`/`provider` are ours and simply ignored — sending them costs nothing
+ * and keeps the request self-describing in a log.
+ */
+function enrollWire(body: EnrollBody): Record<string, unknown> {
+  const common = { ...body, install_id: body.client.host_id };
+  return body.method === 'idp' ? { ...common, workos_token: body.access_token } : common;
+}
+
+async function enroll(api: string, body: EnrollBody): Promise<EnrollResult> {
+  let res: HttpResult;
+  try {
+    res = await http(`${api}/v1/enroll`, json(enrollWire(body)), HTTP_TIMEOUT_MS);
+  } catch (err) {
+    throw new LoginError(
+      `Couldn't reach the NanoClaw account service at ${api}: ${message(err)}`,
+      `Check your network, then re-run. Point ${ENV.api} elsewhere if you run your own.`,
+    );
+  }
+
+  // 201 is a brand-new account and 200 an existing one relinking — the common
+  // case is the created one, so treating anything but 200 as a failure would
+  // reject almost every real first sign-in.
+  if (res.status !== 200 && res.status !== 201) throw enrollFailure(api, body.method, res);
+
+  const token = str(res.body?.token) ?? str(res.body?.pull_token);
+  const accountId = str(res.body?.account_id);
+  if (!token || !accountId) {
+    throw new LoginError('The account service accepted the sign-in but returned no usable credential.');
+  }
+  return {
+    credential: {
+      version: 1,
+      api,
+      account_id: accountId,
+      email: str(res.body?.email),
+      token,
+      registry: str(res.body?.registry),
+      entitlements: readEntitlements(res.body),
+      created_at: new Date().toISOString(),
+    },
+    // Anything other than a real boolean means "never asked" — including an
+    // older broker that has no idea what this field is.
+    emailUpdates: typeof res.body?.email_updates === 'boolean' ? res.body.email_updates : null,
+  };
+}
+
+/**
+ * `entitlements` is this file's name; the broker calls the same thing `perks`
+ * and, on the probe route, returns them as objects carrying quota alongside the
+ * name. Read all three shapes — the alternative is an empty entitlement list
+ * that silently overwrites a good one on the next re-run.
+ */
+function readEntitlements(body: Record<string, unknown> | undefined): string[] {
+  const raw = body?.entitlements ?? body?.perks;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((v) => (typeof v === 'string' ? v : str((v as Record<string, unknown> | null)?.perk)))
+    .filter((v): v is string => Boolean(v));
+}
+
+/** Map the broker's error code to something the operator can act on. */
+function idpRejectionHint(code?: string): string {
+  switch (code) {
+    case 'email_unverified':
+      return 'Verify your email address with your identity provider, then sign in again.';
+    case 'email_missing':
+      return 'Your identity provider returned no email address. An email is required to create an account.';
+    case 'unknown_user':
+      return 'That account no longer exists at your identity provider.';
+    case 'token_expired':
+      return 'The sign-in took too long. Run this again — the code is valid for 5 minutes.';
+    case 'account_unavailable':
+      return 'This account is suspended. Contact whoever administers your NanoClaw account.';
+    case 'identity_provider_unconfigured':
+      return 'Browser sign-in is not enabled on this deployment. Use an enrollment code instead.';
+    default:
+      return 'The identity provider approved you, but the account service would not accept it.';
+  }
+}
+
+function enrollFailure(api: string, method: 'code' | 'idp', res: HttpResult): LoginError {
+  const detail = str(res.body?.error_description) ?? str(res.body?.error) ?? `HTTP ${res.status}`;
+  if (res.status === 401 || res.status === 403) {
+    return method === 'code'
+      ? new LoginError(
+          'That enrollment code was not accepted.',
+          'Codes are single-use and expire. Ask whoever issued it for a fresh one.',
+        )
+      : new LoginError(
+          `The account service rejected the sign-in (${detail}).`,
+          // The broker sends a specific reason and it is the only thing that
+          // makes this diagnosable -- collapsing every 401/403 into one generic
+          // sentence turns a five-second fix into a log-diving session.
+          idpRejectionHint(str(res.body?.error)),
+        );
+  }
+  if (res.status === 404) {
+    return new LoginError(
+      `${api} has no enrollment endpoint.`,
+      `Set ${ENV.api} to the right base URL, or skip sign-in and build the image locally.`,
+    );
+  }
+  if (res.status === 429) {
+    return new LoginError(
+      'The account service is rate-limiting sign-ins right now.',
+      'Wait a few minutes and re-run. Nothing is wrong with your account.',
+    );
+  }
+  if (res.status >= 500) {
+    return new LoginError(`The account service is unavailable (${detail}).`, 'Try again shortly.');
+  }
+  return new LoginError(`Sign-in was refused: ${detail}`);
+}
+
+// ---------------------------------------------------------------------------
+// Device flow
+
+interface IdpConfig {
+  clientId: string;
+  deviceEndpoint: string;
+  tokenEndpoint: string;
+}
+
+/**
+ * A client id is public, but it is still deployment state — a fork pointing at
+ * its own broker must not inherit ours — so it is never committed. Environment
+ * first, then ask the broker. Any failure means "no browser sign-in here",
+ * never an error: the enrollment-code path still works, and that is the whole
+ * reason it exists.
+ */
+/**
+ * Three outcomes, not two.
+ *
+ * "No identity provider" and "that URL is not a NanoClaw registry" are different
+ * problems with different fixes, and collapsing them is how a wrong
+ * NANOCLAW_REGISTRY_API presents as "browser authentication is not configured" — which
+ * sends someone looking in entirely the wrong place. The default host resolves
+ * and answers 404 from the marketing site, so "unreachable" is not a safe proxy
+ * for "misconfigured" either.
+ */
+type BrokerProbe =
+  | { kind: 'idp'; config: IdpConfig }
+  | { kind: 'no-idp' }
+  | { kind: 'not-a-broker'; detail: string };
+
+async function probeBroker(api: string): Promise<BrokerProbe> {
+  const fromEnv = str(process.env[ENV.clientId]);
+  if (fromEnv) {
+    return {
+      kind: 'idp',
+      config: {
+        clientId: fromEnv,
+        deviceEndpoint: str(process.env[ENV.deviceEndpoint]) ?? DEFAULT_DEVICE_ENDPOINT,
+        tokenEndpoint: str(process.env[ENV.tokenEndpoint]) ?? DEFAULT_TOKEN_ENDPOINT,
+      },
+    };
+  }
+
+  let res;
+  try {
+    res = await http(`${api}/v1/auth-config`, { method: 'GET', headers: { accept: 'application/json' } }, PROBE_TIMEOUT_MS);
+  } catch (err) {
+    return { kind: 'not-a-broker', detail: message(err) };
+  }
+
+  // A real broker answers this route as JSON either way: 200 when a device flow
+  // is configured, 503 with device_flow_available:false when it is not. Anything
+  // else — a 404 page, an HTML body, a proxy error — is a different service.
+  const declared = res.body && typeof res.body === 'object' ? res.body : undefined;
+  const looksLikeBroker = declared !== undefined && 'device_flow_available' in declared;
+  if (!looksLikeBroker) {
+    return { kind: 'not-a-broker', detail: `HTTP ${res.status} with no NanoClaw registry response` };
+  }
+
+  const clientId = str(declared.client_id);
+  if (!clientId) return { kind: 'no-idp' };
+  return {
+    kind: 'idp',
+    config: {
+      clientId,
+      deviceEndpoint: str(declared.device_authorization_endpoint) ?? DEFAULT_DEVICE_ENDPOINT,
+      tokenEndpoint: str(declared.token_endpoint) ?? DEFAULT_TOKEN_ENDPOINT,
+    },
+  };
+}
+
+function misconfiguredClient(): LoginError {
+  return new LoginError(
+    "The sign-in provider rejected this install's client id.",
+    `Set ${ENV.clientId} to a WorkOS application that has CLI Auth enabled, or use an enrollment code instead.`,
+  );
+}
+
+interface DeviceAuthorization {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+  expiresInS: number;
+  intervalS: number;
+}
+
+async function requestDeviceAuthorization(cfg: IdpConfig): Promise<DeviceAuthorization> {
+  let res: HttpResult;
+  try {
+    res = await http(cfg.deviceEndpoint, form({ client_id: cfg.clientId }), HTTP_TIMEOUT_MS);
+  } catch (err) {
+    throw new LoginError(`Couldn't reach the sign-in provider: ${message(err)}`, 'Check your network and re-run.');
+  }
+
+  if (res.status !== 200) {
+    const code = str(res.body?.error);
+    if (code === 'invalid_client' || code === 'unauthorized_client' || res.status === 401 || res.status === 404) {
+      throw misconfiguredClient();
+    }
+    const detail = str(res.body?.error_description) ?? code ?? `HTTP ${res.status}`;
+    throw new LoginError(`The sign-in provider wouldn't start a session: ${detail}`);
+  }
+
+  const deviceCode = str(res.body?.device_code);
+  const userCode = str(res.body?.user_code);
+  const verificationUri = str(res.body?.verification_uri);
+  if (!deviceCode || !userCode || !verificationUri) {
+    throw new LoginError('The sign-in provider returned an incomplete device authorization response.');
+  }
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    verificationUriComplete: str(res.body?.verification_uri_complete),
+    // Defaults are RFC 8628's own; a provider that omits them is unusual, not fatal.
+    expiresInS: num(res.body?.expires_in) ?? 300,
+    intervalS: Math.max(1, num(res.body?.interval) ?? 5),
+  };
+}
+
+/**
+ * Plain stdout on purpose. A status block here would be parsed and discarded by
+ * every runner in the tree, and this is the one thing the user must actually see.
+ */
+function printDeviceCard(device: DeviceAuthorization, headless: boolean): void {
+  const minutes = Math.max(1, Math.round(device.expiresInS / 60));
+  const lines = ['', '   Finish authenticating in a browser:', ''];
+
+  // One link rather than a bare URL and a pre-filled one side by side — the
+  // pre-filled URL carries the code, so the second was only a way to pick the
+  // wrong one. The code still prints: it is what you type when you open this on
+  // a phone, it survives a terminal wrapping the URL, and it is the value the
+  // provider's page shows back, which is how you tell you are approving this
+  // sign-in and not another one.
+  //
+  // `verification_uri_complete` is OPTIONAL in RFC 8628 §3.2, so the two-part
+  // form stays as a fallback — without it a provider that omits the field
+  // leaves the user unable to sign in at all.
+  if (device.verificationUriComplete) {
+    lines.push(`     ${device.verificationUriComplete}`);
+    lines.push('', `     Code:  ${device.userCode}   — the page should show this back to you`);
+  } else {
+    lines.push(`     Open:  ${device.verificationUri}`);
+    lines.push(`     Code:  ${device.userCode}`);
+  }
+  lines.push(
+    '',
+    headless
+      ? `   No browser on this machine — open that link on your phone or laptop.`
+      : `   Your browser should open on its own; if it doesn't, use the link above.`,
+    `   Waiting… this code expires in about ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+    '',
+  );
+  console.log(lines.join('\n'));
+}
+
+/** Non-blocking best effort. Silent on failure — the URL is already on screen. */
+function openInBrowser(url: string): void {
+  let cmd: [string, string[]] | undefined;
+  if (process.platform === 'darwin') cmd = ['open', [url]];
+  else if (process.platform === 'linux') {
+    if (commandExists('xdg-open')) cmd = ['xdg-open', [url]];
+    else if (isWSL() && commandExists('wslview')) cmd = ['wslview', [url]];
+    else if (isWSL()) cmd = ['cmd.exe', ['/c', 'start', '', url]];
+  }
+  if (!cmd) return;
+  try {
+    // Detached and unref'd: some xdg-open implementations don't return until the
+    // browser exits, and this process has minutes of polling left to do.
+    const child = spawn(cmd[0], cmd[1], { stdio: 'ignore', detached: true });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // No opener available. The card already printed the URL.
+  }
+}
+
+async function pollForIdpToken(cfg: IdpConfig, device: DeviceAuthorization): Promise<string> {
+  let intervalMs = device.intervalS * 1000;
+  const deadline = Date.now() + Math.min(device.expiresInS * 1000, MAX_DEVICE_WAIT_MS);
+  let transportFailures = 0;
+
+  for (;;) {
+    if (Date.now() >= deadline) {
+      throw new LoginError(
+        'Timed out waiting for the sign-in to be approved.',
+        'Re-run setup to get a fresh code.',
+      );
+    }
+    await sleep(intervalMs);
+
+    let res: HttpResult;
+    try {
+      res = await http(
+        cfg.tokenEndpoint,
+        form({ grant_type: DEVICE_GRANT_TYPE, device_code: device.deviceCode, client_id: cfg.clientId }),
+        HTTP_TIMEOUT_MS,
+      );
+    } catch (err) {
+      // A closed lid or a flaky hotspot must not cost the user their code, so a
+      // transport failure is retried rather than surfaced.
+      if (++transportFailures > MAX_POLL_TRANSPORT_FAILURES) {
+        throw new LoginError(`Lost contact with the sign-in provider: ${message(err)}`);
+      }
+      continue;
+    }
+    transportFailures = 0;
+
+    if (res.status === 200) {
+      const token = str(res.body?.access_token);
+      if (!token) throw new LoginError('The sign-in was approved but no access token came back.');
+      return token;
+    }
+
+    switch (str(res.body?.error)) {
+      case 'authorization_pending':
+        continue;
+      case 'slow_down':
+        intervalMs += SLOW_DOWN_STEP_MS;
+        continue;
+      case 'expired_token':
+        throw new LoginError(
+          'That sign-in code expired before it was approved.',
+          'Re-run setup to get a fresh code.',
+        );
+      case 'access_denied':
+        throw new LoginError(
+          'The sign-in was declined in the browser.',
+          'Re-run setup if that was a mistake.',
+        );
+      case 'invalid_client':
+      case 'unauthorized_client':
+        throw misconfiguredClient();
+      case 'unsupported_grant_type':
+        throw new LoginError(
+          "The sign-in provider doesn't have the device grant enabled for this client.",
+          'Enable CLI Auth on the WorkOS application, or use an enrollment code.',
+        );
+      case 'invalid_grant':
+        throw new LoginError(
+          'The sign-in provider no longer recognises this device code.',
+          'Re-run setup to start a fresh sign-in.',
+        );
+      default: {
+        const detail = str(res.body?.error_description) ?? str(res.body?.error) ?? `HTTP ${res.status}`;
+        throw new LoginError(`Sign-in failed: ${detail}`);
+      }
+    }
+  }
+}
+
+async function deviceLogin(api: string, cfg: IdpConfig): Promise<EnrollResult> {
+  const device = await requestDeviceAuthorization(cfg);
+  const headless = isHeadless();
+  printDeviceCard(device, headless);
+  if (!headless) openInBrowser(device.verificationUriComplete ?? device.verificationUri);
+
+  const idpToken = await pollForIdpToken(cfg, device);
+  return enroll(api, { method: 'idp', provider: 'workos', access_token: idpToken, client: clientRecord() });
+}
+
+// ---------------------------------------------------------------------------
+// Entry
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = { interactive: Boolean(process.stdin.isTTY), force: false };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--non-interactive':
+        opts.interactive = false;
+        break;
+      case '--force':
+        opts.force = true;
+        break;
+      case '--api':
+        opts.api = argv[++i];
+        break;
+      case '--code':
+        opts.code = argv[++i];
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        console.error(`Unknown option: ${argv[i]}`);
+        printHelp();
+        process.exit(1);
+    }
+  }
+  return opts;
+}
+
+function printHelp(): void {
+  console.log(
+    [
+      'Usage: setup/registry-login.sh [--non-interactive] [--force] [--api <url>] [--code <code>]',
+      '',
+      '  --non-interactive  Never prompt. Uses only the environment; exits 2 if nothing is set.',
+      '  --force            Sign in again even if a valid credential is already stored.',
+      `  --api <url>        Account service base URL (default ${DEFAULT_BROKER_URL}).`,
+      '  --code <code>      Enrollment code, instead of the browser sign-in.',
+      '',
+      'Environment:',
+      `  ${ENV.token}        Existing account token to adopt.`,
+      `  ${ENV.enrollCode}  Enrollment code.`,
+      `  ${ENV.api}          Account service base URL.`,
+      `  ${ENV.clientId}      Device-flow client id.`,
+      '',
+      'Exit codes: 0 signed in · 2 skipped, caller may continue · 1 failed.',
+    ].join('\n'),
+  );
+}
+
+/**
+ * Undefined means the user ended input (Ctrl-D) rather than answering — which
+ * is a decline, not a crash. `rl.question` rejects on EOF, so without this a
+ * piped or redirected stdin turns a skip into a failed sign-in.
+ */
+async function askLine(prompt: string): Promise<string | undefined> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await rl.question(prompt)).trim();
+  } catch {
+    return undefined;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Wording and version travel together. The broker keeps its own copy of the
+ * text for each version and stamps that onto the record, so what is stored is
+ * what was displayed.
+ *
+ * Once this ships, editing the string below means adding a version on both
+ * sides instead — re-labelling consent somebody already gave is the one thing
+ * this pair exists to prevent. Until then there is nothing to protect, so the
+ * wording stays on v1 and gets edited in place.
+ *
+ * Written as lines and joined for the record, so the text a person reads and
+ * the text stored against their answer cannot drift apart.
+ *
+ * Echo is named because they are a second sender: somebody agreeing to hear
+ * from NanoClaw has not thereby agreed to hear from whoever builds the image.
+ */
+const CONSENT_VERSION = 'cli-v1';
+const CONSENT_LINES = [
+  'NanoClaw and Echo, who build the agent image, may email me security notices',
+  'and project updates. I can unsubscribe at any time.',
+  'What we do with your address: https://nanoclaw.dev/privacy',
+];
+const CONSENT_TEXT = CONSENT_LINES.join(' ');
+
+/**
+ * Ask once per account.
+ *
+ * Three properties here are load-bearing: it never runs without somebody at the
+ * terminal, it is asked once per account rather than once per machine, and
+ * declining costs nothing — the image is already fetched by the time this runs
+ * and nothing below can revoke it, which is what keeps the ask separable from
+ * the thing being signed in for.
+ *
+ * Interim surface. The perks portal will own preferences, including the
+ * withdrawal path a one-shot terminal prompt cannot offer; until it exists the
+ * unsubscribe link in every email is that path.
+ */
+async function maybeAskEmailConsent(
+  api: string,
+  cred: AccountCredential,
+  current: boolean | null,
+): Promise<void> {
+  if (current !== null) return;
+
+  // clack rather than this file's own readline, so the question looks like the
+  // rest of setup instead of a raw shell prompt appearing mid-flow. Safe from a
+  // spawned child: stdio is inherited, so the rail lands in the same terminal
+  // the wizard is drawing into, and standalone runs simply render without an
+  // enclosing session.
+  //
+  // Line by line rather than one wrapped string: this ends with a URL, and a
+  // terminal breaking it mid-link makes it unclickable and hard to copy.
+  p.log.message(CONSENT_LINES.join('\n'));
+  const answer = await p.confirm({
+    message: 'Email me security and project updates?',
+    initialValue: true,
+    active: 'Yes',
+    inactive: 'No',
+  });
+  // Ctrl-C, or stdin closing under a wrapper, is not an answer. Returning here
+  // leaves the preference unset so the question can be asked again, where
+  // falling through would store a decline and never ask anybody twice.
+  if (p.isCancel(answer)) return;
+  const optIn = answer === true;
+
+  try {
+    const res = await http(
+      `${api}/v1/account/preferences`,
+      json({ email_updates: optIn, consent_version: CONSENT_VERSION, source: 'cli' }, cred.token),
+      HTTP_TIMEOUT_MS,
+    );
+    if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  } catch (err) {
+    // A lost decline changes nothing — the absence of a record is already a
+    // no. A lost opt-in is the only case worth interrupting a good sign-in for.
+    if (optIn) p.log.warn(`Couldn't record that (${message(err)}). Sign in again to retry.`);
+    return;
+  }
+  if (optIn) p.log.success("You're on the list.");
+}
+
+function reportSuccess(cred: AccountCredential, method: LoginMethod): void {
+  // The wizard reports the outcome itself, in its own voice, immediately after
+  // we exit. Saying it here too gives the user the same fact twice in two
+  // different formats.
+  if (!SPAWNED_BY_WIZARD) {
+    console.log(`\n   Authenticated as ${cred.email ?? cred.account_id}.`);
+    if (cred.entitlements.length > 0) {
+      console.log(`   Connected: ${cred.entitlements.join(', ')}`);
+    }
+    console.log('');
+  }
+  emitLoginStatus({
+    STATUS: 'success',
+    METHOD: method,
+    ACCOUNT: cred.account_id,
+    EMAIL: cred.email ?? '',
+    ENTITLEMENTS: cred.entitlements.join(','),
+  });
+}
+
+function reportSkipped(reason: string, detail?: string): void {
+  if (detail) console.log(detail);
+  process.exitCode = EXIT_SKIPPED;
+  emitLoginStatus({ STATUS: 'skipped', REASON: reason });
+}
+
+export async function run(argv: string[]): Promise<void> {
+  const opts = parseArgs(argv);
+  // Only a non-interactive caller can be parsing us. See `emitLoginStatus`.
+  machineReadable = !opts.interactive;
+  const api = resolveApiBase(opts.api);
+
+  // Idempotence first: a resumed or re-run setup must not drag the user back
+  // through a browser dance it already completed. A credential for a different
+  // service is not that — tokens are meaningless across brokers, so retargeting
+  // has to mean signing in again rather than probing the old one.
+  const existing = readAccountCredential();
+  if (existing && !opts.force && existing.api !== api) {
+    console.log(`The stored sign-in is for ${existing.api}; signing in to ${api} instead.`);
+  } else if (existing && !opts.force) {
+    const probe = await probeSession(existing.api, existing.token);
+    if (probe.state === 'ok') {
+      const refreshed: AccountCredential = {
+        ...existing,
+        email: probe.email ?? existing.email,
+        registry: probe.registry ?? existing.registry,
+        entitlements: probe.entitlements,
+      };
+      persistCredential(refreshed);
+      console.log(`Already authenticated as ${refreshed.email ?? refreshed.account_id}.`);
+      emitLoginStatus({
+        STATUS: 'skipped',
+        REASON: 'already-signed-in',
+        ACCOUNT: refreshed.account_id,
+        EMAIL: refreshed.email ?? '',
+        ENTITLEMENTS: refreshed.entitlements.join(','),
+      });
+      return;
+    }
+    if (probe.state === 'unreachable') {
+      // Offline is not a reason to discard a working credential — the pull that
+      // needs it may well be served from the local image cache anyway.
+      console.log(`Couldn't reach the account service (${probe.reason}); keeping the stored sign-in.`);
+      emitLoginStatus({
+        STATUS: 'skipped',
+        REASON: 'already-signed-in-unverified',
+        ACCOUNT: existing.account_id,
+      });
+      return;
+    }
+    console.log('The stored NanoClaw sign-in is no longer valid — signing in again.');
+  }
+
+  const presetToken = str(process.env[ENV.token]);
+  if (presetToken) {
+    const probe = await probeSession(api, presetToken);
+    if (probe.state !== 'ok') {
+      const why = probe.state === 'unauthorized' ? 'it was rejected' : `the service was unreachable (${probe.reason})`;
+      throw new LoginError(`The token in ${ENV.token} can't be used: ${why}.`);
+    }
+    const cred: AccountCredential = {
+      version: 1,
+      api,
+      account_id: probe.account_id,
+      email: probe.email,
+      token: presetToken,
+      registry: probe.registry,
+      entitlements: probe.entitlements,
+      created_at: new Date().toISOString(),
+    };
+    // Written to disk even though it came from the environment: docker spawns
+    // the credential helper with an environment we don't control, so the file
+    // is the only channel that reaches it.
+    persistCredential(cred);
+    reportSuccess(cred, 'token');
+    return;
+  }
+
+  const presetCode = opts.code ?? str(process.env[ENV.enrollCode]);
+  if (presetCode) {
+    // No consent prompt on this path or the one above: both are the CI and
+    // scripted route, where there is nobody to ask and a default of "yes"
+    // would not be consent.
+    const { credential: cred } = await enroll(api, { method: 'code', code: presetCode, client: clientRecord() });
+    persistCredential(cred);
+    reportSuccess(cred, 'code');
+    return;
+  }
+
+  if (!opts.interactive) {
+    reportSkipped(
+      'non-interactive',
+      `No sign-in credentials in the environment; set ${ENV.enrollCode} or ${ENV.token} to sign in without a terminal.`,
+    );
+    return;
+  }
+
+  const probe = await probeBroker(api);
+  if (probe.kind === 'not-a-broker') {
+    throw new LoginError(
+      `No NanoClaw registry at ${api} (${probe.detail}).`,
+      `Nothing at that address answers as a NanoClaw registry. If ${ENV.api} is set, check it points at one — unset, this reaches the hosted service. Either way \`./container/build.sh\` builds the image locally and needs no account.`,
+    );
+  }
+  const idp = probe.kind === 'idp' ? probe.config : undefined;
+  if (!idp) {
+    // A real registry with no identity provider. Supported: the enrollment-code
+    // path predates the IdP and outlives it.
+    console.log('\n   Browser authentication is not configured for this registry.');
+    const code = await askLine('   Enrollment code (or press Enter to skip): ');
+    if (!code) {
+      reportSkipped('declined');
+      return;
+    }
+    const { credential: cred, emailUpdates } = await enroll(api, {
+      method: 'code',
+      code,
+      client: clientRecord(),
+    });
+    persistCredential(cred);
+    reportSuccess(cred, 'code');
+    await maybeAskEmailConsent(api, cred, emailUpdates);
+    return;
+  }
+
+  // Bare newline rather than a lead-in sentence: the prompt below says what
+  // pressing Enter does, and the spacing keeps it off whatever printed last.
+  console.log('');
+  const typed = await askLine(
+    '   Press Enter to open your browser and authenticate, or paste an enrollment code: ',
+  );
+  if (typed === undefined) {
+    reportSkipped('declined');
+    return;
+  }
+  const { credential: cred, emailUpdates } = typed
+    ? await enroll(api, { method: 'code', code: typed, client: clientRecord() })
+    : await deviceLogin(api, idp);
+  persistCredential(cred);
+
+  reportSuccess(cred, typed ? 'code' : 'device');
+  await maybeAskEmailConsent(api, cred, emailUpdates);
+}
+
+async function main(): Promise<void> {
+  try {
+    await run(process.argv.slice(2));
+  } catch (err) {
+    const isLogin = err instanceof LoginError;
+    console.error(`\n${isLogin ? err.message : `Sign-in failed: ${message(err)}`}`);
+    if (isLogin && err.hint) console.error(err.hint);
+    emitLoginStatus({
+      STATUS: 'failed',
+      ERROR: message(err),
+      ...(isLogin && err.hint ? { HINT: err.hint } : {}),
+    });
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  void main();
+}

--- a/setup/registry-reconcile.ts
+++ b/setup/registry-reconcile.ts
@@ -1,0 +1,184 @@
+/**
+ * Step: registry-reconcile — drop per-agent-group derived images so every group
+ * actually runs the image at the slug tag.
+ *
+ * `container-runner.ts` spawns `containerConfig.imageTag || CONTAINER_IMAGE`, so
+ * any group that ran `install_packages` carries a pin to its own derived image
+ * built `FROM <base>:latest` months ago. That pin wins, which means retagging
+ * the slug tag onto newly pulled bytes does nothing for that group while verify
+ * still reports the install as hardened — inverting the property being bought.
+ * Clearing the pin costs the group its extra apt/npm packages; that is the trade.
+ *
+ * NOTE: nothing yet *disables* `install_packages` on the hardened path, so a
+ * group can re-derive afterwards and drop off the hardened base again. This is a
+ * one-shot correction, not an invariant.
+ *
+ * Idempotent — a second run finds nothing pinned and nothing to remove.
+ */
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import type DatabaseType from 'better-sqlite3';
+
+import { CONTAINER_IMAGE_BASE, DATA_DIR } from '../src/config.js';
+import { CONTAINER_RUNTIME_BIN } from '../src/container-runtime.js';
+import { getAllContainerConfigs, updateContainerConfigScalars } from '../src/db/container-configs.js';
+import { getDb, hasTable, initDb } from '../src/db/connection.js';
+import { log } from '../src/log.js';
+import { readImageSource } from './lib/registry-state.js';
+import { emitStatus } from './status.js';
+
+export interface ReconcileResult {
+  /** Agent groups whose pin pointed at an image this install built. */
+  cleared: string[];
+  /** Derived image tags actually removed from the runtime. */
+  removed: string[];
+  /** Tags whose row we cleared but whose image is still on disk. */
+  notRemoved: string[];
+  /** Pins pointing somewhere we didn't build — left alone, reported. */
+  foreign: { agentGroupId: string; imageTag: string }[];
+}
+
+function emptyResult(): ReconcileResult {
+  return { cleared: [], removed: [], notRemoved: [], foreign: [] };
+}
+
+/**
+ * Conservative shape for a tag we're willing to hand to `docker rmi`. The value
+ * is already constrained (it has to equal a string we built ourselves), but an
+ * argv element beginning with `-` would be read as a flag, so gate it the same
+ * way `stopContainer` gates container names.
+ */
+const SAFE_IMAGE_REF = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*:[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+
+/**
+ * Clear every derived-image pin and remove the images behind them.
+ *
+ * Unconditional by design so the pull path can call it immediately after a
+ * retag without re-reading state. **Do not call it on the local build path** —
+ * there a derived image is a working feature, not residue. The `run()` entry
+ * point below carries that guard; a direct caller has to carry it itself.
+ */
+export function reconcileDerivedImages(): ReconcileResult {
+  const result = emptyResult();
+
+  const dbPath = path.join(DATA_DIR, 'v2.db');
+  if (!fs.existsSync(dbPath)) {
+    // First install: no central DB, so no group has ever built a derived
+    // image. Bail before initDb, which would create an empty file here.
+    log.info('No central DB — nothing to reconcile', { dbPath });
+    return result;
+  }
+
+  // The step runs standalone (`--step registry-reconcile`) or is called from
+  // the container step, which has no DB open. Reuse an existing handle rather
+  // than opening a second writer onto the same file.
+  let db: DatabaseType.Database;
+  try {
+    db = getDb();
+  } catch {
+    db = initDb(dbPath);
+  }
+
+  if (!hasTable(db, 'container_configs')) {
+    // Migrations haven't run yet. Nothing can be pinned before the table exists.
+    log.info('container_configs not present — nothing to reconcile');
+    return result;
+  }
+
+  for (const row of getAllContainerConfigs()) {
+    if (!row.image_tag) continue;
+
+    const derivedTag = `${CONTAINER_IMAGE_BASE}:${row.agent_group_id}`;
+    if (row.image_tag !== derivedTag) {
+      // An operator-supplied image, not one buildAgentGroupImage produced.
+      // Removing it would destroy something we never created, so report it and
+      // leave it: the group won't run the pulled image, and that's the
+      // operator's standing decision to revisit, not ours to overrule.
+      result.foreign.push({ agentGroupId: row.agent_group_id, imageTag: row.image_tag });
+      log.warn('Agent group pins a non-derived image — left in place', {
+        agentGroupId: row.agent_group_id,
+        imageTag: row.image_tag,
+      });
+      continue;
+    }
+
+    // Clear the pin BEFORE touching the runtime. The host re-reads this row at
+    // every spawn, so the instant it is NULL the group is back on the slug tag
+    // regardless of what the `docker rmi` below does. Doing it the other way
+    // round would open a window where the row points at an image that no
+    // longer exists, and the group would fail to spawn instead of downgrading.
+    updateContainerConfigScalars(row.agent_group_id, { image_tag: null });
+    result.cleared.push(row.agent_group_id);
+    log.info('Cleared derived image pin', { agentGroupId: row.agent_group_id, imageTag: derivedTag });
+
+    if (!SAFE_IMAGE_REF.test(derivedTag)) {
+      result.notRemoved.push(derivedTag);
+      continue;
+    }
+    // Not `-f`: a derived image still held by a running container should stay
+    // until that container exits. The row is already clear, so the leftover is
+    // inert — the next spawn uses the slug tag either way.
+    const rmi = spawnSync(CONTAINER_RUNTIME_BIN, ['rmi', derivedTag], { encoding: 'utf-8' });
+    const stderr = (rmi.stderr ?? '').trim();
+    if (rmi.status === 0) {
+      result.removed.push(derivedTag);
+    } else if (/no such image/i.test(stderr)) {
+      // The pin outlived its image — a pruned or manually removed build. The
+      // group was already failing to spawn; clearing the row is the whole fix,
+      // so this is normal housekeeping, not a warning.
+      log.info('Derived image already absent', { imageTag: derivedTag });
+    } else {
+      result.notRemoved.push(derivedTag);
+      log.warn('Could not remove derived image — pin is cleared, image left behind', {
+        imageTag: derivedTag,
+        stderr,
+      });
+    }
+  }
+
+  return result;
+}
+
+export async function run(args: string[]): Promise<void> {
+  const force = args.includes('--force');
+  const source = readImageSource();
+
+  // On the local build path a derived image is a live capability, so the
+  // default is a no-op. `--force` exists for the operator who wants the pins
+  // dropped without switching image source (e.g. after a manual `docker load`).
+  if (source !== 'hardened' && !force) {
+    log.info('Image source is local — skipping reconcile', { source });
+    emitStatus('REGISTRY_RECONCILE', {
+      IMAGE_SOURCE: source,
+      SKIPPED: 'local_image_source',
+      CLEARED: 0,
+      IMAGES_REMOVED: 0,
+      IMAGES_NOT_REMOVED: 0,
+      FOREIGN_PINS: 0,
+      STATUS: 'success',
+      LOG: 'logs/setup.log',
+    });
+    return;
+  }
+
+  const result = reconcileDerivedImages();
+
+  log.info('Reconcile complete', {
+    cleared: result.cleared.length,
+    removed: result.removed.length,
+    notRemoved: result.notRemoved.length,
+    foreign: result.foreign.length,
+  });
+
+  emitStatus('REGISTRY_RECONCILE', {
+    IMAGE_SOURCE: source,
+    CLEARED: result.cleared.length,
+    IMAGES_REMOVED: result.removed.length,
+    IMAGES_NOT_REMOVED: result.notRemoved.length,
+    FOREIGN_PINS: result.foreign.length,
+    STATUS: 'success',
+    LOG: 'logs/setup.log',
+  });
+}

--- a/setup/registry.ts
+++ b/setup/registry.ts
@@ -1,0 +1,436 @@
+/**
+ * Step: registry — inspect and manage the pulled-image path after setup.
+ *
+ *   --status           what this install pulls, and who it is to the registry
+ *   --refresh          re-acquire the pinned reference and reconcile
+ *   --opt-out          go back to locally built images
+ *   --logout           revoke the session and remove the local credential + helper
+ *   --non-interactive  emit only the status block, no prose
+ *
+ * **This step never prompts, and that is a hard constraint rather than a
+ * stylistic one.** It is reachable both under `runWindowedStep` (stdin
+ * discarded — `setup/lib/runner.ts` spawns with `stdio:['ignore','pipe','pipe']`)
+ * and, through the container step it sits alongside, under the Linux
+ * `sg docker` re-exec, which has a real TTY. A prompt would work in one and
+ * hang forever in the other. `--non-interactive` therefore does not turn
+ * prompting off — nothing to turn off — it turns the human prose off for
+ * callers that only want the status block.
+ *
+ * Signing in is deliberately NOT here: it needs a TTY and up to 15 minutes of
+ * device-flow wait, so it lives in `setup/registry-login.sh` and runs through
+ * `runInheritScript` from `setup/auto.ts`.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { log } from '../src/log.js';
+import { credentialHelperStatus, uninstallCredentialHelper } from './install-cred-helper.js';
+import {
+  AGENT_IMAGE_PIN,
+  AGENT_IMAGE_REF_ENV_KEY,
+  HARDENED_IMAGE_ENV_KEY,
+  clearRegistryAccount,
+  inspectAgentImage,
+  readAgentImageDigest,
+  readAgentImagePin,
+  readBrokerUrl,
+  readImageSource,
+  readRegistryAccount,
+  readRegistryHost,
+  unsupportedPlatformPin,
+  writeImageSource,
+  type RegistryAccount,
+} from './lib/registry-state.js';
+import { emitStatus } from './status.js';
+
+type Mode = 'status' | 'refresh' | 'opt-out' | 'logout';
+
+const MODE_FLAGS: Record<string, Mode> = {
+  '--status': 'status',
+  '--refresh': 'refresh',
+  '--opt-out': 'opt-out',
+  '--logout': 'logout',
+};
+
+// One line: the step's own failures are rendered through setup/index.ts's
+// catch, which puts the message in an ERROR field of a line-oriented block.
+const USAGE =
+  'Usage: --step registry -- [--status | --refresh | --opt-out | --logout] [--non-interactive]';
+
+/**
+ * The block name has to be `stepName.toUpperCase()`: on a thrown error
+ * `setup/index.ts` emits a failure block under that name without loading this
+ * module, and a consumer matching on two different names would miss one of the
+ * two. ("registry" has no hyphen, so the transform is a no-op here — unlike
+ * `registry-reconcile`, whose crash block reads REGISTRY-RECONCILE while its
+ * own reads REGISTRY_RECONCILE.)
+ */
+const BLOCK = 'REGISTRY';
+
+function parseArgs(args: string[]): { mode: Mode; quiet: boolean } {
+  let mode: Mode | undefined;
+  let quiet = false;
+  for (const arg of args) {
+    if (arg === '--non-interactive') {
+      quiet = true;
+      continue;
+    }
+    const flagged = MODE_FLAGS[arg];
+    if (!flagged) {
+      throw new Error(`Unknown flag: ${arg}. ${USAGE}`);
+    }
+    if (mode && mode !== flagged) {
+      throw new Error(`Pick one action, not both ${mode} and ${flagged}. ${USAGE}`);
+    }
+    mode = flagged;
+  }
+  return { mode: mode ?? 'status', quiet };
+}
+
+export async function run(args: string[]): Promise<void> {
+  const { mode, quiet } = parseArgs(args);
+  const say = (line = ''): void => {
+    if (!quiet) console.log(line);
+  };
+
+  switch (mode) {
+    case 'refresh':
+      return refresh(say);
+    case 'opt-out':
+      return optOut(say);
+    case 'logout':
+      return logout(say);
+    default:
+      return status(say);
+  }
+}
+
+// ─── status ────────────────────────────────────────────────────────────
+
+async function status(say: (line?: string) => void): Promise<void> {
+  const source = readImageSource();
+  const pin = readAgentImagePin();
+  // A per-platform pin that names other architectures is not "no pin" — saying
+  // so would send someone to add a pin they already have.
+  const wrongPlatform = pin ? undefined : unsupportedPlatformPin();
+  const pinnedDigest = readAgentImageDigest();
+  const image = inspectAgentImage();
+  const account = readRegistryAccount();
+  const helper = credentialHelperStatus();
+
+  // `unknown` covers three different states — unpinned, not a digest ref, and
+  // docker unreachable — and none of them is a mismatch. Only claim drift when
+  // both sides answered.
+  const pinMatch =
+    !pinnedDigest || !image.registryDigest
+      ? 'unknown'
+      : String(pinnedDigest === image.registryDigest);
+
+  const row = (label: string, value: string): void => say(`${(label + ':').padEnd(18)}${value}`);
+  row('Image source', source === 'hardened' ? 'pull a pinned image' : 'build here');
+  row('On this machine', `${image.source}  (${image.ref})`);
+  if (pin) row('Pinned', pin);
+  row('Signed in as', account ? accountLabel(account) : 'not signed in');
+  if (account?.entitlements?.length) row('Perks', account.entitlements.join(', '));
+  row('Docker helper', helperLabel(helper));
+
+  // This step reports; it cannot sign anyone in (it must never prompt, because it
+  // is reachable from runners with no stdin). So say what to run instead —
+  // otherwise the honest "not signed in" above is a dead end.
+  if (!account) {
+    say('');
+    say('Not signed in. To use the pinned image:');
+    say('  bash setup/registry-login.sh                 sign in (opens your browser)');
+    say('  bash setup/registry-login.sh --code <code>   or redeem an enrollment code');
+    if (!pin && !wrongPlatform) {
+      say('');
+      say('This copy also has no agent-image pin in versions.json, so there is');
+      say('nothing for it to fetch — ./container/build.sh is the only path here.');
+    }
+  } else if (source !== 'hardened') {
+    // Signed in but still set to build locally: the container step would build
+    // and never touch the registry, which reads as "the pull silently did not
+    // happen". Worth naming rather than leaving the two rows to contradict
+    // each other.
+    say('');
+    say('Signed in, but this install is still set to build its own image.');
+    say('  bash setup/registry-login.sh --force       re-run sign-in, which sets the pinned path');
+    say('  ... or set NANOCLAW_HARDENED_IMAGE=true in .env');
+  } else if (!helper.installed) {
+    say('');
+    say('Signed in, but docker has no credential helper — re-run');
+    say('  bash setup/registry-login.sh --force');
+  }
+
+  if (pinMatch === 'false') {
+    say('');
+    say('The image behind the local tag is not the pinned one — run --refresh.');
+  }
+
+  if (wrongPlatform) {
+    say('');
+    say(`The agent-image pin has no reference for ${wrongPlatform.platform}.`);
+    say(`  it pins: ${wrongPlatform.available.join(', ')}`);
+    say('Build locally with ./container/build.sh build, or set');
+    say(`${AGENT_IMAGE_REF_ENV_KEY} to a reference for this architecture.`);
+  } else if (source === 'hardened' && !pin) {
+    say('');
+    say('This install is set to pull, but nothing says which image.');
+    say(`Set ${AGENT_IMAGE_REF_ENV_KEY} in .env, or add an "${AGENT_IMAGE_PIN}" pin to versions.json.`);
+  }
+
+  // The pin names the host docker authenticates against, so it is the only host
+  // whose wiring matters. Wired-to-something-else and wired-but-uninstalled both
+  // surface at pull time as a bare failure with no mention of a helper.
+  const pinnedHost = readRegistryHost();
+  if (source === 'hardened' && pinnedHost && !(helper.installed && helper.wiredHosts.includes(pinnedHost))) {
+    say('');
+    say(`Nothing supplies docker with credentials for ${pinnedHost} — a pull will not be authenticated.`);
+  }
+
+  emitStatus(BLOCK, {
+    MODE: 'status',
+    IMAGE_SOURCE: source,
+    IMAGE_SOURCE_ACTUAL: image.source,
+    IMAGE_REF: pin ?? '',
+    IMAGE_PIN_DIGEST: pinnedDigest ?? '',
+    IMAGE_DIGEST: image.registryDigest ?? '',
+    PIN_MATCH: pinMatch,
+    REGISTRY_HOST: pinnedHost ?? '',
+    ACCOUNT: accountLabel(account),
+    ACCOUNT_ID: account?.account_id ?? '',
+    CRED_HELPER: helper.installed,
+    CRED_HELPER_HOSTS: helper.wiredHosts.join(','),
+    BROKER: readBrokerUrl(account),
+    STATUS: 'success',
+    LOG: 'logs/setup.log',
+  });
+}
+
+/** Never the token, and never an empty string that reads as a missing field. */
+function accountLabel(account: RegistryAccount | undefined): string {
+  if (!account) return 'none';
+  return account.email ?? account.account_id ?? 'signed-in';
+}
+
+/**
+ * Installed and wired are independent, and the pair that reads as fine but is
+ * not — a `credHelpers` key naming a binary that is gone — deserves its own
+ * sentence rather than being flattened into a host list.
+ */
+function helperLabel(helper: { installed: boolean; wiredHosts: string[] }): string {
+  const hosts = helper.wiredHosts.join(', ');
+  if (helper.installed) return hosts || 'installed, wired to nothing';
+  return hosts ? `${hosts} — but the helper binary is missing` : 'not installed';
+}
+
+// ─── refresh ───────────────────────────────────────────────────────────
+
+/**
+ * Re-acquire the pinned reference. A no-op when those exact bytes are already
+ * here — `container/pull.sh` guards on `docker image inspect` — so this moves
+ * an install onto a digest that changed under it, rather than re-downloading
+ * the one it already runs.
+ */
+async function refresh(say: (line?: string) => void): Promise<void> {
+  const source = readImageSource();
+  if (source !== 'hardened') {
+    // Refusing rather than pulling anyway: on a local-build install the bytes
+    // under the slug tag are ones this machine made, and a retag would replace
+    // them with somebody else's under the same name.
+    say(`This install builds its agent image here (${HARDENED_IMAGE_ENV_KEY} is not true).`);
+    say('Re-run setup to switch, or `./container/build.sh pull` to fetch once without switching.');
+    emitStatus(BLOCK, {
+      MODE: 'refresh',
+      IMAGE_SOURCE: source,
+      STATUS: 'failed',
+      ERROR: 'not_hardened',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(1);
+  }
+
+  const projectRoot = process.cwd();
+  const before = inspectAgentImage(projectRoot).registryDigest ?? '';
+  const pull = spawnSync('bash', [path.join(projectRoot, 'container', 'pull.sh')], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  if (pull.status !== 0) {
+    // pull.sh exits 2 when nothing is configured to acquire; everything else is
+    // a real failure. Never fall back to a local build — that would replace the
+    // pinned bytes under the same tag and report success.
+    const errorCode = pull.status === 2 ? 'image_ref_not_configured' : 'image_pull_failed';
+    log.error('Agent image refresh failed', { exitCode: pull.status, errorCode });
+    emitStatus(BLOCK, {
+      MODE: 'refresh',
+      IMAGE_SOURCE: source,
+      IMAGE_REF: readAgentImagePin() ?? '',
+      IMAGE_DIGEST: before,
+      STATUS: 'failed',
+      ERROR: errorCode,
+      LOG: 'logs/setup.log',
+    });
+    process.exit(1);
+  }
+
+  const after = inspectAgentImage(projectRoot).registryDigest ?? '';
+
+  // Same reasoning as the container step: retagging the slug tag does nothing
+  // for a group pinned to its own derived image, so the reconcile is part of
+  // acquiring the image rather than a follow-up someone might not run. Imported
+  // lazily so `--status` and `--logout` never load the DB layer.
+  let cleared = 0;
+  let removed = 0;
+  let foreign = 0;
+  try {
+    const { reconcileDerivedImages } = await import('./registry-reconcile.js');
+    const result = reconcileDerivedImages();
+    cleared = result.cleared.length;
+    removed = result.removed.length;
+    foreign = result.foreign.length;
+  } catch (err) {
+    // Loud, not fatal: the image is here and tagged. What is left is groups
+    // still spawning pre-hardened derived images, which `--step
+    // registry-reconcile` exists to fix by hand.
+    log.error('Could not reconcile derived agent-group images', { err });
+  }
+
+  say();
+  say(after && after !== before ? `Now running ${after}.` : 'Already up to date.');
+  if (cleared > 0) {
+    say(`Cleared ${cleared} agent-group image pin(s) so they run the refreshed image.`);
+  }
+
+  emitStatus(BLOCK, {
+    MODE: 'refresh',
+    IMAGE_SOURCE: source,
+    IMAGE_REF: readAgentImagePin() ?? '',
+    IMAGE_DIGEST: after,
+    CHANGED: String(after !== before),
+    CLEARED: cleared,
+    IMAGES_REMOVED: removed,
+    FOREIGN_PINS: foreign,
+    STATUS: 'success',
+    LOG: 'logs/setup.log',
+  });
+}
+
+// ─── opt-out ───────────────────────────────────────────────────────────
+
+/**
+ * Back to locally built images. Only the setting changes: the bytes already
+ * under the slug tag keep running until the next `./container/build.sh`, which
+ * is what makes this safe to run at any time.
+ */
+async function optOut(say: (line?: string) => void): Promise<void> {
+  const before = readImageSource();
+  writeImageSource('local');
+  log.info('Agent image source set to local', { before });
+
+  if (before === 'hardened') {
+    say('This install now builds its own agent image.');
+    say('The pulled image keeps running until you rebuild: ./container/build.sh');
+    if (readRegistryAccount()) {
+      say('Your account credential is untouched — remove it with --logout.');
+    }
+  } else {
+    say('Already building locally. Nothing changed.');
+  }
+
+  emitStatus(BLOCK, {
+    MODE: 'opt-out',
+    IMAGE_SOURCE: 'local',
+    CHANGED: String(before === 'hardened'),
+    STATUS: 'success',
+    LOG: 'logs/setup.log',
+  });
+}
+
+// ─── logout ────────────────────────────────────────────────────────────
+
+/**
+ * Revoke server-side, then remove the local credential and the docker pointer.
+ *
+ * The local half runs even when the revoke fails. A token we cannot revoke is a
+ * record on somebody's server; the same token sitting 0600 on this disk is a
+ * local oracle any process running as this user can call. Removing it is the
+ * part the operator actually asked for, so a broker that is down must not block
+ * it — but the failure is reported rather than swallowed.
+ */
+async function logout(say: (line?: string) => void): Promise<void> {
+  const account = readRegistryAccount();
+  const broker = readBrokerUrl(account);
+  const revoke = account ? await revokeSession(broker, account.token) : 'skipped';
+
+  const removedFiles = clearRegistryAccount();
+  // The helper binary goes with the credential: left on PATH with nothing to
+  // read, it is a `docker pull` that fails with a helper error instead of an
+  // honest "not signed in".
+  const helper = uninstallCredentialHelper();
+  log.info('Registry logout', { revoke, removedFiles, helper });
+
+  if (!account) {
+    say('Not signed in — nothing to revoke.');
+  } else if (revoke === 'revoked') {
+    say('Session revoked.');
+  } else if (revoke === 'gone') {
+    say('That session was already invalid; removed it locally.');
+  } else {
+    say(`Couldn't reach ${broker} to revoke the session — removed it locally anyway.`);
+    say('If you believe the token was copied elsewhere, revoke it from your account page.');
+  }
+  if (removedFiles.length) say('Credential removed.');
+  if (helper.removedHosts.length) {
+    say(`Docker no longer asks us for ${helper.removedHosts.join(', ')}.`);
+  }
+
+  // Deliberately not coupled to --opt-out: someone re-signing-in on the same
+  // machine should not have to re-opt-in. But a pull with no credential fails,
+  // so say so rather than letting the next container step discover it.
+  if (readImageSource() === 'hardened') {
+    say('');
+    say(`This install still pulls its agent image (${HARDENED_IMAGE_ENV_KEY}=true) and no longer has`);
+    say('credentials for it. Sign in again by re-running setup, or switch back with --opt-out.');
+  }
+
+  emitStatus(BLOCK, {
+    MODE: 'logout',
+    REVOKE: revoke,
+    CREDENTIAL_REMOVED: String(removedFiles.length > 0),
+    CRED_HELPER_REMOVED: helper.removedBinaries.join(',') || '',
+    CRED_HELPER_HOSTS: helper.removedHosts.join(','),
+    IMAGE_SOURCE: readImageSource(),
+    STATUS: 'success',
+    LOG: 'logs/setup.log',
+  });
+}
+
+type RevokeOutcome = 'revoked' | 'gone' | 'failed' | 'skipped';
+
+/**
+ * `DELETE /v1/session`, authenticated with the token being revoked.
+ *
+ * 401/404 count as success: both mean the broker does not recognise this token,
+ * which is the state we were trying to reach. Short timeout because this is
+ * cleanup — a hanging broker must not hold up removing a local file.
+ */
+async function revokeSession(broker: string, token: string): Promise<RevokeOutcome> {
+  try {
+    const res = await fetch(`${broker}/v1/session`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.status === 401 || res.status === 404) return 'gone';
+    if (!res.ok) {
+      log.warn('Broker refused the revoke', { status: res.status });
+      return 'failed';
+    }
+    return 'revoked';
+  } catch (err) {
+    log.warn('Could not reach the broker to revoke the session', { broker, err });
+    return 'failed';
+  }
+}

--- a/setup/registry/credential-helper.mjs
+++ b/setup/registry/credential-helper.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+/**
+ * docker-credential-nanoclaw — vends a short-lived password for the gated
+ * agent-image registry, one pull at a time.
+ *
+ * Docker execs this once per `docker pull`, argv `["get"]`, with the bare
+ * registry hostname on stdin, before DNS resolution. `~/.docker/config.json`
+ * routes only our registry here via a single `credHelpers` entry, which holds
+ * a pointer and never a secret.
+ *
+ * Two properties are load-bearing:
+ *
+ * **Zero repo dependency.** Docker spawns this from an arbitrary cwd, and
+ * uninstalling NanoClaw deletes the checkout while this file stays on PATH.
+ * Node builtins only, nothing resolved relative to the tree, no cwd assumption.
+ *
+ * **Stdout is a protocol channel, not a log.** The docker CLI reads stdout and
+ * matches two strings literally — `credentials not found in native keychain`
+ * is the one that means "no credential here, continue anonymously". Any other
+ * stdout on a non-zero exit is shown to the user verbatim, so it has to be one
+ * useful line. Docker gives the helper its own stderr, so diagnostics go there
+ * and reach the terminal alongside whatever docker prints next.
+ *
+ * The installed copy's shebang is rewritten to an absolute node path by
+ * setup/install-cred-helper.ts — nvm/asdf shims are not reliably resolvable
+ * from docker's spawn environment.
+ */
+import { timingSafeEqual } from 'node:crypto';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { arch, homedir, platform } from 'node:os';
+import { join } from 'node:path';
+
+/** Also the marker the installer greps for before deleting a binary. */
+const HELPER_ID = 'nanoclaw-docker-credential-helper';
+const HELPER_VERSION = '1.0.0';
+
+const CONFIG_DIR = join(homedir(), '.config', 'nanoclaw');
+/**
+ * Written by sign-in. `{ api, token }` are required — the broker base and the
+ * opaque bearer. `registry` (the one host this install serves) and `host_id`
+ * (mint-log attribution) are optional and only tighten behaviour. `broker_url`
+ * is accepted as a synonym for `api`.
+ */
+const AUTH_FILE = join(CONFIG_DIR, 'registry-auth.json');
+/** Written by container/pull.sh for the duration of one pull. */
+const NONCE_FILE = join(CONFIG_DIR, '.pull-nonce');
+/** Broker-only random id. Deliberately not the PostHog install id. */
+const HOST_ID_FILE = join(CONFIG_DIR, 'host-id');
+
+/**
+ * The docker CLI compares these against the helper's stdout, trimmed, byte for
+ * byte. `credentials not found` is downgraded to "no credential for this
+ * registry" and the pull continues unauthenticated; anything else becomes a
+ * hard error carrying our text. Do not reword them.
+ */
+const ERR_NOT_FOUND = 'credentials not found in native keychain';
+const ERR_NO_SERVER_URL = 'no credentials server URL';
+
+/** A nonce older than this is a leftover from a crashed pull, not a live one. */
+const NONCE_MAX_AGE_MS = 5 * 60_000;
+const BROKER_TIMEOUT_MS = 20_000;
+/** Stdin is one hostname or one small JSON object. Nothing legitimate is big. */
+const MAX_STDIN_BYTES = 64 * 1024;
+
+/**
+ * Carries what stdout gets (`message`, the one line docker surfaces) separately
+ * from what stderr gets (`detail`, as long as it is useful).
+ */
+class HelperError extends Error {
+  constructor(message, detail) {
+    super(message);
+    this.detail = detail;
+  }
+}
+
+function note(line) {
+  try {
+    process.stderr.write(`docker-credential-nanoclaw: ${line}\n`);
+  } catch (_err) {
+    // stderr can be closed or a broken pipe; diagnostics are best-effort.
+  }
+}
+
+function errText(err) {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Bare hostname, lower-cased — what docker sends and what ECR is keyed by. */
+function normalizeHost(raw) {
+  const trimmed = (raw ?? '').trim().replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+  const slash = trimmed.indexOf('/');
+  return (slash === -1 ? trimmed : trimmed.slice(0, slash)).toLowerCase();
+}
+
+async function readStdin() {
+  // A human running this by hand gets an empty read rather than a hang.
+  if (process.stdin.isTTY) return '';
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of process.stdin) {
+    total += chunk.length;
+    if (total > MAX_STDIN_BYTES) throw new HelperError('input too large');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/**
+ * The auth file, or null when this machine has never logged in. A read error
+ * that is not "absent" is reported rather than silently read as "no account" —
+ * an unreadable token file is a broken install, not an unenrolled one.
+ */
+function readAuth() {
+  let raw;
+  try {
+    const st = statSync(AUTH_FILE);
+    if (st.mode & 0o077) {
+      note(`${AUTH_FILE} is readable beyond your account — chmod 600 it`);
+    }
+    raw = readFileSync(AUTH_FILE, 'utf-8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw new HelperError(
+      'nanoclaw: could not read the NanoClaw registry credential',
+      `${AUTH_FILE}: ${errText(err)}`,
+    );
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (err) {
+    throw new HelperError(
+      'nanoclaw: the NanoClaw registry credential file is not valid JSON',
+      `${AUTH_FILE}: ${errText(err)} — re-run \`nanoclaw login\``,
+    );
+  }
+}
+
+function writeAuth(auth) {
+  writeFileSync(AUTH_FILE, `${JSON.stringify(auth, null, 2)}\n`, { mode: 0o600 });
+}
+
+function equalConstantTime(a, b) {
+  const left = Buffer.from(a, 'utf-8');
+  const right = Buffer.from(b, 'utf-8');
+  // Length is not secret — both sides are fixed-width random strings.
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Refuse to mint outside a NanoClaw pull.
+ *
+ * This file sits 0755 on PATH and answers `get` with a live 12-hour registry
+ * password, so by itself it is a standing oracle: any process running as this
+ * user — a malicious npm postinstall, a compromised dev tool — could mint a
+ * credential that our own telemetry attributes to the legitimate account. The
+ * nonce narrows that to processes inside a real pull: the environment variable
+ * shows the caller was handed it by container/pull.sh, and the 0600 file shows
+ * the value came from something that can write our config directory.
+ *
+ * It is not a boundary against an attacker who can read both — same uid, same
+ * files. It removes the always-available oracle, which is the whole claim.
+ */
+function requirePullNonce() {
+  const refuse = (detail) =>
+    new HelperError(
+      'nanoclaw: refusing to mint a registry credential outside a NanoClaw pull',
+      detail,
+    );
+
+  const provided = (process.env.NANOCLAW_PULL_NONCE ?? '').trim();
+  if (!provided) {
+    throw refuse(
+      'NANOCLAW_PULL_NONCE is unset. container/pull.sh sets it for the pull it runs; nothing else should be asking for a registry credential.',
+    );
+  }
+
+  let st;
+  let expected;
+  try {
+    st = statSync(NONCE_FILE);
+    expected = readFileSync(NONCE_FILE, 'utf-8').trim();
+  } catch (err) {
+    throw refuse(`no pull nonce at ${NONCE_FILE}: ${errText(err)}`);
+  }
+
+  if (st.mode & 0o077) {
+    throw refuse(`${NONCE_FILE} is accessible beyond your account — it must be 0600`);
+  }
+  const ageMs = Date.now() - st.mtimeMs;
+  if (ageMs > NONCE_MAX_AGE_MS) {
+    throw refuse(
+      `the pull nonce is ${Math.round(ageMs / 1000)}s old — a leftover from an interrupted pull, not a live one`,
+    );
+  }
+  if (!expected || !equalConstantTime(provided, expected)) {
+    throw refuse('NANOCLAW_PULL_NONCE does not match the current pull');
+  }
+}
+
+/** Optional, client-asserted, and recorded by the broker as a hint only. */
+function pullDigest() {
+  const ref = (process.env.NANOCLAW_PULL_REF ?? '').trim();
+  const match = ref.match(/@(sha256:[0-9a-f]{64})$/);
+  return match ? match[1] : undefined;
+}
+
+function hostId(auth) {
+  if (typeof auth.host_id === 'string' && auth.host_id.trim()) return auth.host_id.trim();
+  try {
+    const value = readFileSync(HOST_ID_FILE, 'utf-8').trim();
+    return value && value.length <= 128 ? value : undefined;
+  } catch (_err) {
+    // Sign-in writes both; absence costs the broker one telemetry field.
+    return undefined;
+  }
+}
+
+/**
+ * Never send the bearer token in the clear. Loopback is exempt so a broker can
+ * be exercised locally without a certificate.
+ */
+function brokerBase(auth) {
+  const configured = [auth.api, auth.broker_url].find((v) => typeof v === 'string' && v.trim());
+  const raw = configured ? configured.trim() : '';
+  if (!raw) {
+    throw new HelperError(
+      'nanoclaw: no credential broker configured for this machine',
+      `${AUTH_FILE} names no broker — re-run \`nanoclaw login\``,
+    );
+  }
+  let url;
+  try {
+    url = new URL(raw);
+  } catch (err) {
+    throw new HelperError('nanoclaw: the configured credential broker URL is unusable', `${raw}: ${errText(err)}`);
+  }
+  const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+  if (url.protocol !== 'https:' && !loopback) {
+    throw new HelperError(
+      'nanoclaw: refusing to send the pull token to a non-HTTPS broker',
+      `${raw} is not https and not loopback`,
+    );
+  }
+  return raw.replace(/\/+$/, '');
+}
+
+/** One short line from the broker, safe to append to the message docker shows. */
+function brokerMessage(body) {
+  const raw = body && typeof body === 'object' ? (body.message ?? body.error) : undefined;
+  if (typeof raw !== 'string') return '';
+  const oneLine = raw.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 0 && oneLine.length <= 200 ? oneLine : '';
+}
+
+/**
+ * Two accepted response shapes, both natural readings of the broker's generic
+ * `mint() -> { credential, expires_at }` contract: `credential` as
+ * `{ username, password }`, or as a bare password string (username defaults to
+ * `AWS`, which is what ECR expects).
+ */
+function toDockerCredential(payload, serverURL) {
+  const credential = payload && typeof payload === 'object' && 'credential' in payload ? payload.credential : payload;
+
+  let username = 'AWS';
+  let secret;
+  if (typeof credential === 'string') {
+    secret = credential;
+  } else if (credential && typeof credential === 'object') {
+    if (typeof credential.username === 'string' && credential.username) username = credential.username;
+    secret = credential.password ?? credential.secret;
+  }
+
+  if (typeof secret !== 'string' || !secret) {
+    throw new HelperError(
+      'nanoclaw: the credential broker returned no usable registry password',
+      'expected { credential: { username, password } } or { credential: "<password>" }',
+    );
+  }
+  return { ServerURL: serverURL, Username: username, Secret: secret };
+}
+
+async function mint(auth, serverURL) {
+  const body = {
+    perk: 'agent-image',
+    registry: serverURL,
+    digest: pullDigest(),
+    install_id: hostId(auth),
+    client: {
+      os: platform(),
+      arch: arch(),
+      node: process.versions.node,
+      helper: HELPER_VERSION,
+    },
+  };
+
+  let res;
+  try {
+    res = await fetch(`${brokerBase(auth)}/v1/credentials`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${auth.token}`,
+        'content-type': 'application/json',
+        accept: 'application/json',
+        'user-agent': `${HELPER_ID}/${HELPER_VERSION} (${platform()}; ${arch()})`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(BROKER_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof HelperError) throw err;
+    throw new HelperError(
+      'nanoclaw: could not reach the NanoClaw credential broker',
+      `${errText(err)} — check network access, then retry`,
+    );
+  }
+
+  const text = await res.text().catch(() => '');
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : undefined;
+  } catch (_err) {
+    payload = undefined;
+  }
+
+  if (res.ok) return toDockerCredential(payload, serverURL);
+
+  const reason = brokerMessage(payload);
+  const suffix = reason ? ` — ${reason}` : '';
+  const detail = `HTTP ${res.status} from the broker: ${text.slice(0, 500)}`;
+  if (res.status === 401 || res.status === 403) {
+    throw new HelperError(
+      `nanoclaw: this machine is not signed in, or its image access was revoked — run \`nanoclaw login\`${suffix}`,
+      detail,
+    );
+  }
+  if (res.status === 429) {
+    // Quota exhaustion is a product behaviour, not an incident. Say what it is
+    // and stop; the operator's fallback is ./container/build.sh.
+    throw new HelperError(`nanoclaw: image-pull quota reached for this account${suffix}`, detail);
+  }
+  if (res.status >= 500) {
+    throw new HelperError(`nanoclaw: the credential broker is temporarily unavailable${suffix}`, detail);
+  }
+  throw new HelperError(`nanoclaw: the credential broker refused this request (HTTP ${res.status})${suffix}`, detail);
+}
+
+async function get(serverURL) {
+  if (!serverURL) throw new HelperError(ERR_NO_SERVER_URL);
+
+  const auth = readAuth();
+  if (!auth) {
+    note(`no ${AUTH_FILE} — run \`nanoclaw login\` if this machine should pull the hardened agent image`);
+    throw new HelperError(ERR_NOT_FOUND);
+  }
+
+  // A host we do not serve is not an error: answering "not found" is what lets
+  // docker fall through to whatever else the operator has configured. An
+  // unrecorded registry skips the check rather than refusing everything — the
+  // only route to this helper is a credHelpers entry the installer wired to one
+  // host, and the broker decides what it will mint regardless of what we ask.
+  const registry = normalizeHost(auth.registry);
+  if (registry && registry !== serverURL) {
+    note(`asked for ${serverURL}; this install holds a credential for ${registry}`);
+    throw new HelperError(ERR_NOT_FOUND);
+  }
+
+  requirePullNonce();
+
+  if (typeof auth.token !== 'string' || !auth.token) {
+    throw new HelperError(
+      'nanoclaw: the NanoClaw registry credential is incomplete — run `nanoclaw login`',
+      `${AUTH_FILE} has no token`,
+    );
+  }
+
+  return mint(auth, serverURL);
+}
+
+/**
+ * `docker logout <host>`. Drops cached credential fields and keeps the pull
+ * token: the token is the account's enrolment, not a docker session, and a
+ * logout must not silently unenrol the machine. Never fails the command —
+ * docker treats a non-zero erase as a failed logout.
+ */
+function erase(serverURL) {
+  try {
+    const auth = readAuth();
+    if (!auth) return;
+    const registry = normalizeHost(auth.registry);
+    if (registry && registry !== serverURL) return;
+    if (auth.cached === undefined) return;
+    delete auth.cached;
+    writeAuth(auth);
+  } catch (err) {
+    note(`erase left ${AUTH_FILE} untouched: ${errText(err)}`);
+  }
+}
+
+async function dispatch(argv) {
+  const command = argv[0];
+  switch (command) {
+    case 'get':
+      return { code: 0, line: JSON.stringify(await get(normalizeHost(await readStdin()))) };
+    case 'store':
+      // Docker calls this after `docker login`. We persist nothing it hands us
+      // — no secret is meant to land on disk here — but failing would break a
+      // login the operator ran by hand against some other registry.
+      await readStdin();
+      return { code: 0 };
+    case 'erase':
+      erase(normalizeHost(await readStdin()));
+      return { code: 0 };
+    case 'list':
+      // Empty by design. `docker build`/`compose` enumerate credentials by
+      // calling `list` and then `get` on every entry returned, which would mint
+      // — and burn quota — on commands that never touch our registry. The
+      // per-registry credHelpers entry routes real pulls to `get` directly.
+      return { code: 0, line: '{}' };
+    case 'version':
+      return { code: 0, line: `${HELPER_ID} ${HELPER_VERSION}` };
+    default:
+      return { code: 1, line: `unknown credential helper command: ${command ?? '(none)'}` };
+  }
+}
+
+/**
+ * Single exit point. Writing to a pipe is asynchronous in Node, so exiting
+ * before the flush callback can truncate the credential JSON docker is reading.
+ */
+function finish(code, line) {
+  if (line === undefined) {
+    process.exit(code);
+    return;
+  }
+  process.stdout.write(`${line}\n`, () => process.exit(code));
+}
+
+dispatch(process.argv.slice(2)).then(
+  ({ code, line }) => finish(code, line),
+  (err) => {
+    if (err instanceof HelperError) {
+      if (err.detail) note(err.detail);
+      finish(1, err.message);
+      return;
+    }
+    note(errText(err));
+    finish(1, 'nanoclaw: the credential helper failed unexpectedly');
+  },
+);

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -15,6 +15,7 @@ import { DATA_DIR } from '../src/config.js';
 import { readEnvFile } from '../src/env.js';
 import { log } from '../src/log.js';
 import { getLaunchdLabel, getSystemdUnit } from '../src/install-slug.js';
+import { inspectAgentImage, readImageSource } from './lib/registry-state.js';
 import {
   getPlatform,
   getServiceManager,
@@ -187,23 +188,45 @@ export async function run(_args: string[]): Promise<void> {
 
   const configuredChannels = Object.keys(channelAuth);
 
-  // 5. Check registered groups in v2 central DB (agent_groups + messaging_group_agents)
+  // 5. Check registered groups in v2 central DB (agent_groups + messaging_group_agents),
+  //    plus how many agent groups pin an image of their own (reported in step 7).
+  //    The two counts get their own try/catch: they read different tables, and a
+  //    partially migrated DB must not hide one behind the other's failure.
   let registeredGroups = 0;
+  let derivedGroups = 0;
   const dbPath = path.join(DATA_DIR, 'v2.db');
   if (fs.existsSync(dbPath)) {
+    let db: Database.Database | null = null;
     try {
-      const db = new Database(dbPath, { readonly: true });
-      // Count agent groups that have at least one messaging group wired
-      const row = db
-        .prepare(
-          `SELECT COUNT(DISTINCT ag.id) as count FROM agent_groups ag
-           JOIN messaging_group_agents mga ON mga.agent_group_id = ag.id`,
-        )
-        .get() as { count: number };
-      registeredGroups = row.count;
-      db.close();
+      db = new Database(dbPath, { readonly: true });
     } catch {
-      // Table might not exist (DB not migrated yet)
+      // Unreadable (permissions, or mid-migration) — leave both counts at 0
+      // rather than failing the health check on a transient condition.
+    }
+    if (db) {
+      try {
+        // Count agent groups that have at least one messaging group wired
+        const row = db
+          .prepare(
+            `SELECT COUNT(DISTINCT ag.id) as count FROM agent_groups ag
+             JOIN messaging_group_agents mga ON mga.agent_group_id = ag.id`,
+          )
+          .get() as { count: number };
+        registeredGroups = row.count;
+      } catch {
+        // Table might not exist (DB not migrated yet)
+      }
+      try {
+        const row = db
+          .prepare(
+            'SELECT COUNT(*) as count FROM container_configs WHERE image_tag IS NOT NULL',
+          )
+          .get() as { count: number };
+        derivedGroups = row.count;
+      } catch {
+        // Same: container_configs arrives with the migrations
+      }
+      db.close();
     }
   }
 
@@ -216,6 +239,22 @@ export async function run(_args: string[]): Promise<void> {
   ) {
     mountAllowlist = 'configured';
   }
+
+  // 7. Where the agent image came from — intended vs actual.
+  //
+  // These two can disagree, and reporting the disagreement is the whole point.
+  // The hardened path pulls by digest and retags onto the same slug tag a local
+  // build writes, so nothing downstream can tell them apart; a pull that failed
+  // and fell back to `./container/build.sh` would leave `.env` saying "hardened"
+  // over locally built bits. IMAGE_SOURCE is the operator's intent, read from
+  // `.env`; IMAGE_SOURCE_ACTUAL is read off the image itself and cannot be
+  // talked into agreeing. Only inspect once `docker info` has already
+  // succeeded — otherwise a stopped daemon reads as "image missing".
+  const imageSource = readImageSource();
+  const image =
+    containerRuntime === 'docker'
+      ? inspectAgentImage(projectRoot)
+      : { source: 'unknown' as const, registryDigest: undefined };
 
   // Deferred-wire channels can't have a group yet: their platform id only
   // exists after the first inbound DM (see add-teams' "Finish wiring"), so
@@ -237,8 +276,21 @@ export async function run(_args: string[]): Promise<void> {
     wiringPending,
   });
 
-  log.info('Verification complete', { status, channelAuth, wiringPending });
+  log.info('Verification complete', {
+    status,
+    channelAuth,
+    wiringPending,
+    imageSource,
+    imageSourceActual: image.source,
+    derivedGroups,
+  });
 
+  // The image fields are reporting only — they are not inputs to
+  // determineVerifyStatus above. A derived-image pin is a real finding on the
+  // hardened path but the normal, supported state of an install_packages user
+  // on the local path, and IMAGE_SOURCE_ACTUAL is 'unknown' whenever Docker
+  // isn't reachable. Failing verify on either would fire offerClaudeOnFailure
+  // (setup/auto.ts) at installs that are working exactly as designed.
   emitStatus('VERIFY', {
     SERVICE: service,
     CONTAINER_RUNTIME: containerRuntime,
@@ -247,6 +299,12 @@ export async function run(_args: string[]): Promise<void> {
     CHANNEL_AUTH: JSON.stringify(channelAuth),
     REGISTERED_GROUPS: registeredGroups,
     MOUNT_ALLOWLIST: mountAllowlist,
+    IMAGE_SOURCE: imageSource,
+    IMAGE_SOURCE_ACTUAL: image.source,
+    // Registry manifest digest, to compare against the `agent-image` pin in
+    // versions.json. Empty for a locally built image — it has never had one.
+    IMAGE_DIGEST: image.registryDigest ?? '',
+    DERIVED_GROUPS: derivedGroups,
     ...(wiringPending ? { WIRING: 'pending_first_dm' } : {}),
     STATUS: status,
     LOG: 'logs/setup.log',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -562,6 +562,18 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
     throw new Error('No packages to install. Use install_packages first.');
   }
 
+  // Which bytes this is built on. Recorded on the derived image so an operator
+  // can tell which base a group's packages were layered onto — the image id
+  // rather than a RepoDigest, because a locally built base has no RepoDigest at
+  // all and an id is unambiguous either way.
+  let baseId = '';
+  try {
+    const { stdout } = await execAsync(`${CONTAINER_RUNTIME_BIN} image inspect --format '{{.Id}}' ${CONTAINER_IMAGE}`);
+    baseId = stdout.trim();
+  } catch {
+    // Non-fatal: the build below fails on its own if the base is really absent.
+  }
+
   let dockerfile = `FROM ${CONTAINER_IMAGE}\nUSER root\n`;
   if (aptPackages.length > 0) {
     dockerfile += `RUN apt-get update && apt-get install -y ${aptPackages.join(' ')} && rm -rf /var/lib/apt/lists/*\n`;
@@ -575,6 +587,17 @@ export async function buildAgentGroupImage(agentGroupId: string): Promise<void> 
     dockerfile += `RUN ${allowlist} && pnpm install -g ${npmPackages.join(' ')}\n`;
   }
   dockerfile += 'USER node\n';
+
+  // Overwrite the provenance label rather than letting it be inherited.
+  //
+  // `dev.nanoclaw.image-source` is documented as the one claim a retag cannot
+  // forge, and --status treats it as the trustworthy answer. But a derived
+  // build inherits the base's labels, so without this a group that has just
+  // added arbitrary apt/npm packages would keep asserting `hardened` — the
+  // vendor's claim, over bytes the vendor never saw. `derived` is the honest
+  // answer, and `derived-from` says what it was layered onto.
+  dockerfile += 'LABEL dev.nanoclaw.image-source="derived"\n';
+  if (baseId) dockerfile += `LABEL dev.nanoclaw.derived-from="${baseId}"\n`;
 
   const imageTag = `${CONTAINER_IMAGE_BASE}:${agentGroupId}`;
 

--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -36,7 +36,21 @@ export interface AllowedRoot {
 let cache: { path: string; mtimeMs: number; allowlist: MountAllowlist } | null = null;
 
 /**
- * Default blocked patterns - paths that should never be mounted
+ * Default blocked patterns - paths that should never be mounted.
+ *
+ * Entries are matched by {@link matchesBlockedPattern} as substrings of the
+ * mount's resolved realPath, so an entry may carry a separator
+ * (`.config/nanoclaw`) to pin a name to its parent instead of blocking every
+ * `.config` on the host.
+ *
+ * SCOPE — read this before treating the list as protection. The check runs
+ * exactly once, against the realPath of the mount ROOT (`validateMount`
+ * below), and does NOT descend. It stops an operator from *naming* one of
+ * these paths as a mount; it does nothing about what lives underneath an
+ * allowed root. Allowlist `~` (or `~/.config`) and every credential below it
+ * is mounted regardless of what this list says. That is a structural property
+ * of a root-only check — closing it would need a walk of the mounted subtree,
+ * which nothing here does. Do not read an entry here as "this file is safe."
  */
 const DEFAULT_BLOCKED_PATTERNS = [
   '.ssh',
@@ -47,6 +61,17 @@ const DEFAULT_BLOCKED_PATTERNS = [
   '.gcloud',
   '.kube',
   '.docker',
+  // NanoClaw's own host-side state. The mount allowlist itself lives at
+  // ~/.config/nanoclaw/mount-allowlist.json specifically so a container agent
+  // cannot edit the rules that govern it (see the module header) — handing that
+  // directory to a container as a mount root would undo the whole arrangement.
+  // It is also where host credentials land as they are added.
+  '.config/nanoclaw',
+  // Host-executed helper binaries. Setup installs onecli and claude here and
+  // then invokes them by name as the operator, so a read-write mount of this
+  // directory is a container-to-host code-execution primitive: drop a file,
+  // wait for the host to run it.
+  '.local/bin',
   'credentials',
   '.env',
   '.netrc',
@@ -193,7 +218,14 @@ function getRealPath(p: string): string | null {
 }
 
 /**
- * Check if a path matches any blocked pattern
+ * Check if a path matches any blocked pattern.
+ *
+ * Substring match, both per path component and against the whole realPath —
+ * so `.env` also rejects `.envrc`, and a pattern may span a separator.
+ *
+ * Its only caller passes the realPath of the mount ROOT, so this answers
+ * "may this path be named as a mount?" and never "is anything blocked inside
+ * it?". See the note on {@link DEFAULT_BLOCKED_PATTERNS}.
  */
 function matchesBlockedPattern(realPath: string, blockedPatterns: string[]): string | null {
   const pathParts = realPath.split(path.sep);

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,5 @@
 {
   "onecli-gateway": "1.36.0",
-  "onecli-cli": "2.2.5"
+  "onecli-cli": "2.2.5",
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:089ff730cd24ede22cf6c643216efb0e144a1198644ace773c774e018c8b148f"
 }


### PR DESCRIPTION
Adds a second way to get the agent container image: **fetch a prebuilt, hardened one from the NanoClaw registry** instead of building it locally. Building stays the default, stays the only path that needs no account, and is unchanged.

The image is built by **[Echo](https://echo.ai)**, who rebuild the sandbox's contents — Chromium, Node, Bun, pnpm, git and the rest — from scratch with only the essentials, and patch what remains. Isolation already keeps a misbehaving agent away from the host; this is the other half, and the reason it exists: the software the agent *uses* is worth patching too. A local build gives you the same components straight from their public base, unpatched — which is what setup now says, rather than framing the choice as build-time versus download-time.

Pinned to `797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:089ff730…`, a multi-arch index covering `linux/amd64` and `linux/arm64` with build attestations attached.

## How it works

The whole mechanism is a retag. `container/pull.sh` pulls a digest-pinned reference and tags it onto exactly the name a local build would have written, so **nothing in `src/` learns a registry exists** — the host spawns the same tag either way, and derived per-group builds still work offline. That constraint is what keeps the feature out of the runtime: every downstream consumer is untouched.

## Guards

A wrong image here fails in places that are hard to read, so each of these fails early and loudly instead:

| | |
|---|---|
| **Architecture** | Checked against the *daemon's*, not the host CPU's — Docker Desktop, a remote daemon and cross-arch contexts all make those differ. A multi-arch index never trips this; a single-arch reference on the wrong machine is refused rather than landing an image that only runs under emulation. |
| **Lockfile** | The image must carry a label matching this checkout's `container/agent-runner/bun.lock`. `/app/node_modules` is baked in while `/app/src` is bind-mounted at spawn, so a mismatched pair dies as a missing module inside a `--rm` container whose logs are discarded. |
| **Provenance** | Travels in an image label a retag cannot forge, so `--status` reports what the tag actually holds as well as what was asked for. |

## Adding dependencies layers, it does not rebuild

A skill that adds a runtime dependency appends to `cli-tools.json` and calls `./container/build.sh`. On an install that fetches its image, that builds **one layer on top of the published image** rather than rebuilding from the public Node base — so adding a CLI no longer discards every layer the publisher hardened.

The additions themselves were in nobody's scan. The build says so plainly, and records it in its own label without overwriting the base's claim, because the bytes underneath really are what the publisher hardened:

```
Tools added.

The published image underneath is unchanged, so you keep its hardening in
full. The tools just layered on top are a different matter: they were not
part of that build, nobody scanned them, and they may carry known
vulnerabilities of their own.

To have added dependencies hardened too: https://echo.ai
```

The one exception is the agent-runner's own dependencies, which are baked into the base. A checkout whose `bun.lock` has moved needs a base built for it and no overlay can fix that, so that case refuses and prints both hashes.

## Accounts

Fetching from the gated registry needs a free account, and it is the only part of NanoClaw that involves one. Pointing at any registry you can already `docker login` to — a corporate Harbor, an internal mirror, a `docker save`/`load` image — needs no account at all.

The credential helper is nonce-gated and answers for exactly one host. What is collected, and what is not, is spelled out in [`docs/hardened-image.md`](docs/hardened-image.md).

## Also included

`.github/workflows/verify-agent-image.yml` gates changes to the image pin. Shape checks — multi-arch index, both platforms, lock label, provenance, size — block a merge outright. Auto-merge turns on for exactly one thing, a verified publisher signature, because every other check is a claim the image makes about itself and detects drift rather than forgery.

Typecheck clean, 1174 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
