### PR TITLE
docs(hardened-image): note that install_packages covers apt and npm only

### DIFF
--- a/docs/hardened-image.md
+++ b/docs/hardened-image.md
@@ -59,7 +59,7 @@ allowlist, and per-group resource limits all do more here than any image can.
 
 | | Pull | Build |
 |---|---|---|
-| `install_packages` | Works, as a derived image | Works |
+| `install_packages` (apt and npm only) | Works, as a derived image | Works |
 | Non-Claude providers | Only if the publisher baked the CLI, or you add it | Work |
 | Custom `Dockerfile` edits | Replaced on the next refresh | Yours |
 | `INSTALL_CJK_FONTS` | Whatever the publisher baked — or `fonts-noto-cjk` via `install_packages` | Your choice |
@@ -70,6 +70,12 @@ prints what to run instead, so a skill that rebuilds can't silently replace the 
 `install_packages` is the exception, and it works because it never rebuilds the base — it builds
 a small image `FROM` the one you pulled and adds your layers, then pins that group to it. The
 vendor's bytes are still underneath, unmodified.
+
+It reaches apt and npm packages only (`packages_apt` and `packages_npm`). A `Dockerfile` that
+installs by any other means — `pip`, a `curl | sh` vendor installer, a language toolchain fetched
+in a `RUN` — has no equivalent here, so those additions are lost on the switch and cannot be put
+back through the derived image. Check what your `Dockerfile` adds before opting in; if anything
+it installs falls outside apt and npm, local builds are the path that keeps it.
 
 What that costs is the vendor's claim over that one group. Their scan covered the base, not
 whatever you added on top, so a derived image labels itself `derived` rather than inheriting


### PR DESCRIPTION
## What

Documents an existing limitation in the hardened-image guide: `install_packages` reaches apt and npm packages only (`packages_apt`, `packages_npm`).

## Why

The guide presents `install_packages` as the answer to "Custom `Dockerfile` edits — replaced on the next refresh", but never states its scope. That reads as though anything a custom Dockerfile installed can be layered back on after switching to the pulled image.

For a Dockerfile that installs by any other route, it can't. I hit this evaluating the switch on an install whose Dockerfile adds `python3`/`pip` packages (`yt-dlp`, `youtube-transcript-api`) that several agent groups depend on. There is no pip channel in the container config, so those packages can't be restored through the derived image — the switch would have quietly broken those groups.

The derived-image path also can't help indirectly, since a refresh clears the pins and returns the group to the shared image.

## Change

- `install_packages` row in the "What changes" table → `install_packages (apt and npm only)`
- One paragraph after the derived-image explanation naming the cases that fall outside it (pip, `curl | sh` vendor installers, language toolchains fetched in a `RUN`) and suggesting readers check their Dockerfile before opting in

Documentation only — no behavior change. This describes current behavior rather than proposing a pip channel; that question is filed separately as an issue.