### PR TITLE
versions: repin the agent image to hardened-2026-08-13

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "onecli-gateway": "1.36.0",
   "onecli-cli": "2.2.5",
-  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:af60e54fc0c8139157244c2b2f23d3d365fd2446210f816ce013e5282d64fd60"
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:ccde3d9c86fb655be66c93e07bc38a62faab2d951651a1fba345a7a47defeb85"
 }


### PR DESCRIPTION
Repins the agent image to `hardened-2026-08-13`.

```
old  sha256:af60e54f…   620,725,759 B   built 2026-08-02
new  sha256:ccde3d9c…   620,769,684 B   built 2026-08-13
```

### This one carries our own content, not just a base refresh

The previous two bumps shared an `ai.echo.image.upstream.digest`, so they were the same NanoClaw content on newer hardened layers. This one is different — the upstream digest moved:

```
was  sha256:dce9da56…
now  sha256:9aa4fb42…
```

That digest is `docker.io/nanoco/nanoclaw:agent-alpha`, which **we** republished on 2026-08-09. Echo rebuilt from it on 08-13. So what is new here originated on our side; Echo's contribution is the same hardening applied to newer input.

All eight layers changed, which is what a full rebuild looks like, while the total moved by **+43,925 bytes (+0.007%)** — consistent with a small content delta rather than a different image.

### Verified before pinning

| | |
|---|---|
| Multi-arch OCI index | `linux/amd64` + `linux/arm64` |
| `dev.nanoclaw.image-source` | `hardened`, both children |
| `dev.nanoclaw.agent-runner-lock-sha256` | `5f49954570dd…` — exact match with `main` |
| User / entrypoint | `node` / `tini -- /app/entrypoint.sh` |
| Layer structure | 8 layers, largest 27%, top three 67% — unchanged |

Both architectures were built 7 seconds apart, so they come from one build run.

The lock label is the check that matters most here, because the content changed: a mismatch would pair baked `/app/node_modules` against a different `bun.lock` and surface as a missing module inside a `--rm` container whose logs are discarded. It matches `main` exactly.

### Promotion

Published to `nanoclaw/agent` with `crane copy`, which preserves the manifest bytes, so the index digest is identical to what Echo published. Source was `echo/nanoclaw-agent` — the ECR pull-through cache of Echo's registry, not a repo anyone pushes to by hand.

### Not signature-verified, deliberately

Cosign keeps signatures as sibling tags in the same repository and they do not travel with a push, so `nanoclaw/agent` holds no `.sig`/`.att` artifacts to verify against. This is a human merge by design. See #3158.

Worth noting this build sat unnoticed for about eleven hours, which is the gap the refresh automation is meant to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
