### PR TITLE
refactor: add host seams for skill-owned capabilities

### DIFF
--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -6,11 +6,15 @@ The authoritative checklist for writing a NanoClaw skill: the bar that conforman
 
 ## Principles
 
-Every customization is an additive **skill**: not an edit buried in core, but a skill that carries its own code and knows how to install and remove itself. Two principles make a skill *maintainable*; everything else in this document follows from them.
+Every customization is an additive **skill**: not an edit buried in core, but a skill that carries its own code and knows how to install and remove itself. Three principles make a skill *maintainable*; everything else in this document follows from them.
 
-### 1. Minimal integration surface
+### 1. Single responsibility
 
-A skill adds files and makes the **smallest possible reach-ins** into existing code. Adding a file or a dependency never breaks on upgrade; reaching into existing code is the only thing that does, so the integration surface *is* the upgrade risk. Keep reach-ins few, tiny, and ideally a single line that *calls* into the skill's own code.
+A skill provides one independently useful customization and has one cohesive reason to change. Split customizations users can install or remove independently; keep one workflow together when its parts only make sense as a whole.
+
+### 2. Open for extension, closed for modification
+
+A skill extends NanoClaw through skill-owned files and existing extension points, keeping working core code unchanged whenever possible. When an edit is unavoidable, make the **smallest possible reach-in**. Adding a file or a dependency never breaks on upgrade; reaching into existing code is the only thing that does, so the integration surface *is* the upgrade risk.
 
 Follows from this:
 
@@ -19,7 +23,7 @@ Follows from this:
 - **Colocated, self-contained** edits over edits in two places.
 - **Use an existing registry or hook when there is one**: appending to a registry is a smaller surface than reaching into code. When none exists, a true code-level edit is fine and first-class. (Whether to *add* a hook because a spot has become a hotspot is the maintainer's call, not the skill's.)
 
-### 2. A test for every functional integration point
+### 3. A test for every functional integration point
 
 Every reach-in with a **functional consequence** gets a test that goes **red if the wiring is deleted or drifts**. That's what protects the fork from upstream changes. The tests are also the verification: there is no separate "verify" step.
 
@@ -31,7 +35,7 @@ Follows from this:
 - **The test lives where the point runs**: host code uses vitest under `src/`; container code uses `bun:test` under `container/agent-runner/`.
 - **"Functional" is the filter**: weigh a reach-in by what breaks if it's gone. A cosmetic one (raising a log line's level) gets no test.
 
-The two interlock: a minimal surface keeps the integration points few and testable; a test per point keeps the surface safe. *Maintainable = small surface, every functional point guarded.*
+Together they define a maintainable skill: focused responsibility, a small integration surface, and every functional point guarded.
 
 ---
 

--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -84,6 +84,8 @@ For a fence-carrying skill, conformance means:
 
 The integration point is wherever the skill reaches into existing code. Make it **minimal, colocated, and self-contained**:
 
+Lifecycle hooks are operational boundaries: an `onHostStart` error aborts host startup, while shutdown callback errors are logged and remaining cleanup continues.
+
 - All real logic lives in the skill's own file behind a single entry function; the edit to core is just the call.
 - **Prefer one colocated block** over edits in two places. For an inserted call, a dynamic import at the call site keeps the import and call together and avoids touching the top-of-file import block (itself a merge hotspot):
 

--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -130,6 +130,7 @@ Two consequences. First, **don't mock the adapter's package in the shipped test*
 The test matches the kind of integration point:
 
 - **In-process seam with core** (a channel into the router, a pusher into the central DB): drive the real added component against the **real core collaborators** (DB, registry, router), faking only the external edge. The highest-value archetype: it exercises the added file's consumption of core, which is what catches core drift.
+- **Module migration**: import the real modules barrel, initialize a real test DB, call `runMigrations()` with its default combined list, then exercise the skill's actual DB behavior. Do not pass an explicit migration list or import the skill migration directly: either bypasses the core migrations that must participate for an incompatible upstream schema change to make the composed skill test fail.
 - **Wiring / registration** (a barrel import, a `main()` call, an entry in an `mcpServers` map): behavior test via the registry where queryable (see above); structural / AST test where not.
 - **Config / container probe** (mounts, Dockerfile, a tool installed in the image): run the change where you can. Spin up a container to confirm a mount or binary. Checking that a line exists in a file is the last resort.
 - **Agentic run** (operational, instruction-only skills): run the workflow with a small model; did it complete?

--- a/docs/skills-model.md
+++ b/docs/skills-model.md
@@ -64,6 +64,8 @@ The one risky move is when a skill has to *reach into* existing code and wire so
 
 Rule of thumb: aim for skills that are almost all "adds." Not 100%; some reach-ins are fine. But a skill full of reach-ins is a smell, and a sign that spot in the core should become a proper hook.
 
+The skill's name and description declare the capability. Runtime registration uses the registry that owns the behavior, with one explicit import where required.
+
 ## Where a skill's files live
 
 The files a skill adds live in the skill's own folder, and the skill copies them into the project when it runs. The skill is self-contained.

--- a/src/channels/chat-sdk-bridge-byline.test.ts
+++ b/src/channels/chat-sdk-bridge-byline.test.ts
@@ -24,6 +24,7 @@ import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { createPendingApproval } from '../db/sessions.js';
 import type { ChannelSetup } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { registerQuestionRenderResolver } from './question-render-registry.js';
 
 interface CapturedEdit {
   threadId: string;
@@ -52,6 +53,7 @@ function terminalText(edit: CapturedEdit): Array<{ type: string; content?: strin
 async function fireAction(
   user: Record<string, unknown>,
   selectedOption = 'approve',
+  actionId = `ncq:q-1:${selectedOption}`,
 ): Promise<{ edits: CapturedEdit[]; actions: string[] }> {
   const edits: CapturedEdit[] = [];
   const actions: string[] = [];
@@ -71,7 +73,7 @@ async function fireAction(
   expect(chat).toBeTruthy();
   await chat.processAction(
     {
-      actionId: `ncq:q-1:${selectedOption}`,
+      actionId,
       adapter,
       messageId: 'msg-1',
       raw: {},
@@ -149,5 +151,26 @@ describe('chat-sdk-bridge approval-card terminal state', () => {
       content: '✅ Approved',
       style: 'muted',
     });
+  });
+
+  it('resolves compact option indexes through a module resolver', async () => {
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-compact-question') return undefined;
+      return {
+        title: 'Custom approval',
+        options: [{ label: 'Approve', selectedLabel: 'Approved safely', value: 'approve-real-value' }],
+      };
+    });
+
+    const { edits, actions } = await fireAction(
+      { userId: 'U4', userName: 'reviewer' },
+      '0',
+      'ncq:module-compact-question:0',
+    );
+
+    const message = edits[0].message as { markdown: string };
+    expect(message.markdown).toContain('Custom approval');
+    expect(message.markdown).toContain('Approved safely by reviewer');
+    expect(actions).toEqual(['module-compact-question:approve-real-value:U4']);
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -21,9 +21,9 @@ import {
 import { log } from '../log.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
-import { getAskQuestionRender } from '../db/sessions.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
+import { resolveQuestionRender } from './question-render-registry.js';
 
 /** Adapter with optional gateway support (e.g., Discord). */
 interface GatewayAdapter extends Adapter {
@@ -101,7 +101,7 @@ export interface ChatSdkBridgeConfig {
 /**
  * Decode the actual option value from a button callback. Buttons are encoded
  * with an integer index (to keep under Telegram's 64-byte callback_data cap),
- * and the real value is looked up via `getAskQuestionRender(questionId)`.
+ * and the real value is looked up via `resolveQuestionRender(questionId)`.
  * Falls back to treating the tail as a literal value so old in-flight cards
  * (encoded before this shortening landed) still resolve.
  */
@@ -338,7 +338,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         const userId = event.user?.userId || '';
 
         // Resolve render metadata BEFORE dispatching onAction (which deletes the row).
-        const render = getAskQuestionRender(questionId);
+        const render = resolveQuestionRender(questionId);
         // New format: button id/value is an integer index into options (kept
         // short to fit Telegram's 64-byte callback_data cap). Old format:
         // the full value is embedded in actionId/value directly.
@@ -489,7 +489,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
               // full value. Telegram caps callback_data at 64 bytes, and
               // long values (e.g. ISO datetimes, URLs) push the JSON payload
               // well past that. The onAction handlers resolve the index back
-              // to the real value via getAskQuestionRender(questionId).
+              // to the real value via resolveQuestionRender(questionId).
               options.map((opt, idx) =>
                 Button({ id: `ncq:${questionId}:${idx}`, label: opt.label, value: String(idx), style: opt.style }),
               ),
@@ -718,7 +718,7 @@ async function handleForwardedEvent(
       const originalEmbeds =
         ((interaction.message as Record<string, unknown>)?.embeds as Array<Record<string, unknown>>) || [];
       const originalDescription = (originalEmbeds[0]?.description as string) || '';
-      const render = questionId ? getAskQuestionRender(questionId) : undefined;
+      const render = questionId ? resolveQuestionRender(questionId) : undefined;
       // Discord custom_id mirrors the new index-based encoding (see Button
       // construction). Decode back to the real option value for downstream.
       const selectedOption = resolveSelectedOption(render, tail, tail);

--- a/src/channels/question-render-registry.test.ts
+++ b/src/channels/question-render-registry.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, initTestDb } from '../db/connection.js';
+import { runMigrations } from '../db/migrations/index.js';
+import { createPendingApproval } from '../db/sessions.js';
+import { log } from '../log.js';
+import { registerQuestionRenderResolver, resolveQuestionRender } from './question-render-registry.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+  vi.restoreAllMocks();
+});
+
+describe('question render resolver registry', () => {
+  it('runs module resolvers in registration order and stops on the first result', () => {
+    const order: string[] = [];
+    const later = vi.fn(() => undefined);
+    const expected = {
+      title: 'Module question',
+      options: [{ label: 'Approve', selectedLabel: 'Approved', value: 'approve' }],
+    };
+
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      order.push('first');
+      return undefined;
+    });
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      order.push('second');
+      return expected;
+    });
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      later();
+      return undefined;
+    });
+
+    expect(resolveQuestionRender('module-order-question')).toBe(expected);
+    expect(order).toEqual(['first', 'second']);
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it('resolves over a snapshot when a resolver registers another resolver', () => {
+    const expected = {
+      title: 'Registered during resolution',
+      options: [{ label: 'Continue', selectedLabel: 'Continued', value: 'continue' }],
+    };
+    const registeredDuringResolution = vi.fn((questionId: string) =>
+      questionId === 'snapshot-question' ? expected : undefined,
+    );
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'snapshot-question') return undefined;
+      registerQuestionRenderResolver(registeredDuringResolution);
+      return undefined;
+    });
+
+    expect(resolveQuestionRender('snapshot-question')).toBeUndefined();
+    expect(registeredDuringResolution).not.toHaveBeenCalled();
+
+    expect(resolveQuestionRender('snapshot-question')).toBe(expected);
+    expect(registeredDuringResolution).toHaveBeenCalledOnce();
+  });
+
+  it('logs an optional resolver failure and continues to the built-in fallback', () => {
+    const failure = new Error('resolver failure');
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => undefined);
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId === 'resolver-failure-question') throw failure;
+      return undefined;
+    });
+    createPendingApproval({
+      approval_id: 'resolver-failure-question',
+      request_id: 'request-resolver-failure',
+      action: 'test-action',
+      payload: '{}',
+      created_at: new Date().toISOString(),
+      title: 'Built-in fallback after failure',
+      options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
+    });
+
+    expect(resolveQuestionRender('resolver-failure-question')).toEqual({
+      title: 'Built-in fallback after failure',
+      question: '',
+      options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
+    });
+    expect(errorSpy).toHaveBeenCalledWith('Question render resolver threw', { err: failure });
+  });
+
+  it('uses the existing database lookup as the final built-in fallback', () => {
+    createPendingApproval({
+      approval_id: 'built-in-render-question',
+      request_id: 'request-1',
+      action: 'test-action',
+      payload: '{}',
+      created_at: new Date().toISOString(),
+      title: 'Built-in approval',
+      options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
+    });
+
+    expect(resolveQuestionRender('built-in-render-question')).toEqual({
+      title: 'Built-in approval',
+      question: '',
+      options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
+    });
+  });
+
+  it('returns undefined when neither a module nor the built-in fallback owns the id', () => {
+    expect(resolveQuestionRender('unowned-render-question')).toBeUndefined();
+  });
+});

--- a/src/channels/question-render-registry.ts
+++ b/src/channels/question-render-registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Question-card render resolver registry.
+ *
+ * Optional modules register compact-card metadata lookups at import time.
+ * The host's existing DB lookup remains the final fallback for core question
+ * and approval rows.
+ */
+import { getAskQuestionRender } from '../db/sessions.js';
+import { log } from '../log.js';
+import type { NormalizedOption } from './ask-question.js';
+
+export interface QuestionRender {
+  title: string;
+  question?: string;
+  options: NormalizedOption[];
+}
+
+export type QuestionRenderResolver = (questionId: string) => QuestionRender | undefined;
+
+const resolvers: QuestionRenderResolver[] = [];
+
+export function registerQuestionRenderResolver(resolver: QuestionRenderResolver): void {
+  resolvers.push(resolver);
+}
+
+export function resolveQuestionRender(questionId: string): QuestionRender | undefined {
+  for (const resolver of [...resolvers]) {
+    /* eslint-disable no-catch-all/no-catch-all -- one optional resolver must not block later resolvers or the built-in fallback */
+    try {
+      const render = resolver(questionId);
+      if (render) return render;
+    } catch (err) {
+      log.error('Question render resolver threw', { err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
+  }
+  return getAskQuestionRender(questionId);
+}

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -5,7 +5,7 @@
  * formats the response, exits non-zero on error.
  *
  * Usage:
- *   ncl <resource> <verb> [target] [--key value ...] [--json]
+ *   ncl <resource> <verb> [target] [--key value ...] [--stdin-json] [--json]
  *
  * Examples:
  *   ncl groups list
@@ -16,10 +16,12 @@
  *   ncl groups help
  */
 import { randomUUID } from 'crypto';
+import { pathToFileURL } from 'url';
 
 import { formatResponse } from './format.js';
 import type { RequestFrame } from './frame.js';
 import { SocketTransport } from './socket-client.js';
+import { readStdinJsonArgs, StdinJsonInputError } from './stdin-json.js';
 import type { Transport } from './transport.js';
 import { formatTransportError } from './transport-errors.js';
 
@@ -31,8 +33,20 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const { command, args, json } = parseArgv(argv);
-  const req: RequestFrame = { id: randomUUID(), command, args };
+  const { command, args, json, stdinJson } = parseArgv(argv);
+  let requestArgs = args;
+  if (stdinJson) {
+    try {
+      requestArgs = await readStdinJsonArgs(process.stdin, args);
+    } catch (err) {
+      if (!(err instanceof StdinJsonInputError)) throw err;
+      process.stderr.write(`ncl: ${err.message}\n`);
+      process.exit(2);
+    }
+  }
+  // Stdin is only a client-side encoding for args. The daemon receives the
+  // same stable request frame it would receive if every value came from argv.
+  const req: RequestFrame = { id: randomUUID(), command, args: requestArgs };
   const transport: Transport = pickTransport();
 
   let res;
@@ -57,19 +71,25 @@ function pickTransport(): Transport {
   return new SocketTransport();
 }
 
-function parseArgv(argv: string[]): {
+export function parseArgv(argv: string[]): {
   command: string;
   args: Record<string, unknown>;
   json: boolean;
+  stdinJson: boolean;
 } {
   const positional: string[] = [];
   const args: Record<string, unknown> = {};
   let json = false;
+  let stdinJson = false;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--json') {
       json = true;
+      continue;
+    }
+    if (a === '--stdin-json') {
+      stdinJson = true;
       continue;
     }
     if (a.startsWith('--')) {
@@ -98,13 +118,15 @@ function parseArgv(argv: string[]): {
   // → command "groups-get", id "abc").
   const command = positional.join('-');
 
-  return { command, args, json };
+  return { command, args, json, stdinJson };
 }
 
 function printUsage(): void {
   process.stdout.write(
     [
-      'Usage: ncl <resource> <verb> [target] [--key value ...] [--json]',
+      'Usage: ncl <resource> <verb> [target] [--key value ...] [--stdin-json] [--json]',
+      '',
+      '  --stdin-json  Read one bounded JSON object from stdin and merge it with argv flags.',
       '',
       'Run `ncl help` to list available resources and commands.',
       '',
@@ -112,7 +134,9 @@ function printUsage(): void {
   );
 }
 
-main().catch((err) => {
-  process.stderr.write(`ncl: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
-  process.exit(2);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`ncl: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(2);
+  });
+}

--- a/src/cli/stdin-json.e2e.test.ts
+++ b/src/cli/stdin-json.e2e.test.ts
@@ -1,0 +1,108 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, it } from 'vitest';
+
+import type { ResponseFrame } from './frame.js';
+import { register } from './registry.js';
+import { startCliServer, stopCliServer } from './socket-server.js';
+
+type EchoArgs = {
+  'argv-value': string;
+  stdin_value: string;
+  nested: { enabled: boolean };
+};
+
+register<EchoArgs, EchoArgs>({
+  name: 'stdin-json-e2e-echo',
+  description: 'Echo structured args for the stdin JSON E2E test.',
+  access: 'open',
+  parseArgs: (raw) => {
+    if (
+      typeof raw['argv-value'] !== 'string' ||
+      typeof raw.stdin_value !== 'string' ||
+      !raw.nested ||
+      typeof raw.nested !== 'object' ||
+      (raw.nested as Record<string, unknown>).enabled !== true
+    ) {
+      throw new Error('unexpected E2E args');
+    }
+    return raw as EchoArgs;
+  },
+  handler: async (args) => args,
+});
+
+it('pipes stdin JSON through the real CLI and socket server into a registered command', async () => {
+  const tempDir = fs.mkdtempSync('/tmp/ncl-stdin-e2e-');
+  const dataDir = path.join(tempDir, 'data');
+  const socketPath = path.join(dataDir, 'ncl.sock');
+  fs.mkdirSync(dataDir);
+
+  try {
+    await startCliServer(socketPath);
+
+    const result = await runCli(tempDir, {
+      stdin_value: 'from-stdin',
+      nested: { enabled: true },
+    });
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: '' });
+    const frame = JSON.parse(result.stdout) as ResponseFrame;
+    expect(frame).toEqual({
+      id: expect.any(String),
+      ok: true,
+      data: {
+        'argv-value': 'from-argv',
+        stdin_value: 'from-stdin',
+        nested: { enabled: true },
+      },
+    });
+  } finally {
+    await stopCliServer();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function runCli(
+  cwd: string,
+  stdin: Record<string, unknown>,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  const clientPath = fileURLToPath(new URL('./client.ts', import.meta.url));
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      import.meta.resolve('tsx'),
+      clientPath,
+      'stdin-json-e2e',
+      'echo',
+      '--argv-value',
+      'from-argv',
+      '--stdin-json',
+      '--json',
+    ],
+    { cwd, stdio: ['pipe', 'pipe', 'pipe'] },
+  );
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => (stdout += chunk));
+  child.stderr.on('data', (chunk: string) => (stderr += chunk));
+  child.stdin.end(JSON.stringify(stdin));
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 10_000);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}

--- a/src/cli/stdin-json.test.ts
+++ b/src/cli/stdin-json.test.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseArgv } from './client.js';
+import { MAX_STDIN_JSON_BYTES, readStdinJsonArgs, type StdinJsonStream } from './stdin-json.js';
+
+async function* stream(...chunks: Array<string | Uint8Array>): StdinJsonStream {
+  for (const chunk of chunks) yield chunk;
+}
+
+describe('bounded stdin JSON', () => {
+  it('merges one chunked JSON object into argv args', async () => {
+    const result = await readStdinJsonArgs(stream('{"issuer":"gateway",', Buffer.from('"nested":{"enabled":true}}')), {
+      subject: 'service-a',
+    });
+
+    expect(result).toEqual({
+      subject: 'service-a',
+      issuer: 'gateway',
+      nested: { enabled: true },
+    });
+  });
+
+  it('accepts an object whose UTF-8 representation is exactly 64 KiB', async () => {
+    const envelopeBytes = Buffer.byteLength('{"payload":""}', 'utf8');
+    const source = `{"payload":"${'a'.repeat(MAX_STDIN_JSON_BYTES - envelopeBytes)}"}`;
+    expect(Buffer.byteLength(source, 'utf8')).toBe(MAX_STDIN_JSON_BYTES);
+
+    const result = await readStdinJsonArgs(stream(source), {});
+
+    expect((result.payload as string).length).toBe(MAX_STDIN_JSON_BYTES - envelopeBytes);
+  });
+
+  it('rejects input one byte over the 64 KiB limit', async () => {
+    const envelopeBytes = Buffer.byteLength('{"payload":""}', 'utf8');
+    const source = `{"payload":"${'a'.repeat(MAX_STDIN_JSON_BYTES - envelopeBytes + 1)}"}`;
+
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow(
+      `--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`,
+    );
+  });
+
+  it('measures multibyte input as UTF-8 bytes across chunk boundaries', async () => {
+    const source = Buffer.from('{"value":"שלום"}', 'utf8');
+    const result = await readStdinJsonArgs(stream(source.subarray(0, 12), source.subarray(12)), {});
+
+    expect(result).toEqual({ value: 'שלום' });
+  });
+
+  it.each(['', '   \n\t'])('rejects empty input %#', async (source) => {
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow('--stdin-json input is empty');
+  });
+
+  it('rejects malformed JSON', async () => {
+    await expect(readStdinJsonArgs(stream('{"broken":'), {})).rejects.toThrow('--stdin-json input is not valid JSON');
+  });
+
+  it.each(['null', '[]', '"text"', '42', 'true'])('rejects a non-object JSON value: %s', async (source) => {
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow('--stdin-json input must be one JSON object');
+  });
+
+  it('rejects a key also supplied on argv', async () => {
+    await expect(readStdinJsonArgs(stream('{"subject":"stdin-value"}'), { subject: 'argv-value' })).rejects.toThrow(
+      '--stdin-json key "subject" is also supplied on argv',
+    );
+  });
+
+  it('rejects a stdin key that aliases a hyphenated argv key after CLI normalization', async () => {
+    await expect(
+      readStdinJsonArgs(stream('{"approver_user_id":"stdin-value"}'), {
+        'approver-user-id': 'argv-value',
+      }),
+    ).rejects.toThrow(
+      '--stdin-json key "approver_user_id" conflicts with argv key "approver-user-id" after CLI key normalization',
+    );
+  });
+
+  it('rejects two stdin keys that alias each other after CLI normalization', async () => {
+    await expect(
+      readStdinJsonArgs(stream('{"approver-user-id":"first","approver_user_id":"second"}'), {}),
+    ).rejects.toThrow(
+      '--stdin-json keys "approver-user-id" and "approver_user_id" conflict after CLI key normalization',
+    );
+  });
+
+  it('rejects __proto__ before downstream argument normalization', async () => {
+    await expect(readStdinJsonArgs(stream('{"__proto__":{"id":"task-123"}}'), {})).rejects.toThrow(
+      '--stdin-json key "__proto__" is not allowed',
+    );
+  });
+});
+
+describe('host CLI flags', () => {
+  it('keeps --json as output mode while excluding --stdin-json from request args', () => {
+    expect(parseArgv(['nanoco-approver-bindings', 'set', '--stdin-json', '--json', '--force'])).toEqual({
+      command: 'nanoco-approver-bindings-set',
+      args: { force: true },
+      json: true,
+      stdinJson: true,
+    });
+  });
+
+  it('reports malformed stdin as an input error, not an unexpected failure', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', 'src/cli/client.ts', 'groups', 'list', '--stdin-json'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        input: '{"broken":',
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('ncl: --stdin-json input is not valid JSON\n');
+  });
+});

--- a/src/cli/stdin-json.ts
+++ b/src/cli/stdin-json.ts
@@ -1,0 +1,91 @@
+/** Maximum structured CLI input accepted from stdin (64 KiB, measured as UTF-8 bytes). */
+export const MAX_STDIN_JSON_BYTES = 64 * 1024;
+
+export type StdinJsonStream = AsyncIterable<string | Uint8Array>;
+
+/** Expected validation failure caused by the contents of `--stdin-json`. */
+export class StdinJsonInputError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StdinJsonInputError';
+  }
+}
+
+/** Match the key normalization applied by command parsers in crud.ts. */
+function canonicalArgKey(key: string): string {
+  return key.replace(/-/g, '_');
+}
+
+/**
+ * Read one bounded JSON object from stdin and merge it with argv-derived args.
+ * A key may come from exactly one source so shell-visible flags cannot be
+ * silently replaced by piped data.
+ */
+export async function readStdinJsonArgs(
+  stream: StdinJsonStream,
+  argvArgs: Readonly<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+
+  for await (const chunk of stream) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : Buffer.from(chunk);
+    byteLength += buffer.byteLength;
+    if (byteLength > MAX_STDIN_JSON_BYTES) {
+      throw new StdinJsonInputError(`--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`);
+    }
+    chunks.push(buffer);
+  }
+
+  const source = Buffer.concat(chunks, byteLength).toString('utf8');
+  if (source.trim().length === 0) {
+    throw new StdinJsonInputError('--stdin-json input is empty');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (err) {
+    throw new StdinJsonInputError('--stdin-json input is not valid JSON', { cause: err });
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new StdinJsonInputError('--stdin-json input must be one JSON object');
+  }
+
+  const stdinArgs = parsed as Record<string, unknown>;
+  const argvKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(argvArgs)) {
+    const canonical = canonicalArgKey(key);
+    if (!argvKeysByCanonical.has(canonical)) argvKeysByCanonical.set(canonical, key);
+  }
+
+  const stdinKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(stdinArgs)) {
+    if (key === '__proto__') {
+      throw new StdinJsonInputError('--stdin-json key "__proto__" is not allowed');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(argvArgs, key)) {
+      throw new StdinJsonInputError(`--stdin-json key "${key}" is also supplied on argv`);
+    }
+
+    const canonical = canonicalArgKey(key);
+    const argvKey = argvKeysByCanonical.get(canonical);
+    if (argvKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json key "${key}" conflicts with argv key "${argvKey}" after CLI key normalization`,
+      );
+    }
+
+    const priorStdinKey = stdinKeysByCanonical.get(canonical);
+    if (priorStdinKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json keys "${priorStdinKey}" and "${key}" conflict after CLI key normalization`,
+      );
+    }
+    stdinKeysByCanonical.set(canonical, key);
+  }
+
+  return Object.fromEntries([...Object.entries(argvArgs), ...Object.entries(stdinArgs)]);
+}

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -23,6 +23,7 @@ import { migration021 } from './021-approval-question.js';
 
 export interface Migration {
   version: number;
+  /** Permanent applied identity. Never rename a migration after release. */
   name: string;
   up: (db: Database.Database) => void;
   /**
@@ -35,6 +36,13 @@ export interface Migration {
    */
   disableForeignKeys?: boolean;
 }
+
+/**
+ * Public module migrations use a core-reserved, owner-qualified identity so
+ * independent modules may reuse local migration names without colliding.
+ */
+export type ModuleMigrationName = `module:${string}:${string}`;
+export type ModuleMigration = Omit<Migration, 'name'> & { name: ModuleMigrationName };
 
 export const migrations: Migration[] = [
   migration001,
@@ -58,6 +66,33 @@ export const migrations: Migration[] = [
   migration021,
 ];
 
+/**
+ * Migrations contributed by self-registering modules.
+ *
+ * When multiple migrations are pending, built-in migrations run first. Module
+ * migrations are not interleaved with built-ins by `version`; they follow the
+ * deterministic import order of their owning modules because the modules
+ * barrel uses explicit side-effect imports.
+ */
+const moduleMigrations: Migration[] = [];
+const MODULE_MIGRATION_NAME_RE = /^module:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/;
+
+export function registerMigration(migration: ModuleMigration): void {
+  if (!MODULE_MIGRATION_NAME_RE.test(migration.name)) {
+    throw new Error(
+      `Module migration "${migration.name}" must use "module:<module-id>:<migration-id>" and remain stable after release`,
+    );
+  }
+  if ([...migrations, ...moduleMigrations].some((candidate) => candidate.name === migration.name)) {
+    throw new Error(`Migration "${migration.name}" already registered`);
+  }
+  moduleMigrations.push(migration);
+}
+
+export function getRegisteredMigrations(): readonly Migration[] {
+  return [...migrations, ...moduleMigrations];
+}
+
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a
  *  parent-table recreate (child tables aren't touched), so this JSON identity
  *  is a reliable before/after diff key. */
@@ -71,7 +106,7 @@ interface FkViolation {
 const fkIdentity = (v: FkViolation): string =>
   JSON.stringify({ table: v.table, rowid: v.rowid, parent: v.parent, fkid: v.fkid });
 
-export function runMigrations(db: Database.Database, list: Migration[] = migrations): void {
+export function runMigrations(db: Database.Database, list: readonly Migration[] = getRegisteredMigrations()): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY,

--- a/src/db/migrations/registry.test.ts
+++ b/src/db/migrations/registry.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Migration, ModuleMigration, ModuleMigrationName } from './index.js';
+
+let closeCurrentDb: (() => void) | undefined;
+
+afterEach(() => {
+  closeCurrentDb?.();
+  closeCurrentDb = undefined;
+});
+
+function testMigration(name: string, table = name.replace(/[^a-zA-Z0-9_]/g, '_'), version = 999): Migration {
+  return {
+    version,
+    name,
+    up(db) {
+      db.exec(`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`);
+    },
+  };
+}
+
+function testModuleMigration(name: ModuleMigrationName, table?: string, version?: number): ModuleMigration {
+  return testMigration(name, table, version) as ModuleMigration;
+}
+
+async function freshRegistry() {
+  vi.resetModules();
+  return import('./index.js');
+}
+
+async function freshTestDb() {
+  const connection = await import('../connection.js');
+  const db = connection.initTestDb();
+  closeCurrentDb = connection.closeDb;
+  return db;
+}
+
+describe('module migration registry', () => {
+  it('keeps built-ins first and module migrations in registration order regardless of version', async () => {
+    const registry = await freshRegistry();
+    const first = testModuleMigration('module:test-first:create-state', undefined, Number.MAX_SAFE_INTEGER);
+    const second = testModuleMigration('module:test-second:create-state', undefined, 0);
+
+    registry.registerMigration(first);
+    registry.registerMigration(second);
+
+    expect(registry.getRegisteredMigrations()).toEqual([...registry.migrations, first, second]);
+  });
+
+  it('reserves the module namespace away from built-in migrations', async () => {
+    const registry = await freshRegistry();
+
+    expect(registry.migrations.every((migration) => !migration.name.startsWith('module:'))).toBe(true);
+  });
+
+  it('rejects an unqualified module migration name at runtime', async () => {
+    const registry = await freshRegistry();
+    const unqualified = testMigration('create-state') as ModuleMigration;
+
+    expect(() => registry.registerMigration(unqualified)).toThrow(
+      'must use "module:<module-id>:<migration-id>" and remain stable after release',
+    );
+  });
+
+  it('rejects duplicate module migration names', async () => {
+    const registry = await freshRegistry();
+    registry.registerMigration(testModuleMigration('module:test-owner:duplicate', 'test_module_duplicate_first'));
+
+    expect(() =>
+      registry.registerMigration(testModuleMigration('module:test-owner:duplicate', 'test_module_duplicate_second')),
+    ).toThrow('Migration "module:test-owner:duplicate" already registered');
+  });
+
+  it('applies and records registered migrations with the default run', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    registry.registerMigration(testModuleMigration('module:test-owner:applied', 'test_module_applied'));
+
+    registry.runMigrations(db);
+
+    expect(db.prepare("SELECT name FROM schema_version WHERE name = 'module:test-owner:applied'").get()).toEqual({
+      name: 'module:test-owner:applied',
+    });
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_applied'").get(),
+    ).toEqual({ name: 'test_module_applied' });
+  });
+
+  it('preserves the explicit migration-list override', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    const explicit = testMigration('test-explicit-only');
+    registry.registerMigration(testModuleMigration('module:test-owner:not-selected', 'test_module_not_selected'));
+
+    registry.runMigrations(db, [explicit]);
+
+    expect(db.prepare('SELECT name FROM schema_version ORDER BY version').all()).toEqual([
+      { name: 'test-explicit-only' },
+    ]);
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_not_selected'").get(),
+    ).toBeUndefined();
+  });
+});

--- a/src/host-lifecycle.test.ts
+++ b/src/host-lifecycle.test.ts
@@ -1,0 +1,178 @@
+import fs from 'fs';
+import path from 'path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe('host module lifecycle registry', () => {
+  it('registration is inert and exposes callbacks for registration proofs', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const start = vi.fn();
+    const stop = vi.fn();
+
+    lifecycle.onHostStart(start);
+    lifecycle.onHostShutdown(stop);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(lifecycle.getHostStartCallbacks()).toEqual([start]);
+    expect(lifecycle.getHostShutdownCallbacks()).toEqual([stop]);
+  });
+
+  it('returns callback snapshots that cannot mutate the registry', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const firstStart = vi.fn();
+    const secondStart = vi.fn();
+    const firstStop = vi.fn();
+    const secondStop = vi.fn();
+
+    lifecycle.onHostStart(firstStart);
+    lifecycle.onHostShutdown(firstStop);
+    const startSnapshot = lifecycle.getHostStartCallbacks();
+    const shutdownSnapshot = lifecycle.getHostShutdownCallbacks();
+
+    lifecycle.onHostStart(secondStart);
+    lifecycle.onHostShutdown(secondStop);
+
+    expect(startSnapshot).toEqual([firstStart]);
+    expect(shutdownSnapshot).toEqual([firstStop]);
+    expect(lifecycle.getHostStartCallbacks()).toEqual([firstStart, secondStart]);
+    expect(lifecycle.getHostShutdownCallbacks()).toEqual([firstStop, secondStop]);
+  });
+
+  it('starts callbacks serially in registration order with the same context', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const order: string[] = [];
+    const controller = new AbortController();
+    const ctx = { db: {} as never, signal: controller.signal };
+
+    lifecycle.onHostStart(async (received) => {
+      expect(received).toBe(ctx);
+      order.push('first-start');
+      await Promise.resolve();
+      order.push('first-end');
+    });
+    lifecycle.onHostStart((received) => {
+      expect(received.signal.aborted).toBe(false);
+      order.push('second');
+    });
+
+    await lifecycle.startHostModules(ctx);
+    controller.abort();
+
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+    expect(ctx.signal.aborted).toBe(true);
+  });
+
+  it('propagates a startup error and does not start later callbacks', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const { log } = await import('./log.js');
+    const later = vi.fn();
+    const failure = new Error('start-sentinel');
+
+    lifecycle.onHostStart(() => {
+      throw failure;
+    });
+    lifecycle.onHostStart(later);
+
+    await expect(lifecycle.startHostModules({ db: {} as never, signal: new AbortController().signal })).rejects.toBe(
+      failure,
+    );
+    expect(later).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith('Host module startup callback threw', { err: failure });
+  });
+
+  it('stops callbacks LIFO, logs the error, and continues', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const { log } = await import('./log.js');
+    const order: string[] = [];
+
+    lifecycle.onHostShutdown(async () => {
+      order.push('first-start');
+      await Promise.resolve();
+      order.push('first-end');
+    });
+    lifecycle.onHostShutdown(() => {
+      order.push('failed');
+      throw new Error('shutdown-sentinel');
+    });
+    lifecycle.onHostShutdown(() => {
+      order.push('last');
+    });
+
+    await lifecycle.stopHostModules();
+
+    expect(order).toEqual(['last', 'failed', 'first-start', 'first-end']);
+    expect(log.error).toHaveBeenCalledWith('Shutdown callback threw', {
+      err: expect.objectContaining({ message: 'shutdown-sentinel' }),
+    });
+  });
+
+  it('preserves legacy shutdown callbacks in FIFO order', async () => {
+    const registry = await import('./response-registry.js');
+    const lifecycle = await import('./host-lifecycle.js');
+    const { log } = await import('./log.js');
+    const order: string[] = [];
+
+    lifecycle.onHostShutdown(() => {
+      order.push('new-module');
+    });
+    registry.onShutdown(() => {
+      order.push('legacy-first');
+    });
+    registry.onShutdown(() => {
+      order.push('legacy-failed');
+      throw new Error('legacy-shutdown-sentinel');
+    });
+    registry.onShutdown(() => {
+      order.push('legacy-last');
+    });
+
+    expect(registry.getShutdownCallbacks()).toHaveLength(3);
+
+    await lifecycle.stopHostModules();
+
+    expect(order).toEqual(['new-module', 'legacy-first', 'legacy-failed', 'legacy-last']);
+    expect(log.error).toHaveBeenCalledWith('Shutdown callback threw', {
+      err: expect.objectContaining({ message: 'legacy-shutdown-sentinel' }),
+    });
+  });
+});
+
+describe('host lifecycle orchestration', () => {
+  it('starts after delivery is ready and before delivery polling', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
+    const deliveryReady = source.indexOf('setDeliveryAdapter(createChannelDeliveryAdapter())');
+    const modulesStart = source.indexOf('await startHostModules(');
+    const pollingStart = source.indexOf('startActiveDeliveryPoll()');
+
+    expect(deliveryReady).toBeGreaterThan(-1);
+    expect(modulesStart).toBeGreaterThan(deliveryReady);
+    expect(pollingStart).toBeGreaterThan(modulesStart);
+  });
+
+  it('aborts modules and awaits their LIFO shutdown before host cleanup', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
+    const abort = source.indexOf('hostAbortController.abort()');
+    const modulesStop = source.indexOf('await stopHostModules()');
+    const pollsStop = source.indexOf('stopDeliveryPolls()');
+
+    expect(abort).toBeGreaterThan(-1);
+    expect(modulesStop).toBeGreaterThan(abort);
+    expect(pollsStop).toBeGreaterThan(modulesStop);
+  });
+});

--- a/src/host-lifecycle.ts
+++ b/src/host-lifecycle.ts
@@ -1,0 +1,72 @@
+/**
+ * Host module lifecycle registry.
+ *
+ * Modules register callbacks at import time. Registration is deliberately
+ * inert: startup work begins only after the database and delivery adapter are
+ * ready, and shutdown work begins only from the host's graceful-shutdown path.
+ */
+import type Database from 'better-sqlite3';
+
+import { log } from './log.js';
+import { getShutdownCallbacks } from './response-registry.js';
+
+export interface HostStartContext {
+  db: Database.Database;
+  signal: AbortSignal;
+}
+
+export type HostStartCallback = (ctx: HostStartContext) => void | Promise<void>;
+export type HostShutdownCallback = () => void | Promise<void>;
+
+const startCallbacks: HostStartCallback[] = [];
+const shutdownCallbacks: HostShutdownCallback[] = [];
+
+export function onHostStart(cb: HostStartCallback): void {
+  startCallbacks.push(cb);
+}
+
+export function onHostShutdown(cb: HostShutdownCallback): void {
+  shutdownCallbacks.push(cb);
+}
+
+export function getHostStartCallbacks(): readonly HostStartCallback[] {
+  return [...startCallbacks];
+}
+
+export function getHostShutdownCallbacks(): readonly HostShutdownCallback[] {
+  return [...shutdownCallbacks];
+}
+
+/** Start registered modules serially. A failed start aborts host startup. */
+export async function startHostModules(ctx: HostStartContext): Promise<void> {
+  for (const cb of [...startCallbacks]) {
+    try {
+      await cb(ctx);
+    } catch (err) {
+      log.error('Host module startup callback threw', { err });
+      throw err;
+    }
+  }
+}
+
+async function runShutdownCallbacks(callbacks: readonly HostShutdownCallback[]): Promise<void> {
+  for (const cb of callbacks) {
+    /* eslint-disable no-catch-all/no-catch-all -- graceful shutdown must continue through every registered cleanup */
+    try {
+      await cb();
+    } catch (err) {
+      log.error('Shutdown callback threw', { err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
+  }
+}
+
+/**
+ * Stop registered modules serially in reverse registration order, then retain
+ * FIFO execution for callbacks registered through the legacy shutdown API.
+ * One failed cleanup must not prevent later callbacks or host cleanup.
+ */
+export async function stopHostModules(): Promise<void> {
+  await runShutdownCallbacks([...shutdownCallbacks].reverse());
+  await runShutdownCallbacks(getShutdownCallbacks());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,18 @@ import { runMigrations } from './db/migrations/index.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { startHostModules, stopHostModules } from './host-lifecycle.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
 import { enforceUpgradeTripwire } from './upgrade-state.js';
 
-// Response + shutdown registries live in response-registry.ts to break the
+// Response registry lives in response-registry.ts to break the
 // circular import cycle: src/index.ts imports src/modules/index.js for side
-// effects, and the modules call registerResponseHandler/onShutdown at top
-// level — which would hit a TDZ error if the arrays lived here. Re-exported
-// here so existing callers see the same surface.
-import { getResponseHandlers, getShutdownCallbacks, type ResponsePayload } from './response-registry.js';
+// effects, and the modules call registerResponseHandler at top level — which
+// would hit a TDZ error if the array lived here.
+import { getResponseHandlers, type ResponsePayload } from './response-registry.js';
+
+const hostAbortController = new AbortController();
 
 async function dispatchResponse(payload: ResponsePayload): Promise<void> {
   for (const handler of getResponseHandlers()) {
@@ -146,16 +148,20 @@ async function main(): Promise<void> {
   // createChannelDeliveryAdapter in channels/channel-registry.ts.
   setDeliveryAdapter(createChannelDeliveryAdapter());
 
-  // 5. Start delivery polls
+  // 5. Start registered host modules. Imports only registered callbacks; the
+  // actual work begins here, after DB + delivery are ready and before polls.
+  await startHostModules({ db, signal: hostAbortController.signal });
+
+  // 6. Start delivery polls
   startActiveDeliveryPoll();
   startSweepDeliveryPoll();
   log.info('Delivery polls started');
 
-  // 6. Start host sweep
+  // 7. Start host sweep
   startHostSweep();
   log.info('Host sweep started');
 
-  // 7. Start the `ncl` CLI socket server (data/ncl.sock).
+  // 8. Start the `ncl` CLI socket server (data/ncl.sock).
   await startCliServer();
 
   log.info('NanoClaw running');
@@ -164,13 +170,8 @@ async function main(): Promise<void> {
 /** Graceful shutdown. */
 async function shutdown(signal: string): Promise<void> {
   log.info('Shutdown signal received', { signal });
-  for (const cb of getShutdownCallbacks()) {
-    try {
-      await cb();
-    } catch (err) {
-      log.error('Shutdown callback threw', { err });
-    }
-  }
+  hostAbortController.abort();
+  await stopHostModules();
   stopDeliveryPolls();
   stopHostSweep();
   await stopCliServer();

--- a/src/modules/permissions/user-dm.test.ts
+++ b/src/modules/permissions/user-dm.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+import type { ChannelAdapter } from '../../channels/adapter.js';
+import {
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from '../../channels/channel-registry.js';
+import { closeDb, getDb, initTestDb } from '../../db/connection.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { log } from '../../log.js';
+import { createUser } from './db/users.js';
+import { upsertUserDm } from './db/user-dms.js';
+import { ensureUserDm } from './user-dm.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedUser(id: string, kind: string): void {
+  createUser({ id, kind, display_name: null, created_at: now() });
+}
+
+function registerTestAdapter(channelType: string, openDM?: (handle: string) => Promise<string>): void {
+  const adapter: ChannelAdapter = {
+    name: channelType,
+    channelType,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected: () => true,
+    async deliver() {
+      return undefined;
+    },
+  };
+  if (openDM) adapter.openDM = openDM;
+  registerChannelAdapter(channelType, { factory: () => adapter });
+}
+
+async function startRegisteredAdapters(): Promise<void> {
+  await initChannelAdapters(() => ({
+    conversations: [],
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  closeDb();
+});
+
+describe('ensureUserDm privacy-safe logging', () => {
+  it('preserves the existing detailed log shape by default', async () => {
+    const failure = new Error('default-sdk-error-sentinel');
+    registerTestAdapter('legacy-default', async () => {
+      throw failure;
+    });
+    await startRegisteredAdapters();
+    seedUser('legacy-default:default-handle-sentinel', 'legacy-default');
+
+    await expect(ensureUserDm('legacy-default:default-handle-sentinel')).resolves.toBeNull();
+
+    expect(log.error).toHaveBeenCalledWith('ensureUserDm: adapter.openDM failed', {
+      channelType: 'legacy-default',
+      handle: 'default-handle-sentinel',
+      err: failure,
+    });
+  });
+
+  it('omits identities, messaging-group ids, and SDK errors when requested', async () => {
+    registerTestAdapter('privacy-error', async () => {
+      throw new Error('private-sdk-error-sentinel');
+    });
+    registerTestAdapter('privacy-direct');
+    await startRegisteredAdapters();
+
+    seedUser('privacy-error:private-handle-sentinel', 'privacy-error');
+    seedUser('privacy-direct:stale-handle-sentinel', 'privacy-direct');
+    seedUser('invalid-user-private-sentinel', 'invalid-kind');
+
+    createMessagingGroup({
+      id: 'messaging-group-private-sentinel',
+      channel_type: 'privacy-direct',
+      platform_id: 'old-platform-private-sentinel',
+      name: null,
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    upsertUserDm({
+      user_id: 'privacy-direct:stale-handle-sentinel',
+      channel_type: 'privacy-direct',
+      messaging_group_id: 'messaging-group-private-sentinel',
+      resolved_at: now(),
+    });
+    getDb().pragma('foreign_keys = OFF');
+    getDb().prepare("DELETE FROM messaging_groups WHERE id = 'messaging-group-private-sentinel'").run();
+    getDb().pragma('foreign_keys = ON');
+
+    const options = { privacySafeLogs: true };
+    await expect(ensureUserDm('unknown-user-private-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('invalid-user-private-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-error:private-handle-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-direct:stale-handle-sentinel', options)).resolves.toBeDefined();
+
+    expect(log.error).toHaveBeenCalledWith('ensureUserDm: adapter.openDM failed', {
+      channelType: 'privacy-error',
+    });
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user not found', undefined);
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user id not namespaced', undefined);
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: cached row references missing messaging_group, re-resolving', {
+      channelType: 'privacy-direct',
+    });
+    expect(log.info).toHaveBeenCalledWith('ensureUserDm: created DM messaging_group', {
+      channelType: 'privacy-direct',
+    });
+
+    const serializedLogs = JSON.stringify({
+      info: vi.mocked(log.info).mock.calls,
+      warn: vi.mocked(log.warn).mock.calls,
+      error: vi.mocked(log.error).mock.calls,
+    });
+    for (const sentinel of [
+      'unknown-user-private-sentinel',
+      'invalid-user-private-sentinel',
+      'private-handle-sentinel',
+      'stale-handle-sentinel',
+      'messaging-group-private-sentinel',
+      'old-platform-private-sentinel',
+      'private-sdk-error-sentinel',
+    ]) {
+      expect(serializedLogs).not.toContain(sentinel);
+    }
+  });
+});

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -48,17 +48,22 @@ import { getUserDm, upsertUserDm } from './db/user-dms.js';
  *   - openDM throws (platform error, user blocked bot, etc.)
  *
  * Callers should treat null as "this user is unreachable on this channel".
+ * Set privacySafeLogs for security-sensitive flows to omit user, handle,
+ * messaging-group, and raw platform-error details from log data.
  */
-export async function ensureUserDm(userId: string): Promise<MessagingGroup | null> {
+export async function ensureUserDm(
+  userId: string,
+  { privacySafeLogs = false }: { privacySafeLogs?: boolean } = {},
+): Promise<MessagingGroup | null> {
   const user = getUser(userId);
   if (!user) {
-    log.warn('ensureUserDm: user not found', { userId });
+    log.warn('ensureUserDm: user not found', privacySafeLogs ? undefined : { userId });
     return null;
   }
 
   const { channelType, handle } = parseUserId(user);
   if (!channelType || !handle) {
-    log.warn('ensureUserDm: user id not namespaced', { userId });
+    log.warn('ensureUserDm: user id not namespaced', privacySafeLogs ? undefined : { userId });
     return null;
   }
 
@@ -68,14 +73,14 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
     const mg = getMessagingGroup(cached.messaging_group_id);
     if (mg) return mg;
     // Row points to a deleted messaging_group — fall through and re-resolve.
-    log.warn('ensureUserDm: cached row references missing messaging_group, re-resolving', {
-      userId,
-      messagingGroupId: cached.messaging_group_id,
-    });
+    log.warn(
+      'ensureUserDm: cached row references missing messaging_group, re-resolving',
+      privacySafeLogs ? { channelType } : { userId, messagingGroupId: cached.messaging_group_id },
+    );
   }
 
   // Cache miss: resolve the DM platform_id either via openDM or directly.
-  const dmPlatformId = await resolveDmPlatformId(channelType, handle);
+  const dmPlatformId = await resolveDmPlatformId(channelType, handle, privacySafeLogs);
   if (!dmPlatformId) return null;
 
   // Find-or-create the underlying messaging_group. A DM we received
@@ -98,11 +103,10 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
       created_at: now,
     };
     createMessagingGroup(mg);
-    log.info('ensureUserDm: created DM messaging_group', {
-      userId,
-      channelType,
-      messagingGroupId: mgId,
-    });
+    log.info(
+      'ensureUserDm: created DM messaging_group',
+      privacySafeLogs ? { channelType } : { userId, channelType, messagingGroupId: mgId },
+    );
   }
 
   upsertUserDm({
@@ -119,7 +123,11 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
  * Call the adapter's openDM if it has one; otherwise fall through to using
  * the handle directly. Returns null if the adapter is missing entirely.
  */
-async function resolveDmPlatformId(channelType: string, handle: string): Promise<string | null> {
+async function resolveDmPlatformId(
+  channelType: string,
+  handle: string,
+  privacySafeLogs: boolean,
+): Promise<string | null> {
   const adapter = getChannelAdapter(channelType);
   if (!adapter) {
     log.warn('ensureUserDm: no adapter for channel', { channelType });
@@ -129,12 +137,14 @@ async function resolveDmPlatformId(channelType: string, handle: string): Promise
     // Direct-addressable channel — handle doubles as the DM chat id.
     return handle;
   }
+  /* eslint-disable no-catch-all/no-catch-all -- platform DM resolution failure makes this user unreachable */
   try {
     return await adapter.openDM(handle);
   } catch (err) {
-    log.error('ensureUserDm: adapter.openDM failed', { channelType, handle, err });
+    log.error('ensureUserDm: adapter.openDM failed', privacySafeLogs ? { channelType } : { channelType, handle, err });
     return null;
   }
+  /* eslint-enable no-catch-all/no-catch-all */
 }
 
 function parseUserId(user: User): { channelType: string; handle: string } | { channelType: null; handle: null } {

--- a/src/response-registry.ts
+++ b/src/response-registry.ts
@@ -1,11 +1,12 @@
 /**
- * Response handler + shutdown callback registries.
+ * Response handler registry and legacy shutdown compatibility.
  *
  * Extracted from index.ts so that modules calling `registerResponseHandler()`
- * or `onShutdown()` at import time don't hit a TDZ error on the const-array
- * declarations. index.ts imports src/modules/index.js for its side effects,
- * which triggers module registrations that would otherwise happen before
- * index.ts's own const initializers have run.
+ * at import time don't hit a TDZ error on the const-array declaration.
+ * index.ts imports src/modules/index.js for its side effects, which triggers
+ * module registrations that would otherwise happen before index.ts's own
+ * const initializers have run. New host start/shutdown hooks live in
+ * host-lifecycle.ts; the legacy shutdown API remains here for compatibility.
  *
  * Keep this file dependency-free (log.js is fine, but nothing from
  * modules/* or index.ts itself). Any file imported here must not in turn
@@ -36,10 +37,15 @@ export function getResponseHandlers(): readonly ResponseHandler[] {
 type ShutdownCallback = () => void | Promise<void>;
 const shutdownCallbacks: ShutdownCallback[] = [];
 
+/**
+ * @deprecated Existing callers retain FIFO ordering. New modules should use
+ * `onHostShutdown()` from host-lifecycle.ts.
+ */
 export function onShutdown(cb: ShutdownCallback): void {
   shutdownCallbacks.push(cb);
 }
 
+/** @deprecated Used to inspect callbacks registered through `onShutdown()`. */
 export function getShutdownCallbacks(): readonly ShutdownCallback[] {
   return shutdownCallbacks;
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Add small, typed host extension seams so an optional TypeScript module can own one responsibility and integrate through explicit registration instead of spreading implementation across core files.

### Logical changes

| Area | Change | Compatibility |
|---|---|---|
| Skill authoring | Document single responsibility, the Open/Closed Principle, skill-owned files, and minimal integration through the owning typed seam. | Guidance only. Existing skills are unchanged. |
| Database migrations | Allow modules to register owner-qualified migrations after the built-in migration list. Public names must use the stable `module:<module-id>:<migration-id>` identity. | Built-in migration order and execution remain unchanged; independent modules can reuse local migration names without collisions. |
| Host lifecycle | Add registration-only start/shutdown hooks. Starts run after the database and delivery adapter are ready; shutdown aborts the shared signal and runs cleanups in reverse registration order. | The existing approval cleanup moves to this host-owned lifecycle with the same single callback behavior. |
| Question rendering | Add ordered render resolvers with the existing database lookup as the final fallback. | Existing question and approval cards keep their current fallback behavior. |
| Direct-message logs | Add an opt-in privacy-safe logging mode to `ensureUserDm()`. | The default call path preserves the existing messages and metadata. |
| CLI structured input | Add bounded client-side `--stdin-json` parsing and merge one JSON object with argv flags before transport. | The wire frame, command registry, dispatcher, approval replay, and command parsing remain unchanged; `--json` remains output formatting. |

The response-handler registry and dispatch semantics are unchanged; lifecycle ownership is simply separated from response routing.

### Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm format:check`
- Focused dispatcher, migration, stdin unit, and real CLI/socket E2E tests — 4 files, 82 tests passed
- `pnpm test` — 105 files, 1,303 tests passed
- ESLint on every changed TypeScript file — 0 errors; remaining warnings are existing patterns in shared files

The repository-wide lint command still reports unrelated existing errors outside this diff.
