### PR TITLE
fix(opencode): honor the group reasoning effort in the model config

### DIFF
--- a/container/agent-runner/src/providers/opencode.config.test.ts
+++ b/container/agent-runner/src/providers/opencode.config.test.ts
@@ -274,3 +274,37 @@ describe('buildOpenCodeConfig permission', () => {
     }
   });
 });
+
+describe('buildOpenCodeConfig reasoning effort', () => {
+  function effortEnv() {
+    process.env.OPENCODE_PROVIDER = 'opencode-go';
+    process.env.OPENCODE_MODEL = 'opencode-go/deepseek-v4-flash';
+    process.env.ANTHROPIC_BASE_URL = 'https://opencode.ai/zen/go/v1';
+    delete process.env.OPENCODE_SMALL_MODEL;
+  }
+
+  function modelOptions(config: Record<string, unknown>, modelId: string) {
+    const entry = (config.provider as Record<string, Record<string, unknown>>)['opencode-go'];
+    return (entry.models as Record<string, Record<string, unknown>>)[modelId].options;
+  }
+
+  it('emits reasoningEffort on the main model when the group config sets an effort', () => {
+    effortEnv();
+    const config = buildOpenCodeConfig({ effort: 'max' });
+    expect(modelOptions(config, 'deepseek-v4-flash')).toEqual({ reasoningEffort: 'max' });
+  });
+
+  it('omits model options when no effort is set', () => {
+    effortEnv();
+    const config = buildOpenCodeConfig({});
+    expect(modelOptions(config, 'deepseek-v4-flash')).toBeUndefined();
+  });
+
+  it('leaves a distinct small model untouched', () => {
+    effortEnv();
+    process.env.OPENCODE_SMALL_MODEL = 'opencode-go/deepseek-v4-flash-lite';
+    const config = buildOpenCodeConfig({ effort: 'high' });
+    expect(modelOptions(config, 'deepseek-v4-flash')).toEqual({ reasoningEffort: 'high' });
+    expect(modelOptions(config, 'deepseek-v4-flash-lite')).toBeUndefined();
+  });
+});

--- a/container/agent-runner/src/providers/opencode.ts
+++ b/container/agent-runner/src/providers/opencode.ts
@@ -212,6 +212,11 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
   const provider = process.env.OPENCODE_PROVIDER || 'anthropic';
   const model = process.env.OPENCODE_MODEL;
   const smallModel = process.env.OPENCODE_SMALL_MODEL;
+  // Reasoning effort from the group's container config (ncl groups config
+  // update --effort). OpenCode forwards a free-form per-model `options` object
+  // to the ai-sdk provider, which maps reasoningEffort onto reasoning_effort in
+  // the request body.
+  const effort = options.effort;
   const proxyUrl = process.env.ANTHROPIC_BASE_URL;
 
   const providerModelId = model ? model.replace(new RegExp(`^${provider}/`), '') : undefined;
@@ -298,6 +303,7 @@ export function buildOpenCodeConfig(options: ProviderOptions): Record<string, un
                           id: mid,
                           name: mid,
                           tool_call: true,
+                          ...(isMainModel && effort ? { options: { reasoningEffort: effort } } : {}),
                           ...(isMainModel && modelLimit ? { limit: modelLimit } : {}),
                           ...(isMainModel && modelModalities ? { attachment: true, modalities: modelModalities } : {}),
                         },


### PR DESCRIPTION
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What** — the opencode provider now honors the group's `effort` container config field.

**Why** — #2233 added per-group `model` + `effort` overrides, but only the claude and codex providers read `effort`. The opencode provider dropped it silently, so a group set to `effort=max` ran at the model's default with no warning and no log line.

**How** — OpenCode accepts a free-form `options` object per model entry and forwards it to the ai-sdk provider, which maps `reasoningEffort` onto `reasoning_effort` in the request body. `buildOpenCodeConfig` now emits it on the main model only: the small model is a separate model whose effort the group config does not describe.

**Tested** — three new cases in `opencode.config.test.ts` (emitted on the main model, absent when no effort is set, distinct small model left untouched); `bun test src/providers/opencode.config.test.ts` is green, 24/24. Verified live against
`opencode-go/deepseek-v4-flash`: the spawned opencode server config carries `options.reasoningEffort=max`.