### PR TITLE
fix: idle container with no heartbeat file is exempt from the absolute-ceiling kill forever

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@ Thanks to everyone who has contributed to NanoClaw!
 - [lbsnrs](https://github.com/lbsnrs) — Andreas Liebschner
 - [spencer-whitman](https://github.com/spencer-whitman)
 - [lazure-ocean](https://github.com/lazure-ocean) — Cyril Ionov
+- [joel-nanoco](https://github.com/joel-nanoco) — Joel

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -56,7 +56,7 @@ import type { AgentGroup, Session } from './types.js';
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 /** Active containers tracked by session ID. */
-const activeContainers = new Map<string, { process: ChildProcess; containerName: string }>();
+const activeContainers = new Map<string, { process: ChildProcess; containerName: string; startedAtMs: number }>();
 
 /**
  * In-flight wake promises, keyed by session id. Deduplicates concurrent
@@ -74,6 +74,10 @@ export function getActiveContainerCount(): number {
 
 export function isContainerRunning(sessionId: string): boolean {
   return activeContainers.has(sessionId);
+}
+
+export function getContainerStartedAtMs(sessionId: string): number | undefined {
+  return activeContainers.get(sessionId)?.startedAtMs;
 }
 
 /**
@@ -169,7 +173,7 @@ async function spawnContainer(session: Session): Promise<void> {
 
   const container = spawn(CONTAINER_RUNTIME_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
-  activeContainers.set(session.id, { process: container, containerName });
+  activeContainers.set(session.id, { process: container, containerName, startedAtMs: Date.now() });
   markContainerRunning(session.id);
 
   // Log stderr. A container that dies at boot (unknown provider, missing

--- a/src/host-sweep-grace.test.ts
+++ b/src/host-sweep-grace.test.ts
@@ -22,6 +22,7 @@ vi.mock('./config.js', async () => {
 
 // Mock container runner to prevent actual Docker spawning
 vi.mock('./container-runner.js', () => ({
+  getContainerStartedAtMs: vi.fn(() => Date.now()),
   isContainerRunning: vi.fn().mockReturnValue(false),
   wakeContainer: vi.fn().mockResolvedValue(true),
   killContainer: vi.fn(),

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -49,7 +49,7 @@ describe('decideStuckAction', () => {
     expect(res.heartbeatAgeMs).toBeGreaterThan(ABSOLUTE_CEILING_MS);
   });
 
-  it('skips the ceiling check when no heartbeat file exists (fresh container not yet ticked)', () => {
+  it('skips the ceiling check when no heartbeat file exists and no fallback is known', () => {
     // A freshly-spawned container hasn't produced any SDK events yet, so no
     // heartbeat. Prior behavior treated this as infinitely stale and killed
     // every container within seconds of spawn. With no claims either, we
@@ -61,6 +61,38 @@ describe('decideStuckAction', () => {
       claims: [],
     });
     expect(res.action).toBe('ok');
+  });
+
+  it('does not kill a fresh spawn when heartbeat is absent but last_active is recent', () => {
+    // sessionLastActiveMs stands in for the heartbeat file right after spawn
+    // (markContainerRunning sets last_active at the same moment), so a
+    // container that hasn't ticked yet still gets the full grace window.
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: 0,
+      sessionLastActiveMs: BASE - 5_000,
+      containerState: null,
+      claims: [],
+    });
+    expect(res.action).toBe('ok');
+  });
+
+  it('kills on ceiling using session last_active as a fallback when heartbeat never ticked', () => {
+    // Regression: a container spawns, finds nothing that warrants an SDK
+    // event, and sits idle indefinitely with no heartbeat file ever created.
+    // Prior behavior exempted it from the ceiling check forever; last_active
+    // closes that loophole.
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: 0,
+      sessionLastActiveMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
+      containerState: null,
+      claims: [],
+    });
+    expect(res.action).toBe('kill-ceiling');
+    if (res.action !== 'kill-ceiling') return;
+    expect(res.ceilingMs).toBe(ABSOLUTE_CEILING_MS);
+    expect(res.heartbeatAgeMs).toBeGreaterThan(ABSOLUTE_CEILING_MS);
   });
 
   it('kills on claim-stuck when heartbeat is absent AND a claim has aged past tolerance', () => {

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -63,29 +63,25 @@ describe('decideStuckAction', () => {
     expect(res.action).toBe('ok');
   });
 
-  it('does not kill a fresh spawn when heartbeat is absent but last_active is recent', () => {
-    // sessionLastActiveMs stands in for the heartbeat file right after spawn
-    // (markContainerRunning sets last_active at the same moment), so a
-    // container that hasn't ticked yet still gets the full grace window.
+  it('does not kill a fresh spawn when heartbeat is absent', () => {
     const res = decideStuckAction({
       now: BASE,
       heartbeatMtimeMs: 0,
-      sessionLastActiveMs: BASE - 5_000,
+      containerStartedAtMs: BASE - 5_000,
       containerState: null,
       claims: [],
     });
     expect(res.action).toBe('ok');
   });
 
-  it('kills on ceiling using session last_active as a fallback when heartbeat never ticked', () => {
+  it('kills on ceiling using container spawn time when heartbeat never ticked', () => {
     // Regression: a container spawns, finds nothing that warrants an SDK
     // event, and sits idle indefinitely with no heartbeat file ever created.
-    // Prior behavior exempted it from the ceiling check forever; last_active
-    // closes that loophole.
+    // Prior behavior exempted it from the ceiling check forever.
     const res = decideStuckAction({
       now: BASE,
       heartbeatMtimeMs: 0,
-      sessionLastActiveMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
+      containerStartedAtMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
       containerState: null,
       claims: [],
     });
@@ -93,6 +89,17 @@ describe('decideStuckAction', () => {
     if (res.action !== 'kill-ceiling') return;
     expect(res.ceilingMs).toBe(ABSOLUTE_CEILING_MS);
     expect(res.heartbeatAgeMs).toBeGreaterThan(ABSOLUTE_CEILING_MS);
+  });
+
+  it('prefers a heartbeat over the container spawn time', () => {
+    const res = decideStuckAction({
+      now: BASE,
+      heartbeatMtimeMs: BASE - 5_000,
+      containerStartedAtMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
+      containerState: null,
+      claims: [],
+    });
+    expect(res.action).toBe('ok');
   });
 
   it('kills on claim-stuck when heartbeat is absent AND a claim has aged past tolerance', () => {

--- a/src/host-sweep.test.ts
+++ b/src/host-sweep.test.ts
@@ -18,35 +18,37 @@ import {
 import type { Session } from './types.js';
 
 const BASE = Date.parse('2026-04-20T12:00:00.000Z');
+const JUST_WITHIN_CEILING_MS = ABSOLUTE_CEILING_MS - 1;
+const JUST_OVER_CEILING_MS = ABSOLUTE_CEILING_MS + 1;
 
 function claim(id: string, offsetMs: number) {
   return { message_id: id, status_changed: new Date(BASE - offsetMs).toISOString() };
 }
 
 describe('decideStuckAction', () => {
-  it('returns ok when heartbeat is fresh and no claims', () => {
+  it('returns ok when heartbeat is within the absolute ceiling', () => {
     expect(
       decideStuckAction({
         now: BASE,
-        heartbeatMtimeMs: BASE - 5_000,
+        heartbeatMtimeMs: BASE - JUST_WITHIN_CEILING_MS,
         containerState: null,
         claims: [],
       }),
     ).toEqual({ action: 'ok' });
   });
 
-  it('returns kill-ceiling when heartbeat older than 30 min', () => {
-    const heartbeatMtimeMs = BASE - ABSOLUTE_CEILING_MS - 1_000;
+  it('returns kill-ceiling when heartbeat exceeds the absolute ceiling', () => {
     const res = decideStuckAction({
       now: BASE,
-      heartbeatMtimeMs,
+      heartbeatMtimeMs: BASE - JUST_OVER_CEILING_MS,
       containerState: null,
       claims: [],
     });
-    expect(res.action).toBe('kill-ceiling');
-    if (res.action !== 'kill-ceiling') return;
-    expect(res.ceilingMs).toBe(ABSOLUTE_CEILING_MS);
-    expect(res.heartbeatAgeMs).toBeGreaterThan(ABSOLUTE_CEILING_MS);
+    expect(res).toEqual({
+      action: 'kill-ceiling',
+      heartbeatAgeMs: JUST_OVER_CEILING_MS,
+      ceilingMs: ABSOLUTE_CEILING_MS,
+    });
   });
 
   it('skips the ceiling check when no heartbeat file exists and no fallback is known', () => {
@@ -63,11 +65,11 @@ describe('decideStuckAction', () => {
     expect(res.action).toBe('ok');
   });
 
-  it('does not kill a fresh spawn when heartbeat is absent', () => {
+  it('does not kill a spawn within the absolute ceiling when heartbeat is absent', () => {
     const res = decideStuckAction({
       now: BASE,
       heartbeatMtimeMs: 0,
-      containerStartedAtMs: BASE - 5_000,
+      containerStartedAtMs: BASE - JUST_WITHIN_CEILING_MS,
       containerState: null,
       claims: [],
     });
@@ -81,21 +83,22 @@ describe('decideStuckAction', () => {
     const res = decideStuckAction({
       now: BASE,
       heartbeatMtimeMs: 0,
-      containerStartedAtMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
+      containerStartedAtMs: BASE - JUST_OVER_CEILING_MS,
       containerState: null,
       claims: [],
     });
-    expect(res.action).toBe('kill-ceiling');
-    if (res.action !== 'kill-ceiling') return;
-    expect(res.ceilingMs).toBe(ABSOLUTE_CEILING_MS);
-    expect(res.heartbeatAgeMs).toBeGreaterThan(ABSOLUTE_CEILING_MS);
+    expect(res).toEqual({
+      action: 'kill-ceiling',
+      heartbeatAgeMs: JUST_OVER_CEILING_MS,
+      ceilingMs: ABSOLUTE_CEILING_MS,
+    });
   });
 
   it('prefers a heartbeat over the container spawn time', () => {
     const res = decideStuckAction({
       now: BASE,
-      heartbeatMtimeMs: BASE - 5_000,
-      containerStartedAtMs: BASE - ABSOLUTE_CEILING_MS - 1_000,
+      heartbeatMtimeMs: BASE - JUST_WITHIN_CEILING_MS,
+      containerStartedAtMs: BASE - JUST_OVER_CEILING_MS,
       containerState: null,
       claims: [],
     });

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -19,6 +19,11 @@
  *        → kill. Covers the "alive but silent for 30 min" case. Extended
  *        only while Bash is declared as running longer, honouring the
  *        user's own timeout directive. Kill then resets processing rows.
+ *        When no heartbeat file exists yet, falls back to the session's
+ *        `last_active` (set when the container is marked running) so a
+ *        container that goes idle without ever reaching an SDK event —
+ *        and so never writes a heartbeat — still ages out instead of
+ *        living forever (see decideStuckAction's grace-period comment).
  *
  *     2. Message-scoped stuck: for each 'processing' row, tolerance =
  *        max(60s, current_bash_timeout_ms_if_Bash_running). If
@@ -83,22 +88,39 @@ export type StuckDecision =
 export function decideStuckAction(args: {
   now: number;
   heartbeatMtimeMs: number; // 0 when heartbeat file absent
+  // 0/undefined when unknown. Used only as a fallback for the ceiling check
+  // when heartbeatMtimeMs is 0 — see comment below. Callers should pass the
+  // session's `last_active` (set when the container is marked running), NOT
+  // a value that free-runs on every inbound message, or a container that
+  // keeps receiving messages without ever ticking a heartbeat would dodge
+  // the ceiling indefinitely — the same failure mode this fallback exists
+  // to close.
+  sessionLastActiveMs?: number;
   containerState: ContainerState | null;
   claims: Array<{ message_id: string; status_changed: string }>;
 }): StuckDecision {
-  const { now, heartbeatMtimeMs, containerState, claims } = args;
+  const { now, heartbeatMtimeMs, sessionLastActiveMs, containerState, claims } = args;
   const declaredBashMs = bashTimeoutMs(containerState);
 
-  // Ceiling check only applies when we have an actual heartbeat timestamp.
-  // A freshly-spawned container hasn't had any SDK activity yet so no
-  // heartbeat file exists — if we treated that as infinitely stale we'd
-  // kill every container within seconds of spawn. Genuinely-dead containers
-  // that never wrote a heartbeat are caught by the separate "container
-  // process not running" cleanup path, not here. If a fresh container is
-  // hanging at the gate (claimed a message but never did anything) the
-  // claim-stuck check below handles it.
-  if (heartbeatMtimeMs !== 0) {
-    const heartbeatAge = now - heartbeatMtimeMs;
+  // Ceiling check prefers the heartbeat file's mtime. A freshly-spawned
+  // container hasn't had any SDK activity yet so no heartbeat file exists —
+  // if we treated that as infinitely stale we'd kill every container within
+  // seconds of spawn. But "no heartbeat file" isn't only a spawn-grace-period
+  // signal: a container can also finish its one turn (or find nothing to do)
+  // without its poll loop ever reaching an SDK event, in which case a
+  // heartbeat file is never created for the rest of that container's life,
+  // and it sits alive-but-idle forever, immune to this check. Falling back
+  // to the session's last-marked-running timestamp gives fresh spawns the
+  // same grace period as before (age starts at ~0) while still aging out a
+  // container that never ticks. Genuinely-dead containers that never wrote a
+  // heartbeat AND have no session record are caught by the separate
+  // "container process not running" cleanup path, not here. If a fresh
+  // container is hanging at the gate (claimed a message but never did
+  // anything) the claim-stuck check below handles it independently of this
+  // fallback.
+  const effectiveHeartbeatMs = heartbeatMtimeMs !== 0 ? heartbeatMtimeMs : (sessionLastActiveMs ?? 0);
+  if (effectiveHeartbeatMs !== 0) {
+    const heartbeatAge = now - effectiveHeartbeatMs;
     const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredBashMs ?? 0);
     if (heartbeatAge > ceiling) {
       return { action: 'kill-ceiling', heartbeatAgeMs: heartbeatAge, ceilingMs: ceiling };
@@ -276,6 +298,12 @@ function heartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
   }
 }
 
+function lastActiveMs(lastActive: string | null): number | undefined {
+  if (!lastActive) return undefined;
+  const ms = parseSqliteUtc(lastActive);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
 function bashTimeoutMs(state: ContainerState | null): number | null {
   if (!state || state.current_tool !== 'Bash') return null;
   return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : null;
@@ -290,6 +318,7 @@ function enforceRunningContainerSla(
   const decision = decideStuckAction({
     now: Date.now(),
     heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
+    sessionLastActiveMs: lastActiveMs(session.last_active),
     containerState: getContainerState(outDb),
     claims: getProcessingClaims(outDb),
   });

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -19,9 +19,9 @@
  *        → kill. Covers the "alive but silent for 30 min" case. Extended
  *        only while Bash is declared as running longer, honouring the
  *        user's own timeout directive. Kill then resets processing rows.
- *        When no heartbeat file exists yet, falls back to the session's
- *        `last_active` (set when the container is marked running) so a
- *        container that goes idle without ever reaching an SDK event —
+ *        When no heartbeat file exists yet, falls back to the tracked
+ *        container spawn time so a container that goes idle without ever
+ *        reaching an SDK event —
  *        and so never writes a heartbeat — still ages out instead of
  *        living forever (see decideStuckAction's grace-period comment).
  *
@@ -50,7 +50,7 @@ import {
 } from './db/session-db.js';
 import { log } from './log.js';
 import { openInboundDb, openOutboundDb, openOutboundDbRw, inboundDbPath, heartbeatPath } from './session-manager.js';
-import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
+import { getContainerStartedAtMs, isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
 
 /**
@@ -88,18 +88,11 @@ export type StuckDecision =
 export function decideStuckAction(args: {
   now: number;
   heartbeatMtimeMs: number; // 0 when heartbeat file absent
-  // 0/undefined when unknown. Used only as a fallback for the ceiling check
-  // when heartbeatMtimeMs is 0 — see comment below. Callers should pass the
-  // session's `last_active` (set when the container is marked running), NOT
-  // a value that free-runs on every inbound message, or a container that
-  // keeps receiving messages without ever ticking a heartbeat would dodge
-  // the ceiling indefinitely — the same failure mode this fallback exists
-  // to close.
-  sessionLastActiveMs?: number;
+  containerStartedAtMs?: number; // fallback when heartbeat file absent
   containerState: ContainerState | null;
   claims: Array<{ message_id: string; status_changed: string }>;
 }): StuckDecision {
-  const { now, heartbeatMtimeMs, sessionLastActiveMs, containerState, claims } = args;
+  const { now, heartbeatMtimeMs, containerStartedAtMs, containerState, claims } = args;
   const declaredBashMs = bashTimeoutMs(containerState);
 
   // Ceiling check prefers the heartbeat file's mtime. A freshly-spawned
@@ -110,15 +103,15 @@ export function decideStuckAction(args: {
   // without its poll loop ever reaching an SDK event, in which case a
   // heartbeat file is never created for the rest of that container's life,
   // and it sits alive-but-idle forever, immune to this check. Falling back
-  // to the session's last-marked-running timestamp gives fresh spawns the
-  // same grace period as before (age starts at ~0) while still aging out a
+  // to the container's spawn timestamp gives fresh spawns the same grace
+  // period as before (age starts at ~0) while still aging out a
   // container that never ticks. Genuinely-dead containers that never wrote a
   // heartbeat AND have no session record are caught by the separate
   // "container process not running" cleanup path, not here. If a fresh
   // container is hanging at the gate (claimed a message but never did
   // anything) the claim-stuck check below handles it independently of this
   // fallback.
-  const effectiveHeartbeatMs = heartbeatMtimeMs !== 0 ? heartbeatMtimeMs : (sessionLastActiveMs ?? 0);
+  const effectiveHeartbeatMs = heartbeatMtimeMs !== 0 ? heartbeatMtimeMs : (containerStartedAtMs ?? 0);
   if (effectiveHeartbeatMs !== 0) {
     const heartbeatAge = now - effectiveHeartbeatMs;
     const ceiling = Math.max(ABSOLUTE_CEILING_MS, declaredBashMs ?? 0);
@@ -298,12 +291,6 @@ function heartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
   }
 }
 
-function lastActiveMs(lastActive: string | null): number | undefined {
-  if (!lastActive) return undefined;
-  const ms = parseSqliteUtc(lastActive);
-  return Number.isNaN(ms) ? undefined : ms;
-}
-
 function bashTimeoutMs(state: ContainerState | null): number | null {
   if (!state || state.current_tool !== 'Bash') return null;
   return typeof state.tool_declared_timeout_ms === 'number' ? state.tool_declared_timeout_ms : null;
@@ -318,7 +305,7 @@ function enforceRunningContainerSla(
   const decision = decideStuckAction({
     now: Date.now(),
     heartbeatMtimeMs: heartbeatMtimeMs(agentGroupId, session.id),
-    sessionLastActiveMs: lastActiveMs(session.last_active),
+    containerStartedAtMs: getContainerStartedAtMs(session.id),
     containerState: getContainerState(outDb),
     claims: getProcessingClaims(outDb),
   });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

**What:** `decideStuckAction` (host-sweep's idle/stuck-container check) skips the absolute-ceiling kill entirely whenever a running container has no `.heartbeat` file, with no upper bound on that exemption.

**Why:** The no-heartbeat exemption is meant as a brief grace period for a container that just spawned and hasn't had its first SDK event yet. But a container can also finish everything it woke up for without its poll loop ever reaching an SDK event, leaving it alive-but-idle indefinitely and invisible to the ceiling check.

**How it works:** The existing in-memory `activeContainers` record now tracks the container's actual spawn time. When no heartbeat file exists, `decideStuckAction` uses that timestamp as the ceiling fallback. A fresh container keeps the full grace period; a container that never emits a heartbeat ages out after the same ceiling; inbound messages cannot extend that deadline. Once a heartbeat exists, it remains the preferred liveness signal. No schema or persistence change is required because containers from a previous host process are cleaned up as orphans at startup.

**How it was tested:** Added decision tests for a fresh no-heartbeat spawn, a stale no-heartbeat container, and heartbeat precedence, and updated the host-sweep grace integration mock for the new lifecycle datum. The focused lifecycle suite passes (27 tests), the full host suite passes (1,178 tests), `pnpm run build` is clean, formatting passes, and ESLint reports no errors.

---
Verified against current trunk: clean application, focused lifecycle suite 44/44, full host suite 1444/1444, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
