### PR TITLE
Add Mattermost channel integration (v2 ChannelAdapter)

### DIFF
--- a/.claude/skills/add-mattermost/REMOVE.md
+++ b/.claude/skills/add-mattermost/REMOVE.md
@@ -1,0 +1,6 @@
+# Remove Mattermost Channel
+
+1. Comment out `import './mattermost.js'` in `src/channels/index.ts`
+2. Remove `MATTERMOST_BASE_URL` and `MATTERMOST_BOT_TOKEN` from `.env`
+3. `pnpm uninstall chat-adapter-mattermost`
+4. Rebuild and restart

--- a/.claude/skills/add-mattermost/SKILL.md
+++ b/.claude/skills/add-mattermost/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: add-mattermost
+description: Add Mattermost channel integration via Chat SDK.
+---
+
+# Add Mattermost Channel
+
+Adds Mattermost support via the Chat SDK bridge, wrapping the community
+[`chat-adapter-mattermost`](https://github.com/thiagoferolla/chat-adapter-mattermost)
+package. Events arrive over an outbound WebSocket (`/api/v4/websocket`) — no
+public URL or webhook is needed for basic messaging.
+
+## Install
+
+NanoClaw doesn't ship channels in trunk. This skill copies the Mattermost
+adapter in from the `channels` branch.
+
+### Pre-flight (idempotent)
+
+Skip to **Credentials** if all of these are already in place:
+
+- `src/channels/mattermost.ts` exists
+- `src/channels/index.ts` contains `import './mattermost.js';`
+- `chat-adapter-mattermost` is listed in `package.json` dependencies
+
+Otherwise continue. Every step below is safe to re-run.
+
+### 1. Fetch the channels branch
+
+```bash
+git fetch origin channels
+```
+
+### 2. Copy the adapter and registration test
+
+```bash
+git show origin/channels:src/channels/mattermost.ts > src/channels/mattermost.ts
+git show origin/channels:src/channels/mattermost-registration.test.ts > src/channels/mattermost-registration.test.ts
+```
+
+### 3. Append the self-registration import
+
+Append to `src/channels/index.ts` (skip if the line is already present):
+
+```typescript
+import './mattermost.js';
+```
+
+### 4. Install the adapter package (pinned)
+
+`chat-adapter-mattermost` is an unscoped, community-maintained package (one
+individual maintainer, a handful of releases) — a materially higher risk tier
+than the official `@chat-adapter/*` packages, so pin it exactly:
+
+```bash
+pnpm install chat-adapter-mattermost@1.1.3
+```
+
+### 5. Build and validate
+
+```bash
+pnpm run build
+pnpm exec vitest run src/channels/mattermost-registration.test.ts
+```
+
+`mattermost-registration.test.ts` imports the real channel barrel and asserts
+the registry contains `mattermost`. It goes red if the import line is deleted
+or drifts, or if `chat-adapter-mattermost` isn't installed (the import
+throws). End-to-end delivery against a real server is verified manually once
+the service runs.
+
+## Credentials
+
+Mattermost has no interactive OAuth app flow like Slack — auth is a single
+bot account token.
+
+### Create the bot account
+
+1. Enable bot account creation if it isn't already: **System Console →
+   Integrations → Bot Accounts → "Enable Bot Account Creation"** (requires a
+   System Admin).
+2. Still in **System Console → Integrations → Bot Accounts**, click **Add Bot
+   Account**. Give it a username (e.g. `nanoclaw`) and display name, then
+   create it.
+3. Copy the **Access Token** shown immediately after creation — it is only
+   ever displayed at creation time.
+4. Invite the bot to any team/channel it should participate in (add it like a
+   regular member, or an admin can add it via the API). Bot accounts don't
+   auto-join channels.
+
+If the token is lost, generate a new one from the same Bot Accounts screen
+(**select the bot → "Create New Token"**) — this does **not** revoke the old
+token; both remain valid simultaneously. Explicitly deactivate the old token
+from the same screen if you want it revoked.
+
+### Configure environment
+
+```bash
+MATTERMOST_BASE_URL=https://mattermost.example.com
+MATTERMOST_BOT_TOKEN=your-bot-access-token
+```
+
+`MATTERMOST_BASE_URL` must include the scheme and no trailing slash.
+
+Sync to container: `mkdir -p data/env && cp .env data/env/env`
+
+### Confirm the token works
+
+```bash
+curl -sf "$MATTERMOST_BASE_URL/api/v4/users/me" -H "Authorization: Bearer $MATTERMOST_BOT_TOKEN" | jq -er '"@" + .username'
+```
+
+A failure here means the token is wrong, expired, or the bot account was
+deactivated.
+
+### Resolve your DM channel
+
+You'll need the bot's user id (from the same `users/me` call — `jq -er .id`)
+and your own Mattermost user id. There's no self-service page that shows your
+own ID; resolve it from your bot token instead:
+
+```bash
+curl -sf "$MATTERMOST_BASE_URL/api/v4/users/username/<your-username>" -H "Authorization: Bearer $MATTERMOST_BOT_TOKEN" | jq -er '.id'
+```
+
+(An admin can also look this up via **System Console → Users**.)
+
+Then open (or fetch) the DM channel and take its id as the conversation
+address `mattermost:<channelId>`:
+
+```bash
+curl -sf -X POST "$MATTERMOST_BASE_URL/api/v4/channels/direct" -H "Authorization: Bearer $MATTERMOST_BOT_TOKEN" -H "Content-Type: application/json" -d '["<your-user-id>","<bot-user-id>"]' | jq -er '"mattermost:" + .id'
+```
+
+## Next Steps
+
+If you're in the middle of `/setup`, return to the setup flow now.
+
+Otherwise, run `/manage-channels` to wire this channel to an agent group.
+
+## Channel Info
+
+- **type**: `mattermost`
+- **terminology**: Mattermost has "teams" containing "channels." Channels can be public or private. The bot can also receive direct messages.
+- **platform-id-format**: `mattermost:{channelId}` for channels and DMs (e.g. `mattermost:a1b2c3d4e5f6g7h8i9j0k1l2m3`)
+- **how-to-find-id**: Open the channel, click its name → "View Info" — the channel ID is shown there. Copying the channel link gives the channel *slug*, not the ID the adapter needs — use "View Info" or the `/api/v4/channels/direct` lookup above for DMs.
+- **supports-threads**: yes — Mattermost models replies as optional reply-threads within a channel (a post with no root is top-level; a post with a root id is a thread reply), the same shape as Slack.
+- **typical-use**: Interactive chat — team channels or direct messages, self-hosted or Mattermost Cloud
+- **default-isolation**: Same agent group for channels where you're the primary user. Separate agent group for channels with different teams or sensitive contexts.
+
+## Troubleshooting
+
+**A token or URL is rejected.** `MATTERMOST_BASE_URL` must include the scheme (`https://` or `http://`) and no trailing slash. The bot token is shown once at creation — regenerate it from System Console → Integrations → Bot Accounts → select the bot → "Create New Token" if lost (old tokens keep working until you deactivate them separately).
+
+**The bot never connects, or connects and repeatedly drops.** Check that `MATTERMOST_BASE_URL` is reachable from the host (not just from a browser behind a VPN or reverse-proxy auth) and that nothing in front of the server (load balancer, CDN) blocks or aggressively idle-times WebSocket upgrades to `/api/v4/websocket`. The adapter retries with backoff and NanoClaw's channel-registry retries adapter setup on network errors, but a very short idle timeout in front of the server will cause repeated reconnects. Check `logs/nanoclaw.error.log` for repeated adapter setup-retry warnings.
+
+**The bot can't see a channel or can't DM someone.** The bot account must be added as a member of any channel it should read/post in — bot accounts don't auto-join. For DMs, the target user must exist and be reachable via `/api/v4/channels/direct`.
+
+**Known feature gaps** (inherent to this community adapter, not a NanoClaw bug):
+- File uploads can't be edited after posting — a follow-up edit that adds/changes an attachment posts a new message instead.
+- Interactive cards (buttons/selects) are not wired up — the adapter supports rendering them, but only when constructed with a `callbackUrl` for Mattermost to call back on, which this integration doesn't currently configure. Cards fall back to a plain-text rendering.
+- Streaming responses fall back to post-and-edit (no native streaming transport), so long responses may appear to "jump" rather than stream in place.
+- Slash commands and modals are not supported — only plain message send/receive and reactions.
+- Rate-limit responses aren't specially surfaced; sustained high-volume channels may see delivery errors during Mattermost API throttling.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "better-sqlite3": "11.10.0",
     "chat": "4.29.0",
     "chat-adapter-imessage": "^0.1.1",
+    "chat-adapter-mattermost": "^1.1.3",
     "cron-parser": "5.5.0",
     "kleur": "^4.1.5",
     "pino": "^9.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       chat-adapter-imessage:
         specifier: ^0.1.1
         version: 0.1.1(chat@4.29.0(zod@4.3.6))(typescript@5.9.3)
+      chat-adapter-mattermost:
+        specifier: ^1.1.3
+        version: 1.1.3(chat@4.29.0(zod@4.3.6))(zod@4.3.6)
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
@@ -1417,6 +1420,7 @@ packages:
 
   audio-decode@2.2.3:
     resolution: {integrity: sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==}
+    deprecated: Renamed to @audio/decode — same API; this name remains a thin alias. npm i @audio/decode
 
   audio-type@2.4.1:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
@@ -1538,6 +1542,12 @@ packages:
     resolution: {integrity: sha512-Lq4FZqvV8QnwtD3CVUPF56L6J4aIEaOY08+uuSWBsxKKtTBH/rbJltJiiz2QRGvvWRyuBsjJ0RzXn4kiDG0LaQ==}
     peerDependencies:
       chat: ^4.14.0
+
+  chat-adapter-mattermost@1.1.3:
+    resolution: {integrity: sha512-IQk6RGb5JAdyOxR7djSSVhZoYnfY/BdpzG48Gslnna8sprbp1kpCfYWy3z1Gh9jxjwTm9Wpcj9UkajzcVQ+fhg==}
+    engines: {node: '>=20', pnpm: '>=10'}
+    peerDependencies:
+      chat: ^4.29.0
 
   chat@4.26.0:
     resolution: {integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==}
@@ -4814,6 +4824,15 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  chat-adapter-mattermost@1.1.3(chat@4.29.0(zod@4.3.6))(zod@4.3.6):
+    dependencies:
+      '@chat-adapter/shared': 4.29.0(zod@4.3.6)
+      chat: 4.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - zod
 
   chat@4.26.0:
     dependencies:

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -45,6 +45,9 @@ import './whatsapp-cloud.js';
 // imessage
 import './imessage.js';
 
+// mattermost
+import './mattermost.js';
+
 // gmail (native, no Chat SDK)
 
 // whatsapp (native, no Chat SDK)

--- a/src/channels/mattermost-registration.test.ts
+++ b/src/channels/mattermost-registration.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Integration test for the mattermost channel's single reach-in: the self-registration
+ * import in the `src/channels/index.ts` barrel. Importing the barrel runs mattermost.ts's
+ * top-level `registerChannelAdapter('mattermost', …)`; without the import the channel is
+ * silently absent.
+ *
+ * Behavior, not structural: it imports the real barrel and asserts the registry
+ * actually contains the channel. This reflects what happens at host boot — if the
+ * `import './mattermost.js';` line is deleted, or the barrel fails to evaluate for any
+ * reason (so the channel genuinely would not register), this goes red. A structural
+ * check of the import line would falsely pass in that second case.
+ *
+ * Importing the barrel is safe: registration is a pure top-level call, and mattermost.ts
+ * builds the SDK adapter / bridge only inside its factory (invoked at host startup),
+ * never at import. It does require the adapter package to be installed, which holds
+ * in a composed install: the skill's `pnpm install` step runs before this test.
+ *
+ * Note on the Chat SDK family: mattermost.ts also consumes a load-bearing *core* API —
+ * `createChatSdkBridge(...)` from ./chat-sdk-bridge.js — with a specific options
+ * shape. That core-consumption is a typed call, so the build/typecheck leg
+ * (`pnpm run build`) guards it against upstream drift, not this test. Every Chat SDK
+ * channel (discord, telegram, teams, gchat, webex, …) follows this same shape:
+ * swap the channel name below and the adapter package in the build.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getRegisteredChannelNames } from './channel-registry.js';
+import './index.js'; // the real barrel — triggers every channel's self-registration
+
+describe('mattermost channel registration', () => {
+  it('registers mattermost via the channel barrel', () => {
+    expect(getRegisteredChannelNames()).toContain('mattermost');
+  });
+});

--- a/src/channels/mattermost.ts
+++ b/src/channels/mattermost.ts
@@ -1,0 +1,57 @@
+/**
+ * Mattermost channel adapter (v2) — uses Chat SDK bridge.
+ * Self-registers on import.
+ *
+ * Wraps the community `chat-adapter-mattermost` package. Mattermost, like
+ * Slack, models replies as optional threads within a channel (a thread id
+ * with no root post is the channel itself; a thread id with a root post is
+ * a specific reply-thread) — so this follows the Slack shape, not
+ * Telegram's channel-is-the-only-conversation model.
+ */
+import { createMattermostAdapter } from 'chat-adapter-mattermost';
+
+import { readEnvFile } from '../env.js';
+import type { ChannelDefaults } from './adapter.js';
+import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { registerChannelAdapter } from './channel-registry.js';
+
+/**
+ * Dedicated bot account on a threaded platform. group threads:true keeps
+ * mention-sticky bounded — engagement sticks per-thread, not forever.
+ * dm.threads:false mirrors Slack's policy: DM sub-threads collapse into the
+ * one DM session unless a wiring overrides it.
+ */
+const MATTERMOST_DEFAULTS: ChannelDefaults = {
+  dm: { engageMode: 'pattern', engagePattern: '.', threads: false, unknownSenderPolicy: 'request_approval' },
+  group: { engageMode: 'mention-sticky', threads: true, unknownSenderPolicy: 'request_approval' },
+  mentions: 'platform',
+};
+
+registerChannelAdapter('mattermost', {
+  factory: () => {
+    const env = readEnvFile(['MATTERMOST_BASE_URL', 'MATTERMOST_BOT_TOKEN']);
+    if (!env.MATTERMOST_BASE_URL || !env.MATTERMOST_BOT_TOKEN) return null;
+
+    const mattermostAdapter = createMattermostAdapter({
+      baseUrl: env.MATTERMOST_BASE_URL,
+      botToken: env.MATTERMOST_BOT_TOKEN,
+    });
+
+    const bridge = createChatSdkBridge({
+      adapter: mattermostAdapter,
+      concurrency: 'concurrent',
+      supportsThreads: true,
+      defaults: MATTERMOST_DEFAULTS,
+    });
+    bridge.resolveChannelName = async (platformId: string) => {
+      try {
+        const info = await mattermostAdapter.fetchThread(platformId);
+        return info.channelName ?? null;
+      } catch {
+        return null;
+      }
+    };
+    return bridge;
+  },
+  defaults: MATTERMOST_DEFAULTS,
+});


### PR DESCRIPTION
Supersedes #546, which targeted the pre-v2 `Channel`/`registry.ts` architecture that no longer exists on `main`. This is a fresh implementation against the current `ChannelAdapter`/`channel-registry.ts` contract.

## Summary
- `src/channels/mattermost.ts` — registers via `registerChannelAdapter`, wraps the community [`chat-adapter-mattermost`](https://github.com/thiagoferolla/chat-adapter-mattermost) package through `createChatSdkBridge`, following the same pattern as `slack.ts`.
- WebSocket-based (`/api/v4/websocket`) rather than REST polling — a behavior improvement over the original v1 approach.
- `supportsThreads: true`, verified against the adapter's actual `channelId`/`rootPostId` thread model (channel-is-default, thread-is-optional-sub-conversation — same shape as Slack), not assumed from the Slack template.
- `src/channels/mattermost-registration.test.ts` mirrors the existing `slack-registration.test.ts`.
- `.claude/skills/add-mattermost/SKILL.md` — written in the current `nc:` directive format (modeled on `add-slack`/`add-imessage`), with `apply-fixtures.json` for `scripts/skill-conformance.test.ts`.
- `chat-adapter-mattermost` added as a pinned dependency — community/unscoped package, same risk tier already accepted for `chat-adapter-imessage`.

## Known limitations (from the adapter, documented in the skill's Troubleshooting section)
- No editable file uploads after posting
- Cards render as plain-text fallback (no native card support)
- No native streaming (post-and-edit only)
- No slash commands or interactive modals

## Testing
- `pnpm run build` — passes
- `pnpm test` — full suite (1270 tests) passes, including the new registration test and skill-conformance checks for `add-mattermost`
- `pnpm run lint` — no new issues (baseline-identical before/after)
- `pnpm run format:check` — clean