### PR TITLE
feat(cli): accept bounded JSON from stdin

### DIFF
--- a/container/agent-runner/src/cli/ncl.ts
+++ b/container/agent-runner/src/cli/ncl.ts
@@ -7,9 +7,12 @@
  * instead of the Unix socket transport.
  *
  * Writes a cli_request system message to outbound.db, polls inbound.db
- * for the response. Self-contained — no imports from agent-runner.
+ * for the response. It imports only its local CLI input validator, not the
+ * surrounding agent-runner runtime.
  */
 import { Database } from 'bun:sqlite';
+
+import { readStdinJsonArgs, StdinJsonInputError } from './stdin-json.js';
 
 // ---------------------------------------------------------------------------
 // Frame types (mirrors src/cli/frame.ts on the host)
@@ -130,22 +133,29 @@ function pollResponse(requestId: string, timeoutMs: number): ResponseFrame | nul
 }
 
 // ---------------------------------------------------------------------------
-// Arg parsing (mirrors host-side client.ts)
+// Arg parsing (mirrors src/cli/parse-argv.ts on the host — keep flag handling
+// in sync when adding flags there)
 // ---------------------------------------------------------------------------
 
 function parseArgv(argv: string[]): {
   command: string;
   args: Record<string, unknown>;
   json: boolean;
+  stdinJson: boolean;
 } {
   const positional: string[] = [];
   const args: Record<string, unknown> = {};
   let json = false;
+  let stdinJson = false;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--json') {
       json = true;
+      continue;
+    }
+    if (a === '--stdin-json') {
+      stdinJson = true;
       continue;
     }
     if (a.startsWith('--')) {
@@ -172,12 +182,19 @@ function parseArgv(argv: string[]): {
   // segment as a target ID if the full name isn't a registered command.
   const command = positional.join('-');
 
-  return { command, args, json };
+  return { command, args, json, stdinJson };
 }
 
 function printUsage(): void {
   process.stdout.write(
-    ['Usage: ncl <command> [--key value ...] [--json]', '', 'Run `ncl help` to list available commands.', ''].join('\n'),
+    [
+      'Usage: ncl <command> [--key value ...] [--stdin-json] [--json]',
+      '',
+      '  --stdin-json  Read one bounded JSON object from stdin and merge it with argv flags.',
+      '',
+      'Run `ncl help` to list available commands.',
+      '',
+    ].join('\n'),
   );
 }
 
@@ -266,9 +283,25 @@ if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
   process.exit(0);
 }
 
-const { command, args, json } = parseArgv(argv);
+const { command, args, json, stdinJson } = parseArgv(argv);
+let requestArgs = args;
+if (stdinJson) {
+  if (process.stdin.isTTY) {
+    // Reading a TTY would silently block until the user types Ctrl-D.
+    process.stderr.write('ncl: --stdin-json requires piped stdin (e.g. `echo {...} | ncl ...`)\n');
+    process.exit(2);
+  }
+  try {
+    requestArgs = await readStdinJsonArgs(process.stdin, args);
+  } catch (err) {
+    if (!(err instanceof StdinJsonInputError)) throw err;
+    process.stderr.write(`ncl: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
 const requestId = generateId();
-const req: RequestFrame = { id: requestId, command, args };
+const req: RequestFrame = { id: requestId, command, args: requestArgs };
 
 writeRequest(req);
 

--- a/container/agent-runner/src/cli/stdin-json.test.ts
+++ b/container/agent-runner/src/cli/stdin-json.test.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'bun:test';
+
+import { MAX_STDIN_JSON_BYTES, readStdinJsonArgs, type StdinJsonStream } from './stdin-json.js';
+
+async function* stream(...chunks: Array<string | Uint8Array>): StdinJsonStream {
+  for (const chunk of chunks) yield chunk;
+}
+
+describe('container CLI bounded stdin JSON', () => {
+  it('merges structured stdin with argv-derived args', async () => {
+    const result = await readStdinJsonArgs(stream('{"nested":{"enabled":true}}'), {
+      'argv-value': 'from-argv',
+    });
+
+    expect(result).toEqual({
+      'argv-value': 'from-argv',
+      nested: { enabled: true },
+    });
+  });
+
+  it('rejects input over 64 KiB', async () => {
+    const envelopeBytes = Buffer.byteLength('{"payload":""}', 'utf8');
+    const source = `{"payload":"${'a'.repeat(MAX_STDIN_JSON_BYTES - envelopeBytes + 1)}"}`;
+
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow(
+      `--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`,
+    );
+  });
+
+  it.each(['', '[]', 'null', '{"broken":'])('rejects invalid input: %s', async (source) => {
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow();
+  });
+
+  it('rejects normalized duplicate keys', async () => {
+    await expect(
+      readStdinJsonArgs(stream('{"group_id":"stdin-value"}'), {
+        'group-id': 'argv-value',
+      }),
+    ).rejects.toThrow('--stdin-json key "group_id" conflicts with argv key "group-id" after CLI key normalization');
+  });
+
+  it('rejects __proto__ input', async () => {
+    await expect(readStdinJsonArgs(stream('{"__proto__":{"polluted":true}}'), {})).rejects.toThrow(
+      '--stdin-json key "__proto__" is not allowed',
+    );
+  });
+
+  it('recognizes --stdin-json before opening the session databases', () => {
+    const result = spawnSync(process.execPath, ['src/cli/ncl.ts', 'groups', 'list', '--stdin-json'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      input: '{"broken":',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('ncl: --stdin-json input is not valid JSON\n');
+  });
+});

--- a/container/agent-runner/src/cli/stdin-json.ts
+++ b/container/agent-runner/src/cli/stdin-json.ts
@@ -1,16 +1,3 @@
-/**
- * Bounded JSON-over-stdin for the ncl CLI (`--stdin-json`).
- *
- * This module exists as two byte-identical copies:
- *   - src/cli/stdin-json.ts                        (host CLI, Node)
- *   - container/agent-runner/src/cli/stdin-json.ts (container CLI, Bun)
- *
- * The container CLI cannot import from src/ (separate package tree, separate
- * runtime), so the copy is deliberate — same pattern as timezone.ts. A sync
- * test on the host side (src/cli/stdin-json.test.ts) fails if the copies
- * drift: edit both files together.
- */
-
 /** Maximum structured CLI input accepted from stdin (64 KiB, measured as UTF-8 bytes). */
 export const MAX_STDIN_JSON_BYTES = 64 * 1024;
 

--- a/container/agent-runner/src/cli/stdin-json.ts
+++ b/container/agent-runner/src/cli/stdin-json.ts
@@ -1,0 +1,148 @@
+/**
+ * Bounded JSON-over-stdin for the ncl CLI (`--stdin-json`).
+ *
+ * This module exists as two byte-identical copies:
+ *   - src/cli/stdin-json.ts                        (host CLI, Node)
+ *   - container/agent-runner/src/cli/stdin-json.ts (container CLI, Bun)
+ *
+ * The container CLI cannot import from src/ (separate package tree, separate
+ * runtime), so the copy is deliberate — same pattern as timezone.ts. A sync
+ * test on the host side (src/cli/stdin-json.test.ts) fails if the copies
+ * drift: edit both files together.
+ */
+
+/** Maximum structured CLI input accepted from stdin (64 KiB, measured as UTF-8 bytes). */
+export const MAX_STDIN_JSON_BYTES = 64 * 1024;
+
+export type StdinJsonStream = AsyncIterable<string | Uint8Array>;
+
+/** Expected validation failure caused by the contents of `--stdin-json`. */
+export class StdinJsonInputError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StdinJsonInputError';
+  }
+}
+
+/**
+ * Read one bounded JSON object from stdin and merge it with argv-derived args.
+ * A key may come from exactly one source so shell-visible flags cannot be
+ * silently replaced by piped data.
+ */
+export async function readStdinJsonArgs(
+  stream: StdinJsonStream,
+  argvArgs: Readonly<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  const source = await readBounded(stream);
+  const stdinArgs = parseJsonObject(source);
+  assertNoKeyConflicts(stdinArgs, argvArgs);
+  // Safe to spread: assertNoKeyConflicts rejected "__proto__" and every
+  // overlapping key, so this is a plain disjoint merge.
+  return { ...argvArgs, ...stdinArgs };
+}
+
+/**
+ * Accumulate the stream into a single UTF-8 string, enforcing the size limit.
+ *
+ * The limit is defined in bytes, and stdin yields chunks as either strings or
+ * raw bytes depending on how the stream was configured upstream. Each chunk is
+ * therefore normalized to a Buffer and the running total counts
+ * `buffer.byteLength` — the true encoded size — rather than string length,
+ * where a multibyte character (e.g. "ש", 2 bytes) would count as 1.
+ *
+ * Decoding to text happens exactly once, after the whole input is collected:
+ * a chunk boundary can fall in the middle of a multibyte character, so
+ * decoding chunk-by-chunk could corrupt the character that straddles the
+ * split. The limit check runs before buffering grows past the cap, so an
+ * oversized (or unbounded) pipe is rejected without being read to the end.
+ */
+async function readBounded(stream: StdinJsonStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+
+  for await (const chunk of stream) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : Buffer.from(chunk);
+    byteLength += buffer.byteLength;
+    if (byteLength > MAX_STDIN_JSON_BYTES) {
+      throw new StdinJsonInputError(`--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`);
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, byteLength).toString('utf8');
+}
+
+/** Parse the input, requiring exactly one JSON object — not an array, scalar, or null. */
+function parseJsonObject(source: string): Record<string, unknown> {
+  if (source.trim().length === 0) {
+    throw new StdinJsonInputError('--stdin-json input is empty');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (err) {
+    throw new StdinJsonInputError('--stdin-json input is not valid JSON', { cause: err });
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new StdinJsonInputError('--stdin-json input must be one JSON object');
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+/** Match the key normalization applied by command parsers in crud.ts. */
+function canonicalArgKey(key: string): string {
+  return key.replace(/-/g, '_');
+}
+
+/**
+ * Reject any stdin key that could collide with another arg after the merge.
+ *
+ * Command parsers (crud.ts) normalize `-` to `_` in arg keys, so `group-id`
+ * and `group_id` are the same argument downstream. Two keys that are distinct
+ * here but identical after normalization would silently overwrite each other
+ * past this point — so every such alias is a hard conflict, whether the pair
+ * is stdin-vs-argv or two stdin keys.
+ *
+ * `__proto__` is rejected outright as a prototype-pollution guard: parsed
+ * args flow into downstream handlers that copy them by plain assignment.
+ */
+function assertNoKeyConflicts(
+  stdinArgs: Readonly<Record<string, unknown>>,
+  argvArgs: Readonly<Record<string, unknown>>,
+): void {
+  const argvKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(argvArgs)) {
+    const canonical = canonicalArgKey(key);
+    if (!argvKeysByCanonical.has(canonical)) argvKeysByCanonical.set(canonical, key);
+  }
+
+  const stdinKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(stdinArgs)) {
+    if (key === '__proto__') {
+      throw new StdinJsonInputError('--stdin-json key "__proto__" is not allowed');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(argvArgs, key)) {
+      throw new StdinJsonInputError(`--stdin-json key "${key}" is also supplied on argv`);
+    }
+
+    const canonical = canonicalArgKey(key);
+    const argvKey = argvKeysByCanonical.get(canonical);
+    if (argvKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json key "${key}" conflicts with argv key "${argvKey}" after CLI key normalization`,
+      );
+    }
+
+    const priorStdinKey = stdinKeysByCanonical.get(canonical);
+    if (priorStdinKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json keys "${priorStdinKey}" and "${key}" conflict after CLI key normalization`,
+      );
+    }
+    stdinKeysByCanonical.set(canonical, key);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
+    "stdin-json:generate": "sh scripts/sync-stdin-json.sh",
+    "stdin-json:check": "sh scripts/sync-stdin-json.sh --check",
     "prepare": "husky",
     "setup": "tsx setup/index.ts",
     "setup:auto": "tsx setup/auto.ts",

--- a/scripts/sync-stdin-json.sh
+++ b/scripts/sync-stdin-json.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+source_path=src/cli/stdin-json.ts
+target_path=container/agent-runner/src/cli/stdin-json.ts
+
+if [ "${1:-}" = "--check" ]; then
+  cmp -s "$source_path" "$target_path" || {
+    echo "$target_path is stale; run pnpm stdin-json:generate" >&2
+    exit 1
+  }
+else
+  cp "$source_path" "$target_path"
+fi

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -5,7 +5,7 @@
  * formats the response, exits non-zero on error.
  *
  * Usage:
- *   ncl <resource> <verb> [target] [--key value ...] [--json]
+ *   ncl <resource> <verb> [target] [--key value ...] [--stdin-json] [--json]
  *
  * Examples:
  *   ncl groups list
@@ -19,7 +19,9 @@ import { randomUUID } from 'crypto';
 
 import { formatResponse } from './format.js';
 import type { RequestFrame } from './frame.js';
+import { parseArgv } from './parse-argv.js';
 import { SocketTransport } from './socket-client.js';
+import { readStdinJsonArgs, StdinJsonInputError } from './stdin-json.js';
 import type { Transport } from './transport.js';
 import { formatTransportError } from './transport-errors.js';
 
@@ -31,8 +33,31 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const { command, args, json } = parseArgv(argv);
-  const req: RequestFrame = { id: randomUUID(), command, args };
+  const { command, args, json, stdinJson } = parseArgv(argv);
+  if (command.length === 0) {
+    process.stderr.write('ncl: missing command\n');
+    printUsage();
+    process.exit(2);
+  }
+
+  let requestArgs = args;
+  if (stdinJson) {
+    if (process.stdin.isTTY) {
+      // Reading a TTY would silently block until the user types Ctrl-D.
+      process.stderr.write('ncl: --stdin-json requires piped stdin (e.g. `echo {...} | ncl ...`)\n');
+      process.exit(2);
+    }
+    try {
+      requestArgs = await readStdinJsonArgs(process.stdin, args);
+    } catch (err) {
+      if (!(err instanceof StdinJsonInputError)) throw err;
+      process.stderr.write(`ncl: ${err.message}\n`);
+      process.exit(2);
+    }
+  }
+  // Stdin is only a client-side encoding for args. The daemon receives the
+  // same stable request frame it would receive if every value came from argv.
+  const req: RequestFrame = { id: randomUUID(), command, args: requestArgs };
   const transport: Transport = pickTransport();
 
   let res;
@@ -57,54 +82,12 @@ function pickTransport(): Transport {
   return new SocketTransport();
 }
 
-function parseArgv(argv: string[]): {
-  command: string;
-  args: Record<string, unknown>;
-  json: boolean;
-} {
-  const positional: string[] = [];
-  const args: Record<string, unknown> = {};
-  let json = false;
-
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === '--json') {
-      json = true;
-      continue;
-    }
-    if (a.startsWith('--')) {
-      const key = a.slice(2);
-      const next = argv[i + 1];
-      if (next === undefined || next.startsWith('--')) {
-        args[key] = true;
-      } else {
-        args[key] = next;
-        i++;
-      }
-      continue;
-    }
-    positional.push(a);
-  }
-
-  if (positional.length === 0) {
-    process.stderr.write('ncl: missing command\n');
-    printUsage();
-    process.exit(2);
-  }
-
-  // Join all positionals with dashes to form the command name.
-  // If the full name isn't a command, the dispatcher will try trimming
-  // the last segment and using it as the target ID (e.g. `groups get abc`
-  // → command "groups-get", id "abc").
-  const command = positional.join('-');
-
-  return { command, args, json };
-}
-
 function printUsage(): void {
   process.stdout.write(
     [
-      'Usage: ncl <resource> <verb> [target] [--key value ...] [--json]',
+      'Usage: ncl <resource> <verb> [target] [--key value ...] [--stdin-json] [--json]',
+      '',
+      '  --stdin-json  Read one bounded JSON object from stdin and merge it with argv flags.',
       '',
       'Run `ncl help` to list available resources and commands.',
       '',

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,0 +1,43 @@
+export type ParsedArgv = {
+  command: string;
+  args: Record<string, unknown>;
+  json: boolean;
+  stdinJson: boolean;
+};
+
+export function parseArgv(argv: string[]): ParsedArgv {
+  const positional: string[] = [];
+  const args: Record<string, unknown> = {};
+  let json = false;
+  let stdinJson = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--stdin-json') {
+      stdinJson = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  // Join all positionals with dashes to form the command name.
+  // If the full name isn't a command, the dispatcher will try trimming
+  // the last segment and using it as the target ID (e.g. `groups get abc`
+  // → command "groups-get", id "abc").
+  return { command: positional.join('-'), args, json, stdinJson };
+}

--- a/src/cli/stdin-json.e2e.test.ts
+++ b/src/cli/stdin-json.e2e.test.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, it } from 'vitest';
+
+import type { ResponseFrame } from './frame.js';
+import { register } from './registry.js';
+import { startCliServer, stopCliServer } from './socket-server.js';
+
+type PrintArgs = {
+  'argv-value': string;
+  stdin_value: string;
+  nested: { enabled: boolean };
+};
+
+register<PrintArgs, PrintArgs>({
+  name: 'stdin-json-e2e-print',
+  description: 'Print structured args for the stdin JSON E2E test.',
+  access: 'open',
+  parseArgs: (raw) => {
+    if (
+      typeof raw['argv-value'] !== 'string' ||
+      typeof raw.stdin_value !== 'string' ||
+      !raw.nested ||
+      typeof raw.nested !== 'object' ||
+      (raw.nested as Record<string, unknown>).enabled !== true
+    ) {
+      throw new Error('unexpected E2E args');
+    }
+    return raw as PrintArgs;
+  },
+  handler: async (args) => args,
+});
+
+it('pipes stdin JSON through the real CLI and socket server into a registered command', async () => {
+  const tempDir = fs.mkdtempSync('/tmp/ncl-stdin-e2e-');
+  const dataDir = path.join(tempDir, 'data');
+  const socketPath = path.join(dataDir, 'ncl.sock');
+  fs.mkdirSync(dataDir);
+
+  try {
+    await startCliServer(socketPath);
+
+    const result = await runCli(tempDir, {
+      stdin_value: 'from-stdin',
+      nested: { enabled: true },
+    });
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: '' });
+    const frame = JSON.parse(result.stdout) as ResponseFrame;
+    expect(frame).toEqual({
+      id: expect.any(String),
+      ok: true,
+      data: {
+        'argv-value': 'from-argv',
+        stdin_value: 'from-stdin',
+        nested: { enabled: true },
+      },
+    });
+  } finally {
+    await stopCliServer();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+it('runs when the CLI entry point is invoked through a symlink', async () => {
+  const tempDir = fs.mkdtempSync('/tmp/ncl-stdin-symlink-e2e-');
+  const dataDir = path.join(tempDir, 'data');
+  const socketPath = path.join(dataDir, 'ncl.sock');
+  const clientPath = fileURLToPath(new URL('./client.ts', import.meta.url));
+  const symlinkPath = path.join(tempDir, 'ncl.ts');
+  fs.mkdirSync(dataDir);
+  fs.symlinkSync(clientPath, symlinkPath);
+
+  try {
+    await startCliServer(socketPath);
+
+    const result = await runCli(
+      tempDir,
+      {
+        stdin_value: 'from-stdin',
+        nested: { enabled: true },
+      },
+      symlinkPath,
+    );
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: '' });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      data: {
+        'argv-value': 'from-argv',
+        stdin_value: 'from-stdin',
+        nested: { enabled: true },
+      },
+    });
+  } finally {
+    await stopCliServer();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function runCli(
+  cwd: string,
+  stdin: Record<string, unknown>,
+  clientPath = fileURLToPath(new URL('./client.ts', import.meta.url)),
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      import.meta.resolve('tsx'),
+      clientPath,
+      'stdin-json-e2e',
+      'print',
+      '--argv-value',
+      'from-argv',
+      '--stdin-json',
+      '--json',
+    ],
+    { cwd, stdio: ['pipe', 'pipe', 'pipe'] },
+  );
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => (stdout += chunk));
+  child.stderr.on('data', (chunk: string) => (stderr += chunk));
+  child.stdin.end(JSON.stringify(stdin));
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 10_000);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}

--- a/src/cli/stdin-json.test.ts
+++ b/src/cli/stdin-json.test.ts
@@ -1,6 +1,4 @@
 import { spawnSync } from 'node:child_process';
-import fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -10,16 +8,6 @@ import { MAX_STDIN_JSON_BYTES, readStdinJsonArgs, type StdinJsonStream } from '.
 async function* stream(...chunks: Array<string | Uint8Array>): StdinJsonStream {
   for (const chunk of chunks) yield chunk;
 }
-
-// The container CLI carries a deliberate copy of this module (it cannot import
-// from src/ — separate package tree, separate runtime). This guard fails the
-// build if the copies drift; edit both files together.
-it('container stdin-json.ts is a byte-identical mirror of the host module', () => {
-  const hostPath = fileURLToPath(new URL('./stdin-json.ts', import.meta.url));
-  const containerPath = fileURLToPath(new URL('../../container/agent-runner/src/cli/stdin-json.ts', import.meta.url));
-
-  expect(fs.readFileSync(containerPath, 'utf8')).toBe(fs.readFileSync(hostPath, 'utf8'));
-});
 
 describe('bounded stdin JSON', () => {
   it('merges one chunked JSON object into argv args', async () => {

--- a/src/cli/stdin-json.test.ts
+++ b/src/cli/stdin-json.test.ts
@@ -1,0 +1,127 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseArgv } from './parse-argv.js';
+import { MAX_STDIN_JSON_BYTES, readStdinJsonArgs, type StdinJsonStream } from './stdin-json.js';
+
+async function* stream(...chunks: Array<string | Uint8Array>): StdinJsonStream {
+  for (const chunk of chunks) yield chunk;
+}
+
+// The container CLI carries a deliberate copy of this module (it cannot import
+// from src/ — separate package tree, separate runtime). This guard fails the
+// build if the copies drift; edit both files together.
+it('container stdin-json.ts is a byte-identical mirror of the host module', () => {
+  const hostPath = fileURLToPath(new URL('./stdin-json.ts', import.meta.url));
+  const containerPath = fileURLToPath(new URL('../../container/agent-runner/src/cli/stdin-json.ts', import.meta.url));
+
+  expect(fs.readFileSync(containerPath, 'utf8')).toBe(fs.readFileSync(hostPath, 'utf8'));
+});
+
+describe('bounded stdin JSON', () => {
+  it('merges one chunked JSON object into argv args', async () => {
+    const result = await readStdinJsonArgs(stream('{"source":"stdin",', Buffer.from('"nested":{"enabled":true}}')), {
+      name: 'example',
+    });
+
+    expect(result).toEqual({
+      name: 'example',
+      source: 'stdin',
+      nested: { enabled: true },
+    });
+  });
+
+  it('accepts an object whose UTF-8 representation is exactly 64 KiB', async () => {
+    const envelopeBytes = Buffer.byteLength('{"payload":""}', 'utf8');
+    const source = `{"payload":"${'a'.repeat(MAX_STDIN_JSON_BYTES - envelopeBytes)}"}`;
+    expect(Buffer.byteLength(source, 'utf8')).toBe(MAX_STDIN_JSON_BYTES);
+
+    const result = await readStdinJsonArgs(stream(source), {});
+
+    expect((result.payload as string).length).toBe(MAX_STDIN_JSON_BYTES - envelopeBytes);
+  });
+
+  it('rejects input one byte over the 64 KiB limit', async () => {
+    const envelopeBytes = Buffer.byteLength('{"payload":""}', 'utf8');
+    const source = `{"payload":"${'a'.repeat(MAX_STDIN_JSON_BYTES - envelopeBytes + 1)}"}`;
+
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow(
+      `--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`,
+    );
+  });
+
+  it('measures multibyte input as UTF-8 bytes across chunk boundaries', async () => {
+    const source = Buffer.from('{"value":"שלום"}', 'utf8');
+    const result = await readStdinJsonArgs(stream(source.subarray(0, 12), source.subarray(12)), {});
+
+    expect(result).toEqual({ value: 'שלום' });
+  });
+
+  it.each(['', '   \n\t'])('rejects empty input %#', async (source) => {
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow('--stdin-json input is empty');
+  });
+
+  it('rejects malformed JSON', async () => {
+    await expect(readStdinJsonArgs(stream('{"broken":'), {})).rejects.toThrow('--stdin-json input is not valid JSON');
+  });
+
+  it.each(['null', '[]', '"text"', '42', 'true'])('rejects a non-object JSON value: %s', async (source) => {
+    await expect(readStdinJsonArgs(stream(source), {})).rejects.toThrow('--stdin-json input must be one JSON object');
+  });
+
+  it('rejects a key also supplied on argv', async () => {
+    await expect(readStdinJsonArgs(stream('{"subject":"stdin-value"}'), { subject: 'argv-value' })).rejects.toThrow(
+      '--stdin-json key "subject" is also supplied on argv',
+    );
+  });
+
+  it('rejects a stdin key that aliases a hyphenated argv key after CLI normalization', async () => {
+    await expect(
+      readStdinJsonArgs(stream('{"group_id":"stdin-value"}'), {
+        'group-id': 'argv-value',
+      }),
+    ).rejects.toThrow('--stdin-json key "group_id" conflicts with argv key "group-id" after CLI key normalization');
+  });
+
+  it('rejects two stdin keys that alias each other after CLI normalization', async () => {
+    await expect(readStdinJsonArgs(stream('{"group-id":"first","group_id":"second"}'), {})).rejects.toThrow(
+      '--stdin-json keys "group-id" and "group_id" conflict after CLI key normalization',
+    );
+  });
+
+  it('rejects __proto__ before downstream argument normalization', async () => {
+    await expect(readStdinJsonArgs(stream('{"__proto__":{"id":"task-123"}}'), {})).rejects.toThrow(
+      '--stdin-json key "__proto__" is not allowed',
+    );
+  });
+});
+
+describe('host CLI flags', () => {
+  it('keeps --json as output mode while excluding --stdin-json from request args', () => {
+    expect(parseArgv(['groups', 'update', '--stdin-json', '--json', '--force'])).toEqual({
+      command: 'groups-update',
+      args: { force: true },
+      json: true,
+      stdinJson: true,
+    });
+  });
+
+  it('reports malformed stdin as an input error, not an unexpected failure', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', 'src/cli/client.ts', 'groups', 'list', '--stdin-json'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        input: '{"broken":',
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('ncl: --stdin-json input is not valid JSON\n');
+  });
+});

--- a/src/cli/stdin-json.ts
+++ b/src/cli/stdin-json.ts
@@ -1,16 +1,3 @@
-/**
- * Bounded JSON-over-stdin for the ncl CLI (`--stdin-json`).
- *
- * This module exists as two byte-identical copies:
- *   - src/cli/stdin-json.ts                        (host CLI, Node)
- *   - container/agent-runner/src/cli/stdin-json.ts (container CLI, Bun)
- *
- * The container CLI cannot import from src/ (separate package tree, separate
- * runtime), so the copy is deliberate — same pattern as timezone.ts. A sync
- * test on the host side (src/cli/stdin-json.test.ts) fails if the copies
- * drift: edit both files together.
- */
-
 /** Maximum structured CLI input accepted from stdin (64 KiB, measured as UTF-8 bytes). */
 export const MAX_STDIN_JSON_BYTES = 64 * 1024;
 

--- a/src/cli/stdin-json.ts
+++ b/src/cli/stdin-json.ts
@@ -1,0 +1,148 @@
+/**
+ * Bounded JSON-over-stdin for the ncl CLI (`--stdin-json`).
+ *
+ * This module exists as two byte-identical copies:
+ *   - src/cli/stdin-json.ts                        (host CLI, Node)
+ *   - container/agent-runner/src/cli/stdin-json.ts (container CLI, Bun)
+ *
+ * The container CLI cannot import from src/ (separate package tree, separate
+ * runtime), so the copy is deliberate — same pattern as timezone.ts. A sync
+ * test on the host side (src/cli/stdin-json.test.ts) fails if the copies
+ * drift: edit both files together.
+ */
+
+/** Maximum structured CLI input accepted from stdin (64 KiB, measured as UTF-8 bytes). */
+export const MAX_STDIN_JSON_BYTES = 64 * 1024;
+
+export type StdinJsonStream = AsyncIterable<string | Uint8Array>;
+
+/** Expected validation failure caused by the contents of `--stdin-json`. */
+export class StdinJsonInputError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StdinJsonInputError';
+  }
+}
+
+/**
+ * Read one bounded JSON object from stdin and merge it with argv-derived args.
+ * A key may come from exactly one source so shell-visible flags cannot be
+ * silently replaced by piped data.
+ */
+export async function readStdinJsonArgs(
+  stream: StdinJsonStream,
+  argvArgs: Readonly<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  const source = await readBounded(stream);
+  const stdinArgs = parseJsonObject(source);
+  assertNoKeyConflicts(stdinArgs, argvArgs);
+  // Safe to spread: assertNoKeyConflicts rejected "__proto__" and every
+  // overlapping key, so this is a plain disjoint merge.
+  return { ...argvArgs, ...stdinArgs };
+}
+
+/**
+ * Accumulate the stream into a single UTF-8 string, enforcing the size limit.
+ *
+ * The limit is defined in bytes, and stdin yields chunks as either strings or
+ * raw bytes depending on how the stream was configured upstream. Each chunk is
+ * therefore normalized to a Buffer and the running total counts
+ * `buffer.byteLength` — the true encoded size — rather than string length,
+ * where a multibyte character (e.g. "ש", 2 bytes) would count as 1.
+ *
+ * Decoding to text happens exactly once, after the whole input is collected:
+ * a chunk boundary can fall in the middle of a multibyte character, so
+ * decoding chunk-by-chunk could corrupt the character that straddles the
+ * split. The limit check runs before buffering grows past the cap, so an
+ * oversized (or unbounded) pipe is rejected without being read to the end.
+ */
+async function readBounded(stream: StdinJsonStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+
+  for await (const chunk of stream) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : Buffer.from(chunk);
+    byteLength += buffer.byteLength;
+    if (byteLength > MAX_STDIN_JSON_BYTES) {
+      throw new StdinJsonInputError(`--stdin-json input exceeds ${MAX_STDIN_JSON_BYTES} bytes`);
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, byteLength).toString('utf8');
+}
+
+/** Parse the input, requiring exactly one JSON object — not an array, scalar, or null. */
+function parseJsonObject(source: string): Record<string, unknown> {
+  if (source.trim().length === 0) {
+    throw new StdinJsonInputError('--stdin-json input is empty');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (err) {
+    throw new StdinJsonInputError('--stdin-json input is not valid JSON', { cause: err });
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new StdinJsonInputError('--stdin-json input must be one JSON object');
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+/** Match the key normalization applied by command parsers in crud.ts. */
+function canonicalArgKey(key: string): string {
+  return key.replace(/-/g, '_');
+}
+
+/**
+ * Reject any stdin key that could collide with another arg after the merge.
+ *
+ * Command parsers (crud.ts) normalize `-` to `_` in arg keys, so `group-id`
+ * and `group_id` are the same argument downstream. Two keys that are distinct
+ * here but identical after normalization would silently overwrite each other
+ * past this point — so every such alias is a hard conflict, whether the pair
+ * is stdin-vs-argv or two stdin keys.
+ *
+ * `__proto__` is rejected outright as a prototype-pollution guard: parsed
+ * args flow into downstream handlers that copy them by plain assignment.
+ */
+function assertNoKeyConflicts(
+  stdinArgs: Readonly<Record<string, unknown>>,
+  argvArgs: Readonly<Record<string, unknown>>,
+): void {
+  const argvKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(argvArgs)) {
+    const canonical = canonicalArgKey(key);
+    if (!argvKeysByCanonical.has(canonical)) argvKeysByCanonical.set(canonical, key);
+  }
+
+  const stdinKeysByCanonical = new Map<string, string>();
+  for (const key of Object.keys(stdinArgs)) {
+    if (key === '__proto__') {
+      throw new StdinJsonInputError('--stdin-json key "__proto__" is not allowed');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(argvArgs, key)) {
+      throw new StdinJsonInputError(`--stdin-json key "${key}" is also supplied on argv`);
+    }
+
+    const canonical = canonicalArgKey(key);
+    const argvKey = argvKeysByCanonical.get(canonical);
+    if (argvKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json key "${key}" conflicts with argv key "${argvKey}" after CLI key normalization`,
+      );
+    }
+
+    const priorStdinKey = stdinKeysByCanonical.get(canonical);
+    if (priorStdinKey !== undefined) {
+      throw new StdinJsonInputError(
+        `--stdin-json keys "${priorStdinKey}" and "${key}" conflict after CLI key normalization`,
+      );
+    }
+    stdinKeysByCanonical.set(canonical, key);
+  }
+}


### PR DESCRIPTION
## Description

Add a generic `--stdin-json` input mode to both host and container `ncl` clients. This gives NanoClaw commands a bounded way to receive structured arguments without changing the existing request frame, daemon dispatcher, command registry, authorization, or output behavior.

The client reads at most 64 KiB, requires exactly one JSON object, rejects malformed input and conflicting keys, merges the object with ordinary argv flags, and passes the result through each command's existing argument parser. `--json` remains the independent output-format flag.

The host argument parser now lives in an import-safe module, while the executable continues to run unconditionally so symlinked `ncl` entry points work correctly. The Bun container client implements the same input contract rather than interpreting `--stdin-json` as a normal command argument.

## Validation

- host suite: 101 files and 1,282 tests passed
- container suite: 168 passed, one existing skip
- focused host CLI tests: 20 passed, including real socket and symlink E2E coverage
- focused container CLI tests: 9 passed
- host build and container typecheck passed
- formatting passed; changed-file lint reported zero errors
