### PR TITLE
DO NOT MERGE — smoke test for the verify-agent-image gate

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "onecli-gateway": "1.36.0",
   "onecli-cli": "2.2.5",
-  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:ccde3d9c86fb655be66c93e07bc38a62faab2d951651a1fba345a7a47defeb85"
+  "agent-image": "797273591697.dkr.ecr.us-east-1.amazonaws.com/nanoclaw/agent@sha256:af60e54fc0c8139157244c2b2f23d3d365fd2446210f816ce013e5282d64fd60"
 }


### PR DESCRIPTION
Throwaway draft. Moves the pin to the previous hardened build purely to make `verify-agent-image` take its full path now that `AGENT_IMAGE_CI_ROLE_ARN` exists — role assumption, ECR login, manifest inspection, label checks, size delta.

Before the role existed, every run died on a 401 in ~15s. This proves the gate can authenticate before it is added to the ruleset's required checks.

**Will be closed unmerged.**