### PR TITLE
fix(migrate-v2): call insertTaskRow, not the removed insertTask

### DIFF
--- a/setup/migrate-v2/tasks.ts
+++ b/setup/migrate-v2/tasks.ts
@@ -20,7 +20,7 @@ import { initDb, closeDb } from '../../src/db/connection.js';
 import { getAgentGroupByFolder } from '../../src/db/agent-groups.js';
 import { getMessagingGroupByPlatform } from '../../src/db/messaging-groups.js';
 import { runMigrations } from '../../src/db/migrations/index.js';
-import { insertTask } from '../../src/modules/scheduling/db.js';
+import { insertTaskRow } from '../../src/modules/scheduling/db.js';
 import { openInboundDb, resolveSession } from '../../src/session-manager.js';
 import { readEnvFile } from '../../src/env.js';
 import { buildDiscordResolver, type DiscordResolver } from './discord-resolver.js';
@@ -145,13 +145,15 @@ async function main(): Promise<void> {
           .get(t.id) as { id: string } | undefined;
         if (existing) { skipped++; continue; }
 
-        insertTask(inboxDb, {
+        // seriesId equals id for a brand-new series, per insertTaskRow's
+        // contract. Platform/channel/thread are deliberately not passed: a task
+        // fires into an isolated system session, so those columns are always
+        // NULL. platformId is still needed above to locate the messaging group.
+        insertTaskRow(inboxDb, {
           id: t.id,
+          seriesId: t.id,
           processAfter: scheduling.processAfter,
           recurrence: scheduling.recurrence,
-          platformId,
-          channelType: parsed.channel_type,
-          threadId: null,
           content: JSON.stringify({
             prompt: t.prompt,
             script: t.script ?? null,


### PR DESCRIPTION
## The bug

`setup/migrate-v2/tasks.ts:23` imports `insertTask` from `src/modules/scheduling/db.js`, but that module exports **`insertTaskRow`**. The rename landed without updating this caller.

Because it is a static ESM import, the step dies before executing anything:

```
SyntaxError: The requested module '../../src/modules/scheduling/db.js'
does not provide an export named 'insertTask'
```

`upstream/channels` still carries the old `insertTask`, which is likely why this went unnoticed — the symbol exists on that branch.

## Impact

Step `1e-tasks` fails outright, so **every active v1 scheduled task is dropped** during a v1 → v2 migration. It is not silent — `run_step` prints a `✗` — but the script then prints `Phase 1 complete` and carries on to phase 2, so a migration can walk right past it and only notice later that no task ever fires.

## Reproduction

Any v1 install with at least one active row in `scheduled_tasks`:

```bash
pnpm exec tsx setup/migrate-v2/tasks.ts /path/to/v1
```

Fails at import on `main`; succeeds with this patch.

## The fix

Not a pure rename — `insertTaskRow` takes a different shape:

- it requires `seriesId` (equal to `id` for a brand-new series, per its contract);
- it does not take `platformId` / `channelType` / `threadId`, since a task fires into an isolated system session and those columns are always `NULL`.

`platformId` is still computed just above — it locates the messaging group, it simply no longer travels with the row.

## Verification

Run against a real v1 install (4 registered groups, 13 active tasks), v1 database opened read-only:

```
1b-db        OK:groups=4,created=4,reused=0,skipped=0
1d-sessions  OK:created=4,reused=0,skipped=3,files=225
1e-tasks     OK:active=13,migrated=8,skipped=5,failed=0     <- was a SyntaxError
```

The 5 skips are unrelated to this patch: those tasks belong to group folders with no row in v1 `registered_groups`, so `getAgentGroupByFolder` returns nothing. Happy to open that as a separate issue if it is of interest — a folder can host a live scheduled task without ever being registered, via the ephemeral-group path in v1's `task-scheduler.ts`.

## Notes

- One thing per PR: this only repairs the broken call.
- No test added — `setup/migrate-v2/` currently has no harness for the step files (only `discord-resolver.test.ts`). Glad to add one if you would like, and to point it in whatever direction you prefer.
