### PR TITLE
fix(claude): rotate on missing transcript instead of resuming into a dead session

### DIFF
--- a/container/agent-runner/src/providers/claude.rotate.test.ts
+++ b/container/agent-runner/src/providers/claude.rotate.test.ts
@@ -82,8 +82,17 @@ describe('ClaudeProvider.maybeRotateContinuation', () => {
     expect(provider.maybeRotateContinuation('sess-old', CWD)).toContain('d');
   });
 
-  it('returns null for an unknown session id', () => {
+  // A missing transcript is not "nothing to rotate" — see maybeRotateContinuation
+  // for why resuming into one costs the user's message.
+  it('rotates when the transcript is gone — nothing to archive, nothing to move aside', () => {
     const provider = new ClaudeProvider();
-    expect(provider.maybeRotateContinuation('does-not-exist', CWD)).toBeNull();
+
+    const reason = provider.maybeRotateContinuation('does-not-exist', CWD);
+
+    expect(reason).toContain('missing');
+    // Nothing on disk to summarise, and nothing to leave behind.
+    expect(fs.existsSync(path.join(tmp, 'conversations'))).toBe(false);
+    const dir = path.join(tmp, '.claude', 'projects', PROJECT_DIR);
+    expect(fs.existsSync(dir) ? fs.readdirSync(dir) : []).toHaveLength(0);
   });
 });

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -489,13 +489,20 @@ export class ClaudeProvider implements AgentProvider {
 
   maybeRotateContinuation(continuation: string): string | null {
     const transcriptPath = findTranscriptPath(continuation);
-    if (!transcriptPath) return null;
+    // Gone, not absent-by-design: the caller only asks about a continuation
+    // it actually stored. Resuming into a missing transcript fails as a
+    // result event — after the batch is acked — so the message is lost, not
+    // retried. Report a reason so the rotation path starts fresh instead.
+    if (!transcriptPath) return 'transcript missing — reaped by retention cleanup or never written';
 
     let size: number;
     try {
       size = fs.statSync(transcriptPath).size;
     } catch {
-      return null;
+      // The same loss as above, caught a moment later: the reaper can delete
+      // between the lookup and the stat. Anything we can't read, we can't
+      // resume from either.
+      return 'transcript unreadable — deleted mid-check, or not readable';
     }
 
     const maxBytes = transcriptRotateBytes();

--- a/docs/agent-runner-details.md
+++ b/docs/agent-runner-details.md
@@ -198,7 +198,7 @@ SDK message (so the idle timer stays honest) and maps recognized messages to `Pr
 - **PreToolUse hook** records the current tool + its declared timeout to `container_state` (so the host sweep widens its stuck tolerance while a long Bash runs) and, as defense-in-depth, blocks any `SDK_DISALLOWED_TOOLS` call that slips through. It does **not** sanitize bash env vars — there is no such hook.
 - **PostToolUse / PostToolUseFailure** hooks clear the in-flight tool
 - **PreCompact** hook archives the transcript to `conversations/` before compaction
-- `maybeRotateContinuation` drops an oversized/aged transcript (default caps 12 MB / 14 days, both operator-overridable) so a cold container isn't killed reloading days of `.jsonl` before the host idle ceiling; `isSessionInvalid` clears a continuation whose transcript is gone
+- `maybeRotateContinuation` drops a continuation whose transcript is missing, oversized, or aged (default caps 12 MB / 14 days, both operator-overridable) — archiving it first when there is still a file to archive — so a cold container neither resumes into a deleted transcript nor is killed reloading days of `.jsonl` before the host idle ceiling; `isSessionInvalid` is the reactive fallback for staleness that only surfaces mid-query (it sees thrown errors only)
 - `additionalDirectories` for multi-directory access
 
 ### Codex Provider
@@ -748,9 +748,12 @@ The agent-runner tracks a single opaque `continuation` token per provider:
 
 Because it lives in the session folder's `outbound.db`, the continuation survives container
 teardown and restart — a fresh container reads it back and resumes. `/clear` deletes the row
-to start a clean session. Before resuming, `maybeRotateContinuation` may archive and drop an
-oversized/aged transcript (so a cold container isn't killed reloading it), and
-`isSessionInvalid` clears a continuation whose backing transcript has gone missing.
+to start a clean session. Before resuming, `maybeRotateContinuation` drops a continuation whose
+transcript is missing, oversized, or aged — archiving it first when there is still a file to
+archive — so a cold container neither resumes into a deleted transcript nor is killed reloading
+a huge one. `isSessionInvalid` is the reactive fallback, for staleness that only surfaces once
+a query is already running — note it sees only errors the SDK *throws*, not those returned as
+result events.
 
 ### Container Startup
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**Impact:** when a stored continuation's transcript file no longer exists, the next
message to that session dies with `No conversation found with session ID: <uuid>` —
and every later message dies the same way. The batch is acked `completed` before
the error surfaces, so the user's message is lost, not retried. The session is
permanently bricked until something else clears the continuation.

**When:** any time a transcript disappears out from under a stored continuation —
external cleanup, a deploy that didn't carry session files over, manual deletion.
On the install where this was diagnosed, 22 sessions across 6 agent groups were in
this state.

**Cause:** `maybeRotateContinuation` treats "transcript not found" (and a failing
`stat`) as "nothing to rotate, resume normally". The SDK's resume failure then
arrives as a **result event**, not a thrown error, so `isSessionInvalid` — which
only inspects thrown errors — never fires, and the dead continuation is never
cleared (#2669 has the analysis of why result-event errors bypass the catch path).

**After this change:** the pre-resume check returns a rotate reason for a missing
or unreadable transcript, so the existing rotation path clears the continuation
and starts a fresh session — same silent fresh-start behavior the size/age
rotation already has. No archive is attempted (there is no file to archive), and
fresh sessions get the memory tree injected on startup, so this is the existing
first-class path, not a degraded one. The 11-line core is textually disjoint from
the three open rotation/recovery PRs.

**Test:** the `returns null for an unknown session id` assertion (from #2586) is
inverted — it was locking the bug in as a contract. Its defensive spirit is kept
by the replacement's extra assertions: no crash, no `conversations/` archive
written, no `.rotated-*` residue. Verified red-first (reverting the source change
fails the new test). Container suite failure set identical to base (one
pre-existing flaky timeout that passes standalone); host suite unaffected (1262
passed). The docs paragraph claiming `isSessionInvalid` handles missing
transcripts is corrected — it cannot see result-event errors.

**Related:** #1216 reports this exact symptom; #1761's own "possible fix 2" (eager
validation before resume) is what this implements. #2184 fixes the error catch
path and is complementary (prevention here, cure there); #2864 / #2865 extend
rotation the same direction and touch different files — no conflicts, happy to
rebase whichever lands second.
