### PR TITLE
fix(agent-runner): disallow built-in SendMessage so agent-to-agent messaging works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- **Agent-to-agent messaging no longer loses to Claude Code's built-in `SendMessage`.** That built-in addresses the SDK's own in-session subagents, so an agent that had just run `create_agent` reached for it by name and got `No agent named 'x' is currently addressable` — reading as "the group was never provisioned" while `mcp__nanoclaw__send_message` (the real path) was never called. `SendMessage` joins `AskUserQuestion` in `SDK_DISALLOWED_TOOLS`, so the PreToolUse hook now blocks it and points at the nanoclaw equivalent.
 - [BREAKING] **Existing Claude installs should review the hardened agent image.** Local builds remain supported, but the Echo-built image is recommended for patched sandbox components. **Migration:** follow [the hardened-image guide](docs/hardened-image.md) to detect your current image source, switch, verify, or roll back.
 - **Release publication tolerates GitHub API propagation.** The Release workflow now retries bounded post-publication read-backs when the new Release is not listed yet or its immutable state is not visible yet. Exact title, body, tag, or SHA mismatches still fail immediately.
 

--- a/container/agent-runner/src/providers/claude.tool-collisions.test.ts
+++ b/container/agent-runner/src/providers/claude.tool-collisions.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'bun:test';
+
+import { SDK_DISALLOWED_TOOLS, TOOL_ALLOWLIST } from './claude.js';
+
+// Built-in Claude Code tools whose NAME reads as the obvious way to do
+// something NanoClaw already models differently. Leaving one of these
+// available is a silent failure: the agent calls the built-in, gets a
+// coherent-sounding refusal about a subsystem NanoClaw doesn't use, and
+// reports that NanoClaw is broken.
+//
+// SendMessage is the regression this guards. It addresses Claude Code's own
+// in-session subagents; an agent that had just created a NanoClaw agent group
+// called it four times and read "No agent named 'growth' is currently
+// addressable" as "the group was never provisioned".
+const COLLIDES_WITH_NANOCLAW_MCP: Array<[builtin: string, mcpEquivalent: string]> = [
+  ['SendMessage', 'mcp__nanoclaw__send_message'],
+  ['AskUserQuestion', 'mcp__nanoclaw__ask_user_question'],
+];
+
+describe('built-in tools that collide with NanoClaw MCP tools', () => {
+  for (const [builtin, mcpEquivalent] of COLLIDES_WITH_NANOCLAW_MCP) {
+    it(`${builtin} is disallowed in favour of ${mcpEquivalent}`, () => {
+      expect(SDK_DISALLOWED_TOOLS).toContain(builtin);
+      expect(TOOL_ALLOWLIST).not.toContain(builtin);
+    });
+  }
+
+  it('no tool is both allowlisted and disallowed', () => {
+    const overlap = TOOL_ALLOWLIST.filter((t) => SDK_DISALLOWED_TOOLS.includes(t));
+    expect(overlap).toEqual([]);
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -73,18 +73,25 @@ export function classifyRateLimitEvent(
 // - AskUserQuestion: SDK returns a placeholder instead of blocking on a
 //   real answer — we have mcp__nanoclaw__ask_user_question that persists
 //   the question and blocks on the real reply.
+// - SendMessage: addresses Claude Code's own in-session subagents, which are
+//   unrelated to NanoClaw agent groups — but the name reads as the obvious
+//   way to message another agent, so an agent that just called
+//   mcp__nanoclaw__create_agent reaches for it and gets "No agent named 'x'
+//   is currently addressable". mcp__nanoclaw__send_message is the real
+//   agent-to-agent path (it resolves the destination map in inbound.db).
 // - EnterPlanMode / ExitPlanMode / EnterWorktree / ExitWorktree: Claude
 //   Code UI affordances; in a headless container they'd appear stuck.
 // - DesignSync: desktop design-tool integration — nothing to sync with in a
 //   headless container (~9.3KB/turn schema).
 // - ReportFindings: code-review-reporting UI affordance with no headless
 //   host surface to receive it (~1.9KB/turn schema).
-const SDK_DISALLOWED_TOOLS = [
+export const SDK_DISALLOWED_TOOLS = [
   'CronCreate',
   'CronDelete',
   'CronList',
   'ScheduleWakeup',
   'AskUserQuestion',
+  'SendMessage',
   'EnterPlanMode',
   'ExitPlanMode',
   'EnterWorktree',
@@ -98,7 +105,7 @@ const SDK_DISALLOWED_TOOLS = [
 // added via `add_mcp_server` (or wired in container.json directly) is
 // reachable to the agent — without this, the SDK's allowedTools filter
 // silently drops every MCP namespace not listed here.
-const TOOL_ALLOWLIST = [
+export const TOOL_ALLOWLIST = [
   'Bash',
   'Read',
   'Write',
@@ -112,7 +119,6 @@ const TOOL_ALLOWLIST = [
   'TaskStop',
   'TeamCreate',
   'TeamDelete',
-  'SendMessage',
   'TodoWrite',
   'ToolSearch',
   'Skill',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What.** Move `SendMessage` from `TOOL_ALLOWLIST` to `SDK_DISALLOWED_TOOLS` in `container/agent-runner/src/providers/claude.ts`.

**Why.** Claude Code's built-in `SendMessage` addresses the SDK's own in-session subagents, which have nothing to do with NanoClaw agent groups. But the name reads as the obvious way to message another agent, so an agent that has just run `mcp__nanoclaw__create_agent` reaches for it instead of `mcp__nanoclaw__send_message`.

The failure is silent and misleading. The built-in answers:

```
{"success":false,"message":"No agent named 'growth' is currently addressable. Spawn a new one or use the agent ID."}
```

The agent reads that as "the group was never provisioned", so it retries the same wrong tool instead of the working one. Observed on a live install: `create_agent` succeeded (agent group row, group filesystem, and both `agent_destinations` rows all written, destination projected into `inbound.db`), but the parent agent called `SendMessage` four times over three minutes, never called `mcp__nanoclaw__send_message`, wrote nothing to `messages_out`, and reported to its user that agent creation had failed.

Transcript excerpt from the container (`~/.claude/projects/.../<session>.jsonl`):

```
05:37:03 CALL   mcp__nanoclaw__create_agent {"name":"Growth", ...}
         RESULT "Creating agent \"Growth\". You will be notified when it is ready."
05:37:56 CALL   SendMessage {"to":"Growth", ...}
         RESULT {"success":false,"message":"No agent named 'Growth' is currently addressable..."}
05:38:43 CALL   SendMessage {"to":"growth", ...}   -> same
05:38:51 CALL   SendMessage {"to":"growth", ...}   -> same
05:40:21 CALL   SendMessage {"to":"growth", ...}   -> same
```

**How it works.** `SDK_DISALLOWED_TOOLS` already exists for exactly this class of built-in — one that collides with a nanoclaw equivalent (`AskUserQuestion` vs `mcp__nanoclaw__ask_user_question`, the Cron tools vs `ncl tasks`). `SendMessage` is the same case and was just missed. Entries on that list go through `preToolUseHook`, which blocks the call and returns `Tool 'SendMessage' is not available in this environment — use the nanoclaw equivalent.`

Removing it from `TOOL_ALLOWLIST` alone would not have helped: that list is a permission auto-approve list, and this runner already sets `permissionMode: 'bypassPermissions'`. The PreToolUse hook is the deterministic block.

Both lists are now exported so the regression test can assert the invariant directly; nothing else changed about them.

## How it was tested

- New `container/agent-runner/src/providers/claude.tool-collisions.test.ts` asserts each colliding built-in is in `SDK_DISALLOWED_TOOLS`, absent from `TOOL_ALLOWLIST`, and that the two lists never overlap.
- `cd container/agent-runner && bun test` — 159 pass, 1 skip, 0 fail.
- `bun run typecheck` — clean.
- `pnpm test` (host) — 1262 pass across 99 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)