### PR TITLE
fix(telegram): generate pairing codes with a CSPRNG, not Math.random()

### DIFF
--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -46,27 +46,27 @@ describe('extractAddressedText', () => {
 });
 
 describe('extractCode', () => {
-  it('accepts a bare 4-digit code', () => {
-    expect(extractCode('0349', 'nanobot')).toBe('0349');
+  it('accepts a bare 6-digit code', () => {
+    expect(extractCode('034927', 'nanobot')).toBe('034927');
   });
-  it('accepts 4-digit code after @botname', () => {
-    expect(extractCode('@nanobot 0042', 'nanobot')).toBe('0042');
+  it('accepts 6-digit code after @botname', () => {
+    expect(extractCode('@nanobot 004217', 'nanobot')).toBe('004217');
   });
-  it('rejects non-4-digit numbers', () => {
-    expect(extractCode('@nanobot 12345', 'nanobot')).toBeNull();
-    expect(extractCode('@nanobot 12', 'nanobot')).toBeNull();
+  it('rejects non-6-digit numbers', () => {
+    expect(extractCode('@nanobot 1234567', 'nanobot')).toBeNull();
+    expect(extractCode('@nanobot 1234', 'nanobot')).toBeNull();
     expect(extractCode('12345', 'nanobot')).toBeNull();
   });
   it('rejects loose matches with surrounding text', () => {
-    expect(extractCode('my pin is 0349', 'nanobot')).toBeNull();
-    expect(extractCode('0349 thanks', 'nanobot')).toBeNull();
+    expect(extractCode('my pin is 034927', 'nanobot')).toBeNull();
+    expect(extractCode('034927 thanks', 'nanobot')).toBeNull();
   });
 });
 
 describe('createPairing', () => {
-  it('generates a 4-digit code', async () => {
+  it('generates a 6-digit zero-padded code', async () => {
     const r = await createPairing('main');
-    expect(r.code).toMatch(/^\d{4}$/);
+    expect(r.code).toMatch(/^\d{6}$/);
     expect(r.status).toBe('pending');
   });
 
@@ -130,7 +130,7 @@ describe('tryConsume', () => {
   it('cannot consume an invalidated pairing', async () => {
     const r = await createPairing('main');
     // Invalidate by sending a wrong code
-    await tryConsume({ text: '9999', botUsername: 'b', platformId: 'p', isGroup: false });
+    await tryConsume({ text: '999999', botUsername: 'b', platformId: 'p', isGroup: false });
     const out = await tryConsume({ text: `@b ${r.code}`, botUsername: 'b', platformId: 'p', isGroup: false });
     expect(out).toBeNull();
     expect(getStatus(r.code)).toBe('invalidated');
@@ -139,7 +139,7 @@ describe('tryConsume', () => {
 
 describe('getStatus', () => {
   it('returns unknown for missing codes', () => {
-    expect(getStatus('0000')).toBe('unknown');
+    expect(getStatus('000000')).toBe('unknown');
   });
 });
 
@@ -159,7 +159,7 @@ describe('waitForPairing', () => {
     const r = await createPairing('main');
     const waiter = waitForPairing(r.code, { pollMs: 30 });
     setTimeout(() => {
-      tryConsume({ text: '0000', botUsername: 'b', platformId: 'tg:1', isGroup: false });
+      tryConsume({ text: '000000', botUsername: 'b', platformId: 'tg:1', isGroup: false });
     }, 60);
     await expect(waiter).rejects.toThrow(/invalidated/);
   });
@@ -198,10 +198,10 @@ describe('attempt tracking', () => {
       onAttempt: (a) => attempts.push(a.candidate),
     });
     setTimeout(() => {
-      tryConsume({ text: '9999', botUsername: 'b', platformId: 'tg:1', isGroup: false });
+      tryConsume({ text: '999999', botUsername: 'b', platformId: 'tg:1', isGroup: false });
     }, 60);
-    await expect(waiter).rejects.toThrow(/invalidated by wrong code \(9999\)/);
-    expect(attempts).toEqual(['9999']);
+    await expect(waiter).rejects.toThrow(/invalidated by wrong code \(999999\)/);
+    expect(attempts).toEqual(['999999']);
     expect(getStatus(r.code)).toBe('invalidated');
   });
 
@@ -230,7 +230,7 @@ describe('attempt tracking', () => {
 
   it('a second code attempt after invalidation does not match', async () => {
     const r = await createPairing('main');
-    await tryConsume({ text: '9999', botUsername: 'b', platformId: 'p', isGroup: false });
+    await tryConsume({ text: '999999', botUsername: 'b', platformId: 'p', isGroup: false });
     const retry = await tryConsume({ text: r.code, botUsername: 'b', platformId: 'p', isGroup: false });
     expect(retry).toBeNull();
   });

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -3,10 +3,10 @@
  *
  * BotFather hands out tokens with no user binding, so anyone who guesses the
  * bot's username can DM it. Pairing closes that gap: setup creates a one-time
- * 4-digit code and the operator echoes it back from the chat they want to
- * register. The message must be exactly the 4 digits (optionally prefixed by
+ * 6-digit code and the operator echoes it back from the chat they want to
+ * register. The message must be exactly the 6 digits (optionally prefixed by
  * `@botname ` for groups with privacy ON) — arbitrary messages that happen to
- * contain a 4-digit number do NOT match. The inbound interceptor in
+ * contain a 6-digit number do NOT match. The inbound interceptor in
  * telegram.ts matches the code, records the chat, upserts the paired user,
  * and (if no owner exists yet) promotes them to owner — all before the
  * message ever reaches the router.
@@ -14,6 +14,7 @@
  * Storage is a JSON file at data/telegram-pairings.json — single-process,
  * read-modify-write under an in-process mutex.
  */
+import { randomInt } from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -105,11 +106,14 @@ function sweep(store: Store): boolean {
 }
 
 function generateCode(active: Set<string>): string {
-  // 4-digit numeric, zero-padded. 10k space, fine for one-at-a-time intents.
+  // 6-digit numeric, zero-padded, from a CSPRNG. The code is the sole
+  // authenticator binding a Telegram account to an agent group (and can
+  // promote to owner on a fresh install), and codes do not expire — so the
+  // stream must not be predictable from previously issued codes.
+  // Math.random() (xorshift128+) is state-recoverable from observed outputs.
+  // randomInt is rejection-sampled, so the draw is uniform.
   for (let i = 0; i < 50; i++) {
-    const code = Math.floor(Math.random() * 10000)
-      .toString()
-      .padStart(4, '0');
+    const code = randomInt(0, 1_000_000).toString().padStart(6, '0');
     if (!active.has(code)) return code;
   }
   throw new Error('Could not allocate a free pairing code (too many active).');
@@ -162,13 +166,13 @@ export function extractAddressedText(text: string, botUsername: string): string 
 
 /**
  * Extract a pairing code from an inbound message. The message must be exactly
- * 4 digits (optionally prefixed by `@botname `) — loose matches like
- * "my pin is 1234" are rejected to avoid false positives from chatter.
+ * 6 digits (optionally prefixed by `@botname `) — loose matches like
+ * "my pin is 123456" are rejected to avoid false positives from chatter.
  */
 export function extractCode(text: string, botUsername: string): string | null {
   const addressed = extractAddressedText(text, botUsername);
   const candidate = (addressed !== null ? addressed : text).trim();
-  const m = candidate.match(/^(\d{4})$/);
+  const m = candidate.match(/^(\d{6})$/);
   return m ? m[1] : null;
 }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

### What

`generateCode()` in `src/channels/telegram-pairing.ts` mints pairing codes with `Math.random()`. This switches it to `crypto.randomInt` and widens the space from 4 to 6 digits.

### Why

The pairing code **is** the authentication for this flow: presenting a valid code binds the sender's Telegram identity to an agent group — and on a fresh install promotes them to global owner (`if (!hasAnyOwner()) grantRole({ role: 'owner' })`). Two properties combine badly:

1. **`Math.random()` is not cryptographically secure.** V8's `xorshift128+` state can be recovered from a handful of observed outputs, after which subsequent values are predictable.
2. **Codes do not expire** (by design, per the comment in the file) — a predicted code stays valid until consumed or invalidated.

`MAX_ATTEMPTS_PER_RECORD` correctly bounds blind guessing, but does nothing against prediction — a predicted code succeeds on the first attempt.

**This matters most for multi-user installs.** Pairing is the onboarding path for every person sharing one bot, and codes are minted repeatedly from the same PRNG stream. A legitimate user who has received a few of their *own* codes is exactly the observer the xorshift-recovery attack assumes — and a predicted pending code lets them bind their own Telegram account to a *colleague's* agent group, gaining that group's workspace, memory, and credentials. (Context: we run a ~16-user departmental install; single-user installs are barely exposed since the only observer is the owner.)

### How

- `Math.floor(Math.random() * 10000)` → `randomInt(0, 1_000_000)` from `node:crypto` (rejection-sampled, so uniform — unlike `% n`).
- 4 → 6 digits: entropy quality is the fix; the wider space additionally hardens blind guessing at trivial UX cost (typed once during onboarding).
- `extractCode`'s exact-match regex and doc comments updated to match.

### Notes

- **Not breaking** for stored state — nothing persists or validates a 4-digit shape. One transitional edge: a code issued *before* this deploys can't be consumed *after* (the matcher now requires 6 digits); pairing is interactive and codes are free to re-issue, so the cost is one retry.
- **Codes still don't expire.** A TTL would bound exposure further — deliberately not bundled here (one thing per PR); happy to file it as a follow-up issue if wanted.
- Grepped the `channels` branch for other `Math.random()` authenticator minting: this is the only site (remaining uses are request-ID/filename generation and backoff jitter).

### Testing

- Existing `telegram-pairing.test.ts` fixtures widened to 6 digits; full channel suite passes (100/100).
- Covered: 6-digit zero-padded shape, exact-match extraction (bare and `@botname`-prefixed), rejection of non-6-digit candidates and loose matches, collision retry against active codes, invalidation-by-wrong-guess flow.
- Running in production on our install since 2026-08-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uwSbCp2V5NJryrWSgfATy
