### PR TITLE
fix: route command-gate denials through the delivery adapter, not outbound.db

### DIFF
--- a/docs/db-session.md
+++ b/docs/db-session.md
@@ -118,7 +118,15 @@ Every message (in or out) gets a monotonic integer `seq`, unique *within the ses
 
 Why disjoint? `seq` is the agent-facing message ID. When the agent calls `edit_message(seq=5)` or `add_reaction(seq=6)`, `getMessageIdBySeq()` uses the parity to route the lookup: odd → `messages_out`, even → `messages_in`. The parity alone disambiguates without a join. Collisions would break editing.
 
-If you add a code path that writes to either table, preserve parity — the invariant isn't enforced by a constraint, only by the two helper functions.
+The host never writes `messages_out` — the container owns that table.
+Host-generated user notices (e.g. command-gate denials) go through the live
+`ChannelDeliveryAdapter` instead of the DB. (Host-sweep still opens
+`outbound.db` read-write for its post-container `processing_ack` cleanup,
+under its own container-is-dead contract — that touches bookkeeping tables,
+never `messages_out`.) A former `writeOutboundDirect()` wrote denial rows
+into `messages_out` and was removed.
+
+If you add a code path that writes to either table, preserve this scheme — the invariant isn't enforced by a constraint, only by the helper functions.
 
 ---
 

--- a/src/command-gate.ts
+++ b/src/command-gate.ts
@@ -4,7 +4,8 @@
  *
  * - Filtered commands: dropped silently (never reach the container)
  * - Admin commands: checked against user_roles; denied senders get a
- *   "Permission denied" response written directly to messages_out
+ *   "Permission denied" notice via the live delivery adapter (the host
+ *   never writes messages_out — see docs/db-session.md §3)
  * - Normal messages: pass through unchanged
  */
 import { hasAdminPrivilege } from './modules/permissions/db/user-roles.js';

--- a/src/router.deny-notice.test.ts
+++ b/src/router.deny-notice.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Command-gate denial notices go through the live ChannelDeliveryAdapter —
+ * the host must never write the container-owned outbound.db (single-writer
+ * invariant). These tests
+ * drive the real `routeInbound` deny branch and assert:
+ *   - the notice is delivered to the originating address WITH the exact
+ *     adapter instance (named-instance channels must not fall through to a
+ *     default sibling bot),
+ *   - delivery is fire-and-forget: a slow adapter never blocks the route,
+ *   - nothing is written to the session (no writeSessionMessage, no wake),
+ *   - failed or missing adapters degrade to a logged warning, never a throw.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./log.js', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('./db/messaging-groups.js', () => ({
+  getMessagingGroupWithAgentCount: vi.fn(() => null),
+  getMessagingGroupAgents: vi.fn(() => []),
+  getMessagingGroupByPlatform: vi.fn(() => undefined),
+  createMessagingGroup: vi.fn(),
+}));
+
+vi.mock('./db/agent-groups.js', () => ({
+  getAgentGroup: vi.fn(() => ({ id: 'ag-test', name: 'Test' })),
+}));
+
+vi.mock('./db/dropped-messages.js', () => ({
+  recordDroppedMessage: vi.fn(),
+}));
+
+vi.mock('./db/sessions.js', () => ({
+  findSessionForAgent: vi.fn(() => undefined),
+  getSession: vi.fn(() => ({ id: 'sess-test', agent_group_id: 'ag-test' })),
+}));
+
+vi.mock('./session-manager.js', () => ({
+  resolveSession: vi.fn(() => ({
+    session: { id: 'sess-test', agent_group_id: 'ag-test', messaging_group_id: 'mg-1', thread_id: null },
+    created: false,
+  })),
+  writeSessionMessage: vi.fn(),
+}));
+
+vi.mock('./container-runner.js', () => ({
+  wakeContainer: vi.fn(async () => true),
+}));
+
+vi.mock('./modules/typing/index.js', () => ({
+  startTypingRefresh: vi.fn(),
+  stopTypingRefresh: vi.fn(),
+}));
+
+vi.mock('./channels/channel-registry.js', () => ({
+  getChannelAdapter: vi.fn(() => null),
+  getChannelDefaults: vi.fn(() => ({
+    dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+    group: { engageMode: 'mention-sticky', threads: false, unknownSenderPolicy: 'request_approval' },
+    mentions: 'platform',
+  })),
+}));
+
+vi.mock('./command-gate.js', () => ({
+  gateCommand: vi.fn(() => ({ action: 'deny', command: '/clear' })),
+}));
+
+vi.mock('./delivery.js', () => ({
+  getDeliveryAdapter: vi.fn(),
+}));
+
+import { routeInbound, setChannelRequestGate } from './router.js';
+import {
+  getMessagingGroupWithAgentCount,
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from './db/messaging-groups.js';
+import { resolveSession, writeSessionMessage } from './session-manager.js';
+import { wakeContainer } from './container-runner.js';
+import { getDeliveryAdapter } from './delivery.js';
+import { log } from './log.js';
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const wiredAgent = {
+  id: 'mga-1',
+  messaging_group_id: 'mg-1',
+  agent_group_id: 'ag-test',
+  engage_mode: 'pattern' as const,
+  engage_pattern: '.',
+  sender_scope: 'all' as const,
+  ignored_message_policy: 'drop' as const,
+  session_mode: 'shared' as const,
+  priority: 0,
+  created_at: '2026-06-05T00:00:00Z',
+};
+
+function wiredGroup(instance: string) {
+  return {
+    id: 'mg-1',
+    channel_type: 'slack',
+    platform_id: 'slack:C123',
+    instance,
+    name: null,
+    is_group: 0,
+    unknown_sender_policy: 'public' as const,
+    denied_at: null,
+    created_at: '2026-06-05T00:00:00Z',
+  };
+}
+
+function makeDeniedCommandEvent(instance?: string): Parameters<typeof routeInbound>[0] {
+  return {
+    channelType: 'slack',
+    platformId: 'slack:C123',
+    threadId: null,
+    ...(instance !== undefined ? { instance } : {}),
+    message: {
+      id: 'msg-deny',
+      kind: 'chat',
+      content: JSON.stringify({ text: '/clear' }),
+      timestamp: '2026-06-05T08:00:00Z',
+      isMention: true,
+      isGroup: false,
+    },
+  };
+}
+
+describe('router command-gate denial notice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setChannelRequestGate(null as never);
+    vi.mocked(getMessagingGroupAgents).mockReturnValue([wiredAgent]);
+  });
+
+  it('delivers via the adapter to the originating address with the exact instance', async () => {
+    // Named-instance channel (second Slack app): the registry dispatches by
+    // exact instance key, so the denial must carry mg.instance — falling
+    // through to the default sibling would reply as the wrong bot identity.
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack-cit'), agentCount: 1 });
+    const deliver = vi.fn(async () => undefined);
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    await routeInbound(makeDeniedCommandEvent('slack-cit'));
+    await flush();
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    const [channelType, platformId, threadId, kind, content, files, instance] = deliver.mock.calls[0] as unknown as [
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      unknown,
+      string | undefined,
+    ];
+    expect(channelType).toBe('slack');
+    expect(platformId).toBe('slack:C123');
+    expect(threadId).toBeNull();
+    expect(kind).toBe('chat');
+    expect(JSON.parse(content).text).toContain('Permission denied: /clear');
+    expect(files).toBeUndefined();
+    expect(instance).toBe('slack-cit');
+
+    // The gate runs BEFORE session resolution: a denied command creates no
+    // session row, initializes no session databases, writes nothing, and
+    // wakes nothing.
+    expect(resolveSession).not.toHaveBeenCalled();
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+    expect(wakeContainer).not.toHaveBeenCalled();
+  });
+
+  it('replyTo redirect resolves the TARGET address instance, not the origin instance', async () => {
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack-cit'), agentCount: 1 });
+    vi.mocked(getMessagingGroupByPlatform).mockReturnValue({ instance: 'discord-ops' } as never);
+    const deliver = vi.fn(async () => undefined);
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    const event = makeDeniedCommandEvent('slack-cit');
+    (event as { replyTo?: unknown }).replyTo = {
+      channelType: 'discord',
+      platformId: 'discord:C9',
+      threadId: null,
+    };
+    await routeInbound(event);
+    await flush();
+
+    expect(getMessagingGroupByPlatform).toHaveBeenCalledWith('discord', 'discord:C9');
+    const args = deliver.mock.calls[0] as unknown as [string, string, string | null, string, string, unknown, string?];
+    expect(args[0]).toBe('discord');
+    expect(args[1]).toBe('discord:C9');
+    expect(args[6]).toBe('discord-ops');
+  });
+
+  it('same-address replyTo (thread-only redirect) keeps the ORIGIN instance', async () => {
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack-cit'), agentCount: 1 });
+    // Poisoned lookup: if the code consults by-platform for a same-address
+    // redirect, it would get the default sibling's instance — wrong bot.
+    vi.mocked(getMessagingGroupByPlatform).mockReturnValue({ instance: 'slack' } as never);
+    const deliver = vi.fn(async () => undefined);
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    const event = makeDeniedCommandEvent('slack-cit');
+    (event as { replyTo?: unknown }).replyTo = {
+      channelType: 'slack',
+      platformId: 'slack:C123',
+      threadId: 'T-99',
+    };
+    await routeInbound(event);
+    await flush();
+
+    expect(getMessagingGroupByPlatform).not.toHaveBeenCalled();
+    const args = deliver.mock.calls[0] as unknown as [string, string, string | null, string, string, unknown, string?];
+    expect(args[2]).toBe('T-99');
+    expect(args[6]).toBe('slack-cit');
+  });
+
+  it('does not block the route on a slow adapter (fire-and-forget)', async () => {
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack'), agentCount: 1 });
+    // A deliver() that never settles: routeInbound must still return.
+    const deliver = vi.fn(() => new Promise<undefined>(() => {}));
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    await expect(routeInbound(makeDeniedCommandEvent())).resolves.toBeUndefined();
+    expect(deliver).toHaveBeenCalledTimes(1);
+    // The denial audit log is reached even though delivery never settled.
+    expect(log.info).toHaveBeenCalledWith(
+      'Admin command denied by gate',
+      expect.objectContaining({ command: '/clear' }),
+    );
+  });
+
+  it('a failing adapter is best-effort: warning logged, never thrown', async () => {
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack'), agentCount: 1 });
+    const deliver = vi.fn(async () => {
+      throw new Error('socket closed');
+    });
+    vi.mocked(getDeliveryAdapter).mockReturnValue({ deliver } as never);
+
+    await expect(routeInbound(makeDeniedCommandEvent())).resolves.toBeUndefined();
+    await flush();
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      'Denial notice delivery failed',
+      expect.objectContaining({ command: '/clear' }),
+    );
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+  });
+
+  it('no adapter yet (host booting) degrades to a logged warning, not a throw', async () => {
+    vi.mocked(getMessagingGroupWithAgentCount).mockReturnValue({ mg: wiredGroup('slack'), agentCount: 1 });
+    vi.mocked(getDeliveryAdapter).mockReturnValue(null);
+
+    await expect(routeInbound(makeDeniedCommandEvent())).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Denial notice not deliverable (no adapter or address)',
+      expect.objectContaining({ command: '/clear' }),
+    );
+    expect(writeSessionMessage).not.toHaveBeenCalled();
+    expect(wakeContainer).not.toHaveBeenCalled();
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -25,12 +25,14 @@ import { recordDroppedMessage } from './db/dropped-messages.js';
 import {
   createMessagingGroup,
   getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
   getMessagingGroupWithAgentCount,
 } from './db/messaging-groups.js';
 import { findSessionForAgent } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import { resolveSession, writeSessionMessage } from './session-manager.js';
+import { getDeliveryAdapter } from './delivery.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
@@ -467,8 +469,8 @@ async function deliverToAgent(
     effectiveSessionMode = 'per-thread';
   }
 
-  const { session, created } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
-
+  // Gate BEFORE resolveSession: a denied or filtered command must not
+  // create a session row or initialize session databases as a side effect.
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source
   // (stamped from the event, with the wiring's thread policy applied). When
@@ -483,7 +485,12 @@ async function deliverToAgent(
 
   // Command gate: classify slash commands before they reach the container.
   // Filtered commands are dropped silently. Denied admin commands get a
-  // permission-denied response written directly to messages_out.
+  // permission-denied notice sent through the live delivery adapter — the
+  // host must never write the container-owned outbound.db itself (single-
+  // writer invariant).
+  // Fire-and-forget: the route must not block on a
+  // slow adapter, and a lost notice is worse than silence-with-logs but not
+  // worth stalling routing over.
   if (event.message.kind === 'chat' || event.message.kind === 'chat-sdk') {
     const gate = gateCommand(event.message.content, userId, agent.agent_group_id);
     if (gate.action === 'filter') {
@@ -491,18 +498,44 @@ async function deliverToAgent(
       return;
     }
     if (gate.action === 'deny') {
-      writeOutboundDirect(session.agent_group_id, session.id, {
-        id: `deny-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        kind: 'chat',
-        platformId: deliveryAddr.platformId,
-        channelType: deliveryAddr.channelType,
-        threadId: deliveryAddr.threadId,
-        content: JSON.stringify({ text: `Permission denied: ${gate.command} requires admin access.` }),
-      });
+      const adapter = getDeliveryAdapter();
+      if (adapter && deliveryAddr.channelType && deliveryAddr.platformId) {
+        // The registry dispatches by exact instance key — a named-instance
+        // channel (e.g. a second Slack app) must not fall through to its
+        // default sibling. The origin address is this mg; a replyTo redirect
+        // resolves its own mg row (same as normal outbound delivery), and an
+        // unknown redirect address defaults downstream to channelType.
+        // Same-address replyTo (e.g. only the thread differs) keeps the
+        // ORIGIN instance — the by-platform lookup deliberately prefers the
+        // default instance and would reply through a sibling bot. Only a
+        // genuinely different target address resolves its own mg row.
+        const sameAddress = deliveryAddr.channelType === mg.channel_type && deliveryAddr.platformId === mg.platform_id;
+        const notifyInstance =
+          event.replyTo === undefined || sameAddress
+            ? mg.instance
+            : getMessagingGroupByPlatform(deliveryAddr.channelType, deliveryAddr.platformId)?.instance;
+        void adapter
+          .deliver(
+            deliveryAddr.channelType,
+            deliveryAddr.platformId,
+            deliveryAddr.threadId,
+            'chat',
+            JSON.stringify({ text: `Permission denied: ${gate.command} requires admin access.` }),
+            undefined,
+            notifyInstance,
+          )
+          .catch((err) => {
+            log.warn('Denial notice delivery failed', { command: gate.command, userId, err });
+          });
+      } else {
+        log.warn('Denial notice not deliverable (no adapter or address)', { command: gate.command, userId });
+      }
       log.info('Admin command denied by gate', { command: gate.command, userId, agentGroupId: agent.agent_group_id });
       return;
     }
   }
+
+  const { session, created } = resolveSession(agent.agent_group_id, mg.id, effectiveThreadId, effectiveSessionMode);
 
   writeSessionMessage(session.agent_group_id, session.id, {
     id: messageIdForAgent(event.message.id, agent.agent_group_id),

--- a/src/session-manager.test.ts
+++ b/src/session-manager.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for session-manager's direct outbound write path.
+ * Tests for session-manager's session-folder lifecycle paths.
  *
- * Drives the real `writeOutboundDirect` entry against a real session folder
- * on disk. A previous implementation opened the outbound DB through
- * `openOutboundDb` (readonly: true), so every INSERT threw SQLITE_READONLY
- * and the command-gate denial path silently never delivered. Goes red if the
- * open call reverts to the readonly form.
+ * (The former writeOutboundDirect suite is gone with the function: the host
+ * never writes messages_out, and never writes outbound.db while a container
+ * may be running — command-gate denials go through the delivery adapter (see
+ * router.deny-notice.test.ts); host-sweep's post-container processing_ack
+ * cleanup via openOutboundDbRw remains the one sanctioned host write.)
  */
 import fs from 'fs';
 import Database from 'better-sqlite3';
@@ -16,14 +16,7 @@ vi.mock('./config.js', async () => {
   return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-write-outbound' };
 });
 
-import {
-  initSessionFolder,
-  inboundDbPath,
-  outboundDbPath,
-  sessionDir,
-  writeOutboundDirect,
-  writeSessionMessage,
-} from './session-manager.js';
+import { initSessionFolder, inboundDbPath, sessionDir, writeSessionMessage } from './session-manager.js';
 import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
 import { createSession } from './db/sessions.js';
 import type { Session } from './types.js';
@@ -31,20 +24,6 @@ import type { Session } from './types.js';
 const TEST_DIR = '/tmp/nanoclaw-test-write-outbound';
 const AG = 'ag-test';
 const SESS = 'sess-test';
-
-function readMessagesOut(): Array<{ id: string; seq: number; kind: string; content: string }> {
-  const db = new Database(outboundDbPath(AG, SESS), { readonly: true });
-  try {
-    return db.prepare('SELECT id, seq, kind, content FROM messages_out ORDER BY seq').all() as Array<{
-      id: string;
-      seq: number;
-      kind: string;
-      content: string;
-    }>;
-  } finally {
-    db.close();
-  }
-}
 
 beforeEach(() => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
@@ -54,59 +33,6 @@ beforeEach(() => {
 
 afterEach(() => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
-});
-
-describe('writeOutboundDirect', () => {
-  it('inserts into messages_out with an even host-side seq (requires a writable outbound.db)', () => {
-    // With a readonly open this very call throws SQLITE_READONLY.
-    writeOutboundDirect(AG, SESS, {
-      id: 'denial-1',
-      kind: 'chat',
-      platformId: 'slack:C1',
-      channelType: 'slack',
-      threadId: null,
-      content: JSON.stringify({ text: 'Admin commands are restricted.' }),
-    });
-
-    const rows = readMessagesOut();
-    expect(rows).toHaveLength(1);
-    expect(rows[0].id).toBe('denial-1');
-    expect(rows[0].seq).toBe(2);
-    expect(rows[0].seq % 2).toBe(0); // host uses even seq numbers
-    expect(JSON.parse(rows[0].content).text).toBe('Admin commands are restricted.');
-  });
-
-  it('keeps host seq numbers even across multiple writes and ignores duplicate ids', () => {
-    writeOutboundDirect(AG, SESS, {
-      id: 'denial-1',
-      kind: 'chat',
-      platformId: null,
-      channelType: null,
-      threadId: null,
-      content: '{"text":"first"}',
-    });
-    writeOutboundDirect(AG, SESS, {
-      id: 'denial-2',
-      kind: 'chat',
-      platformId: null,
-      channelType: null,
-      threadId: null,
-      content: '{"text":"second"}',
-    });
-    // INSERT OR IGNORE — a delivery retry with the same id must not throw or duplicate.
-    writeOutboundDirect(AG, SESS, {
-      id: 'denial-1',
-      kind: 'chat',
-      platformId: null,
-      channelType: null,
-      threadId: null,
-      content: '{"text":"retry"}',
-    });
-
-    const rows = readMessagesOut();
-    expect(rows.map((r) => r.id)).toEqual(['denial-1', 'denial-2']);
-    expect(rows.map((r) => r.seq)).toEqual([2, 4]);
-  });
 });
 
 /**

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -399,47 +399,13 @@ export function openOutboundDbRw(agentGroupId: string, sessionId: string): Datab
   return openOutboundDbRwRaw(outboundDbPath(agentGroupId, sessionId));
 }
 
-/**
- * Write a message directly to a session's outbound DB so the host delivery
- * loop picks it up. Used by the command gate to send denial responses
- * without waking a container.
- *
- * Needs the read-write open — the readonly handle the delivery poll uses
- * can't INSERT. This is a host-side write to the container-owned outbound.db,
- * but it's safe even with a container running: both sides open with DELETE
- * journal + busy_timeout, and the even host seq stays out of the container's
- * odd-seq space.
- */
-export function writeOutboundDirect(
-  agentGroupId: string,
-  sessionId: string,
-  message: {
-    id: string;
-    kind: string;
-    platformId: string | null;
-    channelType: string | null;
-    threadId: string | null;
-    content: string;
-  },
-): void {
-  const db = openOutboundDbRw(agentGroupId, sessionId);
-  try {
-    db.prepare(
-      `INSERT OR IGNORE INTO messages_out (id, seq, timestamp, kind, platform_id, channel_type, thread_id, content)
-       VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 2 FROM messages_out), ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      message.id,
-      new Date().toISOString(),
-      message.kind,
-      message.platformId,
-      message.channelType,
-      message.threadId,
-      message.content,
-    );
-  } finally {
-    db.close();
-  }
-}
+// NOTE: there is deliberately no host-side writer for a session's
+// outbound.db while a container may be running — that DB is container-owned
+// and single-writer (see the invariant at the top of this file). Host-
+// generated notices (e.g. command-gate denials) go
+// through the live ChannelDeliveryAdapter instead — the same path normal
+// outbound delivery takes. A previous `writeOutboundDirect` here wrote
+// denial rows into messages_out and was removed for exactly that reason.
 
 /**
  * Load outbox attachments for a delivered message.


### PR DESCRIPTION
`writeOutboundDirect()` (command-gate denial notices) had the host INSERT rows into a session's `outbound.db` — a second writer on a container-owned database that this repo's own invariants (docs/db.md single-writer rule, the session-manager.ts header) treat as a corruption risk. Its seq allocation (`MAX(seq)+2` from `messages_out` alone) could also collide with both the container's odd namespace and the inbound even namespace under `UNIQUE(seq)` + `INSERT OR IGNORE` — silently dropping the denial, so a user who was refused an admin command saw nothing at all.

This PR routes denial notices through the live `ChannelDeliveryAdapter` instead — the same path normal outbound delivery takes:

- **Exact-instance dispatch.** The origin messaging group's `instance` rides the deliver call, so a named-instance channel (e.g. a second Slack app in one workspace) never replies through its default sibling bot. A `replyTo` redirect that only changes the thread keeps the origin instance; a genuinely different target resolves its own messaging-group row.
- **Fire-and-forget.** `void` + `.catch` with a logged warning: a slow or hung adapter cannot stall `routeInbound()`, and the denial audit log always runs.
- **Gate before session creation.** The command gate now runs before `resolveSession()`, so a denied or filtered command no longer creates a session row or initializes session databases as a side effect.
- **`writeOutboundDirect` deleted** (no remaining callers). `docs/db-session.md` §3 now states the invariant plainly: the host never writes `messages_out`.

New `src/router.deny-notice.test.ts` drives the real deny branch: exact-instance assertion on the deliver call, a same-address `replyTo` regression with a poisoned by-platform lookup (proving it is not consulted), a never-settling adapter proving the route returns, degraded modes asserting their logged warnings, and no-session-state assertions.

Full vitest suite: 1240/1240 on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
