### PR TITLE
fix(discord): strip \n delimiter in webhook interaction custom_id so approvals resolve correctly

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -711,6 +711,11 @@ async function handleForwardedEvent(
         if (colonIdx !== -1) {
           questionId = customId.slice(4, colonIdx);
           tail = customId.slice(colonIdx + 1);
+          // custom_id from @chat-adapter/discord is `${actionId}\n${value}`
+          // (encodeDiscordCustomId). Splitting on ':' leaves the trailing
+          // `\n<value>`; strip it so the index resolves like the Gateway path.
+          const nlIdx = tail.indexOf('\n');
+          if (nlIdx !== -1) tail = tail.slice(0, nlIdx);
         }
       }
 


### PR DESCRIPTION
On Discord, clicking any button on an `ask_question` / approval card resolves to the wrong option — in practice **every approval is rejected even when the user clicks Approve**. The bug is in the raw HTTP-interaction (webhook) path of the Chat SDK bridge, which decodes `custom_id` by splitting on `:` only and never strips the `\n` delimiter that `@chat-adapter/discord` inserts.

Verified live on a self-hosted v2 install; the fix below resolves it.

## Root cause

Question buttons are built with an index-based encoding (`src/channels/chat-sdk-bridge.ts:494`):

```ts
Button({ id: `ncq:${questionId}:${idx}`, label: opt.label, value: String(idx), style: opt.style })
```

`@chat-adapter/discord`'s `encodeDiscordCustomId(actionId, value)` joins the two with a **newline**:

```
custom_id = `${actionId}\n${value}` = `ncq:<questionId>:<idx>\n<idx>`
```

The webhook handler parses `custom_id` by splitting on `:` only (`chat-sdk-bridge.ts:709-714`):

```ts
if (customId?.startsWith('ncq:')) {
  const colonIdx = customId.indexOf(':', 4); // after "ncq:"
  if (colonIdx !== -1) {
    questionId = customId.slice(4, colonIdx);
    tail = customId.slice(colonIdx + 1);   // becomes "<idx>\n<idx>", e.g. "0\n0"
  }
}
```

`tail` still contains the `\n<idx>` suffix. `resolveSelectedOption` (`chat-sdk-bridge.ts:108-119`) then tries to map an integer index back to the option value, but the numeric guard fails on the embedded newline:

```ts
const candidate = eventValue ?? tail ?? '';
if (render && /^\d+$/.test(candidate)) {   // /^\d+$/.test("0\n0") === false
  const idx = Number(candidate);
  if (render.options[idx]) return render.options[idx].value;
}
return candidate;                          // returns the literal "0\n0"
```

So `selectedOption` becomes `"0\n0"`, matching no option. For approvals the decision is a strict `if (selectedOption !== 'approve') finalizeReject(...)`, so **Approve is rejected**.

**Log fingerprint:** `unknown response value value="0\n0"` and repeated `Approval rejected ... withReason=false`.

## Why the Gateway path hides this

The Discord **Gateway** `onAction` path (`chat-sdk-bridge.ts:333-345`) is correct — the adapter has already decoded the `\n`, so it passes a clean `event.value` (`"0"`) into `resolveSelectedOption`, the numeric guard passes, and the index maps back to `"approve"`. The bug only surfaces when interactions arrive over the **HTTP webhook fallback** (e.g. when the Gateway listener is down, such as an app that hasn't enabled the Message Content privileged intent the adapter requests). The webhook path should decode identically to the Gateway path.

## Fix

Strip the `\n` delimiter from `tail` before resolving:

```ts
if (colonIdx !== -1) {
  questionId = customId.slice(4, colonIdx);
  tail = customId.slice(colonIdx + 1);
  // custom_id from @chat-adapter/discord is `${actionId}\n${value}`
  // (encodeDiscordCustomId). Splitting on ':' leaves the trailing
  // `\n<value>`; strip it so the index resolves like the Gateway path.
  const nlIdx = tail.indexOf('\n');
  if (nlIdx !== -1) tail = tail.slice(0, nlIdx);
}
```

After the strip, `tail` is `"0"`, the numeric guard passes, and `resolveSelectedOption` returns `render.options[0].value` (`"approve"`). Verified on a live install: Approve now resolves to approve and the approval executes.

## Testing

- Reproduced on a live Discord install: every approval-card click rejected; logs showed `value="0\n0"`.
- With the fix applied, `pnpm run build` clean, service restarted — clicking Approve now approves and executes; clicking Reject rejects. No change to the Gateway path.