### PR TITLE
feat(providers): remote Streamable HTTP MCP servers for codex and opencode

### DIFF
--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -50,6 +50,11 @@ describe('Codex config TOML', () => {
           args: ['run', '/app/src/mcp-tools/index.ts'],
           env: { FOO: 'bar' },
         },
+        docs: {
+          type: 'http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { 'X-Api-Version': '2024-06' },
+        },
       },
       MEMORY_SESSION_HOOK,
       { model: 'gpt-5', effort: 'medium' },
@@ -70,6 +75,9 @@ describe('Codex config TOML', () => {
     expect(content).toContain('args = ["run", "/app/src/mcp-tools/index.ts"]');
     expect(content).toContain('[mcp_servers.nanoclaw.env]');
     expect(content).toContain('FOO = "bar"');
+    expect(content).toContain(
+      '[mcp_servers.docs]\nurl = "https://mcp.example.com/mcp"\n[mcp_servers.docs.http_headers]\n"X-Api-Version" = "2024-06"',
+    );
 
     const hooks = JSON.parse(fs.readFileSync(path.join(tmpHome, '.codex', 'hooks.json'), 'utf-8'));
     expect(hooks.hooks.SessionStart).toEqual([

--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -35,6 +35,10 @@ describe('Codex config TOML', () => {
     expect(tomlBasicString('a "quoted" \\\\ value')).toBe('"a \\"quoted\\" \\\\\\\\ value"');
   });
 
+  it('escapes control characters TOML forbids raw', () => {
+    expect(tomlBasicString('bell\u0007tab\tdel\u007f')).toBe('"bell\\u0007tab\\u0009del\\u007F"');
+  });
+
   it('rejects newlines', () => {
     expect(() => tomlBasicString('bad\nvalue')).toThrow(/newline/);
   });

--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -89,6 +89,42 @@ describe('Codex config TOML', () => {
     expect(CODEX_APP_SERVER_ARGS).toContain('--dangerously-bypass-hook-trust');
   });
 
+  it('quotes non-bare server names and env keys so they cannot open new tables', () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+    process.env.HOME = tmpHome;
+
+    writeCodexConfigToml(
+      {
+        'docs] [mcp_servers.evil]': {
+          type: 'http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { 'X-V': '1' },
+        },
+        plain: { command: 'bun', env: { 'BAD KEY': 'v' } },
+      },
+      MEMORY_SESSION_HOOK,
+    );
+
+    const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf-8');
+    expect(content).toContain('[mcp_servers."docs] [mcp_servers.evil]"]');
+    expect(content).toContain('[mcp_servers."docs] [mcp_servers.evil]".http_headers]');
+    expect(content).not.toContain('\n[mcp_servers.evil]');
+    expect(content).toContain('[mcp_servers.plain.env]');
+    expect(content).toContain('"BAD KEY" = "v"');
+  });
+
+  it('fails closed on a server name containing a newline', () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+    process.env.HOME = tmpHome;
+
+    expect(() =>
+      writeCodexConfigToml(
+        { 'docs]\n[mcp_servers.evil]': { type: 'http', url: 'https://mcp.example.com/mcp' } },
+        MEMORY_SESSION_HOOK,
+      ),
+    ).toThrow(/newline/);
+  });
+
   it('preserves unrelated hooks and refreshes only the NanoClaw memory entry', () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
     process.env.HOME = tmpHome;

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -507,11 +507,13 @@ export function buildCodexProcessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv 
 }
 
 /**
- * Server names and env keys are attacker-influenced (add_mcp_server approval
- * flow validates content, not charset). Quoting anything that isn't a bare
- * TOML key keeps a crafted name from closing the header and opening its own
- * [mcp_servers.*] table with a command line the approval card never showed.
- * Bare and quoted forms name the same table, so safe names stay byte-identical.
+ * Defense in depth behind the host-side charset allowlist
+ * (MCP_SERVER_NAME_RE in src/container-config.ts): configs stored before
+ * that validation existed, or hand-edited DB rows, can still carry names
+ * that are not bare TOML keys. [A-Za-z0-9_-]+ is exactly TOML's bare-key
+ * grammar, so safe names stay byte-identical, and anything else is quoted —
+ * a crafted name can never close the header and open its own
+ * [mcp_servers.*] table. Bare and quoted forms name the same table.
  */
 function tomlKey(name: string): string {
   return /^[A-Za-z0-9_-]+$/.test(name) ? name : tomlBasicString(name);
@@ -521,7 +523,14 @@ export function tomlBasicString(value: string): string {
   if (value.includes('\n') || value.includes('\r')) {
     throw new Error(`MCP config value contains newline: ${JSON.stringify(value.slice(0, 40))}`);
   }
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  // TOML forbids raw control chars in basic strings — emit \uXXXX escapes so
+  // one stray invisible byte can't make codex reject the whole config file.
+  // The control-char replace must stay last: earlier replaces would double
+  // the backslash it emits into a literal \\uXXXX.
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\x00-\x1f\x7f]/g, (c) => `\\u${c.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`)}"`;
 }
 
 function sendCodexError(server: AppServer, id: number | string, message: string, data?: unknown): void {

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -407,11 +407,12 @@ export function writeCodexConfigToml(
   lines.push('');
 
   for (const [name, config] of Object.entries(servers)) {
-    lines.push(`[mcp_servers.${name}]`);
+    const tomlName = tomlKey(name);
+    lines.push(`[mcp_servers.${tomlName}]`);
     if (config.type === 'http') {
       lines.push(`url = ${tomlBasicString(config.url)}`);
       if (config.headers && Object.keys(config.headers).length > 0) {
-        lines.push(`[mcp_servers.${name}.http_headers]`);
+        lines.push(`[mcp_servers.${tomlName}.http_headers]`);
         for (const [key, value] of Object.entries(config.headers)) {
           lines.push(`${tomlBasicString(key)} = ${tomlBasicString(value)}`);
         }
@@ -425,9 +426,9 @@ export function writeCodexConfigToml(
       lines.push(`args = [${config.args.map(tomlBasicString).join(', ')}]`);
     }
     if (config.env && Object.keys(config.env).length > 0) {
-      lines.push(`[mcp_servers.${name}.env]`);
+      lines.push(`[mcp_servers.${tomlName}.env]`);
       for (const [key, value] of Object.entries(config.env)) {
-        lines.push(`${key} = ${tomlBasicString(value)}`);
+        lines.push(`${tomlKey(key)} = ${tomlBasicString(value)}`);
       }
     }
     lines.push('');
@@ -503,6 +504,17 @@ export function buildCodexProcessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv 
   if (!next.CODEX_HOME) next.CODEX_HOME = next.HOME ? path.join(next.HOME, '.codex') : '/home/node/.codex';
   if (!next.HOME) next.HOME = '/home/node';
   return next;
+}
+
+/**
+ * Server names and env keys are attacker-influenced (add_mcp_server approval
+ * flow validates content, not charset). Quoting anything that isn't a bare
+ * TOML key keeps a crafted name from closing the header and opening its own
+ * [mcp_servers.*] table with a command line the approval card never showed.
+ * Bare and quoted forms name the same table, so safe names stay byte-identical.
+ */
+function tomlKey(name: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(name) ? name : tomlBasicString(name);
 }
 
 export function tomlBasicString(value: string): string {

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { spawn, type ChildProcess } from 'child_process';
 import { createInterface, type Interface as ReadlineInterface } from 'readline';
 
+import type { McpServerConfig } from './types.js';
+
 // Cap Codex's project-doc loading (AGENTS.md). The host-side composer
 // (src/providers/codex-agents-md.ts) enforces the same cap at compose time —
 // host and container share no modules, so the constant lives in both.
@@ -61,12 +63,6 @@ export interface AppServer {
    * already taken the server's stderr with it.
    */
   exitHandlers: Array<(err: Error) => void>;
-}
-
-export interface CodexMcpServer {
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
 }
 
 export type CodexReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
@@ -381,7 +377,7 @@ export function attachCodexAutoApproval(server: AppServer): void {
 }
 
 export function writeCodexConfigToml(
-  servers: Record<string, CodexMcpServer>,
+  servers: Record<string, McpServerConfig>,
   memorySessionHook: CodexMemorySessionHook,
   opts: { model?: string; effort?: string } = {},
 ): void {
@@ -412,6 +408,18 @@ export function writeCodexConfigToml(
 
   for (const [name, config] of Object.entries(servers)) {
     lines.push(`[mcp_servers.${name}]`);
+    if (config.type === 'http') {
+      lines.push(`url = ${tomlBasicString(config.url)}`);
+      if (config.headers && Object.keys(config.headers).length > 0) {
+        lines.push(`[mcp_servers.${name}.http_headers]`);
+        for (const [key, value] of Object.entries(config.headers)) {
+          lines.push(`${tomlBasicString(key)} = ${tomlBasicString(value)}`);
+        }
+      }
+      lines.push('');
+      continue;
+    }
+
     lines.push(`command = ${tomlBasicString(config.command)}`);
     if (config.args && config.args.length > 0) {
       lines.push(`args = [${config.args.map(tomlBasicString).join(', ')}]`);

--- a/container/agent-runner/src/providers/mcp-to-opencode.test.ts
+++ b/container/agent-runner/src/providers/mcp-to-opencode.test.ts
@@ -42,13 +42,42 @@ describe('mcpServersToOpenCodeConfig', () => {
     });
   });
 
-  it('omits environment when env is empty', () => {
+  it('preserves local defaults when args and env are omitted', () => {
     const mcp = mcpServersToOpenCodeConfig({
-      x: { command: 'true', args: [], env: {} },
+      x: { command: 'true' },
     });
     expect(mcp.x).toEqual({
       type: 'local',
       command: ['true'],
+      enabled: true,
+    });
+  });
+
+  it('maps Streamable HTTP servers to remote entries', () => {
+    expect(
+      mcpServersToOpenCodeConfig({
+        docs: { type: 'http', url: 'https://mcp.example.com/mcp' },
+      }).docs,
+    ).toEqual({
+      type: 'remote',
+      url: 'https://mcp.example.com/mcp',
+      enabled: true,
+    });
+  });
+
+  it('passes remote headers through', () => {
+    expect(
+      mcpServersToOpenCodeConfig({
+        docs: {
+          type: 'http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { 'X-Api-Version': '2024-06' },
+        },
+      }).docs,
+    ).toEqual({
+      type: 'remote',
+      url: 'https://mcp.example.com/mcp',
+      headers: { 'X-Api-Version': '2024-06' },
       enabled: true,
     });
   });

--- a/container/agent-runner/src/providers/mcp-to-opencode.ts
+++ b/container/agent-runner/src/providers/mcp-to-opencode.ts
@@ -18,20 +18,29 @@ export type OpenCodeMcpRemote = {
 
 export type OpenCodeMcpEntry = OpenCodeMcpLocal | OpenCodeMcpRemote;
 
-/**
- * Map NanoClaw v2 MCP definitions (same shape as Claude Agent SDK) into
- * OpenCode config `mcp` field. Stdio-only until `McpServerConfig` gains remote.
- */
+/** Map NanoClaw MCP definitions into OpenCode's local/remote MCP config. */
 export function mcpServersToOpenCodeConfig(
   servers: Record<string, McpServerConfig> | undefined,
 ): Record<string, OpenCodeMcpEntry> {
   const out: Record<string, OpenCodeMcpEntry> = {};
   if (!servers) return out;
   for (const [name, cfg] of Object.entries(servers)) {
+    if (cfg.type === 'http') {
+      out[name] = {
+        type: 'remote',
+        url: cfg.url,
+        ...(cfg.headers && Object.keys(cfg.headers).length > 0 ? { headers: cfg.headers } : {}),
+        enabled: true,
+      };
+      continue;
+    }
+
+    const args = cfg.args ?? [];
+    const env = cfg.env ?? {};
     out[name] = {
       type: 'local',
-      command: [cfg.command, ...cfg.args],
-      ...(Object.keys(cfg.env).length > 0 ? { environment: cfg.env } : {}),
+      command: [cfg.command, ...args],
+      ...(Object.keys(env).length > 0 ? { environment: env } : {}),
       enabled: true,
     };
   }

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -49,11 +49,21 @@ export interface QueryInput {
   };
 }
 
-export interface McpServerConfig {
-  command: string;
-  args: string[];
-  env: Record<string, string>;
-}
+export type McpServerConfig =
+  | {
+      type?: 'stdio';
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      /**
+       * Container-side root of the plugin this server shipped in, recorded by
+       * the host at stamp time. Consumed (and stripped) by plugin-mcp.ts,
+       * which expands ${PLUGIN_ROOT}/${PLUGIN_DATA} and injects both env vars
+       * before the config reaches a provider.
+       */
+      pluginRoot?: string;
+    }
+  | { type: 'http'; url: string; headers?: Record<string, string> };
 
 export interface AgentQuery {
   /** Push a follow-up message into the active query. */


### PR DESCRIPTION
## Problem

PR #3092 teaches the engine and the Claude provider to accept remote Streamable HTTP MCP servers (`{ type: 'http', url }` entries in `mcpServers`). The codex and opencode payloads on this branch still assume stdio-only `McpServerConfig`: an http entry reaching them throws at config-write time (`tomlBasicString(config.command)` on a missing `command` in the codex TOML writer; `[cfg.command, ...cfg.args]` spread of `undefined` in the opencode mapper), so a codex or opencode group with a remote server configured breaks on wake.

## The change

- `types.ts`: twin-patch the frozen `McpServerConfig` to trunk's discriminated union, exactly the shape after #3092 + #3220 (stdio arm with optional `args`/`env`/`pluginRoot`; http arm with `url` + optional `headers`). Install skills do not materialize this file; the patch keeps the registry tree self-consistent and identical to what the payload compiles against on trunk.
- `codex-app-server.ts`: the TOML writer emits `url` for http servers, plus an `http_headers` sub-table when headers are present (header keys quoted, since legal HTTP header names admit characters bare TOML keys reject). Stdio emission unchanged; `args`/`env` access now guards the widened optionality. The single-consumer `CodexMcpServer` alias is deleted.
- `mcp-to-opencode.ts`: http servers map to `{ type: 'remote', url, headers?, enabled: true }`; the local arm defaults omitted `args`/`env`.
- Both test files pin the new emission.

## Why it's safe

Payload-only; nothing on main changes. Stdio behavior is byte-identical for existing configs (the old required-field shape satisfies the widened optional arms; the frozen engine's `config.ts` still constructs `{command, args, env}`). Codex emission verified against the pinned codex 0.138.0 source (`codex-rs/config/src/mcp_types.rs`: `serde(untagged, deny_unknown_fields)`; `StreamableHttp { url, http_headers, bearer_token_env_var, env_http_headers }`; no experimental flag required). OpenCode remote entry shape (`url`/`headers`/`enabled`) verified against the opencode MCP docs.

## Merge order / lockstep

Do not merge before #3220. The materialized payload compiles against trunk's `types.ts`, and its `headers` references need the http arm #3220 introduces; #3092 alone (`{ type: 'http', url }`) is not enough. On a pre-#3220 trunk, `/add-codex` / `/add-opencode` would install payload that fails the documented container typecheck step (runtime is unaffected either way, since Bun executes source and a pre-#3092 host cannot emit an http entry at all). Intended landing: same window as #3092/#3220, after both.

## Scope

Five files, all under `container/agent-runner/src/providers/`. No skill manifest changes needed: add-codex and add-opencode already copy the four payload files, and `types.ts` is intentionally not copied. No host or engine files.

## Verification (registry PRs run no CI)

Registry tree (this branch):
- `cd container/agent-runner && bun test`: 139 pass, 2 skip, 0 fail. One unhandled error from `opencode.config.test.ts` reproduces on the clean tip 428aefce, pre-existing.
- `bun run typecheck`: the four known pre-existing `codex.ts` drift errors (`ProviderExchange`, `model`, `effort`, `'file'`), unchanged by this PR; the payload tracks trunk seams the frozen registry engine lacks.

Materialized landing-window tree (main 743e32df + #3092 + #3220 + add-codex payload from this branch):
- `pnpm exec tsc --noEmit`: clean.
- `pnpm test`: 1364/1364.
- `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`: only the pre-existing `codex.ts` `'file'` drift error.
- `cd container/agent-runner && bun test src/providers/`: 45/45.
- Red-on-revert: the new assertions (`[mcp_servers.docs]` url + `http_headers` emission, the remote opencode mapping) fail with the source hunks reverted.

## Live e2e (codex, 2026-08-10)

Run on the landing-window install (main + #3092 + #3220 + this payload), codex provider, Telegram DM. The agent added the server itself via the approval-gated `add_mcp_server` tool (`{ name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" }`), requested a restart via `cli_request`, and after the wake the fresh container's `config.toml` carried the mixed config (`[mcp_servers.nanoclaw]` stdio + `[mcp_servers.deepwiki]` with `url =`), codex parsed it, connected, and answered a live DeepWiki tool query. Full chain green: self-mod approval, config materialization, TOML emission, codex `deny_unknown_fields` parse, remote connect, tool call.

## Declared gaps

- OpenCode + remote MCP is unit-tested and schema-verified but has not run live against a real endpoint.
- Headers cannot currently be set via `ncl` (`--url` only); they arrive via plugin `mcp.json` (#3220), so the headers path is unit-tested only (on both providers).
- The `codex.ts` `'file'` event drift predates this PR and is out of scope.
- Unrelated baseline bug found during the run (ChatGPT-subscription codex fails on the read-only OneCLI auth sentinel), tracked separately on the team hub; worked around with API-key auth.

## Template

Type of Change: no checkbox fits (payload update to existing providers on the registry branch, no skill changes); closest is Feature.
