### PR TITLE
refactor(host): unify module lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+- [BREAKING] **Host modules now use one lifecycle registry.** Custom modules that import `onShutdown()` or `getShutdownCallbacks()` from `response-registry.ts` must move to the host lifecycle API. **Migration:** follow [the host lifecycle migration guide](docs/host-lifecycle-migration.md) to detect affected code, update it, verify the cutover, or roll back.
 - **Agent-to-agent messaging no longer loses to Claude Code's built-in `SendMessage`.** That built-in addresses the SDK's own in-session subagents, so an agent that had just run `create_agent` reached for it by name and got `No agent named 'x' is currently addressable` — reading as "the group was never provisioned" while `mcp__nanoclaw__send_message` (the real path) was never called. `SendMessage` joins `AskUserQuestion` in `SDK_DISALLOWED_TOOLS`, so the PreToolUse hook now blocks it and points at the nanoclaw equivalent.
 - [BREAKING] **Existing Claude installs should review the hardened agent image.** Local builds remain supported, but the Echo-built image is recommended for patched sandbox components. **Migration:** follow [the hardened-image guide](docs/hardened-image.md) to detect your current image source, switch, verify, or roll back.
 - **Release publication tolerates GitHub API propagation.** The Release workflow now retries bounded post-publication read-backs when the new Release is not listed yet or its immutable state is not visible yet. Exact title, body, tag, or SHA mismatches still fail immediately.

--- a/docs/host-lifecycle-migration.md
+++ b/docs/host-lifecycle-migration.md
@@ -1,0 +1,70 @@
+# Host lifecycle migration
+
+NanoClaw now has one host lifecycle registry. The legacy shutdown hooks in
+`src/response-registry.ts` have been removed, and all host modules register
+startup and shutdown work through `src/host-lifecycle.ts`.
+
+## Detect affected custom modules
+
+Search custom NanoClaw source for the removed exports:
+
+```bash
+rg -n "onShutdown|getShutdownCallbacks" src
+```
+
+No result means the custom source does not use the removed interface. A match
+in an import from `response-registry.ts` requires migration.
+
+## Why the interface changed
+
+Keeping shutdown callbacks in both the response registry and the lifecycle
+registry created two ordering rules and two cleanup paths. One registry makes
+startup and shutdown ordering explicit: startup callbacks run FIFO, while
+shutdown callbacks run LIFO so later-started modules clean up first.
+
+## Update custom modules
+
+Replace `onShutdown()` with `onHostShutdown()` and keep the callback body
+unchanged:
+
+```ts
+// Before
+import { onShutdown } from './response-registry.js';
+
+onShutdown(() => {
+  stopCustomModule();
+});
+
+// After
+import { onHostShutdown } from './host-lifecycle.js';
+
+onHostShutdown(() => {
+  stopCustomModule();
+});
+```
+
+Adjust the relative import path to the custom module's location.
+
+Code that inspected `getShutdownCallbacks()` in a registration test should use
+`getHostShutdownCallbacks()` instead. Host orchestration should call
+`stopHostModules()` rather than execute registered callbacks directly.
+
+## Verify the migration
+
+Confirm that no removed calls remain, then build and test NanoClaw:
+
+```bash
+rg -n "onShutdown|getShutdownCallbacks" src
+pnpm run build
+pnpm test
+```
+
+The first command should return no matches. During a graceful shutdown, each
+registered cleanup should run once in reverse registration order.
+
+## Roll back
+
+This change does not migrate stored data. To roll back, return NanoClaw to the
+previous revision and restore the custom module's `response-registry.ts`
+import. Rebuild and restart NanoClaw using the same procedure used for the
+update, then verify a graceful shutdown again.

--- a/docs/skill-guidelines.md
+++ b/docs/skill-guidelines.md
@@ -80,6 +80,8 @@ For a fence-carrying skill, conformance means:
 
 The integration point is wherever the skill reaches into existing code. Make it **minimal, colocated, and self-contained**:
 
+Lifecycle hooks are operational boundaries: an `onHostStart` error aborts host startup, while shutdown callback errors are logged and remaining cleanup continues.
+
 - All real logic lives in the skill's own file behind a single entry function; the edit to core is just the call.
 - **Prefer one colocated block** over edits in two places. For an inserted call, a dynamic import at the call site keeps the import and call together and avoids touching the top-of-file import block (itself a merge hotspot):
 

--- a/src/host-lifecycle.test.ts
+++ b/src/host-lifecycle.test.ts
@@ -1,0 +1,156 @@
+import fs from 'fs';
+import path from 'path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe('host module lifecycle registry', () => {
+  it('registration is inert and exposes callbacks for registration proofs', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const start = vi.fn();
+    const stop = vi.fn();
+
+    lifecycle.onHostStart(start);
+    lifecycle.onHostShutdown(stop);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(lifecycle.getHostStartCallbacks()).toEqual([start]);
+    expect(lifecycle.getHostShutdownCallbacks()).toEqual([stop]);
+  });
+
+  it('returns callback snapshots that cannot mutate the registry', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const firstStart = vi.fn();
+    const secondStart = vi.fn();
+    const firstStop = vi.fn();
+    const secondStop = vi.fn();
+
+    lifecycle.onHostStart(firstStart);
+    lifecycle.onHostShutdown(firstStop);
+    const startSnapshot = lifecycle.getHostStartCallbacks();
+    const shutdownSnapshot = lifecycle.getHostShutdownCallbacks();
+
+    lifecycle.onHostStart(secondStart);
+    lifecycle.onHostShutdown(secondStop);
+
+    expect(startSnapshot).toEqual([firstStart]);
+    expect(shutdownSnapshot).toEqual([firstStop]);
+    expect(lifecycle.getHostStartCallbacks()).toEqual([firstStart, secondStart]);
+    expect(lifecycle.getHostShutdownCallbacks()).toEqual([firstStop, secondStop]);
+  });
+
+  it('starts callbacks serially in registration order with the same context', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const order: string[] = [];
+    const controller = new AbortController();
+    const ctx = { db: {} as never, signal: controller.signal };
+
+    lifecycle.onHostStart(async (received) => {
+      expect(received).toBe(ctx);
+      order.push('first-start');
+      await Promise.resolve();
+      order.push('first-end');
+    });
+    lifecycle.onHostStart((received) => {
+      expect(received.signal.aborted).toBe(false);
+      order.push('second');
+    });
+
+    await lifecycle.startHostModules(ctx);
+    controller.abort();
+
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+    expect(ctx.signal.aborted).toBe(true);
+  });
+
+  it('propagates a startup error and does not start later callbacks', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const { log } = await import('./log.js');
+    const later = vi.fn();
+    const failure = new Error('start-sentinel');
+
+    lifecycle.onHostStart(() => {
+      throw failure;
+    });
+    lifecycle.onHostStart(later);
+
+    await expect(lifecycle.startHostModules({ db: {} as never, signal: new AbortController().signal })).rejects.toBe(
+      failure,
+    );
+    expect(later).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith('Host module startup callback threw', { err: failure });
+  });
+
+  it('stops callbacks LIFO, logs the error, and continues', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+    const { log } = await import('./log.js');
+    const order: string[] = [];
+
+    lifecycle.onHostShutdown(async () => {
+      order.push('first-start');
+      await Promise.resolve();
+      order.push('first-end');
+    });
+    lifecycle.onHostShutdown(() => {
+      order.push('failed');
+      throw new Error('shutdown-sentinel');
+    });
+    lifecycle.onHostShutdown(() => {
+      order.push('last');
+    });
+
+    await lifecycle.stopHostModules();
+
+    expect(order).toEqual(['last', 'failed', 'first-start', 'first-end']);
+    expect(log.error).toHaveBeenCalledWith('Shutdown callback threw', {
+      err: expect.objectContaining({ message: 'shutdown-sentinel' }),
+    });
+  });
+
+  it('registers built-in approvals cleanup with the host lifecycle', async () => {
+    const lifecycle = await import('./host-lifecycle.js');
+
+    expect(lifecycle.getHostShutdownCallbacks()).toHaveLength(0);
+    await import('./modules/approvals/index.js');
+    expect(lifecycle.getHostShutdownCallbacks()).toHaveLength(1);
+  });
+});
+
+describe('host lifecycle orchestration', () => {
+  it('starts after delivery is ready and before delivery polling', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
+    const deliveryReady = source.indexOf('setDeliveryAdapter(createChannelDeliveryAdapter())');
+    const modulesStart = source.indexOf('await startHostModules(');
+    const pollingStart = source.indexOf('startActiveDeliveryPoll()');
+
+    expect(deliveryReady).toBeGreaterThan(-1);
+    expect(modulesStart).toBeGreaterThan(deliveryReady);
+    expect(pollingStart).toBeGreaterThan(modulesStart);
+  });
+
+  it('aborts modules and awaits their LIFO shutdown before host cleanup', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'index.ts'), 'utf8');
+    const abort = source.indexOf('hostAbortController.abort()');
+    const modulesStop = source.indexOf('await stopHostModules()');
+    const pollsStop = source.indexOf('stopDeliveryPolls()');
+
+    expect(abort).toBeGreaterThan(-1);
+    expect(modulesStop).toBeGreaterThan(abort);
+    expect(pollsStop).toBeGreaterThan(modulesStop);
+  });
+});

--- a/src/host-lifecycle.ts
+++ b/src/host-lifecycle.ts
@@ -1,0 +1,69 @@
+/**
+ * Host module lifecycle registry.
+ *
+ * Modules register callbacks at import time. Registration is deliberately
+ * inert: startup work begins only after the database and delivery adapter are
+ * ready, and shutdown work begins only from the host's graceful-shutdown path.
+ */
+import type Database from 'better-sqlite3';
+
+import { log } from './log.js';
+
+export interface HostStartContext {
+  db: Database.Database;
+  signal: AbortSignal;
+}
+
+export type HostStartCallback = (ctx: HostStartContext) => void | Promise<void>;
+export type HostShutdownCallback = () => void | Promise<void>;
+
+const startCallbacks: HostStartCallback[] = [];
+const shutdownCallbacks: HostShutdownCallback[] = [];
+
+export function onHostStart(cb: HostStartCallback): void {
+  startCallbacks.push(cb);
+}
+
+export function onHostShutdown(cb: HostShutdownCallback): void {
+  shutdownCallbacks.push(cb);
+}
+
+export function getHostStartCallbacks(): readonly HostStartCallback[] {
+  return [...startCallbacks];
+}
+
+export function getHostShutdownCallbacks(): readonly HostShutdownCallback[] {
+  return [...shutdownCallbacks];
+}
+
+/** Start registered modules serially. A failed start aborts host startup. */
+export async function startHostModules(ctx: HostStartContext): Promise<void> {
+  for (const cb of [...startCallbacks]) {
+    try {
+      await cb(ctx);
+    } catch (err) {
+      log.error('Host module startup callback threw', { err });
+      throw err;
+    }
+  }
+}
+
+async function runShutdownCallbacks(callbacks: readonly HostShutdownCallback[]): Promise<void> {
+  for (const cb of callbacks) {
+    /* eslint-disable no-catch-all/no-catch-all -- graceful shutdown must continue through every registered cleanup */
+    try {
+      await cb();
+    } catch (err) {
+      log.error('Shutdown callback threw', { err });
+    }
+    /* eslint-enable no-catch-all/no-catch-all */
+  }
+}
+
+/**
+ * Stop registered modules serially in reverse registration order. One failed
+ * cleanup must not prevent later callbacks or host cleanup.
+ */
+export async function stopHostModules(): Promise<void> {
+  await runShutdownCallbacks([...shutdownCallbacks].reverse());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,18 @@ import { runMigrations } from './db/migrations/index.js';
 import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
+import { startHostModules, stopHostModules } from './host-lifecycle.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
 import { enforceUpgradeTripwire } from './upgrade-state.js';
 
-// Response + shutdown registries live in response-registry.ts to break the
+// Response registry lives in response-registry.ts to break the
 // circular import cycle: src/index.ts imports src/modules/index.js for side
-// effects, and the modules call registerResponseHandler/onShutdown at top
-// level — which would hit a TDZ error if the arrays lived here. Re-exported
-// here so existing callers see the same surface.
-import { getResponseHandlers, getShutdownCallbacks, type ResponsePayload } from './response-registry.js';
+// effects, and the modules call registerResponseHandler at top level — which
+// would hit a TDZ error if the array lived here.
+import { getResponseHandlers, type ResponsePayload } from './response-registry.js';
+
+const hostAbortController = new AbortController();
 
 async function dispatchResponse(payload: ResponsePayload): Promise<void> {
   for (const handler of getResponseHandlers()) {
@@ -146,16 +148,20 @@ async function main(): Promise<void> {
   // createChannelDeliveryAdapter in channels/channel-registry.ts.
   setDeliveryAdapter(createChannelDeliveryAdapter());
 
-  // 5. Start delivery polls
+  // 5. Start registered host modules. Imports only registered callbacks; the
+  // actual work begins here, after DB + delivery are ready and before polls.
+  await startHostModules({ db, signal: hostAbortController.signal });
+
+  // 6. Start delivery polls
   startActiveDeliveryPoll();
   startSweepDeliveryPoll();
   log.info('Delivery polls started');
 
-  // 6. Start host sweep
+  // 7. Start host sweep
   startHostSweep();
   log.info('Host sweep started');
 
-  // 7. Start the `ncl` CLI socket server (data/ncl.sock).
+  // 8. Start the `ncl` CLI socket server (data/ncl.sock).
   await startCliServer();
 
   log.info('NanoClaw running');
@@ -164,13 +170,8 @@ async function main(): Promise<void> {
 /** Graceful shutdown. */
 async function shutdown(signal: string): Promise<void> {
   log.info('Shutdown signal received', { signal });
-  for (const cb of getShutdownCallbacks()) {
-    try {
-      await cb();
-    } catch (err) {
-      log.error('Shutdown callback threw', { err });
-    }
-  }
+  hostAbortController.abort();
+  await stopHostModules();
   stopDeliveryPolls();
   stopHostSweep();
   await stopCliServer();

--- a/src/modules/approvals/index.ts
+++ b/src/modules/approvals/index.ts
@@ -23,7 +23,8 @@
  * + approval handlers via this module's public API.
  */
 import { onDeliveryAdapterReady } from '../../delivery.js';
-import { registerResponseHandler, onShutdown } from '../../response-registry.js';
+import { onHostShutdown } from '../../host-lifecycle.js';
+import { registerResponseHandler } from '../../response-registry.js';
 import { handleApprovalsResponse } from './response-handler.js';
 import { startOneCLIApprovalHandler, stopOneCLIApprovalHandler } from './onecli-approvals.js';
 
@@ -40,6 +41,6 @@ onDeliveryAdapterReady((adapter) => {
   startOneCLIApprovalHandler(adapter);
 });
 
-onShutdown(() => {
+onHostShutdown(() => {
   stopOneCLIApprovalHandler();
 });

--- a/src/modules/approvals/project.md
+++ b/src/modules/approvals/project.md
@@ -13,7 +13,7 @@ Admin-gated approval flow for agent self-modification and OneCLI credential acce
 - **Delivery actions:** `install_packages`, `add_mcp_server` via `registerDeliveryAction`.
 - **Response handler:** single handler claims both agent-initiated and OneCLI approvals. OneCLI is tried first (in-memory Promise); falls through to `pending_approvals` lookup.
 - **Adapter-ready hook (`onDeliveryAdapterReady`):** starts the OneCLI manual-approval handler once the delivery adapter is set.
-- **Shutdown hook (`onShutdown`):** stops the OneCLI handler.
+- **Host shutdown hook (`onHostShutdown`):** stops the OneCLI handler.
 
 ### Tables
 

--- a/src/response-registry.ts
+++ b/src/response-registry.ts
@@ -1,11 +1,11 @@
 /**
- * Response handler + shutdown callback registries.
+ * Response handler registry.
  *
  * Extracted from index.ts so that modules calling `registerResponseHandler()`
- * or `onShutdown()` at import time don't hit a TDZ error on the const-array
- * declarations. index.ts imports src/modules/index.js for its side effects,
- * which triggers module registrations that would otherwise happen before
- * index.ts's own const initializers have run.
+ * at import time don't hit a TDZ error on the const-array declaration.
+ * index.ts imports src/modules/index.js for its side effects, which triggers
+ * module registrations that would otherwise happen before index.ts's own
+ * const initializers have run.
  *
  * Keep this file dependency-free (log.js is fine, but nothing from
  * modules/* or index.ts itself). Any file imported here must not in turn
@@ -31,15 +31,4 @@ export function registerResponseHandler(handler: ResponseHandler): void {
 
 export function getResponseHandlers(): readonly ResponseHandler[] {
   return responseHandlers;
-}
-
-type ShutdownCallback = () => void | Promise<void>;
-const shutdownCallbacks: ShutdownCallback[] = [];
-
-export function onShutdown(cb: ShutdownCallback): void {
-  shutdownCallbacks.push(cb);
-}
-
-export function getShutdownCallbacks(): readonly ShutdownCallback[] {
-  return shutdownCallbacks;
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds one host lifecycle registry for module startup and shutdown. Startup callbacks run FIFO after the database and delivery adapter are ready; shutdown callbacks run LIFO and continue after individual cleanup failures.

The approvals module now registers its cleanup through `onHostShutdown()`, and the legacy shutdown API is removed from the response registry. Because that interface removal is breaking for custom NanoClaw modules, the changelog links a migration guide covering detection, rationale, migration, verification, and rollback.

## Testing

- `pnpm run build`
- `pnpm run format:check`
- changed-file ESLint check
- `pnpm test` — 1,270 tests passed
- pairwise Git merge simulations for all split branches
