### PR TITLE
fix(whatsapp): bound setup() to a timeout so a logged-out session can't hang host startup

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -977,11 +977,31 @@ registerChannelAdapter('whatsapp', {
       async setup(hostConfig: ChannelSetup) {
         setupConfig = hostConfig;
 
-        // Connect and wait for first open
+        // Connect and wait for first open, but never longer than
+        // SETUP_TIMEOUT_MS: initChannelAdapters() awaits every adapter's
+        // setup() sequentially, so an unattended QR/pairing wait here (no
+        // `open`, no `close`/loggedOut either) would otherwise hang the
+        // whole host — no other channel connects, no scheduled task fires —
+        // with nothing logged to explain why. Connection continues in the
+        // background past the timeout; resolveFirstOpen/rejectFirstOpen are
+        // nulled out by whichever settles first, so this is a no-op once the
+        // real connection resolves normally.
+        const SETUP_TIMEOUT_MS = 45_000;
         await new Promise<void>((resolve, reject) => {
           resolveFirstOpen = resolve;
           rejectFirstOpen = reject;
           connectSocket().catch(reject);
+          setTimeout(() => {
+            if (resolveFirstOpen) {
+              log.warn(
+                'WhatsApp did not reach connection:open within timeout — continuing host startup, connecting in background',
+                { timeoutMs: SETUP_TIMEOUT_MS },
+              );
+              resolveFirstOpen();
+              resolveFirstOpen = undefined;
+              rejectFirstOpen = undefined;
+            }
+          }, SETUP_TIMEOUT_MS);
         });
 
         log.info('WhatsApp adapter initialized');


### PR DESCRIPTION
## Summary

`ChannelAdapter.setup()` in `src/channels/whatsapp.ts` awaits an unbounded `Promise` for Baileys' first `connection: open` event. If the linked WhatsApp session is logged out and nobody is present to re-scan a QR/pairing code, that event never fires — and it isn't a `close`/`loggedOut` event either, so the existing reject path never triggers.

Since `initChannelAdapters()` (`src/channels/channel-registry.ts`) awaits each channel adapter's `setup()` sequentially before moving to the next, a stuck WhatsApp `setup()` blocks **every other channel** and all post-init host work (delivery poll, host sweep, scheduled tasks) indefinitely, with nothing logged to explain why.

Observed in the wild: a logged-out WhatsApp session stalled an entire host for ~57 minutes after a VPS restart, with no channel delivering and no scheduled tasks firing, before the cause was tracked down.

## Fix

Race the first-open wait against a 45s timeout in `adapter.setup()`. If the timeout fires first, resolve anyway (with a `warn` log) and let the socket keep connecting in the background. The existing `open`/`loggedOut` handlers (`resolveFirstOpen`/`rejectFirstOpen`) still fire normally afterward and are no-ops if the timeout already resolved — both paths null out the refs after firing, so there's no double-settle.

## Test plan

- [x] Verified against a logged-out WhatsApp session on a live host: without the fix, host startup hangs indefinitely; with the fix, startup proceeds after 45s with a warn log, and the WhatsApp adapter connects normally in the background once re-linked.
- [ ] CI (typecheck/tests) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)