### PR TITLE
feat(permissions): add opt-in privacy-safe DM logs

### DIFF
--- a/src/modules/permissions/user-dm.test.ts
+++ b/src/modules/permissions/user-dm.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../log.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+import type { ChannelAdapter } from '../../channels/adapter.js';
+import {
+  initChannelAdapters,
+  registerChannelAdapter,
+  teardownChannelAdapters,
+} from '../../channels/channel-registry.js';
+import { closeDb, getDb, initTestDb } from '../../db/connection.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { runMigrations } from '../../db/migrations/index.js';
+import { log } from '../../log.js';
+import { createUser } from './db/users.js';
+import { upsertUserDm } from './db/user-dms.js';
+import { ensureUserDm } from './user-dm.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedUser(id: string, kind: string): void {
+  createUser({ id, kind, display_name: null, created_at: now() });
+}
+
+function registerTestAdapter(channelType: string, openDM?: (handle: string) => Promise<string>): void {
+  const adapter: ChannelAdapter = {
+    name: channelType,
+    channelType,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected: () => true,
+    async deliver() {
+      return undefined;
+    },
+  };
+  if (openDM) adapter.openDM = openDM;
+  registerChannelAdapter(channelType, { factory: () => adapter });
+}
+
+async function startRegisteredAdapters(): Promise<void> {
+  await initChannelAdapters(() => ({
+    conversations: [],
+    onInbound: () => {},
+    onInboundEvent: () => {},
+    onMetadata: () => {},
+    onAction: () => {},
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(async () => {
+  await teardownChannelAdapters();
+  closeDb();
+});
+
+describe('ensureUserDm privacy-safe logging', () => {
+  it('preserves the existing detailed log shape by default', async () => {
+    const failure = new Error('default-sdk-error-sentinel');
+    registerTestAdapter('legacy-default', async () => {
+      throw failure;
+    });
+    await startRegisteredAdapters();
+    seedUser('legacy-default:default-handle-sentinel', 'legacy-default');
+
+    await expect(ensureUserDm('legacy-default:default-handle-sentinel')).resolves.toBeNull();
+
+    expect(log.error).toHaveBeenCalledWith('ensureUserDm: adapter.openDM failed', {
+      channelType: 'legacy-default',
+      handle: 'default-handle-sentinel',
+      err: failure,
+    });
+  });
+
+  it('omits identities, messaging-group ids, and SDK errors when requested', async () => {
+    registerTestAdapter('privacy-error', async () => {
+      throw new Error('private-sdk-error-sentinel');
+    });
+    registerTestAdapter('privacy-direct');
+    await startRegisteredAdapters();
+
+    seedUser('privacy-error:private-handle-sentinel', 'privacy-error');
+    seedUser('privacy-direct:stale-handle-sentinel', 'privacy-direct');
+    seedUser('invalid-user-private-sentinel', 'invalid-kind');
+
+    createMessagingGroup({
+      id: 'messaging-group-private-sentinel',
+      channel_type: 'privacy-direct',
+      platform_id: 'old-platform-private-sentinel',
+      name: null,
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    upsertUserDm({
+      user_id: 'privacy-direct:stale-handle-sentinel',
+      channel_type: 'privacy-direct',
+      messaging_group_id: 'messaging-group-private-sentinel',
+      resolved_at: now(),
+    });
+    getDb().pragma('foreign_keys = OFF');
+    getDb().prepare("DELETE FROM messaging_groups WHERE id = 'messaging-group-private-sentinel'").run();
+    getDb().pragma('foreign_keys = ON');
+
+    const options = { privacySafeLogs: true };
+    await expect(ensureUserDm('unknown-user-private-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('invalid-user-private-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-error:private-handle-sentinel', options)).resolves.toBeNull();
+    await expect(ensureUserDm('privacy-direct:stale-handle-sentinel', options)).resolves.toBeDefined();
+
+    expect(log.error).toHaveBeenCalledWith('ensureUserDm: adapter.openDM failed', {
+      channelType: 'privacy-error',
+    });
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user not found', undefined);
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: user id not namespaced', undefined);
+    expect(log.warn).toHaveBeenCalledWith('ensureUserDm: cached row references missing messaging_group, re-resolving', {
+      channelType: 'privacy-direct',
+    });
+    expect(log.info).toHaveBeenCalledWith('ensureUserDm: created DM messaging_group', {
+      channelType: 'privacy-direct',
+    });
+
+    const serializedLogs = JSON.stringify({
+      info: vi.mocked(log.info).mock.calls,
+      warn: vi.mocked(log.warn).mock.calls,
+      error: vi.mocked(log.error).mock.calls,
+    });
+    for (const sentinel of [
+      'unknown-user-private-sentinel',
+      'invalid-user-private-sentinel',
+      'private-handle-sentinel',
+      'stale-handle-sentinel',
+      'messaging-group-private-sentinel',
+      'old-platform-private-sentinel',
+      'private-sdk-error-sentinel',
+    ]) {
+      expect(serializedLogs).not.toContain(sentinel);
+    }
+  });
+});

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -48,17 +48,22 @@ import { getUserDm, upsertUserDm } from './db/user-dms.js';
  *   - openDM throws (platform error, user blocked bot, etc.)
  *
  * Callers should treat null as "this user is unreachable on this channel".
+ * Set privacySafeLogs for security-sensitive flows to omit user, handle,
+ * messaging-group, and raw platform-error details from log data.
  */
-export async function ensureUserDm(userId: string): Promise<MessagingGroup | null> {
+export async function ensureUserDm(
+  userId: string,
+  { privacySafeLogs = false }: { privacySafeLogs?: boolean } = {},
+): Promise<MessagingGroup | null> {
   const user = getUser(userId);
   if (!user) {
-    log.warn('ensureUserDm: user not found', { userId });
+    log.warn('ensureUserDm: user not found', privacySafeLogs ? undefined : { userId });
     return null;
   }
 
   const { channelType, handle } = parseUserId(user);
   if (!channelType || !handle) {
-    log.warn('ensureUserDm: user id not namespaced', { userId });
+    log.warn('ensureUserDm: user id not namespaced', privacySafeLogs ? undefined : { userId });
     return null;
   }
 
@@ -68,14 +73,14 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
     const mg = getMessagingGroup(cached.messaging_group_id);
     if (mg) return mg;
     // Row points to a deleted messaging_group — fall through and re-resolve.
-    log.warn('ensureUserDm: cached row references missing messaging_group, re-resolving', {
-      userId,
-      messagingGroupId: cached.messaging_group_id,
-    });
+    log.warn(
+      'ensureUserDm: cached row references missing messaging_group, re-resolving',
+      privacySafeLogs ? { channelType } : { userId, messagingGroupId: cached.messaging_group_id },
+    );
   }
 
   // Cache miss: resolve the DM platform_id either via openDM or directly.
-  const dmPlatformId = await resolveDmPlatformId(channelType, handle);
+  const dmPlatformId = await resolveDmPlatformId(channelType, handle, privacySafeLogs);
   if (!dmPlatformId) return null;
 
   // Find-or-create the underlying messaging_group. A DM we received
@@ -98,11 +103,10 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
       created_at: now,
     };
     createMessagingGroup(mg);
-    log.info('ensureUserDm: created DM messaging_group', {
-      userId,
-      channelType,
-      messagingGroupId: mgId,
-    });
+    log.info(
+      'ensureUserDm: created DM messaging_group',
+      privacySafeLogs ? { channelType } : { userId, channelType, messagingGroupId: mgId },
+    );
   }
 
   upsertUserDm({
@@ -119,7 +123,11 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
  * Call the adapter's openDM if it has one; otherwise fall through to using
  * the handle directly. Returns null if the adapter is missing entirely.
  */
-async function resolveDmPlatformId(channelType: string, handle: string): Promise<string | null> {
+async function resolveDmPlatformId(
+  channelType: string,
+  handle: string,
+  privacySafeLogs: boolean,
+): Promise<string | null> {
   const adapter = getChannelAdapter(channelType);
   if (!adapter) {
     log.warn('ensureUserDm: no adapter for channel', { channelType });
@@ -129,12 +137,14 @@ async function resolveDmPlatformId(channelType: string, handle: string): Promise
     // Direct-addressable channel — handle doubles as the DM chat id.
     return handle;
   }
+  /* eslint-disable no-catch-all/no-catch-all -- platform DM resolution failure makes this user unreachable */
   try {
     return await adapter.openDM(handle);
   } catch (err) {
-    log.error('ensureUserDm: adapter.openDM failed', { channelType, handle, err });
+    log.error('ensureUserDm: adapter.openDM failed', privacySafeLogs ? { channelType } : { channelType, handle, err });
     return null;
   }
+  /* eslint-enable no-catch-all/no-catch-all */
 }
 
 function parseUserId(user: User): { channelType: string; handle: string } | { channelType: null; handle: null } {


### PR DESCRIPTION
## Summary

- add an optional `privacySafeLogs` setting to `ensureUserDm`
- preserve the existing detailed logging behavior by default
- when enabled, omit user IDs, handles, messaging-group IDs, and raw adapter errors while retaining non-identifying channel context
- cover both the default and opt-in log shapes with regression tests

## Validation

- `pnpm exec vitest run src/modules/permissions/user-dm.test.ts`
- `pnpm run build`
- `pnpm exec eslint src/modules/permissions/user-dm.ts src/modules/permissions/user-dm.test.ts`
- `pnpm exec prettier --check src/modules/permissions/user-dm.ts src/modules/permissions/user-dm.test.ts`
