### PR TITLE
fix(scheduling): retire a malformed cron string instead of re-erroring every sweep tick

### DIFF
--- a/src/modules/scheduling/recurrence.test.ts
+++ b/src/modules/scheduling/recurrence.test.ts
@@ -156,6 +156,31 @@ describe('handleRecurrence', () => {
     const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
     expect(count).toBe(1);
   });
+
+  it('clears a malformed cron string instead of re-erroring on every sweep tick', async () => {
+    const db = freshDb();
+    insertTaskRow(db, {
+      id: 'task-1',
+      seriesId: 'task-1',
+      processAfter: '2020-01-01T00:00:00.000Z',
+      // cron-parser rejects min>max ranges ("21-5") — the string observed in
+      // the wild after an agent hand-wrote a wrap-around range.
+      recurrence: '0 21-5 * * *',
+      content: JSON.stringify({ prompt: 'night shift' }),
+    });
+    db.prepare(`UPDATE messages_in SET status='completed' WHERE id='task-1'`).run();
+
+    await handleRecurrence(db, fakeSession());
+
+    // The dead string is retired in place: no clone inserted, recurrence
+    // cleared — the next sweep tick won't parse (and error on) it again.
+    const count = (db.prepare(`SELECT COUNT(*) AS c FROM messages_in`).get() as { c: number }).c;
+    expect(count).toBe(1);
+    const row = db.prepare(`SELECT recurrence FROM messages_in WHERE id='task-1'`).get() as {
+      recurrence: string | null;
+    };
+    expect(row.recurrence).toBeNull();
+  });
 });
 
 describe('handleRecurrence — script-failure backoff (streak derived from failed runs)', () => {

--- a/src/modules/scheduling/recurrence.ts
+++ b/src/modules/scheduling/recurrence.ts
@@ -99,7 +99,18 @@ export async function handleRecurrence(inDb: Database.Database, session: Session
         sessionId: session.id,
       });
     } catch (err) {
-      log.error('Failed to compute next recurrence', {
+      // A cron string can't fix itself. Clearing the recurrence retires the
+      // dead row in place — otherwise it re-parses and errors on every sweep
+      // tick, forever, and the series' next run never comes.
+      try {
+        clearRecurrence(inDb, msg.id);
+      } catch (clearErr) {
+        log.error('Failed to clear malformed recurrence after parse error', {
+          messageId: msg.id,
+          err: clearErr,
+        });
+      }
+      log.error('Cleared malformed recurrence after parse failure', {
         messageId: msg.id,
         recurrence: msg.recurrence,
         err,


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What.** When cron-parser rejects a recurrence string (e.g. an agent hand-writes a wrap-around range like `0 21-5 * * *`, min>max), `handleRecurrence` logs the parse error but leaves the row untouched.

**Why.** The row still matches `getCompletedRecurring`, so the same dead string is re-parsed and re-errors on **every sweep tick, forever** — permanent error-log noise, wasted work each tick, and the series' next run never comes.

**How it works.** A cron string can't fix itself: on parse failure, clear the recurrence on the failing row and log once. The row is retired in place and the sweep goes quiet. Clearing is best-effort (its own failure is logged); the loop continues to the next row either way.

## How it was tested

- New unit test in `recurrence.test.ts` (same pattern as the neighboring "already cleared" case): inserts a `0 21-5 * * *` row, runs `handleRecurrence`, asserts no clone was inserted and `recurrence` is `NULL`
- `pnpm run build` clean
- Note: this Windows workstation cannot execute the scheduling suite locally (pre-existing `EPERM` on the suite's hardcoded `/tmp` test dir — affects upstream's own tests here too); the test runs in CI on Linux. The behavior has run in production on our fork since June, where the original incident (an invalid range re-erroring for ~16h of sweep ticks) motivated it

🤖 Generated with [Claude Code](https://claude.com/claude-code)