### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to NanoClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-13
+
 - **Stamped plugins update in place through `ncl groups create --template <ref>`.** When a group already carries the template's plugin, the same command becomes an in-place update instead of minting a duplicate agent: a dry run prints a plan of every plugin-owned surface (plugin files, skills, MCP servers, persona, context files, tasks), flagging locally customized files whose edits would be lost; `--yes` applies, `--id` picks among several stamped groups, `--new` deliberately stamps another agent. Agent state the plugin does not own (memory, `plugin-data/`, user-added MCP servers, task pause/resume state, wiring) is never touched. Plugin-stamped MCP servers now carry an ownership marker and refuse direct edits via `ncl groups config add-mcp-server` / `remove-mcp-server` or the agent's `add_mcp_server` tool: update the plugin and restamp instead.
 - [BREAKING] **Agent templates are now Agent Plugins 1.0.0 directories.** `plugin.json` replaces `context/instructions.md` as the required file; MCP servers move to a spec-shaped `mcp.json`; persona, extra context, and tasks move under the `ai.nanoco.nanoclaw/` extension dir. Templates become portable to other plugin clients, and any conformant third-party plugin stamps as a NanoClaw agent. **Migration:** re-fetch templates from the registry (the pre-plugin layout fails with a migration error); to convert a local custom template, see [docs/templates.md](docs/templates.md).
 - **Plugin MCP servers may declare a working directory.** `cwd` in `mcp.json` (fixed forms `./p`, `${PLUGIN_ROOT}[/p]`, `${PLUGIN_DATA}[/p]`) now launches the server in that directory instead of being skipped: resolved to an absolute container path at runtime, consumed natively by providers that support it and via a `cd`-then-`exec` launch shim on Claude. A stdio server that omits `cwd` runs from the plugin root (the spec default).
@@ -13,6 +15,17 @@ All notable changes to NanoClaw will be documented in this file.
 - **Agent-to-agent messaging no longer loses to Claude Code's built-in `SendMessage`.** That built-in addresses the SDK's own in-session subagents, so an agent that had just run `create_agent` reached for it by name and got `No agent named 'x' is currently addressable` — reading as "the group was never provisioned" while `mcp__nanoclaw__send_message` (the real path) was never called. `SendMessage` joins `AskUserQuestion` in `SDK_DISALLOWED_TOOLS`, so the PreToolUse hook now blocks it and points at the nanoclaw equivalent.
 - [BREAKING] **Existing Claude installs should review the hardened agent image.** Local builds remain supported, but the Echo-built image is recommended for patched sandbox components. **Migration:** follow [the hardened-image guide](docs/hardened-image.md) to detect your current image source, switch, verify, or roll back.
 - **Release publication tolerates GitHub API propagation.** The Release workflow now retries bounded post-publication read-backs when the new Release is not listed yet or its immutable state is not visible yet. Exact title, body, tag, or SHA mismatches still fail immediately.
+- The `add-tavily-tool` skill adds Tavily Search and Extract as keyless remote MCP tools for selected agent groups, bridged through a pinned `mcp-remote`.
+- Scheduled tasks now run with their effective scheduled occurrence as the task time, plus a task-only `current_time` (weekday included, in the agent group's timezone) instead of the creation timestamp.
+- Accumulated messages stay available as context without spuriously triggering warm-container follow-up turns; group-scoped agents can inspect their wirings and request approved engagement-policy updates; invalid engagement regexes are rejected.
+- Hosted iMessage setup now provisions the line's user row directly and prints the assigned number to text once; that first message is the opt-in the delivery plane checks, and re-runs reuse the existing row.
+- Resolved approval cards keep their title and request details, replace buttons with the decision and actor (or a timeout status), and survive host restarts and delayed resolution.
+- Setup failure assist now offers diagnosis through the provider the operator picked instead of always offering to install Claude.
+- `ensureUserDm` gains an opt-in privacy-safe logging mode for security-sensitive flows: user IDs, handles, messaging-group IDs, and raw adapter errors are omitted while non-identifying channel context is kept.
+- The stale `add-gcal-tool`, `add-gmail-tool`, and `get-qodo-rules` skills were removed.
+- The recommended hardened agent image is repinned to `hardened-2026-08-13`.
+- The package description now says personal AI assistant: NanoClaw is provider-agnostic, not Claude-only.
+- Docs: skills define a single-responsibility integration rule, and the hardened-image guide states that `install_packages` covers apt and npm packages only.
 
 ## [2.1.54] - 2026-08-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanoclaw",
   "version": "2.1.54",
-  "description": "Personal Claude assistant. Lightweight, secure, customizable.",
+  "description": "Personal AI assistant. Lightweight, secure, customizable.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoclaw",
-  "version": "2.1.54",
+  "version": "2.2.0",
   "description": "Personal AI assistant. Lightweight, secure, customizable.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Release PR for v2.2.0, per RELEASING.md.

- Bumps `package.json` to `2.2.0`.
- Moves the curated notes from `Unreleased` to `## [2.2.0] - 2026-08-13` and leaves `Unreleased` in place for the next cycle.
- Adds plain bullets for user-visible changes merged since v2.1.54 that had no changelog entry yet.
- Changes the package description to provider-neutral wording, matching the README intro. NanoClaw is not Claude-only anymore.

Minor bump instead of a patch: the Agent Plugins 1.0.0 template format is the biggest breaking change since v2.

After merge: Release workflow on the merge SHA, `verify` first, then `publish` after a separate confirmation.

Assisted by Claude; reviewed and verified by a human before submission.
