### PR TITLE
fix: support rootless Docker for agent containers

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { hardeningArgs, resolveProviderName } from './container-runner.js';
+import { hardeningArgs, isRootlessDocker, resolveProviderName, userMappingArgs } from './container-runner.js';
 
 describe('resolveProviderName', () => {
   it('prefers session over container config', () => {
@@ -136,5 +136,52 @@ describe('hardeningArgs', () => {
 
   it('floors fractional values', () => {
     expect(hardeningArgs('2048.7').join(' ')).toContain('--pids-limit 2048');
+  });
+});
+
+describe('isRootlessDocker', () => {
+  it('detects the XDG runtime socket', () => {
+    expect(isRootlessDocker('unix:///run/user/1003/docker.sock')).toBe(true);
+  });
+
+  it('treats the system socket and an unset DOCKER_HOST as rootful', () => {
+    expect(isRootlessDocker('unix:///var/run/docker.sock')).toBe(false);
+    expect(isRootlessDocker(undefined)).toBe(false);
+    expect(isRootlessDocker('')).toBe(false);
+  });
+});
+
+describe('userMappingArgs', () => {
+  const ROOTFUL = 'unix:///var/run/docker.sock';
+  const ROOTLESS = 'unix:///run/user/1003/docker.sock';
+
+  // Under rootless the host user IS container uid 0; mapping to the host uid
+  // resolves against the subuid range and loses access to every bind mount.
+  it('maps to 0:0 under rootless regardless of host uid', () => {
+    for (const uid of [0, 500, 1000, 1003]) {
+      expect(userMappingArgs(uid, uid, ROOTLESS)).toEqual([
+        '--user',
+        '0:0',
+        '-e',
+        'HOME=/home/node',
+        '-e',
+        'IS_SANDBOX=1',
+      ]);
+    }
+  });
+
+  it('maps to the host uid under rootful when it is neither 0 nor 1000', () => {
+    expect(userMappingArgs(1003, 1003, ROOTFUL)).toEqual(['--user', '1003:1003', '-e', 'HOME=/home/node']);
+  });
+
+  it('emits nothing under rootful for uid 0 and 1000', () => {
+    expect(userMappingArgs(0, 0, ROOTFUL)).toEqual([]);
+    expect(userMappingArgs(1000, 1000, ROOTFUL)).toEqual([]);
+  });
+
+  // Non-Linux hosts (macOS Docker Desktop) have no getuid; the VM handles it.
+  it('emits nothing when the host has no uid', () => {
+    expect(userMappingArgs(undefined, undefined, ROOTFUL)).toEqual([]);
+    expect(userMappingArgs(undefined, undefined, ROOTLESS)).toEqual([]);
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -247,13 +247,64 @@ export function resolveProviderName(
 }
 
 /**
+ * Is this a rootless Docker daemon? Rootless puts its socket under the user's
+ * XDG runtime dir (`/run/user/<uid>/docker.sock`), which is the only signal we
+ * get from the host side without shelling out to `docker info`.
+ *
+ * Pure so the detection can be unit-tested without a daemon.
+ */
+export function isRootlessDocker(dockerHost: string | undefined): boolean {
+  return !!dockerHost && dockerHost.includes('/run/user/');
+}
+
+/**
+ * `--user` mapping for the agent container.
+ *
+ * Rootful: the host uid owns the bind-mounted session DBs and workspace, so the
+ * container has to run as that uid. uid 0 and 1000 are skipped — root needs no
+ * mapping, and 1000 already matches the image's `node` user.
+ *
+ * Rootless: the daemon runs inside a user namespace where the host user is
+ * *already* container uid 0. Passing `--user 1003:1003` there resolves against
+ * the subuid range, not the host user, producing an id that owns none of the
+ * mounts — every container dies with EACCES on `mkdir /workspace/agent/memory`.
+ * `--user 0:0` is the identity mapping back to the host user, not host root.
+ *
+ * `HOME=/home/node` rides along on both paths: neither uid has a passwd entry
+ * matching the image's home, and tools that fall back to `getpwuid()` write to
+ * `/` otherwise.
+ *
+ * Pure so the mapping can be unit-tested without a daemon.
+ */
+export function userMappingArgs(
+  hostUid: number | undefined,
+  hostGid: number | undefined,
+  dockerHost: string | undefined,
+): string[] {
+  if (hostUid == null) return [];
+
+  if (isRootlessDocker(dockerHost)) {
+    return ['--user', '0:0', '-e', 'HOME=/home/node', '-e', 'IS_SANDBOX=1'];
+  }
+
+  if (hostUid !== 0 && hostUid !== 1000) {
+    return ['--user', `${hostUid}:${hostGid}`, '-e', 'HOME=/home/node'];
+  }
+
+  return [];
+}
+
+/**
  * Container hardening flags. Applied to every agent container; no per-group or
  * per-install override.
  *
- * cap-drop and no-new-privileges are inert while containers run under the
- * `--user` mapping below (the capability sets are already empty and the image
- * carries no file capabilities) — they are depth against a root-in-container
- * path. `--init` is not optional: the `--entrypoint bash` override further down
+ * cap-drop and no-new-privileges are inert while containers run under a
+ * non-root `--user` mapping (the capability sets are already empty and the
+ * image carries no file capabilities) — they are depth against a
+ * root-in-container path. On rootless Docker, where `userMappingArgs` returns
+ * `--user 0:0`, that path is live and these stop being inert: the uid is root
+ * inside the namespace even though it is the unprivileged host user outside it.
+ * `--init` is not optional: the `--entrypoint bash` override further down
  * defeats the image's tini, leaving bun as PID 1 with no signal handler, and
  * Linux discards default-action signals to PID 1. Without docker-init, SIGTERM
  * is ignored and every stop ends in SIGKILL after the full grace period.
@@ -501,12 +552,7 @@ async function buildContainerArgs(
   }
 
   // User mapping
-  const hostUid = process.getuid?.();
-  const hostGid = process.getgid?.();
-  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
-    args.push('--user', `${hostUid}:${hostGid}`);
-    args.push('-e', 'HOME=/home/node');
-  }
+  args.push(...userMappingArgs(process.getuid?.(), process.getgid?.(), process.env.DOCKER_HOST));
 
   // Volume mounts
   for (const mount of mounts) {


### PR DESCRIPTION
Agent containers are unusable on a rootless Docker daemon. Two independent failures, both invisible when the host user is in the `docker` group — which is presumably why they haven't surfaced before.

I hit them because I deliberately kept the agent account out of the docker group: on my host that group is root-equivalent, and `docs/SECURITY.md` makes a point of non-root execution and OS-level isolation. Rootless seemed like the setup the security model is written for.

## 1. `--user` mapping is inverted under rootless

`buildContainerArgs` pushes `--user ${hostUid}:${hostGid}`. Under rootless the daemon runs in a user namespace where the invoking host user **is already container uid 0**, so passing the host uid resolves against the subuid range instead and owns none of the bind mounts.

```
[agent-runner] Fatal error: EACCES: permission denied, mkdir '/workspace/agent/memory'
```

Verified directly (host uid 1003):

```bash
docker run --rm --user 1003:1003 -v ~/nanoclaw-v2/groups:/workspace alpine touch /workspace/probe
# touch: /workspace/probe: Permission denied

docker run --rm --user 0:0 -v ~/nanoclaw-v2/groups:/workspace alpine touch /workspace/probe
# succeeds
```

`--user 0:0` is the identity mapping back to the host user here — not host root.

## 2. Claude Code refuses `bypassPermissions` as root

With (1) fixed, containers run as uid 0 and `providers/claude.ts` always passes `permissionMode: 'bypassPermissions'`:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

The runner surfaces only `Claude Code process exited with code 1`, so this isn't visible from the logs — it took a manual `docker exec` to find. `IS_SANDBOX=1` is the documented escape, and the claim is accurate on this path: it is a container, on a rootless daemon, where container-root maps to an unprivileged host user.

I confirmed the confinement holds — a container running as namespace-root with `/` bind-mounted still cannot read the host user's home or `/etc/shadow`.

## Changes

- `isRootlessDocker(dockerHost)` — detection via `DOCKER_HOST` containing `/run/user/`
- `userMappingArgs(uid, gid, dockerHost)` — the whole decision, pure and testable
- Rootful behaviour is byte-identical
- Corrects the `hardeningArgs` comment: `cap-drop` / `no-new-privileges` are described as inert under the `--user` mapping, which stops being true on the rootless path where the uid is namespace-root — they carry real weight there

**Tests:** 1241 pass, 4 new covering both mappings and the detection.

## Known limitation

Detection is `DOCKER_HOST`-only. A rootless install where the socket comes from the Docker CLI context rather than the env var would still hit (1). Happy to extend it to `docker context inspect` if you'd prefer.

Also unaddressed: `setup/container.ts` duplicates the old inline mapping for the setup smoke-test container and will fail the same way under rootless. Left alone to keep this reviewable — glad to route it through `userMappingArgs` in the same PR if useful.