### PR TITLE
fix(session-db): preserve inbound messages across platform ID reuse

### DIFF
--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -10,7 +10,13 @@ import fs from 'fs';
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { ensureSchema, getInboundSourceSessionId, migrateMessagesInTable, syncProcessingAcks } from './session-db.js';
+import {
+  ensureSchema,
+  getInboundSourceSessionId,
+  insertMessage,
+  migrateMessagesInTable,
+  syncProcessingAcks,
+} from './session-db.js';
 
 const TEST_DIR = '/tmp/nanoclaw-session-db-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
@@ -89,6 +95,67 @@ describe('migrateMessagesInTable', () => {
 
     expect(getInboundSourceSessionId(db, 'legacy-2')).toBeNull();
     expect(getInboundSourceSessionId(db, 'does-not-exist')).toBeNull();
+    db.close();
+  });
+});
+
+describe('insertMessage — platform id-space wraparound', () => {
+  function freshInbound() {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    ensureSchema(DB_PATH, 'inbound');
+    return new Database(DB_PATH);
+  }
+
+  const row = (id: string) => ({
+    id,
+    kind: 'chat-sdk',
+    timestamp: '2026-08-08T23:28:08.000Z',
+    platformId: 'telegram:1295462156',
+    channelType: 'telegram',
+    threadId: null,
+    content: '{"text":"1"}',
+    processAfter: null,
+    recurrence: null,
+  });
+
+  it('stores a colliding id under a disambiguated id instead of throwing', () => {
+    const db = freshInbound();
+    // A months-old row from before the chat's message_id counter restarted.
+    insertMessage(db, { ...row('tg:688'), timestamp: '2026-06-16T15:13:20.000Z', content: '{"text":"old"}' });
+
+    expect(() => insertMessage(db, row('tg:688'))).not.toThrow();
+
+    const stored = db.prepare('SELECT id, series_id, content FROM messages_in ORDER BY seq').all() as Array<{
+      id: string;
+      series_id: string;
+      content: string;
+    }>;
+    expect(stored.map((r) => r.id)).toEqual(['tg:688', 'tg:688#2']);
+    expect(stored[1].content).toBe('{"text":"1"}');
+    // series_id tracks the stored id, not the requested one.
+    expect(stored[1].series_id).toBe('tg:688#2');
+    db.close();
+  });
+
+  it('is a no-op when the same message is re-delivered (idempotent replay)', () => {
+    const db = freshInbound();
+    insertMessage(db, row('tg:688'));
+    insertMessage(db, row('tg:688'));
+
+    expect((db.prepare('SELECT COUNT(*) AS n FROM messages_in').get() as { n: number }).n).toBe(1);
+    db.close();
+  });
+
+  it('keeps seq even and monotonic across a disambiguated insert', () => {
+    const db = freshInbound();
+    insertMessage(db, { ...row('tg:688'), timestamp: '2026-06-16T15:13:20.000Z' });
+    insertMessage(db, row('tg:688'));
+
+    const seqs = (db.prepare('SELECT seq FROM messages_in ORDER BY seq').all() as Array<{ seq: number }>).map(
+      (r) => r.seq,
+    );
+    expect(seqs).toEqual([2, 4]);
     db.close();
   });
 });

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -111,7 +111,7 @@ describe('insertMessage — platform id-space wraparound', () => {
     id,
     kind: 'chat-sdk',
     timestamp: '2026-08-08T23:28:08.000Z',
-    platformId: 'telegram:1295462156',
+    platformId: 'telegram:test-chat',
     channelType: 'telegram',
     threadId: null,
     content: '{"text":"1"}',

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -7,6 +7,7 @@
  */
 import Database from 'better-sqlite3';
 
+import { log } from '../log.js';
 import { INBOUND_SCHEMA, OUTBOUND_SCHEMA } from './schema.js';
 
 /** Apply the inbound or outbound schema to a DB file. Idempotent. */
@@ -121,16 +122,48 @@ export function insertMessage(
     onWake?: 0 | 1;
   },
 ): void {
-  db.prepare(
+  // ON CONFLICT(id) — targeted, not bare: a `seq` UNIQUE violation is a real
+  // invariant break (host/container seq parity) and must still throw.
+  const stmt = db.prepare(
     `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger, source_session_id, on_wake)
-     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)`,
-  ).run({
+     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger, @sourceSessionId, @onWake)
+     ON CONFLICT(id) DO NOTHING`,
+  );
+  const existing = db.prepare('SELECT timestamp, content FROM messages_in WHERE id = ?');
+
+  const base = {
     ...message,
     trigger: message.trigger ?? 1,
     onWake: message.onWake ?? 0,
     sourceSessionId: message.sourceSessionId ?? null,
-    seq: nextEvenSeq(db),
-  });
+  };
+
+  // Row ids are derived from platform message ids, and platform id spaces are
+  // NOT globally unique over the life of a session. A Telegram chat that gets
+  // a new bot (or is cleared) restarts message_id at 1, so today's id collides
+  // with a months-old row in the same long-lived inbound.db. That INSERT used
+  // to throw straight out of routeInbound, and the caller in src/index.ts
+  // logged-and-dropped: the message vanished with no messages_in row at all
+  // and no user-visible sign. Disambiguate instead of dying.
+  for (let attempt = 0; attempt < 64; attempt++) {
+    const id = attempt === 0 ? message.id : `${message.id}#${attempt + 1}`;
+    if (stmt.run({ ...base, id, seq: nextEvenSeq(db) }).changes > 0) {
+      if (attempt > 0) {
+        log.warn('messages_in id collided with an older row — stored under a disambiguated id', {
+          requestedId: message.id,
+          storedId: id,
+          kind: message.kind,
+        });
+      }
+      return;
+    }
+
+    const prior = existing.get(id) as { timestamp: string; content: string } | undefined;
+    // Same message re-delivered (approval replay, adapter redelivery) — the
+    // PK is the idempotency guard, so a no-op is the correct outcome.
+    if (prior && prior.timestamp === message.timestamp && prior.content === message.content) return;
+  }
+  throw new Error(`Could not allocate a free messages_in id for ${message.id} (64 collisions)`);
 }
 
 export function countDueMessages(db: Database.Database): number {


### PR DESCRIPTION
## Summary

Preserve inbound messages when a platform reuses an identifier in a long-lived session database.

## Root cause

Some platforms can restart or reuse their message-ID space. The existing primary-key insert then threw on the reused ID, and the inbound message was logged and dropped before it could be stored.

## Changes

- Treat an exact replay of an existing message as idempotent.
- Store a distinct colliding message under a deterministic `#N` suffix.
- Keep the host-owned even `seq` invariant and continue surfacing real sequence conflicts.
- Add regression coverage for collision handling, replay idempotency, and sequence monotonicity.

## Validation

- `pnpm exec vitest run src/db/session-db.test.ts` — 8 passed
- `pnpm exec tsc --noEmit` — passed
- Prettier check passed
- Fixture platform identifiers are synthetic.

Fixes #3226
Related: #3075 (same insert, duplicate-delivery variant on Matrix)
