### PR TITLE
Cross-session context: fan-out, DM backfill, echo pruning, and `ncl sessions history`

### DIFF
--- a/container/agent-runner/src/cross-session-echo.test.ts
+++ b/container/agent-runner/src/cross-session-echo.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Cross-session echo rows (channel_type='session-echo') — the container side
+ * of the accumulate fan-out contract:
+ *
+ * - render as <cross-session-context> blocks, never as <message> blocks;
+ * - never provide reply routing;
+ * - never flip a task batch's one-door delivery off;
+ * - never count as commands (a copied "/clear" is inert);
+ * - never trigger on their own (accumulate gate regression).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+
+import { initTestSessionDb, closeSessionDb, getInboundDb } from './db/connection.js';
+import { getPendingMessages } from './db/messages-in.js';
+import {
+  formatMessages,
+  extractRouting,
+  categorizeMessage,
+  isClearCommand,
+  isRunnerCommand,
+  isSessionEcho,
+} from './formatter.js';
+import { TIMEZONE, formatLocalStamp } from './timezone.js';
+
+beforeEach(() => {
+  initTestSessionDb();
+});
+
+afterEach(() => {
+  closeSessionDb();
+});
+
+interface EchoOpts {
+  seq?: number;
+  text?: string;
+  sender?: string;
+  label?: string;
+  timestamp?: string;
+}
+
+/** Insert an echo row per the fan-out contract: kind='chat', trigger=0, NULL routing. */
+function insertEcho(id: string, opts?: EchoOpts): void {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, "trigger", channel_type, thread_id, content)
+       VALUES (?, ?, 'chat', ?, 'pending', 0, 'session-echo', NULL, ?)`,
+    )
+    .run(
+      id,
+      opts?.seq ?? null,
+      opts?.timestamp ?? new Date().toISOString(),
+      JSON.stringify({
+        text: opts?.text ?? 'hello from elsewhere',
+        sender: opts?.sender ?? 'Gavriel',
+        senderId: 'slack:U1',
+        echo: { surface: 'room', label: opts?.label ?? '#Pixel room' },
+      }),
+    );
+}
+
+function insertMessage(
+  id: string,
+  kind: string,
+  content: object,
+  opts?: { seq?: number; trigger?: 0 | 1; platformId?: string; channelType?: string; threadId?: string },
+) {
+  getInboundDb()
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, "trigger", platform_id, channel_type, thread_id, content)
+       VALUES (?, ?, ?, datetime('now'), 'pending', ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      opts?.seq ?? null,
+      kind,
+      opts?.trigger ?? 1,
+      opts?.platformId ?? null,
+      opts?.channelType ?? null,
+      opts?.threadId ?? null,
+      JSON.stringify(content),
+    );
+}
+
+describe('formatter rendering', () => {
+  it('renders an echo row exactly per the contract', () => {
+    const ts = '2026-06-15T12:00:00.000Z';
+    insertEcho('e1', { text: "hey what's up", sender: 'Gavriel', label: '#Pixel room', timestamp: ts });
+
+    const result = formatMessages(getPendingMessages());
+    const expectedTime = formatLocalStamp(new Date(ts), TIMEZONE);
+    expect(result).toContain(
+      `<cross-session-context from="#Pixel room" sender="Gavriel" time="${expectedTime}">hey what's up</cross-session-context>`,
+    );
+    // Never rendered as an addressable <message> block.
+    expect(result).not.toContain('<message');
+  });
+
+  it('XML-escapes label, sender, and text', () => {
+    insertEcho('e1', { text: '<b>&"hi"</b>', sender: 'A & B', label: 'DM with <Gavriel>' });
+
+    const result = formatMessages(getPendingMessages());
+    expect(result).toContain('from="DM with &lt;Gavriel&gt;"');
+    expect(result).toContain('sender="A &amp; B"');
+    expect(result).toContain('&lt;b&gt;&amp;&quot;hi&quot;&lt;/b&gt;');
+  });
+
+  it('keeps chronological order when echo rows interleave with real chat', () => {
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'real one' }, { seq: 2 });
+    insertEcho('e1', { seq: 4, text: 'ambient' });
+    insertMessage('m2', 'chat', { sender: 'Alice', text: 'real two' }, { seq: 6 });
+
+    const result = formatMessages(getPendingMessages());
+    const echoIdx = result.indexOf('<cross-session-context');
+    expect(result.indexOf('real one')).toBeLessThan(echoIdx);
+    expect(echoIdx).toBeLessThan(result.indexOf('real two'));
+  });
+});
+
+describe('routing (extractRouting)', () => {
+  it('never takes reply routing from an echo row, even when it sorts first', () => {
+    insertEcho('e1', { seq: 2 });
+    insertMessage(
+      'm1',
+      'chat',
+      { sender: 'Alice', text: 'the real trigger' },
+      { seq: 4, platformId: 'C123', channelType: 'slack', threadId: 'th-1' },
+    );
+
+    const routing = extractRouting(getPendingMessages());
+    expect(routing.platformId).toBe('C123');
+    expect(routing.channelType).toBe('slack');
+    expect(routing.threadId).toBe('th-1');
+    expect(routing.inReplyTo).toBe('m1');
+  });
+
+  it('falls back to the first row when the batch is all echo (defensive)', () => {
+    insertEcho('e1', { seq: 2 });
+    insertEcho('e2', { seq: 4 });
+
+    const routing = extractRouting(getPendingMessages());
+    expect(routing.inReplyTo).toBe('e1');
+    expect(routing.platformId).toBeNull();
+    expect(routing.taskRun).toBe(false);
+  });
+
+  it('taskRun stays true when echo rows ride along with a task', () => {
+    insertMessage('t1', 'task', { prompt: 'daily digest' }, { seq: 2 });
+    insertEcho('e1', { seq: 4 });
+    insertEcho('e2', { seq: 6 });
+
+    const routing = extractRouting(getPendingMessages());
+    expect(routing.taskRun).toBe(true);
+    expect(routing.inReplyTo).toBe('t1');
+  });
+
+  it('taskRun is false when a real chat row is in the batch', () => {
+    insertMessage('t1', 'task', { prompt: 'daily digest' }, { seq: 2 });
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'hi' }, { seq: 4 });
+
+    expect(extractRouting(getPendingMessages()).taskRun).toBe(false);
+  });
+
+  it('taskRun is false without any task row (echo-only batch)', () => {
+    insertEcho('e1', { seq: 2 });
+
+    expect(extractRouting(getPendingMessages()).taskRun).toBe(false);
+  });
+});
+
+describe('command classification', () => {
+  it('categorizeMessage returns none for an echoed slash command', () => {
+    insertEcho('e1', { text: '/clear' });
+
+    const [msg] = getPendingMessages();
+    expect(isSessionEcho(msg)).toBe(true);
+    expect(categorizeMessage(msg).category).toBe('none');
+  });
+
+  it('echoed /clear and /compact are never runner commands', () => {
+    insertEcho('e1', { seq: 2, text: '/clear' });
+    insertEcho('e2', { seq: 4, text: '/compact' });
+
+    const messages = getPendingMessages();
+    expect(messages.some((m) => isClearCommand(m))).toBe(false);
+    expect(messages.some((m) => isRunnerCommand(m))).toBe(false);
+  });
+
+  it('a real /clear in the same batch still classifies normally', () => {
+    insertEcho('e1', { seq: 2, text: '/clear' });
+    insertMessage('m1', 'chat', { sender: 'Alice', text: '/clear' }, { seq: 4 });
+
+    const messages = getPendingMessages();
+    const real = messages.find((m) => m.id === 'm1')!;
+    expect(isClearCommand(real)).toBe(true);
+  });
+});
+
+describe('accumulate gate regression', () => {
+  it('an echo-only batch has no trigger=1 row — the poll-loop gate stays closed', () => {
+    for (let i = 1; i <= 3; i++) insertEcho(`e${i}`, { seq: i * 2 });
+
+    const messages = getPendingMessages();
+    expect(messages).toHaveLength(3);
+    // Exact predicate from runPollLoop's accumulate gate: false → sleep, no wake.
+    expect(messages.some((m) => m.trigger === 1)).toBe(false);
+  });
+
+  it('one real trigger opens the gate and the echo backlog rides along', () => {
+    insertEcho('e1', { seq: 2 });
+    insertEcho('e2', { seq: 4 });
+    insertMessage('m1', 'chat', { sender: 'Alice', text: 'wake up' }, { seq: 6 });
+
+    const messages = getPendingMessages();
+    expect(messages.some((m) => m.trigger === 1)).toBe(true);
+    expect(messages.map((m) => m.id)).toEqual(['e1', 'e2', 'm1']);
+  });
+});

--- a/container/agent-runner/src/db/messages-in.test.ts
+++ b/container/agent-runner/src/db/messages-in.test.ts
@@ -103,6 +103,50 @@ describe('trigger=1 rows never crowded out', () => {
   });
 });
 
+describe('claimed-but-unsynced rows never hide new work', () => {
+  // Claimed rows stay status='pending' in inbound.db until the host sweep
+  // syncs processing_ack back (~60s). The ack filter must run BEFORE the cap
+  // windowing: windowing first lets a cap-sized claimed batch fill the
+  // window, the filter empties it, and newer rows are invisible all turn.
+  it('a new message arriving after a full claimed batch is returned immediately', () => {
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertMessage(`claimed-${i}`, i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
+      claimed.push(`claimed-${i}`);
+    }
+    markProcessing(claimed);
+
+    insertMessage('fresh', (CAP + 1) * 2, 'chat', { sender: 'A', text: 'follow-up' });
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['fresh']);
+  });
+
+  it('an older unclaimed task row survives a cap of newer claimed rows', () => {
+    insertMessage('task-old', 2, 'task', { prompt: 'due work' });
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertMessage(`claimed-${i}`, 100 + i * 2, 'chat', { sender: 'A', text: `msg ${i}` });
+      claimed.push(`claimed-${i}`);
+    }
+    markProcessing(claimed);
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['task-old']);
+  });
+
+  it('claimed context rows do not consume phase-2 slots', () => {
+    const claimed: string[] = [];
+    for (let i = 1; i <= CAP; i++) {
+      insertContextRow(`claimed-ctx-${i}`, i * 2, `old ambient ${i}`);
+      claimed.push(`claimed-ctx-${i}`);
+    }
+    markProcessing(claimed);
+    insertMessage('chat-new', 100, 'chat', { sender: 'A', text: 'real' });
+    insertContextRow('ctx-new', 102, 'fresh ambient');
+
+    expect(getPendingMessages().map((m) => m.id)).toEqual(['chat-new', 'ctx-new']);
+  });
+});
+
 describe('existing selection semantics preserved', () => {
   it('skips rows whose process_after is in the future, both phases', () => {
     const future = new Date(Date.now() + 60_000).toISOString();

--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -64,6 +64,13 @@ function getMaxMessagesPerPrompt(): number {
  * itself out of the batch. The combined batch is returned in chronological
  * order (oldest first). Host's countDueMessages gates waking on trigger=1
  * separately (see src/db/session-db.ts).
+ *
+ * ORDER MATTERS: the processing_ack filter runs BEFORE the cap windowing.
+ * Rows this container already claimed stay status='pending' in inbound.db
+ * until the host sweep syncs the ack back (up to ~60s) — windowing first
+ * would let a cap-sized batch of those claimed rows fill the window, the
+ * ack filter would then empty it, and genuinely new rows beyond the window
+ * would be invisible for the rest of the turn.
  */
 export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
   const inbound = openInboundDb();
@@ -71,51 +78,35 @@ export function getPendingMessages(isFirstPoll = false): MessageInRow[] {
 
   try {
     const cap = getMaxMessagesPerPrompt();
-    const firstPollArg = isFirstPoll ? 1 : 0;
-    const onWakeFilter = hasOnWakeColumn(inbound) ? 'AND (on_wake = 0 OR ?1 = 1)' : '';
-    const dueFilter = `WHERE status = 'pending'
-           AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
-           ${onWakeFilter}`;
+    const hasOnWake = hasOnWakeColumn(inbound);
+    const stmt = inbound.prepare(
+      `SELECT * FROM messages_in
+       WHERE status = 'pending'
+         AND (process_after IS NULL OR datetime(process_after) <= datetime('now'))
+         ${hasOnWake ? 'AND (on_wake = 0 OR ?1 = 1)' : ''}
+       ORDER BY seq ASC`,
+    );
+    const due = (hasOnWake ? stmt.all(isFirstPoll ? 1 : 0) : stmt.all()) as MessageInRow[];
+    if (due.length === 0) return [];
 
-    // Phase 1: due wake-eligible rows, oldest-first — these always make the batch.
-    const wakeRows = inbound
-      .prepare(
-        `SELECT * FROM messages_in
-         ${dueFilter}
-           AND "trigger" = 1
-         ORDER BY seq ASC
-         LIMIT ?2`,
-      )
-      .all(firstPollArg, cap) as MessageInRow[];
-
-    // Phase 2: fill remaining slots with the most recent context-only rows.
-    const remaining = cap - wakeRows.length;
-    const contextRows =
-      remaining > 0
-        ? (inbound
-            .prepare(
-              `SELECT * FROM messages_in
-               ${dueFilter}
-                 AND "trigger" = 0
-               ORDER BY seq DESC
-               LIMIT ?2`,
-            )
-            .all(firstPollArg, remaining) as MessageInRow[])
-        : [];
-
-    // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
-    // keep wake rows ahead of context rows.
-    const pending = [...wakeRows, ...contextRows].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
-    if (pending.length === 0) return [];
-
-    // Filter out messages already acknowledged in outbound.db
+    // Drop rows already acknowledged in outbound.db (claimed by this or a
+    // previous container run) BEFORE windowing — see the doc comment above.
     const ackedIds = new Set(
       (outbound.prepare('SELECT message_id FROM processing_ack').all() as Array<{ message_id: string }>).map(
         (r) => r.message_id,
       ),
     );
+    const unclaimed = due.filter((m) => !ackedIds.has(m.id));
 
-    return pending.filter((m) => !ackedIds.has(m.id));
+    // Phase 1: wake-eligible rows, oldest-first — these always make the batch.
+    const wakeRows = unclaimed.filter((m) => m.trigger === 1).slice(0, cap);
+    // Phase 2: fill remaining slots with the NEWEST context-only rows.
+    const remaining = cap - wakeRows.length;
+    const contextRows = remaining > 0 ? unclaimed.filter((m) => m.trigger === 0).slice(-remaining) : [];
+
+    // Merge oldest-first. JS sort is stable, so ties (null seq in tests)
+    // keep wake rows ahead of context rows.
+    return [...wakeRows, ...contextRows].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
   } finally {
     inbound.close();
   }

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -1,6 +1,18 @@
 import { findByRouting } from './destinations.js';
 import type { MessageInRow } from './db/messages-in.js';
-import { TIMEZONE, formatLocalTime } from './timezone.js';
+import { TIMEZONE, formatLocalTime, formatLocalStamp } from './timezone.js';
+
+/**
+ * channel_type marking cross-session context copies (accumulate fan-out from
+ * the agent group's other sessions). Echo rows are ambient context only: they
+ * never provide reply routing, never count as commands, and render as
+ * <cross-session-context> blocks.
+ */
+export const SESSION_ECHO_CHANNEL = 'session-echo';
+
+export function isSessionEcho(msg: MessageInRow): boolean {
+  return msg.channel_type === SESSION_ECHO_CHANNEL;
+}
 
 /**
  * Command categories for messages starting with '/'.
@@ -37,7 +49,9 @@ export function categorizeMessage(msg: MessageInRow): CommandInfo {
   const text = (content.text || '').trim();
   const senderId = extractSenderId(msg, content);
 
-  if (!text.startsWith('/')) {
+  // Cross-session echo rows are ambient copies of another conversation —
+  // a copied "/clear" etc. must never execute here.
+  if (isSessionEcho(msg) || !text.startsWith('/')) {
     return { category: 'none', command: '', text, senderId };
   }
 
@@ -61,6 +75,7 @@ export function categorizeMessage(msg: MessageInRow): CommandInfo {
  * before messages reach the container.
  */
 export function isClearCommand(msg: MessageInRow): boolean {
+  if (isSessionEcho(msg)) return false;
   const content = parseContent(msg.content);
   const text = (content.text || '').trim();
   return text.toLowerCase().startsWith('/clear');
@@ -106,16 +121,24 @@ export interface RoutingContext {
 
 /**
  * Extract routing context from a batch of messages.
- * Uses the first message's routing fields.
+ * Uses the first non-echo message's routing fields — a cross-session echo
+ * row must never decide where the reply goes (its routing is NULL by
+ * contract, but even a malformed row with routing set is skipped). Falls
+ * back to the plain first row if the batch is somehow all echo (shouldn't
+ * happen — echo rows never trigger).
  */
 export function extractRouting(messages: MessageInRow[]): RoutingContext {
-  const first = messages[0];
+  const first = messages.find((m) => !isSessionEcho(m)) ?? messages[0];
   return {
     platformId: first?.platform_id ?? null,
     channelType: first?.channel_type ?? null,
     threadId: first?.thread_id ?? null,
     inReplyTo: first?.id ?? null,
-    taskRun: messages.length > 0 && messages.every((m) => m.kind === 'task'),
+    // Echo rows riding along with a task must not disable one-door delivery:
+    // taskRun as long as at least one task row and no non-task/non-echo row.
+    taskRun:
+      messages.some((m) => m.kind === 'task') &&
+      messages.every((m) => m.kind === 'task' || isSessionEcho(m)),
   };
 }
 
@@ -172,6 +195,7 @@ function formatChatMessages(messages: MessageInRow[]): string {
 }
 
 function formatSingleChat(msg: MessageInRow): string {
+  if (isSessionEcho(msg)) return formatEchoMessage(msg);
   const content = parseContent(msg.content);
   const sender = content.sender || content.author?.fullName || content.author?.userName || 'Unknown';
   const time = formatLocalTime(msg.timestamp, TIMEZONE);
@@ -186,6 +210,28 @@ function formatSingleChat(msg: MessageInRow): string {
   const fromAttr = originAttr(msg);
 
   return `<message${idAttr}${fromAttr} sender="${escapeXml(sender)}" time="${escapeXml(time)}"${replyAttr}>${replyPrefix}${escapeXml(text)}${linksSuffix}${attachmentsSuffix}${appContextSuffix}</message>`;
+}
+
+/**
+ * Render a cross-session context copy. No id/reply_to attributes — echo rows
+ * are ambient context, not addressable messages. `from` is the human label of
+ * the source conversation (e.g. "#Pixel room", "DM with Gavriel") written by
+ * the host at fan-out time; content.text is already truncated host-side.
+ */
+function formatEchoMessage(msg: MessageInRow): string {
+  const content = parseContent(msg.content);
+  const label = content.echo?.label || 'another conversation';
+  const sender = content.sender || 'Unknown';
+  const time = formatLocalStamp(new Date(msg.timestamp), TIMEZONE);
+  // dm-timeline rows are the DM's own preceding timeline — FIRST-CLASS
+  // conversation history this thread continues from (the agent's own posts
+  // render as sender="you"), unlike cross-session-context ambient echoes
+  // from other live surfaces which must never be acted on in-place.
+  if (content.echo?.surface === 'dm-timeline') {
+    const who = (content as { self?: boolean }).self ? 'you' : sender;
+    return `<dm-history sender="${escapeXml(who)}" time="${escapeXml(time)}">${escapeXml(content.text || '')}</dm-history>`;
+  }
+  return `<cross-session-context from="${escapeXml(label)}" sender="${escapeXml(sender)}" time="${escapeXml(time)}">${escapeXml(content.text || '')}</cross-session-context>`;
 }
 
 /**

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -21,6 +21,7 @@ import {
   categorizeMessage,
   isClearCommand,
   isRunnerCommand,
+  isSessionEcho,
   stripInternalTags,
   type RoutingContext,
 } from './formatter.js';
@@ -181,7 +182,9 @@ export async function runPollLoop(config: PollLoopConfig): Promise<void> {
         commandIds.push(msg.id);
         continue;
       }
-      if ((msg.kind === 'chat' || msg.kind === 'chat-sdk') && isUploadTraceCommand(msg)) {
+      // isSessionEcho guard: a copied "/upload-trace" from another session is
+      // ambient context, never a runner command (isClearCommand self-guards).
+      if ((msg.kind === 'chat' || msg.kind === 'chat-sdk') && !isSessionEcho(msg) && isUploadTraceCommand(msg)) {
         log('Uploading session trace to Hugging Face');
         writeMessageOut({
           id: generateId(),

--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -248,6 +248,16 @@ register({
   handler: async (args) => ({ id: (args as Record<string, unknown>).id, agent_group_id: 'g1' }),
 });
 
+// The real `sessions-history` name — the same pre-handler check covers it.
+register({
+  name: 'sessions-history',
+  description: 'sessions history custom op',
+  resource: 'sessions',
+  access: 'open',
+  parseArgs: (raw) => raw,
+  handler: async (args) => [{ id: (args as Record<string, unknown>).id }],
+});
+
 // Echoes args back — used to assert dash-joined positional id resolution.
 register({
   name: 'groups-get',
@@ -785,6 +795,19 @@ describe('CLI scope enforcement', () => {
     mockGetSession.mockReturnValue(undefined);
 
     const resp = await dispatch({ id: '1', command: 'sessions-get', args: { id: 's-nope' } }, agentCtx());
+
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.error.code).toBe('handler-error');
+      expect(resp.error.message).toContain('session not found');
+    }
+  });
+
+  it('group: sessions-history gets the same "session not found" for a foreign session UUID', async () => {
+    mockGetContainerConfig.mockReturnValue({ cli_scope: 'group' });
+    mockGetSession.mockReturnValue({ id: 's-x', agent_group_id: 'other-group' });
+
+    const resp = await dispatch({ id: '1', command: 'sessions-history', args: { id: 's-x' } }, agentCtx());
 
     expect(resp.ok).toBe(false);
     if (!resp.ok) {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -6,7 +6,7 @@
  * Every command passes the guard before its handler runs — the decision
  * (allow / hold / deny) comes from the command's catalog entry, derived at
  * registration (see cli/guard.ts). Dispatch keeps the mechanics: arg
- * auto-fill, the sessions-get existence oracle, `--help` interception,
+ * auto-fill, the sessions-get/-history existence-oracle guard, `--help` interception,
  * parseArgs, and post-handler row filtering. An approved replay re-enters
  * here carrying the verified approval row as its grant — the guard re-checks
  * the structural checks live, and the `approved: true` boolean no longer
@@ -98,10 +98,15 @@ export async function dispatch(
       }
       req = { ...req, args: { ...req.args, ...fill } };
 
-      // Fail-closed pre-handler check for sessions-get: returns "not found"
-      // regardless of whether the UUID exists in another group, preventing an
-      // existence oracle across group boundaries.
-      if (cmd.resource === 'sessions' && req.command === 'sessions-get' && req.args.id) {
+      // Fail-closed pre-handler check for sessions-get/-history: returns
+      // "not found" regardless of whether the UUID exists in another group,
+      // preventing an existence oracle across group boundaries. (history
+      // also self-scopes in its handler — this is defense-in-depth.)
+      if (
+        cmd.resource === 'sessions' &&
+        (req.command === 'sessions-get' || req.command === 'sessions-history') &&
+        req.args.id
+      ) {
         const s = getSession(req.args.id as string);
         if (!s || s.agent_group_id !== ctx.agentGroupId) {
           return err(req.id, 'handler-error', `session not found: ${req.args.id}`);

--- a/src/cli/resources/sessions.ts
+++ b/src/cli/resources/sessions.ts
@@ -1,4 +1,9 @@
-import { HISTORY_DEFAULT_LIMIT, sessionHistory } from '../../modules/cross-session-context/index.js';
+import {
+  formatHistoryLines,
+  HISTORY_DEFAULT_LIMIT,
+  sessionHistory,
+  type HistoryRow,
+} from '../../modules/cross-session-context/index.js';
 import { registerResource } from '../crud.js';
 
 registerResource({
@@ -50,7 +55,8 @@ registerResource({
       description:
         'Read a session transcript: inbound + outbound messages merged chronologically.\n\n' +
         'Output: pipe-separated lines "timestamp|direction(in/out)|kind|sender|text" (text capped at ' +
-        '200 chars), the newest --limit rows in chronological order. Use after `ncl sessions list` to ' +
+        '200 chars), the newest --limit rows in chronological order; `--json` returns the raw rows ' +
+        'with ISO timestamps and uncapped text. Use after `ncl sessions list` to ' +
         'catch up fully on another conversation of your agent group (you only ever see your own ' +
         "group's sessions).",
       examples: [`# Catch up on another session of your group:\nncl sessions history sess-1751234-abc123 --limit 100`],
@@ -64,8 +70,10 @@ registerResource({
         },
       ],
       // Self-scoped in the handler: custom ops bypass the dispatcher's generic
-      // scope post-filter, so cross-group callers get "session not found".
+      // scope post-filter, so cross-group callers get "session not found"
+      // (the dispatcher's sessions pre-handler check covers this verb too).
       handler: async (args, ctx) => sessionHistory(args, ctx),
+      formatHuman: (data) => formatHistoryLines(data as HistoryRow[]),
     },
   },
 });

--- a/src/cli/resources/sessions.ts
+++ b/src/cli/resources/sessions.ts
@@ -1,3 +1,4 @@
+import { HISTORY_DEFAULT_LIMIT, sessionHistory } from '../../modules/cross-session-context/index.js';
 import { registerResource } from '../crud.js';
 
 registerResource({
@@ -43,4 +44,28 @@ registerResource({
     { name: 'created_at', type: 'string', description: 'Auto-set.', generated: true },
   ],
   operations: { list: 'open', get: 'open' },
+  customOperations: {
+    history: {
+      access: 'open',
+      description:
+        'Read a session transcript: inbound + outbound messages merged chronologically.\n\n' +
+        'Output: pipe-separated lines "timestamp|direction(in/out)|kind|sender|text" (text capped at ' +
+        '200 chars), the newest --limit rows in chronological order. Use after `ncl sessions list` to ' +
+        'catch up fully on another conversation of your agent group (you only ever see your own ' +
+        "group's sessions).",
+      examples: [`# Catch up on another session of your group:\nncl sessions history sess-1751234-abc123 --limit 100`],
+      args: [
+        { name: 'id', type: 'string', description: 'Session id (from `ncl sessions list`).', required: true },
+        {
+          name: 'limit',
+          type: 'number',
+          description: `Max rows returned, newest first (default ${HISTORY_DEFAULT_LIMIT}).`,
+          default: HISTORY_DEFAULT_LIMIT,
+        },
+      ],
+      // Self-scoped in the handler: custom ops bypass the dispatcher's generic
+      // scope post-filter, so cross-group callers get "session not found".
+      handler: async (args, ctx) => sessionHistory(args, ctx),
+    },
+  },
 });

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -33,6 +33,7 @@ import {
 } from './db/session-db.js';
 import { runGuarded, type DeliveryGuardSpec, type GuardedDeliveryHandler } from './delivery-guard.js';
 import { isUnguarded, type Unguarded } from './guard/index.js';
+import { fanOutboundMessage } from './modules/cross-session-context/index.js';
 import { log } from './log.js';
 import { normalizeOptions } from './channels/ask-question.js';
 import { clearOutbox, openInboundDb, openOutboundDb, readOutboxFiles } from './session-manager.js';
@@ -241,6 +242,13 @@ async function drainSession(session: Session): Promise<void> {
         // shouldn't get a gap in their typing indicator for them.
         if (msg.kind !== 'system' && msg.channel_type !== 'agent') {
           pauseTypingRefreshAfterDelivery(session.id);
+          // Cross-session context: fan the agent's own user-facing
+          // message into sibling sessions. task_log rows are series
+          // bookkeeping (one-door delivery), not user-facing — excluded.
+          // Runs after markDelivered so a delivery retry never double-fans.
+          if (msg.kind !== 'task_log') {
+            fanOutboundMessage(msg, session, agentGroup);
+          }
         }
       } catch (err) {
         const attempts = (deliveryAttempts.get(msg.id) ?? 0) + 1;

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -242,10 +242,11 @@ async function drainSession(session: Session): Promise<void> {
         // shouldn't get a gap in their typing indicator for them.
         if (msg.kind !== 'system' && msg.channel_type !== 'agent') {
           pauseTypingRefreshAfterDelivery(session.id);
-          // Cross-session context: fan the agent's own user-facing
-          // message into sibling sessions. task_log rows are series
-          // bookkeeping (one-door delivery), not user-facing — excluded.
-          // Runs after markDelivered so a delivery retry never double-fans.
+          // Cross-session context: fan the agent's own user-facing message
+          // into the sessions of the conversation it was delivered to.
+          // task_log rows are series bookkeeping (one-door delivery), not
+          // user-facing — excluded. Runs after markDelivered so a delivery
+          // retry never double-fans.
           if (msg.kind !== 'task_log') {
             fanOutboundMessage(msg, session, agentGroup);
           }

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -261,6 +261,22 @@ async function sweepSession(session: Session): Promise<void> {
         log.info('Closed spent task session', { sessionId: session.id, threadId: session.thread_id });
       }
     }
+
+    // 7. Cross-session echo backlog pruning. Pending trigger=0 'session-echo'
+    // rows have no other TTL — cap them (newest-N per session, task sessions
+    // get a longer horizon, plus a hard age cutoff) so fan-out can never grow
+    // inbound.db unboundedly.
+    // MODULE-HOOK:cross-session-echo-prune:start
+    try {
+      const { pruneEchoBacklog } = await import('./modules/cross-session-context/index.js');
+      const pruned = pruneEchoBacklog(inDb, { isTaskSession: isTaskThread(session.thread_id) });
+      if (pruned > 0) {
+        log.info('Pruned session-echo backlog', { sessionId: session.id, pruned });
+      }
+    } catch (err) {
+      log.error('Echo backlog prune failed', { sessionId: session.id, err });
+    }
+    // MODULE-HOOK:cross-session-echo-prune:end
   } finally {
     inDb.close();
     outDb?.close();

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -263,13 +263,12 @@ async function sweepSession(session: Session): Promise<void> {
     }
 
     // 7. Cross-session echo backlog pruning. Pending trigger=0 'session-echo'
-    // rows have no other TTL — cap them (newest-N per session, task sessions
-    // get a longer horizon, plus a hard age cutoff) so fan-out can never grow
-    // inbound.db unboundedly.
+    // rows have no other TTL — cap them (newest-N per session, plus a hard
+    // age cutoff) so fan-out can never grow inbound.db unboundedly.
     // MODULE-HOOK:cross-session-echo-prune:start
     try {
       const { pruneEchoBacklog } = await import('./modules/cross-session-context/index.js');
-      const pruned = pruneEchoBacklog(inDb, { isTaskSession: isTaskThread(session.thread_id) });
+      const pruned = pruneEchoBacklog(inDb);
       if (pruned > 0) {
         log.info('Pruned session-echo backlog', { sessionId: session.id, pruned });
       }

--- a/src/modules/cross-session-context/backfill.test.ts
+++ b/src/modules/cross-session-context/backfill.test.ts
@@ -1,0 +1,132 @@
+/**
+ * New-session backfill (the pull half of cross-session context): a just-born
+ * DM session is seeded with the DM's TOP-LEVEL timeline from sibling sessions
+ * — each sibling's root user message + top-level agent posts (welcome-style),
+ * never the interiors of other threads. Live-hit this guards against: the
+ * user replies to the welcome tour offer, the reply roots a new thread, and
+ * the fresh session knows nothing about the offer.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const written: Array<Record<string, unknown>> = [];
+const inboundSql: string[] = [];
+const outboundSql: string[] = [];
+
+let inboundRows: Array<{ timestamp: string; content: string }> = [];
+let outboundRows: Array<{ timestamp: string; content: string }> = [];
+let siblingSessions: Array<{ id: string; status: string; messaging_group_id: string | null }> = [];
+
+vi.mock('fs', () => ({ default: { existsSync: () => true }, existsSync: () => true }));
+vi.mock('../../session-manager.js', () => ({
+  inboundDbPath: (g: string, s: string) => `/tmp/${g}/${s}/inbound.db`,
+  withInboundDb: (_g: string, _s: string, fn: (db: unknown) => unknown) =>
+    fn({
+      prepare: (sql: string) => {
+        inboundSql.push(sql);
+        return { all: () => inboundRows };
+      },
+    }),
+  openOutboundDb: () => ({
+    prepare: (sql: string) => {
+      outboundSql.push(sql);
+      return { all: () => outboundRows };
+    },
+    close: () => {},
+  }),
+  writeSessionMessage: (agentGroupId: string, sessionId: string, msg: Record<string, unknown>) => {
+    written.push({ agentGroupId, sessionId, ...msg });
+  },
+}));
+vi.mock('../../db/sessions.js', () => ({
+  getSessionsByAgentGroup: () => siblingSessions,
+  isTaskThread: (t: string) => t.startsWith('system:tasks'),
+}));
+
+const { backfillNewDmSession, BACKFILL_LIMIT } = await import('./backfill.js');
+
+const AG = { id: 'ag-1', name: 'Pete', folder: 'pete', agent_provider: null, created_at: '' } as never;
+const DM_MG = { id: 'mg-dm', channel_type: 'slack', platform_id: 'slack:D1', is_group: 0 } as never;
+const ROOM_MG = { id: 'mg-room', channel_type: 'slack', platform_id: 'slack:C1', is_group: 1 } as never;
+const NEW_SESSION = {
+  id: 'sess-new',
+  agent_group_id: 'ag-1',
+  messaging_group_id: 'mg-dm',
+  thread_id: 'slack:D1:2.0',
+} as never;
+
+function chat(text: string, sender = 'Gavriel', senderId = 'U1'): string {
+  return JSON.stringify({ text, sender, senderId });
+}
+
+beforeEach(() => {
+  written.length = 0;
+  inboundSql.length = 0;
+  outboundSql.length = 0;
+  inboundRows = [];
+  outboundRows = [];
+  siblingSessions = [{ id: 'sess-old', status: 'active', messaging_group_id: 'mg-dm' }];
+});
+
+describe('backfillNewDmSession', () => {
+  it('seeds the new session with sibling roots + top-level agent posts, ordered by time', () => {
+    outboundRows = [
+      { timestamp: '2026-08-01T19:14:00Z', content: JSON.stringify({ text: 'Hey Gavriel! I am Pete… tour?' }) },
+    ];
+    inboundRows = [{ timestamp: '2026-08-01T19:10:00Z', content: chat('hello there') }];
+
+    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+
+    expect(written).toHaveLength(2);
+    expect(written[0]).toMatchObject({
+      sessionId: 'sess-new',
+      kind: 'chat',
+      channelType: 'session-echo',
+      trigger: 0,
+    });
+    const first = JSON.parse(written[0]!.content as string) as Record<string, unknown>;
+    const second = JSON.parse(written[1]!.content as string) as Record<string, unknown>;
+    expect(first.text).toBe('hello there');
+    expect(second.text).toBe('Hey Gavriel! I am Pete… tour?');
+    expect(second.sender).toBe('Pete');
+    expect((second.echo as Record<string, unknown>).surface).toBe('dm-timeline');
+    expect(second.self).toBe(true);
+    expect(first.self).toBeUndefined();
+  });
+
+  it('queries only conversation roots inbound and top-level outbound (SQL shape)', () => {
+    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    expect(inboundSql[0]).toContain('ORDER BY seq ASC LIMIT 1');
+    expect(inboundSql[0]).toContain('trigger = 1');
+    expect(outboundSql[0]).toContain("thread_id IS NULL OR thread_id = '' OR thread_id LIKE '%:'");
+    expect(outboundSql[0]).toContain("kind NOT IN ('system','task_log')");
+  });
+
+  it('skips rooms, task sessions, and sessions without siblings', () => {
+    backfillNewDmSession(AG, NEW_SESSION, ROOM_MG);
+    backfillNewDmSession(AG, { ...(NEW_SESSION as object), thread_id: 'system:tasks:t-1' } as never, DM_MG);
+    siblingSessions = [];
+    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    expect(written).toHaveLength(0);
+  });
+
+  it('ignores system-sender roots and caps at BACKFILL_LIMIT newest rows', () => {
+    inboundRows = [{ timestamp: '2026-08-01T18:00:00Z', content: chat('Introduce yourself', 'system', 'system') }];
+    outboundRows = Array.from({ length: 20 }, (_, i) => ({
+      timestamp: `2026-08-01T19:${String(10 + i).padStart(2, '0')}:00Z`,
+      content: JSON.stringify({ text: `post ${i}` }),
+    }));
+
+    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+
+    expect(written).toHaveLength(BACKFILL_LIMIT);
+    const texts = written.map((w) => (JSON.parse(w.content as string) as { text: string }).text);
+    expect(texts).not.toContain('Introduce yourself');
+    expect(texts.at(-1)).toBe('post 19');
+  });
+
+  it('only considers siblings of the same messaging group', () => {
+    siblingSessions = [{ id: 'sess-other-dm', status: 'active', messaging_group_id: 'mg-other' }];
+    backfillNewDmSession(AG, NEW_SESSION, DM_MG);
+    expect(written).toHaveLength(0);
+  });
+});

--- a/src/modules/cross-session-context/backfill.ts
+++ b/src/modules/cross-session-context/backfill.ts
@@ -1,0 +1,165 @@
+/**
+ * New-session backfill — the pull half of cross-session context.
+ *
+ * The fan-out layer (fan.ts) pushes echoes only into sessions that EXIST at
+ * delivery time, so a brand-new per-thread DM session is born blind: the user
+ * replies to something the agent just said in another thread (live-hit: the
+ * welcome message tour offer) and the fresh session has no idea. At session
+ * birth we seed the new session with the most recent user-facing exchanges
+ * from sibling sessions of the SAME messaging group — identical audience, so
+ * the same privacy argument as the dm-thread fan applies.
+ *
+ * Bounded: last BACKFILL_LIMIT rows across all siblings, echo truncation as
+ * usual. Rows are trigger=0 session-echo rows written BEFORE the triggering
+ * message (lower seq → the formatter renders them first, as ambient context).
+ */
+import fs from 'fs';
+
+import { getSessionsByAgentGroup, isTaskThread } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { inboundDbPath, openOutboundDb, withInboundDb, writeSessionMessage } from '../../session-manager.js';
+import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
+import { ECHO_CHANNEL_TYPE, ECHO_TIMELINE_SURFACE } from './config.js';
+import { truncateEchoText } from './fan.js';
+
+export const BACKFILL_LIMIT = 12;
+
+interface BackfillRow {
+  timestamp: string;
+  sender: string;
+  senderId: string;
+  text: string;
+  /** Row authored by the agent itself — rendered as "you" in the prelude. */
+  self: boolean;
+}
+
+function parseContent(raw: string): { text?: string; sender?: string; senderId?: string; echo?: unknown } {
+  try {
+    return JSON.parse(raw) as { text?: string; sender?: string; senderId?: string; echo?: unknown };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * TOP-LEVEL timeline rows from one sibling session — what a human sees
+ * scrolling the DM's Messages tab, not the interiors of other threads:
+ *  - the session's ROOT user message (per-thread sessions: the first
+ *    triggering chat row IS the conversation opener), and
+ *  - top-level agent posts (outbound with an empty/absent thread — e.g. the
+ *    welcome message), which start conversations of their own.
+ * Thread replies stay in their threads; deep conversations contribute one
+ * line here, not their whole tail.
+ */
+function collectSiblingTopLevel(agentGroup: AgentGroup, sessionId: string, limit: number): BackfillRow[] {
+  const rows: BackfillRow[] = [];
+  if (fs.existsSync(inboundDbPath(agentGroup.id, sessionId))) {
+    const inbound = withInboundDb(agentGroup.id, sessionId, (db) =>
+      db
+        .prepare(
+          "SELECT timestamp, content FROM messages_in WHERE kind IN ('chat','chat-sdk') " +
+            "AND trigger = 1 AND (channel_type IS NULL OR channel_type NOT IN (?, 'agent')) " +
+            'ORDER BY seq ASC LIMIT 1',
+        )
+        .all(ECHO_CHANNEL_TYPE),
+    ) as Array<{ timestamp: string; content: string }>;
+    for (const r of inbound) {
+      const c = parseContent(r.content);
+      if (!c.text || c.senderId === 'system' || c.sender === 'system') continue;
+      // Host-injected triggers (the welcome hand-off) are attributed to the
+      // OWNER for sender-gating, so filter them by shape too — internal
+      // prompts must never surface as user timeline entries (live-hit: the
+      // raw "System instruction: run /welcome…" leaked into a new thread).
+      if (c.text.startsWith('System instruction:')) continue;
+      rows.push({
+        timestamp: r.timestamp,
+        sender: c.sender ?? 'user',
+        senderId: c.senderId ?? '',
+        text: c.text,
+        self: false,
+      });
+    }
+  }
+  try {
+    const outDb = openOutboundDb(agentGroup.id, sessionId);
+    try {
+      const outbound = outDb
+        .prepare(
+          "SELECT timestamp, content FROM messages_out WHERE kind NOT IN ('system','task_log') " +
+            "AND (channel_type IS NULL OR channel_type != 'agent') " +
+            "AND (thread_id IS NULL OR thread_id = '' OR thread_id LIKE '%:') " +
+            'ORDER BY seq DESC LIMIT ?',
+        )
+        .all(limit) as Array<{ timestamp: string; content: string }>;
+      for (const r of outbound) {
+        const c = parseContent(r.content);
+        if (!c.text) continue;
+        rows.push({
+          timestamp: r.timestamp,
+          sender: agentGroup.name,
+          senderId: agentGroup.id,
+          text: c.text,
+          self: true,
+        });
+      }
+    } finally {
+      outDb.close();
+    }
+  } catch {
+    // outbound.db may not exist yet — inbound-only view.
+  }
+  return rows;
+}
+
+/**
+ * Seed a just-created DM session with recent sibling-thread context. Call
+ * BEFORE the triggering message is written. Non-throwing; no-ops for rooms,
+ * task sessions, and sessions with no siblings.
+ */
+export function backfillNewDmSession(agentGroup: AgentGroup, session: Session, mg: MessagingGroup): void {
+  try {
+    if (mg.is_group !== 0) return;
+    if (session.thread_id !== null && isTaskThread(session.thread_id)) return;
+
+    const siblings = getSessionsByAgentGroup(agentGroup.id).filter(
+      (s) => s.id !== session.id && s.status === 'active' && s.messaging_group_id === mg.id,
+    );
+    if (siblings.length === 0) return;
+
+    const rows: BackfillRow[] = [];
+    for (const sibling of siblings) {
+      rows.push(...collectSiblingTopLevel(agentGroup, sibling.id, BACKFILL_LIMIT));
+    }
+    rows.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+    const newest = rows.slice(-BACKFILL_LIMIT);
+    if (newest.length === 0) return;
+
+    const label = 'this DM, just before this conversation';
+    newest.forEach((row, i) => {
+      // The most recent entry is what a short opener ("sure") is usually
+      // answering — deliver it whole; earlier entries get the normal cap.
+      const isLast = i === newest.length - 1;
+      writeSessionMessage(agentGroup.id, session.id, {
+        id: `${session.id}:backfill:${i}`,
+        kind: 'chat',
+        timestamp: row.timestamp,
+        channelType: ECHO_CHANNEL_TYPE,
+        content: JSON.stringify({
+          text: isLast ? row.text.slice(0, 4000) : truncateEchoText(row.text),
+          sender: row.sender,
+          senderId: row.senderId,
+          ...(row.self ? { self: true } : {}),
+          echo: { surface: ECHO_TIMELINE_SURFACE, label },
+        }),
+        trigger: 0,
+      });
+    });
+    log.debug('Backfilled new DM session with sibling context', {
+      sessionId: session.id,
+      rows: newest.length,
+      siblings: siblings.length,
+    });
+  } catch (err) {
+    log.warn('New-session backfill failed (continuing without context)', { sessionId: session.id, err });
+  }
+}

--- a/src/modules/cross-session-context/config.ts
+++ b/src/modules/cross-session-context/config.ts
@@ -1,0 +1,34 @@
+/**
+ * Cross-session context caps.
+ *
+ * Module-level constants for now — no DB config. Exported so the
+ * router/delivery fan hooks, the host-sweep pruner, and tests share one
+ * source of truth.
+ */
+
+/** channel_type stamped on fanned rows (cross-stream contract — the
+ *  container formatter renders these as <cross-session-context> blocks). */
+export const ECHO_CHANNEL_TYPE = 'session-echo';
+
+/** echo.surface value stamped on same-messaging-group sibling echoes — a DM's
+ *  parallel conversation-threads seeing each other (audience-subset rule: same
+ *  DM = same audience). Wire contract fields stay {surface,label}; this is
+ *  just a new surface value. */
+export const ECHO_SIBLING_SURFACE = 'dm-thread';
+
+/** Per-message text cap on echo rows: head-truncated, '…' appended when cut. */
+export const ECHO_TEXT_MAX_CHARS = 500;
+
+/** Pending echo rows the sweep pruner keeps per non-task session (newest first). */
+export const ECHO_BACKLOG_CAP = 50;
+
+/** Pending echo rows kept per task session — task series wake with "what
+ *  happened since last run", so they get a longer horizon. */
+export const ECHO_BACKLOG_CAP_TASK = 100;
+
+/** Pending echo rows older than this are dropped regardless of the count caps. */
+export const ECHO_MAX_AGE_DAYS = 7;
+
+/** Backfill prelude surface: THIS DM's preceding timeline (first-class
+ *  conversation history), distinct from live cross-thread fan echoes. */
+export const ECHO_TIMELINE_SURFACE = 'dm-timeline';

--- a/src/modules/cross-session-context/config.ts
+++ b/src/modules/cross-session-context/config.ts
@@ -16,15 +16,19 @@ export const ECHO_CHANNEL_TYPE = 'session-echo';
  *  just a new surface value. */
 export const ECHO_SIBLING_SURFACE = 'dm-thread';
 
+/** echo.surface value stamped on task-session-source echoes — a scheduled
+ *  task's delivered user-facing send, fanned ONLY into sessions of the
+ *  messaging group it was delivered to (audience-subset rule: that surface
+ *  already displayed the message, so the fan widens nothing). */
+export const ECHO_TASK_SURFACE = 'task-delivery';
+
 /** Per-message text cap on echo rows: head-truncated, '…' appended when cut. */
 export const ECHO_TEXT_MAX_CHARS = 500;
 
-/** Pending echo rows the sweep pruner keeps per non-task session (newest first). */
+/** Pending echo rows the sweep pruner keeps per session (newest first).
+ *  One cap for all sessions: under the same-conversation audience rule,
+ *  task sessions receive no echoes. */
 export const ECHO_BACKLOG_CAP = 50;
-
-/** Pending echo rows kept per task session — task series wake with "what
- *  happened since last run", so they get a longer horizon. */
-export const ECHO_BACKLOG_CAP_TASK = 100;
 
 /** Pending echo rows older than this are dropped regardless of the count caps. */
 export const ECHO_MAX_AGE_DAYS = 7;

--- a/src/modules/cross-session-context/fan.test.ts
+++ b/src/modules/cross-session-context/fan.test.ts
@@ -2,7 +2,7 @@
  * Cross-session context fan-out tests.
  *
  * Drives the real fan entries against real session folders on disk plus an
- * in-memory central DB, and the pure v1 audience rule directly.
+ * in-memory central DB, and the pure audience rule directly.
  */
 import fs from 'fs';
 import Database from 'better-sqlite3';
@@ -20,6 +20,7 @@ import { createDestination } from '../agent-to-agent/db/agent-destinations.js';
 import { inboundDbPath } from '../../session-manager.js';
 import type { MessagingGroup, Session } from '../../types.js';
 import {
+  buildDeliveredEchoLabel,
   buildEchoLabel,
   buildSiblingEchoLabel,
   fanInboundMessage,
@@ -27,7 +28,7 @@ import {
   selectEchoTargets,
   truncateEchoText,
 } from './fan.js';
-import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
+import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TASK_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
 
 const TEST_DIR = '/tmp/nanoclaw-test-cross-session-fan';
 const AG = 'ag-1';
@@ -119,83 +120,36 @@ afterEach(() => {
   if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
 });
 
-describe('selectEchoTargets (audience rule)', () => {
+describe('selectEchoTargets (same-conversation audience rule)', () => {
   const candidates = [
-    { id: 's-src', status: 'active', messaging_group_id: 'mg-room', thread_id: null },
-    { id: 's-room-t2', status: 'active', messaging_group_id: 'mg-room', thread_id: 't2' },
-    { id: 's-dm', status: 'active', messaging_group_id: 'mg-dm', thread_id: null },
-    { id: 's-dm-t2', status: 'active', messaging_group_id: 'mg-dm', thread_id: 't2' },
-    { id: 's-dm2', status: 'active', messaging_group_id: 'mg-dm2', thread_id: null },
-    { id: 's-room2', status: 'active', messaging_group_id: 'mg-room2', thread_id: null },
-    { id: 's-task', status: 'active', messaging_group_id: null, thread_id: 'system:tasks:daily-1' },
-    { id: 's-task-legacy', status: 'active', messaging_group_id: null, thread_id: 'system:tasks' },
-    { id: 's-a2a', status: 'active', messaging_group_id: null, thread_id: null },
-    { id: 's-closed', status: 'closed', messaging_group_id: 'mg-dm', thread_id: 'x' },
+    { id: 's-src', status: 'active', messaging_group_id: 'mg-room' },
+    { id: 's-room-t2', status: 'active', messaging_group_id: 'mg-room' },
+    { id: 's-dm', status: 'active', messaging_group_id: 'mg-dm' },
+    { id: 's-dm-t2', status: 'active', messaging_group_id: 'mg-dm' },
+    { id: 's-dm2', status: 'active', messaging_group_id: 'mg-dm2' },
+    { id: 's-room2', status: 'active', messaging_group_id: 'mg-room2' },
+    { id: 's-task', status: 'active', messaging_group_id: null },
+    { id: 's-a2a', status: 'active', messaging_group_id: null },
+    { id: 's-closed', status: 'closed', messaging_group_id: 'mg-dm' },
   ];
-  const isDm = (mgId: string) => mgId.startsWith('mg-dm');
 
-  it('room source → DM sessions + task sessions; never room→room (even same-mg), never closed/a2a/source', () => {
-    const ids = selectEchoTargets(candidates, 's-src', 'room', 'mg-room', isDm).map((s) => s.id);
-    expect(ids.sort()).toEqual(['s-dm', 's-dm-t2', 's-dm2', 's-task', 's-task-legacy']);
+  it('targets ONLY active same-mg siblings: never other conversations, task/a2a sessions, closed, or the source', () => {
+    const ids = selectEchoTargets(candidates, 's-dm', 'mg-dm').map((s) => s.id);
+    expect(ids.sort()).toEqual(['s-dm-t2']);
   });
 
-  it('DM source → task sessions + same-mg sibling threads; never rooms, never other DMs, never closed', () => {
-    const ids = selectEchoTargets(candidates, 's-dm', 'dm', 'mg-dm', isDm).map((s) => s.id);
-    expect(ids.sort()).toEqual(['s-dm-t2', 's-task', 's-task-legacy']);
+  it('room thread siblings are same-mg and therefore targets', () => {
+    const ids = selectEchoTargets(candidates, 's-src', 'mg-room').map((s) => s.id);
+    expect(ids.sort()).toEqual(['s-room-t2']);
   });
 
-  it('DM source with unknown source mg → task sessions only (defensive)', () => {
-    const ids = selectEchoTargets(candidates, 's-dm', 'dm', null, isDm).map((s) => s.id);
-    expect(ids.sort()).toEqual(['s-task', 's-task-legacy']);
+  it('an unresolved source conversation fans nowhere', () => {
+    expect(selectEchoTargets(candidates, 's-dm', null)).toEqual([]);
   });
 });
 
 describe('fanInboundMessage', () => {
-  it('fans a room trigger into DM + task sessions with the contract row shape', () => {
-    const written = fanInboundMessage({
-      session: SRC_ROOM,
-      mg: ROOM_MG,
-      messageId: 'msg-1:ag-1',
-      kind: 'chat',
-      channelType: 'slack',
-      content: chatContent('hello from the room'),
-      timestamp: NOW,
-    });
-    expect(written).toBe(4);
-
-    const dmRows = readEchoRows('s-dm');
-    expect(dmRows).toHaveLength(1);
-    const row = dmRows[0];
-    expect(row.id).toBe('msg-1:ag-1:echo:s-dm');
-    expect(row.kind).toBe('chat');
-    expect(row.trigger).toBe(0);
-    expect(row.thread_id).toBeNull();
-    expect(row.platform_id).toBe('C123');
-    expect(row.source_session_id).toBe('s-room');
-    const content = JSON.parse(row.content as string);
-    expect(content.text).toBe('hello from the room');
-    expect(content.sender).toBe('Gavriel');
-    expect(content.senderId).toBe('slack:U1');
-    expect(content.echo).toEqual({ surface: 'room', label: '#pixel-room room' });
-
-    expect(readEchoRows('s-task')).toHaveLength(1);
-    // All DM sessions get the room-surface echo (never the sibling flavor —
-    // the source mg is the room, not their DM).
-    for (const sid of ['s-dm-t2', 's-dm2']) {
-      const rows = readEchoRows(sid);
-      expect(rows).toHaveLength(1);
-      expect(JSON.parse(rows[0].content as string).echo).toEqual({ surface: 'room', label: '#pixel-room room' });
-    }
-    // Room→room is not v1; a2a/closed/other-group sessions never targeted.
-    expect(readEchoRows('s-room2')).toHaveLength(0);
-    expect(readEchoRows('s-a2a')).toHaveLength(0);
-    expect(readEchoRows('s-dm-closed')).toHaveLength(0);
-    expect(fs.existsSync(inboundDbPath('ag-2', 's-other-group'))).toBe(false);
-    // Source session itself never receives its own echo.
-    expect(readEchoRows('s-room')).toHaveLength(0);
-  });
-
-  it('fans a DM trigger into task sessions + same-mg sibling threads, never rooms or other DMs', () => {
+  it('fans a DM trigger into same-mg sibling threads ONLY — never rooms, other DMs, or task sessions', () => {
     const written = fanInboundMessage({
       session: SRC_DM,
       mg: DM_MG,
@@ -205,30 +159,63 @@ describe('fanInboundMessage', () => {
       content: chatContent('private note'),
       timestamp: NOW,
     });
-    expect(written).toBe(2);
-    expect(readEchoRows('s-task')).toHaveLength(1);
-    expect(readEchoRows('s-room')).toHaveLength(0);
-    expect(readEchoRows('s-room2')).toHaveLength(0);
-    // Other DMs' sessions stay blind — same-mg siblings only.
-    expect(readEchoRows('s-dm2')).toHaveLength(0);
-    const content = JSON.parse(readEchoRows('s-task')[0].content as string);
-    expect(content.echo).toEqual({ surface: 'dm', label: 'DM with Gavriel' });
+    expect(written).toBe(1);
 
-    // Sibling thread of the SAME DM gets the sibling-flavored echo (contract
-    // fields identical — surface/label values differ).
+    // Sibling thread of the SAME DM gets the sibling-flavored echo with the
+    // contract row shape.
     const sibRows = readEchoRows('s-dm-t2');
     expect(sibRows).toHaveLength(1);
     expect(sibRows[0].id).toBe('msg-2:ag-1:echo:s-dm-t2');
+    expect(sibRows[0].kind).toBe('chat');
     expect(sibRows[0].trigger).toBe(0);
     expect(sibRows[0].thread_id).toBeNull();
+    expect(sibRows[0].platform_id).toBe('D456');
     expect(sibRows[0].source_session_id).toBe('s-dm');
     const sibContent = JSON.parse(sibRows[0].content as string);
     expect(sibContent.text).toBe('private note');
     expect(sibContent.sender).toBe('Gavriel');
+    expect(sibContent.senderId).toBe('slack:U1');
     expect(sibContent.echo).toEqual({
       surface: ECHO_SIBLING_SURFACE,
       label: 'another conversation with Gavriel',
     });
+
+    // Nothing else in the group hears it: not task sessions, not rooms, not
+    // other DMs, not a2a/closed/other-group sessions.
+    expect(readEchoRows('s-task')).toHaveLength(0);
+    expect(readEchoRows('s-room')).toHaveLength(0);
+    expect(readEchoRows('s-room2')).toHaveLength(0);
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
+    expect(readEchoRows('s-a2a')).toHaveLength(0);
+    expect(readEchoRows('s-dm-closed')).toHaveLength(0);
+    expect(fs.existsSync(inboundDbPath('ag-2', 's-other-group'))).toBe(false);
+    // Source session itself never receives its own echo.
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+  });
+
+  it('a room trigger reaches same-mg room thread siblings only — room→DM and room→task are retired', () => {
+    createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
+    const written = fanInboundMessage({
+      session: SRC_ROOM,
+      mg: ROOM_MG,
+      messageId: 'msg-1:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent('hello from the room'),
+      timestamp: NOW,
+    });
+    expect(written).toBe(1);
+    const rows = readEchoRows('s-room-t2');
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0].content as string).echo).toEqual({
+      surface: ECHO_SIBLING_SURFACE,
+      label: 'another conversation in #pixel-room room',
+    });
+    // The retired v1 targets stay silent.
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+    expect(readEchoRows('s-dm-t2')).toHaveLength(0);
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
+    expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
   it('a DM sibling-thread source fans back to the original DM session (symmetric)', () => {
@@ -241,7 +228,7 @@ describe('fanInboundMessage', () => {
       content: chatContent('from the other thread'),
       timestamp: NOW,
     });
-    expect(written).toBe(2);
+    expect(written).toBe(1);
     const rows = readEchoRows('s-dm');
     expect(rows).toHaveLength(1);
     expect(rows[0].source_session_id).toBe('s-dm-t2');
@@ -253,15 +240,15 @@ describe('fanInboundMessage', () => {
   it('truncates text to 500 chars head with … appended', () => {
     const long = 'x'.repeat(ECHO_TEXT_MAX_CHARS + 100);
     fanInboundMessage({
-      session: SRC_ROOM,
-      mg: ROOM_MG,
+      session: SRC_DM,
+      mg: DM_MG,
       messageId: 'msg-3:ag-1',
       kind: 'chat',
       channelType: 'slack',
       content: chatContent(long),
       timestamp: NOW,
     });
-    const content = JSON.parse(readEchoRows('s-dm')[0].content as string);
+    const content = JSON.parse(readEchoRows('s-dm-t2')[0].content as string);
     expect(content.text).toBe('x'.repeat(ECHO_TEXT_MAX_CHARS) + '…');
     expect(content.text.length).toBe(ECHO_TEXT_MAX_CHARS + 1);
   });
@@ -303,28 +290,7 @@ describe('fanInboundMessage', () => {
 describe('fanOutboundMessage', () => {
   const agentGroup = { id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW };
 
-  it('fans a delivered room message into DM + task sessions with the agent as sender', () => {
-    const written = fanOutboundMessage(
-      {
-        id: 'out-1',
-        kind: 'chat',
-        platform_id: 'C123',
-        channel_type: 'slack',
-        content: JSON.stringify({ text: 'agent answer' }),
-      },
-      SRC_ROOM,
-      agentGroup,
-    );
-    expect(written).toBe(4);
-    const content = JSON.parse(readEchoRows('s-dm')[0].content as string);
-    expect(content.sender).toBe('Pixel');
-    expect(content.senderId).toBe(AG);
-    expect(content.echo.surface).toBe('room');
-    expect(readEchoRows('s-dm')[0].id).toBe('out-1:echo:s-dm');
-    expect(readEchoRows('s-task')).toHaveLength(1);
-  });
-
-  it('fans a delivered DM message into task sessions + same-mg sibling threads', () => {
+  it('fans a delivered DM reply into same-mg sibling threads ONLY, with the agent as sender', () => {
     const written = fanOutboundMessage(
       {
         id: 'out-2',
@@ -336,18 +302,41 @@ describe('fanOutboundMessage', () => {
       SRC_DM,
       agentGroup,
     );
-    expect(written).toBe(2);
-    expect(readEchoRows('s-task')).toHaveLength(1);
+    expect(written).toBe(1);
+    // Retired v1 targets stay silent.
+    expect(readEchoRows('s-task')).toHaveLength(0);
     expect(readEchoRows('s-room')).toHaveLength(0);
     expect(readEchoRows('s-dm2')).toHaveLength(0);
     const sibRows = readEchoRows('s-dm-t2');
     expect(sibRows).toHaveLength(1);
+    expect(sibRows[0].id).toBe('out-2:echo:s-dm-t2');
     const sibContent = JSON.parse(sibRows[0].content as string);
     expect(sibContent.sender).toBe('Pixel');
+    expect(sibContent.senderId).toBe(AG);
     expect(sibContent.echo).toEqual({
       surface: ECHO_SIBLING_SURFACE,
       label: 'another conversation with Gavriel',
     });
+  });
+
+  it('a delivered room reply reaches same-mg room siblings only — never the group DMs or task sessions', () => {
+    createSession(session('s-room-t2', AG, 'mg-room', 'room-thread-2'));
+    const written = fanOutboundMessage(
+      {
+        id: 'out-1',
+        kind: 'chat',
+        platform_id: 'C123',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'agent answer' }),
+      },
+      SRC_ROOM,
+      agentGroup,
+    );
+    expect(written).toBe(1);
+    expect(readEchoRows('s-room-t2')).toHaveLength(1);
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+    expect(readEchoRows('s-dm-t2')).toHaveLength(0);
+    expect(readEchoRows('s-task')).toHaveLength(0);
   });
 
   it("resolves the sender's own instance, not a lexically-first sibling, when instances share a platform address", () => {
@@ -390,16 +379,21 @@ describe('fanOutboundMessage', () => {
       agentGroup,
     );
 
-    // Fans as a DM (correct surface) into task sessions plus exactly the
-    // sender's own sibling — never the "alpha" sibling it isn't wired to.
+    // Fans into exactly the sender's own sibling — never the "alpha" sibling
+    // it isn't wired to, and never task sessions. This is a cross-
+    // conversation send (source is the room session), so the echo carries
+    // the delivered flavor, not the sibling-thread one.
     expect(readEchoRows('s-sib-zulu')).toHaveLength(1);
     expect(readEchoRows('s-sib-alpha')).toHaveLength(0);
-    expect(JSON.parse(readEchoRows('s-sib-zulu')[0].content as string).echo.surface).toBe(ECHO_SIBLING_SURFACE);
-    expect(readEchoRows('s-task')).toHaveLength(1);
-    expect(written).toBe(2);
+    expect(JSON.parse(readEchoRows('s-sib-zulu')[0].content as string).echo).toEqual({
+      surface: ECHO_SIBLING_SURFACE,
+      label: 'this DM, posted by you from another conversation',
+    });
+    expect(readEchoRows('s-task')).toHaveLength(0);
+    expect(written).toBe(1);
   });
 
-  it('skips system/task_log/agent/echo/unrouted messages and task-session sources', () => {
+  it('skips system/task_log/agent/echo/unrouted messages', () => {
     const content = JSON.stringify({ text: 'x' });
     const base = { id: 'out-3', platform_id: 'C123', channel_type: 'slack', content };
     expect(fanOutboundMessage({ ...base, kind: 'system' }, SRC_ROOM, agentGroup)).toBe(0);
@@ -409,10 +403,71 @@ describe('fanOutboundMessage', () => {
       0,
     );
     expect(fanOutboundMessage({ ...base, kind: 'chat', platform_id: null }, SRC_ROOM, agentGroup)).toBe(0);
-    // Task session sending (send_message tool) never fans.
-    expect(fanOutboundMessage({ ...base, kind: 'chat' }, TASK_SESS, agentGroup)).toBe(0);
+    // task_log from a task session (series bookkeeping) still never fans.
+    expect(fanOutboundMessage({ ...base, kind: 'task_log' }, TASK_SESS, agentGroup)).toBe(0);
     expect(readEchoRows('s-dm')).toHaveLength(0);
     expect(readEchoRows('s-task')).toHaveLength(0);
+  });
+
+  it("a task-session DM send fans ONLY into that DM's sessions, with the task-delivery shape", () => {
+    // A second task session proves task sessions are excluded as targets for
+    // task-delivery fans (the source itself is excluded by id).
+    createSession(session('s-task2', AG, null, 'system:tasks:weekly-1'));
+    const written = fanOutboundMessage(
+      {
+        id: 'out-task-dm',
+        kind: 'chat',
+        platform_id: 'D456',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'daily digest' }),
+      },
+      TASK_SESS,
+      agentGroup,
+    );
+    // Exactly the two sessions of mg-dm (the delivered-to conversation).
+    expect(written).toBe(2);
+    for (const sid of ['s-dm', 's-dm-t2']) {
+      const rows = readEchoRows(sid);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(`out-task-dm:echo:${sid}`);
+      expect(rows[0].trigger).toBe(0);
+      expect(rows[0].source_session_id).toBe('s-task');
+      const content = JSON.parse(rows[0].content as string);
+      expect(content.text).toBe('daily digest');
+      expect(content.sender).toBe('Pixel');
+      expect(content.echo).toEqual({
+        surface: ECHO_TASK_SURFACE,
+        label: 'this DM, posted by your scheduled task',
+      });
+    }
+    // Never other DMs, rooms, or task sessions.
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
+    expect(readEchoRows('s-room')).toHaveLength(0);
+    expect(readEchoRows('s-task2')).toHaveLength(0);
+  });
+
+  it("a task-session room send fans only into that room's sessions — never the DM fan the room rule would give", () => {
+    const written = fanOutboundMessage(
+      {
+        id: 'out-task-room',
+        kind: 'chat',
+        platform_id: 'C123',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'nightly report' }),
+      },
+      TASK_SESS,
+      agentGroup,
+    );
+    expect(written).toBe(1);
+    const rows = readEchoRows('s-room');
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0].content as string).echo).toEqual({
+      surface: ECHO_TASK_SURFACE,
+      label: 'this room, posted by your scheduled task',
+    });
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+    expect(readEchoRows('s-dm-t2')).toHaveLength(0);
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
   });
 });
 
@@ -438,6 +493,13 @@ describe('label + truncation helpers', () => {
     expect(buildSiblingEchoLabel({ name: 'pixel-room', platform_id: 'C1', is_group: 1 })).toBe(
       'another conversation in #pixel-room room',
     );
+  });
+
+  it("buildDeliveredEchoLabel names the delivered-to surface from the receiver's perspective", () => {
+    expect(buildDeliveredEchoLabel({ is_group: 0 }, true)).toBe('this DM, posted by your scheduled task');
+    expect(buildDeliveredEchoLabel({ is_group: 1 }, true)).toBe('this room, posted by your scheduled task');
+    expect(buildDeliveredEchoLabel({ is_group: 0 }, false)).toBe('this DM, posted by you from another conversation');
+    expect(buildDeliveredEchoLabel({ is_group: 1 }, false)).toBe('this room, posted by you from another conversation');
   });
 
   it('truncateEchoText leaves short text untouched', () => {

--- a/src/modules/cross-session-context/fan.test.ts
+++ b/src/modules/cross-session-context/fan.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Cross-session context fan-out tests.
+ *
+ * Drives the real fan entries against real session folders on disk plus an
+ * in-memory central DB, and the pure v1 audience rule directly.
+ */
+import fs from 'fs';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../config.js')>('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-cross-session-fan' };
+});
+
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup } from '../../db/messaging-groups.js';
+import { createSession } from '../../db/sessions.js';
+import { createDestination } from '../agent-to-agent/db/agent-destinations.js';
+import { inboundDbPath } from '../../session-manager.js';
+import type { MessagingGroup, Session } from '../../types.js';
+import {
+  buildEchoLabel,
+  buildSiblingEchoLabel,
+  fanInboundMessage,
+  fanOutboundMessage,
+  selectEchoTargets,
+  truncateEchoText,
+} from './fan.js';
+import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-cross-session-fan';
+const AG = 'ag-1';
+const NOW = new Date().toISOString();
+
+function mg(id: string, platformId: string, isGroup: number, name: string | null): MessagingGroup {
+  return {
+    id,
+    channel_type: 'slack',
+    platform_id: platformId,
+    instance: 'slack',
+    name,
+    is_group: isGroup,
+    unknown_sender_policy: 'public',
+    denied_at: null,
+    created_at: NOW,
+  };
+}
+
+function session(
+  id: string,
+  agentGroupId: string,
+  mgId: string | null,
+  threadId: string | null,
+  status: 'active' | 'closed' = 'active',
+): Session {
+  return {
+    id,
+    agent_group_id: agentGroupId,
+    messaging_group_id: mgId,
+    thread_id: threadId,
+    agent_provider: null,
+    status,
+    container_status: 'stopped',
+    last_active: null,
+    created_at: NOW,
+  };
+}
+
+const ROOM_MG = mg('mg-room', 'C123', 1, 'pixel-room');
+const DM_MG = mg('mg-dm', 'D456', 0, 'Gavriel');
+const ROOM2_MG = mg('mg-room2', 'C789', 1, null);
+const DM2_MG = mg('mg-dm2', 'D999', 0, 'Someone');
+
+const SRC_ROOM = session('s-room', AG, 'mg-room', null);
+const SRC_DM = session('s-dm', AG, 'mg-dm', null);
+// Sibling conversation-thread of the SAME DM (agent-mode per-thread session).
+const DM_SIBLING = session('s-dm-t2', AG, 'mg-dm', '1723456.789');
+const TASK_SESS = session('s-task', AG, null, 'system:tasks:daily-1');
+
+function readEchoRows(sessionId: string): Array<Record<string, unknown>> {
+  const dbPath = inboundDbPath(AG, sessionId);
+  if (!fs.existsSync(dbPath)) return [];
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare('SELECT * FROM messages_in WHERE channel_type = ? ORDER BY seq').all(ECHO_CHANNEL_TYPE) as Array<
+      Record<string, unknown>
+    >;
+  } finally {
+    db.close();
+  }
+}
+
+function chatContent(text: string): string {
+  return JSON.stringify({ text, sender: 'Gavriel', senderId: 'slack:U1' });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+  createAgentGroup({ id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW });
+  createAgentGroup({ id: 'ag-2', name: 'Other', folder: 'other', agent_provider: null, created_at: NOW });
+  for (const m of [ROOM_MG, DM_MG, ROOM2_MG, DM2_MG]) createMessagingGroup(m);
+  createSession(SRC_ROOM);
+  createSession(SRC_DM);
+  createSession(DM_SIBLING);
+  createSession(TASK_SESS);
+  createSession(session('s-room2', AG, 'mg-room2', null));
+  createSession(session('s-dm2', AG, 'mg-dm2', null));
+  createSession(session('s-dm-closed', AG, 'mg-dm', 'closed-thread', 'closed'));
+  createSession(session('s-a2a', AG, null, null));
+  createSession(session('s-other-group', 'ag-2', 'mg-dm', null));
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('selectEchoTargets (audience rule)', () => {
+  const candidates = [
+    { id: 's-src', status: 'active', messaging_group_id: 'mg-room', thread_id: null },
+    { id: 's-room-t2', status: 'active', messaging_group_id: 'mg-room', thread_id: 't2' },
+    { id: 's-dm', status: 'active', messaging_group_id: 'mg-dm', thread_id: null },
+    { id: 's-dm-t2', status: 'active', messaging_group_id: 'mg-dm', thread_id: 't2' },
+    { id: 's-dm2', status: 'active', messaging_group_id: 'mg-dm2', thread_id: null },
+    { id: 's-room2', status: 'active', messaging_group_id: 'mg-room2', thread_id: null },
+    { id: 's-task', status: 'active', messaging_group_id: null, thread_id: 'system:tasks:daily-1' },
+    { id: 's-task-legacy', status: 'active', messaging_group_id: null, thread_id: 'system:tasks' },
+    { id: 's-a2a', status: 'active', messaging_group_id: null, thread_id: null },
+    { id: 's-closed', status: 'closed', messaging_group_id: 'mg-dm', thread_id: 'x' },
+  ];
+  const isDm = (mgId: string) => mgId.startsWith('mg-dm');
+
+  it('room source → DM sessions + task sessions; never room→room (even same-mg), never closed/a2a/source', () => {
+    const ids = selectEchoTargets(candidates, 's-src', 'room', 'mg-room', isDm).map((s) => s.id);
+    expect(ids.sort()).toEqual(['s-dm', 's-dm-t2', 's-dm2', 's-task', 's-task-legacy']);
+  });
+
+  it('DM source → task sessions + same-mg sibling threads; never rooms, never other DMs, never closed', () => {
+    const ids = selectEchoTargets(candidates, 's-dm', 'dm', 'mg-dm', isDm).map((s) => s.id);
+    expect(ids.sort()).toEqual(['s-dm-t2', 's-task', 's-task-legacy']);
+  });
+
+  it('DM source with unknown source mg → task sessions only (defensive)', () => {
+    const ids = selectEchoTargets(candidates, 's-dm', 'dm', null, isDm).map((s) => s.id);
+    expect(ids.sort()).toEqual(['s-task', 's-task-legacy']);
+  });
+});
+
+describe('fanInboundMessage', () => {
+  it('fans a room trigger into DM + task sessions with the contract row shape', () => {
+    const written = fanInboundMessage({
+      session: SRC_ROOM,
+      mg: ROOM_MG,
+      messageId: 'msg-1:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent('hello from the room'),
+      timestamp: NOW,
+    });
+    expect(written).toBe(4);
+
+    const dmRows = readEchoRows('s-dm');
+    expect(dmRows).toHaveLength(1);
+    const row = dmRows[0];
+    expect(row.id).toBe('msg-1:ag-1:echo:s-dm');
+    expect(row.kind).toBe('chat');
+    expect(row.trigger).toBe(0);
+    expect(row.thread_id).toBeNull();
+    expect(row.platform_id).toBe('C123');
+    expect(row.source_session_id).toBe('s-room');
+    const content = JSON.parse(row.content as string);
+    expect(content.text).toBe('hello from the room');
+    expect(content.sender).toBe('Gavriel');
+    expect(content.senderId).toBe('slack:U1');
+    expect(content.echo).toEqual({ surface: 'room', label: '#pixel-room room' });
+
+    expect(readEchoRows('s-task')).toHaveLength(1);
+    // All DM sessions get the room-surface echo (never the sibling flavor —
+    // the source mg is the room, not their DM).
+    for (const sid of ['s-dm-t2', 's-dm2']) {
+      const rows = readEchoRows(sid);
+      expect(rows).toHaveLength(1);
+      expect(JSON.parse(rows[0].content as string).echo).toEqual({ surface: 'room', label: '#pixel-room room' });
+    }
+    // Room→room is not v1; a2a/closed/other-group sessions never targeted.
+    expect(readEchoRows('s-room2')).toHaveLength(0);
+    expect(readEchoRows('s-a2a')).toHaveLength(0);
+    expect(readEchoRows('s-dm-closed')).toHaveLength(0);
+    expect(fs.existsSync(inboundDbPath('ag-2', 's-other-group'))).toBe(false);
+    // Source session itself never receives its own echo.
+    expect(readEchoRows('s-room')).toHaveLength(0);
+  });
+
+  it('fans a DM trigger into task sessions + same-mg sibling threads, never rooms or other DMs', () => {
+    const written = fanInboundMessage({
+      session: SRC_DM,
+      mg: DM_MG,
+      messageId: 'msg-2:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent('private note'),
+      timestamp: NOW,
+    });
+    expect(written).toBe(2);
+    expect(readEchoRows('s-task')).toHaveLength(1);
+    expect(readEchoRows('s-room')).toHaveLength(0);
+    expect(readEchoRows('s-room2')).toHaveLength(0);
+    // Other DMs' sessions stay blind — same-mg siblings only.
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
+    const content = JSON.parse(readEchoRows('s-task')[0].content as string);
+    expect(content.echo).toEqual({ surface: 'dm', label: 'DM with Gavriel' });
+
+    // Sibling thread of the SAME DM gets the sibling-flavored echo (contract
+    // fields identical — surface/label values differ).
+    const sibRows = readEchoRows('s-dm-t2');
+    expect(sibRows).toHaveLength(1);
+    expect(sibRows[0].id).toBe('msg-2:ag-1:echo:s-dm-t2');
+    expect(sibRows[0].trigger).toBe(0);
+    expect(sibRows[0].thread_id).toBeNull();
+    expect(sibRows[0].source_session_id).toBe('s-dm');
+    const sibContent = JSON.parse(sibRows[0].content as string);
+    expect(sibContent.text).toBe('private note');
+    expect(sibContent.sender).toBe('Gavriel');
+    expect(sibContent.echo).toEqual({
+      surface: ECHO_SIBLING_SURFACE,
+      label: 'another conversation with Gavriel',
+    });
+  });
+
+  it('a DM sibling-thread source fans back to the original DM session (symmetric)', () => {
+    const written = fanInboundMessage({
+      session: DM_SIBLING,
+      mg: DM_MG,
+      messageId: 'msg-2b:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent('from the other thread'),
+      timestamp: NOW,
+    });
+    expect(written).toBe(2);
+    const rows = readEchoRows('s-dm');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source_session_id).toBe('s-dm-t2');
+    expect(JSON.parse(rows[0].content as string).echo.surface).toBe(ECHO_SIBLING_SURFACE);
+    // Sibling source never echoes to itself.
+    expect(readEchoRows('s-dm-t2')).toHaveLength(0);
+  });
+
+  it('truncates text to 500 chars head with … appended', () => {
+    const long = 'x'.repeat(ECHO_TEXT_MAX_CHARS + 100);
+    fanInboundMessage({
+      session: SRC_ROOM,
+      mg: ROOM_MG,
+      messageId: 'msg-3:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent(long),
+      timestamp: NOW,
+    });
+    const content = JSON.parse(readEchoRows('s-dm')[0].content as string);
+    expect(content.text).toBe('x'.repeat(ECHO_TEXT_MAX_CHARS) + '…');
+    expect(content.text.length).toBe(ECHO_TEXT_MAX_CHARS + 1);
+  });
+
+  it('never fans echo rows, a2a rows, non-chat kinds, or empty text', () => {
+    const base = {
+      session: SRC_ROOM,
+      mg: ROOM_MG,
+      messageId: 'msg-4:ag-1',
+      content: chatContent('hi'),
+      timestamp: NOW,
+    };
+    expect(fanInboundMessage({ ...base, kind: 'chat', channelType: ECHO_CHANNEL_TYPE })).toBe(0);
+    expect(fanInboundMessage({ ...base, kind: 'chat', channelType: 'agent' })).toBe(0);
+    expect(fanInboundMessage({ ...base, kind: 'task', channelType: 'slack' })).toBe(0);
+    expect(fanInboundMessage({ ...base, kind: 'system', channelType: 'slack' })).toBe(0);
+    expect(
+      fanInboundMessage({ ...base, kind: 'chat', channelType: 'slack', content: JSON.stringify({ text: '' }) }),
+    ).toBe(0);
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+    expect(readEchoRows('s-task')).toHaveLength(0);
+  });
+
+  it('never fans from a task session (task sessions are not a source)', () => {
+    const written = fanInboundMessage({
+      session: TASK_SESS,
+      mg: ROOM_MG,
+      messageId: 'msg-5:ag-1',
+      kind: 'chat',
+      channelType: 'slack',
+      content: chatContent('task chatter'),
+      timestamp: NOW,
+    });
+    expect(written).toBe(0);
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+  });
+});
+
+describe('fanOutboundMessage', () => {
+  const agentGroup = { id: AG, name: 'Pixel', folder: 'pixel', agent_provider: null, created_at: NOW };
+
+  it('fans a delivered room message into DM + task sessions with the agent as sender', () => {
+    const written = fanOutboundMessage(
+      {
+        id: 'out-1',
+        kind: 'chat',
+        platform_id: 'C123',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'agent answer' }),
+      },
+      SRC_ROOM,
+      agentGroup,
+    );
+    expect(written).toBe(4);
+    const content = JSON.parse(readEchoRows('s-dm')[0].content as string);
+    expect(content.sender).toBe('Pixel');
+    expect(content.senderId).toBe(AG);
+    expect(content.echo.surface).toBe('room');
+    expect(readEchoRows('s-dm')[0].id).toBe('out-1:echo:s-dm');
+    expect(readEchoRows('s-task')).toHaveLength(1);
+  });
+
+  it('fans a delivered DM message into task sessions + same-mg sibling threads', () => {
+    const written = fanOutboundMessage(
+      {
+        id: 'out-2',
+        kind: 'chat',
+        platform_id: 'D456',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'dm reply' }),
+      },
+      SRC_DM,
+      agentGroup,
+    );
+    expect(written).toBe(2);
+    expect(readEchoRows('s-task')).toHaveLength(1);
+    expect(readEchoRows('s-room')).toHaveLength(0);
+    expect(readEchoRows('s-dm2')).toHaveLength(0);
+    const sibRows = readEchoRows('s-dm-t2');
+    expect(sibRows).toHaveLength(1);
+    const sibContent = JSON.parse(sibRows[0].content as string);
+    expect(sibContent.sender).toBe('Pixel');
+    expect(sibContent.echo).toEqual({
+      surface: ECHO_SIBLING_SURFACE,
+      label: 'another conversation with Gavriel',
+    });
+  });
+
+  it("resolves the sender's own instance, not a lexically-first sibling, when instances share a platform address", () => {
+    // Two sibling messaging groups share one platform address (e.g. two bot
+    // identities in the same multi-bot conversation) but belong to different
+    // adapter instances. "alpha" sorts before "zulu", so a plain by-platform
+    // lookup with no instance hint would pick "alpha" — the wrong sibling
+    // for this sender.
+    const dmAlpha = { ...mg('mg-dm-alpha', 'D-multi', 0, 'Shared DM'), instance: 'alpha' };
+    const dmZulu = { ...mg('mg-dm-zulu', 'D-multi', 0, 'Shared DM'), instance: 'zulu' };
+    createMessagingGroup(dmAlpha);
+    createMessagingGroup(dmZulu);
+
+    // The sender is only authorized against (and only reaches Slack through)
+    // its "zulu" sibling.
+    createDestination({
+      agent_group_id: AG,
+      local_name: 'shared-dm',
+      target_type: 'channel',
+      target_id: 'mg-dm-zulu',
+      created_at: NOW,
+    });
+
+    // Two candidate sibling sessions, one per instance's row — only the one
+    // on the sender's own ("zulu") row should count as "the same DM".
+    createSession(session('s-sib-zulu', AG, 'mg-dm-zulu', 'thread-zulu'));
+    createSession(session('s-sib-alpha', AG, 'mg-dm-alpha', 'thread-alpha'));
+
+    // Source is a room session (not the origin of "D-multi"), so resolution
+    // falls into the non-origin, sibling-collision-prone branch.
+    const written = fanOutboundMessage(
+      {
+        id: 'out-shared-dm',
+        kind: 'chat',
+        platform_id: 'D-multi',
+        channel_type: 'slack',
+        content: JSON.stringify({ text: 'heads up' }),
+      },
+      SRC_ROOM,
+      agentGroup,
+    );
+
+    // Fans as a DM (correct surface) into task sessions plus exactly the
+    // sender's own sibling — never the "alpha" sibling it isn't wired to.
+    expect(readEchoRows('s-sib-zulu')).toHaveLength(1);
+    expect(readEchoRows('s-sib-alpha')).toHaveLength(0);
+    expect(JSON.parse(readEchoRows('s-sib-zulu')[0].content as string).echo.surface).toBe(ECHO_SIBLING_SURFACE);
+    expect(readEchoRows('s-task')).toHaveLength(1);
+    expect(written).toBe(2);
+  });
+
+  it('skips system/task_log/agent/echo/unrouted messages and task-session sources', () => {
+    const content = JSON.stringify({ text: 'x' });
+    const base = { id: 'out-3', platform_id: 'C123', channel_type: 'slack', content };
+    expect(fanOutboundMessage({ ...base, kind: 'system' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(fanOutboundMessage({ ...base, kind: 'task_log' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(fanOutboundMessage({ ...base, kind: 'chat', channel_type: 'agent' }, SRC_ROOM, agentGroup)).toBe(0);
+    expect(fanOutboundMessage({ ...base, kind: 'chat', channel_type: ECHO_CHANNEL_TYPE }, SRC_ROOM, agentGroup)).toBe(
+      0,
+    );
+    expect(fanOutboundMessage({ ...base, kind: 'chat', platform_id: null }, SRC_ROOM, agentGroup)).toBe(0);
+    // Task session sending (send_message tool) never fans.
+    expect(fanOutboundMessage({ ...base, kind: 'chat' }, TASK_SESS, agentGroup)).toBe(0);
+    expect(readEchoRows('s-dm')).toHaveLength(0);
+    expect(readEchoRows('s-task')).toHaveLength(0);
+  });
+});
+
+describe('label + truncation helpers', () => {
+  it('buildEchoLabel renders room and DM labels', () => {
+    expect(buildEchoLabel({ name: 'pixel-room', platform_id: 'C1', is_group: 1 })).toBe('#pixel-room room');
+    expect(buildEchoLabel({ name: null, platform_id: 'C1', is_group: 1 })).toBe('#C1 room');
+    expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Gavriel')).toBe('DM with Gavriel');
+    expect(buildEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, null)).toBe('DM (D1)');
+  });
+
+  it('buildSiblingEchoLabel renders same-DM sibling labels with sensible fallbacks', () => {
+    expect(buildSiblingEchoLabel({ name: 'Gavriel', platform_id: 'D1', is_group: 0 })).toBe(
+      'another conversation with Gavriel',
+    );
+    expect(buildSiblingEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, 'Gav')).toBe(
+      'another conversation with Gav',
+    );
+    expect(buildSiblingEchoLabel({ name: null, platform_id: 'D1', is_group: 0 }, null)).toBe(
+      'another conversation in DM (D1)',
+    );
+    // Defensive room shape (siblings are only selected for DM sources today).
+    expect(buildSiblingEchoLabel({ name: 'pixel-room', platform_id: 'C1', is_group: 1 })).toBe(
+      'another conversation in #pixel-room room',
+    );
+  });
+
+  it('truncateEchoText leaves short text untouched', () => {
+    expect(truncateEchoText('short')).toBe('short');
+  });
+});

--- a/src/modules/cross-session-context/fan.ts
+++ b/src/modules/cross-session-context/fan.ts
@@ -1,0 +1,310 @@
+/**
+ * Cross-session context — accumulate fan-out.
+ *
+ * Copies triggering user messages (router hook) and the agent's own delivered
+ * user-facing messages (delivery hook) into sibling sessions of the same agent
+ * group as trigger=0 rows with channel_type 'session-echo'. Echo rows ride
+ * along as ambient context with the next real trigger — they never wake a
+ * container, never provide reply routing (thread_id NULL; the formatter's
+ * reply-routing extraction skips 'session-echo'), and are never themselves
+ * fanned (loop guard: fan entries reject 'session-echo' rows, and fan writes
+ * go through writeSessionMessage, which never re-enters routeInbound).
+ *
+ * Audience rule (pragmatic form — membership tracking lands later):
+ *   - task sessions of the group are ALWAYS targets, from DM and room sources
+ *   - room source → additionally the group's DM sessions
+ *   - DM source  → task sessions, plus sibling sessions of the SAME messaging
+ *     group (parallel conversation-threads of that same DM — same audience,
+ *     so trivially safe). DM content never enters rooms or OTHER DMs.
+ *   - room→room: not in v1 (not even same-mg room threads); task sessions are
+ *     never a SOURCE
+ */
+import {
+  getMessagingGroup,
+  getMessagingGroupByPlatform,
+  getMessagingGroupForOwnDestination,
+} from '../../db/messaging-groups.js';
+import { getSessionsByAgentGroup, isTaskThread } from '../../db/sessions.js';
+import { log } from '../../log.js';
+import { writeSessionMessage } from '../../session-manager.js';
+import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
+import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
+
+export type EchoSurface = 'dm' | 'room';
+
+/** Surface values that appear on the wire in echo.{surface}: the two source
+ *  surfaces plus the same-mg sibling-thread marker. */
+export type EchoWireSurface = EchoSurface | typeof ECHO_SIBLING_SURFACE;
+
+/** Inbound kinds that are real chat traffic. Everything else (task, system,
+ *  approval plumbing) never fans. */
+const CHAT_KINDS = new Set(['chat', 'chat-sdk']);
+
+/** Head-truncate to the cap, appending '…' when cut (contract: ≤500 chars). */
+export function truncateEchoText(text: string): string {
+  return text.length <= ECHO_TEXT_MAX_CHARS ? text : `${text.slice(0, ECHO_TEXT_MAX_CHARS)}…`;
+}
+
+/** Echo-row id: namespaced by target session so the same source message can
+ *  land in every sibling inbound.db without PK collisions (contract shape). */
+export function echoRowId(origMessageId: string, targetSessionId: string): string {
+  return `${origMessageId}:echo:${targetSessionId}`;
+}
+
+/** Human label for the source conversation, e.g. '#Pixel room' / 'DM with Gavriel'. */
+export function buildEchoLabel(
+  mg: Pick<MessagingGroup, 'name' | 'platform_id' | 'is_group'>,
+  senderName?: string | null,
+): string {
+  if (mg.is_group === 1) return `#${mg.name ?? mg.platform_id} room`;
+  const who = mg.name ?? senderName;
+  return who ? `DM with ${who}` : `DM (${mg.platform_id})`;
+}
+
+/** Human label for a same-mg sibling-thread echo — the target session is
+ *  another conversation-thread of the very same DM, so the label reads as
+ *  "another conversation with <who>" rather than naming a different surface. */
+export function buildSiblingEchoLabel(
+  mg: Pick<MessagingGroup, 'name' | 'platform_id' | 'is_group'>,
+  senderName?: string | null,
+): string {
+  const who = mg.is_group === 0 ? (mg.name ?? senderName) : null;
+  return who ? `another conversation with ${who}` : `another conversation in ${buildEchoLabel(mg, senderName)}`;
+}
+
+export interface EchoTargetCandidate {
+  id: string;
+  status: string;
+  messaging_group_id: string | null;
+  thread_id: string | null;
+}
+
+/**
+ * Pure audience rule. `isDmMessagingGroup` resolves whether a candidate's
+ * messaging group is a DM (is_group=0) — injected so the rule stays testable
+ * without a central DB. `sourceMessagingGroupId` is the source conversation's
+ * messaging group, used to admit same-mg sibling threads for DM sources.
+ */
+export function selectEchoTargets<T extends EchoTargetCandidate>(
+  candidates: T[],
+  sourceSessionId: string,
+  sourceSurface: EchoSurface,
+  sourceMessagingGroupId: string | null,
+  isDmMessagingGroup: (messagingGroupId: string) => boolean,
+): T[] {
+  return candidates.filter((s) => {
+    if (s.id === sourceSessionId || s.status !== 'active') return false;
+    // System sessions: task sessions are always in the audience; any other
+    // messaging-group-less session (a2a targets, future system threads) is not.
+    if (s.messaging_group_id === null) return isTaskThread(s.thread_id);
+    // Room sources additionally reach the group's DM sessions (never other
+    // rooms — not even same-mg room threads; room→room is not in v1).
+    if (sourceSurface === 'room') return isDmMessagingGroup(s.messaging_group_id);
+    // DM sources additionally reach sibling sessions of the SAME messaging
+    // group — the parallel conversation-threads of that same DM (identical
+    // audience). Never rooms, never other DMs' sessions.
+    return sourceMessagingGroupId !== null && s.messaging_group_id === sourceMessagingGroupId;
+  });
+}
+
+function parseContent(raw: string): { text: string; sender: string | null; senderId: string | null } {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      text: typeof parsed.text === 'string' ? parsed.text : '',
+      sender: typeof parsed.sender === 'string' ? parsed.sender : null,
+      senderId: typeof parsed.senderId === 'string' ? parsed.senderId : null,
+    };
+  } catch {
+    return { text: raw, sender: null, senderId: null };
+  }
+}
+
+interface EchoFanInput {
+  agentGroupId: string;
+  sourceSessionId: string;
+  /** Messaging group of the source conversation (same-mg sibling detection). */
+  sourceMessagingGroupId: string | null;
+  origMessageId: string;
+  timestamp: string;
+  surface: EchoSurface;
+  label: string;
+  /** Label used when the target is a sibling thread of the same messaging group. */
+  siblingLabel: string;
+  platformId: string;
+  text: string;
+  sender: string;
+  senderId: string | null;
+}
+
+function fanEcho(input: EchoFanInput): number {
+  const candidates = getSessionsByAgentGroup(input.agentGroupId);
+  const dmCache = new Map<string, boolean>();
+  const isDm = (mgId: string): boolean => {
+    let v = dmCache.get(mgId);
+    if (v === undefined) {
+      v = getMessagingGroup(mgId)?.is_group === 0;
+      dmCache.set(mgId, v);
+    }
+    return v;
+  };
+  const targets = selectEchoTargets(
+    candidates,
+    input.sourceSessionId,
+    input.surface,
+    input.sourceMessagingGroupId,
+    isDm,
+  );
+  if (targets.length === 0) return 0;
+
+  const body = {
+    text: truncateEchoText(input.text),
+    sender: input.sender,
+    senderId: input.senderId,
+  };
+  const content = JSON.stringify({ ...body, echo: { surface: input.surface, label: input.label } });
+  // Same-mg sibling threads get a sibling-flavored echo (contract fields
+  // identical — only the surface/label values differ).
+  const siblingContent = JSON.stringify({
+    ...body,
+    echo: { surface: ECHO_SIBLING_SURFACE, label: input.siblingLabel },
+  });
+
+  let written = 0;
+  for (const target of targets) {
+    const isSibling =
+      input.sourceMessagingGroupId !== null && target.messaging_group_id === input.sourceMessagingGroupId;
+    try {
+      writeSessionMessage(input.agentGroupId, target.id, {
+        id: echoRowId(input.origMessageId, target.id),
+        kind: 'chat',
+        timestamp: input.timestamp,
+        platformId: input.platformId,
+        channelType: ECHO_CHANNEL_TYPE,
+        threadId: null,
+        content: isSibling ? siblingContent : content,
+        trigger: 0,
+        sourceSessionId: input.sourceSessionId,
+      });
+      written++;
+    } catch (err) {
+      // Per-target isolation: one broken session DB (or a duplicate id from a
+      // replay) must not stop the rest of the fan — or, upstream, routing.
+      log.warn('Echo fan write failed', {
+        targetSessionId: target.id,
+        origMessageId: input.origMessageId,
+        err,
+      });
+    }
+  }
+  return written;
+}
+
+/**
+ * Router hook: fan a just-written trigger=1 inbound message into sibling
+ * sessions. Call ONLY for the engaged (wake) branch — accumulate (trigger=0)
+ * writes must never fan. Never throws; returns rows written.
+ */
+export function fanInboundMessage(args: {
+  /** Source session the trigger=1 row was written to. */
+  session: Session;
+  /** Messaging group the message arrived on (the source surface). */
+  mg: MessagingGroup;
+  /** The id the source row was written with (post agent-group namespacing). */
+  messageId: string;
+  kind: string;
+  /** channel_type as written on the source row. */
+  channelType: string;
+  content: string;
+  timestamp: string;
+}): number {
+  try {
+    const { session, mg } = args;
+    if (!CHAT_KINDS.has(args.kind)) return 0;
+    // Only real chat surfaces fan: a2a rows and echo rows never re-fan.
+    if (args.channelType === 'agent' || args.channelType === ECHO_CHANNEL_TYPE) return 0;
+    // Task sessions are never a SOURCE (their traffic is series-internal).
+    if (isTaskThread(session.thread_id)) return 0;
+    const parsed = parseContent(args.content);
+    if (!parsed.text) return 0;
+    const surface: EchoSurface = mg.is_group === 1 ? 'room' : 'dm';
+    return fanEcho({
+      agentGroupId: session.agent_group_id,
+      sourceSessionId: session.id,
+      sourceMessagingGroupId: mg.id,
+      origMessageId: args.messageId,
+      timestamp: args.timestamp,
+      surface,
+      label: buildEchoLabel(mg, parsed.sender),
+      siblingLabel: buildSiblingEchoLabel(mg, parsed.sender),
+      platformId: mg.platform_id,
+      text: parsed.text,
+      sender: parsed.sender ?? 'unknown',
+      senderId: parsed.senderId,
+    });
+  } catch (err) {
+    log.warn('Inbound echo fan failed', { sessionId: args.session.id, err });
+    return 0;
+  }
+}
+
+/**
+ * Delivery hook: fan the agent's own just-delivered user-facing message into
+ * sibling sessions. Caller applies the user-facing predicate (kind not
+ * system/task_log, channel_type not 'agent'); the guards here are
+ * belt-and-braces so the contract holds even if call sites drift. The source
+ * surface is the conversation the message was DELIVERED to (origin-session-
+ * first, then own-destination-first, mirroring delivery.ts's resolution
+ * order — needed so sibling-instance rows sharing one channel address
+ * resolve to the sender's own row, not an arbitrary sibling's). Never
+ * throws.
+ */
+export function fanOutboundMessage(
+  msg: {
+    id: string;
+    kind: string;
+    platform_id: string | null;
+    channel_type: string | null;
+    content: string;
+  },
+  session: Session,
+  agentGroup: AgentGroup,
+): number {
+  try {
+    if (msg.kind === 'system' || msg.kind === 'task_log') return 0;
+    if (!msg.channel_type || !msg.platform_id) return 0;
+    if (msg.channel_type === 'agent' || msg.channel_type === ECHO_CHANNEL_TYPE) return 0;
+    // Task sessions are never a SOURCE — their sends already log to the series
+    // run log, and fanning them would leak scheduled-run output everywhere.
+    if (isTaskThread(session.thread_id)) return 0;
+
+    const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
+    const mg =
+      originMg && originMg.channel_type === msg.channel_type && originMg.platform_id === msg.platform_id
+        ? originMg
+        : (getMessagingGroupForOwnDestination(session.agent_group_id, msg.channel_type, msg.platform_id) ??
+          getMessagingGroupByPlatform(msg.channel_type, msg.platform_id));
+    if (!mg) return 0;
+
+    const parsed = parseContent(msg.content);
+    if (!parsed.text) return 0;
+    const surface: EchoSurface = mg.is_group === 1 ? 'room' : 'dm';
+    return fanEcho({
+      agentGroupId: session.agent_group_id,
+      sourceSessionId: session.id,
+      sourceMessagingGroupId: mg.id,
+      origMessageId: msg.id,
+      timestamp: new Date().toISOString(),
+      surface,
+      label: buildEchoLabel(mg, mg.name),
+      siblingLabel: buildSiblingEchoLabel(mg, mg.name),
+      platformId: mg.platform_id,
+      text: parsed.text,
+      sender: agentGroup.name,
+      senderId: agentGroup.id,
+    });
+  } catch (err) {
+    log.warn('Outbound echo fan failed', { sessionId: session.id, messageId: msg.id, err });
+    return 0;
+  }
+}

--- a/src/modules/cross-session-context/fan.ts
+++ b/src/modules/cross-session-context/fan.ts
@@ -10,14 +10,18 @@
  * fanned (loop guard: fan entries reject 'session-echo' rows, and fan writes
  * go through writeSessionMessage, which never re-enters routeInbound).
  *
- * Audience rule (pragmatic form — membership tracking lands later):
- *   - task sessions of the group are ALWAYS targets, from DM and room sources
- *   - room source → additionally the group's DM sessions
- *   - DM source  → task sessions, plus sibling sessions of the SAME messaging
- *     group (parallel conversation-threads of that same DM — same audience,
- *     so trivially safe). DM content never enters rooms or OTHER DMs.
- *   - room→room: not in v1 (not even same-mg room threads); task sessions are
- *     never a SOURCE
+ * Audience rule: a message fans
+ * ONLY into sibling sessions of the conversation it actually appeared in —
+ * for inbound, the messaging group it arrived on; for outbound, the
+ * messaging group it was delivered to. Same messaging group = identical
+ * audience by definition, so every fan is provably audience-safe with no
+ * membership knowledge needed. Nothing else is ever a target: not the
+ * group's other conversations (room→DM is retired), not task sessions
+ * (conversation→task is retired — task sessions have no messaging group).
+ * Cross-conversation awareness is pull-only: `ncl sessions history`.
+ * Task sessions are still never an inbound source (the series prompt is
+ * series-internal); a task's DELIVERED user-facing send fans like any other
+ * delivery — into the sessions of the conversation it landed in.
  */
 import {
   getMessagingGroup,
@@ -28,13 +32,14 @@ import { getSessionsByAgentGroup, isTaskThread } from '../../db/sessions.js';
 import { log } from '../../log.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { AgentGroup, MessagingGroup, Session } from '../../types.js';
-import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
+import { ECHO_CHANNEL_TYPE, ECHO_SIBLING_SURFACE, ECHO_TASK_SURFACE, ECHO_TEXT_MAX_CHARS } from './config.js';
 
-export type EchoSurface = 'dm' | 'room';
-
-/** Surface values that appear on the wire in echo.{surface}: the two source
- *  surfaces plus the same-mg sibling-thread marker. */
-export type EchoWireSurface = EchoSurface | typeof ECHO_SIBLING_SURFACE;
+/** Surface values that appear on the wire in echo.{surface}: the sibling-
+ *  thread marker and the task-delivery marker (backfill's dm-timeline is
+ *  written by backfill.ts directly). Every fan target is a session of the
+ *  conversation the message appeared in, so the old cross-surface 'dm'/'room'
+ *  values are no longer emitted. */
+export type EchoWireSurface = typeof ECHO_SIBLING_SURFACE | typeof ECHO_TASK_SURFACE;
 
 /** Inbound kinds that are real chat traffic. Everything else (task, system,
  *  approval plumbing) never fans. */
@@ -72,39 +77,37 @@ export function buildSiblingEchoLabel(
   return who ? `another conversation with ${who}` : `another conversation in ${buildEchoLabel(mg, senderName)}`;
 }
 
+/** Label for an echo of a message the agent delivered INTO this conversation
+ *  from elsewhere (a task run, or a cross-conversation send). Targets are
+ *  always sessions of the very conversation the message landed in, so
+ *  "this DM"/"this room" is accurate from every receiver's perspective. */
+export function buildDeliveredEchoLabel(mg: Pick<MessagingGroup, 'is_group'>, fromTask: boolean): string {
+  const where = mg.is_group === 1 ? 'this room' : 'this DM';
+  return fromTask ? `${where}, posted by your scheduled task` : `${where}, posted by you from another conversation`;
+}
+
 export interface EchoTargetCandidate {
   id: string;
   status: string;
   messaging_group_id: string | null;
-  thread_id: string | null;
 }
 
 /**
- * Pure audience rule. `isDmMessagingGroup` resolves whether a candidate's
- * messaging group is a DM (is_group=0) — injected so the rule stays testable
- * without a central DB. `sourceMessagingGroupId` is the source conversation's
- * messaging group, used to admit same-mg sibling threads for DM sources.
+ * Pure audience rule: only active sibling sessions of the conversation
+ * the message appeared in. Same messaging group = identical audience, so the
+ * rule needs no membership knowledge. Sessions with no messaging group (task
+ * sessions, a2a targets) are never targets, and an unresolved source
+ * conversation fans nowhere.
  */
 export function selectEchoTargets<T extends EchoTargetCandidate>(
   candidates: T[],
   sourceSessionId: string,
-  sourceSurface: EchoSurface,
   sourceMessagingGroupId: string | null,
-  isDmMessagingGroup: (messagingGroupId: string) => boolean,
 ): T[] {
-  return candidates.filter((s) => {
-    if (s.id === sourceSessionId || s.status !== 'active') return false;
-    // System sessions: task sessions are always in the audience; any other
-    // messaging-group-less session (a2a targets, future system threads) is not.
-    if (s.messaging_group_id === null) return isTaskThread(s.thread_id);
-    // Room sources additionally reach the group's DM sessions (never other
-    // rooms — not even same-mg room threads; room→room is not in v1).
-    if (sourceSurface === 'room') return isDmMessagingGroup(s.messaging_group_id);
-    // DM sources additionally reach sibling sessions of the SAME messaging
-    // group — the parallel conversation-threads of that same DM (identical
-    // audience). Never rooms, never other DMs' sessions.
-    return sourceMessagingGroupId !== null && s.messaging_group_id === sourceMessagingGroupId;
-  });
+  if (sourceMessagingGroupId === null) return [];
+  return candidates.filter(
+    (s) => s.id !== sourceSessionId && s.status === 'active' && s.messaging_group_id === sourceMessagingGroupId,
+  );
 }
 
 function parseContent(raw: string): { text: string; sender: string | null; senderId: string | null } {
@@ -123,14 +126,13 @@ function parseContent(raw: string): { text: string; sender: string | null; sende
 interface EchoFanInput {
   agentGroupId: string;
   sourceSessionId: string;
-  /** Messaging group of the source conversation (same-mg sibling detection). */
+  /** Messaging group of the conversation the message appeared in — the ONLY
+   *  conversation whose sessions are targets. */
   sourceMessagingGroupId: string | null;
   origMessageId: string;
   timestamp: string;
-  surface: EchoSurface;
+  surface: EchoWireSurface;
   label: string;
-  /** Label used when the target is a sibling thread of the same messaging group. */
-  siblingLabel: string;
   platformId: string;
   text: string;
   sender: string;
@@ -139,41 +141,18 @@ interface EchoFanInput {
 
 function fanEcho(input: EchoFanInput): number {
   const candidates = getSessionsByAgentGroup(input.agentGroupId);
-  const dmCache = new Map<string, boolean>();
-  const isDm = (mgId: string): boolean => {
-    let v = dmCache.get(mgId);
-    if (v === undefined) {
-      v = getMessagingGroup(mgId)?.is_group === 0;
-      dmCache.set(mgId, v);
-    }
-    return v;
-  };
-  const targets = selectEchoTargets(
-    candidates,
-    input.sourceSessionId,
-    input.surface,
-    input.sourceMessagingGroupId,
-    isDm,
-  );
+  const targets = selectEchoTargets(candidates, input.sourceSessionId, input.sourceMessagingGroupId);
   if (targets.length === 0) return 0;
 
-  const body = {
+  const content = JSON.stringify({
     text: truncateEchoText(input.text),
     sender: input.sender,
     senderId: input.senderId,
-  };
-  const content = JSON.stringify({ ...body, echo: { surface: input.surface, label: input.label } });
-  // Same-mg sibling threads get a sibling-flavored echo (contract fields
-  // identical — only the surface/label values differ).
-  const siblingContent = JSON.stringify({
-    ...body,
-    echo: { surface: ECHO_SIBLING_SURFACE, label: input.siblingLabel },
+    echo: { surface: input.surface, label: input.label },
   });
 
   let written = 0;
   for (const target of targets) {
-    const isSibling =
-      input.sourceMessagingGroupId !== null && target.messaging_group_id === input.sourceMessagingGroupId;
     try {
       writeSessionMessage(input.agentGroupId, target.id, {
         id: echoRowId(input.origMessageId, target.id),
@@ -182,7 +161,7 @@ function fanEcho(input: EchoFanInput): number {
         platformId: input.platformId,
         channelType: ECHO_CHANNEL_TYPE,
         threadId: null,
-        content: isSibling ? siblingContent : content,
+        content,
         trigger: 0,
         sourceSessionId: input.sourceSessionId,
       });
@@ -203,7 +182,7 @@ function fanEcho(input: EchoFanInput): number {
 /**
  * Router hook: fan a just-written trigger=1 inbound message into sibling
  * sessions. Call ONLY for the engaged (wake) branch — accumulate (trigger=0)
- * writes must never fan. Never throws; returns rows written.
+ * writes must never fan (D3). Never throws; returns rows written.
  */
 export function fanInboundMessage(args: {
   /** Source session the trigger=1 row was written to. */
@@ -227,16 +206,16 @@ export function fanInboundMessage(args: {
     if (isTaskThread(session.thread_id)) return 0;
     const parsed = parseContent(args.content);
     if (!parsed.text) return 0;
-    const surface: EchoSurface = mg.is_group === 1 ? 'room' : 'dm';
+    // Targets are always sibling threads of the conversation the message
+    // arrived on, so every echo is sibling-flavored.
     return fanEcho({
       agentGroupId: session.agent_group_id,
       sourceSessionId: session.id,
       sourceMessagingGroupId: mg.id,
       origMessageId: args.messageId,
       timestamp: args.timestamp,
-      surface,
-      label: buildEchoLabel(mg, parsed.sender),
-      siblingLabel: buildSiblingEchoLabel(mg, parsed.sender),
+      surface: ECHO_SIBLING_SURFACE,
+      label: buildSiblingEchoLabel(mg, parsed.sender),
       platformId: mg.platform_id,
       text: parsed.text,
       sender: parsed.sender ?? 'unknown',
@@ -250,14 +229,13 @@ export function fanInboundMessage(args: {
 
 /**
  * Delivery hook: fan the agent's own just-delivered user-facing message into
- * sibling sessions. Caller applies the user-facing predicate (kind not
- * system/task_log, channel_type not 'agent'); the guards here are
- * belt-and-braces so the contract holds even if call sites drift. The source
- * surface is the conversation the message was DELIVERED to (origin-session-
- * first, then own-destination-first, mirroring delivery.ts's resolution
- * order — needed so sibling-instance rows sharing one channel address
- * resolve to the sender's own row, not an arbitrary sibling's). Never
- * throws.
+ * the sessions of the conversation it was delivered to. Caller applies the
+ * user-facing predicate (kind not system/task_log, channel_type not 'agent');
+ * the guards here are belt-and-braces so the contract holds even if call
+ * sites drift. The delivered-to conversation resolves origin-session-first,
+ * then own-destination-first, mirroring delivery.ts's resolution order —
+ * needed so sibling-instance rows sharing one channel address resolve to the
+ * sender's own row, not an arbitrary sibling's. Never throws.
  */
 export function fanOutboundMessage(
   msg: {
@@ -274,9 +252,7 @@ export function fanOutboundMessage(
     if (msg.kind === 'system' || msg.kind === 'task_log') return 0;
     if (!msg.channel_type || !msg.platform_id) return 0;
     if (msg.channel_type === 'agent' || msg.channel_type === ECHO_CHANNEL_TYPE) return 0;
-    // Task sessions are never a SOURCE — their sends already log to the series
-    // run log, and fanning them would leak scheduled-run output everywhere.
-    if (isTaskThread(session.thread_id)) return 0;
+    const isTaskSource = isTaskThread(session.thread_id);
 
     const originMg = session.messaging_group_id ? getMessagingGroup(session.messaging_group_id) : undefined;
     const mg =
@@ -288,16 +264,20 @@ export function fanOutboundMessage(
 
     const parsed = parseContent(msg.content);
     if (!parsed.text) return 0;
-    const surface: EchoSurface = mg.is_group === 1 ? 'room' : 'dm';
+    // Targets are the sessions of the conversation the message was DELIVERED
+    // to. An origin-conversation reply reads as a sibling-thread echo;
+    // a message the agent posted INTO this conversation from elsewhere (a
+    // task run, or a cross-conversation send) gets the delivered flavor.
+    const isOriginSend = session.messaging_group_id === mg.id;
     return fanEcho({
       agentGroupId: session.agent_group_id,
       sourceSessionId: session.id,
       sourceMessagingGroupId: mg.id,
       origMessageId: msg.id,
       timestamp: new Date().toISOString(),
-      surface,
-      label: buildEchoLabel(mg, mg.name),
-      siblingLabel: buildSiblingEchoLabel(mg, mg.name),
+      surface: isTaskSource ? ECHO_TASK_SURFACE : ECHO_SIBLING_SURFACE,
+      label:
+        !isTaskSource && isOriginSend ? buildSiblingEchoLabel(mg, mg.name) : buildDeliveredEchoLabel(mg, isTaskSource),
       platformId: mg.platform_id,
       text: parsed.text,
       sender: agentGroup.name,

--- a/src/modules/cross-session-context/history.test.ts
+++ b/src/modules/cross-session-context/history.test.ts
@@ -15,7 +15,7 @@ import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/i
 import { createSession } from '../../db/sessions.js';
 import { initSessionFolder, writeOutboundDirect, writeSessionMessage } from '../../session-manager.js';
 import type { CallerContext } from '../../cli/frame.js';
-import { sessionHistory } from './history.js';
+import { formatHistoryLines, sessionHistory } from './history.js';
 
 const TEST_DIR = '/tmp/nanoclaw-test-cross-session-history';
 const AG = 'ag-hist';
@@ -74,7 +74,7 @@ afterEach(() => {
 });
 
 describe('sessionHistory', () => {
-  it('merges inbound + outbound chronologically as pipe-separated lines', () => {
+  it('merges inbound + outbound chronologically as structured rows (ISO timestamps)', () => {
     writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
     writeInbound('in-2', '2026-08-01T10:02:00.000Z', 'second message');
     // writeOutboundDirect stamps now() — always sorts after the fixed 2026 stamps.
@@ -87,30 +87,46 @@ describe('sessionHistory', () => {
       content: JSON.stringify({ text: 'agent reply' }),
     });
 
-    const lines = sessionHistory({ id: SESS }, HOST).split('\n');
-    expect(lines).toHaveLength(3);
-    expect(lines[0]).toBe('2026-08-01T10:00:00.000Z|in|chat|Gavriel|hello there');
-    expect(lines[1]).toBe('2026-08-01T10:02:00.000Z|in|chat|Gavriel|second message');
-    const out = lines[2].split('|');
-    expect(out[1]).toBe('out');
-    expect(out[2]).toBe('chat');
-    expect(out[3]).toBe('Pixel'); // agent group name as outbound sender
-    expect(out[4]).toBe('agent reply');
+    const rows = sessionHistory({ id: SESS }, HOST);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual({
+      timestamp: '2026-08-01T10:00:00.000Z',
+      direction: 'in',
+      kind: 'chat',
+      sender: 'Gavriel',
+      text: 'hello there',
+    });
+    expect(rows[1].text).toBe('second message');
+    expect(rows[2].direction).toBe('out');
+    expect(rows[2].kind).toBe('chat');
+    expect(rows[2].sender).toBe('Pixel'); // agent group name as outbound sender
+    expect(rows[2].text).toBe('agent reply');
+  });
+
+  it('formatHistoryLines renders pipe lines with localized stamps and capped cells', () => {
+    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
+    const lines = formatHistoryLines(sessionHistory({ id: SESS }, HOST), 'UTC').split('\n');
+    expect(lines).toEqual(['2026-08-01 10:00|in|chat|Gavriel|hello there']);
+    // A non-UTC install timezone shifts the human stamp; data stays ISO.
+    const berlin = formatHistoryLines(sessionHistory({ id: SESS }, HOST), 'Europe/Berlin');
+    expect(berlin.startsWith('2026-08-01 12:00|')).toBe(true);
   });
 
   it('applies --limit keeping the NEWEST rows', () => {
     for (let i = 0; i < 5; i++) {
       writeInbound(`in-${i}`, `2026-08-01T10:0${i}:00.000Z`, `msg ${i}`);
     }
-    const lines = sessionHistory({ id: SESS, limit: 2 }, HOST).split('\n');
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain('msg 3');
-    expect(lines[1]).toContain('msg 4');
+    const rows = sessionHistory({ id: SESS, limit: 2 }, HOST);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].text).toBe('msg 3');
+    expect(rows[1].text).toBe('msg 4');
   });
 
-  it('sanitizes newlines and pipes out of the text cell', () => {
+  it('sanitizes newlines and pipes in the human rendering only — rows keep the raw text', () => {
     writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'line one\nline two | with pipe');
-    const line = sessionHistory({ id: SESS }, HOST);
+    const rows = sessionHistory({ id: SESS }, HOST);
+    expect(rows[0].text).toBe('line one\nline two | with pipe');
+    const line = formatHistoryLines(rows, 'UTC');
     expect(line.split('\n')).toHaveLength(1);
     expect(line.endsWith('line one line two / with pipe')).toBe(true);
   });
@@ -124,7 +140,7 @@ describe('sessionHistory', () => {
 
   it('allows the owning agent group and the host', () => {
     writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'visible');
-    expect(sessionHistory({ id: SESS }, OWN_AGENT)).toContain('visible');
-    expect(sessionHistory({ id: SESS }, HOST)).toContain('visible');
+    expect(sessionHistory({ id: SESS }, OWN_AGENT)[0].text).toBe('visible');
+    expect(sessionHistory({ id: SESS }, HOST)[0].text).toBe('visible');
   });
 });

--- a/src/modules/cross-session-context/history.test.ts
+++ b/src/modules/cross-session-context/history.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `ncl sessions history` handler tests: merge/format, limit, and — the
+ * critical one — self-scoping (custom ops bypass the dispatcher's generic
+ * scope filter, so cross-group agents must get "session not found" here).
+ */
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../config.js')>('../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/nanoclaw-test-cross-session-history' };
+});
+
+import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { createSession } from '../../db/sessions.js';
+import { initSessionFolder, writeOutboundDirect, writeSessionMessage } from '../../session-manager.js';
+import type { CallerContext } from '../../cli/frame.js';
+import { sessionHistory } from './history.js';
+
+const TEST_DIR = '/tmp/nanoclaw-test-cross-session-history';
+const AG = 'ag-hist';
+const SESS = 'sess-hist';
+
+const HOST: CallerContext = { caller: 'host' };
+const OWN_AGENT: CallerContext = { caller: 'agent', sessionId: 'sess-x', agentGroupId: AG, messagingGroupId: 'mg-x' };
+const FOREIGN_AGENT: CallerContext = {
+  caller: 'agent',
+  sessionId: 'sess-y',
+  agentGroupId: 'ag-other',
+  messagingGroupId: 'mg-y',
+};
+
+function writeInbound(id: string, timestamp: string, text: string, sender = 'Gavriel'): void {
+  writeSessionMessage(AG, SESS, {
+    id,
+    kind: 'chat',
+    timestamp,
+    platformId: 'D1',
+    channelType: 'slack',
+    threadId: null,
+    content: JSON.stringify({ text, sender, senderId: 'slack:U1' }),
+  });
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  const db = initTestDb();
+  runMigrations(db);
+  createAgentGroup({
+    id: AG,
+    name: 'Pixel',
+    folder: 'pixel',
+    agent_provider: null,
+    created_at: '2026-08-01T00:00:00.000Z',
+  });
+  createSession({
+    id: SESS,
+    agent_group_id: AG,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'stopped',
+    last_active: null,
+    created_at: '2026-08-01T00:00:00.000Z',
+  });
+  initSessionFolder(AG, SESS);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('sessionHistory', () => {
+  it('merges inbound + outbound chronologically as pipe-separated lines', () => {
+    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'hello there');
+    writeInbound('in-2', '2026-08-01T10:02:00.000Z', 'second message');
+    // writeOutboundDirect stamps now() — always sorts after the fixed 2026 stamps.
+    writeOutboundDirect(AG, SESS, {
+      id: 'out-1',
+      kind: 'chat',
+      platformId: 'D1',
+      channelType: 'slack',
+      threadId: null,
+      content: JSON.stringify({ text: 'agent reply' }),
+    });
+
+    const lines = sessionHistory({ id: SESS }, HOST).split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('2026-08-01T10:00:00.000Z|in|chat|Gavriel|hello there');
+    expect(lines[1]).toBe('2026-08-01T10:02:00.000Z|in|chat|Gavriel|second message');
+    const out = lines[2].split('|');
+    expect(out[1]).toBe('out');
+    expect(out[2]).toBe('chat');
+    expect(out[3]).toBe('Pixel'); // agent group name as outbound sender
+    expect(out[4]).toBe('agent reply');
+  });
+
+  it('applies --limit keeping the NEWEST rows', () => {
+    for (let i = 0; i < 5; i++) {
+      writeInbound(`in-${i}`, `2026-08-01T10:0${i}:00.000Z`, `msg ${i}`);
+    }
+    const lines = sessionHistory({ id: SESS, limit: 2 }, HOST).split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('msg 3');
+    expect(lines[1]).toContain('msg 4');
+  });
+
+  it('sanitizes newlines and pipes out of the text cell', () => {
+    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'line one\nline two | with pipe');
+    const line = sessionHistory({ id: SESS }, HOST);
+    expect(line.split('\n')).toHaveLength(1);
+    expect(line.endsWith('line one line two / with pipe')).toBe(true);
+  });
+
+  it('self-scopes: a cross-group agent gets "session not found", same as a bogus id', () => {
+    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'private');
+    expect(() => sessionHistory({ id: SESS }, FOREIGN_AGENT)).toThrow(`session not found: ${SESS}`);
+    expect(() => sessionHistory({ id: 'sess-nope' }, FOREIGN_AGENT)).toThrow('session not found: sess-nope');
+    expect(() => sessionHistory({ id: 'sess-nope' }, HOST)).toThrow('session not found: sess-nope');
+  });
+
+  it('allows the owning agent group and the host', () => {
+    writeInbound('in-1', '2026-08-01T10:00:00.000Z', 'visible');
+    expect(sessionHistory({ id: SESS }, OWN_AGENT)).toContain('visible');
+    expect(sessionHistory({ id: SESS }, HOST)).toContain('visible');
+  });
+});

--- a/src/modules/cross-session-context/history.ts
+++ b/src/modules/cross-session-context/history.ts
@@ -1,0 +1,106 @@
+/**
+ * `ncl sessions history <session-id>` — the pull layer of cross-session
+ * context (plan 01): full-depth catch-up on another conversation after the
+ * push layer's one-line ambient copies.
+ *
+ * Reads the target session's inbound messages_in + outbound messages_out
+ * (both read-only; safe with a live container) merged chronologically.
+ *
+ * SCOPING: custom operations bypass the dispatcher's generic post-handler
+ * scope filter, so this handler self-scopes like tasks.ts `ownSession` —
+ * an agent caller asking about another group's session gets the same
+ * "session not found" as a nonexistent id (no cross-group existence oracle).
+ */
+import fs from 'fs';
+
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getSession } from '../../db/sessions.js';
+import { inboundDbPath, openOutboundDb, withInboundDb } from '../../session-manager.js';
+import type { CallerContext } from '../../cli/frame.js';
+
+export const HISTORY_DEFAULT_LIMIT = 50;
+/** Per-line text cap in the pipe-separated output. */
+export const HISTORY_TEXT_MAX_CHARS = 200;
+
+interface HistoryRow {
+  timestamp: string;
+  direction: 'in' | 'out';
+  kind: string;
+  sender: string;
+  text: string;
+}
+
+function cell(value: string): string {
+  // Keep the one-line-per-message format intact: newlines and pipes in
+  // message text would shred downstream line/field parsing.
+  return value.replace(/\s+/g, ' ').replace(/\|/g, '/').trim().slice(0, HISTORY_TEXT_MAX_CHARS);
+}
+
+function parseText(raw: string): { text: string; sender: string | null } {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const text =
+      typeof parsed.text === 'string' && parsed.text.length > 0
+        ? parsed.text
+        : typeof parsed.action === 'string'
+          ? `[${parsed.action}]`
+          : '';
+    return { text, sender: typeof parsed.sender === 'string' ? parsed.sender : null };
+  } catch {
+    return { text: raw, sender: null };
+  }
+}
+
+/**
+ * Handler for the sessions `history` custom operation. Returns the merged
+ * transcript as pipe-separated lines:
+ *   timestamp|direction(in/out)|kind|sender|text(first 200 chars)
+ * newest `limit` rows, chronological order.
+ */
+export function sessionHistory(args: Record<string, unknown>, ctx: CallerContext): string {
+  const sessionId = typeof args.id === 'string' && args.id.length > 0 ? args.id : undefined;
+  if (!sessionId) throw new Error('session id is required');
+  const limitRaw = Number(args.limit ?? HISTORY_DEFAULT_LIMIT);
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : HISTORY_DEFAULT_LIMIT;
+
+  const session = getSession(sessionId);
+  // Self-scope (see header): cross-group agents get "not found", never "forbidden".
+  if (!session || (ctx.caller === 'agent' && session.agent_group_id !== ctx.agentGroupId)) {
+    throw new Error(`session not found: ${sessionId}`);
+  }
+
+  const agentName = getAgentGroup(session.agent_group_id)?.name ?? 'agent';
+  const rows: HistoryRow[] = [];
+
+  if (fs.existsSync(inboundDbPath(session.agent_group_id, session.id))) {
+    const inbound = withInboundDb(session.agent_group_id, session.id, (db) =>
+      db.prepare('SELECT timestamp, kind, content FROM messages_in ORDER BY seq DESC LIMIT ?').all(limit),
+    ) as Array<{ timestamp: string; kind: string; content: string }>;
+    for (const r of inbound) {
+      const { text, sender } = parseText(r.content);
+      rows.push({ timestamp: r.timestamp, direction: 'in', kind: r.kind, sender: sender ?? '', text });
+    }
+  }
+
+  try {
+    const outDb = openOutboundDb(session.agent_group_id, session.id);
+    try {
+      const outbound = outDb
+        .prepare('SELECT timestamp, kind, content FROM messages_out ORDER BY seq DESC LIMIT ?')
+        .all(limit) as Array<{ timestamp: string; kind: string; content: string }>;
+      for (const r of outbound) {
+        const { text } = parseText(r.content);
+        rows.push({ timestamp: r.timestamp, direction: 'out', kind: r.kind, sender: agentName, text });
+      }
+    } finally {
+      outDb.close();
+    }
+  } catch {
+    // outbound.db may not exist yet (container never started) — inbound-only view.
+  }
+
+  rows.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+  const newest = rows.slice(-limit);
+
+  return newest.map((r) => `${r.timestamp}|${r.direction}|${r.kind}|${cell(r.sender)}|${cell(r.text)}`).join('\n');
+}

--- a/src/modules/cross-session-context/history.ts
+++ b/src/modules/cross-session-context/history.ts
@@ -1,7 +1,7 @@
 /**
  * `ncl sessions history <session-id>` — the pull layer of cross-session
- * context (plan 01): full-depth catch-up on another conversation after the
- * push layer's one-line ambient copies.
+ * context: full-depth catch-up on another conversation after the push
+ * layer's one-line ambient copies.
  *
  * Reads the target session's inbound messages_in + outbound messages_out
  * (both read-only; safe with a live container) merged chronologically.
@@ -13,16 +13,19 @@
  */
 import fs from 'fs';
 
+import { TIMEZONE } from '../../config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
 import { getSession } from '../../db/sessions.js';
 import { inboundDbPath, openOutboundDb, withInboundDb } from '../../session-manager.js';
+import { formatLocalStamp } from '../../timezone.js';
 import type { CallerContext } from '../../cli/frame.js';
 
 export const HISTORY_DEFAULT_LIMIT = 50;
-/** Per-line text cap in the pipe-separated output. */
+/** Per-line text cap in the human pipe-separated rendering. */
 export const HISTORY_TEXT_MAX_CHARS = 200;
 
-interface HistoryRow {
+export interface HistoryRow {
+  /** ISO-8601 UTC on the wire; the human renderer localizes. */
   timestamp: string;
   direction: 'in' | 'out';
   kind: string;
@@ -53,11 +56,12 @@ function parseText(raw: string): { text: string; sender: string | null } {
 
 /**
  * Handler for the sessions `history` custom operation. Returns the merged
- * transcript as pipe-separated lines:
- *   timestamp|direction(in/out)|kind|sender|text(first 200 chars)
- * newest `limit` rows, chronological order.
+ * transcript as structured rows (newest `limit`, chronological order) —
+ * the frame `data`, so `--json` callers get real rows with ISO timestamps.
+ * Human rendering (pipe lines, localized stamps, capped cells) lives in
+ * `formatHistoryLines`, wired as the operation's `formatHuman`.
  */
-export function sessionHistory(args: Record<string, unknown>, ctx: CallerContext): string {
+export function sessionHistory(args: Record<string, unknown>, ctx: CallerContext): HistoryRow[] {
   const sessionId = typeof args.id === 'string' && args.id.length > 0 ? args.id : undefined;
   if (!sessionId) throw new Error('session id is required');
   const limitRaw = Number(args.limit ?? HISTORY_DEFAULT_LIMIT);
@@ -100,7 +104,20 @@ export function sessionHistory(args: Record<string, unknown>, ctx: CallerContext
   }
 
   rows.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
-  const newest = rows.slice(-limit);
+  return rows.slice(-limit);
+}
 
-  return newest.map((r) => `${r.timestamp}|${r.direction}|${r.kind}|${cell(r.sender)}|${cell(r.text)}`).join('\n');
+/**
+ * Human rendering: pipe-separated lines
+ *   timestamp|direction(in/out)|kind|sender|text(first 200 chars)
+ * with the timestamp in the install timezone (`timezone` injectable for
+ * deterministic tests). `--json` bypasses this and gets the raw rows.
+ */
+export function formatHistoryLines(rows: HistoryRow[], timezone: string = TIMEZONE): string {
+  return rows
+    .map(
+      (r) =>
+        `${formatLocalStamp(new Date(r.timestamp), timezone)}|${r.direction}|${r.kind}|${cell(r.sender)}|${cell(r.text)}`,
+    )
+    .join('\n');
 }

--- a/src/modules/cross-session-context/index.ts
+++ b/src/modules/cross-session-context/index.ts
@@ -3,7 +3,9 @@
  *
  * Push layer: accumulate fan-out of triggering user messages (router hook)
  * and delivered user-facing agent messages (delivery hook) into sibling
- * sessions as trigger=0 'session-echo' rows. Backlog capped by the
+ * sessions OF THE SAME CONVERSATION as trigger=0 'session-echo' rows (a message
+ * fans only into sessions of the messaging group it appeared in —
+ * cross-conversation awareness is pull-only). Backlog capped by the
  * host-sweep pruner. Pull layer: `ncl sessions history` (registered by
  * src/cli/resources/sessions.ts).
  *
@@ -12,13 +14,14 @@
  */
 export {
   ECHO_BACKLOG_CAP,
-  ECHO_BACKLOG_CAP_TASK,
   ECHO_CHANNEL_TYPE,
   ECHO_MAX_AGE_DAYS,
   ECHO_SIBLING_SURFACE,
+  ECHO_TASK_SURFACE,
   ECHO_TEXT_MAX_CHARS,
 } from './config.js';
 export {
+  buildDeliveredEchoLabel,
   buildEchoLabel,
   buildSiblingEchoLabel,
   echoRowId,
@@ -26,7 +29,6 @@ export {
   fanOutboundMessage,
   selectEchoTargets,
   truncateEchoText,
-  type EchoSurface,
   type EchoTargetCandidate,
   type EchoWireSurface,
 } from './fan.js';

--- a/src/modules/cross-session-context/index.ts
+++ b/src/modules/cross-session-context/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Cross-session context module.
+ *
+ * Push layer: accumulate fan-out of triggering user messages (router hook)
+ * and delivered user-facing agent messages (delivery hook) into sibling
+ * sessions as trigger=0 'session-echo' rows. Backlog capped by the
+ * host-sweep pruner. Pull layer: `ncl sessions history` (registered by
+ * src/cli/resources/sessions.ts).
+ *
+ * No import-time registration — the hooks are direct calls from
+ * router.ts / delivery.ts / host-sweep.ts, kept modular.
+ */
+export {
+  ECHO_BACKLOG_CAP,
+  ECHO_BACKLOG_CAP_TASK,
+  ECHO_CHANNEL_TYPE,
+  ECHO_MAX_AGE_DAYS,
+  ECHO_SIBLING_SURFACE,
+  ECHO_TEXT_MAX_CHARS,
+} from './config.js';
+export {
+  buildEchoLabel,
+  buildSiblingEchoLabel,
+  echoRowId,
+  fanInboundMessage,
+  fanOutboundMessage,
+  selectEchoTargets,
+  truncateEchoText,
+  type EchoSurface,
+  type EchoTargetCandidate,
+  type EchoWireSurface,
+} from './fan.js';
+export { pruneEchoBacklog } from './prune.js';
+export { HISTORY_DEFAULT_LIMIT, HISTORY_TEXT_MAX_CHARS, sessionHistory } from './history.js';
+export { backfillNewDmSession, BACKFILL_LIMIT } from './backfill.js';

--- a/src/modules/cross-session-context/index.ts
+++ b/src/modules/cross-session-context/index.ts
@@ -33,5 +33,11 @@ export {
   type EchoWireSurface,
 } from './fan.js';
 export { pruneEchoBacklog } from './prune.js';
-export { HISTORY_DEFAULT_LIMIT, HISTORY_TEXT_MAX_CHARS, sessionHistory } from './history.js';
+export {
+  formatHistoryLines,
+  HISTORY_DEFAULT_LIMIT,
+  HISTORY_TEXT_MAX_CHARS,
+  sessionHistory,
+  type HistoryRow,
+} from './history.js';
 export { backfillNewDmSession, BACKFILL_LIMIT } from './backfill.js';

--- a/src/modules/cross-session-context/prune.test.ts
+++ b/src/modules/cross-session-context/prune.test.ts
@@ -1,12 +1,12 @@
 /**
- * Echo backlog pruner tests: keep-newest logic, task-session cap,
- * age cutoff, and non-echo/non-pending rows staying untouched.
+ * Echo backlog pruner tests: keep-newest logic, age cutoff, and
+ * non-echo/non-pending rows staying untouched.
  */
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { INBOUND_SCHEMA } from '../../db/schema.js';
-import { ECHO_BACKLOG_CAP, ECHO_BACKLOG_CAP_TASK, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
+import { ECHO_BACKLOG_CAP, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
 import { pruneEchoBacklog } from './prune.js';
 
 const NOW = Date.parse('2026-08-01T12:00:00.000Z');
@@ -40,11 +40,11 @@ afterEach(() => {
 });
 
 describe('pruneEchoBacklog', () => {
-  it('keeps only the newest CAP pending echo rows in a non-task session', () => {
+  it('keeps only the newest CAP pending echo rows', () => {
     const total = ECHO_BACKLOG_CAP + 5;
     for (let i = 0; i < total; i++) insertRow({ id: `e-${i}`, seq: i * 2 + 2 });
 
-    const pruned = pruneEchoBacklog(db, { isTaskSession: false, now: NOW });
+    const pruned = pruneEchoBacklog(db, { now: NOW });
     expect(pruned).toBe(5);
 
     const ids = remainingIds();
@@ -54,21 +54,11 @@ describe('pruneEchoBacklog', () => {
     expect(ids[ids.length - 1]).toBe(`e-${total - 1}`);
   });
 
-  it('task sessions get the larger cap', () => {
-    const total = ECHO_BACKLOG_CAP_TASK + 3;
-    for (let i = 0; i < total; i++) insertRow({ id: `e-${i}`, seq: i * 2 + 2 });
-
-    expect(pruneEchoBacklog(db, { isTaskSession: true, now: NOW })).toBe(3);
-    expect(remainingIds()).toHaveLength(ECHO_BACKLOG_CAP_TASK);
-    // Same backlog under the non-task cap would have dropped far more.
-    expect(ECHO_BACKLOG_CAP_TASK).toBeGreaterThan(ECHO_BACKLOG_CAP);
-  });
-
   it('drops pending echo rows older than the TTL even under the count cap', () => {
     insertRow({ id: 'old', seq: 2, ageMs: (ECHO_MAX_AGE_DAYS * 24 + 1) * 60 * 60 * 1000 });
     insertRow({ id: 'fresh', seq: 4, ageMs: 60_000 });
 
-    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(1);
+    expect(pruneEchoBacklog(db, { now: NOW })).toBe(1);
     expect(remainingIds()).toEqual(['fresh']);
   });
 
@@ -79,7 +69,7 @@ describe('pruneEchoBacklog', () => {
     // Overflow of pending echoes to prove the delete fires while sparing the above.
     for (let i = 0; i < ECHO_BACKLOG_CAP + 1; i++) insertRow({ id: `e-${i}`, seq: 100 + i * 2 });
 
-    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(1);
+    expect(pruneEchoBacklog(db, { now: NOW })).toBe(1);
     const ids = remainingIds();
     expect(ids).toContain('chat');
     expect(ids).toContain('done-echo');
@@ -87,6 +77,6 @@ describe('pruneEchoBacklog', () => {
   });
 
   it('returns 0 on an empty session', () => {
-    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(0);
+    expect(pruneEchoBacklog(db, { now: NOW })).toBe(0);
   });
 });

--- a/src/modules/cross-session-context/prune.test.ts
+++ b/src/modules/cross-session-context/prune.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Echo backlog pruner tests: keep-newest logic, task-session cap,
+ * age cutoff, and non-echo/non-pending rows staying untouched.
+ */
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { INBOUND_SCHEMA } from '../../db/schema.js';
+import { ECHO_BACKLOG_CAP, ECHO_BACKLOG_CAP_TASK, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
+import { pruneEchoBacklog } from './prune.js';
+
+const NOW = Date.parse('2026-08-01T12:00:00.000Z');
+
+let db: Database.Database;
+
+function insertRow(opts: { id: string; seq: number; channelType?: string; status?: string; ageMs?: number }): void {
+  db.prepare(
+    `INSERT INTO messages_in (id, seq, kind, timestamp, status, channel_type, content, trigger)
+     VALUES (?, ?, 'chat', ?, ?, ?, '{"text":"x"}', 0)`,
+  ).run(
+    opts.id,
+    opts.seq,
+    new Date(NOW - (opts.ageMs ?? 0)).toISOString(),
+    opts.status ?? 'pending',
+    opts.channelType ?? ECHO_CHANNEL_TYPE,
+  );
+}
+
+function remainingIds(): string[] {
+  return (db.prepare('SELECT id FROM messages_in ORDER BY seq').all() as Array<{ id: string }>).map((r) => r.id);
+}
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec(INBOUND_SCHEMA);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('pruneEchoBacklog', () => {
+  it('keeps only the newest CAP pending echo rows in a non-task session', () => {
+    const total = ECHO_BACKLOG_CAP + 5;
+    for (let i = 0; i < total; i++) insertRow({ id: `e-${i}`, seq: i * 2 + 2 });
+
+    const pruned = pruneEchoBacklog(db, { isTaskSession: false, now: NOW });
+    expect(pruned).toBe(5);
+
+    const ids = remainingIds();
+    expect(ids).toHaveLength(ECHO_BACKLOG_CAP);
+    // The oldest (lowest-seq) rows are the ones dropped.
+    expect(ids[0]).toBe('e-5');
+    expect(ids[ids.length - 1]).toBe(`e-${total - 1}`);
+  });
+
+  it('task sessions get the larger cap', () => {
+    const total = ECHO_BACKLOG_CAP_TASK + 3;
+    for (let i = 0; i < total; i++) insertRow({ id: `e-${i}`, seq: i * 2 + 2 });
+
+    expect(pruneEchoBacklog(db, { isTaskSession: true, now: NOW })).toBe(3);
+    expect(remainingIds()).toHaveLength(ECHO_BACKLOG_CAP_TASK);
+    // Same backlog under the non-task cap would have dropped far more.
+    expect(ECHO_BACKLOG_CAP_TASK).toBeGreaterThan(ECHO_BACKLOG_CAP);
+  });
+
+  it('drops pending echo rows older than the TTL even under the count cap', () => {
+    insertRow({ id: 'old', seq: 2, ageMs: (ECHO_MAX_AGE_DAYS * 24 + 1) * 60 * 60 * 1000 });
+    insertRow({ id: 'fresh', seq: 4, ageMs: 60_000 });
+
+    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(1);
+    expect(remainingIds()).toEqual(['fresh']);
+  });
+
+  it('never touches non-echo rows or already-processed echo rows', () => {
+    // A real chat row and a task row far older than the TTL.
+    insertRow({ id: 'chat', seq: 2, channelType: 'slack', ageMs: 30 * 24 * 60 * 60 * 1000 });
+    insertRow({ id: 'done-echo', seq: 4, status: 'completed', ageMs: 30 * 24 * 60 * 60 * 1000 });
+    // Overflow of pending echoes to prove the delete fires while sparing the above.
+    for (let i = 0; i < ECHO_BACKLOG_CAP + 1; i++) insertRow({ id: `e-${i}`, seq: 100 + i * 2 });
+
+    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(1);
+    const ids = remainingIds();
+    expect(ids).toContain('chat');
+    expect(ids).toContain('done-echo');
+    expect(ids).not.toContain('e-0');
+  });
+
+  it('returns 0 on an empty session', () => {
+    expect(pruneEchoBacklog(db, { isTaskSession: false, now: NOW })).toBe(0);
+  });
+});

--- a/src/modules/cross-session-context/prune.ts
+++ b/src/modules/cross-session-context/prune.ts
@@ -1,0 +1,45 @@
+/**
+ * Host-sweep pruner for cross-session echo backlogs.
+ *
+ * Pending trigger=0 rows have no other TTL — without this, fan-out grows
+ * inbound.db unboundedly (plan 01, task-batch hazard #3). Runs inside the
+ * per-session sweep with the session's already-open inbound.db (host-owned,
+ * host is the sole writer). Only 'pending' echo rows are touched: delivered
+ * context (status completed) is the container's history, not backlog.
+ */
+import type Database from 'better-sqlite3';
+
+import { ECHO_BACKLOG_CAP, ECHO_BACKLOG_CAP_TASK, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
+
+/**
+ * Prune pending 'session-echo' rows in one session's inbound.db:
+ *   1. drop rows older than ECHO_MAX_AGE_DAYS,
+ *   2. keep only the newest N by seq (N = task/non-task cap).
+ * Returns the number of rows deleted.
+ */
+export function pruneEchoBacklog(db: Database.Database, opts: { isTaskSession: boolean; now?: number }): number {
+  const keep = opts.isTaskSession ? ECHO_BACKLOG_CAP_TASK : ECHO_BACKLOG_CAP;
+  const cutoffIso = new Date((opts.now ?? Date.now()) - ECHO_MAX_AGE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  const expired = db
+    .prepare(
+      `DELETE FROM messages_in
+        WHERE channel_type = ? AND status = 'pending'
+          AND datetime(timestamp) < datetime(?)`,
+    )
+    .run(ECHO_CHANNEL_TYPE, cutoffIso).changes;
+
+  const overflow = db
+    .prepare(
+      `DELETE FROM messages_in
+        WHERE channel_type = ? AND status = 'pending'
+          AND seq NOT IN (
+            SELECT seq FROM messages_in
+             WHERE channel_type = ? AND status = 'pending'
+             ORDER BY seq DESC LIMIT ?
+          )`,
+    )
+    .run(ECHO_CHANNEL_TYPE, ECHO_CHANNEL_TYPE, keep).changes;
+
+  return expired + overflow;
+}

--- a/src/modules/cross-session-context/prune.ts
+++ b/src/modules/cross-session-context/prune.ts
@@ -2,23 +2,23 @@
  * Host-sweep pruner for cross-session echo backlogs.
  *
  * Pending trigger=0 rows have no other TTL — without this, fan-out grows
- * inbound.db unboundedly (plan 01, task-batch hazard #3). Runs inside the
+ * inbound.db unboundedly. Runs inside the
  * per-session sweep with the session's already-open inbound.db (host-owned,
  * host is the sole writer). Only 'pending' echo rows are touched: delivered
  * context (status completed) is the container's history, not backlog.
  */
 import type Database from 'better-sqlite3';
 
-import { ECHO_BACKLOG_CAP, ECHO_BACKLOG_CAP_TASK, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
+import { ECHO_BACKLOG_CAP, ECHO_CHANNEL_TYPE, ECHO_MAX_AGE_DAYS } from './config.js';
 
 /**
  * Prune pending 'session-echo' rows in one session's inbound.db:
  *   1. drop rows older than ECHO_MAX_AGE_DAYS,
- *   2. keep only the newest N by seq (N = task/non-task cap).
+ *   2. keep only the newest ECHO_BACKLOG_CAP by seq.
  * Returns the number of rows deleted.
  */
-export function pruneEchoBacklog(db: Database.Database, opts: { isTaskSession: boolean; now?: number }): number {
-  const keep = opts.isTaskSession ? ECHO_BACKLOG_CAP_TASK : ECHO_BACKLOG_CAP;
+export function pruneEchoBacklog(db: Database.Database, opts: { now?: number } = {}): number {
+  const keep = ECHO_BACKLOG_CAP;
   const cutoffIso = new Date((opts.now ?? Date.now()) - ECHO_MAX_AGE_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
   const expired = db

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -21,3 +21,4 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
+import './cross-session-context/index.js';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -21,4 +21,3 @@ import './interactive/index.js';
 import './permissions/index.js';
 import './agent-to-agent/index.js';
 import './self-mod/index.js';
-import './cross-session-context/index.js';

--- a/src/router.ts
+++ b/src/router.ts
@@ -527,9 +527,9 @@ async function deliverToAgent(
 
   if (wake) {
     // Cross-session context: fan the triggering message into sibling
-    // sessions of this agent group as trigger=0 'session-echo' rows. Only the
-    // engaged branch fans — the accumulate branch above (trigger=0) never
-    // does, so ambient backlog is never copied twice. Never throws.
+    // sessions of the SAME conversation as trigger=0 'session-echo' rows.
+    // Only the engaged branch fans — the accumulate branch above (trigger=0)
+    // never does, so ambient backlog is never copied twice. Never throws.
     fanInboundMessage({
       session,
       mg,

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,6 +28,7 @@ import {
   getMessagingGroupWithAgentCount,
 } from './db/messaging-groups.js';
 import { findSessionForAgent } from './db/sessions.js';
+import { backfillNewDmSession, fanInboundMessage } from './modules/cross-session-context/index.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
 import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
@@ -504,8 +505,17 @@ async function deliverToAgent(
     }
   }
 
+  if (wake && created) {
+    // New-session backfill (cross-session context): a just-born DM session is
+    // seeded with the DM's top-level timeline from sibling sessions BEFORE
+    // the triggering message is written, so replying to something said in
+    // another conversation thread lands with that context in view.
+    backfillNewDmSession(agentGroup, session, mg);
+  }
+
+  const messageId = messageIdForAgent(event.message.id, agent.agent_group_id);
   writeSessionMessage(session.agent_group_id, session.id, {
-    id: messageIdForAgent(event.message.id, agent.agent_group_id),
+    id: messageId,
     kind: event.message.kind,
     timestamp: event.message.timestamp,
     platformId: deliveryAddr.platformId,
@@ -514,6 +524,22 @@ async function deliverToAgent(
     content: event.message.content,
     trigger: wake ? 1 : 0,
   });
+
+  if (wake) {
+    // Cross-session context: fan the triggering message into sibling
+    // sessions of this agent group as trigger=0 'session-echo' rows. Only the
+    // engaged branch fans — the accumulate branch above (trigger=0) never
+    // does, so ambient backlog is never copied twice. Never throws.
+    fanInboundMessage({
+      session,
+      mg,
+      messageId,
+      kind: event.message.kind,
+      channelType: deliveryAddr.channelType,
+      content: event.message.content,
+      timestamp: event.message.timestamp,
+    });
+  }
 
   log.info('Message routed', {
     sessionId: session.id,


### PR DESCRIPTION
Adds a cross-session context module for agent groups that hold several concurrent sessions: messages that trigger one session (and the agent's own delivered replies) are fanned into sibling sessions as trigger=0 'session-echo' context rows, a just-created DM session is backfilled with the DM's top-level timeline, and a host-sweep pruner caps the echo backlog so inbound DBs stay bounded. Echo rows are ambient by contract — the container formatter renders them as `<cross-session-context>`/`<dm-history>` blocks, never takes reply routing or commands from them, and the poll loop never pushes an echo-only batch into a live turn. Also adds `ncl sessions history` so an agent can read another of its own group's session transcripts on demand (`--json` returns structured rows with ISO timestamps; human mode renders the pipe-line view server-side with install-timezone stamps). The hooks are three direct call sites in router/delivery/host-sweep; the module itself carries no channel literals.

**Audience rule.** A message fans ONLY into sibling sessions of the conversation it actually appeared in — for inbound, the messaging group it arrived on; for outbound (including scheduled-task sends), the messaging group it was delivered to. Same messaging group means an identical audience by definition, so every fan is provably audience-safe with no membership knowledge required: nothing ever crosses conversations automatically (no room→DM, no conversation→task). Cross-conversation awareness is pull-only via `ncl sessions history`. An earlier draft used a broader heuristic (room messages fanned to the group's DM and task sessions); review flagged that it could copy content between unequal audiences, and the second commit replaces it with the same-conversation rule.

---
Part 4/4 of a stacked series: inbound batching → own-destination resolution → detached-state handling → cross-session context. Each builds on the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

