### PR TITLE
db: messaging_groups.detached_at (migration 022) + accessors; delivery refuses sends into detached conversations

### DIFF
--- a/src/db/messaging-groups.ts
+++ b/src/db/messaging-groups.ts
@@ -188,6 +188,26 @@ export function setMessagingGroupDeniedAt(id: string, deniedAt: string | null): 
   getDb().prepare('UPDATE messaging_groups SET denied_at = ? WHERE id = ?').run(deniedAt, id);
 }
 
+/**
+ * Mark a messaging group as detached — our own bot left the platform channel
+ * this row maps to (written by a channel membership module, migration 022).
+ * The wiring, sessions, and destinations all survive detachment;
+ * delivery/typing should skip the row until the bot rejoins. Passing null
+ * clears the flag (rejoin), restoring the room with zero re-setup.
+ */
+export function setMessagingGroupDetachedAt(id: string, detachedAt: string | null): void {
+  getDb().prepare('UPDATE messaging_groups SET detached_at = ? WHERE id = ?').run(detachedAt, id);
+}
+
+/** True when the bot has left this conversation (detached_at set). The check
+ *  delivery-side callers should consult before attempting a send. */
+export function isMessagingGroupDetached(id: string): boolean {
+  const row = getDb().prepare('SELECT detached_at FROM messaging_groups WHERE id = ?').get(id) as
+    | { detached_at: string | null }
+    | undefined;
+  return typeof row?.detached_at === 'string' && row.detached_at.length > 0;
+}
+
 // ── Messaging Group Agents ──
 
 /**

--- a/src/db/migrations/022-messaging-group-detached.ts
+++ b/src/db/migrations/022-messaging-group-detached.ts
@@ -1,0 +1,22 @@
+import type { Migration } from './index.js';
+
+/**
+ * Detached marker on `messaging_groups`.
+ *
+ * Set (ISO timestamp) when our own bot LEFT the channel this row maps to —
+ * the wiring survives, but delivery attempts are pointless until the bot is
+ * re-invited. Cleared (NULL) when the bot rejoins (written by a channel
+ * membership module). Deliberately not a delete: history, wirings, and
+ * destinations all keep their rows so a rejoin restores the room with zero
+ * re-setup.
+ *
+ * No backfill: existing rows stay NULL (= attached), reproducing pre-migration
+ * behavior exactly.
+ */
+export const migration022: Migration = {
+  version: 22,
+  name: 'messaging-group-detached-at',
+  up(db) {
+    db.exec(`ALTER TABLE messaging_groups ADD COLUMN detached_at TEXT;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -20,6 +20,7 @@ import { migration018 } from './018-approvals-approver-user-id.js';
 import { migration019 } from './019-wiring-threads.js';
 import { migration020 } from './020-container-config-timezone.js';
 import { migration021 } from './021-approval-question.js';
+import { migration022 } from './022-messaging-group-detached.js';
 
 export interface Migration {
   version: number;
@@ -64,6 +65,7 @@ export const migrations: Migration[] = [
   migration019,
   migration020,
   migration021,
+  migration022,
 ];
 
 /**

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -363,6 +363,15 @@ async function deliverMessage(
     if (!mg) {
       throw new Error(`unknown messaging group for ${msg.channel_type}/${msg.platform_id} (message ${msg.id})`);
     }
+    if (mg.detached_at) {
+      // The bot was removed from this conversation (a channel membership
+      // module stamps detached_at when the bot leaves). Fail into the retry
+      // path rather than sending into a channel that will reject us; rejoin
+      // clears the stamp.
+      throw new Error(
+        `messaging group ${mg.id} is detached (bot removed from ${mg.channel_type}/${mg.platform_id} at ${mg.detached_at})`,
+      );
+    }
     const isOriginChat = session.messaging_group_id === mg.id;
     // Guarded: without the agent-to-agent module, `agent_destinations`
     // doesn't exist and we permit all non-origin channel sends (the

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,13 @@ export interface MessagingGroup {
    * the column itself defaults to NULL in SQLite.
    */
   denied_at?: string | null;
+  /**
+   * When set, our own bot has LEFT the platform channel this row maps to
+   * (written by a channel membership module, migration 022) — the wiring
+   * survives, but delivery/typing should skip the row until the bot rejoins
+   * (which clears it). Optional on the TS type per the denied_at convention.
+   */
+  detached_at?: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
Adds a detached_at timestamp column to messaging_groups (migration 022, no backfill — NULL reproduces current behavior exactly): set when the bot is removed from the platform conversation a row maps to, cleared on rejoin. Deliberately not a delete — wirings, sessions, and destinations keep their rows so a rejoin restores everything with zero re-setup. Delivery consults it and fails a send into a detached conversation into the normal retry path instead of posting into a channel that will reject the bot. Writers land with the channel-side membership modules; this PR ships the schema, accessors, and the delivery-side read.

---
Part 3/4 of a stacked series: inbound batching → own-destination resolution → detached-state handling → cross-session context. Each builds on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
