### PR TITLE
ci: let verify-agent-image run on every PR so it can gate

### DIFF
--- a/.github/workflows/verify-agent-image.yml
+++ b/.github/workflows/verify-agent-image.yml
@@ -17,12 +17,18 @@
 # OIDC, a missing role: every one of those ends with auto-merge off and the PR
 # waiting for a person. There is no path through this file where uncertainty
 # results in a merge.
+#
+# Runs on every pull request, deliberately, and NOT filtered on the versions.json
+# path. A required status check that is path-filtered never reports on a PR that
+# does not touch the path, and GitHub reads never-reported as forever-pending —
+# so a filtered job here would block every unrelated PR instead of gating this
+# one. Unchanged pin is therefore a fast, green no-op, which is what lets `verify`
+# be a required check at all. It was not one while this was filtered, and a pin
+# bump merged with this job red.
 name: verify-agent-image
 
 on:
   pull_request:
-    paths:
-      - versions.json
 
 permissions:
   contents: read
@@ -60,7 +66,8 @@ jobs:
 
           if [ "$NEW" = "$OLD" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "versions.json changed but the agent-image pin did not — nothing to verify."
+            echo "The agent-image pin is unchanged — nothing to verify."
+            echo "(Most PRs land here: this job runs on all of them so it can be a required check.)"
             exit 0
           fi
           echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`verify-agent-image` has been advisory since it was written, and the reason is one line:

```yaml
on:
  pull_request:
    paths:
      - versions.json
```

A path-filtered workflow can never be a required status check. On a PR that does not touch the path it never reports, and GitHub reads never-reported as forever-pending — so adding it to the ruleset would block every unrelated PR. That is why ruleset `12836988` requires exactly one check, `ci`.

The consequence is not theoretical. Both pin bumps merged with this job red:

| PR | `verify` | merged |
|---|---|---|
| #3182 | fail | yes |
| #3236 | fail 14:38:45 | yes, 14:59:58 |

The file's own header says "there is no path through this file where uncertainty results in a merge." That is true of its logic and false of its wiring — every blocking check it performs has been decorative.

### The change

Drop the filter. The job already computes whether the pin moved, and every step after that is gated on `changed == 'true'`:

```
0. checkout                          (always)
1. Resolve the pin change            (always)
2-9. everything else                 changed == 'true'
```

So on a PR that does not touch the pin it is a checkout plus one `git show`, then green. That is what makes it eligible to be required.

### Deliberately not in this PR

Adding `verify` to the ruleset's required checks. It has to come **after** this merges — do it first and every open PR blocks on a check that never runs. Two other things also need to land before the gate means much:

- `AGENT_IMAGE_CI_ROLE_ARN` is unset, so every run currently dies on a `401` in about 15 seconds. The job cannot authenticate to ECR at all.
- The cosign signer variables are unset, so the auto-merge arm correctly refuses to fire. That design is right; it has just never been switched on. See #3158.

Neither is a reason to hold this — a check that fails closed and blocks is strictly better than one that cannot block. But `verify` will go red on real pin bumps until the role exists, so sequence the ruleset change with that in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
