### PR TITLE
feat(codex,opencode): honor plugin MCP cwd in both provider config writers

### DIFF
--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -45,11 +45,11 @@ git show origin/providers:container/agent-runner/src/providers/opencode.compacti
 git show origin/providers:container/agent-runner/src/providers/opencode.config.test.ts > container/agent-runner/src/providers/opencode.config.test.ts
 git show origin/providers:container/agent-runner/src/providers/opencode.memory.test.ts > container/agent-runner/src/providers/opencode.memory.test.ts
 git show origin/providers:container/agent-runner/src/providers/opencode.question.test.ts > container/agent-runner/src/providers/opencode.question.test.ts
-git show origin/providers:container/agent-runner/src/providers/cwd-shim.ts             > container/agent-runner/src/providers/cwd-shim.ts
-git show origin/providers:container/agent-runner/src/providers/cwd-shim.test.ts        > container/agent-runner/src/providers/cwd-shim.test.ts
+git show origin/providers:container/agent-runner/src/providers/cwd-shim.ts             > container/agent-runner/src/providers/cwd-shim.ts.new && mv container/agent-runner/src/providers/cwd-shim.ts.new container/agent-runner/src/providers/cwd-shim.ts
+git show origin/providers:container/agent-runner/src/providers/cwd-shim.test.ts        > container/agent-runner/src/providers/cwd-shim.test.ts.new && mv container/agent-runner/src/providers/cwd-shim.test.ts.new container/agent-runner/src/providers/cwd-shim.test.ts
 ```
 
-(`cwd-shim.ts` is byte-identical to the trunk copy on current trunks — `mcp-to-opencode.ts` imports it, so copying it keeps the payload self-sufficient on trunks that predate it.)
+(`cwd-shim.ts` is byte-identical to the trunk copy on current trunks — `mcp-to-opencode.ts` imports it, so copying it keeps the payload self-sufficient on trunks that predate it. These two overwrite real trunk files, so they go through a `.new` + `mv` guard: on a providers branch that predates the cwd payload, `git show` fails without truncating the live copy the default provider imports.)
 
 ### 3. Append the self-registration imports
 

--- a/.claude/skills/add-opencode/SKILL.md
+++ b/.claude/skills/add-opencode/SKILL.md
@@ -45,7 +45,11 @@ git show origin/providers:container/agent-runner/src/providers/opencode.compacti
 git show origin/providers:container/agent-runner/src/providers/opencode.config.test.ts > container/agent-runner/src/providers/opencode.config.test.ts
 git show origin/providers:container/agent-runner/src/providers/opencode.memory.test.ts > container/agent-runner/src/providers/opencode.memory.test.ts
 git show origin/providers:container/agent-runner/src/providers/opencode.question.test.ts > container/agent-runner/src/providers/opencode.question.test.ts
+git show origin/providers:container/agent-runner/src/providers/cwd-shim.ts             > container/agent-runner/src/providers/cwd-shim.ts
+git show origin/providers:container/agent-runner/src/providers/cwd-shim.test.ts        > container/agent-runner/src/providers/cwd-shim.test.ts
 ```
+
+(`cwd-shim.ts` is byte-identical to the trunk copy on current trunks — `mcp-to-opencode.ts` imports it, so copying it keeps the payload self-sufficient on trunks that predate it.)
 
 ### 3. Append the self-registration imports
 
@@ -115,6 +119,7 @@ for overlay in data/v2-sessions/*/agent-runner-src/providers/; do
   [ -d "$overlay" ] || continue
   cp container/agent-runner/src/providers/opencode.ts "$overlay"
   cp container/agent-runner/src/providers/mcp-to-opencode.ts "$overlay"
+  cp container/agent-runner/src/providers/cwd-shim.ts "$overlay"
   cp container/agent-runner/src/providers/index.ts "$overlay"
   echo "Updated: $overlay"
 done

--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -93,6 +93,35 @@ describe('Codex config TOML', () => {
     expect(CODEX_APP_SERVER_ARGS).toContain('--dangerously-bypass-hook-trust');
   });
 
+  it('emits cwd for a stdio server above the env sub-table, and omits it when absent', () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+    process.env.HOME = tmpHome;
+
+    writeCodexConfigToml(
+      {
+        probe: {
+          command: '/workspace/agent/plugins/sdr/run.js',
+          args: ['--flag'],
+          env: { FOO: 'bar' },
+          cwd: '/workspace/agent/plugin-data/sdr',
+        },
+        plain: { command: 'bun' },
+      },
+      MEMORY_SESSION_HOOK,
+    );
+
+    const content = fs.readFileSync(path.join(tmpHome, '.codex', 'config.toml'), 'utf-8');
+    expect(content).toContain(
+      'command = "/workspace/agent/plugins/sdr/run.js"\n' +
+        'cwd = "/workspace/agent/plugin-data/sdr"\n' +
+        'args = ["--flag"]\n' +
+        '[mcp_servers.probe.env]',
+    );
+    const plainTable = content.split('[mcp_servers.plain]')[1].split('[mcp_servers.')[0];
+    expect(plainTable).toContain('command = "bun"');
+    expect(plainTable).not.toContain('cwd =');
+  });
+
   it('quotes non-bare server names and env keys so they cannot open new tables', () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
     process.env.HOME = tmpHome;

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -422,6 +422,13 @@ export function writeCodexConfigToml(
     }
 
     lines.push(`command = ${tomlBasicString(config.command)}`);
+    // Codex launches the stdio server in this directory natively (Stdio
+    // transport `cwd`, present since before the pinned 0.138.0). Arrives
+    // absolute — plugin-mcp.ts resolves the plugin fixed forms first.
+    // Must stay above the [.env] sub-table header or TOML re-parents it.
+    if (config.cwd) {
+      lines.push(`cwd = ${tomlBasicString(config.cwd)}`);
+    }
     if (config.args && config.args.length > 0) {
       lines.push(`args = [${config.args.map(tomlBasicString).join(', ')}]`);
     }

--- a/container/agent-runner/src/providers/cwd-shim.test.ts
+++ b/container/agent-runner/src/providers/cwd-shim.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+
+import { shimCwd } from './cwd-shim.js';
+
+describe('shimCwd', () => {
+  it('wraps a cwd-declaring server in a cd-then-exec launch', () => {
+    const shimmed = shimCwd({
+      command: '/workspace/agent/plugins/sdr/run.js',
+      args: ['--flag'],
+      env: { A: 'b' },
+      cwd: '/workspace/agent/plugin-data/sdr',
+    });
+
+    expect(shimmed).toEqual({
+      command: '/bin/sh',
+      args: [
+        '-c',
+        'cd "$0" && exec "$@"',
+        '/workspace/agent/plugin-data/sdr',
+        '/workspace/agent/plugins/sdr/run.js',
+        '--flag',
+      ],
+      env: { A: 'b' },
+    });
+  });
+
+  it('keeps hostile values positional instead of interpolating them', () => {
+    // The script is a fixed constant; hostile strings only ever appear as
+    // discrete argv entries after it.
+    expect(
+      shimCwd({
+        command: 'server',
+        args: ['$(rm -rf /)', '"; evil'],
+        cwd: '/workspace/agent/plugins/p',
+      }),
+    ).toEqual({
+      command: '/bin/sh',
+      args: ['-c', 'cd "$0" && exec "$@"', '/workspace/agent/plugins/p', 'server', '$(rm -rf /)', '"; evil'],
+    });
+  });
+
+  it('passes servers without cwd and http servers through untouched', () => {
+    const stdio = { command: 'bun', args: ['run', 'x.ts'] };
+    expect(shimCwd(stdio)).toBe(stdio);
+
+    const http = { type: 'http' as const, url: 'https://mcp.example.com/mcp' };
+    expect(shimCwd(http)).toBe(http);
+  });
+});

--- a/container/agent-runner/src/providers/cwd-shim.ts
+++ b/container/agent-runner/src/providers/cwd-shim.ts
@@ -1,0 +1,31 @@
+/**
+ * Launch-directory fallback for provider runtimes that cannot set a spawn
+ * cwd on a stdio MCP server. Current consumers: claude (the Agent SDK's
+ * McpStdioServerConfig has no cwd field, checked against 0.3.197) and
+ * opencode (its local MCP entry is a bare argv array). Codex consumes cwd
+ * natively and never calls this. When a runtime gains native cwd support,
+ * delete its call site and pass the value through; when the last call site
+ * goes, delete this file and its test.
+ *
+ * The wrap launches through /bin/sh so the process can chdir before exec.
+ * cwd, command, and args travel as positional parameters ($0, $1, $2…), never
+ * interpolated into the shell string, so hostile values cannot inject shell
+ * syntax. cwd arrives absolute (resolved by plugin-mcp.ts), so `cd` cannot
+ * misread it as a flag.
+ *
+ * Twin-patched at this same path on the providers registry branch (donor-
+ * branch doctrine); keep the two copies byte-identical.
+ */
+import type { McpServerConfig } from './types.js';
+
+/** The wrap as one argv, for runtimes configured with a bare argv array (opencode). */
+export function cwdWrappedArgv(cwd: string, command: string, args: string[]): string[] {
+  return ['/bin/sh', '-c', 'cd "$0" && exec "$@"', cwd, command, ...args];
+}
+
+export function shimCwd(config: McpServerConfig): McpServerConfig {
+  if (config.type === 'http' || !config.cwd) return config;
+  const { cwd, ...server } = config;
+  const [command, ...args] = cwdWrappedArgv(cwd, config.command, config.args ?? []);
+  return { ...server, command, args };
+}

--- a/container/agent-runner/src/providers/mcp-to-opencode.test.ts
+++ b/container/agent-runner/src/providers/mcp-to-opencode.test.ts
@@ -53,6 +53,17 @@ describe('mcpServersToOpenCodeConfig', () => {
     });
   });
 
+  it('wraps a cwd-declaring server in the cd-then-exec argv', () => {
+    const mcp = mcpServersToOpenCodeConfig({
+      probe: { command: './run.js', args: ['--flag'], cwd: '/workspace/agent/plugin-data/sdr' },
+    });
+    expect(mcp.probe).toEqual({
+      type: 'local',
+      command: ['/bin/sh', '-c', 'cd "$0" && exec "$@"', '/workspace/agent/plugin-data/sdr', './run.js', '--flag'],
+      enabled: true,
+    });
+  });
+
   it('maps Streamable HTTP servers to remote entries', () => {
     expect(
       mcpServersToOpenCodeConfig({

--- a/container/agent-runner/src/providers/mcp-to-opencode.ts
+++ b/container/agent-runner/src/providers/mcp-to-opencode.ts
@@ -1,3 +1,4 @@
+import { cwdWrappedArgv } from './cwd-shim.js';
 import type { McpServerConfig } from './types.js';
 
 /** OpenCode `mcp` entry shape (local stdio server). */
@@ -35,11 +36,14 @@ export function mcpServersToOpenCodeConfig(
       continue;
     }
 
+    // OpenCode's local entry is a bare argv array with no spawn-directory
+    // key, so a declared cwd goes through the shared cd-then-exec wrap —
+    // never silently launched in the wrong directory.
     const args = cfg.args ?? [];
     const env = cfg.env ?? {};
     out[name] = {
       type: 'local',
-      command: [cfg.command, ...args],
+      command: cfg.cwd ? cwdWrappedArgv(cfg.cwd, cfg.command, args) : [cfg.command, ...args],
       ...(Object.keys(env).length > 0 ? { environment: env } : {}),
       enabled: true,
     };

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -62,6 +62,14 @@ export type McpServerConfig =
        * before the config reaches a provider.
        */
       pluginRoot?: string;
+      /**
+       * Working directory for the server process. By the time a provider sees
+       * it, plugin-mcp.ts has resolved it to an absolute container path (and
+       * dropped it for servers without a pluginRoot). A provider whose runtime
+       * cannot set a spawn directory must shim it (cwd-shim.ts) or
+       * drop it — never launch in the wrong directory.
+       */
+      cwd?: string;
     }
   | { type: 'http'; url: string; headers?: Record<string, string> };
 

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -64,10 +64,9 @@ export type McpServerConfig =
       pluginRoot?: string;
       /**
        * Working directory for the server process. By the time a provider sees
-       * it, plugin-mcp.ts has resolved it to an absolute container path (and
-       * dropped it for servers without a pluginRoot). A provider whose runtime
-       * cannot set a spawn directory must shim it (cwd-shim.ts) or
-       * drop it — never launch in the wrong directory.
+       * it, plugin-mcp.ts has resolved it to an absolute container path.
+       * A provider whose runtime cannot set a spawn directory must shim it
+       * (cwd-shim.ts) or drop it — never launch in the wrong directory.
        */
       cwd?: string;
     }


### PR DESCRIPTION
Registry payload half of the plugin MCP working-directory support that lands on trunk with #3220.

Codex's stdio MCP transport takes a native cwd (present since before the pinned 0.138.0; launch behavior live-verified on 0.147.0): the TOML writer emits it above the [.env] sub-table header so it stays in the server table, quoted through tomlBasicString like every other value. OpenCode's local entry is a bare argv array with no spawn-directory key, so a declared cwd goes through the shared cd-then-exec wrap (cwd-shim.ts) instead of silently launching in the wrong directory.

Twin-patches the engine pieces this payload needs from trunk: the cwd field on McpServerConfig and cwd-shim.ts itself, which trunk's plugin-mcp.ts feeds with plugin cwd declarations resolved to absolute container paths.

Relationship to #3220: trunk-side, stamped plugin servers now always carry a cwd (the spec default is the plugin root), so these writers are what makes that take effect on codex and opencode. The add-opencode skill on #3220 fetches cwd-shim.ts from this branch. Merge in the same window as #3220.

Verification (registry PRs get no CI): bun test green on the payload tree (89 test lines added, codex TOML shape and opencode shim both pinned); live e2e on a combined install saw codex launch a plugin server with the native cwd in its generated config.toml.