### PR TITLE
Don't follow dangling symlinks when materializing template skills

### DIFF
--- a/src/group-skills.test.ts
+++ b/src/group-skills.test.ts
@@ -60,6 +60,40 @@ describe('materializeTemplateSkills', () => {
     expect(fs.lstatSync(path.join(dest, 'shared')).isSymbolicLink()).toBe(true);
   });
 
+  it('skips dangling shared-skill symlinks in the SOURCE store instead of throwing', () => {
+    // container-runner's syncSkillSymlinks fills this same store with links to
+    // container paths, which never resolve on the host. Following one used to
+    // throw ENOENT out of the caller's container contribution and abort every
+    // spawn for the group — a total outage, not a missing skill.
+    const srcDir = path.join(DATA_DIR, 'v2-sessions', 'g5', '.claude-shared', 'skills');
+    templateSkill('g5', 'widget', 'SKILL.md', 'body');
+    fs.symlinkSync('/app/skills/agent-browser', path.join(srcDir, 'agent-browser'));
+    const dest = path.join(TEST_ROOT, 'grp5', '.agents', 'skills');
+
+    expect(() => materializeTemplateSkills('g5', dest)).not.toThrow();
+
+    // The real template skill still crosses over; the dangling link does not.
+    expect(fs.readFileSync(path.join(dest, 'widget', 'SKILL.md'), 'utf-8')).toBe('body');
+    expect(fs.existsSync(path.join(dest, 'agent-browser'))).toBe(false);
+  });
+
+  it('skips a symlinked directory in the source (template skills are real dirs)', () => {
+    // Resolvable, but still not a template skill — mirroring it would copy
+    // content the provider is expected to get from its own shared-skill links.
+    const realElsewhere = path.join(TEST_ROOT, 'elsewhere', 'linked');
+    fs.mkdirSync(realElsewhere, { recursive: true });
+    fs.writeFileSync(path.join(realElsewhere, 'SKILL.md'), 'linked');
+    templateSkill('g6', 'widget', 'SKILL.md', 'body');
+    const srcDir = path.join(DATA_DIR, 'v2-sessions', 'g6', '.claude-shared', 'skills');
+    fs.symlinkSync(realElsewhere, path.join(srcDir, 'linked'));
+    const dest = path.join(TEST_ROOT, 'grp6', '.agents', 'skills');
+
+    materializeTemplateSkills('g6', dest);
+
+    expect(fs.existsSync(path.join(dest, 'widget'))).toBe(true);
+    expect(fs.existsSync(path.join(dest, 'linked'))).toBe(false);
+  });
+
   it('does not destroy skills when dest equals the source (Claude reads source directly)', () => {
     templateSkill('g4', 'widget', 'SKILL.md', 'body');
     const src = path.join(DATA_DIR, 'v2-sessions', 'g4', '.claude-shared', 'skills');

--- a/src/group-skills.ts
+++ b/src/group-skills.ts
@@ -44,7 +44,17 @@ export function materializeTemplateSkills(agentGroupId: string, destSkillsDir: s
 
   fs.mkdirSync(destSkillsDir, { recursive: true });
   for (const name of fs.readdirSync(src)) {
-    if (!fs.statSync(path.join(src, name)).isDirectory()) continue;
+    // lstat, never stat: the source store also holds shared-skill symlinks
+    // whose targets are container paths (`/app/skills/<name>`, written by
+    // container-runner's syncSkillSymlinks), so they dangle on the host.
+    // Following one throws ENOENT out of the caller's container contribution
+    // and aborts the spawn. Template skills are real directories, so skipping
+    // every symlink is also the correct filter, not just the safe one.
+    // `throwIfNoEntry: false` covers only the entry-vanished-since-readdir
+    // race; a real fault (EACCES, EIO) still throws rather than silently
+    // dropping a skill.
+    const entry = fs.lstatSync(path.join(src, name), { throwIfNoEntry: false });
+    if (!entry?.isDirectory()) continue;
     const dest = path.join(destSkillsDir, name);
     fs.rmSync(dest, { recursive: true, force: true });
     fs.cpSync(path.join(src, name), dest, { recursive: true });


### PR DESCRIPTION
## Summary

`materializeTemplateSkills` filters directory entries with `fs.statSync`, which follows symlinks. The store it reads (`.claude-shared/skills`) is also where `container-runner`'s `syncSkillSymlinks` writes shared-skill links, and those point at **container** paths (`/app/skills/<name>`) that never resolve on the host.

So for any group that has both template skills and shared-skill links, the first `stat` of a link throws `ENOENT`. The throw escapes through the calling provider's container contribution into `spawnContainer`, so **no container starts for that group at all** — every message for that agent stalls, not just the affected skill. The host sweep then retries once a minute and fails identically.

Hit in practice with the `codex` provider, whose contribution mirrors this store into `.agents/skills`:

```
ENOENT: no such file or directory, stat
'.../v2-sessions/<group>/.claude-shared/skills/agent-browser'
  at materializeTemplateSkills (dist/group-skills.js:45)
  at registerProviderContainerConfig.providesAgentSurfaces (dist/providers/codex.js:56)
  at resolveProviderContribution (dist/container-runner.js:195)
  at spawnContainer
```

## Fix

Use `lstat` instead of `stat`.

This is also the *correct* filter rather than merely the safe one: the module's own contract is that template skills are stamped as **real directories**, while symlinks in this store are provider-owned shared-skill links that must not be mirrored — `codex.ts`'s `syncCodexSkillLinks` already guards the same links with `lstatSync`, so this was the one place that followed them.

`throwIfNoEntry: false` narrows the tolerance to the entry-vanished-since-`readdir` race, so a genuine `EACCES`/`EIO` still throws rather than silently dropping a skill.

## Test plan

Two regression tests added to the existing `src/group-skills.test.ts`:

- a dangling `/app/skills/...` link in the source store no longer throws, the real template skill beside it is still mirrored, and the link is not copied
- a *resolvable* symlinked directory is skipped too, per the real-directories contract

Verified red-on-delete against this branch's baseline — reverting only `group-skills.ts` reproduces the production error in-test:

```
× skips dangling shared-skill symlinks in the SOURCE store instead of throwing
× skips a symlinked directory in the source (template skills are real dirs)
AssertionError: expected [Function] to not throw an error but
'Error: ENOENT: no such file or directory, stat .../skills/agent-browser' was thrown
      Tests  2 failed | 4 passed (6)
```

With the fix: `Tests 6 passed (6)`. `tsc --noEmit` reports nothing for either changed file.

Made with [Cursor](https://cursor.com)