### PR TITLE
fix(group-init): pin cleanupPeriodDays so retention cleanup can't reap cold sessions

### DIFF
--- a/src/group-init.settings.test.ts
+++ b/src/group-init.settings.test.ts
@@ -48,6 +48,68 @@ describe('default settings.json for new groups', () => {
     expect(JSON.stringify(settings.hooks.PreCompact)).toContain('compact-instructions');
   });
 
+  // Claude Code's embedded retention cleanup deletes transcripts older than
+  // cleanupPeriodDays (default 30). Sessions in a group share one
+  // .claude-shared, so any warm session's cleanup run reaps a cold sibling's
+  // transcript — before that sibling ever wakes and archives it.
+  it("pins cleanupPeriodDays so a cold session's transcript survives to be archived", () => {
+    const ag = makeGroup('ag-retention');
+    initGroupFilesystem(ag, {});
+
+    const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(file, 'utf-8'));
+
+    expect(settings.cleanupPeriodDays).toBe(3650);
+  });
+
+  // Groups created before this setting existed keep their settings.json, so
+  // the default alone never reaches them — the reconcile pass has to.
+  it('backfills cleanupPeriodDays into a settings.json that predates it', () => {
+    const ag = makeGroup('ag-retention-backfill');
+    initGroupFilesystem(ag, {});
+    const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
+
+    const legacy = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    delete legacy.cleanupPeriodDays;
+    fs.writeFileSync(file, JSON.stringify(legacy, null, 2) + '\n');
+
+    initGroupFilesystem(ag, {}); // next spawn
+
+    expect(JSON.parse(fs.readFileSync(file, 'utf-8')).cleanupPeriodDays).toBe(3650);
+  });
+
+  // Guard rail, not a driver: the backfill above must stay a fill-the-gap, so
+  // an operator who deliberately picked a shorter retention keeps it.
+  it('leaves an operator-chosen cleanupPeriodDays alone', () => {
+    const ag = makeGroup('ag-retention-operator');
+    initGroupFilesystem(ag, {});
+    const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
+
+    const edited = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    edited.cleanupPeriodDays = 30;
+    fs.writeFileSync(file, JSON.stringify(edited, null, 2) + '\n');
+
+    initGroupFilesystem(ag, {}); // next spawn
+
+    expect(JSON.parse(fs.readFileSync(file, 'utf-8')).cleanupPeriodDays).toBe(30);
+  });
+
+  // Claude Code rejects a non-numeric value, which would leave the group on
+  // the 30-day default — the failure this setting exists to prevent.
+  it('repairs a cleanupPeriodDays that Claude Code would reject', () => {
+    const ag = makeGroup('ag-retention-garbage');
+    initGroupFilesystem(ag, {});
+    const file = path.join(TEST_ROOT, 'data', 'v2-sessions', ag.id, '.claude-shared', 'settings.json');
+
+    const broken = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    broken.cleanupPeriodDays = null;
+    fs.writeFileSync(file, JSON.stringify(broken, null, 2) + '\n');
+
+    initGroupFilesystem(ag, {}); // next spawn
+
+    expect(JSON.parse(fs.readFileSync(file, 'utf-8')).cleanupPeriodDays).toBe(3650);
+  });
+
   it('never rewrites an existing settings.json — a hand-edited re-enable sticks', () => {
     const ag = makeGroup('ag-reenable');
     initGroupFilesystem(ag, {});

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -5,7 +5,7 @@ import { DATA_DIR, DEFAULT_AGENT_PROVIDER, GROUPS_DIR } from './config.js';
 import { ensureContainerConfig } from './db/container-configs.js';
 import { stageGroupPersona } from './group-persona.js';
 import { log } from './log.js';
-import { migrateClaudeMemorySettings } from './migrate-claude-memory-settings.js';
+import { CLEANUP_PERIOD_DAYS, migrateClaudeMemorySettings } from './migrate-claude-memory-settings.js';
 import { providerProvidesAgentSurfaces } from './providers/provider-container-registry.js';
 import type { AgentGroup } from './types.js';
 
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS_JSON =
   JSON.stringify(
     {
       autoMemoryEnabled: false,
+      cleanupPeriodDays: CLEANUP_PERIOD_DAYS,
       env: {
         CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
         CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',

--- a/src/migrate-claude-memory-settings.ts
+++ b/src/migrate-claude-memory-settings.ts
@@ -5,6 +5,15 @@ import { log } from './log.js';
 const PRE_COMPACT_COMMAND = 'bun /app/src/compact-instructions.ts';
 const LEGACY_MEMORY_SESSION_START_COMMAND = 'bun /app/src/memory-hook.ts';
 
+/**
+ * Claude Code reaps transcripts older than this (its default is 30 days) on a
+ * timer inside any session sharing the config dir. A group's sessions share
+ * one .claude-shared, so a warm session's cleanup reaps a cold sibling's
+ * transcript before that sibling ever wakes to rotate and archive it. 3650 is
+ * the value Claude Code's own validation message suggests for long retention.
+ */
+export const CLEANUP_PERIOD_DAYS = 3650;
+
 /** Reconcile existing Claude settings with NanoClaw's shared memory system. */
 export function migrateClaudeMemorySettings(settingsFile: string): boolean {
   try {
@@ -17,6 +26,14 @@ export function migrateClaudeMemorySettings(settingsFile: string): boolean {
     let changed = false;
     if (parsed.autoMemoryEnabled !== false) {
       parsed.autoMemoryEnabled = false;
+      changed = true;
+    }
+
+    // Fill the gap only — an operator who picked their own retention keeps it.
+    // Anything non-numeric is not a choice we can honour: Claude Code rejects
+    // it, which would disable the retention setting entirely.
+    if (typeof parsed.cleanupPeriodDays !== 'number') {
+      parsed.cleanupPeriodDays = CLEANUP_PERIOD_DAYS;
       changed = true;
     }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**Impact:** a user messaging a channel that has been quiet for 30+ days gets raw
`No conversation found with session ID: <uuid>` errors instead of a reply, and the
session stays that way — the thread's history is gone before NanoClaw's own rotation
ever archives it. On the install where this was diagnosed, 22 sessions across 6
agent groups were in that state.

**When:** any agent group with one session cold for 30+ days while any sibling
session stays warm. All sessions of a group share one `.claude-shared`, so this is
the default multi-session setup, not an edge configuration.

**Cause:** Claude Code ships a built-in transcript retention cleanup,
`cleanupPeriodDays`, defaulting to 30 days. It fires ~10 minutes into any session
(throttled to once per 24h) and sweeps every `.jsonl` in the config dir — so a warm
session's cleanup reaps a cold sibling's transcript. NanoClaw never sets the key;
`cleanupPeriodDays` is not referenced anywhere in the repo today.

**After this change:** the default settings.json for new groups pins
`cleanupPeriodDays: 3650` (the value Claude Code's own validation message suggests
for long retention), and the existing settings reconcile pass backfills the key on
next container spawn when it is missing or non-numeric — an operator-chosen number
is left untouched. Transcript lifecycle is then governed by NanoClaw's existing
size/age rotation (archive-then-drop) instead of a blind cross-session reaper. Disk
growth stays bounded by that same rotation: per-transcript size is capped at 12MB
regardless, and the busiest group measured during diagnosis grew ~106MB per 30 days.

**Test:** four new vitest cases at the existing `initGroupFilesystem` →
settings.json seam: new-group default, backfill into a pre-existing settings.json,
operator override kept, non-numeric value repaired. Verified red-first (reverting
the source change fails the three driver tests). Full suite: 1266 passed, 0 failed
(baseline before the change: 1262 passed, 0 failed).

<details><summary>Details, if useful</summary>

**Binary archaeology (Claude Code 2.1.197, linux-x64 bundle).** The cleanup is
scheduled via `DELAY_VERY_SLOW_OPERATIONS_THAT_HAPPEN_EVERY_SESSION = 600000` with
`.unref()`, throttled to once per 24h by the mtime of `.last-cleanup`. The settings
schema is `number().int().positive()` with no upper bound, and the validation
message itself suggests 3650 for long retention. A CLI process that exits within 10
minutes never runs cleanup — which is why short agent turns never triggered it and
a group's busiest long-running sibling did.

**Field evidence.** A transcript was deleted on day 30 of a 35-day-cold session,
attributed to a warm sibling via `.last-cleanup` timestamps; the shared dir's live
`.jsonl` count dropped 89→78 during the investigation, while `.rotated-*` archives
from June survived multiple cleanups (only `.jsonl` files are reaped). 22 further
sessions across 6 groups had dangling continuations from earlier reaps.

**Why the session stays bricked.** The provider's pre-resume check treats
"transcript not found" as "resume normally"; the SDK failure then arrives as a
result event, not a thrown error, so the reactive guard never clears the stored
continuation, and each message is acked `completed` before the error surfaces —
lost, not retried. That container-side half is a separate single-purpose fix
(prevention here, cure there); this PR removes the root cause that deletes the
file in the first place.

</details>

**Related:** #1216 describes the resulting symptom (stale session ids causing
permanent resume failures); #1761 is adjacent context on transcript cleanup for
shared session storage. #2184 fixes the error catch path and is complementary and
textually disjoint from this change; happy to rebase whichever lands second.
