### PR TITLE
container: two-phase inbound batch selection — context rows never crowd out or drive a turn

### DIFF
--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -103,6 +103,50 @@ describe('trigger=1 rows never crowded out', () => {
   });
 });
 
+describe('claimed-but-unsynced rows never hide new work', () => {
+  // Claimed rows stay status='pending' in inbound.db until the host sweep
+  // syncs processing_ack back (~60s). The ack filter must run BEFORE the cap
+  // windowing: windowing first lets a cap-sized claimed batch fill the
+  // window, the filter empties it, and newer rows are invisible all turn.
+  it('a new message arriving after a full claimed batch is returned immediately', () => {
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertMessage(`claimed-${i}`, i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
+      claimed.push(`claimed-${i}`);
+    }
+    markProcessing(claimed);
+
+    insertMessage('fresh', (CAP + 1) * 2, 'chat', { sender: 'A', text: 'follow-up' });
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['fresh']);
+  });
+
+  it('an older unclaimed task row survives a cap of newer claimed rows', () => {
+    insertMessage('task-old', 2, 'task', { prompt: 'due work' });
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertMessage(`claimed-${i}`, 100 + i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
+      claimed.push(`claimed-${i}`);
+    }
+    markProcessing(claimed);
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['task-old']);
+  });
+
+  it('claimed context rows do not consume phase-2 slots', () => {
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertContextRow(`claimed-ctx-${i}`, i * 2, `old ambient ${i}`);
+      claimed.push(`claimed-ctx-${i}`);
+    }
+    markProcessing(claimed);
+    insertMessage('chat-new', 100, 'chat', { sender: 'A', text: 'real' });
+    insertContextRow('ctx-new', 102, 'fresh ambient');
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['chat-new', 'ctx-new']);
+  });
+});
+
 describe('existing selection semantics preserved', () => {
   it('skips rows whose process_after is in the future, both phases', () => {
     const future = new Date(Date.now() + 60_000).toISOString();

--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Batch-selection tests for getPendingMessages.
+ *
+ * The two-phase selection (due trigger=1 rows first, oldest-first; remaining
+ * slots filled with the NEWEST trigger=0 rows) exists so accumulated context
+ * (e.g. non-engaged group messages) can never crowd a due wake row (e.g. a
+ * task) out of the batch — without it, the wake fires but the work itself
+ * never reaches the agent.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from './connection.js';
+import { getPendingMessages, markProcessing } from './messages-in.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+// Default cap when config isn't loaded (test harness) — see getMaxMessagesPerPrompt.
+const CAP = 10;
+
+function insertMessage(
+  id: string,
+  seq: number,
+  kind: string,
+  content: object,
+  opts?: { trigger?: 0 | 1; onWake?: 0 | 1; processAfter?: string; channelType?: string },
+) {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, process_after, "trigger", on_wake, channel_type, content)
+       VALUES (?, ?, ?, datetime('now'), 'pending', ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      seq,
+      kind,
+      opts?.processAfter ?? null,
+      opts?.trigger ?? 1,
+      opts?.onWake ?? 0,
+      opts?.channelType ?? null,
+      JSON.stringify(content),
+    );
+}
+
+function insertContextRow(id: string, seq: number, text: string): void {
+  insertMessage(id, seq, 'chat', { text, sender: 'Ambient User', senderId: 'telegram:U1' }, { trigger: 0 });
+}
+
+describe('trigger=1 rows never crowded out', () => {
+  it('a due task row survives 12 newer context rows at cap 10', () => {
+    insertMessage('task-1', 2, 'task', { prompt: 'daily digest' });
+    for (let i = 1; i <= 12; i++) {
+      insertContextRow(`ctx-${i}`, 2 + i * 2, `ambient ${i}`);
+    }
+
+    const batch = getPendingMessages();
+    expect(batch).toHaveLength(CAP);
+    expect(batch.map((m) => m.id)).toContain('task-1');
+    // Oldest-first: the task row (lowest seq) leads the batch.
+    expect(batch[0].id).toBe('task-1');
+    // Remaining slots hold the NEWEST 9 context rows (ctx-1..3 dropped).
+    expect(batch.slice(1).map((m) => m.id)).toEqual(
+      ['ctx-4', 'ctx-5', 'ctx-6', 'ctx-7', 'ctx-8', 'ctx-9', 'ctx-10', 'ctx-11', 'ctx-12'],
+    );
+  });
+
+  it('trigger=1 rows are all included even when they interleave with newer context', () => {
+    insertMessage('chat-old', 2, 'chat', { sender: 'A', text: 'first real' });
+    insertContextRow('ctx-1', 4, 'noise');
+    insertMessage('chat-new', 6, 'chat', { sender: 'A', text: 'second real' });
+    insertContextRow('ctx-2', 8, 'more noise');
+
+    const batch = getPendingMessages();
+    // All four fit — merged in chronological (seq) order.
+    expect(batch.map((m) => m.id)).toEqual(['chat-old', 'ctx-1', 'chat-new', 'ctx-2']);
+  });
+
+  it('takes the oldest trigger=1 rows when wake rows alone exceed the cap', () => {
+    for (let i = 1; i <= 12; i++) {
+      insertMessage(`chat-${i}`, i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
+    }
+
+    const batch = getPendingMessages();
+    expect(batch).toHaveLength(CAP);
+    expect(batch[0].id).toBe('chat-1');
+    expect(batch[batch.length - 1].id).toBe('chat-10');
+  });
+
+  it('context-only backlog still returns the newest rows, oldest-first', () => {
+    for (let i = 1; i <= 12; i++) {
+      insertContextRow(`ctx-${i}`, i * 2, `ambient ${i}`);
+    }
+
+    const batch = getPendingMessages();
+    expect(batch).toHaveLength(CAP);
+    expect(batch[0].id).toBe('ctx-3');
+    expect(batch[batch.length - 1].id).toBe('ctx-12');
+  });
+});
+
+describe('existing selection semantics preserved', () => {
+  it('skips rows whose process_after is in the future, both phases', () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    insertMessage('due-task', 2, 'task', { prompt: 'now' });
+    insertMessage('later-task', 4, 'task', { prompt: 'later' }, { processAfter: future });
+    insertContextRow('ctx-1', 6, 'ambient');
+    getInboundDb()
+      .prepare(`UPDATE messages_in SET process_after = ? WHERE id = 'ctx-1'`)
+      .run(future);
+
+    const batch = getPendingMessages();
+    expect(batch.map((m) => m.id)).toEqual(['due-task']);
+  });
+
+  it('filters rows already acked in processing_ack', () => {
+    insertMessage('m1', 2, 'chat', { sender: 'A', text: 'one' });
+    insertContextRow('ctx-1', 4, 'ambient');
+    markProcessing(['m1', 'ctx-1']);
+
+    expect(getPendingMessages()).toHaveLength(0);
+  });
+
+  it('on_wake=1 rows only surface on the first poll, both phases', () => {
+    insertMessage('wake-1', 2, 'chat', { sender: 'system', text: 'Resuming.' }, { onWake: 1 });
+    insertContextRow('ctx-1', 4, 'ambient');
+    getInboundDb().prepare(`UPDATE messages_in SET on_wake = 1 WHERE id = 'ctx-1'`).run();
+
+    expect(getPendingMessages(true).map((m) => m.id)).toEqual(['wake-1', 'ctx-1']);
+    expect(getPendingMessages(false)).toHaveLength(0);
+  });
+});

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -64,6 +64,13 @@ function getMaxMessagesPerPrompt(): number {
  * itself out of the batch. The combined batch is returned in chronological
  * order (oldest first). Host's countDueMessages gates waking on trigger=1
  * separately (see src/db/session-db.ts).
+ *
+ * ORDER MATTERS: the processing_ack filter runs BEFORE the cap windowing.
+ * Rows this container already claimed stay status='pending' in inbound.db
+ * until the host sweep syncs the ack back (up to ~60s) — windowing first
+ * would let a cap-sized batch of those claimed rows fill the window, the
+ * ack filter would then empty it, and genuinely new rows beyond the window
+ * would be invisible for the rest of the turn.
  */
 export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   const inbound = openInboundDb();
@@ -71,51 +78,35 @@ export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
 
   try {
     const cap = getMaxMessagesPerPrompt();
-    const firstPollArg = isFirstPoll ? 1 : 0;
-    const onWakeFilter = hasOnWakeColumn(inbound) ? 'AND (on_wake = 0 OR ?1 = 1)' : '';
-    const dueFilter = `WHERE status = 'pending'
-           AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
-           ${onWakeFilter}`;
+    const hasOnWake = hasOnWakeColumn(inbound);
+    const stmt = inbound.prepare(
+      `SELECT * FROM messages_in
+       WHERE status = 'pending'
+         AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
+         ${hasOnWake ? 'AND (on_wake = 0 OR ?1 = 1)' : ''}
+       ORDER BY seq ASC`,
+    );
+    const due = (hasOnWake ? stmt.all(isFirstPoll ? 1 : 0) : stmt.all()) as MessageInRow[];
+    if (due.length === 0) return [];
 
-    // Phase 1: due wake-eligible rows, oldest-first — these always make the batch.
-    const wakeRows = inbound
-      .prepare(
-        `SELECT * FROM messages_in
-         ${dueFilter}
-           AND "trigger" = 1
-         ORDER BY seq ASC
-         LIMIT ?2`,
-      )
-      .all(firstPollArg, cap) as MessageInRow[];
-
-    // Phase 2: fill remaining slots with the most recent context-only rows.
-    const remaining = cap - wakeRows.length;
-    const contextRows =
-      remaining > 0
-        ? (inbound
-            .prepare(
-              `SELECT * FROM messages_in
-               ${dueFilter}
-                 AND "trigger" = 0
-               ORDER BY seq DESC
-               LIMIT ?2`,
-            )
-            .all(firstPollArg, remaining) as MessageInRow[])
-        : [];
-
-    // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
-    // keep wake rows ahead of context rows.
-    const pending = [...wakeRows, ...contextRows].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
-    if (pending.length === 0) return [];
-
-    // Filter out messages already acknowledged in outbound.db
+    // Drop rows already acknowledged in outbound.db (claimed by this or a
+    // previous container run) BEFORE windowing — see the doc comment above.
     const ackedIds = new Set(
       (outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>).map(
         (r) => r.message_id,
       ),
     );
+    const unclaimed = due.filter((m) => !ackedIds.has(m.id));
 
-    return pending.filter((m) => !ackedIds.has(m.id));
+    // Phase 1: wake-eligible rows, oldest-first — these always make the batch.
+    const wakeRows = unclaimed.filter((m) => m.trigger === 1).slice(0, cap);
+    // Phase 2: fill remaining slots with the NEWEST context-only rows.
+    const remaining = cap - wakeRows.length;
+    const contextRows = remaining > 0 ? unclaimed.filter((m) => m.trigger === 0).slice(-remaining) : [];
+
+    // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
+    // keep wake rows ahead of context rows.
+    return [...wakeRows, ...contextRows].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
   } finally {
     inbound.close();
   }

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -56,29 +56,56 @@ function getMaxMessagesPerPrompt(): number {
  * Reads from inbound.db (read-only), filters against processing_ack in outbound.db
  * to skip messages already picked up by this or a previous container run.
  *
- * Returns the most recent `maxMessagesPerPrompt` pending rows in
- * chronological order, regardless of their `trigger` flag: accumulated
- * context (trigger=0) rides along with the wake-eligible rows so the agent
- * sees the prior context it missed. Host's countDueMessages gates waking on
- * trigger=1 separately (see src/db/session-db.ts).
+ * Selection is two-phase so accumulated context can never crowd a wake row
+ * out of the batch: all due trigger=1 rows come first (oldest-first, up to
+ * `maxMessagesPerPrompt`), then remaining slots fill with the NEWEST due
+ * trigger=0 rows. Without this, ≥cap accumulated context rows (e.g.
+ * non-engaged group messages) newer than a due task row would push the task
+ * itself out of the batch. The combined batch is returned in chronological
+ * order (oldest first). Host's countDueMessages gates waking on trigger=1
+ * separately (see src/db/session-db.ts).
  */
 export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   const inbound = openInboundDb();
   const outbound = getOutboundDb();
 
   try {
+    const cap = getMaxMessagesPerPrompt();
+    const firstPollArg = isFirstPoll ? 1 : 0;
     const onWakeFilter = hasOnWakeColumn(inbound) ? 'AND (on_wake = 0 OR ?1 = 1)' : '';
-    const pending = inbound
+    const dueFilter = `WHERE status = 'pending'
+           AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
+           ${onWakeFilter}`;
+
+    // Phase 1: due wake-eligible rows, oldest-first — these always make the batch.
+    const wakeRows = inbound
       .prepare(
         `SELECT * FROM messages_in
-         WHERE status = 'pending'
-           AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
-           ${onWakeFilter}
-         ORDER BY seq DESC
+         ${dueFilter}
+           AND "trigger" = 1
+         ORDER BY seq ASC
          LIMIT ?2`,
       )
-      .all(isFirstPoll ? 1 : 0, getMaxMessagesPerPrompt()) as MessageInRow[];
+      .all(firstPollArg, cap) as MessageInRow[];
 
+    // Phase 2: fill remaining slots with the most recent context-only rows.
+    const remaining = cap - wakeRows.length;
+    const contextRows =
+      remaining > 0
+        ? (inbound
+            .prepare(
+              `SELECT * FROM messages_in
+               ${dueFilter}
+                 AND "trigger" = 0
+               ORDER BY seq DESC
+               LIMIT ?2`,
+            )
+            .all(firstPollArg, remaining) as MessageInRow[])
+        : [];
+
+    // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
+    // keep wake rows ahead of context rows.
+    const pending = [...wakeRows, ...contextRows].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
     if (pending.length === 0) return [];
 
     // Filter out messages already acknowledged in outbound.db
@@ -88,9 +115,7 @@ export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
       ),
     );
 
-    // Reverse: we fetched DESC to take the most recent N, but the agent
-    // should see them in chronological order (oldest first).
-    return pending.filter((m) => !ackedIds.has(m.id)).reverse();
+    return pending.filter((m) => !ackedIds.has(m.id));
   } finally {
     inbound.close();
   }

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -457,7 +457,14 @@ export async function processQuery(
         // everything. Filtering on thread_id here caused deadlocks when the
         // initial batch and follow-ups had mismatched thread_ids (e.g. a
         // host-generated welcome trigger with null thread vs a Discord DM reply).
-        const newMessages = pending.filter((m) => m.kind !== 'system');
+        // Accumulated trigger=0 context rows must never be pushed into a live
+        // turn on their own — the agent would answer ambient context that was
+        // not addressed to it. They ride along only when a real trigger=1
+        // follow-up is also pending; otherwise they stay pending for a future
+        // batch (mirrors the two-phase initial-batch selection in
+        // db/messages-in.ts).
+        const hasFollowUpTrigger = pending.some((m) => m.kind !== 'system' && m.trigger === 1);
+        const newMessages = pending.filter((m) => m.kind !== 'system' && (m.trigger === 1 || hasFollowUpTrigger));
         if (newMessages.length === 0) return;
 
         // Accumulated context must not engage a warm query by itself.


### PR DESCRIPTION
getPendingMessages returned the newest N pending rows regardless of the trigger flag, so a backlog of accumulated context (trigger=0) newer than a due task row could push the task itself out of the capped batch — the wake fired but the work never reached the agent. Selection is now two-phase: all due trigger=1 rows first (oldest-first, up to the cap), remaining slots filled with the newest trigger=0 context, merged chronologically. The poll loop's follow-up path gets the matching gate: context-only rows are never pushed into a live turn on their own, only alongside a real trigger=1 follow-up.

**Verification:** `cd container/agent-runner && bun test db/messages-in && bun test` (existing poll-loop tests exercise the follow-up path with trigger=1 rows and stay green); `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit`.

**Update:** selection now reads all due rows in one statement and drops processing_ack-claimed ids BEFORE the cap windowing. Windowing first (the original shape of this PR) let a cap-sized batch of claimed-but-unsynced rows fill the window, the ack filter then emptied it, and a genuinely new message or follow-up stayed invisible until the host sweep synced acks back (~60s). Same two-phase crowd-out guarantee; regression tests cover the claimed-batch, older-unclaimed-task, and claimed-context cases.

---
Part 1/4 of a stacked series: inbound batching → own-destination resolution → detached-state handling → cross-session context. Each builds on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

