### PR TITLE
fix(slack): surface pasted tables to the agent

### DIFF
--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -64,6 +64,15 @@ export interface ChatSdkBridgeConfig {
   /** Platform-specific reply context extraction. */
   extractReplyContext?: ReplyContextExtractor;
   /**
+   * Platform-specific rescue of text content that the Chat SDK adapter does
+   * not surface on the parsed message (e.g. Slack pasted tables live in
+   * `raw.attachments[].blocks`, which @chat-adapter/slack ignores). Called
+   * with `message.raw` before it is dropped; a non-null result is appended
+   * to the message text.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extractRawText?: (raw: Record<string, any>) => string | null;
+  /**
    * Whether this platform uses threads as the primary conversation unit.
    * See `ChannelAdapter.supportsThreads`. Declared by the calling channel
    * skill, not inferred, because some platforms (Discord) can be used either
@@ -136,6 +145,21 @@ export function splitForLimit(text: string, limit: number): string[] {
   return chunks;
 }
 
+/** Append platform-rescued raw text (see `extractRawText`) to serialized.text. */
+export function appendRawText(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serialized: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  raw: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extract?: (raw: Record<string, any>) => string | null,
+): void {
+  if (!extract) return;
+  const extra = extract(raw);
+  if (!extra) return;
+  serialized.text = serialized.text ? `${serialized.text}\n\n${extra}` : extra;
+}
+
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
   const { adapter } = config;
   // The instance name becomes the registry key (and, once the core
@@ -188,6 +212,13 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         enriched.push(entry);
       }
       serialized.attachments = enriched;
+    }
+
+    // Rescue platform-specific text the adapter doesn't parse (e.g. Slack
+    // pasted tables) while message.raw still exists.
+    if (message.raw) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      appendRawText(serialized, message.raw as Record<string, any>, config.extractRawText);
     }
 
     // Extract reply context via platform-specific hook

--- a/src/channels/slack-raw-text.test.ts
+++ b/src/channels/slack-raw-text.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractSlackRawText } from './slack-raw-text.js';
+
+// Trimmed from a real Slack event: user pasted a table into the message.
+// Slack delivers it as attachments[].blocks[] of type "table" — absent from
+// event.text and event.files. Header row cells are rich_text (nested
+// elements), data row cells are raw_text (flat).
+const tableEvent = {
+  text: 'can you tell me which devices support remote firmware upgrades from this list?',
+  attachments: [
+    {
+      id: 1,
+      fallback: '[no preview available]',
+      blocks: [
+        {
+          type: 'table',
+          rows: [
+            [
+              {
+                type: 'rich_text',
+                elements: [
+                  {
+                    type: 'rich_text_section',
+                    elements: [{ type: 'text', text: 'Manufacturer', style: { bold: true } }],
+                  },
+                ],
+              },
+              {
+                type: 'rich_text',
+                elements: [
+                  {
+                    type: 'rich_text_section',
+                    elements: [{ type: 'text', text: 'Hardware Type', style: { bold: true } }],
+                  },
+                ],
+              },
+            ],
+            [
+              { type: 'raw_text', text: 'Samsung' },
+              { type: 'raw_text', text: 'Video display' },
+            ],
+            [
+              { type: 'raw_text', text: 'Neat' },
+              { type: 'raw_text', text: 'Video bar' },
+            ],
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('extractSlackRawText', () => {
+  it('flattens a pasted table from attachments[].blocks into pipe-separated rows', () => {
+    const out = extractSlackRawText(tableEvent);
+    expect(out).toBe(
+      ['Manufacturer | Hardware Type', 'Samsung | Video display', 'Neat | Video bar'].join('\n'),
+    );
+  });
+
+  it('returns null when there is nothing to extract', () => {
+    expect(extractSlackRawText({ text: 'hi' })).toBeNull();
+    expect(extractSlackRawText({ attachments: [{ id: 1, fallback: 'x' }] })).toBeNull();
+    // link-unfurl attachments (title/text, no blocks) are not pasted content
+    expect(
+      extractSlackRawText({ attachments: [{ from_url: 'https://x.com', title: 't', text: 'd' }] }),
+    ).toBeNull();
+  });
+
+  it('caps output size', () => {
+    const bigRows = Array.from({ length: 20000 }, (_, i) => [
+      { type: 'raw_text', text: `row-${i}-cell-with-some-padding-text` },
+    ]);
+    const out = extractSlackRawText({
+      attachments: [{ blocks: [{ type: 'table', rows: bigRows }] }],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(100_000);
+    expect(out).toContain('truncated');
+  });
+});
+
+// Bridge-side wiring: appendRawText is what messageToInbound calls with the
+// configured extractRawText hook, right before serialized.raw is dropped.
+import { appendRawText } from './chat-sdk-bridge.js';
+
+describe('appendRawText', () => {
+  it('appends extractor output to serialized.text', () => {
+    const serialized: Record<string, unknown> = { text: 'question?' };
+    appendRawText(serialized, { attachments: [] }, () => 'a | b');
+    expect(serialized.text).toBe('question?\n\na | b');
+  });
+
+  it('leaves text untouched when extractor returns null or is absent', () => {
+    const serialized: Record<string, unknown> = { text: 'question?' };
+    appendRawText(serialized, {}, () => null);
+    appendRawText(serialized, {}, undefined);
+    expect(serialized.text).toBe('question?');
+  });
+
+  it('sets text when message had none (paste-only message)', () => {
+    const serialized: Record<string, unknown> = { text: '' };
+    appendRawText(serialized, {}, () => 'a | b');
+    expect(serialized.text).toBe('a | b');
+  });
+});

--- a/src/channels/slack-raw-text.ts
+++ b/src/channels/slack-raw-text.ts
@@ -1,0 +1,50 @@
+/**
+ * Rescue pasted-table content from a raw Slack event.
+ *
+ * When a user pastes a table into Slack, it arrives as
+ * `event.attachments[].blocks[]` of type "table" — NOT in `event.text` and
+ * NOT in `event.files`. @chat-adapter/slack only maps `event.files` into
+ * ChatMessage.attachments, so without this the table exists solely in
+ * `message.raw`, which the bridge drops before persisting.
+ *
+ * Passed to the bridge as `extractRawText`; the result is appended to the
+ * message text. Cells are joined with " | ", one line per row.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ponytail: char cap, not row-aware pagination — revisit if agents need full giant tables
+const MAX_CHARS = 100_000;
+
+/** Collect every `text` string in a Slack block subtree (rich_text nesting varies). */
+function cellText(node: any): string {
+  const parts: string[] = [];
+  const walk = (n: any): void => {
+    if (Array.isArray(n)) {
+      n.forEach(walk);
+    } else if (n && typeof n === 'object') {
+      if (typeof n.text === 'string') parts.push(n.text);
+      Object.values(n).forEach(walk);
+    }
+  };
+  walk(node);
+  return parts.join(' ').trim();
+}
+
+export function extractSlackRawText(raw: Record<string, any>): string | null {
+  const lines: string[] = [];
+  for (const att of raw.attachments ?? []) {
+    for (const block of att.blocks ?? []) {
+      if (block.type !== 'table' || !Array.isArray(block.rows)) continue;
+      for (const row of block.rows) {
+        lines.push(row.map(cellText).join(' | '));
+      }
+    }
+  }
+  if (lines.length === 0) return null;
+
+  let out = lines.join('\n');
+  if (out.length > MAX_CHARS) {
+    out = `${out.slice(0, MAX_CHARS - 20)}\n[table truncated]`;
+  }
+  return out;
+}

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -11,6 +11,7 @@ import { readEnvFile } from '../env.js';
 import type { ChannelDefaults } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
+import { extractSlackRawText } from './slack-raw-text.js';
 
 /**
  * Dedicated bot app on a threaded platform. group threads:true keeps
@@ -47,6 +48,7 @@ registerChannelAdapter('slack', {
       concurrency: 'concurrent',
       supportsThreads: true,
       defaults: SLACK_DEFAULTS,
+      extractRawText: extractSlackRawText,
     });
     bridge.resolveChannelName = async (platformId: string) => {
       try {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** When a user pastes a table into Slack, the agent never sees it. The table arrives as `event.attachments[].blocks[]` of type `table` — absent from `event.text` and `event.files`. `@chat-adapter/slack` only maps `event.files` into `ChatMessage.attachments` (confirmed unchanged through 4.37.0), so the table survives only in `message.raw`, which the bridge drops before persisting (`serialized.raw = undefined`). The agent gets the question with an empty attachment list and has to ask the user to re-paste. (The attachment's `fallback` text is no help either — Slack sets it to literally `"[no preview available]"` for table attachments.)

**How:** New optional `extractRawText` hook on `ChatSdkBridgeConfig`, mirroring the existing `extractReplyContext` pattern — platform-specific rescue from `message.raw` right before it's dropped. The Slack adapter supplies `extractSlackRawText`, which walks `raw.attachments[].blocks[]` of type `table` and appends the rows as pipe-separated lines to the message text. Output is size-capped at 100KB so a giant paste can't blow up the session DB row or the model context. Other chat-sdk channels are untouched (hook unset = no-op).

The two `chat-sdk-bridge.ts` hunks are branch-neutral and apply cleanly to `main`'s copy as well, if you'd rather have the hook there too.

**Tested:**
- 6 new unit tests in `slack-raw-text.test.ts` (fixture trimmed from a real Slack event — header cells arrive as `rich_text`, data cells as `raw_text`; both covered), written test-first
- Live-verified on a real install: pasted a 39-row table in Slack, confirmed the rows land in the session's `inbound.db` message text and the agent answers about the devices instead of asking for a re-paste

Root cause is arguably in `@chat-adapter/slack`'s inbound mapping; filing an issue upstream (vercel/chat) as well. If they ever surface these blocks, this hook degrades to a harmless no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)