### PR TITLE
fix: outbound delivery resolves the sender's own channel row, not an arbitrary sibling instance

### DIFF
--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -62,6 +62,42 @@ export function getMessagingGroupByPlatform(
 }
 
 /**
+ * Instance-exact messaging group for a channel a given agent group is
+ * sending to, resolved through THAT agent's own `agent_destinations` entry
+ * rather than by platform address alone.
+ *
+ * Needed because `getMessagingGroupByPlatform`'s no-instance fallback picks
+ * one row deterministically (default instance, else lexically-first named
+ * instance) when several sibling-instance rows share one `(channel_type,
+ * platform_id)` pair — i.e. multiple adapter instances sharing one channel
+ * address, each owning its own row for the same physical channel. That pick
+ * is arbitrary with respect to who's actually sending: it need not be the
+ * row the sending agent is wired to, which silently breaks both destination
+ * authorization (`src/delivery.ts`) and any per-instance state on the
+ * resolved row (e.g. the `instance` used to pick the delivering adapter).
+ * Every caller resolving a non-origin-chat send should prefer this over the
+ * platform-only lookup, falling back to it only when the sender has no
+ * matching destination (e.g. the agent-to-agent module isn't installed).
+ */
+export function getMessagingGroupForOwnDestination(
+  agentGroupId: string,
+  channelType: string,
+  platformId: string,
+): MessagingGroup | undefined {
+  if (!hasTable(getDb(), 'agent_destinations')) return undefined;
+  return getDb()
+    .prepare(
+      `SELECT mg.* FROM agent_destinations ad
+         JOIN messaging_groups mg ON mg.id = ad.target_id
+        WHERE ad.agent_group_id = ? AND ad.target_type = 'channel'
+          AND mg.channel_type = ? AND mg.platform_id = ?
+     ORDER BY ad.created_at ASC
+        LIMIT 1`,
+    )
+    .get(agentGroupId, channelType, platformId) as MessagingGroup | undefined;
+}
+
+/**
  * Combined lookup for the router's fast-drop path. Returns the messaging
  * group (if it exists) and a count of wired agents in one query — lets
  * `routeInbound` short-circuit messages for unwired / unknown channels

--- a/src/delivery.test.ts
+++ b/src/delivery.test.ts
@@ -38,6 +38,7 @@ import { getDeliveredIds } from './db/session-db.js';
 import { resolveSession, resolveTaskSession, outboundDbPath, openInboundDb } from './session-manager.js';
 import { deliverSessionMessages, registerDeliveryBatchPreview, setDeliveryAdapter } from './delivery.js';
 import { createChannelDeliveryAdapter } from './channels/channel-registry.js';
+import { createDestination } from './modules/agent-to-agent/db/agent-destinations.js';
 
 function now(): string {
   return new Date().toISOString();
@@ -374,6 +375,135 @@ describe('deliverSessionMessages — permission check', () => {
     const delivered = getDeliveredIds(inDb);
     inDb.close();
     expect(delivered.has('out-unauth')).toBe(true);
+  });
+
+  it("authorizes and delivers via the sender's own instance when sibling instances share a platform address", async () => {
+    seedAgentAndChannel();
+
+    // Two sibling messaging groups share one physical channel address but
+    // belong to different adapter instances (e.g. two bot identities in the
+    // same multi-bot room). "alpha" sorts before "zulu" lexically, so a
+    // plain by-platform lookup with no instance hint would pick "alpha" —
+    // the wrong sibling for this sender.
+    createMessagingGroup({
+      id: 'mg-sib-alpha',
+      channel_type: 'discord',
+      platform_id: 'discord:999',
+      instance: 'alpha',
+      name: 'Shared Room',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: 'mg-sib-zulu',
+      channel_type: 'discord',
+      platform_id: 'discord:999',
+      instance: 'zulu',
+      name: 'Shared Room',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+
+    // The sender is only authorized against its own ("zulu") sibling.
+    createDestination({
+      agent_group_id: 'ag-1',
+      local_name: 'room',
+      target_type: 'channel',
+      target_id: 'mg-sib-zulu',
+      created_at: now(),
+    });
+
+    // Session origin is mg-1 (telegram) — not the shared room, so the
+    // origin-session shortcut doesn't apply here.
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const outDb = new Database(outboundDbPath('ag-1', session.id));
+    outDb
+      .prepare(
+        `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES (?, datetime('now'), 'chat', 'discord:999', 'discord', ?)`,
+      )
+      .run('out-shared-room', JSON.stringify({ text: 'hello room' }));
+    outDb.close();
+
+    const calls: Array<{ content: string; instance: string | undefined }> = [];
+    setDeliveryAdapter({
+      async deliver(_ct, _pid, _tid, _kind, content, _files, instance) {
+        calls.push({ content, instance });
+        return 'plat-room';
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    // Delivered exactly once, through the sender's own ("zulu") instance —
+    // not the lexically-first ("alpha") sibling.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.instance).toBe('zulu');
+
+    const inDb = openInboundDb('ag-1', session.id);
+    const delivered = getDeliveredIds(inDb);
+    inDb.close();
+    expect(delivered.has('out-shared-room')).toBe(true);
+  });
+
+  it('still authorizes and delivers an ordinary single-instance non-origin channel destination', async () => {
+    seedAgentAndChannel();
+
+    // A second, single-instance channel the agent is legitimately wired to
+    // (the common case: broadcasting from a DM session to a wired channel —
+    // no sibling instances, no ambiguity, exactly one row for this address).
+    createMessagingGroup({
+      id: 'mg-broadcast',
+      channel_type: 'discord',
+      platform_id: 'discord:789',
+      name: 'Team Channel',
+      is_group: 1,
+      unknown_sender_policy: 'public',
+      created_at: now(),
+    });
+    createDestination({
+      agent_group_id: 'ag-1',
+      local_name: 'team-channel',
+      target_type: 'channel',
+      target_id: 'mg-broadcast',
+      created_at: now(),
+    });
+
+    // Session is on mg-1 (telegram) — not the origin of the broadcast target.
+    const { session } = resolveSession('ag-1', 'mg-1', null, 'shared');
+
+    const outDb = new Database(outboundDbPath('ag-1', session.id));
+    outDb
+      .prepare(
+        `INSERT INTO messages_out (id, timestamp, kind, platform_id, channel_type, content)
+       VALUES (?, datetime('now'), 'chat', 'discord:789', 'discord', ?)`,
+      )
+      .run('out-broadcast', JSON.stringify({ text: 'status update' }));
+    outDb.close();
+
+    const calls: Array<{ content: string; instance: string | undefined }> = [];
+    setDeliveryAdapter({
+      async deliver(_ct, _pid, _tid, _kind, content, _files, instance) {
+        calls.push({ content, instance });
+        return 'plat-broadcast';
+      },
+    });
+
+    await deliverSessionMessages(session);
+
+    // Unaffected by the destination-preferring resolution: single-instance
+    // installs have exactly one row per address, so behavior is unchanged —
+    // delivered once, through the channel's (default) instance.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.instance).toBe('discord');
+
+    const inDb = openInboundDb('ag-1', session.id);
+    const delivered = getDeliveredIds(inDb);
+    inDb.close();
+    expect(delivered.has('out-broadcast')).toBe(true);
   });
 });
 

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -19,7 +19,11 @@ import {
 import { appendRunLog } from './modules/scheduling/run-log.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
-import { getMessagingGroup, getMessagingGroupByPlatform } from './db/messaging-groups.js';
+import {
+  getMessagingGroup,
+  getMessagingGroupByPlatform,
+  getMessagingGroupForOwnDestination,
+} from './db/messaging-groups.js';
 import {
   getDueOutboundMessages,
   getDeliveredIds,
@@ -346,12 +350,16 @@ async function deliverMessage(
     // targets the session's own chat address, the origin row wins even if
     // sibling instances share the same (channel_type, platform_id) — so the
     // reply goes out through the instance the message came in on. Otherwise
-    // fall back to the by-platform lookup (default-instance-first).
+    // prefer the sender's own destination-mapped instance (correct even when
+    // sibling instances share the same channel address), falling back to the
+    // by-platform lookup (default-instance-first) when the sender has no
+    // matching destination.
     const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
     const mg =
       originMg && originMg.channel_type === msg.channel_type && originMg.platform_id === msg.platform_id
         ? originMg
-        : getMessagingGroupByPlatform(msg.channel_type, msg.platform_id);
+        : (getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id) ??
+          getMessagingGroupByPlatform(msg.channel_type, msg.platform_id));
     if (!mg) {
       throw new Error(`unknown messaging group for ${msg.channel_type}/${msg.platform_id} (message ${msg.id})`);
     }


### PR DESCRIPTION
When several adapter-instance rows share one (channel_type, platform_id) address — e.g. multiple bot identities in the same room — deliverMessage resolved the target messaging group by platform address alone, whose documented fallback picks a deterministic but arbitrary row (default instance, else lexically first). The destination-authorization check then compared against the wrong row, rejecting legitimately wired sends ('unauthorized channel destination') and dropping them after retries, or delivering through the wrong instance. Non-origin sends now resolve through the sending agent's own agent_destinations entry first, falling back to the platform lookup only when no matching destination exists. Single-instance installs are unaffected (regression test asserts both lookups agree).

---
Part 2/4 of a stacked series: inbound batching → own-destination resolution → detached-state handling → cross-session context. Each builds on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
