### PR TITLE
fix(release): retry post-publish readback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,13 +291,33 @@ jobs:
             echo "::notice::GitHub Release $TAG already matches the requested publication; nothing to change."
           fi
 
-          git fetch --force origin --tags
-          write_tag_state
-          write_release_state
-          FINAL_STATE=$(node scripts/release.mjs plan "$RELEASE_VERSION" "$TARGET_SHA" \
-            "$RUNNER_TEMP/tag-state.json" "$RUNNER_TEMP/release-state.json" \
-            "$RUNNER_TEMP/release-notes.md")
-          test "$FINAL_STATE" = "already-published"
+          READBACK_ATTEMPTS=6
+          READBACK_DELAY_SECONDS=2
+          FINAL_STATE="pending"
+
+          for ((attempt = 1; attempt <= READBACK_ATTEMPTS; attempt++)); do
+            git fetch --force origin --tags
+            write_tag_state
+            write_release_state
+            FINAL_STATE=$(node scripts/release.mjs readback "$RELEASE_VERSION" "$TARGET_SHA" \
+              "$RUNNER_TEMP/tag-state.json" "$RUNNER_TEMP/release-state.json" \
+              "$RUNNER_TEMP/release-notes.md")
+
+            if [ "$FINAL_STATE" = "already-published" ]; then
+              break
+            fi
+            if [ "$attempt" -eq "$READBACK_ATTEMPTS" ]; then
+              echo "::error::Timed out waiting for GitHub to return the exact immutable release after $READBACK_ATTEMPTS attempts."
+              node scripts/release.mjs plan "$RELEASE_VERSION" "$TARGET_SHA" \
+                "$RUNNER_TEMP/tag-state.json" "$RUNNER_TEMP/release-state.json" \
+                "$RUNNER_TEMP/release-notes.md"
+              exit 1
+            fi
+
+            echo "::notice::Release read-back is still propagating (attempt $attempt/$READBACK_ATTEMPTS); retrying in ${READBACK_DELAY_SECONDS}s."
+            sleep "$READBACK_DELAY_SECONDS"
+            READBACK_DELAY_SECONDS=$((READBACK_DELAY_SECONDS * 2))
+          done
 
           RELEASE_URL=$(jq -r .html_url "$RUNNER_TEMP/release-state.json")
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **Release publication tolerates GitHub API propagation.** The Release workflow now retries bounded post-publication read-backs when the new Release is not listed yet or its immutable state is not visible yet. Exact title, body, tag, or SHA mismatches still fail immediately.
+
 ## [2.1.54] - 2026-08-01
 
 Rollup release covering v2.1.18 through v2.1.54 — everything merged since the v2.1.17 tag.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,7 +57,9 @@ The Release workflow independently checks the protected `release` environment in
 5. Run the same workflow again with the same version, the same full SHA, and `publish`. The publish job re-verifies the immutable inputs, creates an annotated `vX.Y.Z` tag on that exact commit, assembles the curated notes plus contributor sections, and publishes the GitHub Release.
 6. Read back the tag target and release body from GitHub. Confirm `package.json`, the tag, the release title, and the changelog all name the same version.
 
-The workflow never commits or pushes to `main`. If publication fails after the tag push, rerun `publish`: it accepts an existing annotated tag only when that tag resolves to the exact workflow SHA, then resumes release creation. If the release was already published, the rerun succeeds without writing only after the tag target, release tag, title, published state, non-prerelease state, immutable state, and body all exactly match the requested publication. A mutable release never becomes a successful retry; any mismatch fails closed.
+The workflow never commits or pushes to `main`. After creating the Release, it retries the read-back six times with bounded exponential backoff while GitHub propagates either the new Release listing or its immutable state. Exact title, body, tag, and SHA mismatches still fail immediately, and the workflow fails closed after the retry deadline.
+
+If publication fails after the tag push, rerun `publish`: it accepts an existing annotated tag only when that tag resolves to the exact workflow SHA, then resumes release creation. If the release was already published, the rerun succeeds without writing only after the tag target, release tag, title, published state, non-prerelease state, immutable state, and body all exactly match the requested publication. A release that remains mutable never becomes a successful retry; any mismatch fails closed.
 
 ## Rollup releases
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -128,6 +128,21 @@ export function publicationPlan({ expectedBody, release, tagState, targetSha, ve
   return tagState.exists ? 'create-release' : 'create-tag-and-release';
 }
 
+export function publicationReadbackStatus(inputs) {
+  const immutablePending = inputs.release !== null && inputs.release.immutable !== true;
+  const release = immutablePending ? { ...inputs.release, immutable: true } : inputs.release;
+  const plan = publicationPlan({ ...inputs, release });
+
+  if (plan === 'already-published') {
+    return immutablePending ? 'pending' : 'already-published';
+  }
+  if (plan === 'create-release') {
+    return 'pending';
+  }
+
+  throw new Error(`post-publication read-back returned unsafe plan ${plan}`);
+}
+
 function repositoryInputs() {
   return {
     changelog: readFileSync('CHANGELOG.md', 'utf8'),
@@ -138,7 +153,9 @@ function repositoryInputs() {
 export function main(argv) {
   const [command, version, ...args] = argv;
   if (!command || !version) {
-    throw new Error('usage: node scripts/release.mjs <verify|extract|assemble|plan> <x.y.z> [command arguments]');
+    throw new Error(
+      'usage: node scripts/release.mjs <verify|extract|assemble|plan|readback> <x.y.z> [command arguments]',
+    );
   }
 
   const inputs = repositoryInputs();
@@ -166,19 +183,20 @@ export function main(argv) {
     );
     return;
   }
-  if (command === 'plan') {
+  if (command === 'plan' || command === 'readback') {
     const [targetSha, tagStatePath, releasePath, expectedBodyPath] = args;
     if (!targetSha || !tagStatePath || !releasePath || !expectedBodyPath) {
-      throw new Error('plan requires target SHA, tag-state JSON, release JSON, and expected release notes paths');
+      throw new Error(`${command} requires target SHA, tag-state JSON, release JSON, and expected release notes paths`);
     }
+    const publicationInputs = {
+      expectedBody: readFileSync(expectedBodyPath, 'utf8'),
+      release: JSON.parse(readFileSync(releasePath, 'utf8')),
+      tagState: JSON.parse(readFileSync(tagStatePath, 'utf8')),
+      targetSha,
+      version,
+    };
     process.stdout.write(
-      `${publicationPlan({
-        expectedBody: readFileSync(expectedBodyPath, 'utf8'),
-        release: JSON.parse(readFileSync(releasePath, 'utf8')),
-        tagState: JSON.parse(readFileSync(tagStatePath, 'utf8')),
-        targetSha,
-        version,
-      })}\n`,
+      `${command === 'plan' ? publicationPlan(publicationInputs) : publicationReadbackStatus(publicationInputs)}\n`,
     );
     return;
   }

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -2,7 +2,13 @@ import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
-import { assembleReleaseBody, changelogSection, publicationPlan, verifyRelease } from './release.mjs';
+import {
+  assembleReleaseBody,
+  changelogSection,
+  publicationPlan,
+  publicationReadbackStatus,
+  verifyRelease,
+} from './release.mjs';
 
 const releaseWorkflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
 const repositoryChangelog = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
@@ -74,6 +80,15 @@ describe('release workflow safeguards', () => {
     expect(releaseWorkflow).toContain('EXPECTED_REVIEWERS=\'["gavrielc","omri-maya"]\'');
     expect(releaseWorkflow).toContain('Release reviewer roster drift');
   });
+
+  it('bounds post-publication API propagation retries and fails closed after the deadline', () => {
+    expect(releaseWorkflow).toContain('READBACK_ATTEMPTS=6');
+    expect(releaseWorkflow).toContain('READBACK_DELAY_SECONDS=2');
+    expect(releaseWorkflow).toContain('node scripts/release.mjs readback');
+    expect(releaseWorkflow).toContain('sleep "$READBACK_DELAY_SECONDS"');
+    expect(releaseWorkflow).toContain('Timed out waiting for GitHub to return the exact immutable release');
+    expect(releaseWorkflow).not.toContain('test "$FINAL_STATE" = "already-published"');
+  });
 });
 
 describe('release body assembly', () => {
@@ -136,6 +151,17 @@ describe('publication recovery', () => {
     });
   }
 
+  function readback(overrides: Record<string, unknown> = {}) {
+    return publicationReadbackStatus({
+      expectedBody,
+      release: matchingRelease,
+      tagState: annotatedTag,
+      targetSha,
+      version: '2.1.54',
+      ...overrides,
+    });
+  }
+
   it('creates both objects when neither exists', () => {
     expect(plan()).toBe('create-tag-and-release');
   });
@@ -146,6 +172,22 @@ describe('publication recovery', () => {
 
   it('treats an exact published release as an idempotent success', () => {
     expect(plan({ release: matchingRelease, tagState: annotatedTag })).toBe('already-published');
+  });
+
+  it('retries only exact release states that are still propagating', () => {
+    expect(readback()).toBe('already-published');
+    expect(readback({ release: null })).toBe('pending');
+    expect(readback({ release: { ...matchingRelease, immutable: false } })).toBe('pending');
+    expect(readback({ release: { ...matchingRelease, immutable: undefined } })).toBe('pending');
+  });
+
+  it.each([
+    ['missing tag and release', { release: null, tagState: { exists: false } }, 'unsafe plan'],
+    ['wrong title', { release: { ...matchingRelease, name: 'Wrong' } }, 'title'],
+    ['changed body', { release: { ...matchingRelease, body: 'Different' } }, 'body'],
+    ['wrong tag target', { tagState: { ...annotatedTag, sha: 'b'.repeat(40) } }, 'not workflow target'],
+  ])('fails post-publication read-back immediately for %s', (_name, overrides, message) => {
+    expect(() => readback(overrides)).toThrow(message);
   });
 
   it.each([


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The v2.1.54 publish run created the exact annotated tag and immutable GitHub Release, then failed its immediate final read-back. A fresh read returned the complete release and passed the same exact-state planner. The workflow log did not preserve which just-created field was still propagating.

This change adds a separate post-publication read-back state. It treats two exact states as pending: the annotated tag exists but the Release is not listed yet, or every Release field matches except that immutability is not visible yet. The workflow retries those states six times with 2, 4, 8, 16, and 32-second waits.

Wrong tag targets, titles, bodies, draft or prerelease state, and other invariant failures still stop immediately. The workflow also fails closed when the bounded retry window expires. `RELEASING.md` and the changelog now describe that behavior.

The failure was observed in [Release run 30713367404](https://github.com/nanocoai/nanoclaw/actions/runs/30713367404).

## Verification

- `pnpm exec vitest run scripts/release.test.ts` (27 tests)
- `pnpm exec vitest run` (1,242 tests)
- `pnpm exec tsc --noEmit`
- Prettier check on all changed files
- Actionlint 1.7.12 on `.github/workflows/release.yml`
- `git diff --check`

Assisted by Claude; reviewed and verified by a human before submission.
