### PR TITLE
fix(imessage): opt in via first message to the assigned line

### DIFF
--- a/.claude/skills/add-imessage/SKILL.md
+++ b/.claude/skills/add-imessage/SKILL.md
@@ -163,14 +163,14 @@ Tell the user what's about to happen:
 Connect your hosted iMessage line (photon.codes):
 1. A login URL and a short code will print below.
 2. Open the URL in a browser, approve the device, and enter the code.
-3. Setup then asks for one dashboard step: add your number as a user in the Photon dashboard and accept the invite that arrives on your phone. Numbers only receive messages after that invite.
-4. Once the opt-in lands, setup finishes on its own and prints your agent's iMessage number.
+3. Setup then registers your number and prints the iMessage line Photon assigned to it. Send one message from your phone to that line — a number only enters routing after it has texted its line once.
+4. Once the opt-in lands, setup finishes on its own and confirms your agent's iMessage number.
 ```
 
 Run the device-login flow. It provisions the project, reuses its current secret
-(regenerating only when the API returns none), walks you through the dashboard
-Add-user + invite step (waiting until your number is opted in), and surfaces
-the iMessage number you'll text — writing
+(regenerating only when the API returns none), registers your number, prints
+the line to text and waits until that message opts the number in, and surfaces
+the iMessage number you'll use — writing
 `PHOTON_PROJECT_ID` + `PHOTON_PROJECT_SECRET` to `.env` and the assigned number
 to `data/photon-auth.json`:
 

--- a/.claude/skills/add-imessage/docs.md
+++ b/.claude/skills/add-imessage/docs.md
@@ -109,8 +109,8 @@ The underlying commands are:
 # 1. install the runtime SDK (pinned — spectrum-ts ships breaking majors)
 pnpm install spectrum-ts@11.0.0
 
-# 2. run the setup wizard (device login + guided provisioning; one manual
-#    dashboard opt-in step — the wizard waits for it)
+# 2. run the setup wizard (device login + guided provisioning; one manual step
+#    — you text the assigned line once, and the wizard waits for it)
 pnpm exec tsx scripts/photon-setup.ts --phone +15551234567
 ```
 
@@ -124,21 +124,23 @@ pnpm exec tsx scripts/photon-setup.ts --phone +15551234567
 3. **Reuse the project's current secret** (regenerating only when the API
    returns none) and write `PHOTON_PROJECT_ID` + `PHOTON_PROJECT_SECRET` to
    `.env`.
-4. **Wait for your phone's dashboard opt-in.** Numbers only enter iMessage
-   routing after the dashboard's Add-user invite is accepted (the user row then
-   carries `meta.opt_in`; the API cannot set it, so the wizard never creates
-   users through the API). The wizard prints the dashboard steps and polls
-   until the opt-in lands — instant if the row is already opted in.
+4. **Register your phone and wait for its opt-in.** The wizard finds your
+   Spectrum user row or creates one (`type: shared`), and prints the
+   `assignedPhoneNumber` the row came back with. A new row never routes: the
+   number only enters iMessage routing once it has sent one message to that
+   assigned line, which is what flips the row's `meta.opt_in` server-side. The
+   wizard polls the user list until it does — instant if the row is already
+   opted in, and it never reports success before then.
 5. **Surface the assigned iMessage line** — the number you text to reach your
-   agent.
+   agent (the same one you texted to opt in).
 
-Everything is idempotent: re-running reuses the stored token/project and only
-fills gaps, so it's safe to finish a partial setup. `pnpm exec tsx
-scripts/photon-setup.ts status` shows what's configured.
+Everything is idempotent: re-running reuses the stored token/project and the
+existing user row, so it's safe to finish a partial setup. `pnpm exec tsx
+scripts/photon-setup.ts status` shows what's configured, re-checking the opt-in
+live.
 
-After setup, restart the service so the adapter connects, then text the
-surfaced number once and wire the DM to an agent with `/init-first-agent`
-(the wizard prints a ready-to-run command).
+After setup, restart the service so the adapter connects, then wire the DM to
+an agent with `/init-first-agent` (the wizard prints a ready-to-run command).
 
 ### Configuration (hosted)
 
@@ -151,7 +153,7 @@ All optional, set in `.env`:
 | `PHOTON_MARKDOWN`                    | `true`                          | Send agent replies as markdown (iMessage renders it natively). `false` sends plain text. |
 | `PHOTON_TELEMETRY`                   | `false`                         | Enable Spectrum SDK telemetry                                                            |
 | `PHOTON_MAX_INLINE_ATTACHMENT_BYTES` | `20971520` (20 MB)              | Max inbound attachment size the adapter reads + caches                                   |
-| `PHOTON_DASHBOARD_HOST`              | `https://app.photon.codes`      | Dashboard API host (setup wizard)                                                        |
+| `PHOTON_DASHBOARD_HOST`              | `https://app.photon.codes`      | Management API host — device login and project provisioning (setup wizard)               |
 | `PHOTON_SPECTRUM_HOST`               | `https://spectrum.photon.codes` | Spectrum API host (setup wizard)                                                         |
 
 ## Platform ids
@@ -211,9 +213,9 @@ deliberate:
 | Symptom                                 | Fix                                                                                                                   |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `spectrum-ts is not installed` at setup | Hosted backend: `pnpm install spectrum-ts@11.0.0`, then restart                                                        |
-| `Target not allowed for this project`   | The number's user row is missing its dashboard opt-in (`meta.opt_in`) — finish the Add-user + invite step, then text the line once (it only messages numbers that have texted it first) |
+| `Target not allowed for this project`   | The number's user row is not opted in yet (`meta.opt_in` absent) — send one message from that phone to the line assigned to the row, then re-run setup (the line only messages numbers that have texted it first) |
 | Device login times out                  | Re-run the wizard (the code expires in ~30 min; a stored token is reused)                                             |
-| No iMessage line assigned               | Re-run `… photon-setup.ts status` or check the [dashboard][photon]; the shared line can take a moment                 |
+| No iMessage line assigned               | The line comes back on your user row — re-run the wizard with `--phone` so the row is created, then `… photon-setup.ts status` |
 | Inbound stops arriving (hosted)         | The adapter re-subscribes automatically; if it persists it's usually upstream — restart to force a fresh stream       |
 | Local: no inbound                       | Confirm Full Disk Access is granted to the Node binary NanoClaw runs under, and that it runs on the signed-in Mac     |
 | Bot silent (hosted)                     | Check `grep "Photon channel connected" logs/nanoclaw.log`, that the channel is wired, and that the service is running |

--- a/scripts/photon-setup.test.ts
+++ b/scripts/photon-setup.test.ts
@@ -13,7 +13,9 @@ import path from 'path';
 
 import {
   basicAuth,
+  createUser,
   deviceTokenCandidates,
+  ensureUser,
   findProjectByName,
   findRoutableUser,
   findUserByPhone,
@@ -21,6 +23,7 @@ import {
   isE164,
   main,
   normalizePhone,
+  optInInstructions,
   parseArgs,
   projectSecretOf,
   unwrapList,
@@ -169,6 +172,86 @@ describe('userOptedIn / waitForOptedInUser', () => {
       }),
     ).rejects.toThrow(/not opted in after 3s.*re-run setup/);
   });
+
+  it('names the assigned line in the timeout message when it is known', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ users: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as typeof fetch;
+    await expect(
+      waitForOptedInUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567', {
+        sleepFn: async () => {},
+        intervalS: 1,
+        timeoutS: 3,
+        assignedLine: '+15558887777',
+      }),
+    ).rejects.toThrow(/from \+15551234567 to \+15558887777/);
+  });
+});
+
+describe('optInInstructions', () => {
+  it('tells the operator to text the exact assigned line from their own number', () => {
+    const text = optInInstructions('+15551234567', '+15558887777').join('\n');
+    expect(text).toContain('Text +15558887777');
+    expect(text).toContain('+15551234567');
+  });
+  it('degrades gracefully when no line has been assigned yet', () => {
+    const text = optInInstructions('+15551234567', null).join('\n');
+    expect(text).toContain('has not assigned');
+    expect(text).toContain('+15551234567');
+  });
+});
+
+describe('createUser / ensureUser', () => {
+  it('posts a shared user without client-supplied meta', async () => {
+    let body: Record<string, unknown> = {};
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({ user: { id: 'u-new', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+    const user = await createUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567');
+    expect(body).toEqual({ type: 'shared', phoneNumber: '+15551234567' });
+    expect('meta' in body).toBe(false);
+    expect(userAssignedLine(user)).toBe('+15558887777');
+    expect(userOptedIn(user)).toBe(false);
+  });
+
+  it('treats an HTTP 200 error body as a create failure', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ error: 'User limit reached for this project' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch;
+    await expect(createUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567')).rejects.toThrow(
+      /User limit reached/,
+    );
+  });
+
+  it('rejects a non-E.164 number before calling the API', async () => {
+    let called = false;
+    const fetchFn = (async () => {
+      called = true;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    await expect(createUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '5551234567')).rejects.toThrow(/E\.164/);
+    expect(called).toBe(false);
+  });
+
+  it('reuses an existing row instead of creating a second one', async () => {
+    let posts = 0;
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      if ((init?.method || 'GET').toUpperCase() === 'POST') posts += 1;
+      return new Response(
+        JSON.stringify({ users: [{ id: 'u-existing', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+    const { user, created } = await ensureUser(fetchFn, 'https://s.example.com', 'proj', 'secret', '+15551234567');
+    expect(created).toBe(false);
+    expect(user.id).toBe('u-existing');
+    expect(posts).toBe(0);
+  });
 });
 
 describe('getImessageLine', () => {
@@ -228,17 +311,22 @@ describe('parseArgs', () => {
 interface Call {
   method: string;
   pathname: string;
+  body?: string;
 }
+
+const POOL_LINE = '+15558887777';
 
 /**
  * Build a fetch that emulates the Photon dashboard + spectrum endpoints.
  *
- * User-list behavior mirrors the live service: rows only route once they carry
- * `meta.opt_in` (set by the dashboard invite flow, never by the API).
+ * User-list behavior mirrors the live service: a POST creates the row with an
+ * assigned line and an empty `meta`, and the row only routes once `meta.opt_in`
+ * flips — which happens out of band, when the human texts the assigned line.
  * - `existingUser`: the row exists and is opted in from the first poll.
  * - `optInAfterListPolls: n`: the first n GET /users/ polls see no opted-in
- *   row; from poll n+1 the row exists with `meta.opt_in`. With `pendingUser`
- *   the pre-flip polls return the row WITHOUT opt_in instead of an empty list.
+ *   row; from poll n+1 whatever rows exist carry `meta.opt_in`. With
+ *   `pendingUser` a row is present from the start, standing in for one an
+ *   earlier run created.
  */
 function makeMockFetch(
   opts: { existingProject?: boolean; existingUser?: boolean; optInAfterListPolls?: number; pendingUser?: boolean } = {},
@@ -248,6 +336,7 @@ function makeMockFetch(
 } {
   const calls: Call[] = [];
   let userListPolls = 0;
+  const createdUsers: Array<Record<string, unknown>> = [];
   const json = (body: unknown, status = 200): Response =>
     new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 
@@ -255,7 +344,7 @@ function makeMockFetch(
     const url = new URL(typeof input === 'string' ? input : input.toString());
     const method = (init?.method || 'GET').toUpperCase();
     const pathname = url.pathname;
-    calls.push({ method, pathname });
+    calls.push({ method, pathname, body: init?.body ? String(init.body) : undefined });
 
     // Device login
     if (pathname === '/api/auth/device/code' && method === 'POST') {
@@ -302,25 +391,31 @@ function makeMockFetch(
       const optedInRow = {
         id: 'u-existing',
         phoneNumber: '+15551234567',
-        assignedPhoneNumber: '+15558887777',
+        assignedPhoneNumber: POOL_LINE,
         meta: { opt_in: true },
       };
       if (opts.existingUser) return json({ users: [optedInRow] });
-      if (opts.optInAfterListPolls !== undefined) {
-        if (userListPolls > opts.optInAfterListPolls) return json({ users: [optedInRow] });
-        return json({
-          users: opts.pendingUser
-            ? [{ id: 'u-pending', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} }]
-            : [],
-        });
-      }
-      return json({ users: [] });
+      const pending = opts.pendingUser
+        ? [{ id: 'u-pending', phoneNumber: '+15551234567', assignedPhoneNumber: POOL_LINE, meta: {} }]
+        : [];
+      const rows = [...pending, ...createdUsers];
+      const flipped = opts.optInAfterListPolls !== undefined && userListPolls > opts.optInAfterListPolls;
+      if (!flipped) return json({ users: rows });
+      // The opt-in flips server-side, standing in for the human's first message.
+      return json({ users: rows.length ? rows.map((r) => ({ ...r, meta: { opt_in: true } })) : [optedInRow] });
     }
     if (/^\/projects\/[^/]+\/users\/$/.test(pathname) && method === 'POST') {
-      // The API accepts creates but strips client-supplied meta, so an
-      // API-created row can never become opted in. The wizard must not call
-      // this at all.
-      return json({ user: { id: 'u-created', phoneNumber: '+15551234567', assignedPhoneNumber: '+15558887777', meta: {} } });
+      // Creates always come back un-opted-in: client-supplied meta is ignored,
+      // and only the human's message to the assigned line sets the flag.
+      const payload = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      const row = {
+        id: `u-created-${createdUsers.length + 1}`,
+        phoneNumber: String(payload.phoneNumber ?? ''),
+        assignedPhoneNumber: POOL_LINE,
+        meta: {},
+      };
+      createdUsers.push(row);
+      return json({ user: row });
     }
     return json({ error: `unmocked ${method} ${pathname}` }, 404);
   }) as typeof fetch;
@@ -347,9 +442,9 @@ describe('photon setup flow (mocked API)', () => {
 
   const noSleep = { sleepFn: async () => {} };
 
-  it('provisions a brand-new project, waits for the dashboard opt-in, and writes creds to .env', async () => {
-    // The user row appears opted in on the third list poll, as if the operator
-    // did the dashboard Add-user + invite dance while the wizard waited.
+  it('provisions a brand-new project, creates the user, waits for the opt-in, and writes creds to .env', async () => {
+    // The row flips to opted in on the third list poll, as if the operator
+    // texted the assigned line while the wizard waited.
     const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 2 });
     const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
     expect(code).toBe(0);
@@ -368,10 +463,12 @@ describe('photon setup flow (mocked API)', () => {
     expect(calls.some((c) => c.pathname === '/api/auth/device/code')).toBe(true);
     // The project was created (not found).
     expect(calls.some((c) => c.method === 'POST' && c.pathname === '/api/projects')).toBe(true);
-    // The user list was polled until the opt-in landed (poll 3).
+    // Lookup poll, then the wait polls until the opt-in landed (poll 3).
     expect(calls.filter((c) => c.method === 'GET' && /\/users\/$/.test(c.pathname)).length).toBe(3);
-    // Users are NEVER created through the API — those rows can't be opted in.
-    expect(calls.some((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname))).toBe(false);
+    // The absent row was created exactly once, with no client-supplied meta.
+    const creates = calls.filter((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname));
+    expect(creates.length).toBe(1);
+    expect(JSON.parse(creates[0].body ?? '{}')).toEqual({ type: 'shared', phoneNumber: '+15551234567' });
     // The create response carried no projectSecret → minted via regenerate.
     expect(calls.some((c) => /regenerate-secret$/.test(c.pathname))).toBe(true);
     // Status only turns green after setup records the successful opt-in —
@@ -384,14 +481,47 @@ describe('photon setup flow (mocked API)', () => {
     const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
     expect(code).toBe(0);
     expect(calls.filter((c) => c.method === 'GET' && /\/users\/$/.test(c.pathname)).length).toBe(3);
+    // An existing row is reused, never duplicated by a second create.
     expect(calls.some((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname))).toBe(false);
+  });
+
+  it('prints the assigned line and tells the operator to text it', async () => {
+    const { fetchFn } = makeMockFetch({ optInAfterListPolls: 2 });
+    const written: string[] = [];
+    const realWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    } finally {
+      process.stdout.write = realWrite;
+    }
+    // The instruction names the exact line the row was assigned.
+    expect(written.join('')).toContain('Text +15558887777');
+  });
+
+  it('does not create a second row when a completed setup is re-run', async () => {
+    const { fetchFn, calls } = makeMockFetch({ optInAfterListPolls: 1 });
+    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    expect(calls.filter((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname)).length).toBe(1);
+  });
+
+  it('short-circuits an already-opted-in row without waiting', async () => {
+    const { fetchFn, calls } = makeMockFetch({ existingUser: true });
+    expect(await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep)).toBe(0);
+    // One lookup, no poll loop.
+    expect(calls.filter((c) => c.method === 'GET' && /\/users\/$/.test(c.pathname)).length).toBe(1);
   });
 
   it('fails (exit 1) when the opt-in never lands, and never claims success', async () => {
     const { fetchFn, calls } = makeMockFetch();
     const code = await main(['setup', '--phone', '+15551234567', '--no-browser', '--non-interactive'], fetchFn, noSleep);
     expect(code).toBe(1);
-    expect(calls.some((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname))).toBe(false);
+    // The row is created once; a never-opted-in row is still not success.
+    expect(calls.filter((c) => c.method === 'POST' && /\/users\/$/.test(c.pathname)).length).toBe(1);
     // Creds persist so a re-run resumes where it left off.
     const env = fs.readFileSync(path.join(tempDir, '.env'), 'utf-8');
     expect(env).toContain('PHOTON_PROJECT_ID=proj-created');

--- a/scripts/photon-setup.ts
+++ b/scripts/photon-setup.ts
@@ -4,19 +4,21 @@
  *
  * Runs Photon's OAuth device-login flow, then provisions everything the
  * `photon` channel needs. One step stays manual by necessity: the delivery
- * plane only routes numbers whose user row carries `meta.opt_in`, which is set
- * by the dashboard's Add-user invite flow and cannot be triggered through the
- * API (client-supplied meta is ignored on create). The wizard guides that step
- * and polls until the opt-in lands, so it never reports success for a number
- * that cannot receive messages.
+ * plane only routes numbers whose user row carries `meta.opt_in`, and that flag
+ * is set when the human sends one message from their phone to the line Photon
+ * assigned to that user row. A freshly created row always starts without it.
+ * The wizard prints the assigned line, waits for that message, and polls until
+ * the opt-in lands, so it never reports success for a number that cannot
+ * receive messages.
  *
  *   [1/5] Device login   — open a URL, approve, we store the bearer token
  *   [2/5] Project        — find or create the "NanoClaw" Photon project
  *   [3/5] Secret         — reuse the project's current secret (rotating only
  *                          when the API doesn't return one) and write
  *                          PHOTON_PROJECT_ID + PHOTON_PROJECT_SECRET to .env
- *   [4/5] User           — guide the dashboard Add-user + invite step, then
- *                          wait until your phone's user row is opted in
+ *   [4/5] User           — find or create your Spectrum user row, print the
+ *                          line it was assigned, and wait until your first
+ *                          message to that line flips the row to opted in
  *   [5/5] iMessage line  — surface the number you text to reach your agent
  *
  * Everything is idempotent — re-running reuses the stored token/project and
@@ -357,10 +359,56 @@ export function findUserByPhone(users: Array<Record<string, unknown>>, phone: st
 }
 
 /**
+ * Create a Spectrum user row for `phone`. The row comes back carrying the
+ * `assignedPhoneNumber` the human must text, and an empty `meta` — the opt-in
+ * flag is server-owned, so client-supplied meta is never sent.
+ */
+export async function createUser(
+  fetchFn: FetchFn,
+  spectrumHost: string,
+  projectId: string,
+  projectSecret: string,
+  phone: string,
+  firstName?: string,
+): Promise<Record<string, unknown>> {
+  if (!isE164(phone)) throw new Error(`phone must be E.164 (e.g. +15551234567); got ${phone}`);
+  const body: Record<string, unknown> = { type: 'shared', phoneNumber: phone };
+  if (firstName) body.firstName = firstName;
+  const resp = await fetchFn(`${spectrumHost}/projects/${projectId}/users/`, {
+    method: 'POST',
+    headers: { Authorization: basicAuth(projectId, projectSecret), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(`Photon create-user failed: ${await errorDetail(resp)}`);
+  const data = await readJson(resp);
+  // The service reports failures as HTTP 200 with an {"error": …} body.
+  if (data.error) throw new Error(`Photon create-user failed: ${data.error}`);
+  return (data.user as Record<string, unknown>) || (data.data as Record<string, unknown>) || data;
+}
+
+/**
+ * The routing row for `phone`, created if it does not exist yet. A re-run must
+ * reuse the row it already made — a second create would hand out a fresh row
+ * and drop an opt-in that already landed.
+ */
+export async function ensureUser(
+  fetchFn: FetchFn,
+  spectrumHost: string,
+  projectId: string,
+  projectSecret: string,
+  phone: string,
+  firstName?: string,
+): Promise<{ user: Record<string, unknown>; created: boolean }> {
+  const existing = findRoutableUser(await listUsers(fetchFn, spectrumHost, projectId, projectSecret), phone);
+  if (existing) return { user: existing, created: false };
+  return { user: await createUser(fetchFn, spectrumHost, projectId, projectSecret, phone, firstName), created: true };
+}
+
+/**
  * True when the delivery plane will route messages for this user: the row
- * carries `meta.opt_in`, which only the dashboard's Add-user invite flow sets.
- * A row without it (however it was created) looks registered everywhere but
- * never sends or receives.
+ * carries `meta.opt_in`, which the service sets once the human has sent a
+ * message from `phoneNumber` to the row's `assignedPhoneNumber`. A row without
+ * it looks registered everywhere but never sends or receives.
  */
 export function userOptedIn(user: Record<string, unknown> | undefined): boolean {
   const meta = user?.meta;
@@ -368,9 +416,9 @@ export function userOptedIn(user: Record<string, unknown> | undefined): boolean 
 }
 
 /**
- * The row that decides routing for `phone`. When duplicates exist (a stale
- * API-created row can sit next to the dashboard-invited one for the same
- * number), an opted-in row wins over whichever happens to list first.
+ * The row that decides routing for `phone`. When duplicates exist for the same
+ * number, an opted-in row wins over whichever happens to list first — opt-in is
+ * scoped to one user-number/assigned-line pair, so only that row routes.
  */
 export function findRoutableUser(users: Array<Record<string, unknown>>, phone: string): Record<string, unknown> | undefined {
   const target = normalizePhone(phone);
@@ -384,14 +432,41 @@ export interface OptInWaitOpts {
   timeoutS?: number;
   /** Progress hook, called once per poll that did not find an opted-in row (1-based). */
   onWaiting?: (attempt: number) => void;
+  /** The line the human has to text, named in the timeout message when known. */
+  assignedLine?: string | null;
+}
+
+/**
+ * The manual step, as printed to the operator: the opt-in is performed by one
+ * message from `phone` to `assignedLine`, and nothing else can stand in for it.
+ */
+export function optInInstructions(phone: string, assignedLine: string | null): string[] {
+  if (!assignedLine) {
+    return [
+      'Photon has not assigned an iMessage line to your number yet.',
+      '',
+      `Once it does, send one message from ${phone} to that line to opt in.`,
+      '',
+      'Setup waits here and continues once the opt-in lands.',
+    ];
+  }
+  return [
+    'Your number only enters iMessage routing after it has messaged',
+    'the line Photon assigned to it, so this one step is manual:',
+    '',
+    `  1. Open Messages on ${phone}.`,
+    `  2. Text ${assignedLine} — one message of any content is enough.`,
+    '',
+    'Setup waits here and continues once the opt-in lands.',
+  ];
 }
 
 /**
  * Poll until `phone`'s user row exists AND is opted in, then return the row.
- * Creating the row through the API cannot produce the opt-in (client-supplied
- * meta is ignored), so the wizard doesn't create users at all — it waits for
- * the dashboard step to land. Throws after `timeoutS` (attempt-count based, so
- * tests with an instant sleepFn stay deterministic).
+ * A row starts un-opted-in whatever created it; the flag lands only after the
+ * human sends a message from `phone` to the row's assigned line. Throws after
+ * `timeoutS` (attempt-count based, so tests with an instant sleepFn stay
+ * deterministic).
  */
 export async function waitForOptedInUser(
   fetchFn: FetchFn,
@@ -413,16 +488,17 @@ export async function waitForOptedInUser(
       if (userOptedIn(user)) return user as Record<string, unknown>;
     } catch (err) {
       // A transient list failure must not abort a wait whose whole point is to
-      // ride out the operator's manual dashboard step — count it as a missed
-      // poll and keep going, like the device-token poll does.
+      // ride out the operator's manual step — count it as a missed poll and
+      // keep going, like the device-token poll does.
       lastError = err;
     }
     opts.onWaiting?.(attempt);
     if (attempt < maxAttempts) await sleepFn(intervalS * 1000);
   }
   const lastErrorNote = lastError ? ` Last API error: ${lastError instanceof Error ? lastError.message : String(lastError)}.` : '';
+  const target = opts.assignedLine ? `to ${opts.assignedLine}` : 'to the line Photon assigned to it';
   throw new Error(
-    `${phone} was not opted in after ${timeoutS}s.${lastErrorNote} Finish the dashboard step (Add user, then accept the invite on that phone) and re-run setup — it resumes where it left off.`,
+    `${phone} was not opted in after ${timeoutS}s.${lastErrorNote} Send one message from ${phone} ${target}, then re-run setup — it resumes where it left off.`,
   );
 }
 
@@ -641,27 +717,30 @@ async function runStatus(args: Args, fetchFn: FetchFn = fetch): Promise<number> 
   const projectId = envValue('PHOTON_PROJECT_ID') || auth.project_id;
   const secret = envValue('PHOTON_PROJECT_SECRET');
   const credentialsReady = Boolean(projectId && secret);
-  // setup writes phone_number only after the dashboard-backed user row carries
-  // meta.opt_in — but state written by older setups can hold a phone_number
-  // whose row was never opted in (and so never routed). When credentials allow
-  // it, ask the API instead of trusting the local marker.
+  // setup writes phone_number only after the user row carries meta.opt_in — but
+  // state written by older setups can hold a phone_number whose row was never
+  // opted in (and so never routed). When credentials allow it, ask the API
+  // instead of trusting the local marker.
   let routing: 'ready' | 'not-opted-in' | 'unverified' | 'unconfigured' = 'unconfigured';
   let routingError = '';
+  let liveAssigned: string | null = null;
   if (credentialsReady && auth.phone_number) {
     try {
       const user = findRoutableUser(
         await listUsers(fetchFn, args.spectrumHost, String(projectId), String(secret)),
         auth.phone_number,
       );
+      liveAssigned = userAssignedLine(user);
       routing = userOptedIn(user) ? 'ready' : 'not-opted-in';
     } catch (err) {
       routing = 'unverified';
       routingError = err instanceof Error ? err.message : String(err);
     }
   }
+  const optInTarget = liveAssigned || auth.assigned_phone_number;
   const routingLine = {
     ready: '✓ opted in (verified live)',
-    'not-opted-in': '✗ not opted in — finish the dashboard Add-user + invite step',
+    'not-opted-in': `✗ not opted in — text ${optInTarget || 'your assigned line'} once from ${auth.phone_number}`,
     unverified: `? could not verify (${routingError})`,
     unconfigured: '✗ not configured',
   }[routing];
@@ -682,7 +761,9 @@ async function runStatus(args: Args, fetchFn: FetchFn = fetch): Promise<number> 
     return 0;
   }
   if (routing === 'not-opted-in') {
-    p.outro('Your number is registered but not opted in. Re-run setup and finish the dashboard invite.');
+    p.outro(
+      `Your number is registered but not opted in. Text ${optInTarget || 'the assigned line'} once from ${auth.phone_number}, then re-run setup.`,
+    );
     return 1;
   }
   if (routing === 'unverified') {
@@ -690,9 +771,7 @@ async function runStatus(args: Args, fetchFn: FetchFn = fetch): Promise<number> 
     return 1;
   }
   if (credentialsReady) {
-    p.outro(
-      'Photon credentials are saved, but phone routing is not ready. Re-run setup with --phone and finish the dashboard invite.',
-    );
+    p.outro('Photon credentials are saved, but phone routing is not ready. Re-run setup with --phone to register and opt in your number.');
     return 1;
   }
   p.outro('Run setup to finish onboarding.');
@@ -799,39 +878,35 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
     p.cancel(`Invalid phone number: ${phone}`);
     return 1;
   } else {
-    p.log.step('[4/5] Registering your phone (dashboard opt-in)');
+    p.log.step('[4/5] Registering your phone');
     try {
-      const user = await waitForOptedInUser(fetchFn, args.spectrumHost, projectId, secret, phone, {
-        sleepFn: deps.sleepFn,
-        onWaiting: (attempt) => {
-          if (attempt === 1) {
-            p.note(
-              [
-                'Numbers only receive messages after the dashboard invite flow,',
-                'so this one step is manual:',
-                '',
-                `  1. Open ${args.dashboardHost} and select the "${args.projectName}" project.`,
-                `  2. Add ${phone} as a user (Add user).`,
-                '  3. Accept the invite that arrives on that phone.',
-                '',
-                'Setup waits here and continues once the opt-in lands.',
-              ].join('\n'),
-              'One dashboard step needed',
-            );
-          } else if (attempt % 6 === 0) {
-            p.log.message(`Still waiting for the dashboard opt-in for ${phone}…`);
-          }
-        },
-      });
-      p.log.info('Phone registered and opted in');
-      assigned = userAssignedLine(user);
+      const { user, created } = await ensureUser(fetchFn, args.spectrumHost, projectId, secret, phone);
+      const line = userAssignedLine(user);
+      p.log.info(created ? `Created your Photon user (assigned line ${line ?? 'pending'})` : 'Found your existing Photon user');
+      if (userOptedIn(user)) {
+        p.log.info('Phone already opted in');
+        assigned = line;
+      } else {
+        p.note(optInInstructions(phone, line).join('\n'), 'One step needed on your phone');
+        const opted = await waitForOptedInUser(fetchFn, args.spectrumHost, projectId, secret, phone, {
+          sleepFn: deps.sleepFn,
+          assignedLine: line,
+          onWaiting: (attempt) => {
+            if (attempt % 6 === 0) p.log.message(`Still waiting for the opt-in for ${phone}…`);
+          },
+        });
+        p.log.info('Phone registered and opted in');
+        assigned = userAssignedLine(opted) ?? line;
+      }
     } catch (err) {
       p.cancel(`User registration failed: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
   }
 
-  // [5/5] Surface the number the operator texts to reach the agent.
+  // [5/5] Surface the number the operator texts to reach the agent. With a
+  // phone this is the user row's assigned line (already learned in [4/5]); the
+  // project-line lookup only covers the no-phone run, which has no row to read.
   p.log.step("[5/5] Your agent's iMessage number");
   if (!assigned) {
     try {
@@ -850,9 +925,9 @@ async function runSetup(args: Args, fetchFn: FetchFn = fetch, deps: SetupDeps = 
   });
 
   if (assigned) {
-    p.note(`📱  ${assigned}\n\nText this number from your phone to talk to your agent.`, "Agent's iMessage number");
+    p.note(`📱  ${assigned}\n\nThis is the number you text to talk to your agent.`, "Agent's iMessage number");
   } else {
-    p.log.warn('No iMessage line assigned yet — check the Photon dashboard (https://app.photon.codes).');
+    p.log.warn('No iMessage line assigned yet — re-run setup with --phone to register your number and get one.');
   }
 
   if (!args.embedded) {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

The setup wizard from #3164 waits on a dashboard Add-user plus invite step to get `meta.opt_in` onto the user row. Photon confirmed the dashboard is not a stable integration surface: opt-in is performed by the user's first message to the line assigned to their user row.

Step [4/5] now creates the user through the project-secret API, prints the `assignedPhoneNumber`, asks the operator to text that line once, and polls until `meta.opt_in` is true. Success is still gated on the opt-in. A re-run reuses the existing row, and an opted-in row short-circuits to success.

Verified against the live Photon service (base `dfac7e0a`): a fresh setup completes after one message to the assigned line and the agent answers it; before that message, outbound fails with `Target not allowed for this project`; a re-run creates no duplicate row. Wizard tests 41 green, full suite 1255 green.

v2.1.54 shipped the dashboard flow, so this wants a v2.1.55 cut.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone

Assisted by Claude; reviewed and verified by a human before submission.
