### PR TITLE
fix(container): forward OneCLI gateway env to spawned MCP servers

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -30,6 +30,7 @@ import { buildSystemPromptAddendum } from './destinations.js';
 import { getTaskSeriesId } from './db/session-routing.js';
 import { ensureMemoryScaffold } from './memory/scaffold.js';
 import { MEMORY_SESSION_HOOK } from './memory/session-hook.js';
+import { withGatewayEnv } from './mcp-gateway-env.js';
 // Providers barrel — each enabled provider self-registers on import.
 // Provider skills append imports to providers/index.ts.
 import './providers/index.js';
@@ -93,7 +94,10 @@ async function main(): Promise<void> {
   };
 
   for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
-    mcpServers[name] = serverConfig;
+    // Forward the OneCLI gateway's proxy/CA env so this server's own outbound
+    // HTTPS calls get transparent credential injection instead of needing a
+    // raw API key embedded in its `env` — see mcp-gateway-env.ts.
+    mcpServers[name] = { ...serverConfig, env: withGatewayEnv(serverConfig.env) };
     log(`Additional MCP server: ${name} (${serverConfig.command})`);
   }
 

--- a/container/agent-runner/src/mcp-gateway-env.test.ts
+++ b/container/agent-runner/src/mcp-gateway-env.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test';
+
+import { gatewayEnv, withGatewayEnv } from './mcp-gateway-env.js';
+
+describe('gatewayEnv', () => {
+  it('picks up known gateway keys and ignores unrelated ones', () => {
+    const source = {
+      HTTPS_PROXY: 'http://x:tok@127.0.0.1:10255',
+      NODE_EXTRA_CA_CERTS: '/tmp/ca.pem',
+      UNRELATED_VAR: 'should-not-appear',
+    };
+    expect(gatewayEnv(source)).toEqual({
+      HTTPS_PROXY: 'http://x:tok@127.0.0.1:10255',
+      NODE_EXTRA_CA_CERTS: '/tmp/ca.pem',
+    });
+  });
+
+  it('returns an empty object when no gateway keys are present', () => {
+    expect(gatewayEnv({ FOO: 'bar' })).toEqual({});
+  });
+});
+
+describe('withGatewayEnv', () => {
+  const source = {
+    HTTPS_PROXY: 'http://x:tok@127.0.0.1:10255',
+    SSL_CERT_FILE: '/tmp/ca.pem',
+  };
+
+  it('forwards gateway env into a server with no explicit env', () => {
+    expect(withGatewayEnv(undefined, source)).toEqual(source);
+  });
+
+  it('merges gateway env with an explicit env', () => {
+    expect(withGatewayEnv({ EXA_API_KEY: 'abc' }, source)).toEqual({
+      ...source,
+      EXA_API_KEY: 'abc',
+    });
+  });
+
+  it('lets an explicit value win over the gateway default on key collision', () => {
+    expect(withGatewayEnv({ HTTPS_PROXY: 'http://explicit-override:1' }, source)).toEqual({
+      HTTPS_PROXY: 'http://explicit-override:1',
+      SSL_CERT_FILE: '/tmp/ca.pem',
+    });
+  });
+});

--- a/container/agent-runner/src/mcp-gateway-env.ts
+++ b/container/agent-runner/src/mcp-gateway-env.ts
@@ -1,0 +1,52 @@
+/**
+ * OneCLI gateway networking vars (HTTPS_PROXY + CA trust) that route and
+ * authenticate outbound HTTPS calls through the credential vault. The
+ * container process gets these injected by the host (see
+ * `onecli.applyContainerConfig` in `src/container-runner.ts`), but MCP
+ * servers spawned over stdio start with a bare environment (HOME/PATH/etc
+ * only — `@modelcontextprotocol/sdk`'s `getDefaultEnvironment()`) and never
+ * see them unless explicitly forwarded. Without this, a third-party MCP
+ * server wired via `add_mcp_server` has no way to reach OneCLI-vaulted
+ * credentials transparently — the operator would have to embed raw API keys
+ * in its `env` instead, which is exactly what the gateway model exists to
+ * avoid.
+ */
+export const GATEWAY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'NODE_EXTRA_CA_CERTS',
+  'NODE_USE_ENV_PROXY',
+  'SSL_CERT_FILE',
+  'REQUESTS_CA_BUNDLE',
+  'CURL_CA_BUNDLE',
+  'GIT_SSL_CAINFO',
+  'GIT_HTTP_PROXY_AUTHMETHOD',
+  'GIT_TERMINAL_PROMPT',
+  'DENO_CERT',
+] as const;
+
+/** Gateway env vars present in `source` (defaults to process.env). */
+export function gatewayEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of GATEWAY_ENV_KEYS) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/**
+ * Merge gateway env into a third-party MCP server's own env. An explicit
+ * value the operator set on the server itself wins over the gateway default
+ * on key collision — the forwarding is a default, not an override.
+ */
+export function withGatewayEnv(
+  env: Record<string, string> | undefined,
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  return { ...gatewayEnv(source), ...(env ?? {}) };
+}


### PR DESCRIPTION
## What

MCP servers spawned as stdio child processes (via `add_mcp_server` or `container.json` directly) start with a bare environment — `@modelcontextprotocol/sdk`'s `getDefaultEnvironment()` only carries `HOME`/`LOGNAME`/`PATH`/`SHELL`/`TERM`/`USER`. They never see the `HTTPS_PROXY`/CA-trust vars the host injects at the container level for OneCLI's credential gateway (`onecli.applyContainerConfig()` in `src/container-runner.ts`). This forwards those gateway vars into each spawned server's own `env` (explicit config wins on collision).

## Why

Without this, a `"onecli-managed"` placeholder in a third-party MCP server's `env` just gets sent to the origin API literally — the gateway never sees the request to rewrite it. The only way to actually authenticate such a server today is a raw API key embedded in plaintext in `container.json`, which defeats the point of the OneCLI vault model.

Closes #2636.

## How it works

New `container/agent-runner/src/mcp-gateway-env.ts`: `withGatewayEnv(env)` merges a fixed allowlist of proxy/CA env keys (`HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`, `NODE_USE_ENV_PROXY`, etc.) from `process.env` into a server's own `env`, with the server's explicit values winning on key collision. Wired into `index.ts`'s existing loop over `config.mcpServers` — a one-line change at the integration point, no new config surface.

## How it was tested

`bun test` (new `mcp-gateway-env.test.ts`, unit-level merge/precedence behavior) plus end-to-end against four real MCP servers with `"onecli-managed"` placeholders and matching OneCLI vault secrets (host-pattern + header injection): `github-mcp-server` (Go binary), `mcp-remote`/huggingface, `exa-mcp-server`, `@upstash/context7-mcp` (all three Node servers use `undici` under the hood). All four authenticated successfully through the gateway with zero raw keys left in `container.json` — verified live via real tool calls (`get_me`, a web search, an authenticated HF check, and `resolve-library-id`).

## Known limitation

This only helps clients that honor `NODE_USE_ENV_PROXY` (native `fetch`/undici). `axios`-based MCP servers (e.g. `@notionhq/notion-mcp-server`) won't pick this up — that needs something like the `NODE_OPTIONS` monkey-patch approach from #2330 (closed, unmerged) on top. Filing this as the general-case fix since it's the fix #2636 asked for; the axios case is a narrower follow-up.