### PR TITLE
fix(container-runtime): stop orphan cleanup from silently no-oping on Windows

### DIFF
--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -45,13 +45,9 @@ describe('readonlyMountArgs', () => {
 describe('stopContainer', () => {
   it('calls docker stop for valid container names', () => {
     stopContainer('nanoclaw-test-123');
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      CONTAINER_RUNTIME_BIN,
-      ['stop', '-t', '1', 'nanoclaw-test-123'],
-      {
-        stdio: 'pipe',
-      },
-    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(CONTAINER_RUNTIME_BIN, ['stop', '-t', '1', 'nanoclaw-test-123'], {
+      stdio: 'pipe',
+    });
   });
 
   it('rejects names with shell metacharacters', () => {

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -11,10 +11,12 @@ vi.mock('./log.js', () => ({
   },
 }));
 
-// Mock child_process — store the mock fn so tests can configure it
+// Mock child_process — store the mock fns so tests can configure them
 const mockExecSync = vi.fn();
+const mockExecFileSync = vi.fn();
 vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
 import {
@@ -43,16 +45,20 @@ describe('readonlyMountArgs', () => {
 describe('stopContainer', () => {
   it('calls docker stop for valid container names', () => {
     stopContainer('nanoclaw-test-123');
-    expect(mockExecSync).toHaveBeenCalledWith(`${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-test-123`, {
-      stdio: 'pipe',
-    });
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      CONTAINER_RUNTIME_BIN,
+      ['stop', '-t', '1', 'nanoclaw-test-123'],
+      {
+        stdio: 'pipe',
+      },
+    );
   });
 
   it('rejects names with shell metacharacters', () => {
     expect(() => stopContainer('foo; rm -rf /')).toThrow('Invalid container name');
     expect(() => stopContainer('foo$(whoami)')).toThrow('Invalid container name');
     expect(() => stopContainer('foo`id`')).toThrow('Invalid container name');
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 });
 
@@ -86,32 +92,43 @@ describe('ensureContainerRuntimeRunning', () => {
 
 describe('cleanupOrphans', () => {
   it('filters ps by the install label so peers are not reaped', () => {
-    mockExecSync.mockReturnValueOnce('');
+    mockExecFileSync.mockReturnValueOnce('');
 
     cleanupOrphans();
 
-    expect(mockExecSync).toHaveBeenCalledWith(
-      `${CONTAINER_RUNTIME_BIN} ps --filter label=${CONTAINER_INSTALL_LABEL} --format '{{.Names}}'`,
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      CONTAINER_RUNTIME_BIN,
+      ['ps', '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
       expect.any(Object),
     );
   });
 
   it('stops orphaned nanoclaw containers', () => {
     // docker ps returns container names, one per line
-    mockExecSync.mockReturnValueOnce('nanoclaw-group1-111\nnanoclaw-group2-222\n');
+    mockExecFileSync.mockReturnValueOnce('nanoclaw-group1-111\nnanoclaw-group2-222\n');
     // stop calls succeed
-    mockExecSync.mockReturnValue('');
+    mockExecFileSync.mockReturnValue('');
 
     cleanupOrphans();
 
     // ps + 2 stop calls
-    expect(mockExecSync).toHaveBeenCalledTimes(3);
-    expect(mockExecSync).toHaveBeenNthCalledWith(2, `${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-group1-111`, {
-      stdio: 'pipe',
-    });
-    expect(mockExecSync).toHaveBeenNthCalledWith(3, `${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-group2-222`, {
-      stdio: 'pipe',
-    });
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      CONTAINER_RUNTIME_BIN,
+      ['stop', '-t', '1', 'nanoclaw-group1-111'],
+      {
+        stdio: 'pipe',
+      },
+    );
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      3,
+      CONTAINER_RUNTIME_BIN,
+      ['stop', '-t', '1', 'nanoclaw-group2-222'],
+      {
+        stdio: 'pipe',
+      },
+    );
     expect(log.info).toHaveBeenCalledWith('Stopped orphaned containers', {
       count: 2,
       names: ['nanoclaw-group1-111', 'nanoclaw-group2-222'],
@@ -119,16 +136,16 @@ describe('cleanupOrphans', () => {
   });
 
   it('does nothing when no orphans exist', () => {
-    mockExecSync.mockReturnValueOnce('');
+    mockExecFileSync.mockReturnValueOnce('');
 
     cleanupOrphans();
 
-    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
     expect(log.info).not.toHaveBeenCalled();
   });
 
   it('warns and continues when ps fails', () => {
-    mockExecSync.mockImplementationOnce(() => {
+    mockExecFileSync.mockImplementationOnce(() => {
       throw new Error('docker not available');
     });
 
@@ -141,20 +158,38 @@ describe('cleanupOrphans', () => {
   });
 
   it('continues stopping remaining containers when one stop fails', () => {
-    mockExecSync.mockReturnValueOnce('nanoclaw-a-1\nnanoclaw-b-2\n');
+    mockExecFileSync.mockReturnValueOnce('nanoclaw-a-1\nnanoclaw-b-2\n');
     // First stop fails
-    mockExecSync.mockImplementationOnce(() => {
+    mockExecFileSync.mockImplementationOnce(() => {
       throw new Error('already stopped');
     });
     // Second stop succeeds
-    mockExecSync.mockReturnValueOnce('');
+    mockExecFileSync.mockReturnValueOnce('');
 
     cleanupOrphans(); // should not throw
 
-    expect(mockExecSync).toHaveBeenCalledTimes(3);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3);
     expect(log.info).toHaveBeenCalledWith('Stopped orphaned containers', {
       count: 2,
       names: ['nanoclaw-a-1', 'nanoclaw-b-2'],
     });
+  });
+
+  it('receives unquoted names on every platform (no shell, argument array)', () => {
+    // The regression this guards against: a shell-mediated call renders
+    // --format '{{.Names}}' with literal single quotes on Windows (cmd.exe),
+    // and docker echoes names wrapped in quotes that then fail the name
+    // validation regex in stopContainer. The argument-array form carries no
+    // quoting, so the parsed output goes straight to stopContainer.
+    mockExecFileSync.mockReturnValueOnce('nanoclaw-a-1\n');
+    mockExecFileSync.mockReturnValue('');
+
+    cleanupOrphans();
+
+    const psCall = mockExecFileSync.mock.calls[0];
+    expect(psCall[1]).toContainEqual('--format');
+    expect(psCall[1][psCall[1].indexOf('--format') + 1]).toBe('{{.Names}}');
+    const stopCall = mockExecFileSync.mock.calls[1];
+    expect(stopCall[1]).toEqual(['stop', '-t', '1', 'nanoclaw-a-1']);
   });
 });

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import os from 'os';
 
 import { CONTAINER_INSTALL_LABEL } from './config.js';
@@ -30,7 +30,7 @@ export function stopContainer(name: string): void {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name)) {
     throw new Error(`Invalid container name: ${name}`);
   }
-  execSync(`${CONTAINER_RUNTIME_BIN} stop -t 1 ${name}`, { stdio: 'pipe' });
+  execFileSync(CONTAINER_RUNTIME_BIN, ['stop', '-t', '1', name], { stdio: 'pipe' });
 }
 
 /** Ensure the container runtime is running, starting it if needed. */
@@ -66,8 +66,15 @@ export function ensureContainerRuntimeRunning(): void {
  */
 export function cleanupOrphans(): void {
   try {
-    const output = execSync(
-      `${CONTAINER_RUNTIME_BIN} ps --filter label=${CONTAINER_INSTALL_LABEL} --format '{{.Names}}'`,
+    // execFileSync (no shell): the shell-quoting of `--format '{{.Names}}'`
+    // is POSIX-only. On Windows, cmd.exe passes the single quotes through
+    // literally, docker echoes names wrapped in them, and every name then
+    // fails stopContainer's validation regex — orphans are listed but never
+    // stopped, silently piling up. Argument-array form is quoting-free on
+    // every platform.
+    const output = execFileSync(
+      CONTAINER_RUNTIME_BIN,
+      ['ps', '--filter', `label=${CONTAINER_INSTALL_LABEL}`, '--format', '{{.Names}}'],
       {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8',


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** `cleanupOrphans()` lists this install's containers through a shell-mediated `execSync` whose `--format '{{.Names}}'` argument uses POSIX single quotes. On Windows, `cmd.exe` passes those quotes through literally, docker echoes every name wrapped in single quotes, and each quoted name then fails `stopContainer()`'s validation regex. Orphans are enumerated but never stopped — they silently pile up across restarts.

**Why.** The cleanup exists to bound leftover containers after unclean shutdowns; on Windows it currently does nothing while reporting success. The doc comment on `stopContainer` already says "Uses execFileSync" — the code didn't.

**How it works.** Both call sites (`ps` listing in `cleanupOrphans`, `docker stop` in `stopContainer`) switch to `execFileSync` with an argument array — no shell, no quoting to get wrong on any platform. Name validation is unchanged.

## How it was tested

- `vitest run src/container-runtime.test.ts` — 11/11 (mock updated to `execFileSync`; new test pins the argument-array shape so a quoted regression can't reintroduce the bug)
- `pnpm run build` clean; eslint reports no new findings
- The same change has run in production on a Windows host since May (found via orphaned containers accumulating across service restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)