### PR TITLE
fix(update): surface hardened image migration

### DIFF
--- a/.claude/skills/update-nanoclaw/SKILL.md
+++ b/.claude/skills/update-nanoclaw/SKILL.md
@@ -33,7 +33,7 @@ Run `/update-nanoclaw` in Claude Code.
 
 **Validation**: runs `pnpm run build` and `pnpm test`. If container files changed, also runs the container typecheck and `./container/build.sh`.
 
-**Breaking changes check**: after validation, reads CHANGELOG.md for any `[BREAKING]` entries introduced by the update. If found, shows each breaking change and offers to run the recommended skill to migrate.
+**Breaking changes check**: after validation, reads CHANGELOG.md for any `[BREAKING]` entries introduced by the update. If found, shows each breaking change, reads its migration skill or guide, and offers the recommended migration.
 
 ## Rollback
 
@@ -63,17 +63,16 @@ Help a user with a customized NanoClaw install safely incorporate upstream chang
 # Step 0a: Refresh this skill first
 The update process itself evolves, so run its newest version before doing anything else:
 - Ensure the `upstream` remote exists (default `https://github.com/nanocoai/nanoclaw.git`) and fetch: `git fetch upstream --prune`. Detect the upstream branch (`main` or `master`).
-- Refresh this skill from upstream: `git checkout upstream/<branch> -- .claude/skills/update-nanoclaw/`
-- Re-read `.claude/skills/update-nanoclaw/SKILL.md`. If it changed, **follow the updated version from the top** instead of this one.
-
-This is the only working-tree change expected before the preflight check; the full update commits it along with everything else.
+- Read the upstream skill without changing the working tree:
+  `git show upstream/<branch>:.claude/skills/update-nanoclaw/SKILL.md`.
+- If it differs from the local copy, **follow the upstream version from the top**
+  instead of this one. The merge will bring that version into the checkout.
 
 # Step 0: Preflight (stop early if unsafe)
 Run:
 - `git status --porcelain`
 If output is non-empty:
 - Tell the user to commit or stash first, then stop.
-- Exception: changes limited to `.claude/skills/update-nanoclaw/` are the Step 0a self-refresh — ignore those and proceed.
 
 Confirm remotes:
 - `git remote -v`
@@ -237,9 +236,12 @@ After validation succeeds, check if the update introduced any breaking changes.
 Determine which CHANGELOG entries are new by diffing against the backup tag:
 - `git diff <backup-tag-from-step-1>..HEAD -- CHANGELOG.md`
 
-Parse the diff output for lines that contain `[BREAKING]` anywhere in the line. Each such line is one breaking change entry. The format is:
+Parse the diff output for lines that contain `[BREAKING]` anywhere in the line.
+Each such line is one breaking change entry and references either a migration
+skill or a local guide:
 ```
 [BREAKING] <description>. Run `/<skill-name>` to <action>.
+[BREAKING] <description>. Follow [the migration guide](docs/<guide>.md).
 ```
 
 If no `[BREAKING]` lines are found:
@@ -248,15 +250,21 @@ If no `[BREAKING]` lines are found:
 If one or more `[BREAKING]` lines are found:
 - Display a warning header to the user: "This update includes breaking changes that may require action:"
 - For each breaking change, display the full description.
-- Collect all skill names referenced in the breaking change entries (the `/<skill-name>` part).
-- Initialize an unresolved-migrations list with every referenced skill. Remove a
-  skill only after it completes successfully.
-- Use AskUserQuestion to ask the user which migration skills they want to run now. Options:
+- Collect every referenced skill (the `/<skill-name>` part) and local
+  `docs/*.md` migration guide.
+- Read every referenced guide before presenting its migration. Summarize its
+  detect, why, fix, verify, and rollback sections.
+- Initialize an unresolved-migrations list with every referenced skill and
+  guide. Remove an item only after its migration and verification complete
+  successfully.
+- Use AskUserQuestion to ask which migrations the user wants to run now. Options:
   - One recommended option per referenced skill (e.g., "Run /add-whatsapp (Recommended)")
+  - One recommended option per guide, named for its documented fix
   - "Skip — I'll handle these manually"
-- Set `multiSelect: true` so the user can pick multiple skills if there are several breaking changes.
-- For each skill the user selects, invoke it using the Skill tool.
-- Keep every skipped, failed, or incomplete skill in the unresolved list, then
+- Set `multiSelect: true` so the user can pick multiple migrations if there are several.
+- Invoke selected skills with the Skill tool. For a selected guide, follow its
+  fix steps and then its verification steps.
+- Keep every skipped, failed, or incomplete migration in the unresolved list, then
   proceed to Step 7.
 
 # Step 7: Skill updates (part of updating NanoClaw)
@@ -340,18 +348,19 @@ Show:
 - New HEAD: `git rev-parse --short HEAD`
 - Upstream HEAD: `git rev-parse --short upstream/$UPSTREAM_BRANCH`
 - Conflicts resolved (list files, if any)
-- Breaking changes applied (list skills run, if any)
-- Unresolved breaking migrations (list skipped, failed, or incomplete skills)
+- Breaking changes applied (list migrations completed, if any)
+- Unresolved breaking migrations (list skipped, failed, or incomplete migrations)
 - Remaining local diff vs upstream: `git diff --name-only upstream/$UPSTREAM_BRANCH..HEAD`
 
 If unresolved migrations remain, explain plainly that the code update succeeded
 but affected features may ignore old state until those migrations run. Use
 AskUserQuestion before showing restart commands:
 
-- **Run unresolved migrations (Recommended):** invoke each unresolved skill,
-  removing it from the list only after successful completion.
+- **Run unresolved migrations (Recommended):** invoke each unresolved skill or
+  follow each unresolved guide, removing it from the list only after successful
+  completion and verification.
 - **Restart anyway:** continue only with explicit confirmation and repeat the
-  unresolved skill names in the final warning.
+  unresolved migration names in the final warning.
 
 If a retried migration remains unresolved, ask again. Do not show restart
 commands until the unresolved list is empty or the user explicitly chooses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- [BREAKING] **Existing Claude installs should review the hardened agent image.** Local builds remain supported, but the Echo-built image is recommended for patched sandbox components. **Migration:** follow [the hardened-image guide](docs/hardened-image.md) to detect your current image source, switch, verify, or roll back.
 - **Release publication tolerates GitHub API propagation.** The Release workflow now retries bounded post-publication read-backs when the new Release is not listed yet or its immutable state is not visible yet. Exact title, body, tag, or SHA mismatches still fail immediately.
 
 ## [2.1.54] - 2026-08-01

--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -1,4 +1,4 @@
-# Agent image: pull instead of build (opt-in)
+# Hardened agent image (recommended for Claude)
 
 By default `./container/build.sh` builds the agent container on your machine from a public Node
 base — three to ten minutes, no account, no request to any service. **That stays the default and
@@ -8,6 +8,9 @@ Alternatively an install can **fetch a prebuilt, hardened image** instead. It is
 exactly the name the build would have written (`nanoclaw-agent-v2-<slug>:latest`), so nothing
 downstream can tell the two apart: the host spawns the same tag either way, and derived per-group
 builds still work offline.
+
+**For Claude installs, we recommend the hardened image.** Local builds remain supported if you
+prefer an unauthenticated build on your own machine.
 
 That image is built by **[Echo](https://echo.ai)**, who rebuild the sandbox's contents — Chromium,
 Node, Bun, pnpm, git and the rest — from scratch with only the essentials, and patch what remains.
@@ -117,23 +120,53 @@ Either way the architecture that gets tagged is checked against the daemon's
 before anything is retagged, so a single-architecture reference on the wrong
 machine fails loudly instead of landing an image that only runs under emulation.
 
-## Using it
+## Existing installs: switch to the hardened image
+
+### Detect
+
+Check what this install is configured to use and what the local image actually contains:
 
 ```bash
-# refresh to the pinned image
-./container/build.sh pull
-
-# force a local build and leave the pull path
-./container/build.sh build
-
-# what am I actually running?
 pnpm exec tsx setup/index.ts --step registry
+```
 
-# go back to building locally
-pnpm exec tsx setup/index.ts --step registry -- --opt-out
+`Image source: build here` means the install is still using the local-build path.
+
+### Why
+
+Echo rebuilds Chromium, Node, Bun, pnpm, git, and the base packages from scratch with only the
+essentials, then patches what remains. This improves patch currency and provenance for the
+sandbox components; it does not change the agent code mounted from your checkout or replace
+NanoClaw's runtime isolation controls.
+
+### Fix
+
+For a Claude install, sign in and refresh to the pinned image:
+
+```bash
+bash setup/registry-login.sh
+pnpm exec tsx setup/index.ts --step registry -- --refresh
 ```
 
 Nothing re-pulls on its own — `--refresh` is how a new image reaches you.
+
+### Verify
+
+```bash
+pnpm exec tsx setup/index.ts --step registry
+```
+
+The status should report `Image source: pull a pinned image`, `On this machine: hardened`, and
+`PIN_MATCH: true`.
+
+### Rollback
+
+Return to the fully supported local-build path:
+
+```bash
+pnpm exec tsx setup/index.ts --step registry -- --opt-out
+./container/build.sh build
+```
 
 `--status` reports what you asked for **and** what the local tag actually holds. Those can
 disagree, for instance if a pull failed and a local build filled in. The image carries its own
@@ -182,7 +215,7 @@ account-takeover bugs happen — and there is no way to merge them today. Pick o
 | Symptom | Cause |
 |---|---|
 | `./container/build.sh` exits 3 | Pinned install. `pull` to refresh, `build` to force local. |
-| Setup never offers the pull option | No `agent-image` pin in `versions.json` — nothing to fetch. |
+| Setup never offers the pull option | The option needs a Claude install and an `agent-image` pin in `versions.json`. Existing installs can follow [the migration above](#existing-installs-switch-to-the-hardened-image). |
 | Pull fails: lockfile mismatch | The image was built against a different `container/agent-runner/bun.lock`. Refresh the pin or build locally. |
 | Pull fails: architecture mismatch | The reference names one architecture and it isn't this daemon's. Use a multi-arch index, or the reference for this architecture. |
 | "No agent-image reference for linux/…" | The pin is per-platform and has no entry for this machine. Build locally, or set `NANOCLAW_AGENT_IMAGE_REF`. |


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [x] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Existing local-build installs could miss the hardened image option after initial setup.

Add a `[BREAKING]` changelog entry and a complete migration section in the hardened-image guide. `/update-nanoclaw` now reads linked migration guides and offers their documented fix.

## Testing

- `pnpm run build`
- host and container typechecks
- update skill lint
- `pnpm test` (1,245 passed)
- container tests (154 passed, 1 skipped)
- end-to-end update from the pre-change commit, including self-refresh, conflict preview, merge, guide recommendation, and unresolved-migration gate

## For Skills

- [x] SKILL.md contains instructions, not inline code
- [x] SKILL.md is under 500 lines