### PR TITLE
fix(telegram): harden pairing code generation and store permissions

### DIFF
--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -70,6 +70,17 @@ describe('createPairing', () => {
     expect(r.status).toBe('pending');
   });
 
+  it.skipIf(process.platform === 'win32')('writes the store with owner-only permissions', async () => {
+    await createPairing('main');
+    const storeFile = path.join(tmpDir, 'pairings.json');
+    expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+
+    // A stale tmp file with loose perms must not survive into the store.
+    fs.writeFileSync(`${storeFile}.tmp`, 'stale', { mode: 0o644 });
+    await createPairing('main');
+    expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+  });
+
   it('does not collide with active codes', async () => {
     const codes = new Set<string>();
     for (let i = 0; i < 20; i++) {

--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -82,12 +82,26 @@ describe('createPairing', () => {
   });
 
   it('does not collide with active codes', async () => {
+    // Distinct intents on purpose: createPairing invalidates any pending
+    // record for the SAME intent, so looping on 'main' leaves at most one
+    // record pending and `active` is always empty — every draw is then
+    // independent over the 10k space and the assertion below fails ~2% of
+    // runs on nothing but bad luck. Distinct intents keep all 20 pending, so
+    // this exercises the uniqueness generateCode actually guarantees.
     const codes = new Set<string>();
     for (let i = 0; i < 20; i++) {
-      const r = await createPairing('main');
+      const r = await createPairing({ kind: 'wire-to', folder: `group-${i}` });
       expect(codes.has(r.code)).toBe(false);
       codes.add(r.code);
     }
+  });
+
+  it('reuses a code once its holder is no longer pending', async () => {
+    // The contract is uniqueness among ACTIVE codes, not for all time — a
+    // consumed or invalidated record must not permanently burn its code.
+    const first = await createPairing('main');
+    await createPairing('main'); // supersedes -> first becomes 'invalidated'
+    expect(getStatus(first.code)).toBe('invalidated');
   });
 });
 

--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -74,10 +74,21 @@ describe('createPairing', () => {
     await createPairing('main');
     const storeFile = path.join(tmpDir, 'pairings.json');
     expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+    fs.chmodSync(tmpDir, 0o755);
 
     // A stale tmp file with loose perms must not survive into the store.
     fs.writeFileSync(`${storeFile}.tmp`, 'stale', { mode: 0o644 });
     await createPairing('main');
+    expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
+
+    // Reads also repair permissions when an existing store was created with
+    // loose modes and no write has happened yet.
+    const existingCode = (await createPairing('main')).code;
+    fs.chmodSync(tmpDir, 0o755);
+    fs.chmodSync(storeFile, 0o644);
+    expect(getStatus(existingCode)).toBe('pending');
+    expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o700);
     expect(fs.statSync(storeFile).mode & 0o777).toBe(0o600);
   });
 

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -14,6 +14,7 @@
  * Storage is a JSON file at data/telegram-pairings.json — single-process,
  * read-modify-write under an in-process mutex.
  */
+import { randomInt } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -91,9 +92,12 @@ function readStore(): Store {
 
 function writeStore(store: Store): void {
   const p = storePath();
-  fs.mkdirSync(path.dirname(p), { recursive: true });
+  // Codes are auth material: dir 0700, file 0600. Modes only apply at
+  // creation, so drop any stale tmp that would carry old perms through rename.
+  fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o700 });
   const tmp = `${p}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(store, null, 2));
+  fs.rmSync(tmp, { force: true });
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
   fs.renameSync(tmp, p);
 }
 
@@ -106,10 +110,10 @@ function sweep(store: Store): boolean {
 
 function generateCode(active: Set<string>): string {
   // 4-digit numeric, zero-padded. 10k space, fine for one-at-a-time intents.
+  // randomInt, not Math.random: the first pairer can be promoted to owner,
+  // and Math.random is predictable from its prior outputs.
   for (let i = 0; i < 50; i++) {
-    const code = Math.floor(Math.random() * 10000)
-      .toString()
-      .padStart(4, '0');
+    const code = randomInt(0, 10000).toString().padStart(4, '0');
     if (!active.has(code)) return code;
   }
   throw new Error('Could not allocate a free pairing code (too many active).');
@@ -317,7 +321,7 @@ export async function waitForPairing(code: string, opts: WaitForPairingOptions =
 
     try {
       const dir = path.dirname(storePath());
-      fs.mkdirSync(dir, { recursive: true });
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
       watcher = fs.watch(dir, (_event, fname) => {
         if (!fname || fname.toString().startsWith(path.basename(storePath()))) check();
       });

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -79,9 +79,26 @@ function withLock<T>(fn: () => Promise<T> | T): Promise<T> {
   return next;
 }
 
+function secureStorePermissions(p: string): void {
+  const dir = path.dirname(p);
+  // mkdir's mode is ignored when the directory already exists, so chmod is
+  // required to repair permissions on directories created by older versions.
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
+  if (fs.existsSync(p)) fs.chmodSync(p, 0o600);
+}
+
 function readStore(): Store {
+  const p = storePath();
+  let raw: string;
   try {
-    const raw = fs.readFileSync(storePath(), 'utf8');
+    raw = fs.readFileSync(p, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { pairings: [] };
+    throw error;
+  }
+  secureStorePermissions(p);
+  try {
     const parsed = JSON.parse(raw) as Store;
     if (!Array.isArray(parsed.pairings)) return { pairings: [] };
     return parsed;
@@ -94,11 +111,13 @@ function writeStore(store: Store): void {
   const p = storePath();
   // Codes are auth material: dir 0700, file 0600. Modes only apply at
   // creation, so drop any stale tmp that would carry old perms through rename.
-  fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o700 });
+  secureStorePermissions(p);
   const tmp = `${p}.tmp`;
   fs.rmSync(tmp, { force: true });
   fs.writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
+  fs.chmodSync(tmp, 0o600);
   fs.renameSync(tmp, p);
+  fs.chmodSync(p, 0o600);
 }
 
 /** Clean up old consumed/invalidated records (keep last 50). */
@@ -322,6 +341,7 @@ export async function waitForPairing(code: string, opts: WaitForPairingOptions =
     try {
       const dir = path.dirname(storePath());
       fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+      fs.chmodSync(dir, 0o700);
       watcher = fs.watch(dir, (_event, fname) => {
         if (!fname || fname.toString().startsWith(path.basename(storePath()))) check();
       });


### PR DESCRIPTION
## Summary

Harden Telegram pairing against predictable codes and permissive filesystem modes.

## Changes

- Generate pairing codes with Node's CSPRNG-backed `randomInt`.
- Enforce owner-only permissions on the pairing directory and store file.
- Repair permissions for existing directories and stores, including on reads.
- Remove stale temporary store files before atomic replacement.
- Add regression coverage for directory/file repair and stale temporary files.
- Keep the corrected uniqueness test based on distinct active pairing intents.

## Validation

- `pnpm exec vitest run src/channels/telegram-pairing.test.ts` — 28 tests passed.
- The suite reports the same five `fs.watch`/EMFILE unhandled errors as upstream's baseline on this macOS runner; they are unrelated to this patch.
- Prettier check passed.
- Full typecheck is currently blocked by the existing missing `@deltachat/stdio-rpc-server` dependency in the channels branch.