### PR TITLE
refactor(channels): register question renderers

### DIFF
--- a/src/channels/chat-sdk-bridge-byline.test.ts
+++ b/src/channels/chat-sdk-bridge-byline.test.ts
@@ -24,6 +24,7 @@ import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { createPendingApproval } from '../db/sessions.js';
 import type { ChannelSetup } from './adapter.js';
 import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { registerQuestionRenderResolver } from './question-render-registry.js';
 
 interface CapturedEdit {
   threadId: string;
@@ -52,6 +53,7 @@ function terminalText(edit: CapturedEdit): Array<{ type: string; content?: strin
 async function fireAction(
   user: Record<string, unknown>,
   selectedOption = 'approve',
+  actionId = `ncq:q-1:${selectedOption}`,
 ): Promise<{ edits: CapturedEdit[]; actions: string[] }> {
   const edits: CapturedEdit[] = [];
   const actions: string[] = [];
@@ -71,7 +73,7 @@ async function fireAction(
   expect(chat).toBeTruthy();
   await chat.processAction(
     {
-      actionId: `ncq:q-1:${selectedOption}`,
+      actionId,
       adapter,
       messageId: 'msg-1',
       raw: {},
@@ -149,5 +151,26 @@ describe('chat-sdk-bridge approval-card terminal state', () => {
       content: '✅ Approved',
       style: 'muted',
     });
+  });
+
+  it('resolves compact option indexes through a module resolver', async () => {
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-compact-question') return undefined;
+      return {
+        title: 'Custom approval',
+        options: [{ label: 'Approve', selectedLabel: 'Approved safely', value: 'approve-real-value' }],
+      };
+    });
+
+    const { edits, actions } = await fireAction(
+      { userId: 'U4', userName: 'reviewer' },
+      '0',
+      'ncq:module-compact-question:0',
+    );
+
+    const message = edits[0].message as { markdown: string };
+    expect(message.markdown).toContain('Custom approval');
+    expect(message.markdown).toContain('Approved safely by reviewer');
+    expect(actions).toEqual(['module-compact-question:approve-real-value:U4']);
   });
 });

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -21,9 +21,9 @@ import {
 import { log } from '../log.js';
 import { SqliteStateAdapter } from '../state-sqlite.js';
 import { registerWebhookAdapter } from '../webhook-server.js';
-import { getAskQuestionRender } from '../db/sessions.js';
 import { normalizeOptions, type NormalizedOption } from './ask-question.js';
 import type { ChannelAdapter, ChannelDefaults, ChannelSetup, InboundMessage } from './adapter.js';
+import { resolveQuestionRender } from './question-render-registry.js';
 
 /** Adapter with optional gateway support (e.g., Discord). */
 interface GatewayAdapter extends Adapter {
@@ -101,7 +101,7 @@ export interface ChatSdkBridgeConfig {
 /**
  * Decode the actual option value from a button callback. Buttons are encoded
  * with an integer index (to keep under Telegram's 64-byte callback_data cap),
- * and the real value is looked up via `getAskQuestionRender(questionId)`.
+ * and the real value is looked up via `resolveQuestionRender(questionId)`.
  * Falls back to treating the tail as a literal value so old in-flight cards
  * (encoded before this shortening landed) still resolve.
  */
@@ -338,7 +338,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
         const userId = event.user?.userId || '';
 
         // Resolve render metadata BEFORE dispatching onAction (which deletes the row).
-        const render = getAskQuestionRender(questionId);
+        const render = resolveQuestionRender(questionId);
         // New format: button id/value is an integer index into options (kept
         // short to fit Telegram's 64-byte callback_data cap). Old format:
         // the full value is embedded in actionId/value directly.
@@ -489,7 +489,7 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
               // full value. Telegram caps callback_data at 64 bytes, and
               // long values (e.g. ISO datetimes, URLs) push the JSON payload
               // well past that. The onAction handlers resolve the index back
-              // to the real value via getAskQuestionRender(questionId).
+              // to the real value via resolveQuestionRender(questionId).
               options.map((opt, idx) =>
                 Button({ id: `ncq:${questionId}:${idx}`, label: opt.label, value: String(idx), style: opt.style }),
               ),
@@ -718,7 +718,7 @@ async function handleForwardedEvent(
       const originalEmbeds =
         ((interaction.message as Record<string, unknown>)?.embeds as Array<Record<string, unknown>>) || [];
       const originalDescription = (originalEmbeds[0]?.description as string) || '';
-      const render = questionId ? getAskQuestionRender(questionId) : undefined;
+      const render = questionId ? resolveQuestionRender(questionId) : undefined;
       // Discord custom_id mirrors the new index-based encoding (see Button
       // construction). Decode back to the real option value for downstream.
       const selectedOption = resolveSelectedOption(render, tail, tail);

--- a/src/channels/question-render-registry.test.ts
+++ b/src/channels/question-render-registry.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDb, initTestDb } from '../db/connection.js';
+import { runMigrations } from '../db/migrations/index.js';
+import { createPendingApproval } from '../db/sessions.js';
+import { log } from '../log.js';
+import { registerQuestionRenderResolver, resolveQuestionRender } from './question-render-registry.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+  vi.restoreAllMocks();
+});
+
+describe('question render resolver registry', () => {
+  it('runs module resolvers in registration order and stops on the first result', () => {
+    const order: string[] = [];
+    const later = vi.fn(() => undefined);
+    const expected = {
+      title: 'Module question',
+      options: [{ label: 'Approve', selectedLabel: 'Approved', value: 'approve' }],
+    };
+
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      order.push('first');
+      return undefined;
+    });
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      order.push('second');
+      return expected;
+    });
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'module-order-question') return undefined;
+      later();
+      return undefined;
+    });
+
+    expect(resolveQuestionRender('module-order-question')).toBe(expected);
+    expect(order).toEqual(['first', 'second']);
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it('resolves over a snapshot when a resolver registers another resolver', () => {
+    const expected = {
+      title: 'Registered during resolution',
+      options: [{ label: 'Continue', selectedLabel: 'Continued', value: 'continue' }],
+    };
+    const registeredDuringResolution = vi.fn((questionId: string) =>
+      questionId === 'snapshot-question' ? expected : undefined,
+    );
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId !== 'snapshot-question') return undefined;
+      registerQuestionRenderResolver(registeredDuringResolution);
+      return undefined;
+    });
+
+    expect(resolveQuestionRender('snapshot-question')).toBeUndefined();
+    expect(registeredDuringResolution).not.toHaveBeenCalled();
+
+    expect(resolveQuestionRender('snapshot-question')).toBe(expected);
+    expect(registeredDuringResolution).toHaveBeenCalledOnce();
+  });
+
+  it('logs an optional resolver failure and continues to the built-in fallback', () => {
+    const failure = new Error('resolver failure');
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => undefined);
+    registerQuestionRenderResolver((questionId) => {
+      if (questionId === 'resolver-failure-question') throw failure;
+      return undefined;
+    });
+    createPendingApproval({
+      approval_id: 'resolver-failure-question',
+      request_id: 'request-resolver-failure',
+      action: 'test-action',
+      payload: '{}',
+      created_at: new Date().toISOString(),
+      title: 'Built-in fallback after failure',
+      options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
+    });
+
+    expect(resolveQuestionRender('resolver-failure-question')).toEqual({
+      title: 'Built-in fallback after failure',
+      question: '',
+      options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
+    });
+    expect(errorSpy).toHaveBeenCalledWith('Question render resolver threw', { err: failure });
+  });
+
+  it('uses the existing database lookup as the final built-in fallback', () => {
+    createPendingApproval({
+      approval_id: 'built-in-render-question',
+      request_id: 'request-1',
+      action: 'test-action',
+      payload: '{}',
+      created_at: new Date().toISOString(),
+      title: 'Built-in approval',
+      options_json: JSON.stringify([{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }]),
+    });
+
+    expect(resolveQuestionRender('built-in-render-question')).toEqual({
+      title: 'Built-in approval',
+      question: '',
+      options: [{ label: 'Allow', selectedLabel: 'Allowed', value: 'allow' }],
+    });
+  });
+
+  it('returns undefined when neither a module nor the built-in fallback owns the id', () => {
+    expect(resolveQuestionRender('unowned-render-question')).toBeUndefined();
+  });
+});

--- a/src/channels/question-render-registry.ts
+++ b/src/channels/question-render-registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Question-card render resolver registry.
+ *
+ * Optional modules register compact-card metadata lookups at import time.
+ * The host's existing DB lookup remains the final fallback for core question
+ * and approval rows.
+ */
+import { getAskQuestionRender } from '../db/sessions.js';
+import { log } from '../log.js';
+import type { NormalizedOption } from './ask-question.js';
+
+export interface QuestionRender {
+  title: string;
+  question?: string;
+  options: NormalizedOption[];
+}
+
+export type QuestionRenderResolver = (questionId: string) => QuestionRender | undefined;
+
+const resolvers: QuestionRenderResolver[] = [];
+
+export function registerQuestionRenderResolver(resolver: QuestionRenderResolver): void {
+  resolvers.push(resolver);
+}
+
+export function resolveQuestionRender(questionId: string): QuestionRender | undefined {
+  for (const resolver of [...resolvers]) {
+    /* eslint-disable no-catch-all/no-catch-all -- one optional resolver must not block later resolvers or the built-in fallback */
+    try {
+      const render = resolver(questionId);
+      if (render) return render;
+    } catch (err) {
+      log.error('Question render resolver threw', { err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
+  }
+  return getAskQuestionRender(questionId);
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds a typed registry for question-card render resolvers. Optional NanoClaw modules can provide compact-card metadata while the existing database lookup remains the final built-in fallback.

Resolvers run over a registration-order snapshot, failures are isolated with the standard error metadata, and the Chat SDK bridge uses the registry for both regular and forwarded interactions without changing its existing card-edit logging.

## Validation

- `pnpm exec vitest run src/channels/question-render-registry.test.ts src/channels/chat-sdk-bridge-byline.test.ts` — 10 tests passed
- `pnpm test` — 1,268 tests passed
- `pnpm run build`
- Prettier and `git diff --check`
