### PR TITLE
fix(permissions): redact DM resolution logs

### DIFF
--- a/src/modules/permissions/user-dm.test.ts
+++ b/src/modules/permissions/user-dm.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+import type { ChannelAdapter } from '../../channels/adapter.js';
+import {
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from '../../channels/channel-registry.js';
+import { closeDb, getDb, initTestDb } from '../../db/connection.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { log } from '../../log.js';
+import { createUser } from './db/users.js';
+import { upsertUserDm } from './db/user-dms.js';
+import { ensureUserDm } from './user-dm.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedUser(id: string, kind: string): void {
+  createUser({ id, kind, display_name: null, created_at: now() });
+}
+
+function registerTestAdapter(channelType: string, openDM?: (handle: string) => Promise<string>): void {
+  const adapter: ChannelAdapter = {
+    name: channelType,
+    channelType,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected: () => true,
+    async deliver() {
+      return undefined;
+    },
+  };
+  if (openDM) adapter.openDM = openDM;
+  registerChannelAdapter(channelType, { factory: () => adapter });
+}
+
+async function startRegisteredAdapters(): Promise<void> {
+  await initChannelAdapters(() => ({
+    conversations: [],
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  closeDb();
+});
+
+describe('ensureUserDm privacy-safe logging', () => {
+  it('always omits identities, messaging-group ids, and SDK errors', async () => {
+    registerTestAdapter('privacy-error', async () => {
+      throw new Error('private-sdk-error-sentinel');
+    });
+    registerTestAdapter('privacy-direct');
+    await startRegisteredAdapters();
+
+    seedUser('privacy-error:private-handle-sentinel', 'privacy-error');
+    seedUser('privacy-direct:stale-handle-sentinel', 'privacy-direct');
+    seedUser('invalid-user-private-sentinel', 'invalid-kind');
+
+    createMessagingGroup({
+      id: 'messaging-group-private-sentinel',
+      channel_type: 'privacy-direct',
+      platform_id: 'old-platform-private-sentinel',
+      name: null,
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    upsertUserDm({
+      user_id: 'privacy-direct:stale-handle-sentinel',
+      channel_type: 'privacy-direct',
+      messaging_group_id: 'messaging-group-private-sentinel',
+      resolved_at: now(),
+    });
+    getDb().pragma('foreign_keys = OFF');
+    getDb().prepare("DELETE FROM messaging_groups WHERE id = 'messaging-group-private-sentinel'").run();
+    getDb().pragma('foreign_keys = ON');
+
+    await expect(ensureUserDm('unknown-user-private-sentinel')).resolves.toBeNull();
+    await expect(ensureUserDm('invalid-user-private-sentinel')).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-error:private-handle-sentinel')).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-direct:stale-handle-sentinel')).resolves.toBeDefined();
+
+    expect(log.error).toHaveBeenCalledWith('ensureUserDm: adapter.openDM failed', {
+      channelType: 'privacy-error',
+    });
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user not found');
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user id not namespaced');
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: cached row references missing messaging_group, re-resolving', {
+      channelType: 'privacy-direct',
+    });
+    expect(log.info).toHaveBeenCalledWith('ensureUserDm: created DM messaging_group', {
+      channelType: 'privacy-direct',
+    });
+
+    const serializedLogs = JSON.stringify({
+      info: vi.mocked(log.info).mock.calls,
+      warn: vi.mocked(log.warn).mock.calls,
+      error: vi.mocked(log.error).mock.calls,
+    });
+    for (const sentinel of [
+      'unknown-user-private-sentinel',
+      'invalid-user-private-sentinel',
+      'private-handle-sentinel',
+      'stale-handle-sentinel',
+      'messaging-group-private-sentinel',
+      'old-platform-private-sentinel',
+      'private-sdk-error-sentinel',
+    ]) {
+      expect(serializedLogs).not.toContain(sentinel);
+    }
+  });
+});

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -48,17 +48,18 @@ import { getUserDm, upsertUserDm } from './db/user-dms.js';
  *   - openDM throws (platform error, user blocked bot, etc.)
  *
  * Callers should treat null as "this user is unreachable on this channel".
+ * Logs omit user, handle, messaging-group, and raw platform-error details.
  */
 export async function ensureUserDm(userId: string): Promise<MessagingGroup | null> {
   const user = getUser(userId);
   if (!user) {
-    log.warn('ensureUserDm: user not found', { userId });
+    log.warn('ensureUserDm: user not found');
     return null;
   }
 
   const { channelType, handle } = parseUserId(user);
   if (!channelType || !handle) {
-    log.warn('ensureUserDm: user id not namespaced', { userId });
+    log.warn('ensureUserDm: user id not namespaced');
     return null;
   }
 
@@ -68,10 +69,7 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
     const mg = getMessagingGroup(cached.messaging_group_id);
     if (mg) return mg;
     // Row points to a deleted messaging_group — fall through and re-resolve.
-    log.warn('ensureUserDm: cached row references missing messaging_group, re-resolving', {
-      userId,
-      messagingGroupId: cached.messaging_group_id,
-    });
+    log.warn('ensureUserDm: cached row references missing messaging_group, re-resolving', { channelType });
   }
 
   // Cache miss: resolve the DM platform_id either via openDM or directly.
@@ -98,11 +96,7 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
       created_at: now,
     };
     createMessagingGroup(mg);
-    log.info('ensureUserDm: created DM messaging_group', {
-      userId,
-      channelType,
-      messagingGroupId: mgId,
-    });
+    log.info('ensureUserDm: created DM messaging_group', { channelType });
   }
 
   upsertUserDm({
@@ -129,12 +123,14 @@ async function resolveDmPlatformId(channelType: string, handle: string): Promise
     // Direct-addressable channel — handle doubles as the DM chat id.
     return handle;
   }
+  /* eslint-disable no-catch-all/no-catch-all -- platform DM resolution failure makes this user unreachable */
   try {
     return await adapter.openDM(handle);
-  } catch (err) {
-    log.error('ensureUserDm: adapter.openDM failed', { channelType, handle, err });
+  } catch {
+    log.error('ensureUserDm: adapter.openDM failed', { channelType });
     return null;
   }
+  /* eslint-enable no-catch-all/no-catch-all */
 }
 
 function parseUserId(user: User): { channelType: string; handle: string } | { channelType: null; handle: null } {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

DM resolution logs could include raw user IDs, handles, messaging-group IDs, platform IDs, and adapter error details. These values are not required to operate or diagnose the resolution path and can expose sensitive identity data in routine host logs.

This change keeps the existing DM resolution behavior while limiting its logs to non-sensitive context. Known invalid-user cases no longer attach identity metadata, and cache/open/create events retain only the channel type. Adapter errors are still reported as failures without serializing the raw error object.

A regression test exercises missing users, malformed IDs, stale cached DMs, adapter failures, and successful DM creation, and verifies that representative sensitive values never appear in emitted logs.

Validation:

- `pnpm test`: 100 test files passed; 1,263 tests passed
- `pnpm run build`
- changed-file ESLint and Prettier checks

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
