### PR TITLE
versions: repin the agent image to hardened-2026-08-02

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "onecli-gateway": "1.36.0",
   "onecli-cli": "2.2.5",
-  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:4e441375454fe3d90b4392069c84ac4478a21e9fb7cad5a183628bebe2e773e3"
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:af60e54fc0c8139157244c2b2f23d3d365fd2446210f816ce013e5282d64fd60"
 }


### PR DESCRIPTION
Repins the agent image to `hardened-2026-08-02`.

```
old  sha256:4e441375…   611 MB   built 2026-07-30
new  sha256:af60e54f…   621 MB   built 2026-08-02
```

### Same agent, refreshed base

Both builds carry an identical `ai.echo.image.upstream.digest` of `sha256:dce9da56…`, so the NanoClaw content going in is byte-for-byte what the current pin was built from. What moved is underneath it — this is a base refresh, not a new agent build, which is what keeps the risk of this bump low.

The +1.6% is consistent with that reading, and the layer structure the previous repin was chosen for is intact:

| | largest layer | top three | layers |
|---|---|---|---|
| old | 26% | 67% | 8 |
| new | 27% | 67% | 8 |

So pull time should be unchanged. A pull is gated by its largest single layer — one layer downloads on one connection — and the 27/22/18/14/13 spread is what lets docker's concurrent fetch actually overlap. Nothing here regresses that.

### Verified before pinning

| | |
|---|---|
| Multi-arch OCI index | `linux/amd64` + `linux/arm64` |
| `dev.nanoclaw.image-source` | `hardened`, both children |
| `dev.nanoclaw.agent-runner-lock-sha256` | `5f49954570dd…` — exact match with this checkout |
| User / entrypoint | `node` / `tini -- /app/entrypoint.sh` |

The lock label is the one that bites silently when it's wrong: without a match, `pull.sh` refuses rather than pairing baked `/app/node_modules` against a different `bun.lock`, which would surface as a missing module inside a `--rm` container whose logs are discarded.

Both architectures were built 15 seconds apart, so they come from a single build run. The current pin's two children were built three minutes apart.

### Promotion

Published to `nanoclaw/agent` via `crane copy`, which preserves the manifest bytes — the index digest is identical to the one Echo published. Registry replication to `eu-central-1` picked it up within 30 seconds, tag included.

The source was `echo/nanoclaw-agent`, which is an ECR **pull-through cache** of Echo's own registry rather than a repo anyone pushes to by hand. Reading a tag through it fetches from upstream on demand, so it doubles as the way to check for a new build without needing `reg.echohq.com` credentials.

### Not signature-verified, deliberately

Cosign keeps signatures as sibling tags in the same repository, and they don't travel with a push, so `nanoclaw/agent` holds no `.sig`/`.att` artifacts to verify against. This bump is a human merge by design — `verify-agent-image` will run its blocking shape checks and leave auto-merge off. See #3158, which wires the publisher identity in and documents the `cosign copy` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
