### PR TITLE
fix: redact secrets from host structured logs

### DIFF
--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactLogData } from './log.js';
+
+describe('operator log redaction', () => {
+  it('redacts nested credentials and omits large payload fields', () => {
+    const value = redactLogData({
+      componentSecret: 'component-secret',
+      nested: {
+        accessToken: 'access-token',
+        authorization: 'Bearer bearer-token',
+        safeId: 'task-123',
+      },
+      arguments: { city: 'Riga', password: 'inside-payload' },
+      payload: { result: 'private-result' },
+    });
+
+    expect(value).toEqual({
+      componentSecret: '[REDACTED]',
+      nested: {
+        accessToken: '[REDACTED]',
+        authorization: '[REDACTED]',
+        safeId: 'task-123',
+      },
+      arguments: '[OMITTED]',
+      payload: '[OMITTED]',
+    });
+  });
+
+  it('redacts credentials embedded in error messages and stacks', () => {
+    const error = new Error('request failed: authorization=BearerToken password=hunter2');
+    const value = redactLogData({ err: error }) as {
+      err: { message: string; stack?: string };
+    };
+
+    expect(value.err.message).not.toContain('BearerToken');
+    expect(value.err.message).not.toContain('hunter2');
+    expect(value.err.stack).not.toContain('BearerToken');
+    expect(value.err.stack).not.toContain('hunter2');
+  });
+});

--- a/src/log.ts
+++ b/src/log.ts
@@ -12,20 +12,56 @@ const KEY_COLOR = '\x1b[35m';
 const MSG_COLOR = '\x1b[36m';
 const RESET = '\x1b[39m';
 const FULL_RESET = '\x1b[0m';
+const REDACTED = '[REDACTED]';
+const OMITTED = '[OMITTED]';
+const TRUNCATED = '[TRUNCATED]';
+const SENSITIVE_KEY = /(?:authorization|cookie|credential|password|secret|token|api[_-]?key)/i;
+const PAYLOAD_KEY = /^(?:args?|arguments?|body|content|input|payload|progress|result|taskContext)$/i;
 
 const threshold = LEVELS[(process.env.LOG_LEVEL as Level) || 'info'] ?? LEVELS.info;
 
-function formatErr(err: unknown): string {
-  if (err instanceof Error) {
-    return `{ type: "${err.constructor.name}", message: "${err.message}", stack: ${err.stack} }`;
+function redactText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[^\s,;]+/gi, `Bearer ${REDACTED}`)
+    .replace(
+      /\b(authorization|cookie|credential|password|secret|token|api[_-]?key)\b(\s*[:=]\s*)(["']?)[^,\s}"']+/gi,
+      `$1$2$3${REDACTED}`,
+    );
+}
+
+function redactValue(value: unknown, key: string, depth: number, seen: WeakSet<object>): unknown {
+  if (SENSITIVE_KEY.test(key)) return REDACTED;
+  if (PAYLOAD_KEY.test(key)) return OMITTED;
+  if (typeof value === 'string') return redactText(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (depth >= 5) return TRUNCATED;
+  if (seen.has(value)) return '[CIRCULAR]';
+  seen.add(value);
+  if (value instanceof Error) {
+    return {
+      type: value.constructor.name,
+      message: redactText(value.message),
+      stack: value.stack ? redactText(value.stack) : undefined,
+    };
   }
-  return JSON.stringify(err);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, '', depth + 1, seen));
+  return Object.fromEntries(
+    Object.entries(value).map(([nestedKey, nestedValue]) => [
+      nestedKey,
+      redactValue(nestedValue, nestedKey, depth + 1, seen),
+    ]),
+  );
+}
+
+export function redactLogData(data: Record<string, unknown>): Record<string, unknown> {
+  const seen = new WeakSet<object>();
+  return Object.fromEntries(Object.entries(data).map(([key, value]) => [key, redactValue(value, key, 0, seen)]));
 }
 
 function formatData(data: Record<string, unknown>): string {
   const parts: string[] = [];
-  for (const [k, v] of Object.entries(data)) {
-    parts.push(`${KEY_COLOR}${k}${RESET}=${k === 'err' ? formatErr(v) : JSON.stringify(v)}`);
+  for (const [k, v] of Object.entries(redactLogData(data))) {
+    parts.push(`${KEY_COLOR}${k}${RESET}=${JSON.stringify(v)}`);
   }
   return parts.length ? ' ' + parts.join(' ') : '';
 }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** Redacts credentials from the host's structured log lines (`log.info/warn/error` data) before they are written to `nanoclaw.log`.

**Why.** Log data was serialized verbatim with `JSON.stringify`, so any secret passed in a log payload — bearer tokens, cookies, API keys, passwords — was written to disk in the clear. The `err` formatter was also broken: it interpolated the raw stack into an unquoted string (`stack: ${err.stack}`), producing invalid, unparseable output.

**How it works.** All structured log data is routed through a new `redactLogData` before formatting:
- values under sensitive keys (`authorization`, `cookie`, `token`, `api_key`, `password`, `secret`, `credential`) are replaced with `[REDACTED]`
- `Bearer` tokens and `key=value` secrets embedded in free text — including inside `Error` messages and stacks — are scrubbed
- bulky payload-shaped fields (`body`, `content`, `result`, ...) that routinely carry user data are `[OMITTED]`
- traversal is depth-capped and circular-reference safe

Errors now serialize to a proper object (`{ type, message, stack }`).

**How it was tested.** New unit tests in `src/log.test.ts` cover nested-credential redaction, payload omission, and secret scrubbing in error messages/stacks. `npx vitest run src/log.test.ts` passes; `tsc --noEmit` clean.

Related (agent-output side, distinct from host logs): #880, #1165.