### PR TITLE
refactor(db): add module migration registry

### DIFF
--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -126,6 +126,7 @@ Two consequences. First, **don't mock the adapter's package in the shipped test*
 The test matches the kind of integration point:
 
 - **In-process seam with core** (a channel into the router, a pusher into the central DB): drive the real added component against the **real core collaborators** (DB, registry, router), faking only the external edge. The highest-value archetype: it exercises the added file's consumption of core, which is what catches core drift.
+- **Module migration**: import the real modules barrel, initialize a real test DB, call `runMigrations()` with its default combined list, then exercise the skill's actual DB behavior. Do not pass an explicit migration list or import the skill migration directly: either bypasses the core migrations that must participate for an incompatible upstream schema change to make the composed skill test fail.
 - **Wiring / registration** (a barrel import, a `main()` call, an entry in an `mcpServers` map): behavior test via the registry where queryable (see above); structural / AST test where not.
 - **Config / container probe** (mounts, Dockerfile, a tool installed in the image): run the change where you can. Spin up a container to confirm a mount or binary. Checking that a line exists in a file is the last resort.
 - **Agentic run** (operational, instruction-only skills): run the workflow with a small model; did it complete?

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -23,6 +23,7 @@ import { migration021 } from './021-approval-question.js';
 
 export interface Migration {
   version: number;
+  /** Permanent applied identity. Never rename a migration after release. */
   name: string;
   up: (db: Database.Database) => void;
   /**
@@ -35,6 +36,13 @@ export interface Migration {
    */
   disableForeignKeys?: boolean;
 }
+
+/**
+ * Public module migrations use a core-reserved, owner-qualified identity so
+ * independent modules may reuse local migration names without colliding.
+ */
+export type ModuleMigrationName = `module:${string}:${string}`;
+export type ModuleMigration = Omit<Migration, 'name'> & { name: ModuleMigrationName };
 
 export const migrations: Migration[] = [
   migration001,
@@ -58,6 +66,33 @@ export const migrations: Migration[] = [
   migration021,
 ];
 
+/**
+ * Migrations contributed by self-registering modules.
+ *
+ * When multiple migrations are pending, built-in migrations run first. Module
+ * migrations are not interleaved with built-ins by `version`; they follow the
+ * deterministic import order of their owning modules because the modules
+ * barrel uses explicit side-effect imports.
+ */
+const moduleMigrations: Migration[] = [];
+const MODULE_MIGRATION_NAME_RE = /^module:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/;
+
+export function registerMigration(migration: ModuleMigration): void {
+  if (!MODULE_MIGRATION_NAME_RE.test(migration.name)) {
+    throw new Error(
+      `Module migration "${migration.name}" must use "module:<module-id>:<migration-id>" and remain stable after release`,
+    );
+  }
+  if ([...migrations, ...moduleMigrations].some((candidate) => candidate.name === migration.name)) {
+    throw new Error(`Migration "${migration.name}" already registered`);
+  }
+  moduleMigrations.push(migration);
+}
+
+export function getRegisteredMigrations(): readonly Migration[] {
+  return [...migrations, ...moduleMigrations];
+}
+
 /** Row shape of PRAGMA foreign_key_check. Child rowids are stable across a
  *  parent-table recreate (child tables aren't touched), so this JSON identity
  *  is a reliable before/after diff key. */
@@ -71,7 +106,7 @@ interface FkViolation {
 const fkIdentity = (v: FkViolation): string =>
   JSON.stringify({ table: v.table, rowid: v.rowid, parent: v.parent, fkid: v.fkid });
 
-export function runMigrations(db: Database.Database, list: Migration[] = migrations): void {
+export function runMigrations(db: Database.Database, list: readonly Migration[] = getRegisteredMigrations()): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY,

--- a/src/db/migrations/registry.test.ts
+++ b/src/db/migrations/registry.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Migration, ModuleMigration, ModuleMigrationName } from './index.js';
+
+let closeCurrentDb: (() => void) | undefined;
+
+afterEach(() => {
+  closeCurrentDb?.();
+  closeCurrentDb = undefined;
+});
+
+function testMigration(name: string, table = name.replace(/[^a-zA-Z0-9_]/g, '_'), version = 999): Migration {
+  return {
+    version,
+    name,
+    up(db) {
+      db.exec(`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`);
+    },
+  };
+}
+
+function testModuleMigration(name: ModuleMigrationName, table?: string, version?: number): ModuleMigration {
+  return testMigration(name, table, version) as ModuleMigration;
+}
+
+async function freshRegistry() {
+  vi.resetModules();
+  return import('./index.js');
+}
+
+async function freshTestDb() {
+  const connection = await import('../connection.js');
+  const db = connection.initTestDb();
+  closeCurrentDb = connection.closeDb;
+  return db;
+}
+
+describe('module migration registry', () => {
+  it('keeps built-ins first and module migrations in registration order regardless of version', async () => {
+    const registry = await freshRegistry();
+    const first = testModuleMigration('module:test-first:create-state', undefined, Number.MAX_SAFE_INTEGER);
+    const second = testModuleMigration('module:test-second:create-state', undefined, 0);
+
+    registry.registerMigration(first);
+    registry.registerMigration(second);
+
+    expect(registry.getRegisteredMigrations()).toEqual([...registry.migrations, first, second]);
+  });
+
+  it('reserves the module namespace away from built-in migrations', async () => {
+    const registry = await freshRegistry();
+
+    expect(registry.migrations.every((migration) => !migration.name.startsWith('module:'))).toBe(true);
+  });
+
+  it('rejects an unqualified module migration name at runtime', async () => {
+    const registry = await freshRegistry();
+    const unqualified = testMigration('create-state') as ModuleMigration;
+
+    expect(() => registry.registerMigration(unqualified)).toThrow(
+      'must use "module:<module-id>:<migration-id>" and remain stable after release',
+    );
+  });
+
+  it('rejects duplicate module migration names', async () => {
+    const registry = await freshRegistry();
+    registry.registerMigration(testModuleMigration('module:test-owner:duplicate', 'test_module_duplicate_first'));
+
+    expect(() =>
+      registry.registerMigration(testModuleMigration('module:test-owner:duplicate', 'test_module_duplicate_second')),
+    ).toThrow('Migration "module:test-owner:duplicate" already registered');
+  });
+
+  it('applies and records registered migrations with the default run', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    registry.registerMigration(testModuleMigration('module:test-owner:applied', 'test_module_applied'));
+
+    registry.runMigrations(db);
+
+    expect(db.prepare("SELECT name FROM schema_version WHERE name = 'module:test-owner:applied'").get()).toEqual({
+      name: 'module:test-owner:applied',
+    });
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_applied'").get(),
+    ).toEqual({ name: 'test_module_applied' });
+  });
+
+  it('preserves the explicit migration-list override', async () => {
+    const registry = await freshRegistry();
+    const db = await freshTestDb();
+    const explicit = testMigration('test-explicit-only');
+    registry.registerMigration(testModuleMigration('module:test-owner:not-selected', 'test_module_not_selected'));
+
+    registry.runMigrations(db, [explicit]);
+
+    expect(db.prepare('SELECT name FROM schema_version ORDER BY version').all()).toEqual([
+      { name: 'test-explicit-only' },
+    ]);
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'test_module_not_selected'").get(),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds a typed registry for module-owned database migrations. Built-in migrations remain first, registered module migrations follow deterministic registration order, and permanent owner-qualified names prevent identity collisions.

This lets self-registering NanoClaw modules own their migrations without editing the built-in migration list. The existing explicit migration-list override remains supported.

## Validation

- `pnpm exec vitest run src/db/migrations/registry.test.ts` — 6 tests passed
- `pnpm test` — 1,268 tests passed
- `pnpm run build`
- `git diff --check`
