### PR TITLE
verify-agent-image: arming auto-merge is not a verdict

### DIFF
--- a/.github/workflows/verify-agent-image.yml
+++ b/.github/workflows/verify-agent-image.yml
@@ -239,13 +239,23 @@ jobs:
           # attach per architecture, so verifying the index alone would pass
           # without ever having looked at an SBOM.
 
+      # Arming auto-merge is a convenience, NOT a verification result, so it
+      # cannot be allowed to decide this job's conclusion. It is the last step,
+      # and without continue-on-error its failure turns the whole job red — on a
+      # draft pull request, whenever allow_auto_merge is off, or on a transient
+      # API error. Now that `verify` is a required check that is a self-inflicted
+      # block, and worse: approve-agent-image only triggers on this workflow
+      # concluding success, so one flaky call here silently breaks the approval
+      # chain behind it. A red job must mean the IMAGE failed a check.
       - name: Enable auto-merge
+        continue-on-error: true
         if: steps.pin.outputs.changed == 'true' && steps.sig.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Signature verified against the configured publisher identity."
-          gh pr merge --squash --auto '${{ github.event.pull_request.number }}'
+          gh pr merge --squash --auto '${{ github.event.pull_request.number }}' \
+            || echo "::notice::Could not arm auto-merge (draft, disabled, or transient). Verification stands; a human merges."
 
       - name: Explain why a human is still needed
         if: steps.pin.outputs.changed == 'true' && steps.sig.outcome != 'success'


### PR DESCRIPTION
`Enable auto-merge` is the last step in the job, and without `continue-on-error` its failure decides the job's conclusion. It fails on a draft pull request, whenever `allow_auto_merge` is off, and on any transient API error — none of which say anything about the image.

Now that `verify` is a required status check, that is a self-inflicted block. And `approve-agent-image` triggers only on this workflow concluding `success`, so one flaky call here silently breaks the approval chain behind it *while looking like a signature problem*.

**Found by a live-fire test.** A draft pin bump verified its signature correctly:

```
success  Verify publisher signature
failure  Enable auto-merge          ← draft cannot be auto-merged
```

and the job went red anyway, blocking the PR and preventing the approver from ever running.

A red job here must mean the image failed a check.