### PR TITLE
fix(setup): handle an existing Node outside the supported range

### DIFF
--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -363,6 +363,41 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
   esac
 fi
 
+# ─── pre-flight: existing Node too old ─────────────────────────────────
+# setup/install-node.sh never replaces a Node the user already owns, and
+# the bootstrap below runs under a spinner with its output captured, so
+# this is the last spot where a consent prompt is possible. Headless runs
+# skip the prompt and get the bootstrap's clear failure instead.
+NODE_MAJOR_REQUIRED=20
+if command -v node >/dev/null 2>&1; then
+  NODE_FOUND_VERSION="$(node --version 2>/dev/null || echo unknown)"
+  NODE_FOUND_MAJOR="${NODE_FOUND_VERSION#v}"
+  NODE_FOUND_MAJOR="${NODE_FOUND_MAJOR%%.*}"
+  if ! [ "$NODE_FOUND_MAJOR" -ge "$NODE_MAJOR_REQUIRED" ] 2>/dev/null && [ -t 1 ] && [ -e /dev/tty ]; then
+    printf '  %s\n' \
+      "$(dim "Node $NODE_FOUND_VERSION is installed, but NanoClaw needs Node ${NODE_MAJOR_REQUIRED}+.")"
+    printf '  %s\n\n' \
+      "$(dim "NanoClaw can install a newer Node now: kept alongside your Node when uv is available, otherwise via the platform installer (which may upgrade it).")"
+    read -r -p "  $(bold 'Install a newer Node now?') [Y/n] " NODE_ANS </dev/tty
+
+    case "${NODE_ANS:-Y}" in
+      [Yy]*|'')
+        printf '\n'
+        # Consent travels to setup.sh and setup/install-node.sh; the PATH
+        # prepend lets a nodeenv install win over the old Node for this
+        # whole flow, including the service unit the wizard writes.
+        export NANOCLAW_NODE_UPGRADE_OK=1
+        export PATH="$HOME/.local/bin:$PATH"
+        ;;
+      *)
+        printf '\n  %s\n\n' \
+          "$(dim "NanoClaw needs Node ${NODE_MAJOR_REQUIRED}+. Upgrade Node and re-run: bash nanoclaw.sh")"
+        exit 1
+        ;;
+    esac
+  fi
+fi
+
 # ─── first step: install the basics (Node + pnpm + native modules) ─────
 
 BOOTSTRAP_RAW="${STEPS_DIR}/01-bootstrap.log"

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -371,7 +371,7 @@ fi
 # The ceiling exists because better-sqlite3 11.x cannot build against
 # Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
 # NODE_MAJOR_MAX only after the better-sqlite3 pin supports the runtime.
-NODE_MAJOR_REQUIRED=20
+NODE_MAJOR_REQUIRED=22
 NODE_MAJOR_MAX=25
 if command -v node >/dev/null 2>&1; then
   NODE_FOUND_VERSION="$(node --version 2>/dev/null || echo unknown)"

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -375,10 +375,12 @@ if command -v node >/dev/null 2>&1; then
   NODE_FOUND_MAJOR="${NODE_FOUND_MAJOR%%.*}"
   if ! [ "$NODE_FOUND_MAJOR" -ge "$NODE_MAJOR_REQUIRED" ] 2>/dev/null && [ -t 1 ] && [ -e /dev/tty ]; then
     printf '  %s\n' \
-      "$(dim "Node $NODE_FOUND_VERSION is installed, but NanoClaw needs Node ${NODE_MAJOR_REQUIRED}+.")"
+      "$(dim "Node $NODE_FOUND_VERSION is installed. NanoClaw needs Node ${NODE_MAJOR_REQUIRED} or higher.")"
+    printf '  %s\n' \
+      "$(dim "NanoClaw can install a new Node now. If uv is available, NanoClaw keeps your Node and installs the new Node next to it.")"
     printf '  %s\n\n' \
-      "$(dim "NanoClaw can install a newer Node now: kept alongside your Node when uv is available, otherwise via the platform installer (which may upgrade it).")"
-    read -r -p "  $(bold 'Install a newer Node now?') [Y/n] " NODE_ANS </dev/tty
+      "$(dim "If uv is not available, NanoClaw uses the platform installer. The platform installer can replace your Node.")"
+    read -r -p "  $(bold 'Install a new Node now?') [Y/n] " NODE_ANS </dev/tty
 
     case "${NODE_ANS:-Y}" in
       [Yy]*|'')
@@ -391,7 +393,7 @@ if command -v node >/dev/null 2>&1; then
         ;;
       *)
         printf '\n  %s\n\n' \
-          "$(dim "NanoClaw needs Node ${NODE_MAJOR_REQUIRED}+. Upgrade Node and re-run: bash nanoclaw.sh")"
+          "$(dim "NanoClaw needs Node ${NODE_MAJOR_REQUIRED} or higher. Update your Node. Then run bash nanoclaw.sh again.")"
         exit 1
         ;;
     esac

--- a/nanoclaw.sh
+++ b/nanoclaw.sh
@@ -363,24 +363,28 @@ if [ "$(uname -s)" = "Darwin" ] && ! command -v brew >/dev/null 2>&1; then
   esac
 fi
 
-# ─── pre-flight: existing Node too old ─────────────────────────────────
+# ─── pre-flight: existing Node outside the supported range ─────────────
 # setup/install-node.sh never replaces a Node the user already owns, and
 # the bootstrap below runs under a spinner with its output captured, so
 # this is the last spot where a consent prompt is possible. Headless runs
 # skip the prompt and get the bootstrap's clear failure instead.
+# The ceiling exists because better-sqlite3 11.x cannot build against
+# Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
+# NODE_MAJOR_MAX only after the better-sqlite3 pin supports the runtime.
 NODE_MAJOR_REQUIRED=20
+NODE_MAJOR_MAX=25
 if command -v node >/dev/null 2>&1; then
   NODE_FOUND_VERSION="$(node --version 2>/dev/null || echo unknown)"
   NODE_FOUND_MAJOR="${NODE_FOUND_VERSION#v}"
   NODE_FOUND_MAJOR="${NODE_FOUND_MAJOR%%.*}"
-  if ! [ "$NODE_FOUND_MAJOR" -ge "$NODE_MAJOR_REQUIRED" ] 2>/dev/null && [ -t 1 ] && [ -e /dev/tty ]; then
+  if ! { [ "$NODE_FOUND_MAJOR" -ge "$NODE_MAJOR_REQUIRED" ] && [ "$NODE_FOUND_MAJOR" -le "$NODE_MAJOR_MAX" ]; } 2>/dev/null && [ -t 1 ] && [ -e /dev/tty ]; then
     printf '  %s\n' \
-      "$(dim "Node $NODE_FOUND_VERSION is installed. NanoClaw needs Node ${NODE_MAJOR_REQUIRED} or higher.")"
+      "$(dim "Node $NODE_FOUND_VERSION is installed. NanoClaw needs Node ${NODE_MAJOR_REQUIRED} to ${NODE_MAJOR_MAX}.")"
     printf '  %s\n' \
-      "$(dim "NanoClaw can install a new Node now. If uv is available, NanoClaw keeps your Node and installs the new Node next to it.")"
+      "$(dim "NanoClaw can install a supported Node now. If uv is available, NanoClaw keeps your Node and installs the supported Node next to it.")"
     printf '  %s\n\n' \
       "$(dim "If uv is not available, NanoClaw uses the platform installer. The platform installer can replace your Node.")"
-    read -r -p "  $(bold 'Install a new Node now?') [Y/n] " NODE_ANS </dev/tty
+    read -r -p "  $(bold 'Install a supported Node now?') [Y/n] " NODE_ANS </dev/tty
 
     case "${NODE_ANS:-Y}" in
       [Yy]*|'')
@@ -393,7 +397,7 @@ if command -v node >/dev/null 2>&1; then
         ;;
       *)
         printf '\n  %s\n\n' \
-          "$(dim "NanoClaw needs Node ${NODE_MAJOR_REQUIRED} or higher. Update your Node. Then run bash nanoclaw.sh again.")"
+          "$(dim "NanoClaw needs Node ${NODE_MAJOR_REQUIRED} to ${NODE_MAJOR_MAX}. Switch to a supported Node. Then run bash nanoclaw.sh again.")"
         exit 1
         ;;
     esac

--- a/setup.sh
+++ b/setup.sh
@@ -51,7 +51,7 @@ detect_platform() {
 # The ceiling exists because better-sqlite3 11.x cannot build against
 # Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
 # NODE_MAJOR_MAX only after the better-sqlite3 pin supports the runtime.
-NODE_MAJOR_MIN=20
+NODE_MAJOR_MIN=22
 NODE_MAJOR_MAX=25
 
 check_node() {
@@ -194,6 +194,15 @@ if [ "$NODE_OK" = "false" ]; then
     log "Node missing or upgrade consented — running setup/install-node.sh"
     echo "Installing Node via setup/install-node.sh"
     if bash "$PROJECT_ROOT/setup/install-node.sh" 2>&1 | tee -a "$LOG_FILE"; then
+      # install-node.sh exports PATH only inside its own process; re-derive
+      # the new Node's location here so check_node sees it.
+      if [ -x "$HOME/.local/bin/node" ]; then
+        export PATH="$HOME/.local/bin:$PATH"
+      elif [ "$PLATFORM" = "macos" ] && command -v brew >/dev/null 2>&1; then
+        if NODE22_PREFIX="$(brew --prefix node@22 2>/dev/null)"; then
+          export PATH="$NODE22_PREFIX/bin:$PATH"
+        fi
+      fi
       hash -r 2>/dev/null || true
       check_node
     else

--- a/setup.sh
+++ b/setup.sh
@@ -58,7 +58,7 @@ check_node() {
     NODE_PATH_FOUND=$(command -v node)
     local major
     major=$(echo "$NODE_VERSION" | cut -d. -f1)
-    if [ "$major" -ge 22 ] 2>/dev/null; then
+    if [ "$major" -ge 20 ] 2>/dev/null; then
       NODE_OK="true"
     fi
     log "Node $NODE_VERSION at $NODE_PATH_FOUND (major=$major, ok=$NODE_OK)"
@@ -184,20 +184,20 @@ detect_platform
 
 check_node
 if [ "$NODE_OK" = "false" ]; then
-  log "Node missing or too old — running setup/install-node.sh"
-  echo "Node 22+ not found — installing via setup/install-node.sh"
-  if bash "$PROJECT_ROOT/setup/install-node.sh" 2>&1 | tee -a "$LOG_FILE"; then
-    if [ -x "$HOME/.local/bin/node" ]; then
-      export PATH="$HOME/.local/bin:$PATH"
-    elif [ "$PLATFORM" = "macos" ] && command -v brew >/dev/null 2>&1; then
-      if NODE22_PREFIX="$(brew --prefix node@22 2>/dev/null)"; then
-        export PATH="$NODE22_PREFIX/bin:$PATH"
-      fi
+  if [ "$NODE_VERSION" = "not_found" ]; then
+    log "Node missing — running setup/install-node.sh"
+    echo "Node not found — installing via setup/install-node.sh"
+    if bash "$PROJECT_ROOT/setup/install-node.sh" 2>&1 | tee -a "$LOG_FILE"; then
+      hash -r 2>/dev/null || true
+      check_node
+    else
+      log "install-node.sh failed"
     fi
-    hash -r 2>/dev/null || true
-    check_node
   else
-    log "install-node.sh failed"
+    # install-node.sh never replaces an existing Node, so don't run it just
+    # to watch it refuse — tell the user the actual fix instead.
+    log "Node $NODE_VERSION too old (need >= 20) — leaving the existing install alone"
+    echo "Node $NODE_VERSION is too old — NanoClaw needs Node 20 or newer. Upgrade your existing Node, then re-run."
   fi
 fi
 install_deps
@@ -206,7 +206,11 @@ check_build_tools
 # Emit status block
 STATUS="success"
 if [ "$NODE_OK" = "false" ]; then
-  STATUS="node_missing"
+  if [ "$NODE_VERSION" = "not_found" ]; then
+    STATUS="node_missing"
+  else
+    STATUS="node_too_old"
+  fi
 elif [ "$DEPS_OK" = "false" ]; then
   STATUS="deps_failed"
 elif [ "$NATIVE_OK" = "false" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -184,9 +184,9 @@ detect_platform
 
 check_node
 if [ "$NODE_OK" = "false" ]; then
-  if [ "$NODE_VERSION" = "not_found" ]; then
-    log "Node missing — running setup/install-node.sh"
-    echo "Node not found — installing via setup/install-node.sh"
+  if [ "$NODE_VERSION" = "not_found" ] || [ "${NANOCLAW_NODE_UPGRADE_OK:-0}" = "1" ]; then
+    log "Node missing or upgrade consented — running setup/install-node.sh"
+    echo "Installing Node via setup/install-node.sh"
     if bash "$PROJECT_ROOT/setup/install-node.sh" 2>&1 | tee -a "$LOG_FILE"; then
       hash -r 2>/dev/null || true
       check_node
@@ -194,10 +194,10 @@ if [ "$NODE_OK" = "false" ]; then
       log "install-node.sh failed"
     fi
   else
-    # install-node.sh never replaces an existing Node, so don't run it just
-    # to watch it refuse — tell the user the actual fix instead.
+    # install-node.sh refuses to replace an existing Node without consent,
+    # so don't run it just to watch it refuse — name the actual fix.
     log "Node $NODE_VERSION too old (need >= 20) — leaving the existing install alone"
-    echo "Node $NODE_VERSION is too old — NanoClaw needs Node 20 or newer. Upgrade your existing Node, then re-run."
+    echo "Node $NODE_VERSION is too old — NanoClaw needs Node 20 or newer. Upgrade your existing Node (or run bash nanoclaw.sh interactively and accept the offered Node upgrade), then re-run."
   fi
 fi
 install_deps

--- a/setup.sh
+++ b/setup.sh
@@ -48,20 +48,26 @@ detect_platform() {
 
 # --- Node.js check ---
 
+# The ceiling exists because better-sqlite3 11.x cannot build against
+# Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
+# NODE_MAJOR_MAX only after the better-sqlite3 pin supports the runtime.
+NODE_MAJOR_MIN=20
+NODE_MAJOR_MAX=25
+
 check_node() {
   NODE_OK="false"
   NODE_VERSION="not_found"
   NODE_PATH_FOUND=""
+  NODE_MAJOR=""
 
   if command -v node >/dev/null 2>&1; then
     NODE_VERSION=$(node --version 2>/dev/null | sed 's/^v//')
     NODE_PATH_FOUND=$(command -v node)
-    local major
-    major=$(echo "$NODE_VERSION" | cut -d. -f1)
-    if [ "$major" -ge 20 ] 2>/dev/null; then
+    NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+    if [ "$NODE_MAJOR" -ge "$NODE_MAJOR_MIN" ] 2>/dev/null && [ "$NODE_MAJOR" -le "$NODE_MAJOR_MAX" ] 2>/dev/null; then
       NODE_OK="true"
     fi
-    log "Node $NODE_VERSION at $NODE_PATH_FOUND (major=$major, ok=$NODE_OK)"
+    log "Node $NODE_VERSION at $NODE_PATH_FOUND (major=$NODE_MAJOR, ok=$NODE_OK)"
   else
     log "Node not found"
   fi
@@ -196,8 +202,8 @@ if [ "$NODE_OK" = "false" ]; then
   else
     # install-node.sh refuses to replace an existing Node without consent,
     # so don't run it just to watch it refuse — name the actual fix.
-    log "Node $NODE_VERSION too old (need >= 20) — leaving the existing install alone"
-    echo "Node $NODE_VERSION is too old. NanoClaw needs Node 20 or higher. Do one of these: (1) Update your Node. (2) Run bash nanoclaw.sh and accept the Node installation. Then do the setup again."
+    log "Node $NODE_VERSION outside the supported range (need >= $NODE_MAJOR_MIN and <= $NODE_MAJOR_MAX) — leaving the existing install alone"
+    echo "Node $NODE_VERSION is not supported. NanoClaw needs Node $NODE_MAJOR_MIN to $NODE_MAJOR_MAX. Do one of these: (1) Switch to a supported Node. (2) Run bash nanoclaw.sh and accept the Node installation. Then do the setup again."
   fi
 fi
 install_deps
@@ -208,6 +214,8 @@ STATUS="success"
 if [ "$NODE_OK" = "false" ]; then
   if [ "$NODE_VERSION" = "not_found" ]; then
     STATUS="node_missing"
+  elif [ "$NODE_MAJOR" -gt "$NODE_MAJOR_MAX" ] 2>/dev/null; then
+    STATUS="node_too_new"
   else
     STATUS="node_too_old"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -197,7 +197,7 @@ if [ "$NODE_OK" = "false" ]; then
     # install-node.sh refuses to replace an existing Node without consent,
     # so don't run it just to watch it refuse — name the actual fix.
     log "Node $NODE_VERSION too old (need >= 20) — leaving the existing install alone"
-    echo "Node $NODE_VERSION is too old — NanoClaw needs Node 20 or newer. Upgrade your existing Node (or run bash nanoclaw.sh interactively and accept the offered Node upgrade), then re-run."
+    echo "Node $NODE_VERSION is too old. NanoClaw needs Node 20 or higher. Do one of these: (1) Update your Node. (2) Run bash nanoclaw.sh and accept the Node installation. Then do the setup again."
   fi
 fi
 install_deps

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -55,6 +55,14 @@ else
         exit 1
       fi
       brew install node@22
+      # node@22 is keg-only (versioned formula): brew installs it without
+      # linking anything onto PATH. Mirror the uvx branch and expose it
+      # via ~/.local/bin so PATH-prepending callers resolve the new node.
+      BREW_NODE_PREFIX="$(brew --prefix node@22)"
+      mkdir -p ~/.local/bin
+      ln -sf "$BREW_NODE_PREFIX/bin/node" ~/.local/bin/node
+      ln -sf "$BREW_NODE_PREFIX/bin/npm" ~/.local/bin/npm
+      ln -sf "$BREW_NODE_PREFIX/bin/npx" ~/.local/bin/npx
       ;;
     Linux)
       echo "STEP: nodesource-setup"

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -8,28 +8,37 @@
 # it. Pure bash by design — runs before Node exists on the host.
 set -euo pipefail
 
+REQUIRED_NODE_MAJOR=20
+
 echo "=== NANOCLAW SETUP: INSTALL_NODE ==="
 
 if command -v node >/dev/null 2>&1; then
-  NODE_MAJOR="$(node --version | sed 's/^v//' | cut -d. -f1)"
-  if [ "$NODE_MAJOR" -ge 22 ] 2>/dev/null; then
+  NODE_VERSION="$(node --version 2>/dev/null || echo unknown)"
+  major="${NODE_VERSION#v}"
+  major="${major%%.*}"
+  if [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] 2>/dev/null; then
     echo "STATUS: already-installed"
-    echo "NODE_VERSION: $(node --version)"
+    echo "NODE_VERSION: $NODE_VERSION"
     echo "=== END ==="
     exit 0
   fi
-  echo "STEP: upgrade-node"
+  # An existing Node is never replaced in place, whatever its version — the
+  # honest outcome for a too-old Node is a clear failure naming the fix.
+  echo "STATUS: node-too-old"
+  echo "NODE_VERSION: $NODE_VERSION"
+  echo "ERROR: Node $NODE_VERSION is older than the required Node ${REQUIRED_NODE_MAJOR}+. This script never replaces an existing Node install; upgrade (or remove) it and re-run."
+  echo "=== END ==="
+  exit 1
 fi
 
 if command -v uvx >/dev/null 2>&1; then
   echo "STEP: uvx-nodeenv"
-  uvx nodeenv --force -n lts ~/node
+  uvx nodeenv -n lts ~/node
   mkdir -p ~/.local/bin
   ln -sf ~/node/bin/node ~/.local/bin/node
   ln -sf ~/node/bin/npm ~/.local/bin/npm
   ln -sf ~/node/bin/npx ~/.local/bin/npx
   ln -sf ~/node/bin/pnpm ~/.local/bin/pnpm
-  export PATH="$HOME/.local/bin:$PATH"
 else
   case "$(uname -s)" in
     Darwin)
@@ -41,7 +50,6 @@ else
         exit 1
       fi
       brew install node@22
-      export PATH="$(brew --prefix node@22)/bin:$PATH"
       ;;
     Linux)
       echo "STEP: nodesource-setup"

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -8,7 +8,7 @@
 # it. Pure bash by design — runs before Node exists on the host.
 set -euo pipefail
 
-REQUIRED_NODE_MAJOR=20
+REQUIRED_NODE_MAJOR=22
 # The ceiling exists because better-sqlite3 11.x cannot build against
 # Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
 # MAX_NODE_MAJOR only after the better-sqlite3 pin supports the runtime.
@@ -46,12 +46,15 @@ fi
 
 if command -v uvx >/dev/null 2>&1; then
   echo "STEP: uvx-nodeenv"
-  uvx nodeenv -n lts ~/node
+  # --force: ~/node can pre-exist (an earlier attempt, or the old Node the
+  # user consented to replace); nodeenv refuses a non-empty target otherwise.
+  uvx nodeenv --force -n lts ~/node
   mkdir -p ~/.local/bin
   ln -sf ~/node/bin/node ~/.local/bin/node
   ln -sf ~/node/bin/npm ~/.local/bin/npm
   ln -sf ~/node/bin/npx ~/.local/bin/npx
   ln -sf ~/node/bin/pnpm ~/.local/bin/pnpm
+  export PATH="$HOME/.local/bin:$PATH"
 else
   case "$(uname -s)" in
     Darwin)
@@ -71,6 +74,7 @@ else
       ln -sf "$BREW_NODE_PREFIX/bin/node" ~/.local/bin/node
       ln -sf "$BREW_NODE_PREFIX/bin/npm" ~/.local/bin/npm
       ln -sf "$BREW_NODE_PREFIX/bin/npx" ~/.local/bin/npx
+      export PATH="$HOME/.local/bin:$PATH"
       ;;
     Linux)
       echo "STEP: nodesource-setup"

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -22,13 +22,18 @@ if command -v node >/dev/null 2>&1; then
     echo "=== END ==="
     exit 0
   fi
-  # An existing Node is never replaced in place, whatever its version — the
-  # honest outcome for a too-old Node is a clear failure naming the fix.
-  echo "STATUS: node-too-old"
-  echo "NODE_VERSION: $NODE_VERSION"
-  echo "ERROR: Node $NODE_VERSION is older than the required Node ${REQUIRED_NODE_MAJOR}+. This script never replaces an existing Node install; upgrade (or remove) it and re-run."
-  echo "=== END ==="
-  exit 1
+  if [ "${NANOCLAW_NODE_UPGRADE_OK:-0}" != "1" ]; then
+    # An existing Node is never replaced without consent — the honest
+    # non-consented outcome for a too-old Node is a clear failure naming
+    # the fix. nanoclaw.sh gathers that consent interactively.
+    echo "STATUS: node-too-old"
+    echo "NODE_VERSION: $NODE_VERSION"
+    echo "ERROR: Node $NODE_VERSION is older than the required Node ${REQUIRED_NODE_MAJOR}+. This script never replaces an existing Node install without consent; upgrade (or remove) it and re-run, or run bash nanoclaw.sh interactively to accept the offered Node upgrade."
+    echo "=== END ==="
+    exit 1
+  fi
+  echo "STEP: node-upgrade-consented"
+  echo "NODE_OLD_VERSION: $NODE_VERSION"
 fi
 
 if command -v uvx >/dev/null 2>&1; then
@@ -73,6 +78,16 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
+NODE_VERSION="$(node --version 2>/dev/null || echo unknown)"
+major="${NODE_VERSION#v}"
+major="${major%%.*}"
+if ! [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] 2>/dev/null; then
+  echo "STATUS: failed"
+  echo "ERROR: PATH still resolves node to $NODE_VERSION after the install. Put the new Node (e.g. ~/.local/bin) ahead of it on PATH and re-run."
+  echo "=== END ==="
+  exit 1
+fi
+
 echo "STATUS: installed"
-echo "NODE_VERSION: $(node --version)"
+echo "NODE_VERSION: $NODE_VERSION"
 echo "=== END ==="

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -28,7 +28,7 @@ if command -v node >/dev/null 2>&1; then
     # the fix. nanoclaw.sh gathers that consent interactively.
     echo "STATUS: node-too-old"
     echo "NODE_VERSION: $NODE_VERSION"
-    echo "ERROR: Node $NODE_VERSION is older than the required Node ${REQUIRED_NODE_MAJOR}+. This script never replaces an existing Node install without consent; upgrade (or remove) it and re-run, or run bash nanoclaw.sh interactively to accept the offered Node upgrade."
+    echo "ERROR: Node $NODE_VERSION is too old. NanoClaw needs Node ${REQUIRED_NODE_MAJOR} or higher. This script does not replace an installed Node without consent. Do one of these: (1) Update or remove your Node, then run the setup again. (2) Run bash nanoclaw.sh and accept the Node installation."
     echo "=== END ==="
     exit 1
   fi
@@ -91,7 +91,7 @@ major="${NODE_VERSION#v}"
 major="${major%%.*}"
 if ! [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] 2>/dev/null; then
   echo "STATUS: failed"
-  echo "ERROR: PATH still resolves node to $NODE_VERSION after the install. Put the new Node (e.g. ~/.local/bin) ahead of it on PATH and re-run."
+  echo "ERROR: The PATH still finds Node $NODE_VERSION after the installation. Put the new Node first in the PATH (for example ~/.local/bin). Then run the setup again."
   echo "=== END ==="
   exit 1
 fi

--- a/setup/install-node.sh
+++ b/setup/install-node.sh
@@ -9,6 +9,10 @@
 set -euo pipefail
 
 REQUIRED_NODE_MAJOR=20
+# The ceiling exists because better-sqlite3 11.x cannot build against
+# Node 26 (V8 removed APIs it uses) and ships no prebuilt for it. Raise
+# MAX_NODE_MAJOR only after the better-sqlite3 pin supports the runtime.
+MAX_NODE_MAJOR=25
 
 echo "=== NANOCLAW SETUP: INSTALL_NODE ==="
 
@@ -16,7 +20,7 @@ if command -v node >/dev/null 2>&1; then
   NODE_VERSION="$(node --version 2>/dev/null || echo unknown)"
   major="${NODE_VERSION#v}"
   major="${major%%.*}"
-  if [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] 2>/dev/null; then
+  if { [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] && [ "$major" -le "$MAX_NODE_MAJOR" ]; } 2>/dev/null; then
     echo "STATUS: already-installed"
     echo "NODE_VERSION: $NODE_VERSION"
     echo "=== END ==="
@@ -24,11 +28,15 @@ if command -v node >/dev/null 2>&1; then
   fi
   if [ "${NANOCLAW_NODE_UPGRADE_OK:-0}" != "1" ]; then
     # An existing Node is never replaced without consent — the honest
-    # non-consented outcome for a too-old Node is a clear failure naming
-    # the fix. nanoclaw.sh gathers that consent interactively.
-    echo "STATUS: node-too-old"
+    # non-consented outcome for an unsupported Node is a clear failure
+    # naming the fix. nanoclaw.sh gathers that consent interactively.
+    if [ "$major" -gt "$MAX_NODE_MAJOR" ] 2>/dev/null; then
+      echo "STATUS: node-too-new"
+    else
+      echo "STATUS: node-too-old"
+    fi
     echo "NODE_VERSION: $NODE_VERSION"
-    echo "ERROR: Node $NODE_VERSION is too old. NanoClaw needs Node ${REQUIRED_NODE_MAJOR} or higher. This script does not replace an installed Node without consent. Do one of these: (1) Update or remove your Node, then run the setup again. (2) Run bash nanoclaw.sh and accept the Node installation."
+    echo "ERROR: Node $NODE_VERSION is not supported. NanoClaw needs Node ${REQUIRED_NODE_MAJOR} to ${MAX_NODE_MAJOR}. This script does not replace an installed Node without consent. Do one of these: (1) Switch to a supported Node, then run the setup again. (2) Run bash nanoclaw.sh and accept the Node installation."
     echo "=== END ==="
     exit 1
   fi
@@ -89,9 +97,9 @@ fi
 NODE_VERSION="$(node --version 2>/dev/null || echo unknown)"
 major="${NODE_VERSION#v}"
 major="${major%%.*}"
-if ! [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] 2>/dev/null; then
+if ! { [ "$major" -ge "$REQUIRED_NODE_MAJOR" ] && [ "$major" -le "$MAX_NODE_MAJOR" ]; } 2>/dev/null; then
   echo "STATUS: failed"
-  echo "ERROR: The PATH still finds Node $NODE_VERSION after the installation. Put the new Node first in the PATH (for example ~/.local/bin). Then run the setup again."
+  echo "ERROR: The PATH finds Node $NODE_VERSION after the installation, and NanoClaw needs Node ${REQUIRED_NODE_MAJOR} to ${MAX_NODE_MAJOR}. If an old Node still shadows the new one, put the new Node first in the PATH (for example ~/.local/bin). Then run the setup again."
   echo "=== END ==="
   exit 1
 fi


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Closes #3248. Refs #3359.

setup.sh routes "Node missing or too old" into setup/install-node.sh, but the helper short-circuits on any `node` on the PATH with no version check. With an old Node, setup says it is installing Node, the helper no-ops as `already-installed`, and the run dies `STATUS=node_missing`.

Now:

- Interactive runs with an old Node get a consent prompt (same shape as the Homebrew one). Accept: the helper installs a new Node, with nodeenv next to the existing one when uvx is available, the platform installer otherwise. Decline: setup exits with the manual fix.
- Headless runs fail clearly instead: `STATUS=node_too_old` with the required version named. Exit code stays 2.
- The helper's final check is version-aware, so an old Node still shadowing the new one fails loudly.
- brew's node@22 is keg-only, so the mac branch symlinks the keg into `~/.local/bin`; the consent flow's PATH prepend picks it up and the service unit bakes in the resolved path.

Update 2026-08-19: the floor check is now a range check (Node 20 to 25), same three files, same consent flow. Homebrew's default node is 26.x today, which passed the old check and then died deep in bootstrap: better-sqlite3 11.x uses V8 APIs that Node 26 removed, and ships no prebuilt for it. Details and the dependency-side fix live in #3359; the ceiling should move when that bump lands. Ceiling receipts: better-sqlite3 11.10.0 builds from source on Node 24.14.1 and 25.9.0 on an Apple Silicon Mac, and fails on 26.7.0. Headless runs with a too-new Node exit 2 with `STATUS=node_too_new`. One known tripwire: the uvx branch installs nodeenv `lts` (24 today); if a future LTS lands past the ceiling, the helper's final range check fails loudly instead of producing an install that cannot build.

Verified: Linux E2E with apt Node 18.20.8 (accept reached "Basics ready" with nodeenv Node next to the old one; decline exit 1; headless `node_too_old` exit 2), brew branch smoke-tested on an Apple Silicon Mac (keg poured unlinked, symlinks won resolution). Range check verified on an Apple Silicon Mac with real Node 26.7.0 (headless `node_too_new` exit 2; install-node.sh refuses without consent at 18/26, accepts at 20/25). Not exercised live: the wizard writing the service unit, and the no-uvx NodeSource branch (unchanged code).

The missing-Node flow on macOS without uv has the same keg-only landmine on main; that predates this PR and deserves its own issue.

_Assisted by Claude; reviewed and verified by a human before submission._
